### PR TITLE
Run `>->` pipelines from the CLI when every stage is in-language

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ mvn -pl souther-cli -am -DskipTests install
 # => "Hello, world"
 ```
 
-`--behavior` may be omitted when the module holds exactly one runnable behavior, and `--input` when the behavior takes no argument. A multi-argument behavior takes a JSON array (`--input '[3, 7]'`). Only a self-contained behavior with a `let` and no `requires` can be driven; an injected behavior or a `>->` pipeline is refused with a reason.
+`--behavior` may be omitted when the module holds exactly one runnable behavior, and `--input` when the behavior takes no argument. A multi-argument behavior takes a JSON array (`--input '[3, 7]'`). A behavior is runnable when it has a `let` and no `requires`, or when it is a `>->` pipeline whose stages are all runnable in that same sense; an injected behavior, one that needs injected dependencies, or a pipeline with such a stage is refused with a reason. The runner drives a single self-contained file — stdlib imports resolve, but it cannot link against other user modules.
 
 The same `souther` binary also compiles to `.class` files (`souther compile hello.sou -d out`). It runs on any Unix shell; on Windows, use it as a plain jar (`java -jar souther-cli/target/souther.jar …`).
 

--- a/examples/cli/pipeline.sou
+++ b/examples/cli/pipeline.sou
@@ -1,0 +1,23 @@
+// A `>->` pipeline run end to end. `run` drives a pipeline whose stages are all in-language
+// (each has a `let` and no `requires`): the pipeline compiles to a no-arg class that chains the
+// stages, so it runs like any other behavior.
+//
+//   souther run pipeline.sou --behavior checkout --input '{"quantity": 3, "unitPrice": 400}'
+//   => {"total":1200}
+
+data Order = {
+    quantity: Int
+    , unitPrice: Int
+}
+data Priced = { total: Int }
+data Receipt = { total: Int }
+
+behavior price : (order: Order) -> Priced
+    constructs Priced
+let price (order) = Priced { total = order.quantity * order.unitPrice }
+
+behavior settle : (priced: Priced) -> Receipt
+    constructs Receipt
+let settle (priced) = Receipt { total = priced.total }
+
+behavior checkout = price >-> settle

--- a/souther-compiler/src/main/java/net/unit8/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/net/unit8/souther/compiler/Runner.java
@@ -30,10 +30,13 @@ import java.util.stream.Collectors;
  * behavior, and encodes the returned domain value back to JSON through its derived encoder. Souther
  * keeps no I/O of its own; a header-less {@code .sou} is named after the file (see {@link Parser}).
  *
- * <p>Only a self-contained module (no imports) and a simple behavior with a {@code let} and no
- * {@code requires} can be driven. An injected behavior (no implementation) or one that needs
- * injected dependencies has no in-language implementation to run, and a {@code >->} pipeline is not
- * yet supported; each is refused with a reason.
+ * <p>The runner drives a single self-contained {@code .sou} file: stdlib imports resolve, but it
+ * cannot link against other user modules. A behavior is runnable when it has a {@code let} and no
+ * {@code requires}, or when it is a {@code >->} pipeline whose stages are all themselves runnable
+ * (each has a {@code let} and no {@code requires}) — such a pipeline compiles to a no-arg {@code
+ * $Impl} that chains the stages, so it runs like any other behavior. An injected behavior (no
+ * implementation), one that needs injected dependencies, or a pipeline with such a stage has nothing
+ * for {@code run} to supply; each is refused with a reason.
  */
 public final class Runner {
 
@@ -103,7 +106,7 @@ public final class Runner {
         Map<String, Ast.Def> symbols = TypeChecker.symbols(module);
         Map<String, TypeChecker.Sig> sigs = TypeChecker.signatures(module, symbols);
 
-        Ast.SpecBehavior spec = resolveBehavior(module, behaviorName);
+        Ast.BehaviorDef spec = resolveBehavior(module, behaviorName);
         TypeChecker.Sig sig = sigs.get(spec.name());
         List<Type> ins = sig.ins();
 
@@ -121,14 +124,18 @@ public final class Runner {
 
     // --- behavior selection ---------------------------------------------------------------------
 
-    private static Ast.SpecBehavior resolveBehavior(Ast.Module module, String requested) {
+    private static Ast.BehaviorDef resolveBehavior(Ast.Module module, String requested) {
         java.util.Set<String> implemented = module.fns().stream()
                 .map(Ast.FnDef::name).collect(Collectors.toSet());
-        Map<String, Ast.SpecBehavior> runnable = new java.util.LinkedHashMap<>();
+        Map<String, List<String>> pipeStages = TypeChecker.pipelineStages(module);
+        Map<String, Ast.BehaviorDef> runnable = new java.util.LinkedHashMap<>();
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (b instanceof Ast.SpecBehavior spec
                     && implemented.contains(spec.name()) && spec.requires().isEmpty()) {
                 runnable.put(spec.name(), spec);
+            } else if (b instanceof Ast.PipeBehavior pipe
+                    && pipelineBlocker(module, pipe, implemented, pipeStages) == null) {
+                runnable.put(pipe.name(), pipe);
             }
         }
         if (requested == null) {
@@ -142,26 +149,59 @@ public final class Runner {
             throw usage("several runnable behaviors — pick one with --behavior: "
                     + String.join(", ", runnable.keySet()));
         }
-        Ast.SpecBehavior found = runnable.get(requested);
+        Ast.BehaviorDef found = runnable.get(requested);
         if (found != null) {
             return found;
         }
         throw new RunException(whyNotRunnable(module, requested, runnable.keySet()));
     }
 
+    /**
+     * Why a {@code >->} pipeline cannot be driven by {@code run}, or null when every stage is
+     * in-language. A pipeline whose flattened stages all have a {@code let} and no {@code requires}
+     * compiles to an {@code $Impl} with a public no-arg constructor, so it runs exactly like a simple
+     * behavior. A stage with no implementation (injected from Java) or one that needs its own injected
+     * dependencies would make that constructor take those behaviors, which {@code run} cannot supply.
+     */
+    private static String pipelineBlocker(Ast.Module module, Ast.PipeBehavior pipe,
+            java.util.Set<String> implemented, Map<String, List<String>> pipeStages) {
+        Map<String, Ast.SpecBehavior> specs = new java.util.HashMap<>();
+        for (Ast.BehaviorDef b : module.behaviors()) {
+            if (b instanceof Ast.SpecBehavior spec) {
+                specs.put(spec.name(), spec);
+            }
+        }
+        for (String stage : TypeChecker.flattenStages(pipe.stages(), pipeStages, pipe.pos())) {
+            if (!implemented.contains(stage)) {
+                return "`" + pipe.name() + "` is a pipeline whose stage `" + stage
+                        + "` has no implementation (it is injected from Java), which `run` cannot supply.";
+            }
+            Ast.SpecBehavior spec = specs.get(stage);
+            if (spec != null && !spec.requires().isEmpty()) {
+                return "`" + pipe.name() + "` is a pipeline whose stage `" + stage
+                        + "` requires injected dependencies (" + String.join(", ", spec.requires())
+                        + "), which `run` cannot supply.";
+            }
+        }
+        return null;
+    }
+
     private static String whyNotRunnable(Ast.Module module, String name, java.util.Set<String> runnable) {
         String available = runnable.isEmpty() ? "none" : String.join(", ", runnable);
+        java.util.Set<String> implemented = module.fns().stream()
+                .map(Ast.FnDef::name).collect(Collectors.toSet());
+        Map<String, List<String>> pipeStages = TypeChecker.pipelineStages(module);
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (!b.name().equals(name)) {
                 continue;
             }
-            if (b instanceof Ast.PipeBehavior) {
-                return "`" + name + "` is a `>->` pipeline, which `run` cannot drive yet. "
-                        + "Runnable: " + available + ".";
+            if (b instanceof Ast.PipeBehavior pipe) {
+                String blocker = pipelineBlocker(module, pipe, implemented, pipeStages);
+                return (blocker == null ? "`" + name + "` is runnable." : blocker)
+                        + " Runnable: " + available + ".";
             }
             if (b instanceof Ast.SpecBehavior spec) {
-                boolean implemented = module.fns().stream().anyMatch(f -> f.name().equals(name));
-                if (!implemented) {
+                if (!implemented.contains(name)) {
                     return "`" + name + "` has no implementation (it is injected from Java). "
                             + "Runnable: " + available + ".";
                 }

--- a/souther-compiler/src/test/java/net/unit8/souther/compiler/RunnerTest.java
+++ b/souther-compiler/src/test/java/net/unit8/souther/compiler/RunnerTest.java
@@ -113,7 +113,7 @@ class RunnerTest {
     }
 
     @Test
-    void refusesAPipelineBehavior() throws Exception {
+    void drivesASingleStageInLanguagePipeline() throws Exception {
         Path file = write("flow.sou", """
                 data In = { v: Int }
                 data Out = { v: Int }
@@ -121,9 +121,40 @@ class RunnerTest {
                 let stage (i) = Out { v = i.v }
                 behavior flow = stage
                 """);
+        assertEquals("{\"v\":1}", Runner.run(file, "flow", "{\"v\": 1}"));
+    }
+
+    @Test
+    void drivesAMultiStageInLanguagePipeline() throws Exception {
+        Path file = write("flow.sou", """
+                data In = { v: Int }
+                data Mid = { v: Int }
+                data Out = { v: Int }
+                behavior first : (i: In) -> Mid constructs Mid
+                let first (i) = Mid { v = i.v }
+                behavior second : (m: Mid) -> Out constructs Out
+                let second (m) = Out { v = m.v }
+                behavior flow = first >-> second
+                """);
+        assertEquals("{\"v\":42}", Runner.run(file, "flow", "{\"v\": 42}"));
+    }
+
+    @Test
+    void refusesAPipelineWhoseStageNeedsInjectedDependencies() throws Exception {
+        Path file = write("flow.sou", """
+                data In = { v: Int }
+                data Out = { at: String }
+                behavior now : () -> String
+                behavior stamp : (i: In) -> Out
+                    requires now
+                    constructs Out
+                let stamp (i, now) = Out { at = now() }
+                behavior flow = stamp
+                """);
         Runner.RunException e = assertThrows(Runner.RunException.class,
                 () -> Runner.run(file, "flow", "{\"v\": 1}"));
-        assertTrue(e.getMessage().contains("pipeline"), e.getMessage());
+        assertTrue(e.getMessage().contains("requires injected dependencies"), e.getMessage());
+        assertTrue(e.getMessage().contains("stamp"), e.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## What

`souther run` can now drive a `>->` pipeline whose stages are all in-language (each has a `let` and no `requires`). Until now every pipeline was refused with "cannot drive yet", so the headline `>->` composition could compile but never be tried from the CLI.

## Why it works with no new machinery

A pipeline of in-language stages compiles to a `$Impl` with a public no-arg constructor whose `apply` chains the stages in bytecode — the exact reflective protocol (`newInstance()` + `apply(Object...)`) that `Runner.invoke` already uses for a simple behavior. `TypeChecker.signatures(...)` already returns a `Sig(ins, out)` for a pipeline. The only blocker was the guard in `resolveBehavior`/`whyNotRunnable` that rejected `Ast.PipeBehavior` outright.

## Change

- `resolveBehavior` returns `Ast.BehaviorDef` (was `Ast.SpecBehavior`); everything downstream only touches `.name()`.
- A pipeline joins the runnable set when its flattened stages (`TypeChecker.flattenStages`) are all fn-implemented with no `requires`.
- A pipeline that can't run — a stage with no implementation, or one needing injected dependencies — is still refused, now with a message naming the offending stage instead of a blanket "cannot drive yet".
- Doc fix: the runner drives a single self-contained file (stdlib imports resolve; it cannot link against other user modules), not a module with "no imports".

Injected dependencies and multi-module runs stay out of scope — those need a way to supply Java-side implementations / a project model, which `run` has no path for.

## Tests

- `RunnerTest`: `drivesASingleStageInLanguagePipeline`, `drivesAMultiStageInLanguagePipeline`, `refusesAPipelineWhoseStageNeedsInjectedDependencies` (RED-verified against the old code first).
- New `examples/cli/pipeline.sou` demonstrates `checkout = price >-> settle`.
- End-to-end via the built CLI: `souther run examples/cli/pipeline.sou --behavior checkout --input '{"quantity": 3, "unitPrice": 400}'` → `{"total":1200}`.
- Full suite green (compiler 723, all modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)