### PR TITLE
Source maps: emit SourceFile + LineNumberTable so stack traces point to .sou (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Souther is deliberately small:
 
 It intentionally does not provide exceptions, `null`, mutable state, asynchronous execution, arbitrary JVM calls, type classes or higher-kinded types, a package manager, or a REPL. These omissions keep construction paths, value constraints, and outside-world dependencies tractable.
 
-Not yet implemented: a Java-source backend, incremental compilation, source maps, static invariant proofs, handwritten codec syntax, and JSON Schema / Wasm / JavaScript output. An LSP server ships (`souther-lsp`); its name resolution is per-module, and workspace-wide (cross-module) resolution is future work.
+Not yet implemented: a Java-source backend, incremental compilation, static invariant proofs, handwritten codec syntax, and JSON Schema / Wasm / JavaScript output. Generated classes carry `SourceFile` / `LineNumberTable` debug info, so a runtime stack trace (an invariant abort above all) points back to the `.sou` source line. An LSP server ships (`souther-lsp`); its name resolution is per-module, and workspace-wide (cross-module) resolution is future work.
 
 ## Details and examples
 

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/BodyGen.java
@@ -256,6 +256,7 @@ final class BodyGen {
          * construction path.
          */
         void emitTail(Core e, ClassDesc cdB, Set<String> requiredNames, Map<String, Type> requiredSuccess) {
+            emitLine(e);
             switch (e) {
                 case Core.LetIn li -> {
                     if (li.value() instanceof Core.Call call && requiredNames.contains(call.fn())) {
@@ -491,7 +492,18 @@ final class BodyGen {
          * parameter types, so those calls go through {@link Core#toAst()}: Core is untyped and type
          * inference lives in the checker, so the backend reuses it rather than re-deriving types.
          */
+        /** Binds the bytecode that follows to {@code e}'s source line, for the {@code LineNumberTable}
+         * (spec 19.1). Every {@code Core} node keeps its {@code SourcePos}, so a runtime stack trace
+         * — an invariant abort above all — points back to the {@code .sou} line. */
+        private void emitLine(Core e) {
+            int line = e.pos() != null ? e.pos().line() : 0;
+            if (line > 0) {
+                code.lineNumber(line);
+            }
+        }
+
         Type genExpr(Core e) {
+            emitLine(e);
             return switch (e) {
                 case Core.Int x -> {
                     code.loadConstant(x.value());

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/BodyGen.java
@@ -79,6 +79,9 @@ final class BodyGen {
         private Set<String> reqNames = Set.of();
         private Map<String, Type> reqSuccess = Map.of();
         private Map<String, Type> reqParam = Map.of();
+        /** The last line already bound in this method's {@code LineNumberTable}; skips consecutive
+         * same-line entries. Fresh per method, since one {@code BodyGen} emits one method's code. */
+        private int lastEmittedLine = -1;
 
         BodyGen(CodegenContext ctx, CodeBuilder code, Ast.Data data, ClassDesc cdName, int firstSlot) {
             this.ctx = ctx;
@@ -485,6 +488,19 @@ final class BodyGen {
             return Type.mentions(t, x -> x instanceof Type.Nothing);
         }
 
+        /** Binds the bytecode that follows to {@code e}'s source line, for the {@code LineNumberTable}
+         * (spec 19.1). Every {@code Core} node keeps its {@code SourcePos}, so a runtime stack trace
+         * — an invariant abort above all — points back to the {@code .sou} line. Consecutive nodes on
+         * the same line (a subexpression tree, or a tail node re-lined by {@code genExpr}) collapse to
+         * one entry. */
+        private void emitLine(Core e) {
+            int line = e.pos() != null ? e.pos().line() : 0;
+            if (line > 0 && line != lastEmittedLine) {
+                code.lineNumber(line);
+                lastEmittedLine = line;
+            }
+        }
+
         /**
          * Emits a Core expression — the single expression emitter (ADR-0021); every node kind is
          * handled here. A {@code let} whose value is a runtime-selected function still asks the
@@ -492,16 +508,6 @@ final class BodyGen {
          * parameter types, so those calls go through {@link Core#toAst()}: Core is untyped and type
          * inference lives in the checker, so the backend reuses it rather than re-deriving types.
          */
-        /** Binds the bytecode that follows to {@code e}'s source line, for the {@code LineNumberTable}
-         * (spec 19.1). Every {@code Core} node keeps its {@code SourcePos}, so a runtime stack trace
-         * — an invariant abort above all — points back to the {@code .sou} line. */
-        private void emitLine(Core e) {
-            int line = e.pos() != null ? e.pos().line() : 0;
-            if (line > 0) {
-                code.lineNumber(line);
-            }
-        }
-
         Type genExpr(Core e) {
             emitLine(e);
             return switch (e) {

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/BodyGen.java
@@ -308,6 +308,7 @@ final class BodyGen {
                     ClassDesc cdType = cd(nd.typeName());
                     Map<String, Type> flds = fieldTypes((Ast.Data) symbols.get(nd.typeName()));
                     emitFieldValues(flds, nd.inits(), nd.spreads());
+                    emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                     code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(flds)));
                     code.invokestatic(CD_ConstraintViolation, "orThrow", MTD_orThrow);
                     code.areturn();
@@ -683,6 +684,7 @@ final class BodyGen {
                 // invariant runs and orThrow either yields the value or aborts with a
                 // ConstraintViolation. orThrow returns Object, so narrow it back to the value type.
                 emitFieldValues(flds, nd.inits(), nd.spreads());
+                emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                 code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(flds)));
                 code.invokestatic(CD_ConstraintViolation, "orThrow", MTD_orThrow);
                 code.checkcast(cdType);

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Descriptors.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Descriptors.java
@@ -3,6 +3,7 @@ package net.unit8.souther.compiler.codegen;
 import java.lang.classfile.ClassBuilder;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassHierarchyResolver;
+import java.lang.classfile.attribute.SourceFileAttribute;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.DirectMethodHandleDesc;
@@ -43,8 +44,25 @@ final class Descriptors {
     static byte[] build(ClassDesc cd, Consumer<ClassBuilder> handler) {
         return CF.build(cd, cb -> {
             cb.withVersion(ClassFile.JAVA_21_VERSION, 0);
+            cb.with(SourceFileAttribute.of(sourceFileName(cd)));
             handler.accept(cb);
         });
+    }
+
+    /**
+     * The {@code .sou} source file a generated class came from, for its {@code SourceFile} attribute:
+     * the module's simple name plus {@code .sou}. A class's package is its module name (a class is
+     * {@code module + "." + name}), so the file name is derived from {@link ClassDesc#packageName()}
+     * without threading the original path down. A single-file module named after its file (ADR-0043)
+     * makes this exact; a multi-segment module resolves to its last segment.
+     */
+    private static String sourceFileName(ClassDesc cd) {
+        String pkg = cd.packageName();
+        if (pkg.isEmpty()) {
+            return "source.sou";
+        }
+        int dot = pkg.lastIndexOf('.');
+        return (dot >= 0 ? pkg.substring(dot + 1) : pkg) + ".sou";
     }
 
     static final ClassDesc CD_Object = ConstantDescs.CD_Object;

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Descriptors.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/codegen/Descriptors.java
@@ -61,8 +61,7 @@ final class Descriptors {
         if (pkg.isEmpty()) {
             return "source.sou";
         }
-        int dot = pkg.lastIndexOf('.');
-        return (dot >= 0 ? pkg.substring(dot + 1) : pkg) + ".sou";
+        return pkg.substring(pkg.lastIndexOf('.') + 1) + ".sou";
     }
 
     static final ClassDesc CD_Object = ConstantDescs.CD_Object;

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSourceMapTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSourceMapTest.java
@@ -1,0 +1,43 @@
+package net.unit8.souther.compiler;
+
+import net.unit8.souther.runtime.ConstraintViolation;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Generated classes carry JVM debug info (a {@code SourceFile} attribute and a
+ * {@code LineNumberTable}) derived from the {@code SourcePos} every {@code Core} node keeps, so a
+ * runtime stack trace — most importantly an invariant abort ({@code ConstraintViolation}) — points
+ * back to the {@code .sou} source line rather than "Unknown Source". The source file name is the
+ * module's simple name plus {@code .sou}.
+ */
+class CompileSourceMapTest {
+
+    @Test
+    void anInvariantAbortStackTraceNamesTheSouSourceAndLine() throws Exception {
+        // 金額(x - 100) sits on line 5 of the module; make(50) builds 金額(-50), which aborts there.
+        String src = """
+                module demo
+                data 金額 = Int
+                    invariant value >= 0
+                behavior make : (x: Int) -> 金額 constructs 金額
+                let make (x) = 金額(x - 100)
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object impl = loader.loadClass("demo.Make$Impl").getConstructor().newInstance();
+
+        ConstraintViolation v = assertThrows(ConstraintViolation.class, () -> Codecs.apply(impl, 50L));
+
+        StackTraceElement frame = Arrays.stream(v.getStackTrace())
+                .filter(f -> f.getClassName().startsWith("demo."))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no generated frame: " + Arrays.toString(v.getStackTrace())));
+        assertEquals("demo.sou", frame.getFileName(), "the stack frame names the .sou source file");
+        assertEquals(5, frame.getLineNumber(), "the stack frame points to the construction's line");
+    }
+}

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSourceMapTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/CompileSourceMapTest.java
@@ -40,4 +40,31 @@ class CompileSourceMapTest {
         assertEquals("demo.sou", frame.getFileName(), "the stack frame names the .sou source file");
         assertEquals(5, frame.getLineNumber(), "the stack frame points to the construction's line");
     }
+
+    @Test
+    void aMultiLineConstructionAbortPointsAtTheConstructionNotTheLastField() throws Exception {
+        // 金額( opens on line 6; its argument x - 100 sits on line 7. The abort must be pinned to the
+        // construction (line 6), not the last field-init line, which emitting fields would otherwise
+        // leave bound.
+        String src = """
+                module demo
+                data 金額 = Int
+                    invariant value >= 0
+                behavior make : (x: Int) -> 金額 constructs 金額
+                let make (x) =
+                    金額(
+                        x - 100
+                    )
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object impl = loader.loadClass("demo.Make$Impl").getConstructor().newInstance();
+
+        ConstraintViolation v = assertThrows(ConstraintViolation.class, () -> Codecs.apply(impl, 50L));
+
+        StackTraceElement frame = Arrays.stream(v.getStackTrace())
+                .filter(f -> f.getClassName().startsWith("demo."))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no generated frame: " + Arrays.toString(v.getStackTrace())));
+        assertEquals(6, frame.getLineNumber(), "the abort points at the construction, not the field-init line");
+    }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -2604,7 +2604,7 @@ var result = handle.apply(rawInput);
 The language core is implemented. The following are future extensions, or current limitations of tooling and boundary codecs — distinct from what is permanently absent (<<out-of-scope>>).
 
 * A full formal grammar (BNF). The key delimiters and precedence are stated ahead in <<delimiters>>.
-* A human-readable Java-source backend, incremental compilation, source maps. The Core layer (<<compiler-pipeline>>) is backend-neutral, so a Java-source backend can be written from it.
+* A human-readable Java-source backend, incremental compilation. The Core layer (<<compiler-pipeline>>) is backend-neutral, so a Java-source backend can be written from it. (Generated classes already carry `+SourceFile+` / `+LineNumberTable+` debug info, so a stack trace points back to the `+.sou+` line.)
 * Workspace-wide (cross-module) name resolution in the LSP. The `+souther-lsp+` server ships and resolves names within a single module; diagnostics and go-to-definition across imported modules are future work.
 * JSON Schema generation, Wasm output, JavaScript output, asynchronous outside-world dependencies.
 * Hand-written decoder / encoder syntax. A different key name, normalization, or business-specific discriminator is handled by a boundary-side custom codec (Java side).


### PR DESCRIPTION
Closes #33.

## Problem

Generated `.class` files carried no debug attributes (`Descriptors.build` set only the class-file version), so a runtime abort — a `ConstraintViolation` from an invariant violation above all — surfaced as "Unknown Source" with no line.

## Why it was cheap

Source positions already flow end to end: `SourcePos` (1-based line) is threaded through the AST→Core lowering and every `Core` node exposes `pos()`. At the abort site (`BodyGen`, just before `orThrow`) the line was already in scope. No position-IR retrofit was needed.

## Change

- **`Descriptors.build`** attaches a `SourceFile` attribute to every generated class, derived from the class package (a class is `module + "." + name`, so the package is the module name): the module's simple name plus `.sou`. No source path is threaded down.
- **`BodyGen`** emits a `LineNumberTable` entry via `code.lineNumber(pos.line())` at each `genExpr`/`emitTail` node, reading the `SourcePos` already on the `Core` node, so the abort site's bytecode is bound to the construction's source line.
- **README / spec** drop "source maps" from the not-yet-implemented list and note the debug info ships.

## Verification

- New test `CompileSourceMapTest`: an invariant abort's stack trace reports `demo.sou` and the construction's line (5).
- End-to-end via the CLI (`javap -v`): `Compiled from "demo.sou"`, `SourceFile: "demo.sou"`, `LineNumberTable: line 5: 8`.
- Full compiler suite (581) and all example projects green.

## Scope note

The `SourceFile` name is derived from the module's simple name (exact for a single-file module named after its file, ADR-0043; the last segment otherwise). Threading the real source path down for a faithful name in every case is a straightforward follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
