### PR TITLE
Fix #71: local `let x: T = expr` type annotation

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -365,11 +365,36 @@ public interface Ast {
      * {@code let name = value} followed by {@code body} — what a body's {@code let} desugars to
      * (spec 16.1). Nesting the rest of the body inside keeps {@code value} from being evaluated
      * when an enclosing {@code if} (a desugared {@code require}) takes the other branch.
+     *
+     * <p>{@code declaredType} is the binding's declared type, if any, and {@code annotated} says
+     * where it came from. A source annotation ({@code let x: T = e}) is pushed into {@code value}
+     * as its expected type and checked against it, so a value only context can type — an empty
+     * collection — is pinned at the binding. A type supplied by helper inlining (the parameter's
+     * declared type, bound to the argument at the call site) is not: the argument's own type and
+     * the call-site check already cover it.
      */
-    record LetIn(String name, Expr value, ParamType declaredType, Expr body, SourcePos pos) implements Expr {
+    record LetIn(String name, Expr value, ParamType declaredType, boolean annotated, Expr body,
+                 SourcePos pos) implements Expr {
         /** An ordinary {@code let x = e}: the bound name takes {@code e}'s inferred type. */
         public LetIn(String name, Expr value, Expr body, SourcePos pos) {
-            this(name, value, null, body, pos);
+            this(name, value, null, false, body, pos);
+        }
+
+        /** A binding carrying an inlined helper parameter's declared type. */
+        public LetIn(String name, Expr value, ParamType declaredType, Expr body, SourcePos pos) {
+            this(name, value, declaredType, false, body, pos);
+        }
+
+        /** {@code let x: T = value} — a binding the source annotated. */
+        public static LetIn annotated(String name, Expr value, RetType type, Expr body, SourcePos pos) {
+            return new LetIn(name, value, type, true, body, pos);
+        }
+
+        /** The type the source wrote on this binding, or null when it wrote none. An annotation is an
+         * ordinary type (a function type belongs only in a helper's parameter), so this is the one
+         * place that narrows {@code declaredType}, and a carrier from inlining never reads as one. */
+        public RetType annotation() {
+            return annotated && declaredType instanceof RetType rt ? rt : null;
         }
     }
 
@@ -459,7 +484,8 @@ public interface Ast {
             case Binary b -> new Binary(b.op(), f.apply(b.left()), f.apply(b.right()), b.pos());
             case Call c -> new Call(c.fn(), mapExprs(c.args(), f), c.pos());
             case If iff -> new If(f.apply(iff.cond()), f.apply(iff.then()), f.apply(iff.els()), iff.pos());
-            case LetIn li -> new LetIn(li.name(), f.apply(li.value()), li.declaredType(), f.apply(li.body()), li.pos());
+            case LetIn li -> new LetIn(li.name(), f.apply(li.value()), li.declaredType(), li.annotated(),
+                    f.apply(li.body()), li.pos());
             case Block bl -> new Block(bl.params(), f.apply(bl.body()), bl.pos());
             case ListLit l -> new ListLit(mapExprs(l.elements(), f), l.pos());
             case ListComp comp -> new ListComp(f.apply(comp.element()), mapExprs(comp.guards(), f), comp.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -132,7 +132,8 @@ public final class Exposing {
                 }
                 yield new Ast.NewData(nd.typeName(), inits, nd.spreads(), nd.pos());
             }
-            case Ast.LetIn li -> new Ast.LetIn(li.name(), rw(li.value()), li.declaredType(), rw(li.body()), li.pos());
+            case Ast.LetIn li -> new Ast.LetIn(li.name(), rw(li.value()), li.declaredType(), li.annotated(),
+                    rw(li.body()), li.pos());
             case Ast.Block bl -> new Ast.Block(bl.params(), rw(bl.body()), bl.pos());
             case Ast.ListLit ll -> {
                 List<Ast.Expr> elems = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -334,10 +334,11 @@ public final class HelperInliner {
                 // escapes, which needs a runtime closure. Keep the binding so the "a block is not a
                 // value" check reports it.
                 yield mentions(body, li.name())
-                        ? new Ast.LetIn(li.name(), inline(lambda), li.declaredType(), body, li.pos())
+                        ? new Ast.LetIn(li.name(), inline(lambda), li.declaredType(), li.annotated(), body, li.pos())
                         : body;
             }
-            case Ast.LetIn li -> new Ast.LetIn(li.name(), inline(li.value()), li.declaredType(), inline(li.body()), li.pos());
+            case Ast.LetIn li -> new Ast.LetIn(li.name(), inline(li.value()), li.declaredType(), li.annotated(),
+                    inline(li.body()), li.pos());
             case Ast.ListLit lit -> new Ast.ListLit(inlineList(lit.elements()), lit.pos());
             case Ast.Tuple tup -> new Ast.Tuple(inlineList(tup.elements()), tup.pos());
             case Ast.TupleGet tg -> new Ast.TupleGet(inline(tg.tuple()), tg.index(), tg.arity(), tg.pos());
@@ -451,7 +452,7 @@ public final class HelperInliner {
             case Ast.LetIn li -> {
                 Ast.Expr value = rename(li.value(), subst, fnParams, at);
                 Ast.Expr body = rename(li.body(), without(subst, li.name()), fnParams, at);
-                yield new Ast.LetIn(li.name(), value, li.declaredType(), body, at(at, li.pos()));
+                yield new Ast.LetIn(li.name(), value, li.declaredType(), li.annotated(), body, at(at, li.pos()));
             }
             case Ast.ListLit lit -> new Ast.ListLit(renameList(lit.elements(), subst, fnParams, at), at(at, lit.pos()));
             case Ast.Tuple tup -> new Ast.Tuple(renameList(tup.elements(), subst, fnParams, at), at(at, tup.pos()));

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -65,7 +65,8 @@ public final class NewtypeDesugar {
             case Ast.ListComp comp ->
                     new Ast.ListComp(go(comp.element(), symbols), mapExprs(comp.guards(), symbols), comp.pos());
             case Ast.LetIn li ->
-                    new Ast.LetIn(li.name(), go(li.value(), symbols), li.declaredType(), go(li.body(), symbols), li.pos());
+                    new Ast.LetIn(li.name(), go(li.value(), symbols), li.declaredType(), li.annotated(),
+                            go(li.body(), symbols), li.pos());
             case Ast.If iff ->
                     new Ast.If(go(iff.cond(), symbols), go(iff.then(), symbols), go(iff.els(), symbols), iff.pos());
             case Ast.Block b -> new Ast.Block(b.params(), go(b.body(), symbols), b.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -255,6 +255,11 @@ public final class TypeChecker {
                 checkInjectionConstructs(spec, symbols, exposeAll, exposed);
             }
         }
+        // A binding whose value is a lambda takes no annotation (spec 16.1). Read on the surface bodies:
+        // lowering has already expanded such a binding away at each of its applications.
+        for (Ast.FnDef fn : module.fns()) {
+            collect(errors, () -> rejectAnnotatedLambdaBindings(fn.body()));
+        }
         // Helper fns (no matching behavior) are expanded inline at each call site (spec 12.5); a
         // helper is checked standalone against its own declared parameter types (spec 13.1). Recovered
         // so a broken helper does not hide the behavior-body errors checked below.
@@ -581,10 +586,16 @@ public final class TypeChecker {
         if (e instanceof Ast.LetIn li) {
             collectHelperCalls(li.value(), env, target, symbols, reqs, inliner, onCall);
             Map<String, Type> inner = new HashMap<>(env);
-            try {
-                inner.put(li.name(), typeOf(inliner.inline(li.value()), env, null, symbols, reqs));
-            } catch (CompileException ignored) {
-                // an untypeable value leaves its name unbound; a later reference just won't infer.
+            if (annotatedType(li, symbols) instanceof Type declared) {
+                // an annotated binding already states its type, so inference reads it rather than
+                // re-deriving one from a value that context alone can type (issue #71)
+                inner.put(li.name(), declared);
+            } else {
+                try {
+                    inner.put(li.name(), typeOf(inliner.inline(li.value()), env, null, symbols, reqs));
+                } catch (CompileException ignored) {
+                    // an untypeable value leaves its name unbound; a later reference just won't infer.
+                }
             }
             collectHelperCalls(li.body(), inner, target, symbols, reqs, inliner, onCall);
             return;
@@ -2128,31 +2139,29 @@ public final class TypeChecker {
                 yield t;
             }
             case Ast.LetIn li -> {
-                // the binding is visible only inside the body, so a sibling branch cannot see it
-                Map<String, Type> inner = new HashMap<>(env);
+                Type annotation = annotatedType(li, symbols);
+                Type bindType;
                 if (isFunctionSelection(li.value())) {
                     // a lambda bound to a local that could not be inlined (e.g. chosen by an `if`):
                     // it is a first-class function value. Its parameter types are unannotated, so
                     // infer them from how the body applies it (spec §blocks).
-                    List<Type> paramTypes = inferFnParamTypes(li.name(), li.body(), env, data, symbols, reqs);
-                    inner.put(li.name(), typeFunctionValue(li.value(), paramTypes, env, data, symbols, reqs));
-                } else {
-                    Type valueType = typeOf(li.value(), env, data, symbols, reqs);
-                    Type bindType = valueType;
-                    if (li.declaredType() instanceof Ast.RetType rt) {
-                        // A binding carrying an inlined helper's declared parameter type. When that type
-                        // is a sum, keep it: a case argument widens to its sum (spec 8.3), so a `match`
-                        // in the body still sees the sum rather than the argument's specific case. Other
-                        // declared types (a type variable in a generic prelude helper, a record, a list)
-                        // are left to the argument's own type, which monomorphisation and the call-site
-                        // check already handle.
-                        Type declared = resolveParamType(rt, symbols);
-                        if (isSumType(declared, symbols) && assignable(valueType, declared, symbols)) {
-                            bindType = declared;
-                        }
+                    if (annotation != null) {
+                        throw functionAnnotation(li);   // no ordinary type describes a function value
                     }
-                    inner.put(li.name(), bindType);
+                    List<Type> paramTypes = inferFnParamTypes(li.name(), li.body(), env, data, symbols, reqs);
+                    bindType = typeFunctionValue(li.value(), paramTypes, env, data, symbols, reqs);
+                } else if (annotation != null) {
+                    // the written type is the value's expected type, so an empty collection bound here
+                    // takes its element/value type from the annotation rather than staying a bottom
+                    Type valueType = typeOf(li.value(), env, data, symbols, reqs, annotation);
+                    checkLetAnnotation(li, annotation, valueType, symbols);
+                    bindType = annotation;
+                } else {
+                    bindType = carriedType(li, typeOf(li.value(), env, data, symbols, reqs), symbols);
                 }
+                // the binding is visible only inside the body, so a sibling branch cannot see it
+                Map<String, Type> inner = new HashMap<>(env);
+                inner.put(li.name(), bindType);
                 yield typeOf(li.body(), inner, data, symbols, reqs, expected);
             }
             // reached only where a block escapes: it may be passed as an argument, or bound to a
@@ -3391,6 +3400,69 @@ public final class TypeChecker {
             case Ast.LetIn li -> producesFunction(li.body());
             default -> false;
         };
+    }
+
+    /** The type a source annotation declares on a binding ({@code let x: T = e}), or null when the
+     * binding carries none. Read wherever a binding's type is needed, so the annotation and the
+     * inference, the checker and the backend cannot drift apart. */
+    private static Type annotatedType(Ast.LetIn li, Map<String, Ast.Def> symbols) {
+        return li.annotation() == null ? null : successType(li.annotation(), symbols);
+    }
+
+    /**
+     * A local binding's written type must be the type of its value (spec 16.1). A declared type that
+     * the value does not have is an error rather than a comment the checker ignores — the same rule a
+     * helper's declared return type follows.
+     */
+    private static void checkLetAnnotation(Ast.LetIn li, Type declared, Type valueType,
+                                           Map<String, Ast.Def> symbols) {
+        if (assignable(valueType, declared, symbols)) {
+            return;
+        }
+        throw CompileException.of(
+                Diagnostic.of(null, "check.let.annotation").title("check.type.mismatch.title")
+                        .at(li.pos()).args(li.name(), Type.show(declared), Type.show(valueType))
+                        .diff(Type.show(valueType), Type.show(declared)).build(),
+                "the binding `" + li.name() + "` declares " + Type.show(declared)
+                        + " but its value is " + Type.show(valueType));
+    }
+
+    /**
+     * The type to bind an un-annotated binding at. A binding carrying an inlined helper's declared
+     * parameter type keeps that type when it is a sum: a case argument widens to its sum (spec 8.3),
+     * so a {@code match} in the body still sees the sum rather than the argument's specific case.
+     * Other declared types (a type variable in a generic prelude helper, a record, a list) are left to
+     * the argument's own type, which monomorphisation and the call-site check already handle.
+     */
+    private static Type carriedType(Ast.LetIn li, Type valueType, Map<String, Ast.Def> symbols) {
+        if (li.declaredType() instanceof Ast.RetType rt) {
+            Type declared = resolveParamType(rt, symbols);
+            if (isSumType(declared, symbols) && assignable(valueType, declared, symbols)) {
+                return declared;
+            }
+        }
+        return valueType;
+    }
+
+    /** {@code let f: T = <function>} — a binding whose value is a function takes no annotation, because
+     * a function type may be written only in a helper's parameter (spec 13.1) and no ordinary type
+     * describes a function. Raised from the surface check below and from the value path, so the two
+     * shapes a function binding takes (a bare lambda, one an {@code if} chooses) read the same. */
+    private static CompileException functionAnnotation(Ast.LetIn li) {
+        return CompileException.of(
+                Diagnostic.of(null, "check.fn.annotation").title("check.fn.title")
+                        .at(li.pos()).args(li.name()).hint("check.fn.annotation.hint").build(),
+                "the binding `" + li.name() + "` is a function, so it takes no annotation: a function"
+                        + " type may be written only in a helper's parameter (spec 13.1)");
+    }
+
+    /** Rejects an annotation on a lambda binding, read on the surface body: lowering expands such a
+     * binding away at its applications, so by the time the body is checked the annotation is gone. */
+    private static void rejectAnnotatedLambdaBindings(Ast.Expr e) {
+        if (e instanceof Ast.LetIn li && li.annotation() != null && li.value() instanceof Ast.Block) {
+            throw functionAnnotation(li);
+        }
+        forEachChild(e, TypeChecker::rejectAnnotatedLambdaBindings);
     }
 
     /** A function value that could not be inlined away and so becomes a first-class {@code Fn}: a

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -297,7 +297,7 @@ final class BodyGen {
                                     li.name(), li.body().toAst(), typesEnv(), data, symbols);
                             vt = emitFunctionValue(valueAst, paramTypes);
                         } else {
-                            vt = genExpr(li.value());
+                            vt = genExpr(li.value(), letExpected(li));
                         }
                         int slot = slot(vt);
                         store(code, slot, vt);
@@ -553,7 +553,7 @@ final class BodyGen {
                                 li.name(), li.body().toAst(), typesEnv(), data, symbols);
                         vt = emitFunctionValue(valueAst, paramTypes);
                     } else {
-                        vt = genExpr(li.value());
+                        vt = genExpr(li.value(), letExpected(li));
                     }
                     int s = slot(vt);
                     store(code, s, vt);
@@ -563,6 +563,12 @@ final class BodyGen {
                 // a block has no value of its own; it is inlined by the call it is passed to
                 case Core.Block b -> throw new CompileException(b.pos(), "a block is not a value");
             };
+        }
+
+        /** The type a binding's value is emitted at when the source annotated it (issue #71) — the same
+         * pin the checker applied, so an empty-collection value materialises at the written type. */
+        private Type letExpected(Core.LetIn li) {
+            return li.annotation() == null ? null : successType(li.annotation());
         }
 
         private Type match(Core.Match m, Type expected) {

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -42,7 +42,10 @@ public sealed interface Core {
             case Binary b -> new Ast.Binary(b.op(), b.left().toAst(), b.right().toAst(), b.pos());
             case Call c -> new Ast.Call(c.fn(), toAstAll(c.args()), c.pos());
             case If iff -> new Ast.If(iff.cond().toAst(), iff.then().toAst(), iff.els().toAst(), iff.pos());
-            case LetIn li -> new Ast.LetIn(li.name(), li.value().toAst(), li.body().toAst(), li.pos());
+            case LetIn li -> li.annotation() == null
+                    ? new Ast.LetIn(li.name(), li.value().toAst(), li.body().toAst(), li.pos())
+                    : Ast.LetIn.annotated(li.name(), li.value().toAst(), li.annotation(),
+                            li.body().toAst(), li.pos());
             case Block bl -> new Ast.Block(bl.params(), bl.body().toAst(), bl.pos());
             case ListLit l -> new Ast.ListLit(toAstAll(l.elements()), l.pos());
             case Tuple t -> new Ast.Tuple(toAstAll(t.elements()), t.pos());
@@ -93,7 +96,17 @@ public sealed interface Core {
 
     record If(Core cond, Core then, Core els, SourcePos pos) implements Core {}
 
-    record LetIn(String name, Core value, Core body, SourcePos pos) implements Core {}
+    /** {@code annotation} is the type the source wrote on the binding ({@code let x: T = e}), or null.
+     * Core carries no types of its own; this is the written annotation, kept so the backend materialises
+     * an empty-collection value at the type the checker pinned it to rather than re-deriving a bottom.
+     * A type that helper inlining put on a binding is not an annotation and does not come along. */
+    record LetIn(String name, Core value, Ast.RetType annotation, Core body, SourcePos pos)
+            implements Core {
+
+        LetIn(String name, Core value, Core body, SourcePos pos) {
+            this(name, value, null, body, pos);
+        }
+    }
 
     /** A second-class block: a step passed to a recursive combinator, or an escaping lambda a {@code
      * let} binds (a closure). Kept as its own node until closure conversion gets an explicit Core form. */
@@ -129,7 +142,7 @@ public sealed interface Core {
             case Ast.FieldAccess fa -> new FieldAccess(of(fa.target()), fa.field(), fa.pos());
             case Ast.Binary b -> new Binary(b.op(), of(b.left()), of(b.right()), b.pos());
             case Ast.If iff -> new If(of(iff.cond()), of(iff.then()), of(iff.els()), iff.pos());
-            case Ast.LetIn li -> new LetIn(li.name(), of(li.value()), of(li.body()), li.pos());
+            case Ast.LetIn li -> new LetIn(li.name(), of(li.value()), li.annotation(), of(li.body()), li.pos());
             case Ast.Block bl -> new Block(bl.params(), of(bl.body()), bl.pos());
             case Ast.ListLit l -> new ListLit(ofAll(l.elements()), l.pos());
             case Ast.Tuple t -> new Tuple(ofAll(t.elements()), t.pos());

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -733,8 +733,14 @@ public final class AstBuilder {
         SyntaxNode s = stmts.get(index);
         SourcePos pos = pos(s);
         return switch (s.kind()) {
-            case LET_STMT -> new Ast.LetIn(firstIdentText(s), expr(onlyExpr(s)),
-                    foldStatements(stmts, index + 1, result), pos);
+            case LET_STMT -> {
+                Ast.RetType annotation = s.child(SyntaxKind.RET_TYPE).map(this::retType).orElse(null);
+                Ast.Expr value = expr(onlyExpr(s));
+                Ast.Expr rest = foldStatements(stmts, index + 1, result);
+                yield annotation == null
+                        ? new Ast.LetIn(firstIdentText(s), value, rest, pos)
+                        : Ast.LetIn.annotated(firstIdentText(s), value, annotation, rest, pos);
+            }
             case REQUIRE_STMT -> {
                 List<SyntaxNode> exprs = exprChildren(s);
                 yield new Ast.If(expr(exprs.get(0)), foldStatements(stmts, index + 1, result),

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -60,9 +60,12 @@ check.list.title=TYPE MISMATCH
 check.list.msg=The elements of this list do not all have the same type.
 check.list.hint=One element is {0} and another is {1}; make every element the same type.
 
+# a local binding's type annotation (`let x: T = e`)
+check.let.annotation=The binding `{0}` declares {1}, but its value is {2}.
+
 # a fold over an empty-collection seed whose accumulator type cannot be inferred from context
 check.fold.seed.title=CANNOT INFER TYPE
-check.fold.seed.untyped=This empty collection's element type cannot be inferred here. Place the fold directly in a typed position — the field or behavior output it feeds — rather than a local binding, or seed it with a non-empty value.
+check.fold.seed.untyped=This empty collection's element type cannot be inferred here. Annotate the binding it feeds (`let x: <type> = ...`), place the fold directly in a typed position — the field or behavior output it feeds — or seed it with a non-empty value.
 check.fold.seed.here=the accumulator's type stays unknown, so this operation has nothing to work on
 
 # binary / unary operand types
@@ -284,6 +287,8 @@ check.newtype.arity=`{0}` wraps one value, but is applied to {1} argument(s).
 check.helper.arity=Helper `let {0}` takes {1} argument(s), but is called with {2}.
 check.fn.mustbenamed=The function passed to `{0}` of `let {1}` must be a named function or a lambda.
 check.fn.recursivelambda=The lambda bound to `{0}` refers to itself; a recursive lambda would not bottom out when expanded inline.
+check.fn.annotation=The binding `{0}` is a function, and a function type may be written only in a helper parameter.
+check.fn.annotation.hint=Remove the annotation.
 check.behavior.collision.data=behavior `{0}`'s first letter is capitalized to form the JVM class `{1}` (spec 19.5), which collides with data `{1}`; rename one so their class names differ.
 check.behavior.collision.behavior=behaviors `{0}` and `{1}` both capitalize to the same JVM class `{2}` (spec 19.5); rename one so their class names differ.
 check.derive.tuplefield=A tuple cannot be a data field in `{0}`: a tuple has no external representation, so no codec can be derived. Use a named data.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -59,9 +59,12 @@ check.list.title=型の不一致
 check.list.msg=このリストの要素の型が揃っていません。
 check.list.hint=ある要素は {0}、別の要素は {1} です。すべての要素を同じ型にしてください。
 
+# 局所束縛の型注釈（`let x: T = e`）
+check.let.annotation=束縛 `{0}` は {1} と宣言していますが、値は {2} です。
+
 # 空コレクションを seed にした fold で、アキュムレータの型が文脈から推論できない
 check.fold.seed.title=型を推論できません
-check.fold.seed.untyped=この空コレクションの要素型をここで推論できません。fold を型のある位置（流れ込む先のフィールドや behavior の出力）に直接置く（局所束縛を挟まない）か、seed を非空の値にしてください。
+check.fold.seed.untyped=この空コレクションの要素型をここで推論できません。流れ込む先の束縛に型注釈を付ける（`let x: <型> = ...`）か、fold を型のある位置（フィールドや behavior の出力）に直接置くか、seed を非空の値にしてください。
 check.fold.seed.here=アキュムレータの型が未確定のままなので、この演算には対象がありません
 
 # 二項/単項オペランドの型
@@ -283,6 +286,8 @@ check.newtype.arity=`{0}` は値を1つ包みますが、{1} 個の引数で適�
 check.helper.arity=ヘルパ `let {0}` は引数を {1} 個取りますが、{2} 個で呼ばれています。
 check.fn.mustbenamed=`let {1}` の `{0}` に渡す関数は、名前付き関数かラムダでなければなりません。
 check.fn.recursivelambda=`{0}` に束縛されたラムダが自分自身を参照しています。再帰ラムダはインライン展開時に停止しません。
+check.fn.annotation=束縛 `{0}` は関数です。関数型はヘルパの引数位置にしか書けません。
+check.fn.annotation.hint=型注釈を外してください。
 check.behavior.collision.data=behavior `{0}` は先頭が大文字化され JVM クラス `{1}` になり（spec 19.5）、data `{1}` と衝突します。クラス名が異なるよう、どちらかをリネームしてください。
 check.behavior.collision.behavior=behavior `{0}` と `{1}` はどちらも先頭大文字化で同じ JVM クラス `{2}` になります（spec 19.5）。クラス名が異なるよう、どちらかをリネームしてください。
 check.derive.tuplefield=タプルは `{0}` の data フィールドにできません。タプルは外部表現を持たず codec を導出できません。名前付き data を使ってください。

--- a/souther-compiler/src/test/java/souther/compiler/CompileLetAnnotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLetAnnotationTest.java
@@ -1,0 +1,234 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Issue #71: a local binding may carry a type annotation, {@code let x: T = expr}. The declared type
+ * is pushed into the bound expression the same way a record field's or a helper return's is, so a
+ * value that only context can type — an empty-collection fold seed — can be pinned where it is bound
+ * instead of forcing the fold into a typed position elsewhere.
+ */
+class CompileLetAnnotationTest {
+
+    private static Diagnostic diagnosticOf(String src) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        return e.diagnostic();
+    }
+
+    @Test
+    void anAnnotatedLocalBindsAndRuns() throws Exception {
+        String src = """
+                module demo
+                data In = { v: Int }
+                data Out = { v: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let doubled: Int = i.v + i.v
+                    Out { v = doubled }
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("v", 21L));
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(42L, out.get("v"));
+    }
+
+    // The motivating case: the fold sits in a local binding, where no surrounding declared type can
+    // reach it. Without the annotation this is `check.fold.seed.untyped`.
+    @Test
+    void anAnnotationPinsAnEmptyMapSeedBoundToALocal() throws Exception {
+        String src = """
+                module demo
+                import List ( fold )
+                data In = { keys: List<String> }
+                data Out = { m: Map<String, Int> }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let counted: Map<String, Int> =
+                        fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), i.keys)
+                    Out { m = counted }
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("keys", List.of("a", "b", "a")));
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(Map.of("a", 2L, "b", 1L), out.get("m"));
+    }
+
+    // An annotated empty list is pinned too, and the binding is readable at that type afterwards.
+    @Test
+    void anAnnotationPinsAnEmptyListSeedBoundToALocal() throws Exception {
+        String src = """
+                module demo
+                import List ( fold )
+                data In = { words: List<String> }
+                data Out = { lengths: List<Int> }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let lengths: List<Int> =
+                        fold((acc, w) -> acc ++ [String.length(w)], [], i.words)
+                    Out { lengths = lengths }
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("words", List.of("a", "bbb")));
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(List.of(1L, 3L), out.get("lengths"));
+    }
+
+    // A declared type the value does not have is a compile error, not a silently ignored comment. It
+    // renders as its family does: the shared TYPE MISMATCH title and a found/expected diff.
+    @Test
+    void aLyingAnnotationIsACompileError() {
+        Diagnostic d = diagnosticOf("""
+                module demo
+                data In = { v: Int }
+                data Out = { v: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let n: Int = "not a number"
+                    Out { v = n }
+                }
+                """);
+        assertEquals("check.type.mismatch.title", d.titleKey());
+        assertEquals("check.let.annotation", d.messageKey());
+        assertEquals("String", d.diff().actualType());
+        assertEquals("Int", d.diff().expectedType());
+    }
+
+    // A function type may be written only in a helper's parameter position (spec 13.1), so the grammar
+    // does not admit one after the colon — the annotation is an ordinary type.
+    @Test
+    void aFunctionTypeCannotBeWrittenOnALocalBinding() {
+        Diagnostic d = diagnosticOf("""
+                module demo
+                data In = { v: Int }
+                data Out = { v: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let f: (Int) -> Int = (x) -> x + 1
+                    Out { v = f(i.v) }
+                }
+                """);
+        assertEquals("parse.expected", d.messageKey());
+    }
+
+    // The annotated type is the binding's type for everything downstream, including the inference that
+    // types a helper's unannotated parameter from its call sites.
+    @Test
+    void anAnnotatedBindingTypesAHelperParameterAtItsCallSite() throws Exception {
+        String src = """
+                module demo
+                import List ( fold )
+                data In = { keys: List<String> }
+                data Out = { n: Int }
+                let entries (m) = Map.size(m)
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let counted: Map<String, Int> =
+                        fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), i.keys)
+                    Out { n = entries(counted) }
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("keys", List.of("a", "b", "a")));
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(2L, out.get("n"));
+    }
+
+    // A lambda binding takes no annotation: a function type may be written only in a helper's
+    // parameter, so whatever ordinary type is written here is a lie. The binding is expanded away at
+    // its applications, so the rule is read on the surface body rather than after lowering.
+    @Test
+    void anAnnotationOnALambdaBindingIsRejected() {
+        Diagnostic d = diagnosticOf("""
+                module demo
+                data In = { v: Int }
+                data Out = { v: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let f: Int = (x) -> x + 1
+                    Out { v = f(i.v) }
+                }
+                """);
+        assertEquals("check.fn.title", d.titleKey());
+        assertEquals("check.fn.annotation", d.messageKey());
+        assertEquals("f", d.args()[0]);
+    }
+
+    // The other shape a function binding takes — one an `if` chooses, which stays a first-class Fn
+    // rather than being expanded away — is rejected by the same rule, with the same message.
+    @Test
+    void anAnnotationOnARuntimeChosenFunctionIsRejected() {
+        Diagnostic d = diagnosticOf("""
+                module demo
+                data In = { v: Int }
+                data Out = { v: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let f: Int = if i.v > 0 then (x) -> x + 1 else (x) -> x - 1
+                    Out { v = f(i.v) }
+                }
+                """);
+        assertEquals("check.fn.title", d.titleKey());
+        assertEquals("check.fn.annotation", d.messageKey());
+    }
+
+    // A sum annotation widens a case value to its sum, so the body's `match` sees both arms.
+    @Test
+    void anAnnotationMayWidenACaseValueToItsSum() throws Exception {
+        String src = """
+                module demo
+                data In = { v: Int }
+                data Big = { v: Int }
+                data Small = { v: Int }
+                behavior run : (i: In) -> Big | Small constructs Big, Small
+                let run (i) = {
+                    let sized: Big | Small = if i.v > 10 then Big { v = i.v } else Small { v = i.v }
+                    match sized with
+                        | Big as b   -> b
+                        | Small as s -> s
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Object big = Codecs.apply(behavior, Codecs.decoded(loader, "demo.In", Map.of("v", 11L)));
+        assertEquals("demo.Big", big.getClass().getName());
+        Object small = Codecs.apply(behavior, Codecs.decoded(loader, "demo.In", Map.of("v", 1L)));
+        assertEquals("demo.Small", small.getClass().getName());
+    }
+
+    // A newtype binding: the annotation names the newtype, and the value is one.
+    @Test
+    void anAnnotationMayNameANewtype() throws Exception {
+        String src = """
+                module demo
+                data 金額 = Int
+                data In = { v: Int }
+                data Out = { total: 金額 }
+                behavior run : (i: In) -> Out constructs Out, 金額
+                let run (i) = {
+                    let total: 金額 = 金額(i.v + 1)
+                    Out { total = total }
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("v", 9L));
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(10L, out.get("total"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/HighValueDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/HighValueDiagnosticTest.java
@@ -73,10 +73,11 @@ class HighValueDiagnosticTest {
 
     @Test
     void foldOverEmptySeedWithNoContextPointsAtTheSeed() {
-        // No expected type reaches the fold (its value is bound to an un-annotated local, which
-        // Souther does not let you annotate), so the accumulator's value type is genuinely
-        // unknown. The error must point at the empty seed and suggest annotating, not at the
-        // arithmetic deep inside the inlined Map.upsert (issue #70, the misleading-location half).
+        // No expected type reaches the fold: its value is bound to a local the source left
+        // un-annotated, so the accumulator's value type is genuinely unknown. The error must point at
+        // the empty seed and say how to type it — annotate the binding (issue #71) or move the fold
+        // into a typed position — not at the arithmetic deep inside the inlined Map.upsert (issue #70,
+        // the misleading-location half).
         Diagnostic d = diagnosticOf("""
                 module demo
                 import List ( fold )

--- a/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -145,6 +145,25 @@ class FormatterTest {
     }
 
     @Test
+    void formattingKeepsALocalLetTypeAnnotation() {
+        // the annotation is what pins an empty-collection value at the binding (issue #71); dropping it
+        // would turn a compiling module into one that cannot infer the accumulator's type.
+        String source = "module demo\n"
+                + "data In = { keys: List<String> }\n"
+                + "data Out = { m: Map<String, Int> }\n"
+                + "behavior run : (i: In) -> Out constructs Out\n"
+                + "let run (i) = {\n"
+                + "let counted:Map<String,Int> = Map.empty()\n"
+                + "Out { m = counted }\n"
+                + "}\n";
+        String formatted = Formatter.format(source);
+        assertEquals(code(source), code(formatted), "the code token stream changed");
+        assertTrue(formatted.contains("let counted: Map<String, Int> ="),
+                "formatter dropped the annotation:\n" + formatted);
+        assertTrue(CstParser.parse(formatted).errors().isEmpty(), "formatted output does not re-parse");
+    }
+
+    @Test
     void canonicalFormOfAnExample() {
         String messy = "module demo\n"
                 + "data M={ n:Int }\n"

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -321,14 +321,18 @@ public final class Formatter {
         return Doc.join(text(", "), names);
     }
 
+    /** The {@code : T} a node wrote, or nothing — a helper's return type, a local binding's annotation. */
+    private Doc writtenType(SyntaxNode n) {
+        return n.child(SyntaxKind.RET_TYPE).map(rt -> concat(text(": "), retType(rt))).orElse(Doc.NIL);
+    }
+
     // --- fn ---
 
     private Doc fnDef(SyntaxNode n) {
         String name = firstIdent(n);
         Doc params = fnParamList(n.child(SyntaxKind.FN_PARAM_LIST).orElseThrow());
-        Doc ret = n.child(SyntaxKind.RET_TYPE).map(rt -> concat(text(": "), retType(rt))).orElse(Doc.NIL);
         Doc keyword = n.child(SyntaxKind.PARTIAL_MODIFIER).isPresent() ? text("partial let ") : text("let ");
-        Doc head = concat(keyword, text(name), text(" "), params, ret);
+        Doc head = concat(keyword, text(name), text(" "), params, writtenType(n));
 
         var intrinsic = n.child(SyntaxKind.INTRINSIC_BODY);
         if (intrinsic.isPresent()) {
@@ -596,7 +600,8 @@ public final class Formatter {
         List<Doc> lines = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             Doc d = switch (c.kind()) {
-                case LET_STMT -> concat(text("let "), text(firstIdent(c)), text(" = "), expr(onlyExpr(c)));
+                case LET_STMT -> concat(text("let "), text(firstIdent(c)), writtenType(c),
+                        text(" = "), expr(onlyExpr(c)));
                 case TUPLE_DESTRUCTURE -> tupleDestructure(c);
                 case REQUIRE_STMT -> requireStmt(c);
                 default -> expr(c);   // the result expression

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -330,6 +330,30 @@ class AnalyzerTest {
     }
 
     @Test
+    void renameEditsIncludeATypeWrittenOnALocalBinding() {
+        // a local binding may carry a type annotation (issue #71); renaming the type must reach it,
+        // or the rename leaves a dangling name in the body.
+        String a = "module a\n"
+                + "data N = { v: Int }\n"
+                + "behavior f : (n: N) -> N\n"
+                + "let f (n) = {\n"
+                + "let kept: N = n\n"
+                + "kept\n"
+                + "}\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a));
+
+        // cursor on the `data N` declaration (line 1, char 5)
+        java.util.Map<String, List<Range>> edits =
+                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph);
+
+        java.util.Set<Integer> lines = new java.util.HashSet<>();
+        for (Range r : edits.get("file:///a.sou")) {
+            lines.add(r.start().line());
+        }
+        assertTrue(lines.contains(4), "the annotation on line 4 is renamed: " + lines);
+    }
+
+    @Test
     void renameEditsIncludeExposingAndImportBindingSites() {
         String a = "module a exposing ( N )\ndata N = { v: Int }\n";
         String b = "module b\nimport a ( N )\nbehavior f : (n: N) -> N\nlet f (n) = n\n";

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -605,6 +605,10 @@ public final class CstParser {
         start(SyntaxKind.LET_STMT);
         bump();   // let
         expect(SyntaxKind.IDENT);
+        if (eat(SyntaxKind.COLON)) {
+            // an ordinary type: a function type may be written only in a helper parameter (spec 13.1)
+            retType();
+        }
         expect(SyntaxKind.ASSIGN);
         expr();
         finish();

--- a/specification.adoc
+++ b/specification.adoc
@@ -1649,9 +1649,12 @@ The base form is written inline, in the same source as the behavior. To keep fix
 [,text]
 ----
 let normalized = String.trim(input)
+let counted: Map<String, Int> = List.fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), keys)
 ----
 
 Reassignment is forbidden. A `+let+` is placed inside a block expression (<<block-expression>>). What follows `+let x = v+` is the scope of that binding, nested at desugaring time.
+
+A binding may carry its type, `+let x: T = v+`. The type is optional — a binding otherwise takes the type of its value — and writing it does two things: the declared type is pushed into the value, so a value only its context can type (an empty `+[]+`, `+Map.empty()+`, `+Set.empty()+`, including one produced by a `+fold+` over such a seed) takes the declared element type instead of staying undetermined (<<algebraic-types>>); and the value is checked against it, so a declared type the value does not have is a compile error rather than an ignored comment. This is the same declaration-into-body direction a helper's declared return type has (<<fn-declaration>>) — it is a declaration, not an extension of inference. As with a helper's return, `+T+` is an ordinary type: a function type belongs only in a helper's parameter position (<<fn-declaration>>), so a binding whose value is a lambda takes no annotation, and neither does a tuple destructure (`+let (a, b) = t+`).
 
 [#if]
 === if


### PR DESCRIPTION
Fixes #71.

A local binding can now carry its type. The annotation is a declaration, not an extension of inference: it reuses the expected-type push-down added for #70 as its consumer, and the value is checked against it, so a declared type the value does not have is a compile error rather than an ignored comment.

## Why it was needed

`check.fold.seed.untyped` told the author to move a fold out of a local binding and into a typed position, because nothing could type an empty seed where it was bound. That is now one annotation away:

```sou
let counted: Map<String, Int> =
    fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), i.keys)
```

Correction to the issue text: the workaround it records — a typed nullary helper for the seed, `let empty (): Map<K, V> = Map.empty()` — does not work, and did not work before #70 either. A non-recursive helper is inline-expanded at its call site, so its declared return type is not the expected type where the seed is checked. Until now the only way out was to restructure so the fold sat directly in a typed position (a record field, a behavior output).

## What is in it

- **Parser**: `: <retType>` after the bound name. A function type may be written only in a helper parameter (spec 13.1), so the grammar admits an ordinary type only, and a binding whose value is a lambda takes no annotation — reported on the surface body, because lowering expands such a binding away at each application.
- **AST**: `Ast.LetIn.annotated`, read through `annotation()`, keeps a source annotation distinct from the parameter type helper inlining puts on a binding; that carrier keeps its narrower sum-widening meaning.
- **Core / codegen**: `Core.LetIn` carries the written annotation, because the backend re-derives a fold's type independently — without it the checker accepts and codegen crashes on a bottom accumulator (the #70 trap).
- **Inference**: an annotated binding types a helper's unannotated parameter at its call site.
- **Diagnostics**: the mismatch reuses the shared TYPE MISMATCH title with a found/expected diff; the function-binding rejection sits with its siblings under FUNCTION; `check.fold.seed.untyped` now names annotating the binding as the first way out. Both locales updated.
- **Tooling**: `souther fmt` keeps the annotation (rendering shared with a helper's return type); type rename reaches into an annotation with no LSP production change, since the annotation lands in a `TYPE_REF`.
- **Spec**: §let states the rule, the direction, and the boundaries (no function type, no annotation on a tuple destructure).

## Verification

- `mvn clean test`: compiler 746, LSP 44, runtime 25 — all green.
- `mvn -o -f examples/pom.xml verify`: green.
- End-to-end through the CLI: the issue's repro compiles, the fold-in-a-local case runs, and a lying annotation reports the TYPE MISMATCH diff in both `--lang en` and `--lang ja`.

## Known follow-up

`Exposing`, `NewtypeDesugar`, and `HelperInliner` rebuild the expression tree by hand, so adding a component to `Ast.LetIn` had to be threaded through six sites. `Ast.mapChildren` exists for exactly that. Collapsing those passes onto it is a separate change, left out of this one deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
