### PR TITLE
Write countByLabel's map with a bound, annotated accumulator

### DIFF
--- a/examples/tagging/src/main/souther/tags.sou
+++ b/examples/tagging/src/main/souther/tags.sou
@@ -92,9 +92,10 @@ let assigneeOf (issue) =
 // === countByLabel: how many issues carry each label (fold + Map.upsert) ===
 // Collect every label occurrence across the board as plain strings (Set.toList each issue's labels,
 // unwrap to the text, concatenate), then fold them into a Map<String, Int>, counting each key with
-// Map.upsert — seed 1 on first sight, +1 on every repeat. The empty-map seed's value type is fixed
-// by the LabelCounts.counts field it feeds. The key is the label text (Label.value); a Map key is a
-// String or String-backed newtype.
+// Map.upsert — seed 1 on first sight, +1 on every repeat. The empty-map seed's value type comes from
+// the binding's annotation `let counts: Map<String, Int>`: a written type is pushed into the value,
+// so a fold over an empty seed can be named on its own line instead of being inlined into the field
+// it feeds. The key is the label text (Label.value); a Map key is a String or String-backed newtype.
 data LabelCounts = { counts: Map<String, Int> }
 
 behavior countByLabel : (board: Board) -> LabelCounts
@@ -104,7 +105,8 @@ behavior countByLabel : (board: Board) -> LabelCounts
 let labelKeys (issues: List<Issue>): List<String> =
     fold((acc, issue) -> acc ++ map(l -> l.value, Set.toList(issue.labels)), [], issues)
 
-let countByLabel (board) =
-    LabelCounts {
-        counts = fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), labelKeys(board.issues))
-    }
+let countByLabel (board) = {
+    let counts: Map<String, Int> =
+        fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), labelKeys(board.issues))
+    LabelCounts { counts = counts }
+}


### PR DESCRIPTION
Dogfoods #71 in the tagging example.

`countByLabel`'s fold was inlined into the `LabelCounts.counts` field because that field was the only thing that could type its `Map.empty()` seed. With a local binding able to state its own type, the fold gets a name and its own line:

```sou
let countByLabel (board) = {
    let counts: Map<String, Int> =
        fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), labelKeys(board.issues))
    LabelCounts { counts = counts }
}
```

The comment above it now describes where the seed's value type comes from, instead of describing the field-position workaround.

This is the only site in `examples/` the annotation improves. The other empty-collection seeds — `labelKeys` and `cart.sou`'s `activeItems` — already take their element type from a helper's declared return or from the other `if` branch, so they are unchanged.

Verified with `mvn -o -f examples/pom.xml verify` (all example modules green). `souther fmt --check` still reports the file, as it did before this change: `tags.sou` is hand-aligned (`data IssueId  = String`) and was never canonical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
