### PR TITLE
Reject a name listed twice in a sum, output union, requires, or constructs

### DIFF
--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/check/TypeChecker.java
@@ -97,6 +97,13 @@ public final class TypeChecker {
                 specNames.add(b.name());
                 rejectAnonymousUnionParams(spec);
                 rejectTupleIO(spec);
+                List<String> outputCases = new ArrayList<>();
+                for (Ast.TypeRef t : spec.ret().cases()) {
+                    outputCases.add(t.name());
+                }
+                rejectDuplicateNames(outputCases, "the behavior output", spec.pos());
+                rejectDuplicateNames(spec.requires(), "`requires`", spec.pos());
+                rejectDuplicateNames(spec.constructs(), "`constructs`", spec.pos());
             }
         }
         // A data is Java-buildable from outside iff the whole module is public (no `exposing`) or
@@ -1535,7 +1542,23 @@ public final class TypeChecker {
         return symbols;
     }
 
+    /** Rejects a name listed more than once in a declaration ({@code where}). The duplicate is
+     * meaningless and, left to codegen, would emit a duplicate JVM member — a duplicate method,
+     * field, or implemented interface, i.e. a malformed class file. */
+    private static void rejectDuplicateNames(List<String> names, String where, SourcePos pos) {
+        Set<String> seen = new HashSet<>();
+        for (String n : names) {
+            if (!seen.add(n)) {
+                throw CompileException.of(
+                        Diagnostic.of(null, "check.dup.name").title("check.duplicate.title")
+                                .at(pos).args(n, where).build(),
+                        "`" + n + "` is listed more than once in " + where);
+            }
+        }
+    }
+
     private static void checkSum(Ast.SumData sum, Map<String, Ast.Def> symbols) {
+        rejectDuplicateNames(sum.cases(), "the sum `" + sum.name() + "`", sum.pos());
         for (String caseName : sum.cases()) {
             if (!symbols.containsKey(caseName)) {
                 throw CompileException.of(

--- a/souther-compiler/src/main/resources/net/unit8/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/net/unit8/souther/compiler/diag/messages.properties
@@ -130,6 +130,7 @@ check.duplicate.title=DUPLICATE DEFINITION
 check.dup.let=`let {0}` is already defined.
 check.dup.data=data `{0}` is already defined.
 check.dup.field=Field `{0}` is defined more than once.
+check.dup.name=`{0}` is listed more than once in {1}.
 
 # match
 check.match.title=MATCH ERROR

--- a/souther-compiler/src/main/resources/net/unit8/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/net/unit8/souther/compiler/diag/messages_ja.properties
@@ -129,6 +129,7 @@ check.duplicate.title=重複した定義
 check.dup.let=`let {0}` は既に定義されています。
 check.dup.data=data `{0}` は既に定義されています。
 check.dup.field=フィールド `{0}` が複数回定義されています。
+check.dup.name=`{0}` が {1} に複数回書かれています。
 
 # match
 check.match.title=match のエラー

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileDuplicateNameTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileDuplicateNameTest.java
@@ -1,0 +1,58 @@
+package net.unit8.souther.compiler;
+
+import net.unit8.souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A name listed twice in a declaration — a sum's cases, a behavior's output union, {@code requires},
+ * or {@code constructs} — is a meaningless duplicate that, left to codegen, produces a duplicate JVM
+ * member (a malformed class file). The checker rejects it at compile time instead.
+ */
+class CompileDuplicateNameTest {
+
+    @Test
+    void aRepeatedSumCaseIsRejected() {
+        assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                data S = A | A
+                """));
+    }
+
+    @Test
+    void aRepeatedOutputUnionCaseIsRejected() {
+        assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Ok = { n: Int }
+                data Bad
+                data In = { x: Int }
+                behavior mk : (i: In) -> Ok | Bad | Bad constructs Ok, Bad
+                """));
+    }
+
+    @Test
+    void aRepeatedRequiresIsRejected() {
+        assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Out = { n: Int }
+                data In = { x: Int }
+                behavior dep : (i: In) -> Out constructs Out
+                behavior use : (i: In) -> Out requires dep, dep
+                let use (i, dep, dep) = dep(i)
+                """));
+    }
+
+    @Test
+    void aRepeatedConstructsIsRejected() {
+        assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Out = { n: Int }
+                data In = { x: Int }
+                behavior mk : (i: In) -> Out constructs Out, Out
+                """));
+    }
+}


### PR DESCRIPTION
## Audit follow-up (duplicate-member class of bugs)

A comprehensive audit of the codegen — generalizing the duplicate-`constructs` bug found in #20 review — turned up three more places where a **repeated name in a declaration** was accepted by the checker and only failed at class load with a `ClassFormatError` (all reproduced):

| Source | Result before |
| --- | --- |
| `data S = A \| A` | duplicate implemented interface on the case class |
| injected `-> Ok \| Bad \| Bad` | duplicate unit factory method |
| `requires dep, dep` | duplicate injected field |
| `constructs T, T` | duplicate factory method |

Each is a meaningless duplicate. The right fix is at the checker, not per-emit-site de-duplication: one `rejectDuplicateNames` check on the four lists (sum cases, behavior output union, `requires`, `constructs`) turns each into a clear compile error.

```
3:1 `A` is listed more than once in the sum `S`
4:1 `O` is listed more than once in `constructs`
```

## Tests

- `CompileDuplicateNameTest`: each of the four duplicate forms is rejected at compile time.
- Full clean build green: compiler, lsp; all 9 examples green.

Related: the field-bearing factory of #20 (PR #23) also de-duplicates its input defensively; this checker rejection is the general fix and gives the user error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)