### PR TITLE
Aggregate a per-element failing load with fold + match (no traverse)

### DIFF
--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/ast/Ast.java
@@ -358,7 +358,12 @@ public interface Ast {
      * (spec 16.1). Nesting the rest of the body inside keeps {@code value} from being evaluated
      * when an enclosing {@code if} (a desugared {@code require}) takes the other branch.
      */
-    record LetIn(String name, Expr value, Expr body, SourcePos pos) implements Expr {}
+    record LetIn(String name, Expr value, ParamType declaredType, Expr body, SourcePos pos) implements Expr {
+        /** An ordinary {@code let x = e}: the bound name takes {@code e}'s inferred type. */
+        public LetIn(String name, Expr value, Expr body, SourcePos pos) {
+            this(name, value, null, body, pos);
+        }
+    }
 
     /** A list literal {@code [e1, e2, ...]} (one or more elements of the same type). */
     record ListLit(List<Expr> elements, SourcePos pos) implements Expr {}
@@ -434,7 +439,7 @@ public interface Ast {
             case Binary b -> new Binary(b.op(), f.apply(b.left()), f.apply(b.right()), b.pos());
             case Call c -> new Call(c.fn(), mapExprs(c.args(), f), c.pos());
             case If iff -> new If(f.apply(iff.cond()), f.apply(iff.then()), f.apply(iff.els()), iff.pos());
-            case LetIn li -> new LetIn(li.name(), f.apply(li.value()), f.apply(li.body()), li.pos());
+            case LetIn li -> new LetIn(li.name(), f.apply(li.value()), li.declaredType(), f.apply(li.body()), li.pos());
             case Block bl -> new Block(bl.params(), f.apply(bl.body()), bl.pos());
             case ListLit l -> new ListLit(mapExprs(l.elements(), f), l.pos());
             case ListComp comp -> new ListComp(f.apply(comp.element()), mapExprs(comp.guards(), f), comp.pos());

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/check/Exposing.java
@@ -132,7 +132,7 @@ public final class Exposing {
                 }
                 yield new Ast.NewData(nd.typeName(), inits, nd.spreads(), nd.pos());
             }
-            case Ast.LetIn li -> new Ast.LetIn(li.name(), rw(li.value()), rw(li.body()), li.pos());
+            case Ast.LetIn li -> new Ast.LetIn(li.name(), rw(li.value()), li.declaredType(), rw(li.body()), li.pos());
             case Ast.Block bl -> new Ast.Block(bl.params(), rw(bl.body()), bl.pos());
             case Ast.ListLit ll -> {
                 List<Ast.Expr> elems = new ArrayList<>();

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/check/HelperInliner.java
@@ -138,6 +138,7 @@ public final class HelperInliner {
                 Map<String, Ast.FnDef> scopedLambdas = new HashMap<>();   // lambdas given to fn params
                 List<String> letNames = new ArrayList<>();
                 List<Ast.Expr> letValues = new ArrayList<>();
+                List<Ast.ParamType> letTypes = new ArrayList<>();
                 for (int i = 0; i < helper.params().size(); i++) {
                     Ast.FnParam p = helper.params().get(i);
                     Ast.Expr arg = args.get(i);
@@ -172,6 +173,10 @@ public final class HelperInliner {
                         subst.put(p.name(), f);
                         letNames.add(f);
                         letValues.add(arg);
+                        // carry the parameter's declared type onto the binding, so a value known to
+                        // be a sum (an annotated `s: S`) is not narrowed to the argument's specific
+                        // case when the body is re-checked inline — a `match s` inside still sees S.
+                        letTypes.add(p.type());
                     }
                 }
                 scopedLambdas.forEach(helpers::put);
@@ -183,7 +188,7 @@ public final class HelperInliner {
                 scopedLambdas.keySet().forEach(helpers::remove);
                 // wrap innermost-first so the value parameters bind in declared order
                 for (int i = letNames.size() - 1; i >= 0; i--) {
-                    body = new Ast.LetIn(letNames.get(i), letValues.get(i), body, call.pos());
+                    body = new Ast.LetIn(letNames.get(i), letValues.get(i), letTypes.get(i), body, call.pos());
                 }
                 yield body;
             }
@@ -227,10 +232,10 @@ public final class HelperInliner {
                 // escapes, which needs a runtime closure. Keep the binding so the "a block is not a
                 // value" check reports it.
                 yield mentions(body, li.name())
-                        ? new Ast.LetIn(li.name(), inline(lambda), body, li.pos())
+                        ? new Ast.LetIn(li.name(), inline(lambda), li.declaredType(), body, li.pos())
                         : body;
             }
-            case Ast.LetIn li -> new Ast.LetIn(li.name(), inline(li.value()), inline(li.body()), li.pos());
+            case Ast.LetIn li -> new Ast.LetIn(li.name(), inline(li.value()), li.declaredType(), inline(li.body()), li.pos());
             case Ast.ListLit lit -> new Ast.ListLit(inlineList(lit.elements()), lit.pos());
             case Ast.Tuple tup -> new Ast.Tuple(inlineList(tup.elements()), tup.pos());
             case Ast.TupleGet tg -> new Ast.TupleGet(inline(tg.tuple()), tg.index(), tg.arity(), tg.pos());
@@ -343,7 +348,7 @@ public final class HelperInliner {
             case Ast.LetIn li -> {
                 Ast.Expr value = rename(li.value(), subst, fnParams, at);
                 Ast.Expr body = rename(li.body(), without(subst, li.name()), fnParams, at);
-                yield new Ast.LetIn(li.name(), value, body, at(at, li.pos()));
+                yield new Ast.LetIn(li.name(), value, li.declaredType(), body, at(at, li.pos()));
             }
             case Ast.ListLit lit -> new Ast.ListLit(renameList(lit.elements(), subst, fnParams, at), at(at, lit.pos()));
             case Ast.Tuple tup -> new Ast.Tuple(renameList(tup.elements(), subst, fnParams, at), at(at, tup.pos()));

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/check/NewtypeDesugar.java
@@ -65,7 +65,7 @@ public final class NewtypeDesugar {
             case Ast.ListComp comp ->
                     new Ast.ListComp(go(comp.element(), symbols), mapExprs(comp.guards(), symbols), comp.pos());
             case Ast.LetIn li ->
-                    new Ast.LetIn(li.name(), go(li.value(), symbols), go(li.body(), symbols), li.pos());
+                    new Ast.LetIn(li.name(), go(li.value(), symbols), li.declaredType(), go(li.body(), symbols), li.pos());
             case Ast.If iff ->
                     new Ast.If(go(iff.cond(), symbols), go(iff.then(), symbols), go(iff.els(), symbols), iff.pos());
             case Ast.Block b -> new Ast.Block(b.params(), go(b.body(), symbols), b.pos());

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/check/TypeChecker.java
@@ -2044,7 +2044,24 @@ public final class TypeChecker {
                     List<Type> paramTypes = inferFnParamTypes(li.name(), li.body(), env, data, symbols, reqs);
                     inner.put(li.name(), typeFunctionValue(li.value(), paramTypes, env, data, symbols, reqs));
                 } else {
-                    inner.put(li.name(), typeOf(li.value(), env, data, symbols, reqs));
+                    Type valueType = typeOf(li.value(), env, data, symbols, reqs);
+                    Type bindType = valueType;
+                    if (li.declaredType() instanceof Ast.RetType rt) {
+                        // A binding carrying an inlined helper's declared parameter type. When that type
+                        // is a sum, keep it: a case argument widens to its sum (spec 8.3), so a `match`
+                        // in the body still sees the sum rather than the argument's specific case. Other
+                        // declared types (a type variable in a generic prelude helper, a record, a list)
+                        // are left to the argument's own type, which monomorphisation and the call-site
+                        // check already handle.
+                        Type declared = resolveParamType(rt, symbols);
+                        boolean isSum = declared instanceof Type.Union
+                                || (declared instanceof Type.Ref r
+                                        && symbols.get(r.name()) instanceof Ast.SumData);
+                        if (isSum && assignable(valueType, declared, symbols)) {
+                            bindType = declared;
+                        }
+                    }
+                    inner.put(li.name(), bindType);
                 }
                 yield typeOf(li.body(), inner, data, symbols, reqs);
             }
@@ -2531,14 +2548,23 @@ public final class TypeChecker {
                     }
                     yield Type.mentions(bt, TypeChecker::isBottom) ? acc : bt;
                 }
-                if (!bt.equals(acc) && absorbEmptyList(acc, bt) == null) {
-                    throw CompileException.of(
-                            Diagnostic.of(null, "check.fold.acctype").title("check.type.mismatch.title")
-                                    .at(call.pos()).args(Type.show(acc), Type.show(bt))
-                                    .diff(Type.show(bt), Type.show(acc)).build(),
-                            "fold's block must return the accumulator type " + acc + ", got " + bt);
+                if (bt.equals(acc) || absorbEmptyList(acc, bt) != null) {
+                    yield acc;
                 }
-                yield acc;
+                // The seed is a specific case (e.g. a `Success`) and the block grows the accumulator
+                // into its sum (`Success | Failure`): the accumulator's real type is that sum. Re-type
+                // the block at the wider type — a block that assumed the seed's narrower case is now
+                // rejected — and, if it is a fixpoint there, use it. This is what lets a per-element
+                // failing load be aggregated with a `fold` seeded by the success case.
+                if (assignable(acc, bt, symbols)
+                        && blockType(call, args.get(0), List.of(bt, lo.element()), env, data, symbols, reqs).equals(bt)) {
+                    yield bt;
+                }
+                throw CompileException.of(
+                        Diagnostic.of(null, "check.fold.acctype").title("check.type.mismatch.title")
+                                .at(call.pos()).args(Type.show(acc), Type.show(bt))
+                                .diff(Type.show(bt), Type.show(acc)).build(),
+                        "fold's block must return the accumulator type " + acc + ", got " + bt);
             }
             case "List.get" -> {
                 arity(call, 2);

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/check/TypeChecker.java
@@ -2054,10 +2054,7 @@ public final class TypeChecker {
                         // are left to the argument's own type, which monomorphisation and the call-site
                         // check already handle.
                         Type declared = resolveParamType(rt, symbols);
-                        boolean isSum = declared instanceof Type.Union
-                                || (declared instanceof Type.Ref r
-                                        && symbols.get(r.name()) instanceof Ast.SumData);
-                        if (isSum && assignable(valueType, declared, symbols)) {
+                        if (isSumType(declared, symbols) && assignable(valueType, declared, symbols)) {
                             bindType = declared;
                         }
                     }
@@ -2553,10 +2550,11 @@ public final class TypeChecker {
                 }
                 // The seed is a specific case (e.g. a `Success`) and the block grows the accumulator
                 // into its sum (`Success | Failure`): the accumulator's real type is that sum. Re-type
-                // the block at the wider type — a block that assumed the seed's narrower case is now
+                // the block at the wider sum — a block that assumed the seed's narrower case is now
                 // rejected — and, if it is a fixpoint there, use it. This is what lets a per-element
-                // failing load be aggregated with a `fold` seeded by the success case.
-                if (assignable(acc, bt, symbols)
+                // failing load be aggregated with a `fold` seeded by the success case. Restricted to a
+                // sum target, so a covariant list/map/tuple widening is not silently accepted here.
+                if (isSumType(bt, symbols) && assignable(acc, bt, symbols)
                         && blockType(call, args.get(0), List.of(bt, lo.element()), env, data, symbols, reqs).equals(bt)) {
                     yield bt;
                 }
@@ -3272,6 +3270,13 @@ public final class TypeChecker {
             return true;
         }
         return sup instanceof Type.Union u && u.members().containsAll(namesOf(sub));
+    }
+
+    /** Whether {@code t} is a sum: an anonymous union, or a reference to a named {@code data X = A | B}.
+     * A case→sum widening only matters for these — not for a covariant list/map/tuple. */
+    private static boolean isSumType(Type t, Map<String, Ast.Def> symbols) {
+        return t instanceof Type.Union
+                || (t instanceof Type.Ref r && symbols.get(r.name()) instanceof Ast.SumData);
     }
 
     /** Whether a {@code from} value can be assigned where {@code to} is expected. Lists are

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSumParamMatchTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSumParamMatchTest.java
@@ -1,0 +1,109 @@
+package net.unit8.souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * A helper whose value parameter is declared as a sum keeps that declared type when the helper is
+ * inlined, so a {@code match} inside it still sees the sum even though the argument is a specific
+ * case. This is what lets a per-element failing load be aggregated with an ordinary {@code fold} +
+ * {@code match} whose accumulator is a {@code Success | Failure} sum ([#18]).
+ */
+class CompileSumParamMatchTest {
+
+    @Test
+    void aCaseArgumentToANamedSumParamIsStillMatchable() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                data S = A | B
+                let use (s: S) : Int = match s with
+                    | A a -> a.x
+                    | B b -> b.y
+                let caller () : Int = use(A { x = 1 })
+                """));
+    }
+
+    @Test
+    void aCaseArgumentToAnAnonymousUnionParamIsStillMatchable() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                let use (s: A | B) : Int = match s with
+                    | A a -> a.x
+                    | B b -> b.y
+                let caller () : Int = use(A { x = 1 })
+                """));
+    }
+
+    @Test
+    void aMismatchedCaseArgumentIsStillRejected() {
+        // C is not a member of S; passing it to `use` must still fail.
+        org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> Compiler.compile("""
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                data C = { z: Int }
+                data S = A | B
+                let use (s: S) : Int = match s with
+                    | A a -> a.x
+                    | B b -> b.y
+                let caller () : Int = use(C { z = 1 })
+                """));
+    }
+
+    private static final String PRICING = """
+            module demo
+            import List ( fold )
+            data Sku = Int
+            data Line = { sku: Sku, quantity: Int }
+            data Priced = { sku: Sku, unitPrice: Int }
+            data PricedCart = { lines: List<Priced> }
+            data NotFound = { missing: Sku }
+            data PriceResult = Priced | NotFound
+            data Acc = PricedCart | NotFound
+            data In = { lines: List<Line> }
+
+            behavior priceLines : (i: In) -> PricedCart | NotFound
+                constructs Priced, NotFound, PricedCart
+
+            let priceLines (i) =
+                fold((acc, line) -> step(acc, price(line)), PricedCart { lines = [] }, i.lines)
+
+            let price (line: Line) : PriceResult =
+                if line.quantity > 0
+                then Priced { sku = line.sku, unitPrice = line.quantity * 100 }
+                else NotFound { missing = line.sku }
+
+            let step (acc: Acc, r: PriceResult) : Acc = match acc with
+                | NotFound n -> n
+                | PricedCart c -> match r with
+                    | Priced p -> PricedCart { lines = c.lines ++ [p] }
+                    | NotFound n -> n
+            """;
+
+    @Test
+    void perLineFailingLoadAggregatesWithFoldAndMatch() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(PRICING), getClass().getClassLoader());
+        Object behavior = loader.loadClass("demo.PriceLines" + "$Impl").getConstructor().newInstance();
+
+        // all quantities > 0 -> a PricedCart carrying every priced line
+        Object okIn = Codecs.decoded(loader, "demo.In",
+                Map.of("lines", List.of(Map.of("sku", 1L, "quantity", 2L), Map.of("sku", 2L, "quantity", 3L))));
+        Map<?, ?> ok = (Map<?, ?>) Codecs.encode(loader, "demo.PricedCart", Codecs.apply(behavior, okIn));
+        assertEquals(2, ((List<?>) ok.get("lines")).size());
+
+        // one zero quantity -> the whole thing departs as NotFound for that sku
+        Object badIn = Codecs.decoded(loader, "demo.In",
+                Map.of("lines", List.of(Map.of("sku", 1L, "quantity", 2L), Map.of("sku", 9L, "quantity", 0L))));
+        Map<?, ?> bad = (Map<?, ?>) Codecs.encode(loader, "demo.NotFound", Codecs.apply(behavior, badIn));
+        assertEquals(9L, bad.get("missing"));
+    }
+}

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSumParamMatchTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSumParamMatchTest.java
@@ -93,6 +93,50 @@ class CompileSumParamMatchTest {
             """;
 
     @Test
+    void aFoldSeededWithACaseAcceptsAnEmptyList() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(PRICING), getClass().getClassLoader());
+        Object behavior = loader.loadClass("demo.PriceLines" + "$Impl").getConstructor().newInstance();
+        // no lines -> the seed is returned unchanged, an empty PricedCart, typed at the union
+        Object emptyIn = Codecs.decoded(loader, "demo.In", Map.of("lines", List.of()));
+        Map<?, ?> empty = (Map<?, ?>) Codecs.encode(loader, "demo.PricedCart", Codecs.apply(behavior, emptyIn));
+        assertEquals(0, ((List<?>) empty.get("lines")).size());
+    }
+
+    @Test
+    void aFoldBlockThatAssumesTheSeedsNarrowCaseIsRejected() {
+        // `bump`'s accumulator is declared as the narrow case `Ok`, but the fold grows it to `R`.
+        // At the widened type the block is not a fixpoint (R is not assignable to Ok), so it is rejected
+        // rather than accepted into an unsound fold that could read `acc.n` on a `Bad`.
+        assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                import List ( fold )
+                data Ok = { n: Int }
+                data Bad = { why: Int }
+                data R = Ok | Bad
+                data In = { xs: List<Int> }
+                behavior go : (i: In) -> Ok | Bad constructs Ok, Bad
+                let go (i) = fold((acc, x) -> bump(acc, x), Ok { n = 0 }, i.xs)
+                let bump (acc: Ok, x: Int) : R =
+                    if x > 0 then Ok { n = acc.n + x } else Bad { why = x }
+                """));
+    }
+
+    @Test
+    void aFoldGrowingAListToAWiderElementIsNotWidenedAsASum() {
+        // The seed is `List<A>` and the block returns `List<A | B>`. That target is a list, not a sum,
+        // so the sum-widening branch does not apply and the accumulator-type mismatch still holds.
+        assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                import List ( fold )
+                data A = { x: Int }
+                data B = { y: Int }
+                data AB = A | B
+                let go (xs: List<Int>) : List<A> = fold((acc, x) -> acc ++ [pick(x)], [A { x = 0 }], xs)
+                let pick (x: Int) : AB = if x > 0 then A { x = x } else B { y = x }
+                """));
+    }
+
+    @Test
     void perLineFailingLoadAggregatesWithFoldAndMatch() throws Exception {
         BytesClassLoader loader = new BytesClassLoader(Compiler.compile(PRICING), getClass().getClassLoader());
         Object behavior = loader.loadClass("demo.PriceLines" + "$Impl").getConstructor().newInstance();

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSumParamMatchTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSumParamMatchTest.java
@@ -1,5 +1,7 @@
 package net.unit8.souther.compiler;
 
+import net.unit8.souther.compiler.diag.CompileException;
+
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -7,6 +9,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A helper whose value parameter is declared as a sum keeps that declared type when the helper is
@@ -46,7 +49,7 @@ class CompileSumParamMatchTest {
     @Test
     void aMismatchedCaseArgumentIsStillRejected() {
         // C is not a member of S; passing it to `use` must still fail.
-        org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> Compiler.compile("""
+        assertThrows(CompileException.class, () -> Compiler.compile("""
                 module demo
                 data A = { x: Int }
                 data B = { y: Int }


### PR DESCRIPTION
## What #18 turned out to be

The dogfooding note asked for `traverse`. Probing the type checker showed the real shape is different, and simpler:

- `List<Priced> | NotFound` is **not a valid type** — a union's members must be named data (`union members must be data types`). The success case must wrap the list in a data (`PricedCart { lines: List<Priced> }`), so the output is `PricedCart | NotFound`.
- With that shape, the aggregation is an ordinary `fold` + `match` whose accumulator is a `Success | Failure` sum. No `traverse`, no `Result`/`Either` (ADR-0007 / ADR-0011 keep the domain sum unmarked), no new privileged function.

Two type-checker gaps blocked that pattern; both are fixed here.

### 1. A helper's sum parameter lost its type on inlining

```
let step (acc: PricedCart | NotFound, r: PriceResult) = match acc with ...
```

When `step` was inlined with a specific-case argument, the binding took the argument's case (`PricedCart`), so `match acc` was rejected as "not a sum". The binding now carries the parameter's **declared** type; when it is a sum, the bound name keeps it (a case widens to its sum, spec 8.3). `Ast.LetIn` gains an optional declared type, preserved through `mapChildren` and the inliner's rebuilds. Restricted to sums, so generic prelude helpers (`'a`), records, and lists are unaffected.

### 2. A fold seeded with a case, grown into its sum

```
fold((acc, line) -> step(acc, price(line)), PricedCart { lines = [] }, lines)
```

The seed is a `PricedCart`; the block returns `PricedCart | NotFound`. This was rejected because the block's return did not equal the seed type. The accumulator's real type is the sum: the block is re-typed at the wider type (a block that assumed the seed's narrower case is rejected) and, if it is a fixpoint there, that sum is the fold's type.

## Result

"Load a price per line; depart to `NotFound` on the first miss" is now writable in the domain:

```
behavior priceLines : (i: In) -> PricedCart | NotFound requires loadPrice
let priceLines (i) = fold((acc, line) -> step(acc, price(line)), PricedCart { lines = [] }, i.lines)
let step (acc: PricedCart | NotFound, r: PriceResult) : PricedCart | NotFound = match acc with
    | NotFound n -> n
    | PricedCart c -> match r with
        | Priced p -> PricedCart { lines = c.lines ++ [p] }
        | NotFound n -> n
```

## Tests

`CompileSumParamMatchTest` covers: a case argument to a named-sum param and to an anonymous-union param stays matchable; a mismatched case is still rejected; and an **executable** end-to-end `priceLines` (all lines priced → `PricedCart`; one miss → `NotFound`).

- Full clean build green: compiler 565, lsp 11.
- All 9 examples rebuilt against this compiler stay green.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)