### PR TITLE
Remove obsolete repeated-constructs dedupe test superseded by rejection

### DIFF
--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileInjectedFactoryTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileInjectedFactoryTest.java
@@ -10,7 +10,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -103,17 +102,6 @@ class CompileInjectedFactoryTest {
         Set<String> invoked = invokedIn(classes.get("demo.Mk"), "OrderId");
         assertTrue(invoked.contains("__construct"), "the factory runs the invariant through __construct");
         assertTrue(invoked.contains("orThrow"), "a violation aborts via orThrow");
-    }
-
-    @Test
-    void aRepeatedConstructsEntryDoesNotEmitADuplicateFactory() {
-        // `constructs T, T` must not emit the factory twice, which would be a duplicate-method class file
-        assertDoesNotThrow(() -> base("""
-                module demo
-                data Made = { n: Int }
-                data In = { x: Int }
-                behavior mk : (i: In) -> Made constructs Made, Made
-                """, "demo.Mk"));
     }
 
     /** The names of the methods a given method's body invokes, read from the emitted bytecode. */


### PR DESCRIPTION
## Why

`develop` is red. Two PRs that merged in parallel conflict:

- **#23** added `CompileInjectedFactoryTest.aRepeatedConstructsEntryDoesNotEmitADuplicateFactory`, asserting `constructs Made, Made` is **tolerated** (deduped, factory emitted once) via `assertDoesNotThrow`.
- **#24** (`Reject a name listed twice in a sum, output union, requires, or constructs`) made a duplicate `constructs` entry a **compile error**.

So the dedupe path that test guarded is now unreachable — the input is rejected at type-check before codegen. The two assertions cannot both hold; the merge left the build failing on that test.

## What

Reject is the accepted direction (#24, newer and explicit), so the dedupe test is obsolete. Its scenario is already the rejection covered by `CompileDuplicateNameTest` (`constructs Out, Out`). This removes the stale test and its now-unused `assertDoesNotThrow` import.

`mvn -pl souther-compiler -am test` → 578 passing, 0 failures. Test-only; no production change.