### PR TITLE
Typed factory for an injected behavior's field-bearing constructed types

### DIFF
--- a/examples/ordering/src/main/java/app/ordering/JooqRecordOrder.java
+++ b/examples/ordering/src/main/java/app/ordering/JooqRecordOrder.java
@@ -12,10 +12,6 @@ import example.ordering.OrderId;
 import example.ordering.RecordOrder;
 import example.ordering.RecordedOrder;
 
-import net.unit8.raoh.Err;
-import net.unit8.raoh.Ok;
-import net.unit8.raoh.Path;
-
 import org.jooq.DSLContext;
 
 import java.util.List;
@@ -70,15 +66,11 @@ public final class JooqRecordOrder extends RecordOrder {
                     .execute();
         }
 
-        // RecordedOrder holds fields, so build it through the decoder from a neutral Map (spec 8.5):
-        // the lines are the same neutral maps read above; OrderId's invariant is re-checked here.
-        Map<String, Object> raw = Map.of("orderId", orderId, "items", items, "total", total);
-        return switch (RecordedOrder.decoder().decode(raw, Path.ROOT)) {
-            case Ok<RecordedOrder> ok -> ok.value();
-            case Err<RecordedOrder> e ->
-                    // A freshly minted id and just-read lines, so this cannot fail; if it does it is a
-                    // bug, not a domain outcome (spec 13.4).
-                    throw new IllegalStateException("failed to build RecordedOrder: " + e.issues().asList());
-        };
+        // recordOrder constructs RecordedOrder, OrderId, so the base hands out a typed factory for
+        // each. Build the RecordedOrder directly from the values already in hand — the priced lines
+        // are p.items() as they are — with no encode/decode round-trip. Each factory runs the type's
+        // invariant through __construct (OrderId must be non-empty); a violation aborts, which here
+        // would be a bug, not a domain outcome (spec 13.4).
+        return RecordedOrder(OrderId(orderId), p.items(), total);
     }
 }

--- a/examples/ordering/src/main/souther/ordering.sou
+++ b/examples/ordering/src/main/souther/ordering.sou
@@ -40,7 +40,7 @@ data OutOfStock
 // --- injected DB behaviors (no `let`; implementation comes from Java) ---
 // An injected behavior always writes `constructs`: the declaration is the input to factory generation.
 behavior recordOrder : (order: PricedCart) -> RecordedOrder
-    constructs RecordedOrder
+    constructs RecordedOrder, OrderId
 
 behavior reserveStock : (recorded: RecordedOrder) -> ConfirmedOrder | OutOfStock
     constructs ConfirmedOrder, OutOfStock

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Backend.java
@@ -210,11 +210,14 @@ public final class Backend {
                         unitCases.add(t.name());
                     }
                 }
-                List<String> dataConstructs = new ArrayList<>();
+                List<Ast.Data> dataConstructs = new ArrayList<>();
+                Set<String> seenConstruct = new HashSet<>();
                 if (spec.constructs() != null) {
                     for (String tn : spec.constructs()) {
-                        if (b.symbols.get(tn) instanceof Ast.Data) {   // field-bearing data or newtype
-                            dataConstructs.add(tn);
+                        // a field-bearing data or newtype; de-duplicated so a repeated `constructs`
+                        // entry does not emit the factory method twice (a duplicate-method class file)
+                        if (b.symbols.get(tn) instanceof Ast.Data data && seenConstruct.add(tn)) {
+                            dataConstructs.add(data);
                         }
                     }
                 }
@@ -364,13 +367,16 @@ public final class Backend {
     /**
      * Generates the abstract base class for a required behavior (spec 13.3): an abstract
      * {@code Behavior} that a Java implementation extends. The base exposes a {@code protected}
-     * factory for what the implementation may build (spec 2.1): a no-arg factory for each unit output
-     * case (a unit has nothing to validate, so it is built directly), and a typed factory for each
-     * field-bearing type the behavior declares in {@code constructs}, built through its
-     * {@code __construct} so the invariant is checked. The typed factory lets the implementation
-     * compose already-held values into its declared output without round-tripping through the decoder
-     * (spec 2.7: authority stays scoped to {@code constructs}). The data constructors stay non-public,
-     * so a subclass builds exactly these and nothing else, from any package.
+     * factory for what the implementation may build (spec 2.1). The two kinds are sourced differently.
+     * A unit output case gets a no-arg factory: a unit has no invariant to validate, so it is built
+     * directly, and it is taken from the output cases (an injected behavior may leave {@code constructs}
+     * implicit, and a unit is safe to hand out either way). A field-bearing type gets a typed factory
+     * built through its {@code __construct} so the invariant is checked, but only when the behavior
+     * declares it in {@code constructs}: that declaration is the authority to build it (spec 2.7), and
+     * unlike a unit it cannot be told apart from a decoded pass-through output by shape alone. The typed
+     * factory lets the implementation compose already-held values into its declared output without
+     * round-tripping through the decoder. The data constructors stay non-public, so a subclass builds
+     * exactly these and nothing else, from any package.
      *
      * <p>When both the input and output map to a concrete reference type, the base carries a
      * generic {@code Behavior<In, Out>} signature (spec 19.8, 24) — {@code Out} is the {@code <名>Result}
@@ -378,7 +384,7 @@ public final class Backend {
      * than {@code Object}. If either side is a list/option/map (no single reference class), the
      * signature is omitted and the raw interface stands.
      */
-    private byte[] generateRequiredBase(String name, List<String> unitCases, List<String> dataConstructs,
+    private byte[] generateRequiredBase(String name, List<String> unitCases, List<Ast.Data> dataConstructs,
                                         ClassDesc inputRef, ClassDesc outputRef) {
         ClassDesc cdR = cdBehavior(name);
         return build(cdR, cb -> {
@@ -400,10 +406,8 @@ public final class Backend {
             for (String caseName : unitCases) {
                 emitUnitFactory(cb, caseName);
             }
-            for (String typeName : dataConstructs) {
-                if (symbols.get(typeName) instanceof Ast.Data data) {
-                    emitDataFactory(cb, data);   // a field-bearing data or a newtype
-                }
+            for (Ast.Data data : dataConstructs) {   // a field-bearing data or a newtype
+                emitDataFactory(cb, data);
             }
         });
     }

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Backend.java
@@ -12,6 +12,7 @@ import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassSignature;
 import java.lang.classfile.CodeBuilder;
 import java.lang.classfile.Label;
+import java.lang.classfile.MethodSignature;
 import java.lang.classfile.attribute.PermittedSubclassesAttribute;
 import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.constant.ClassDesc;
@@ -431,18 +432,42 @@ public final class Backend {
         ClassDesc cdType = cd(data.name());
         Map<String, Type> fields = ctx.fieldTypes(data);
         ClassDesc[] fieldDs = fieldDescs(fields, ctx);
-        cb.withMethodBody(data.name(), MethodTypeDesc.of(cdType, fieldDs),
-                ClassFile.ACC_PROTECTED | ClassFile.ACC_FINAL, code -> {
-                    int slot = 1;   // slot 0 is `this`
-                    for (Type t : fields.values()) {
-                        load(code, slot, t);
-                        slot += width(t);
-                    }
-                    code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDs));
-                    code.invokestatic(CD_ConstraintViolation, "orThrow", MTD_orThrow);
-                    code.checkcast(cdType);
-                    code.areturn();
+        String sig = factorySignature(fields, cdType);
+        cb.withMethod(data.name(), MethodTypeDesc.of(cdType, fieldDs),
+                ClassFile.ACC_PROTECTED | ClassFile.ACC_FINAL, mb -> {
+                    if (sig != null) mb.with(SignatureAttribute.of(MethodSignature.parseFrom(sig)));
+                    mb.withCode(code -> {
+                        int slot = 1;   // slot 0 is `this`
+                        for (Type t : fields.values()) {
+                            load(code, slot, t);
+                            slot += width(t);
+                        }
+                        code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDs));
+                        code.invokestatic(CD_ConstraintViolation, "orThrow", MTD_orThrow);
+                        code.checkcast(cdType);
+                        code.areturn();
+                    });
                 });
+    }
+
+    /** A generic method {@code Signature} for a factory whose fields include a container
+     * (List/Set/Map/Option), else {@code null}. Mirrors the value-class accessor signature (spec 8.5)
+     * so a Java caller passes {@code List<Line>} rather than a raw {@code List}. A non-container field
+     * keeps its plain descriptor; the signature erases to the method's descriptor either way. */
+    private String factorySignature(Map<String, Type> fields, ClassDesc ret) {
+        boolean anyContainer = false;
+        StringBuilder sb = new StringBuilder("(");
+        for (Type t : fields.values()) {
+            String g = JvmTypes.genericSig(t, ctx);
+            if (g != null) {
+                anyContainer = true;
+                sb.append(g);
+            } else {
+                sb.append(jvmType(t, ctx).descriptorString());
+            }
+        }
+        sb.append(")").append(ret.descriptorString());
+        return anyContainer ? sb.toString() : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Backend.java
@@ -199,10 +199,23 @@ public final class Backend {
                 requiredSuccess.put(spec.name(), b.successType(spec.ret()));
                 requiredParam.put(spec.name(),
                         spec.params().size() == 1 ? b.successType(spec.params().get(0).type()) : null);
+                // Unit output cases get a no-arg factory (a unit has nothing to validate, so it is
+                // built directly). A field-bearing constructed type gets a typed factory, but only
+                // when the behavior declares it in `constructs` — that declaration is the authority
+                // to build it (spec 2.7), and unlike a unit it cannot be told apart from a decoded
+                // pass-through output (会員) by shape alone.
                 List<String> unitCases = new ArrayList<>();
                 for (Ast.TypeRef t : spec.ret().cases()) {
                     if (b.symbols.get(t.name()) instanceof Ast.UnitData) {
                         unitCases.add(t.name());
+                    }
+                }
+                List<String> dataConstructs = new ArrayList<>();
+                if (spec.constructs() != null) {
+                    for (String tn : spec.constructs()) {
+                        if (b.symbols.get(tn) instanceof Ast.Data) {   // field-bearing data or newtype
+                            dataConstructs.add(tn);
+                        }
                     }
                 }
                 ClassDesc inputRef = spec.params().size() == 1
@@ -210,7 +223,7 @@ public final class Backend {
                         : null;
                 ClassDesc outputRef = b.refTypeOrNull(b.successType(spec.ret()), spec.name());
                 out.put(module.name() + "." + behaviorClass(spec.name()),
-                        b.generateRequiredBase(spec.name(), unitCases, inputRef, outputRef));
+                        b.generateRequiredBase(spec.name(), unitCases, dataConstructs, inputRef, outputRef));
             }
         }
         Map<String, TypeChecker.Sig> sigs = TypeChecker.signatures(module, b.symbols, importedSigs);
@@ -351,10 +364,13 @@ public final class Backend {
     /**
      * Generates the abstract base class for a required behavior (spec 13.3): an abstract
      * {@code Behavior} that a Java implementation extends. The base exposes a {@code protected}
-     * factory for each declared unit-data output case — the only sanctioned way for the
-     * implementation to mint those cases (spec 2.1). The data constructors stay non-public, so
-     * a subclass can build exactly this behavior's declared cases and nothing else, from any
-     * package (no in-package placement required).
+     * factory for what the implementation may build (spec 2.1): a no-arg factory for each unit output
+     * case (a unit has nothing to validate, so it is built directly), and a typed factory for each
+     * field-bearing type the behavior declares in {@code constructs}, built through its
+     * {@code __construct} so the invariant is checked. The typed factory lets the implementation
+     * compose already-held values into its declared output without round-tripping through the decoder
+     * (spec 2.7: authority stays scoped to {@code constructs}). The data constructors stay non-public,
+     * so a subclass builds exactly these and nothing else, from any package.
      *
      * <p>When both the input and output map to a concrete reference type, the base carries a
      * generic {@code Behavior<In, Out>} signature (spec 19.8, 24) — {@code Out} is the {@code <名>Result}
@@ -362,7 +378,7 @@ public final class Backend {
      * than {@code Object}. If either side is a list/option/map (no single reference class), the
      * signature is omitted and the raw interface stands.
      */
-    private byte[] generateRequiredBase(String name, List<String> unitCases,
+    private byte[] generateRequiredBase(String name, List<String> unitCases, List<String> dataConstructs,
                                         ClassDesc inputRef, ClassDesc outputRef) {
         ClassDesc cdR = cdBehavior(name);
         return build(cdR, cb -> {
@@ -382,16 +398,47 @@ public final class Backend {
                 code.return_();
             });
             for (String caseName : unitCases) {
-                ClassDesc caseCd = cd(caseName);
-                cb.withMethodBody(caseName, MethodTypeDesc.of(caseCd),
-                        ClassFile.ACC_PROTECTED | ClassFile.ACC_FINAL, code -> {
-                            code.new_(caseCd);
-                            code.dup();
-                            code.invokespecial(caseCd, "<init>", MTD_void);
-                            code.areturn();
-                        });
+                emitUnitFactory(cb, caseName);
+            }
+            for (String typeName : dataConstructs) {
+                if (symbols.get(typeName) instanceof Ast.Data data) {
+                    emitDataFactory(cb, data);   // a field-bearing data or a newtype
+                }
             }
         });
+    }
+
+    /** A no-arg factory for a unit case: the ctor runs nothing, so it is built directly. */
+    private void emitUnitFactory(ClassBuilder cb, String typeName) {
+        ClassDesc caseCd = cd(typeName);
+        cb.withMethodBody(typeName, MethodTypeDesc.of(caseCd),
+                ClassFile.ACC_PROTECTED | ClassFile.ACC_FINAL, code -> {
+                    code.new_(caseCd);
+                    code.dup();
+                    code.invokespecial(caseCd, "<init>", MTD_void);
+                    code.areturn();
+                });
+    }
+
+    /** A factory taking the data's fields (in declaration order) and building it through
+     * {@code __construct}, so the invariant is checked and a violation aborts (spec 7.3) — the same
+     * path an in-domain construction takes, not a decode of an external representation. */
+    private void emitDataFactory(ClassBuilder cb, Ast.Data data) {
+        ClassDesc cdType = cd(data.name());
+        Map<String, Type> fields = ctx.fieldTypes(data);
+        ClassDesc[] fieldDs = fieldDescs(fields, ctx);
+        cb.withMethodBody(data.name(), MethodTypeDesc.of(cdType, fieldDs),
+                ClassFile.ACC_PROTECTED | ClassFile.ACC_FINAL, code -> {
+                    int slot = 1;   // slot 0 is `this`
+                    for (Type t : fields.values()) {
+                        load(code, slot, t);
+                        slot += width(t);
+                    }
+                    code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDs));
+                    code.invokestatic(CD_ConstraintViolation, "orThrow", MTD_orThrow);
+                    code.checkcast(cdType);
+                    code.areturn();
+                });
     }
 
     /**

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileInjectedFactoryTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileInjectedFactoryTest.java
@@ -2,10 +2,15 @@ package net.unit8.souther.compiler;
 
 import org.junit.jupiter.api.Test;
 
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.instruction.InvokeInstruction;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -67,6 +72,46 @@ class CompileInjectedFactoryTest {
         // and the field-bearing success case now also gets a factory
         Method done = mk.getDeclaredMethod("Done", long.class);
         assertEquals(mk.getClassLoader().loadClass("demo.Done"), done.getReturnType());
+    }
+
+    @Test
+    void theFieldBearingFactoryBuildsThroughConstructNotTheRawConstructor() throws Exception {
+        // The factory must route through __construct (which checks the invariant) and orThrow (which
+        // aborts on a violation), not the raw non-checking constructor. Verify the emitted bytecode.
+        Map<String, byte[]> classes = Compiler.compile("""
+                module demo
+                data OrderId = String
+                    invariant String.length(value) > 0
+                data In = { x: Int }
+                behavior mk : (i: In) -> OrderId constructs OrderId
+                """);
+        Set<String> invoked = invokedIn(classes.get("demo.Mk"), "OrderId");
+        assertTrue(invoked.contains("__construct"), "the factory runs the invariant through __construct");
+        assertTrue(invoked.contains("orThrow"), "a violation aborts via orThrow");
+    }
+
+    @Test
+    void aRepeatedConstructsEntryDoesNotEmitADuplicateFactory() {
+        // `constructs T, T` must not emit the factory twice, which would be a duplicate-method class file
+        assertDoesNotThrow(() -> base("""
+                module demo
+                data Made = { n: Int }
+                data In = { x: Int }
+                behavior mk : (i: In) -> Made constructs Made, Made
+                """, "demo.Mk"));
+    }
+
+    /** The names of the methods a given method's body invokes, read from the emitted bytecode. */
+    private Set<String> invokedIn(byte[] classBytes, String methodName) {
+        Set<String> names = new HashSet<>();
+        ClassFile.of().parse(classBytes).methods().stream()
+                .filter(m -> m.methodName().stringValue().equals(methodName))
+                .forEach(m -> m.code().ifPresent(code -> code.forEach(e -> {
+                    if (e instanceof InvokeInstruction inv) {
+                        names.add(inv.name().stringValue());
+                    }
+                })));
+        return names;
     }
 
     @Test

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileInjectedFactoryTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileInjectedFactoryTest.java
@@ -75,6 +75,21 @@ class CompileInjectedFactoryTest {
     }
 
     @Test
+    void aContainerFactoryParameterCarriesItsElementType() throws Exception {
+        // Like the value-class accessor (#17), the factory's List parameter carries List<Line>, so a
+        // Java caller does not pass a raw List.
+        Class<?> mk = base("""
+                module demo
+                data Line = { n: Int }
+                data Bag = { lines: List<Line> }
+                data In = { x: Int }
+                behavior mk : (i: In) -> Bag constructs Bag
+                """, "demo.Mk");
+        Method factory = mk.getDeclaredMethod("Bag", java.util.List.class);
+        assertEquals("java.util.List<demo.Line>", factory.getGenericParameterTypes()[0].getTypeName());
+    }
+
+    @Test
     void theFieldBearingFactoryBuildsThroughConstructNotTheRawConstructor() throws Exception {
         // The factory must route through __construct (which checks the invariant) and orThrow (which
         // aborts on a violation), not the raw non-checking constructor. Verify the emitted bytecode.

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileInjectedFactoryTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileInjectedFactoryTest.java
@@ -1,0 +1,92 @@
+package net.unit8.souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The abstract base an injected behavior's Java implementation extends hands out a {@code protected}
+ * factory for each type the behavior declares it {@code constructs} — for a field-bearing type as
+ * well as a unit case, so the implementation can build its declared output directly rather than
+ * round-tripping through the decoder.
+ */
+class CompileInjectedFactoryTest {
+
+    private Class<?> base(String moduleSrc, String baseClass) throws Exception {
+        Map<String, byte[]> classes = Compiler.compile(moduleSrc);
+        return new BytesClassLoader(classes, getClass().getClassLoader()).loadClass(baseClass);
+    }
+
+    @Test
+    void aFieldBearingConstructedTypeGetsATypedProtectedFactory() throws Exception {
+        Class<?> mk = base("""
+                module demo
+                data Made = { n: Int, tag: String }
+                data In = { x: Int }
+                behavior mk : (i: In) -> Made constructs Made
+                """, "demo.Mk");
+        Class<?> made = mk.getClassLoader().loadClass("demo.Made");
+        // Int -> long, String -> String, in field declaration order; returns the constructed type
+        Method factory = mk.getDeclaredMethod("Made", long.class, String.class);
+        assertEquals(made, factory.getReturnType());
+        assertTrue(Modifier.isProtected(factory.getModifiers()), "the factory is protected");
+    }
+
+    @Test
+    void aNewtypeConstructedTypeGetsASingleArgFactory() throws Exception {
+        Class<?> mk = base("""
+                module demo
+                data OrderId = String
+                    invariant String.length(value) > 0
+                data In = { x: Int }
+                behavior mk : (i: In) -> OrderId constructs OrderId
+                """, "demo.Mk");
+        Class<?> orderId = mk.getClassLoader().loadClass("demo.OrderId");
+        Method factory = mk.getDeclaredMethod("OrderId", String.class);
+        assertEquals(orderId, factory.getReturnType());
+        assertTrue(Modifier.isProtected(factory.getModifiers()));
+    }
+
+    @Test
+    void aUnitConstructedCaseKeepsItsNoArgFactory() throws Exception {
+        Class<?> mk = base("""
+                module demo
+                data Done = { result: Int }
+                data Failed
+                data In = { x: Int }
+                behavior mk : (i: In) -> Done | Failed constructs Done, Failed
+                """, "demo.Mk");
+        Class<?> failed = mk.getClassLoader().loadClass("demo.Failed");
+        Method unit = mk.getDeclaredMethod("Failed");
+        assertEquals(failed, unit.getReturnType());
+        // and the field-bearing success case now also gets a factory
+        Method done = mk.getDeclaredMethod("Done", long.class);
+        assertEquals(mk.getClassLoader().loadClass("demo.Done"), done.getReturnType());
+    }
+
+    @Test
+    void aPassThroughOutputTypeGetsNoFactory() throws Exception {
+        // `mk` reads Member through a decoder (it is not in `constructs`), so no factory is handed out
+        // for it — only `Missing`, which the behavior mints.
+        Class<?> mk = base("""
+                module demo
+                data Member = { id: Int }
+                data Missing
+                data In = { x: Int }
+                behavior mk : (i: In) -> Member | Missing constructs Missing
+                """, "demo.Mk");
+        mk.getDeclaredMethod("Missing");   // present
+        boolean memberFactory = true;
+        try {
+            mk.getDeclaredMethod("Member", long.class);
+        } catch (NoSuchMethodException e) {
+            memberFactory = false;
+        }
+        assertEquals(false, memberFactory, "no factory for a pass-through (non-constructed) type");
+    }
+}


### PR DESCRIPTION
## #20: no sanctioned construction path for field-bearing values from Java

An injected behavior's Java implementation could build only **unit** output cases directly (the base class handed out a no-arg factory per unit case). Any **field-bearing** constructed output had to be built through the decoder, so the implementation encoded values it already held back to a `Map` and decoded them again — the encode→Map→decode round-trip the dogfooding note reported.

This is not just glue code: even an injected behavior declaring `constructs RecordedOrder` had no way to build `RecordedOrder` except `RecordedOrder.decoder().decode(map)`.

## Change

The generated base class now also exposes a **protected typed factory** for each field-bearing type the behavior declares in `constructs`:

- Takes the type's fields (in declaration order) and builds it through `__construct`, so the invariant is checked and a violation aborts — the same path an in-domain construction takes, not a decode of an external representation.
- Restricted to the explicit `constructs` set (spec 2.7): a pass-through output the behavior does not construct (e.g. a `Member` read through the decoder) gets **no** factory. Construction authority stays scoped to `constructs`.
- Newtypes are covered (single-field factory, invariant checked).
- Unit factories keep their existing output-case source, unchanged (backward-compatible).

This does not widen Souther's construction model: an injected implementation of a behavior with `constructs T` is already a sanctioned construction path; this gives it the tool matching that authority. Invariants still run; parse-don't-validate (external→internal through the decoder) is untouched; it mirrors the existing unit-case factory pattern.

### Before / after (ordering example, `JooqRecordOrder`)

```java
// before: encode the already-held cart, hand-build a Map, decode
Map<String,Object> in = PricedCart.encoder().encode(p);
...
Map<String,Object> raw = Map.of("orderId", orderId, "items", items, "total", total);
return switch (RecordedOrder.decoder().decode(raw, Path.ROOT)) { ... };

// after: build directly from values in hand; each factory runs the invariant
return RecordedOrder(OrderId(orderId), p.items(), total);
```

`ordering.sou` now declares `recordOrder ... constructs RecordedOrder, OrderId`.

## Tests

- New `CompileInjectedFactoryTest`: a field-bearing constructed type and a newtype each get a typed protected factory returning the type; a unit case keeps its no-arg factory; a pass-through (non-constructed) output gets no factory.
- The ordering example exercises the factory end-to-end through a real jOOQ-backed transaction (`CheckoutTransactionTest`, 6 tests), including OrderId's invariant.
- Full clean build green: compiler 572, lsp 11; all 9 examples green.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)