### PR TITLE
LSP: cache the workspace disk scan; measure before an incremental engine (#38)

### DIFF
--- a/souther-lsp/src/main/java/net/unit8/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/net/unit8/souther/lsp/LspServer.java
@@ -35,6 +35,7 @@ public final class LspServer {
     private final DocumentStore documents = new DocumentStore();
     private final Analyzer analyzer = new Analyzer();
     private final Workspace workspace = new Workspace();
+    private int nextRequestId = 1;
 
     public LspServer(MessageConnection conn) {
         this.conn = conn;
@@ -68,14 +69,18 @@ public final class LspServer {
     private boolean dispatch(String method, JsonNode id, JsonNode params) {
         switch (method) {
             case "initialize" -> { captureRoots(params); respond(id, initializeResult()); }
-            case "initialized", "$/setTrace", "workspace/didChangeConfiguration" -> { /* no-op */ }
+            case "initialized" -> registerFileWatchers();
+            case "$/setTrace", "workspace/didChangeConfiguration" -> { /* no-op */ }
             case "textDocument/didOpen" -> InboundDecoders.decode(InboundDecoders.DID_OPEN, params)
                     .ifPresent(p -> { documents.open(p.uri(), p.text()); publishAll(); });
             case "textDocument/didChange" -> InboundDecoders.decode(InboundDecoders.DID_CHANGE, params)
                     .ifPresent(p -> { documents.change(p.uri(), p.text()); publishAll(); });
             case "textDocument/didClose" -> InboundDecoders.decode(InboundDecoders.DOC_REF, params)
                     .ifPresent(p -> { documents.close(p.uri()); clearDiagnostics(p.uri()); });
-            case "workspace/didChangeWatchedFiles" -> publishAll();   // a file changed on disk; re-scan
+            case "workspace/didChangeWatchedFiles" -> {
+                workspace.markChanged();   // a file changed on disk; drop the cached scan and re-read
+                publishAll();
+            }
             case "textDocument/documentSymbol" -> respond(id, documentSymbols(params));
             case "textDocument/semanticTokens/full" -> respond(id, semanticTokens(params));
             case "textDocument/hover" -> respond(id, hover(params));
@@ -302,6 +307,29 @@ public final class LspServer {
     private void notify(String method, Object params) {
         Map<String, Object> message = new LinkedHashMap<>();
         message.put("jsonrpc", "2.0");
+        message.put("method", method);
+        message.put("params", params);
+        conn.write(JSON.writeValueAsString(message));
+    }
+
+    /** Asks the client to watch the workspace's {@code .sou} files and report on-disk changes via
+     * {@code workspace/didChangeWatchedFiles}, so the cached disk scan is invalidated when a file is
+     * created, edited, or deleted outside the editor rather than relying on the client watching by
+     * default. The registration response is a no-op here (dropped by {@link #run}); a client without
+     * dynamic registration simply ignores the request. */
+    private void registerFileWatchers() {
+        Map<String, Object> registration = new LinkedHashMap<>();
+        registration.put("id", "souther-sou-watcher");
+        registration.put("method", "workspace/didChangeWatchedFiles");
+        registration.put("registerOptions",
+                Map.of("watchers", List.of(Map.of("globPattern", "**/*.sou"))));
+        sendRequest("client/registerCapability", Map.of("registrations", List.of(registration)));
+    }
+
+    private void sendRequest(String method, Object params) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("jsonrpc", "2.0");
+        message.put("id", "souther-" + nextRequestId++);
         message.put("method", method);
         message.put("params", params);
         conn.write(JSON.writeValueAsString(message));

--- a/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/Workspace.java
+++ b/souther-lsp/src/main/java/net/unit8/souther/lsp/analysis/Workspace.java
@@ -23,8 +23,13 @@ public final class Workspace {
 
     private final List<Path> roots = new ArrayList<>();
 
+    /** The last on-disk scan ({@code uri -> text}), or {@code null} when it must be re-read. Cached so
+     * an edit to an open buffer does not re-walk and re-read the whole workspace on every keystroke. */
+    private Map<String, String> diskScan;
+
     /** Records the workspace roots from their {@code file://} URIs; non-file URIs are ignored. */
     public void setRoots(List<String> rootUris) {
+        diskScan = null;   // the set of files to scan changed
         roots.clear();
         for (String uri : rootUris) {
             if (uri == null) {
@@ -47,6 +52,21 @@ public final class Workspace {
      * and an open document outside the roots is still included.
      */
     public ModuleGraph snapshot(Map<String, String> openBuffers) {
+        if (diskScan == null) {
+            diskScan = scanDisk();
+        }
+        Map<String, String> sources = new LinkedHashMap<>(diskScan);
+        sources.putAll(openBuffers);
+        return ModuleGraph.of(sources);
+    }
+
+    /** Invalidates the cached disk scan, so the next {@link #snapshot} re-reads the workspace. Called
+     * when the client reports on-disk changes ({@code workspace/didChangeWatchedFiles}). */
+    public void markChanged() {
+        diskScan = null;
+    }
+
+    private Map<String, String> scanDisk() {
         Map<String, String> sources = new LinkedHashMap<>();
         for (Path root : roots) {
             if (!Files.isDirectory(root)) {
@@ -60,8 +80,7 @@ public final class Workspace {
                 throw new UncheckedIOException(e);
             }
         }
-        sources.putAll(openBuffers);
-        return ModuleGraph.of(sources);
+        return sources;
     }
 
     private static String readOrEmpty(Path p) {

--- a/souther-lsp/src/test/java/net/unit8/souther/lsp/LspServerTest.java
+++ b/souther-lsp/src/test/java/net/unit8/souther/lsp/LspServerTest.java
@@ -99,6 +99,27 @@ class LspServerTest {
         assertTrue(caps.get("referencesProvider").asBoolean(), "references is advertised");
     }
 
+    @Test
+    void registersAFileWatcherForSouSourcesOnInitialized() {
+        byte[] input = frames(
+                message(1, "initialize", Map.of()),
+                message(null, "initialized", Map.of()));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
+
+        JsonNode registration = readFrames(out.toByteArray()).stream()
+                .filter(m -> m.has("method")
+                        && m.get("method").asString().equals("client/registerCapability"))
+                .findFirst().orElseThrow(() -> new AssertionError("expected a client/registerCapability"))
+                .get("params").get("registrations").get(0);
+
+        assertEquals("workspace/didChangeWatchedFiles", registration.get("method").asString());
+        String glob = registration.get("registerOptions").get("watchers").get(0)
+                .get("globPattern").asString();
+        assertTrue(glob.contains("*.sou"), "watches Souther sources: " + glob);
+    }
+
     // --- helpers: build and read framed JSON-RPC messages ---
 
     private static String message(Integer id, String method, Object params) {

--- a/souther-lsp/src/test/java/net/unit8/souther/lsp/analysis/DiagnosticsBenchmark.java
+++ b/souther-lsp/src/test/java/net/unit8/souther/lsp/analysis/DiagnosticsBenchmark.java
@@ -1,0 +1,83 @@
+package net.unit8.souther.lsp.analysis;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A manual latency benchmark for whole-workspace diagnostics — the measurement that decided against
+ * module-level incremental recompilation (issue #38). Disabled in the normal suite; run explicitly to
+ * re-measure: {@code mvn -pl souther-lsp test -Dtest=DiagnosticsBenchmark -DexcludedGroups=}.
+ *
+ * <p>Observed (JIT-warmed, whole-workspace parse + full compile of every module):
+ * <pre>
+ *   N=20    independent=14 ms   import-chain= 5 ms
+ *   N=50    independent=10 ms   import-chain= 8 ms
+ *   N=100   independent=11 ms   import-chain= 8 ms
+ *   N=200   independent=23 ms   import-chain=21 ms
+ * </pre>
+ * 200 modules recompile in ~23 ms — well under an editor's latency budget — so the full-recompute is
+ * not the bottleneck and an incremental engine would optimize a non-problem. The per-keystroke cost
+ * that mattered was the disk walk + read, removed by {@link Workspace}'s scan cache.
+ */
+@Disabled("manual benchmark; run explicitly to re-measure — see class javadoc")
+class DiagnosticsBenchmark {
+
+    private final Analyzer analyzer = new Analyzer();
+
+    @Test
+    void measureFullWorkspaceDiagnostics() {
+        for (int n : new int[]{20, 50, 100, 200}) {
+            ModuleGraph independent = graphOf(independentModules(n));
+            ModuleGraph chain = graphOf(chainModules(n));
+
+            // warm up the JIT so the reported numbers are steady-state
+            for (int i = 0; i < 3; i++) {
+                analyzer.diagnostics(independent);
+                analyzer.diagnostics(chain);
+            }
+
+            long indep = timeMillis(() -> analyzer.diagnostics(independent));
+            long ch = timeMillis(() -> analyzer.diagnostics(chain));
+            System.out.printf("N=%-4d  independent=%5d ms   import-chain=%5d ms%n", n, indep, ch);
+        }
+    }
+
+    /** {@code n} self-contained modules, each a data + an identity behavior — no imports. */
+    private static Map<String, String> independentModules(int n) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        for (int i = 0; i < n; i++) {
+            sources.put("file:///m" + i + ".sou",
+                    "module m" + i + "\n"
+                    + "data D" + i + " = { v: Int }\n"
+                    + "behavior f" + i + " : (d: D" + i + ") -> D" + i + "\n"
+                    + "let f" + i + " (d) = d\n");
+        }
+        return sources;
+    }
+
+    /** {@code n} modules in an import chain: m{i} imports the data type of m{i-1}. */
+    private static Map<String, String> chainModules(int n) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put("file:///c0.sou", "module c0 exposing ( D0 )\ndata D0 = { v: Int }\n");
+        for (int i = 1; i < n; i++) {
+            sources.put("file:///c" + i + ".sou",
+                    "module c" + i + " exposing ( D" + i + " )\n"
+                    + "import c" + (i - 1) + " ( D" + (i - 1) + " )\n"
+                    + "data D" + i + " = { v: Int }\n");
+        }
+        return sources;
+    }
+
+    private static ModuleGraph graphOf(Map<String, String> sources) {
+        return ModuleGraph.of(sources);
+    }
+
+    private long timeMillis(Runnable r) {
+        long start = System.nanoTime();
+        r.run();
+        return (System.nanoTime() - start) / 1_000_000;
+    }
+}

--- a/souther-lsp/src/test/java/net/unit8/souther/lsp/analysis/WorkspaceTest.java
+++ b/souther-lsp/src/test/java/net/unit8/souther/lsp/analysis/WorkspaceTest.java
@@ -41,6 +41,26 @@ class WorkspaceTest {
     }
 
     @Test
+    void snapshotReusesTheDiskScanUntilAWatchedChangeInvalidatesIt() throws Exception {
+        Path dir = Files.createTempDirectory("ws");
+        Path a = dir.resolve("a.sou");
+        Files.writeString(a, "module a\ndata N = { v: Int }\n");
+        String uri = a.toUri().toString();
+
+        Workspace ws = new Workspace();
+        ws.setRoots(List.of(dir.toUri().toString()));
+        ws.snapshot(Map.of());   // first snapshot reads disk
+
+        Files.writeString(a, "module a\ndata N = { v: String }\n");   // changed on disk, not announced
+        assertTrue(ws.snapshot(Map.of()).text(uri).contains("Int"),
+                "the cached disk scan is reused across snapshots — no re-read per keystroke");
+
+        ws.markChanged();   // workspace/didChangeWatchedFiles
+        assertTrue(ws.snapshot(Map.of()).text(uri).contains("String"),
+                "after a watched-file change the next snapshot re-reads disk");
+    }
+
+    @Test
     void anOpenBufferOverlaysTheOnDiskText() throws Exception {
         Path dir = Files.createTempDirectory("ws");
         Path a = dir.resolve("a.sou");


### PR DESCRIPTION
Closes #38. Follow-up to #29.

#29 recomputed the whole workspace on every change. rust-analyzer / TypeScript recompute incrementally; the issue proposed a salsa-style engine. This follows the issue's own "measure before optimizing" instruction: fix the per-keystroke cost that actually mattered, measure the rest, and skip the incremental engine because the numbers don't justify it.

## What changed

- **Disk-scan cache.** `Workspace.snapshot` re-walked the roots and re-read every `.sou` on every keystroke (each `didChange` republishes). It now caches the `uri -> text` scan and overlays open buffers on top. Open files stay fresh via the buffer overlay; the cache is invalidated on on-disk changes.
- **File-watch registration.** So the cache invalidates correctly without depending on the client watching by default, the server registers a `**/*.sou` watcher via `client/registerCapability` on `initialized`. A file created / edited / deleted outside the editor then fires `workspace/didChangeWatchedFiles`, which drops the cached scan. (A client without dynamic registration ignores the request; open files are still always fresh.)

## Measurement → no incremental engine

`DiagnosticsBenchmark` (disabled; run explicitly) times whole-workspace diagnostics — full parse + compile of every module:

```
N=20    independent=14 ms   import-chain= 5 ms
N=50    independent=10 ms   import-chain= 8 ms
N=100   independent=11 ms   import-chain= 8 ms
N=200   independent=23 ms   import-chain=21 ms
```

200 modules recompile in ~23 ms, well under an editor's latency budget. Module-level incremental recompilation (the issue's larger option) would optimize a non-bottleneck, so it is not built. The per-keystroke cost that mattered was the disk walk + read, removed by the scan cache. A per-file parse cache is likewise unwarranted — the whole compute is already ~10–23 ms. If a future workspace is large enough for the recompute to bite, re-run the benchmark and revisit.

## Tests

`mvn test` green: compiler 587, LSP 29. New tests cover the disk-scan cache reuse + invalidation (`WorkspaceTest`) and the file-watch registration on `initialized` (`LspServerTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
