### PR TITLE
Fix #75: report a block with no result expression instead of crashing

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -723,6 +723,12 @@ public final class AstBuilder {
                 default -> result = c;   // the trailing result expression
             }
         }
+        if (result == null) {
+            // the parser reports this, so the compiler never gets here; a build over a CST that was
+            // parsed with errors (an editor's, say) says so rather than dereferencing the missing node
+            throw error(pos(n), "parse.block.noresult",
+                    "a block ends in a result expression, and this one has none");
+        }
         return foldStatements(stmts, 0, result);
     }
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -317,6 +317,7 @@ parse.tuple=A tuple type needs at least two elements; `(T)` is not a type.
 parse.typevar.core=A type variable `{0}` is only allowed in the core (the reserved `souther` namespace); a user model stays bounded.
 parse.vpipe.right=The right side of `|>` must be a function call or a function name.
 parse.expr=I expected an expression here.
+parse.block.noresult=This block has no result expression: `let`/`require` lines are followed by one expression, which is the block's value. Note that a line ending in a name and a next line starting with `(` read as a single call, so a result written that way belongs to the line above.
 parse.orpattern=An or-pattern binds the sum type and cannot destructure a case's fields.
 parse.option.positional=Option's wrapped value is bound positionally: write `| Some v`, not `| Some as v`.
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -316,6 +316,7 @@ parse.tuple=タプル型は要素が2つ以上必要です。`(T)` は型では�
 parse.typevar.core=型変数 `{0}` は core（予約された `souther` 名前空間）でのみ使えます。ユーザーのモデルは有界のままです。
 parse.vpipe.right=`|>` の右辺は関数呼び出しか関数名でなければなりません。
 parse.expr=ここには式が必要です。
+parse.block.noresult=このブロックに結果式がありません。`let`／`require` の行のあとに、ブロックの値となる式を1つ置きます。なお、名前で終わる行と `(` で始まる次の行は1つの呼び出しとして読まれるので、その書き方をした結果式は上の行に取り込まれています。
 parse.orpattern=or パターンは直和型を束縛するため、ケースのフィールドを分解できません。
 parse.option.positional=Option の中身は位置で束縛します。`| Some as v` ではなく `| Some v` と書きます。
 

--- a/souther-compiler/src/test/java/souther/compiler/SyntaxDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/SyntaxDiagnosticTest.java
@@ -43,6 +43,37 @@ class SyntaxDiagnosticTest {
         assertTrue(en.contains("SYNTAX ERROR") && ja.contains("構文エラー"));
     }
 
+    // Issue #75: `i.v` and the following line's `(a)` read as one call — Souther is
+    // layout-independent — which leaves the block with statements and no result expression. That used
+    // to reach the AST builder and die with a NullPointerException.
+    @Test
+    void aBlockWhoseResultWasAbsorbedByTheLineAboveIsASyntaxError() {
+        Diagnostic d = diagnosticOf("""
+                module demo
+                data Out = { v: Int }
+                behavior run : (i: Out) -> Out constructs Out
+                let run (i) = {
+                    let a = i.v
+                    (a)
+                }
+                """);
+        assertEquals("parse.title", d.titleKey());
+        assertEquals("parse.block.noresult", d.messageKey());
+    }
+
+    @Test
+    void aBlockOfOnlyStatementsIsASyntaxError() {
+        Diagnostic d = diagnosticOf("""
+                module demo
+                data Out = { v: Int }
+                behavior run : (i: Out) -> Out constructs Out
+                let run (i) = {
+                    let a = i.v
+                }
+                """);
+        assertEquals("parse.block.noresult", d.messageKey());
+    }
+
     @Test
     void lexerErrorIsLocalized() {
         Diagnostic d = diagnosticOf("module demo\ndata M = Int\nlet x = 1.5\n");

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -598,6 +598,12 @@ public final class CstParser {
         }
         if (!at(SyntaxKind.RBRACE) && !at(SyntaxKind.EOF)) {
             expr();   // the result expression
+        } else if (at(SyntaxKind.RBRACE)) {
+            // The block closes with nothing to be its value. Reported here rather than left to the AST
+            // builder, which would have no node to build from. The usual cause is not a missing line
+            // but an absorbed one: Souther is layout-independent, so a statement ending in a name and
+            // a following line starting with `(` are one call.
+            error("parse.block.noresult", "a block ends in a result expression, and this one has none");
         }
     }
 


### PR DESCRIPTION
Fixes #75.

A statement ending in a bare name followed by a line starting with `(` is one call — Souther is layout-independent. That absorbs a result expression written as a parenthesised value, leaving the block with only statements, and `AstBuilder` then dereferenced the missing result node: `NullPointerException`, no position, no message.

## What it does now

```
-- SYNTAX ERROR ----------------------------------z1.sou:7:1

7| }
   ^

This block has no result expression: `let`/`require` lines are followed by one expression, which is
the block's value. Note that a line ending in a name and a next line starting with `(` read as a
single call, so a result written that way belongs to the line above.
```

The message names the usual cause, because the mistake is rarely a missing line — it is an absorbed one. The shape that produced this report in practice is a tuple result in a fold step:

```sou
let (_, out) = fold((acc, x) -> {
    let (seen, ys) = acc
    (Set.insert(x, seen), ys ++ [x])
}, (Set.empty(), []), i.xs)
```

## Where the check lives

- `CstParser.blockStatements` reports it at the closing brace, so the editor and the formatter see it through the same CST error list as every other syntax error.
- `AstBuilder.block` keeps a guard of its own: a build over a CST that was parsed with errors says the same thing rather than dereferencing the missing node. It is unreachable from the compiler pipeline, which stops at the first parse error.

Both message keys are in `messages.properties` and `messages_ja.properties`.

## Verification

- Two new cases in `SyntaxDiagnosticTest`: the absorbed-result block, and a block of only statements. Both crashed with a NullPointerException before this change.
- `mvn clean test`: compiler 748, LSP 44, runtime 25 — green.
- `mvn -o -f examples/pom.xml verify`: green (no example or prelude block relies on having no result).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
