### PR TITLE
Document closed newtype arithmetic and invariant discharge in the spec

### DIFF
--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/check/InvariantChecker.java
@@ -15,7 +15,7 @@ import java.util.Map;
 import java.util.function.Function;
 
 /**
- * The intraprocedural invariant-discharge check. It walks a behavior's body threading a
+ * The intraprocedural invariant-discharge check (spec §invariant-discharge). It walks a behavior's body threading a
  * {@link NumericDomain} — seeded from the input newtypes' invariants and refined along each
  * {@code require}/{@code if} guard (a {@code require} is already an {@code if} here) — and, at every
  * construction whose invariant is expressible in the domain, asks whether the guards

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/check/TypeChecker.java
@@ -2763,8 +2763,8 @@ public final class TypeChecker {
                 // scale/mode. Case handling for a zero divisor is the `divide`/`remainder` functions.
                 Type lt = typeOf(bin.left(), env, data, symbols, reqs);
                 Type rt = typeOf(bin.right(), env, data, symbols, reqs);
-                // Closed newtype arithmetic: `+`/`-` over a single-value numeric newtype yield that
-                // newtype. The result is re-wrapped and its invariant re-checked at construction,
+                // Closed newtype arithmetic (spec §newtype-arithmetic): `+`/`-` over a single-value
+                // numeric newtype yield that newtype. The result is re-wrapped and its invariant re-checked at construction,
                 // which a behavior's guard discharges. `*`/`/` stay base-only (a product or quotient
                 // changes dimension). The operands are the same newtype, or a newtype with a bare
                 // literal of its base (as for comparison).

--- a/specification.adoc
+++ b/specification.adoc
@@ -355,7 +355,7 @@ A single-value newtype is compared by the value it wraps, for both equality and 
 * Two *different* newtypes over the same base do not compare: `+金額 <= 数量+` is a compile error, even though both wrap `+Int+`.
 * A non-literal value of the wrapped type is not taken implicitly: `+金額 <= n+` (where `+n+` is an `+Int+`) is a compile error — write `+金額 <= 金額(n)+`.
 
-The wrapped type must itself be ordered for `+<+` / `+<=+` / `+>+` / `+>=+`; equality works over any wrapped type. Arithmetic on a newtype is not defined.
+The wrapped type must itself be ordered for `+<+` / `+<=+` / `+>+` / `+>=+`; equality works over any wrapped type. Arithmetic on a newtype is `+{plus}+` / `+-+` only (<<newtype-arithmetic>>).
 
 `+Decimal+` ignores scale. `+1.0+` and `+1.00+` are equal.
 
@@ -368,6 +368,17 @@ data 金額 = Decimal
 Scale is not lost from the value. An Encoder emits the scale it read, so a round trip (<<round-trip>>) is preserved. Scale is dropped *only from identity comparison*. If the number of rounding digits is a domain concern, write it as an invariant or a separate field, not as `+Decimal+` scale.
 
 The `+hashCode+` of a data containing `+Decimal+` is computed after dropping scale (`+stripTrailingZeros+`). If equality ignores scale, the hash MUST ignore it too, or using the value as a `+Map+` key breaks. Java sees the same value equality: a generated data class implements `+equals+` / `+hashCode+` from all fields and can be used as a `+Map+` key directly (<<jvm-product>>). This is distinct from Java's `+==+` (reference) and `+BigDecimal.equals+` (scale-sensitive).
+
+[#newtype-arithmetic]
+===== Arithmetic on a newtype
+
+A single-value newtype over `+Int+` or `+Decimal+` supports `+{plus}+` and `+-+`, and the result stays in the newtype: `+金額 {plus} 金額+` and `+金額 - 金額+` are `+金額+`. The operator opens each operand to its wrapped value, computes on the base, and re-wraps the result — so the result's invariant is re-checked at construction, exactly as any other construction is (<<invariant-mvp>>). A subtraction that leaves the invariant (a non-negative `+金額+` going below zero) *aborts* inside the domain (<<violation-destination>>). To make that a business result, guard it with `+require ... else+` (<<require>>); the compiler then confirms the guard discharges the construction (<<invariant-discharge>>).
+
+Operand pairing is the same as comparison (<<newtype-comparison>>): the *same* newtype, or a newtype with a bare literal of its base (`+金額 {plus} 100+`, the `+100+` taken as `+金額+`). Two *different* newtypes do not combine — `+金額 - 数量+` is a compile error even though both wrap `+Int+` — and a non-literal value of the wrapped type is not taken implicitly.
+
+`+*+` and `+/+` are *not* defined on a newtype. A product or quotient changes dimension (`+単価 * 数量+` is a `+金額+`, not a `+単価+`), which the language does not model; compute those on `+.value+` and wrap the result explicitly. Only a newtype whose value is *directly* `+Int+` or `+Decimal+` has arithmetic — a newtype over another newtype does not.
+
+Re-wrapping is a computation, not a fresh construction from raw data, so it needs no `+constructs+` (<<constructs>>) — as `+Int+` arithmetic does not "construct" an `+Int+`. A `+金額(...)+` literal construction (<<newtype>>) still does.
 
 [#collections]
 === Collection types
@@ -725,6 +736,49 @@ behavior 値引きする : (d: 見積) -> 値引き済み          // no violati
 *A behavior's output needs no slot for the violation.* Constructing an invariant-bearing data does not change the output type.
 
 If the business decides "return a different result when the amount is negative", that is not an invariant violation but a business judgment and MUST be written explicitly with `+require ... else+` (<<require>>). These are different: an invariant declares "a value passing here is always so", while `+require+` is a business branch of "if not so, return this". The former breaking is a bug; the latter not holding is an expected result.
+
+[#invariant-discharge]
+=== Discharging an invariant at compile time
+
+An invariant is checked at run time on every construction (<<invariant-mvp>>), and inside the domain a violation aborts (<<violation-destination>>). The compiler *also* checks, per behavior, whether each construction's invariant is *established* where the value is built — so a construction that must abort is caught at compile time, and one a guard makes safe is confirmed.
+
+The check is intraprocedural. Within a behavior's `+let+` body it seeds what the input types guarantee — a newtype's own invariant, a product data's invariant over its fields — which is sound because an input of type `+T+` was built through `+T+`'s checked construction. It refines that along each `+require+` / `+if+` guard (<<require>>, <<if>>), and at every construction asks whether the guards prove its invariant.
+
+* *Discharged* — the guards prove the invariant. No diagnostic; the construction cannot abort here (overflow aside).
+* *Definitely violated* — the guards prove the invariant false on a reachable path. A compile error — the path-sensitive generalization of the constant check `+金額(-5)+` (<<newtype>>).
+* *Possibly violated* — expressible but not proven. A warning: a possible abort. Guard it with `+require+`, or reify the relation into a type invariant (below).
+* *Not expressible* — an invariant outside the checked fragment. No diagnostic; the run-time check stands.
+
+[,text]
+----
+data 金額 = Decimal invariant value >= 0m
+data 引落指示 = { 残高: 金額, 額: 金額 }
+
+behavior 差引く : (指示: 引落指示) -> 金額 | 残高不足
+let 差引く (指示) = {
+    require 指示.額 <= 指示.残高
+        else 残高不足
+    指示.残高 - 指示.額          // discharged: the guard proves 残高 - 額 >= 0
+}
+----
+
+The checked fragment is bounded: the decision procedure reasons over intervals and differences (`+value >= c+`, `+a <= b+`, and the like) with no external solver. The set of *flagged* constructions is tied to that fragment, so every flagged construction has a guard the procedure can verify — an invariant it cannot express (a non-linear or otherwise relational one) is left to the run-time check rather than reported as a possible violation no guard could silence.
+
+[#invariant-reify]
+==== Reifying a cross-behavior relation
+
+The check does not cross behaviors: a relation established in one behavior is not assumed in another (<<sequential-composition>>). Inferring such a precondition would be an implicit cross-unit contract, which the language declines — `+requires+` and an exposed composition's output are always declared, not inferred (<<requires>>, ADR-0017, ADR-0024). The consistent way to carry a relation is to *reify it as a type invariant*, which the seeding then assumes downstream for free.
+
+[,text]
+----
+data 引落指示 = { 残高: 金額, 額: 金額 }
+    invariant 額 <= 残高                 // the relation lives in the type
+
+behavior 差引く : (指示: 引落指示) -> 金額
+let 差引く (指示) = 指示.残高 - 指示.額   // discharged with no guard here
+----
+
+So a possible-violation warning over the fields of one input data is a prompt to declare their relation as that data's invariant. When a value's validity is guaranteed *outside* the language — a Java-side or injected contract stronger than any type — there is no type to reify onto, and that construction keeps its run-time check.
 
 [#decoder]
 == Decoder

--- a/specification.adoc
+++ b/specification.adoc
@@ -372,13 +372,13 @@ The `+hashCode+` of a data containing `+Decimal+` is computed after dropping sca
 [#newtype-arithmetic]
 ===== Arithmetic on a newtype
 
-A single-value newtype over `+Int+` or `+Decimal+` supports `+{plus}+` and `+-+`, and the result stays in the newtype: `+金額 {plus} 金額+` and `+金額 - 金額+` are `+金額+`. The operator opens each operand to its wrapped value, computes on the base, and re-wraps the result — so the result's invariant is re-checked at construction, exactly as any other construction is (<<invariant-mvp>>). A subtraction that leaves the invariant (a non-negative `+金額+` going below zero) *aborts* inside the domain (<<violation-destination>>). To make that a business result, guard it with `+require ... else+` (<<require>>); the compiler then confirms the guard discharges the construction (<<invariant-discharge>>).
+A single-value newtype over `+Int+` or `+Decimal+` supports `+{plus}+` and `+-+`, and the result stays in the newtype: `+Money {plus} Money+` and `+Money - Money+` are `+Money+`. The operator opens each operand to its wrapped value, computes on the base, and re-wraps the result — so the result's invariant is re-checked at construction, exactly as any other construction is (<<invariant-mvp>>). A subtraction that leaves the invariant (a non-negative `+Money+` going below zero) *aborts* inside the domain (<<violation-destination>>). To make that a business result, guard it with `+require ... else+` (<<require>>); the compiler then confirms the guard discharges the construction (<<invariant-discharge>>).
 
-Operand pairing is the same as comparison (<<newtype-comparison>>): the *same* newtype, or a newtype with a bare literal of its base (`+金額 {plus} 100+`, the `+100+` taken as `+金額+`). Two *different* newtypes do not combine — `+金額 - 数量+` is a compile error even though both wrap `+Int+` — and a non-literal value of the wrapped type is not taken implicitly.
+Operand pairing is the same as comparison (<<newtype-comparison>>): the *same* newtype, or a newtype with a bare literal of its base (`+Money {plus} 100+`, the `+100+` taken as `+Money+`). Two *different* newtypes do not combine — `+Money - Quantity+` is a compile error even though both wrap `+Int+` — and a non-literal value of the wrapped type is not taken implicitly.
 
-`+*+` and `+/+` are *not* defined on a newtype. A product or quotient changes dimension (`+単価 * 数量+` is a `+金額+`, not a `+単価+`), which the language does not model; compute those on `+.value+` and wrap the result explicitly. Only a newtype whose value is *directly* `+Int+` or `+Decimal+` has arithmetic — a newtype over another newtype does not.
+`+*+` and `+/+` are *not* defined on a newtype. A product or quotient changes dimension (`+UnitPrice * Quantity+` is a `+Money+`, not a `+UnitPrice+`), which the language does not model; compute those on `+.value+` and wrap the result explicitly. Only a newtype whose value is *directly* `+Int+` or `+Decimal+` has arithmetic — a newtype over another newtype does not.
 
-Re-wrapping is a computation, not a fresh construction from raw data, so it needs no `+constructs+` (<<constructs>>) — as `+Int+` arithmetic does not "construct" an `+Int+`. A `+金額(...)+` literal construction (<<newtype>>) still does.
+Re-wrapping is a computation, not a fresh construction from raw data, so it needs no `+constructs+` (<<constructs>>) — as `+Int+` arithmetic does not "construct" an `+Int+`. A `+Money(...)+` literal construction (<<newtype>>) still does.
 
 [#collections]
 === Collection types
@@ -745,20 +745,20 @@ An invariant is checked at run time on every construction (<<invariant-mvp>>), a
 The check is intraprocedural. Within a behavior's `+let+` body it seeds what the input types guarantee — a newtype's own invariant, a product data's invariant over its fields — which is sound because an input of type `+T+` was built through `+T+`'s checked construction. It refines that along each `+require+` / `+if+` guard (<<require>>, <<if>>), and at every construction asks whether the guards prove its invariant.
 
 * *Discharged* — the guards prove the invariant. No diagnostic; the construction cannot abort here (overflow aside).
-* *Definitely violated* — the guards prove the invariant false on a reachable path. A compile error — the path-sensitive generalization of the constant check `+金額(-5)+` (<<newtype>>).
+* *Definitely violated* — the guards prove the invariant false on a reachable path. A compile error — the path-sensitive generalization of the constant check `+Money(-5)+` (<<newtype>>).
 * *Possibly violated* — expressible but not proven. A warning: a possible abort. Guard it with `+require+`, or reify the relation into a type invariant (below).
 * *Not expressible* — an invariant outside the checked fragment. No diagnostic; the run-time check stands.
 
 [,text]
 ----
-data 金額 = Decimal invariant value >= 0m
-data 引落指示 = { 残高: 金額, 額: 金額 }
+data Money = Decimal invariant value >= 0m
+data WithdrawRequest = { balance: Money, amount: Money }
 
-behavior 差引く : (指示: 引落指示) -> 金額 | 残高不足
-let 差引く (指示) = {
-    require 指示.額 <= 指示.残高
-        else 残高不足
-    指示.残高 - 指示.額          // discharged: the guard proves 残高 - 額 >= 0
+behavior withdraw : (req: WithdrawRequest) -> Money | InsufficientBalance
+let withdraw (req) = {
+    require req.amount <= req.balance
+        else InsufficientBalance
+    req.balance - req.amount          // discharged: the guard proves balance - amount >= 0
 }
 ----
 
@@ -771,11 +771,11 @@ The check does not cross behaviors: a relation established in one behavior is no
 
 [,text]
 ----
-data 引落指示 = { 残高: 金額, 額: 金額 }
-    invariant 額 <= 残高                 // the relation lives in the type
+data WithdrawRequest = { balance: Money, amount: Money }
+    invariant amount <= balance                 // the relation lives in the type
 
-behavior 差引く : (指示: 引落指示) -> 金額
-let 差引く (指示) = 指示.残高 - 指示.額   // discharged with no guard here
+behavior withdraw : (req: WithdrawRequest) -> Money
+let withdraw (req) = req.balance - req.amount   // discharged with no guard here
 ----
 
 So a possible-violation warning over the fields of one input data is a prompt to declare their relation as that data's invariant. When a value's validity is guaranteed *outside* the language — a Java-side or injected contract stronger than any type — there is no type to reify onto, and that construction keeps its run-time check.


### PR DESCRIPTION
Writes the two specification sections the merged implementation (#45) already referenced, closing the gap where the spec did not describe the new features.

## Added
- **§newtype-arithmetic** (under `newtype`): closed `+`/`-` over a single-value numeric newtype yields that newtype; same-newtype or bare-literal pairing; `*`/`/` and nested newtypes excluded; re-wrapping needs no `constructs`. Also fixes the now-stale *"Arithmetic on a newtype is not defined"* sentence in §newtype-comparison.
- **§invariant-discharge** (end of the `invariant` chapter): the intraprocedural compile-time check — seed from input invariants, refine along `require`/`if` guards, classify each construction as *discharged / definitely violated / possibly violated / not expressible*, and the bounded (interval + difference) decision fragment.
- **§invariant-reify**: carry a cross-behavior relation by declaring it as a type invariant rather than inferring a precondition (declare-don't-infer, ADR-0017/0024).

Restores the `spec §…` citations in `TypeChecker`/`InvariantChecker` now that the anchors exist. All cross-references verified against existing anchors; code-fence parity checked.

Follows #45 (the implementation). Docs-only apart from two comment citations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)