### PR TITLE
Carry the element type on a value class's container members

### DIFF
--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/JvmTypes.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/JvmTypes.java
@@ -157,6 +157,36 @@ final class JvmTypes {
         return descs.toArray(new ClassDesc[0]);
     }
 
+    /**
+     * The generic type signature for a container-typed field or accessor
+     * ({@code List<E>} / {@code Set<E>} / {@code Map<K,V>} / {@code Option<E>}), or {@code null} for a
+     * type whose raw descriptor already names it fully (a scalar, a data reference, a union). Attached
+     * as a {@code Signature} attribute so a Java consumer recovers the element type instead of a raw
+     * {@code List} it has to cast out of.
+     */
+    static String genericSig(Type type, CodegenContext ctx) {
+        return switch (type) {
+            case Type.ListOf l -> "Ljava/util/List<" + refSig(l.element(), ctx) + ">;";
+            case Type.SetOf s -> "Ljava/util/Set<" + refSig(s.element(), ctx) + ">;";
+            case Type.OptionOf o -> "Lnet/unit8/souther/runtime/Option<" + refSig(o.element(), ctx) + ">;";
+            case Type.MapOf m -> "Ljava/util/Map<" + refSig(m.key(), ctx) + refSig(m.value(), ctx) + ">;";
+            default -> null;
+        };
+    }
+
+    /**
+     * An element type's signature as a reference (generic arguments are never primitive, so a
+     * primitive element takes its boxed class — {@code Int} is {@code Long}, {@code Bool} is
+     * {@code Boolean}). A nested container recurses ({@code List<List<E>>}); any other type's raw
+     * descriptor is already a reference.
+     */
+    private static String refSig(Type element, CodegenContext ctx) {
+        String nested = genericSig(element, ctx);
+        if (nested != null) return nested;
+        ClassDesc boxed = boxedPrim(element);
+        return (boxed != null ? boxed : jvmType(element, ctx)).descriptorString();
+    }
+
     /** Unboxes/casts the {@code Object} on the stack to {@code type}'s JVM form and stores it in
      * {@code slot}. */
     static void unbox(CodeBuilder code, Type type, int slot, CodegenContext ctx) {

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/ValueClassGen.java
@@ -7,7 +7,10 @@ import net.unit8.souther.compiler.check.TypeChecker;
 import java.lang.classfile.ClassBuilder;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.Label;
+import java.lang.classfile.MethodSignature;
+import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.PermittedSubclassesAttribute;
+import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
@@ -56,7 +59,7 @@ final class ValueClassGen {
                 cb.withInterfaceSymbols(ifaces);
             }
             for (Map.Entry<String, Type> f : fields.entrySet()) {
-                cb.withField(f.getKey(), jvmType(f.getValue()), ClassFile.ACC_FINAL);
+                emitField(cb, f.getKey(), f.getValue());
             }
             emitCtor(cb, cdName, fields);
             emitValueEquality(cb, cdName, fields);
@@ -279,19 +282,36 @@ final class ValueClassGen {
         for (Map.Entry<String, Type> f : fields.entrySet()) {
             Type ft = f.getValue();
             ClassDesc fd = jvmType(ft);
-            cb.withMethodBody(f.getKey(), MethodTypeDesc.of(fd),
-                    ClassFile.ACC_PUBLIC | ClassFile.ACC_FINAL, code -> {
-                        code.aload(0);
-                        code.getfield(cdName, f.getKey(), fd);
-                        if (ft == Type.INT) {
-                            code.lreturn();
-                        } else if (ft == Type.BOOL) {
-                            code.ireturn();
-                        } else {
-                            code.areturn();
-                        }
+            String sig = JvmTypes.genericSig(ft, ctx);
+            cb.withMethod(f.getKey(), MethodTypeDesc.of(fd),
+                    ClassFile.ACC_PUBLIC | ClassFile.ACC_FINAL, mb -> {
+                        if (sig != null) mb.with(SignatureAttribute.of(MethodSignature.parseFrom("()" + sig)));
+                        mb.withCode(code -> {
+                            code.aload(0);
+                            code.getfield(cdName, f.getKey(), fd);
+                            if (ft == Type.INT) {
+                                code.lreturn();
+                            } else if (ft == Type.BOOL) {
+                                code.ireturn();
+                            } else {
+                                code.areturn();
+                            }
+                        });
                     });
         }
+    }
+
+    /**
+     * Emits a {@code final} backing field. A container field ({@code List}/{@code Set}/{@code Map}/
+     * {@code Option}) also gets a generic {@code Signature} so its element type survives to a Java
+     * reader; a field whose raw descriptor already names it fully gets none.
+     */
+    private void emitField(ClassBuilder cb, String name, Type type) {
+        String sig = JvmTypes.genericSig(type, ctx);
+        cb.withField(name, jvmType(type), fb -> {
+            fb.withFlags(ClassFile.ACC_FINAL);
+            if (sig != null) fb.with(SignatureAttribute.of(Signature.parseFrom(sig)));
+        });
     }
 
     /**

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileContainerSignatureTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileContainerSignatureTest.java
@@ -1,0 +1,70 @@
+package net.unit8.souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A value class's accessor and backing field for a List/Set/Map/Option field carry a generic
+ * {@code Signature}, so a Java consumer reads {@code List<LineItem>} rather than a raw {@code List}
+ * and casts on every read. Reflection's {@code getGenericReturnType} / {@code getGenericType} read
+ * exactly that attribute, so they see the raw type when it is missing.
+ */
+class CompileContainerSignatureTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data LineItem = { qty: Int }
+            data 商品ID = String
+
+            data Cart = {
+                items: List<LineItem>
+                , counts: List<Int>
+                , tags: Set<String>
+                , stock: Map<商品ID, Int>
+                , note: String?
+            }
+            """;
+
+    private Class<?> cart() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(MODULE), getClass().getClassLoader());
+        return loader.loadClass("demo.Cart");
+    }
+
+    @Test
+    void listAccessorCarriesItsElementType() throws Exception {
+        assertEquals("java.util.List<demo.LineItem>",
+                cart().getMethod("items").getGenericReturnType().getTypeName());
+    }
+
+    @Test
+    void listFieldCarriesItsElementType() throws Exception {
+        assertEquals("java.util.List<demo.LineItem>",
+                cart().getDeclaredField("items").getGenericType().getTypeName());
+    }
+
+    @Test
+    void aPrimitiveElementIsBoxedInTheSignature() throws Exception {
+        assertEquals("java.util.List<java.lang.Long>",
+                cart().getMethod("counts").getGenericReturnType().getTypeName());
+    }
+
+    @Test
+    void setAccessorCarriesItsElementType() throws Exception {
+        assertEquals("java.util.Set<java.lang.String>",
+                cart().getMethod("tags").getGenericReturnType().getTypeName());
+    }
+
+    @Test
+    void mapAccessorCarriesItsKeyAndValueTypes() throws Exception {
+        assertEquals("java.util.Map<demo.商品ID, java.lang.Long>",
+                cart().getMethod("stock").getGenericReturnType().getTypeName());
+    }
+
+    @Test
+    void optionAccessorCarriesItsElementType() throws Exception {
+        assertEquals("net.unit8.souther.runtime.Option<java.lang.String>",
+                cart().getMethod("note").getGenericReturnType().getTypeName());
+    }
+}


### PR DESCRIPTION
## What

A `List` / `Set` / `Map` / `Option` field's accessor and backing field were emitted as a raw `java.util.List` / `Set` / `Map` (or `Option`) with no generic `Signature` attribute, so a Java consumer read a raw `List` and cast every element out of it (`(OrderLine) order.lines().get(i)`). Generic `Signature` attributes were already emitted for the `decoder()` / `encoder()` factories, but not for the value-class members.

This emits a `Signature` carrying the generic element type on both the accessor and the backing field:

```
public final java.util.List<example.cart.LineItem> items();
  Signature: ()Ljava/util/List<Lexample/cart/LineItem;>;
final java.util.List items;
  Signature: Ljava/util/List<Lexample/cart/LineItem;>;
```

- A primitive element is boxed (`Int -> Long`, `Bool -> Boolean`), since a generic argument is never primitive; nested containers recurse (`List<List<E>>`, `Map<K, List<V>>`).
- A `Map`'s key takes the newtype instance the runtime map is keyed by (bare rendering is an encoder-boundary concern), matching how the value is actually stored.
- The erased descriptor is unchanged (`()Ljava/util/List;`), so no bytecode-level call site changes — only the `Signature` metadata is added.

## Tests

- New `CompileContainerSignatureTest` verifies the consumer-visible generic type via `getGenericReturnType()` / `getGenericType()` for List (of a data ref and of a boxed primitive), Set, Map, and Option.
- Full clean build green: compiler 561, lsp 11.
- All 9 examples rebuilt against this compiler stay green (including the ordering example's Java/Spring/jOOQ boundary), confirming Java consumers still compile.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)