### PR TITLE
LSP: resolve names and diagnostics across modules (#29)

### DIFF
--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/Compiler.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -199,6 +200,228 @@ public final class Compiler {
             ExampleVerifier.verify(m, symbols, sigs, importedPackages(m), out);
         }
         return out;
+    }
+
+    /**
+     * Links a module set like {@link #compileModules}, but collects diagnostics per source — keyed by
+     * the caller's id (the LSP passes a document URI) — instead of throwing on the first error. This is
+     * the entry point the LSP uses to publish diagnostics per file across a workspace.
+     *
+     * <p>Modules are compiled in dependency order (imports first); a module's first compile error is
+     * recorded under its source id and its downstream importers are skipped, so an error surfaces once
+     * at its origin rather than cascading. Examples are then evaluated per source: a module's inline
+     * examples land on that module's id, and an {@code examples for X} file's examples land on that
+     * file's id — never on the target module. A source with no problem maps to an empty list.
+     */
+    public static Map<String, List<Diagnostic>> diagnoseModules(Map<String, String> sourcesById) {
+        return diagnoseModules(sourcesById, Set.of());
+    }
+
+    /**
+     * As {@link #diagnoseModules(Map)}, but {@code brokenModuleNames} lists modules the caller has
+     * already found unparseable (a file the LSP holds out of the compile because of its own syntax
+     * errors). Their importers are skipped rather than told the module is unknown — the error belongs
+     * to the broken file, which reports it separately, not to the importer.
+     */
+    public static Map<String, List<Diagnostic>> diagnoseModules(Map<String, String> sourcesById,
+                                                                Set<String> brokenModuleNames) {
+        Map<String, List<Diagnostic>> result = new LinkedHashMap<>();
+        for (String id : sourcesById.keySet()) {
+            result.put(id, new ArrayList<>());
+        }
+
+        // Parse each source, splitting real modules from `examples for` files. A parse-stage error
+        // (a type variable in a user module, say) is recorded against that source's id.
+        Map<String, Ast.Module> moduleById = new LinkedHashMap<>();
+        Map<String, Ast.Module> exampleFileById = new LinkedHashMap<>();
+        Set<String> failed = new HashSet<>(brokenModuleNames);   // module names whose source is broken
+        for (Map.Entry<String, String> e : sourcesById.entrySet()) {
+            try {
+                Ast.Module raw = CstFrontend.parse(e.getValue(), null);
+                if (raw.exampleFileTarget() != null) {
+                    exampleFileById.put(e.getKey(), raw);
+                } else {
+                    rejectReservedNamespace(raw);
+                    moduleById.put(e.getKey(), Exposing.rewrite(raw));
+                }
+            } catch (CompileException ex) {
+                result.get(e.getKey()).add(ex.diagnostic());
+                String name = moduleNameFromHeader(e.getValue());
+                if (name != null) {
+                    failed.add(name);   // a source that will not parse cannot satisfy an importer
+                }
+            }
+        }
+
+        // Index modules by name, tracking the source id each name came from; a duplicate name is an
+        // error on the offending source.
+        Map<String, Ast.Module> byName = new LinkedHashMap<>();
+        Map<String, String> idByName = new LinkedHashMap<>();
+        for (Map.Entry<String, Ast.Module> e : moduleById.entrySet()) {
+            Ast.Module m = e.getValue();
+            if (byName.containsKey(m.name())) {
+                result.get(e.getKey()).add(Diagnostic.of(null, "check.module.duplicate")
+                        .title("check.module.title").at(m.pos()).args(m.name()).build());
+                continue;
+            }
+            byName.put(m.name(), m);
+            idByName.put(m.name(), e.getKey());
+        }
+
+        List<Ast.Module> order = dependencyOrder(byName, idByName, result);
+
+        // Compile each module (no example evaluation yet). Retain the derived module and its resolution
+        // context so examples can be evaluated afterwards, once every module's bytecode is present.
+        Map<String, Ast.Module> derived = new LinkedHashMap<>();
+        Map<String, byte[]> out = new LinkedHashMap<>();
+        Map<String, VerifyContext> ready = new LinkedHashMap<>();
+        for (Ast.Module original : order) {
+            if (importsAnyFailed(original, failed)) {
+                failed.add(original.name());
+                continue;   // an importer of a broken module is skipped, not cascaded
+            }
+            try {
+                Ast.Module d = Deriver.derive(original, visibleDefs(original, byName));
+                d = HelperInliner.forModule(d).withInlinedInvariants(d);
+                derived.put(original.name(), d);   // visible to its own newtype constructors during desugar
+                Ast.Module m = NewtypeDesugar.rewrite(d, visibleDefs(d, derived));
+                derived.put(original.name(), m);
+                Map<String, Ast.Def> symbols = visibleDefs(m, derived);
+                Map<String, TypeChecker.Sig> importedSigs = importedBehaviorSigs(m, derived);
+                Set<String> importedInjected = importedInjectedBehaviors(m, derived);
+                Ast.Module lowered = Lower.run(m);
+                TypeChecker.check(m, symbols, importedSigs, lowered);
+                out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs, importedInjected));
+                verifyConstConstructions(m, symbols, out);
+                Map<String, TypeChecker.Sig> sigs =
+                        TypeChecker.signatures(m, symbols, importedBehaviorSigs(m, derived));
+                ready.put(original.name(), new VerifyContext(m, symbols, sigs, importedPackages(m)));
+            } catch (CompileException e) {
+                result.get(idByName.get(original.name())).add(e.diagnostic());
+                failed.add(original.name());
+            }
+        }
+
+        // Fakes from `examples for` files are shared with the target module (its own examples may use
+        // them), so gather them per target before evaluating any examples.
+        Map<String, List<Ast.Fake>> attachedFakes = new LinkedHashMap<>();
+        for (Ast.Module f : exampleFileById.values()) {
+            attachedFakes.computeIfAbsent(f.exampleFileTarget(), k -> new ArrayList<>()).addAll(f.fakes());
+        }
+
+        // A module's own inline examples, attributed to the module's source.
+        for (Map.Entry<String, VerifyContext> e : ready.entrySet()) {
+            VerifyContext ctx = e.getValue();
+            List<Ast.Fake> fakes = mergedFakes(ctx.module().fakes(), attachedFakes.get(e.getKey()));
+            result.get(idByName.get(e.getKey())).addAll(evaluate(ctx, ctx.module().examples(), fakes, out));
+        }
+
+        // Each `examples for` file's examples, attributed to that file — a target that is absent (not
+        // merely broken) is E1907.
+        for (Map.Entry<String, Ast.Module> e : exampleFileById.entrySet()) {
+            Ast.Module f = e.getValue();
+            VerifyContext ctx = ready.get(f.exampleFileTarget());
+            if (ctx == null) {
+                if (!byName.containsKey(f.exampleFileTarget())) {
+                    result.get(e.getKey()).add(Diagnostic.of("E1907", "check.example.notarget")
+                            .title("check.example.title").at(f.pos()).args(f.exampleFileTarget()).build());
+                }
+                continue;
+            }
+            List<Ast.Fake> fakes = mergedFakes(ctx.module().fakes(), attachedFakes.get(f.exampleFileTarget()));
+            result.get(e.getKey()).addAll(evaluate(ctx, f.examples(), fakes, out));
+        }
+
+        Map<String, List<Diagnostic>> frozen = new LinkedHashMap<>();
+        for (Map.Entry<String, List<Diagnostic>> e : result.entrySet()) {
+            frozen.put(e.getKey(), List.copyOf(e.getValue()));
+        }
+        return frozen;
+    }
+
+    /** The resolution context a module's examples evaluate against, retained from its compile pass. */
+    private record VerifyContext(Ast.Module module, Map<String, Ast.Def> symbols,
+                                 Map<String, TypeChecker.Sig> sigs, Map<String, String> importedPackages) {}
+
+    /** Evaluates {@code examples} against {@code ctx}'s module (its defs and bytecode), using
+     * {@code fakes} for any {@code requires} dependencies; returns one diagnostic per failing row. */
+    private static List<Diagnostic> evaluate(VerifyContext ctx, List<Ast.Example> examples,
+                                             List<Ast.Fake> fakes, Map<String, byte[]> classes) {
+        Ast.Module m = ctx.module();
+        Ast.Module toCheck = new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
+                m.defs(), m.behaviors(), m.fns(), examples, fakes, m.exampleFileTarget(), m.pos());
+        return ExampleVerifier.check(toCheck, ctx.symbols(), ctx.sigs(), ctx.importedPackages(), classes);
+    }
+
+    private static List<Ast.Fake> mergedFakes(List<Ast.Fake> own, List<Ast.Fake> attached) {
+        if (attached == null || attached.isEmpty()) {
+            return own;
+        }
+        List<Ast.Fake> all = new ArrayList<>(own);
+        all.addAll(attached);
+        return all;
+    }
+
+    private static boolean importsAnyFailed(Ast.Module m, Set<String> failed) {
+        for (Ast.Import imp : m.imports()) {
+            if (failed.contains(imp.module())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** The module name from a source's {@code module <name>} header, for identifying a source that will
+     * not parse (so its importers can be skipped, and the LSP can map a broken file to its module).
+     * {@code null} if no header token is found. */
+    public static String moduleNameFromHeader(String source) {
+        java.util.regex.Matcher mt = java.util.regex.Pattern
+                .compile("(?m)^\\s*module\\s+([\\p{L}\\p{N}_.]+)").matcher(source);
+        return mt.find() ? mt.group(1) : null;
+    }
+
+    /** Modules in dependency order (each module after the modules it imports). A cycle is E1501,
+     * recorded on the source of the module where the back edge is found; cyclic modules are left out
+     * of the order. */
+    private static List<Ast.Module> dependencyOrder(Map<String, Ast.Module> byName,
+                                                    Map<String, String> idByName,
+                                                    Map<String, List<Diagnostic>> result) {
+        List<Ast.Module> order = new ArrayList<>();
+        Set<String> done = new HashSet<>();
+        Set<String> onStack = new LinkedHashSet<>();
+        for (Ast.Module m : byName.values()) {
+            orderVisit(m.name(), byName, idByName, done, onStack, order, result);
+        }
+        return order;
+    }
+
+    private static void orderVisit(String name, Map<String, Ast.Module> byName, Map<String, String> idByName,
+                                   Set<String> done, Set<String> onStack, List<Ast.Module> order,
+                                   Map<String, List<Diagnostic>> result) {
+        if (done.contains(name)) {
+            return;
+        }
+        Ast.Module m = byName.get(name);
+        if (m == null) {
+            return;
+        }
+        onStack.add(name);
+        for (Ast.Import imp : m.imports()) {
+            if (onStack.contains(imp.module())) {
+                result.get(idByName.get(name)).add(
+                        new CompileException(imp.pos(), "E1501", "Cyclic module dependency detected.")
+                                .diagnostic());
+                onStack.remove(name);
+                done.add(name);
+                return;   // leave the cyclic module out of the order
+            }
+            if (byName.containsKey(imp.module())) {
+                orderVisit(imp.module(), byName, idByName, done, onStack, order, result);
+            }
+        }
+        onStack.remove(name);
+        done.add(name);
+        order.add(m);
     }
 
     /** Rebuilds each module with the examples and fakes from its attached {@code examples for} files

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/DiagnoseModulesTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/DiagnoseModulesTest.java
@@ -1,0 +1,99 @@
+package net.unit8.souther.compiler;
+
+import net.unit8.souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * {@link Compiler#diagnoseModules} links a module set the way {@link Compiler#compileModules} does,
+ * but collects diagnostics per source (keyed by the caller's id) instead of throwing on the first
+ * error — the entry point the LSP uses to publish diagnostics per file across a workspace.
+ */
+class DiagnoseModulesTest {
+
+    private static final String A = """
+            module a exposing ( N )
+            data N = { v: Int }
+            """;
+
+    // b imports a and carries a failing inline example (E1905): its declared output does not match
+    // what the identity `f` returns.
+    private static final String B_FAILING_EXAMPLE = """
+            module b
+            import a ( N )
+            data M = { n: Int }
+            behavior f : (x: M) -> M
+            let f (x) = x
+            example f
+              | (M { n = 1 }) -> M { n = 2 }
+            """;
+
+    @Test
+    void attributesAFailingExampleToTheModuleThatHasIt() {
+        Map<String, List<Diagnostic>> diags = Compiler.diagnoseModules(Map.of("a", A, "b", B_FAILING_EXAMPLE));
+        assertEquals(List.of(), diags.get("a"), "the clean imported module has no diagnostics");
+        assertEquals(1, diags.get("b").size(), diags.get("b").toString());
+        assertEquals("E1905", diags.get("b").get(0).code());
+    }
+
+    @Test
+    void aCleanModuleSetYieldsEmptyDiagnosticsForEveryModule() {
+        String bClean = """
+                module b
+                import a ( N )
+                data M = { n: Int }
+                behavior f : (x: M) -> M
+                let f (x) = x
+                """;
+        Map<String, List<Diagnostic>> diags = Compiler.diagnoseModules(Map.of("a", A, "b", bClean));
+        assertEquals(List.of(), diags.get("a"));
+        assertEquals(List.of(), diags.get("b"));
+    }
+
+    @Test
+    void skipsAModuleDownstreamOfAFailedImport() {
+        // a is broken (a field with an unknown type); b imports a. b must not produce a cascade
+        // diagnostic — the error belongs to a.
+        String aBroken = """
+                module a exposing ( N )
+                data N = { v: Nope }
+                """;
+        String b = """
+                module b
+                import a ( N )
+                behavior g : (n: N) -> N
+                let g (n) = n
+                """;
+        Map<String, List<Diagnostic>> diags = Compiler.diagnoseModules(Map.of("a", aBroken, "b", b));
+        assertFalse(diags.get("a").isEmpty(), "the broken module reports its own error");
+        assertEquals(List.of(), diags.get("b"), "the importing module is skipped, not cascaded");
+    }
+
+    @Test
+    void attributesAnExamplesForFilesFailureToThatFile() {
+        String a = """
+                module a exposing ( M, f )
+                data M = { n: Int }
+                behavior f : (x: M) -> M
+                let f (x) = x
+                """;
+        // a separate `examples for a` file carries a failing example
+        String aExamples = """
+                examples for a
+                example f
+                  | (M { n = 1 }) -> M { n = 2 }
+                """;
+        Map<String, List<Diagnostic>> diags =
+                Compiler.diagnoseModules(Map.of("a.sou", a, "a.examples.sou", aExamples));
+
+        assertEquals(List.of(), diags.get("a.sou"), "the module file itself is clean");
+        assertEquals(1, diags.get("a.examples.sou").size(), diags.get("a.examples.sou").toString());
+        assertEquals("E1905", diags.get("a.examples.sou").get(0).code());
+    }
+}

--- a/souther-lsp/src/main/java/net/unit8/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/net/unit8/souther/lsp/LspServer.java
@@ -2,8 +2,11 @@ package net.unit8.souther.lsp;
 
 import net.unit8.souther.lsp.analysis.Analyzer;
 import net.unit8.souther.lsp.analysis.DocumentStore;
+import net.unit8.souther.lsp.analysis.ModuleGraph;
+import net.unit8.souther.lsp.analysis.Workspace;
 import net.unit8.souther.lsp.protocol.DocumentSymbol;
 import net.unit8.souther.lsp.protocol.Hover;
+import net.unit8.souther.lsp.protocol.Location;
 import net.unit8.souther.lsp.protocol.LspDiagnostic;
 import net.unit8.souther.lsp.protocol.Position;
 import net.unit8.souther.lsp.protocol.Range;
@@ -31,6 +34,7 @@ public final class LspServer {
     private final MessageConnection conn;
     private final DocumentStore documents = new DocumentStore();
     private final Analyzer analyzer = new Analyzer();
+    private final Workspace workspace = new Workspace();
 
     public LspServer(MessageConnection conn) {
         this.conn = conn;
@@ -63,18 +67,20 @@ public final class LspServer {
     /** Returns true when the server should stop (on {@code exit}). */
     private boolean dispatch(String method, JsonNode id, JsonNode params) {
         switch (method) {
-            case "initialize" -> respond(id, initializeResult());
+            case "initialize" -> { captureRoots(params); respond(id, initializeResult()); }
             case "initialized", "$/setTrace", "workspace/didChangeConfiguration" -> { /* no-op */ }
             case "textDocument/didOpen" -> InboundDecoders.decode(InboundDecoders.DID_OPEN, params)
-                    .ifPresent(p -> { documents.open(p.uri(), p.text()); publishDiagnostics(p.uri()); });
+                    .ifPresent(p -> { documents.open(p.uri(), p.text()); publishAll(); });
             case "textDocument/didChange" -> InboundDecoders.decode(InboundDecoders.DID_CHANGE, params)
-                    .ifPresent(p -> { documents.change(p.uri(), p.text()); publishDiagnostics(p.uri()); });
+                    .ifPresent(p -> { documents.change(p.uri(), p.text()); publishAll(); });
             case "textDocument/didClose" -> InboundDecoders.decode(InboundDecoders.DOC_REF, params)
                     .ifPresent(p -> { documents.close(p.uri()); clearDiagnostics(p.uri()); });
+            case "workspace/didChangeWatchedFiles" -> publishAll();   // a file changed on disk; re-scan
             case "textDocument/documentSymbol" -> respond(id, documentSymbols(params));
             case "textDocument/semanticTokens/full" -> respond(id, semanticTokens(params));
             case "textDocument/hover" -> respond(id, hover(params));
             case "textDocument/definition" -> respond(id, definition(params));
+            case "textDocument/references" -> respond(id, references(params));
             case "shutdown" -> respond(id, null);
             case "exit" -> { return true; }
             default -> {
@@ -88,12 +94,36 @@ public final class LspServer {
 
     // --- capabilities ---
 
+    /** Records the workspace roots the client announces, from {@code workspaceFolders} (preferred) or
+     * the legacy {@code rootUri}, so the analyzer can resolve names across the whole module set. */
+    private void captureRoots(JsonNode params) {
+        if (params == null || params.isNull()) {
+            return;
+        }
+        List<String> roots = new ArrayList<>();
+        JsonNode folders = params.get("workspaceFolders");
+        if (folders != null && folders.isArray()) {
+            for (JsonNode folder : folders) {
+                JsonNode uri = folder.get("uri");
+                if (uri != null && !uri.isNull()) {
+                    roots.add(uri.asString());
+                }
+            }
+        }
+        JsonNode rootUri = params.get("rootUri");
+        if (roots.isEmpty() && rootUri != null && !rootUri.isNull()) {
+            roots.add(rootUri.asString());
+        }
+        workspace.setRoots(roots);
+    }
+
     private Map<String, Object> initializeResult() {
         Map<String, Object> capabilities = new LinkedHashMap<>();
         capabilities.put("textDocumentSync", 1);   // 1 = full document sync
         capabilities.put("documentSymbolProvider", true);
         capabilities.put("hoverProvider", true);
         capabilities.put("definitionProvider", true);
+        capabilities.put("referencesProvider", true);
         Map<String, Object> semanticTokens = new LinkedHashMap<>();
         semanticTokens.put("legend", Map.of("tokenTypes", Analyzer.TOKEN_TYPES,
                 "tokenModifiers", List.of()));
@@ -159,13 +189,40 @@ public final class LspServer {
     private Object definition(JsonNode params) {
         Params.PositionParams p = InboundDecoders.decode(InboundDecoders.POSITION_PARAMS, params)
                 .orElse(null);
-        String text = p == null ? null : documents.get(p.uri());
-        if (text == null) {
+        if (p == null || documents.get(p.uri()) == null) {
             return null;
         }
-        return analyzer.definition(text, p.position())
-                .<Object>map(range -> Map.of("uri", p.uri(), "range", rangeJson(range)))
+        ModuleGraph graph = workspace.snapshot(documents.openDocuments());
+        return analyzer.definition(p.uri(), p.position(), graph)
+                .<Object>map(loc -> Map.of("uri", loc.uri(), "range", rangeJson(loc.range())))
                 .orElse(null);
+    }
+
+    private Object references(JsonNode params) {
+        Params.PositionParams p = InboundDecoders.decode(InboundDecoders.POSITION_PARAMS, params)
+                .orElse(null);
+        if (p == null || documents.get(p.uri()) == null) {
+            return List.of();
+        }
+        boolean includeDeclaration = includeDeclaration(params);
+        ModuleGraph graph = workspace.snapshot(documents.openDocuments());
+        List<Object> out = new ArrayList<>();
+        for (Location loc : analyzer.references(p.uri(), p.position(), graph, includeDeclaration)) {
+            out.add(Map.of("uri", loc.uri(), "range", rangeJson(loc.range())));
+        }
+        return out;
+    }
+
+    /** The {@code context.includeDeclaration} flag of a references request; defaults to true. */
+    private static boolean includeDeclaration(JsonNode params) {
+        if (params == null) {
+            return true;
+        }
+        JsonNode context = params.get("context");
+        if (context == null || context.get("includeDeclaration") == null) {
+            return true;
+        }
+        return context.get("includeDeclaration").asBoolean();
     }
 
     // --- semantic tokens ---
@@ -186,13 +243,19 @@ public final class LspServer {
 
     // --- diagnostics ---
 
-    private void publishDiagnostics(String uri) {
-        String text = documents.get(uri);
-        if (text == null) {
-            return;
+    /** Recomputes diagnostics for the whole workspace and publishes each open document's set — an edit
+     * to one module can change what its importers report, so every open file is refreshed together. */
+    private void publishAll() {
+        ModuleGraph graph = workspace.snapshot(documents.openDocuments());
+        Map<String, List<LspDiagnostic>> byUri = analyzer.diagnostics(graph);
+        for (String uri : documents.uris()) {
+            publish(uri, byUri.getOrDefault(uri, List.of()));
         }
+    }
+
+    private void publish(String uri, List<LspDiagnostic> diagnostics) {
         List<Object> items = new ArrayList<>();
-        for (LspDiagnostic d : analyzer.diagnostics(text)) {
+        for (LspDiagnostic d : diagnostics) {
             Map<String, Object> item = new LinkedHashMap<>();
             item.put("range", rangeJson(d.range()));
             item.put("severity", d.severity());

--- a/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/Analyzer.java
@@ -7,6 +7,7 @@ import net.unit8.souther.compiler.cst.CstParser;
 import net.unit8.souther.compiler.cst.LineIndex;
 import net.unit8.souther.compiler.diag.CompileException;
 import net.unit8.souther.compiler.diag.Diagnostic;
+import net.unit8.souther.compiler.diag.DiagnosticRenderer;
 import net.unit8.souther.compiler.diag.Region;
 import net.unit8.souther.compiler.diag.SourcePos;
 import net.unit8.souther.compiler.cst.SyntaxElement;
@@ -16,13 +17,19 @@ import net.unit8.souther.compiler.cst.SyntaxToken;
 import net.unit8.souther.compiler.frontend.CstFrontend;
 import net.unit8.souther.lsp.protocol.DocumentSymbol;
 import net.unit8.souther.lsp.protocol.Hover;
+import net.unit8.souther.lsp.protocol.Location;
 import net.unit8.souther.lsp.protocol.LspDiagnostic;
 import net.unit8.souther.lsp.protocol.Position;
 import net.unit8.souther.lsp.protocol.Range;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * The language-analysis core, independent of the LSP transport: pure functions from source text to
@@ -66,8 +73,256 @@ public final class Analyzer {
         return out;
     }
 
+    /**
+     * Diagnostics for every file in a workspace, resolved across imports the way the batch compiler
+     * links a module set. Each file's syntax errors come from its own recovering parse; a file with a
+     * syntax error stays out of the shared compile (it cannot join the graph). The remaining files are
+     * compiled together, and each semantic diagnostic is published on the file of the module that owns
+     * it — so an error in an imported module lands on that module's document, not on its importer.
+     */
+    public Map<String, List<LspDiagnostic>> diagnostics(ModuleGraph graph) {
+        Map<String, List<LspDiagnostic>> out = new LinkedHashMap<>();
+        Map<String, String> compileSet = new LinkedHashMap<>();   // uri -> text, syntactically clean only
+        Set<String> brokenModules = new HashSet<>();   // names of files held out for their syntax errors
+
+        for (String uri : graph.uris()) {
+            String text = graph.text(uri);
+            LineIndex lines = new LineIndex(text);
+            List<LspDiagnostic> syntax = new ArrayList<>();
+            for (CstError e : CstParser.parse(text).errors()) {
+                syntax.add(new LspDiagnostic(range(lines, e.offset(), e.offset() + e.width()),
+                        LspDiagnostic.ERROR, null, e.legacyMessage()));
+            }
+            out.put(uri, syntax);
+            if (syntax.isEmpty()) {
+                compileSet.put(uri, text);   // a syntactically broken file cannot join the compile
+            } else {
+                String name = Compiler.moduleNameFromHeader(text);
+                if (name != null) {
+                    brokenModules.add(name);   // present but unparseable; importers skip, not cascade
+                }
+            }
+        }
+
+        Map<String, List<Diagnostic>> byUri;
+        try {
+            byUri = Compiler.diagnoseModules(compileSet, brokenModules);
+        } catch (RuntimeException e) {
+            return out;   // analysis must never crash the server
+        }
+        for (Map.Entry<String, List<Diagnostic>> e : byUri.entrySet()) {
+            List<LspDiagnostic> list = out.get(e.getKey());
+            if (list == null) {
+                continue;
+            }
+            LineIndex lines = new LineIndex(graph.text(e.getKey()));
+            for (Diagnostic d : e.getValue()) {
+                list.add(fromDiagnostic(lines, d));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Go-to-definition across the workspace: resolves the identifier under the cursor to the document
+     * and name range of the top-level definition it names. A name defined in the current file resolves
+     * locally; otherwise it is resolved through the file's imports to the module that exposes it, and
+     * the target's own document supplies the range.
+     */
+    public Optional<Location> definition(String uri, Position pos, ModuleGraph graph) {
+        String text = graph.text(uri);
+        if (text == null) {
+            return Optional.empty();
+        }
+        LineIndex lines = new LineIndex(text);
+        SyntaxNode root = CstParser.parse(text).root();
+        SyntaxToken ident = identAt(root, lines.offsetOf(pos.line(), pos.character()));
+        if (ident == null) {
+            return Optional.empty();
+        }
+        SyntaxNode local = declaringDef(root, ident.text());
+        if (local != null) {
+            SyntaxToken name = nameToken(local);
+            return name == null ? Optional.empty() : Optional.of(new Location(uri, tokenRange(lines, name)));
+        }
+        String targetModule = importedFrom(text, ident.text());
+        if (targetModule == null) {
+            return Optional.empty();
+        }
+        String targetUri = uriOfModule(graph, targetModule);
+        if (targetUri == null) {
+            return Optional.empty();
+        }
+        String targetText = graph.text(targetUri);
+        SyntaxNode def = declaringDef(CstParser.parse(targetText).root(), ident.text());
+        if (def == null) {
+            return Optional.empty();
+        }
+        SyntaxToken name = nameToken(def);
+        return name == null ? Optional.empty()
+                : Optional.of(new Location(targetUri, tokenRange(new LineIndex(targetText), name)));
+    }
+
+    /**
+     * Find-references across the workspace: every use of the top-level symbol the cursor names, in the
+     * defining module and in every module that imports it. Resolution respects namespaces — a type
+     * mention and a value of the same spelling are different symbols — and scope: a use inside a
+     * definition that binds the name locally (a param or a {@code let}) is that local, not the symbol,
+     * and is excluded. The declaration itself is included only when {@code includeDeclaration} is set.
+     */
+    public List<Location> references(String uri, Position pos, ModuleGraph graph, boolean includeDeclaration) {
+        String text = graph.text(uri);
+        if (text == null) {
+            return List.of();
+        }
+        SyntaxNode root = CstParser.parse(text).root();
+        SyntaxToken ident = identAt(root, new LineIndex(text).offsetOf(pos.line(), pos.character()));
+        if (ident == null) {
+            return List.of();
+        }
+        String name = ident.text();
+        String definingModule = declaringDef(root, name) != null
+                ? Compiler.moduleNameFromHeader(text) : importedFrom(text, name);
+        if (definingModule == null) {
+            return List.of();
+        }
+        String definingUri = uriOfModule(graph, definingModule);
+        if (definingUri == null) {
+            return List.of();
+        }
+        boolean isType = isTypeDef(declaringDef(CstParser.parse(graph.text(definingUri)).root(), name));
+
+        List<Location> out = new ArrayList<>();
+        for (String u : graph.uris()) {
+            String t = graph.text(u);
+            boolean owns = definingModule.equals(Compiler.moduleNameFromHeader(t));
+            if (!owns && !definingModule.equals(importedFrom(t, name))) {
+                continue;   // this file neither defines nor imports the symbol
+            }
+            collectReferences(CstParser.parse(t).root(), name, isType, u, new LineIndex(t),
+                    includeDeclaration && owns, out);
+        }
+        return out;
+    }
+
+    private boolean isTypeDef(SyntaxNode def) {
+        return def != null && def.kind() == SyntaxKind.DATA_DEF;
+    }
+
+    /** Node kinds where an identifier names a type. */
+    private static final java.util.Set<SyntaxKind> TYPE_POSITIONS = java.util.Set.of(
+            SyntaxKind.TYPE_REF, SyntaxKind.TYPE_ARGS, SyntaxKind.SUM_BODY, SyntaxKind.NEWTYPE_BODY,
+            SyntaxKind.CONSTRUCTS_CLAUSE, SyntaxKind.REQUIRES_CLAUSE, SyntaxKind.NEW_DATA_EXPR);
+
+    /** Node kinds where an identifier binds a value name (a param or a {@code let}). */
+    private static final java.util.Set<SyntaxKind> VALUE_BINDINGS = java.util.Set.of(
+            SyntaxKind.PARAM, SyntaxKind.FN_PARAM, SyntaxKind.LAMBDA_EXPR, SyntaxKind.LET_STMT);
+
+    /** Appends every occurrence of {@code name} in {@code root} that refers to the target symbol. A
+     * value use inside a top-level definition that binds {@code name} locally is shadowed and skipped. */
+    private void collectReferences(SyntaxNode root, String name, boolean isType, String uri,
+                                   LineIndex lines, boolean includeDeclaration, List<Location> out) {
+        for (SyntaxNode def : root.childNodes()) {
+            if (def.kind() == SyntaxKind.MODULE_HEADER || def.kind() == SyntaxKind.IMPORT_DECL) {
+                continue;   // names in the header's exposing list or an import list are not uses
+            }
+            boolean shadows = !isType && defBindsName(def, name);
+            collectInNode(def, name, isType, uri, lines, includeDeclaration, shadows, out);
+        }
+    }
+
+    private void collectInNode(SyntaxNode node, String name, boolean isType, String uri, LineIndex lines,
+                               boolean includeDeclaration, boolean shadowed, List<Location> out) {
+        SyntaxKind parent = node.kind();
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxNode child) {
+                collectInNode(child, name, isType, uri, lines, includeDeclaration, shadowed, out);
+            } else {
+                SyntaxToken t = (SyntaxToken) e;
+                if (t.kind() != SyntaxKind.IDENT || !t.text().equals(name)) {
+                    continue;
+                }
+                if (isDeclarationName(node, t)) {
+                    if (includeDeclaration) {
+                        out.add(new Location(uri, tokenRange(lines, t)));
+                    }
+                } else if (isType) {
+                    if (TYPE_POSITIONS.contains(parent)) {
+                        out.add(new Location(uri, tokenRange(lines, t)));
+                    }
+                } else if (!VALUE_BINDINGS.contains(parent) && !TYPE_POSITIONS.contains(parent) && !shadowed) {
+                    out.add(new Location(uri, tokenRange(lines, t)));
+                }
+            }
+        }
+    }
+
+    /** Whether {@code t} is the name token of the top-level definition {@code node}. */
+    private boolean isDeclarationName(SyntaxNode node, SyntaxToken t) {
+        return (node.kind() == SyntaxKind.DATA_DEF || node.kind() == SyntaxKind.BEHAVIOR_DEF
+                || node.kind() == SyntaxKind.FN_DEF) && t == nameToken(node);
+    }
+
+    /** Whether a top-level definition binds {@code name} as a param or a {@code let} anywhere inside it. */
+    private boolean defBindsName(SyntaxNode def, String name) {
+        for (SyntaxElement e : def.children()) {
+            if (e instanceof SyntaxNode child) {
+                if (VALUE_BINDINGS.contains(child.kind())) {
+                    SyntaxToken bound = firstIdent(child);
+                    if (bound != null && bound.text().equals(name)) {
+                        return true;
+                    }
+                }
+                if (defBindsName(child, name)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private SyntaxToken firstIdent(SyntaxNode node) {
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
+                return t;
+            }
+            if (e instanceof SyntaxNode child) {
+                SyntaxToken inner = firstIdent(child);
+                if (inner != null) {
+                    return inner;
+                }
+            }
+        }
+        return null;
+    }
+
+    /** The module a name is imported from in {@code text}, or {@code null} if no import exposes it. */
+    private String importedFrom(String text, String name) {
+        try {
+            for (Ast.Import imp : CstFrontend.parse(text, "Main").imports()) {
+                if (imp.names().contains(name)) {
+                    return imp.module();
+                }
+            }
+        } catch (RuntimeException e) {
+            // a file that does not parse cleanly resolves no imports; go-to-def simply misses
+        }
+        return null;
+    }
+
+    /** The document URI of the module declared with {@code moduleName}, or {@code null} if none. */
+    private String uriOfModule(ModuleGraph graph, String moduleName) {
+        for (String uri : graph.uris()) {
+            if (moduleName.equals(Compiler.moduleNameFromHeader(graph.text(uri)))) {
+                return uri;
+            }
+        }
+        return null;
+    }
+
     /** Go-to-definition within one document: resolves the identifier under the cursor to the name
-     * range of the top-level definition it names, if any. Cross-module resolution is future work. */
+     * range of the top-level definition it names, if any. The workspace-aware
+     * {@link #definition(String, Position, ModuleGraph)} resolves across imports as well. */
     public Optional<Range> definition(String text, Position pos) {
         LineIndex lines = new LineIndex(text);
         SyntaxNode root = CstParser.parse(text).root();
@@ -358,9 +613,24 @@ public final class Analyzer {
 
     private LspDiagnostic fromCompile(LineIndex lines, CompileException e) {
         Diagnostic d = e.diagnostic();
-        Range range = rangeOf(lines, d);
-        String code = d == null ? null : d.code();
-        return new LspDiagnostic(range, LspDiagnostic.ERROR, code, cleanMessage(e.getMessage()));
+        if (d != null) {
+            return fromDiagnostic(lines, d);
+        }
+        return new LspDiagnostic(rangeOf(lines, null), LspDiagnostic.ERROR, null,
+                cleanMessage(e.getMessage()));
+    }
+
+    /** An LSP diagnostic from a structured {@link Diagnostic}: its range from the region, its code
+     * from the stable identity, its message rendered from the catalog (or the compatibility literal).
+     * A found-vs-expected diff (a type mismatch, a failing example) is appended, since the catalog body
+     * alone omits the two values — the detail the editor needs to see what went wrong. */
+    private LspDiagnostic fromDiagnostic(LineIndex lines, Diagnostic d) {
+        String message = DiagnosticRenderer.body(d, Locale.ENGLISH);
+        if (d.diff() != null) {
+            message = message + " (expected " + d.diff().expectedType()
+                    + ", but was " + d.diff().actualType() + ")";
+        }
+        return new LspDiagnostic(rangeOf(lines, d), LspDiagnostic.ERROR, d.code(), message);
     }
 
     private Range rangeOf(LineIndex lines, Diagnostic d) {

--- a/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/DocumentStore.java
+++ b/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/DocumentStore.java
@@ -1,12 +1,13 @@
 package net.unit8.souther.lsp.analysis;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /** The open documents, keyed by URI. Full-sync only: each change replaces the whole text. */
 public final class DocumentStore {
 
-    private final Map<String, String> texts = new HashMap<>();
+    private final Map<String, String> texts = new LinkedHashMap<>();
 
     public void open(String uri, String text) {
         texts.put(uri, text);
@@ -23,5 +24,16 @@ public final class DocumentStore {
     /** The current text of {@code uri}, or {@code null} if it is not open. */
     public String get(String uri) {
         return texts.get(uri);
+    }
+
+    /** The URIs of every open document. */
+    public Set<String> uris() {
+        return texts.keySet();
+    }
+
+    /** A snapshot of every open document's text, keyed by URI — the overlay a {@link Workspace}
+     * applies over the on-disk sources. */
+    public Map<String, String> openDocuments() {
+        return new LinkedHashMap<>(texts);
     }
 }

--- a/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/ModuleGraph.java
+++ b/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/ModuleGraph.java
@@ -1,0 +1,35 @@
+package net.unit8.souther.lsp.analysis;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * An immutable snapshot of the Souther sources in a workspace, keyed by document URI. The
+ * {@link net.unit8.souther.lsp.LspServer} builds it by scanning the workspace root and overlaying the
+ * text of any open buffer; the {@link Analyzer} reads it to resolve names and diagnostics across the
+ * whole module set, the way the batch compiler does.
+ */
+public final class ModuleGraph {
+
+    private final Map<String, String> sources;
+
+    private ModuleGraph(Map<String, String> sources) {
+        this.sources = sources;
+    }
+
+    /** A graph over the given {@code uri -> source text} map. */
+    public static ModuleGraph of(Map<String, String> sources) {
+        return new ModuleGraph(new LinkedHashMap<>(sources));
+    }
+
+    /** Every document URI in the workspace. */
+    public Set<String> uris() {
+        return sources.keySet();
+    }
+
+    /** The source text of {@code uri}, or {@code null} if it is not in the graph. */
+    public String text(String uri) {
+        return sources.get(uri);
+    }
+}

--- a/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/Workspace.java
+++ b/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/Workspace.java
@@ -1,0 +1,74 @@
+package net.unit8.souther.lsp.analysis;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * The Souther sources of a workspace: the {@code .sou} files under the roots the client announced at
+ * initialize, with any open editor buffer overlaid on the on-disk text. A {@link #snapshot} is the
+ * immutable {@link ModuleGraph} the {@link Analyzer} resolves diagnostics and names against — the
+ * same module set the batch compiler would link.
+ */
+public final class Workspace {
+
+    private static final String SUFFIX = ".sou";
+
+    private final List<Path> roots = new ArrayList<>();
+
+    /** Records the workspace roots from their {@code file://} URIs; non-file URIs are ignored. */
+    public void setRoots(List<String> rootUris) {
+        roots.clear();
+        for (String uri : rootUris) {
+            if (uri == null) {
+                continue;
+            }
+            try {
+                URI parsed = URI.create(uri);
+                if ("file".equals(parsed.getScheme())) {
+                    roots.add(Path.of(parsed));
+                }
+            } catch (IllegalArgumentException e) {
+                // a malformed root URI is skipped rather than failing the session
+            }
+        }
+    }
+
+    /**
+     * The current module graph: every {@code .sou} file under the roots, read from disk, with the
+     * given {@code openBuffers} (keyed by document URI) overlaid — an open buffer's unsaved text wins,
+     * and an open document outside the roots is still included.
+     */
+    public ModuleGraph snapshot(Map<String, String> openBuffers) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        for (Path root : roots) {
+            if (!Files.isDirectory(root)) {
+                continue;
+            }
+            try (Stream<Path> walk = Files.walk(root)) {
+                walk.filter(Files::isRegularFile)
+                        .filter(p -> p.getFileName().toString().endsWith(SUFFIX))
+                        .forEach(p -> sources.put(p.toUri().toString(), readOrEmpty(p)));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+        sources.putAll(openBuffers);
+        return ModuleGraph.of(sources);
+    }
+
+    private static String readOrEmpty(Path p) {
+        try {
+            return Files.readString(p);
+        } catch (IOException e) {
+            return "";   // a file that cannot be read contributes nothing, but never crashes the scan
+        }
+    }
+}

--- a/souther-lsp/src/main/java/net/unit8/souther/lsp/protocol/Location.java
+++ b/souther-lsp/src/main/java/net/unit8/souther/lsp/protocol/Location.java
@@ -1,0 +1,6 @@
+package net.unit8.souther.lsp.protocol;
+
+/** An LSP location: a {@code range} within the document named by {@code uri}. Go-to-definition and
+ * references return these, so a target in another file carries its own URI. */
+public record Location(String uri, Range range) {
+}

--- a/souther-lsp/src/test/java/net/unit8/souther/lsp/LspServerTest.java
+++ b/souther-lsp/src/test/java/net/unit8/souther/lsp/LspServerTest.java
@@ -8,6 +8,8 @@ import tools.jackson.databind.json.JsonMapper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -51,6 +53,50 @@ class LspServerTest {
         JsonNode diagnostics = publish.get("params").get("diagnostics");
         assertTrue(diagnostics.size() > 0, "expected at least one diagnostic");
         assertEquals("souther", diagnostics.get(0).get("source").asString());
+    }
+
+    @Test
+    void diagnosticsResolveAcrossModulesFromTheWorkspaceRoot() throws Exception {
+        Path dir = Files.createTempDirectory("lsp");
+        Files.writeString(dir.resolve("a.sou"), "module a exposing ( N )\ndata N = { v: Int }\n");
+        String bText = "module b\nimport a ( N )\ndata M = { n: Int }\n"
+                + "behavior f : (x: M) -> M\nlet f (x) = x\n"
+                + "example f\n  | (M { n = 1 }) -> M { n = 2 }\n";   // failing example (E1905)
+        Path b = dir.resolve("b.sou");
+        Files.writeString(b, bText);
+        String bUri = b.toUri().toString();
+
+        byte[] input = frames(
+                message(1, "initialize", Map.of("rootUri", dir.toUri().toString())),
+                message(null, "initialized", Map.of()),
+                message(null, "textDocument/didOpen", Map.of(
+                        "textDocument", Map.of("uri", bUri, "text", bText))));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
+
+        // the importing module used to bail; now it resolves a against the root and reports E1905
+        JsonNode publish = readFrames(out.toByteArray()).stream()
+                .filter(m -> m.has("method")
+                        && m.get("method").asString().equals("textDocument/publishDiagnostics"))
+                .filter(m -> m.get("params").get("uri").asString().equals(bUri))
+                .reduce((first, second) -> second).orElse(null);   // the latest publish for b
+        assertNotNull(publish, "expected a publishDiagnostics for b");
+        JsonNode diagnostics = publish.get("params").get("diagnostics");
+        assertTrue(diagnostics.size() > 0, "the cross-module compile surfaces the failing example");
+        assertEquals("E1905", diagnostics.get(0).get("code").asString());
+    }
+
+    @Test
+    void capabilitiesAdvertiseReferences() {
+        byte[] input = frames(message(1, "initialize", Map.of()));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
+
+        JsonNode caps = readFrames(out.toByteArray()).stream()
+                .filter(m -> m.has("id") && m.get("id").asInt() == 1).findFirst().orElseThrow()
+                .get("result").get("capabilities");
+        assertTrue(caps.get("referencesProvider").asBoolean(), "references is advertised");
     }
 
     // --- helpers: build and read framed JSON-RPC messages ---

--- a/souther-lsp/src/test/java/net/unit8/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/net/unit8/souther/lsp/analysis/AnalyzerTest.java
@@ -2,6 +2,7 @@ package net.unit8.souther.lsp.analysis;
 
 import net.unit8.souther.lsp.protocol.DocumentSymbol;
 import net.unit8.souther.lsp.protocol.Hover;
+import net.unit8.souther.lsp.protocol.Location;
 import net.unit8.souther.lsp.protocol.LspDiagnostic;
 import net.unit8.souther.lsp.protocol.Position;
 import net.unit8.souther.lsp.protocol.Range;
@@ -130,6 +131,162 @@ class AnalyzerTest {
         Optional<Hover> hover = analyzer.hover(RESOLVE_SRC, new Position(1, 15));
         assertTrue(hover.isPresent());
         assertTrue(hover.get().contents().contains("id: String"), hover.get().contents());
+    }
+
+    @Test
+    void diagnosticsAcrossModulesLandOnTheOwningFile() {
+        String a = "module a exposing ( N )\ndata N = { v: Int }\n";
+        String b = "module b\nimport a ( N )\ndata M = { n: Int }\n"
+                + "behavior f : (x: M) -> M\nlet f (x) = x\n"
+                + "example f\n  | (M { n = 1 }) -> M { n = 2 }\n";   // identity f, so the example fails
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
+
+        java.util.Map<String, List<LspDiagnostic>> diags = analyzer.diagnostics(graph);
+
+        assertEquals(List.of(), diags.get("file:///a.sou"), "the clean imported module has no diagnostics");
+        assertEquals(1, diags.get("file:///b.sou").size(), diags.get("file:///b.sou").toString());
+        assertEquals("E1905", diags.get("file:///b.sou").get(0).code());
+    }
+
+    @Test
+    void diagnosticsDoNotBailWhenAModuleImportsAnother() {
+        // the single-file path returns nothing on an import; the workspace path resolves it and finds
+        // the importing module clean
+        String a = "module a exposing ( N )\ndata N = { v: Int }\n";
+        String b = "module b\nimport a ( N )\ndata M = { n: Int }\n"
+                + "behavior f : (x: M) -> M\nlet f (x) = x\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
+
+        java.util.Map<String, List<LspDiagnostic>> diags = analyzer.diagnostics(graph);
+
+        assertEquals(List.of(), diags.get("file:///b.sou"), "a valid importing module is clean");
+    }
+
+    @Test
+    void aFailingExampleMessageIncludesExpectedAndActual() {
+        String a = "module a\ndata M = { n: Int }\nbehavior f : (x: M) -> M\nlet f (x) = x\n"
+                + "example f\n  | (M { n = 1 }) -> M { n = 2 }\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a));
+
+        List<LspDiagnostic> diags = analyzer.diagnostics(graph).get("file:///a.sou");
+
+        assertEquals(1, diags.size(), diags.toString());
+        assertEquals("E1905", diags.get(0).code());
+        String msg = diags.get(0).message();
+        assertTrue(msg.contains("expected") && msg.contains("was"),
+                "the example message keeps the expected/actual detail: " + msg);
+    }
+
+    @Test
+    void aSyntaxErrorInAnImportedFileDoesNotCascadeToItsImporter() {
+        String a = "module a exposing ( N )\ndata N = { name String }\n";   // missing `:` — a syntax error
+        String b = "module b\nimport a ( N )\nbehavior f : (n: N) -> N\nlet f (n) = n\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
+
+        java.util.Map<String, List<LspDiagnostic>> diags = analyzer.diagnostics(graph);
+
+        assertTrue(!diags.get("file:///a.sou").isEmpty(), "the broken file shows its own syntax error");
+        assertEquals(List.of(), diags.get("file:///b.sou"),
+                "the importer is not told the (broken but present) module is unknown");
+    }
+
+    @Test
+    void examplesForFileFailuresLandOnThatFileNotTheModule() {
+        String a = "module a exposing ( M, f )\ndata M = { n: Int }\n"
+                + "behavior f : (x: M) -> M\nlet f (x) = x\n";
+        String aExamples = "examples for a\nexample f\n  | (M { n = 1 }) -> M { n = 2 }\n";   // fails
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of(
+                "file:///a.sou", a, "file:///a.examples.sou", aExamples));
+
+        java.util.Map<String, List<LspDiagnostic>> diags = analyzer.diagnostics(graph);
+
+        assertEquals(List.of(), diags.get("file:///a.sou"), "the module file itself is clean");
+        assertEquals(1, diags.get("file:///a.examples.sou").size(),
+                diags.get("file:///a.examples.sou").toString());
+        assertEquals("E1905", diags.get("file:///a.examples.sou").get(0).code());
+    }
+
+    @Test
+    void definitionResolvesAcrossAnImport() {
+        String a = "module a exposing ( N )\ndata N = { v: Int }\n";
+        String b = "module b\nimport a ( N )\nbehavior f : (n: N) -> N\nlet f (n) = n\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
+
+        // the `N` param-type reference in b's behavior signature is at line 2, character 17
+        Optional<Location> target = analyzer.definition("file:///b.sou", new Position(2, 17), graph);
+
+        assertTrue(target.isPresent(), "expected a cross-module definition");
+        assertEquals("file:///a.sou", target.get().uri(), "N is defined in module a");
+        assertEquals(1, target.get().range().start().line(), "the `data N` declaration is on line 1");
+        assertEquals(5, target.get().range().start().character(), "at the name `N`");
+    }
+
+    @Test
+    void definitionStillResolvesWithinTheSameFile() {
+        String a = "module a exposing ( N )\ndata N = { v: Int }\n";
+        String b = "module b\nimport a ( N )\ndata Thing = { id: String }\n"
+                + "behavior use : (t: Thing) -> Thing\nlet use (t) = t\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
+
+        // the `Thing` reference in b's own signature (line 3, char 19) resolves within b
+        Optional<Location> target = analyzer.definition("file:///b.sou", new Position(3, 19), graph);
+
+        assertTrue(target.isPresent());
+        assertEquals("file:///b.sou", target.get().uri());
+        assertEquals(2, target.get().range().start().line(), "the `data Thing` declaration is on line 2");
+    }
+
+    @Test
+    void referencesFindTypeUsagesAcrossModules() {
+        String a = "module a exposing ( N )\ndata N = { v: Int }\n";
+        String b = "module b\nimport a ( N )\nbehavior f : (n: N) -> N\nlet f (n) = n\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
+
+        // cursor on the `data N` declaration in a (line 1, char 5)
+        List<Location> refs = analyzer.references("file:///a.sou", new Position(1, 5), graph, true);
+
+        assertEquals(java.util.Set.of("file:///a.sou:1:5", "file:///b.sou:2:17", "file:///b.sou:2:23"),
+                keys(refs), refs.toString());
+    }
+
+    @Test
+    void referencesFindValueUsagesAcrossModules() {
+        String a = "module a exposing ( N, g )\n"
+                + "data N = { v: Int }\n"
+                + "behavior g : (n: N) -> N\n"
+                + "let g (n) = n\n";
+        String b = "module b\nimport a ( N, g )\nbehavior h = g >-> g\n";   // two uses of a.g
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
+
+        // cursor on the first `g` use in b's composition (line 2, char 13); declaration excluded
+        List<Location> refs = analyzer.references("file:///b.sou", new Position(2, 13), graph, false);
+
+        assertEquals(java.util.Set.of("file:///b.sou:2:13", "file:///b.sou:2:19"), keys(refs), refs.toString());
+    }
+
+    @Test
+    void referencesToAValueExcludeAShadowingParam() {
+        String a = "module a exposing ( N, g )\n"
+                + "data N = { v: Int }\n"
+                + "behavior g : (n: N) -> N\n"
+                + "let g (n) = n\n";
+        // c imports g but also binds a param named g; the body `g` is the param, not a.g
+        String c = "module c\nimport a ( N, g )\nbehavior k : (g: N) -> N\nlet k (g) = g\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///c.sou", c));
+
+        // cursor on a's `behavior g` declaration (line 2, char 9)
+        List<Location> refs = analyzer.references("file:///a.sou", new Position(2, 9), graph, true);
+
+        // only a's own two declarations (behavior g, let g); c contributes nothing — its `g` is shadowed
+        assertEquals(java.util.Set.of("file:///a.sou:2:9", "file:///a.sou:3:4"), keys(refs), refs.toString());
+    }
+
+    private static java.util.Set<String> keys(List<Location> refs) {
+        java.util.Set<String> out = new java.util.HashSet<>();
+        for (Location l : refs) {
+            out.add(l.uri() + ":" + l.range().start().line() + ":" + l.range().start().character());
+        }
+        return out;
     }
 
     @Test

--- a/souther-lsp/src/test/java/net/unit8/souther/lsp/analysis/WorkspaceTest.java
+++ b/souther-lsp/src/test/java/net/unit8/souther/lsp/analysis/WorkspaceTest.java
@@ -1,0 +1,56 @@
+package net.unit8.souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class WorkspaceTest {
+
+    @Test
+    void snapshotScansRootForSoutherSources() throws Exception {
+        Path dir = Files.createTempDirectory("ws");
+        Path a = dir.resolve("a.sou");
+        Files.writeString(a, "module a exposing ( N )\ndata N = { v: Int }\n");
+        Files.writeString(dir.resolve("readme.md"), "not souther");
+
+        Workspace ws = new Workspace();
+        ws.setRoots(List.of(dir.toUri().toString()));
+        ModuleGraph graph = ws.snapshot(Map.of());
+
+        assertEquals(1, graph.uris().size(), "only the .sou file is picked up");
+        assertTrue(graph.text(a.toUri().toString()).contains("data N"));
+    }
+
+    @Test
+    void snapshotFindsSourcesInNestedDirectories() throws Exception {
+        Path dir = Files.createTempDirectory("ws");
+        Path nested = Files.createDirectories(dir.resolve("src/main/souther"));
+        Path a = nested.resolve("a.sou");
+        Files.writeString(a, "module a\ndata N = { v: Int }\n");
+
+        Workspace ws = new Workspace();
+        ws.setRoots(List.of(dir.toUri().toString()));
+
+        assertEquals(1, ws.snapshot(Map.of()).uris().size());
+    }
+
+    @Test
+    void anOpenBufferOverlaysTheOnDiskText() throws Exception {
+        Path dir = Files.createTempDirectory("ws");
+        Path a = dir.resolve("a.sou");
+        Files.writeString(a, "module a\ndata N = { v: Int }\n");
+        String uri = a.toUri().toString();
+
+        Workspace ws = new Workspace();
+        ws.setRoots(List.of(dir.toUri().toString()));
+        ModuleGraph graph = ws.snapshot(Map.of(uri, "module a\ndata N = { v: String }\n"));
+
+        assertTrue(graph.text(uri).contains("String"), "the unsaved buffer wins over disk");
+    }
+}


### PR DESCRIPTION
Closes #29.

The LSP Analyzer was single-file: diagnostics bailed on any input with imports or an `examples for` target, and go-to-definition only scanned the one open document. On a real multi-module application the editor experience was incomplete. This resolves diagnostics, go-to-definition, and find-references across the workspace module graph, through the same name resolution the batch compiler uses.

## What changed

**Compiler** — a new `Compiler.diagnoseModules(sourcesById)` links a module set like `compileModules` but collects diagnostics per source (keyed by document URI) instead of throwing on the first error. It compiles in dependency order, records each module's first error under its own id, and skips downstream importers so an error surfaces once at its origin. Examples are evaluated per source via the non-throwing `ExampleVerifier.check`, so an `examples for X` file's failing example lands on that file — not on the target module.

**LSP**
- `Workspace` scans the announced roots for `.sou` sources and overlays open buffers; `ModuleGraph` is the immutable snapshot the `Analyzer` resolves against.
- Diagnostics no longer bail on imports / `examples for` files; the whole graph is compiled and each diagnostic is published on the owning module's document. Found-vs-expected diffs keep their expected/actual detail. Every open document is refreshed together on each edit.
- Go-to-definition resolves through the file's imports to the exposing module's document and range.
- Find-references walks the workspace, respecting namespaces (type vs. value) and excluding uses shadowed by a local binding.
- The server captures `workspaceFolders` / `rootUri`, advertises `referencesProvider`, and re-scans on `workspace/didChangeWatchedFiles`.

## Follow-ups (sequenced, no rework)

- #37 — type checker error recovery (multiple semantic errors per file). The diagnostics plumbing is already list-shaped.
- #38 — incremental (salsa-style) analysis. Analysis is a pure function of a graph snapshot, ready for a caching layer.

## Tests

`mvn test` green: compiler 586, LSP 26 (`DiagnoseModulesTest`, `AnalyzerTest`, `WorkspaceTest`, `LspServerTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
