### PR TITLE
Close the gaps examples ran into

### DIFF
--- a/examples/ordering/src/main/souther/inventory.sou
+++ b/examples/ordering/src/main/souther/inventory.sou
@@ -152,3 +152,36 @@ example putAway
     | "a passed item is put away to a shelf" :
         (InspectionPassed { code = Barcode("9784873115658") }, Location("A-03-12"))
             -> PutAwayRecord { code = Barcode("9784873115658"), location = Location("A-03-12") }
+
+// === checkExpiry: a lot past its best-before date is held back ===
+// The warehouse stores dated lots. Whether a lot may ship today is a pure calendar computation —
+// `Date.daysBetween` over the lot's best-before date — so it stays in the domain rather than becoming
+// an injected behavior; only reading *today* needs the outside world, and it arrives as an input.
+// A date is written `Date("2026-07-25")`, in a body or in a fixture, so the rule is fixed by its
+// examples like any other.
+data Lot =
+    { sku: Sku
+    , bestBefore: Date
+    }
+data Fresh = { sku: Sku }
+data Expired = { daysPast: Int }
+
+behavior checkExpiry : (lot: Lot, today: Date) -> Fresh | Expired
+    constructs Fresh, Expired
+
+let checkExpiry (lot, today) = {
+    let past = Date.daysBetween(lot.bestBefore, today)
+    require past <= 0 else Expired { daysPast = past }
+    Fresh { sku = lot.sku }
+}
+
+example checkExpiry
+    | "a lot still within date ships" :
+        (Lot { sku = Sku("milk"), bestBefore = Date("2026-08-01") }, Date("2026-07-25"))
+            -> Fresh { sku = Sku("milk") }
+    | "a lot past its best-before is held back" :
+        (Lot { sku = Sku("milk"), bestBefore = Date("2026-07-20") }, Date("2026-07-25"))
+            -> Expired { daysPast = 5 }
+    | "the best-before day itself still ships" :
+        (Lot { sku = Sku("milk"), bestBefore = Date("2026-07-25") }, Date("2026-07-25"))
+            -> Fresh { sku = Sku("milk") }

--- a/examples/tagging/src/main/souther/tags.sou
+++ b/examples/tagging/src/main/souther/tags.sou
@@ -157,7 +157,8 @@ let labelKeys (issues: List<Issue>): List<String> =
     fold((acc, issue) -> acc ++ map(l -> l.value, Set.toList(issue.labels)), [], issues)
 
 // The counts themselves, shared with the ranking below. The helper's declared return type is pushed
-// into its body, so the empty-map seed takes its value type from `Map<String, Int>`.
+// into its body wherever it expands, so the empty-map seed takes its value type from
+// `Map<String, Int>` — including under `Map.toList`, whose parameter says nothing concrete.
 let labelCounts (issues: List<Issue>): Map<String, Int> =
     fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), labelKeys(issues))
 
@@ -195,18 +196,14 @@ let entryCount (e: (String, Int)): Int = {
     count
 }
 
-// The counts are named on their own line with their type: `Map.toList`'s parameter is generic, so
-// a fold over an empty seed feeding it directly would have nothing to fix its accumulator type.
-let topLabels (board, n) = {
-    let counts: Map<String, Int> = labelCounts(board.issues)
+let topLabels (board, n) =
     LabelRanking { labels =
-        Map.toList(counts)
+        Map.toList(labelCounts(board.issues))
             |> List.sortBy(e -> entryCount(e))
             |> List.reverse
             |> List.take(n)
             |> map(entryLabel)
     }
-}
 
 example topLabels
     | "the most-used label leads the ranking" :

--- a/examples/tagging/src/main/souther/tags.sou
+++ b/examples/tagging/src/main/souther/tags.sou
@@ -7,13 +7,16 @@
 //   - Set<Label> as a data field (labels): the derived codec reads a JSON array and dedups it into a
 //     Set; Set.fromList / insert / remove / intersect / toList / size drive the label operations.
 //   - Map<Label, Int> as a behavior output (countByLabel): Map.upsert counts each label across a
-//     board of issues (a String-backed newtype key is allowed as a map key).
+//     board of issues (a String-backed newtype key is allowed as a map key), and topLabels ranks those
+//     counts — Map.toList's (label, count) entries read through a tuple-typed helper, ordered with
+//     List.sortBy / reverse and cut with List.take.
 //   - Some(Assignee(name)) destructuring: assigneeOf opens the optional assignee's newtype in one
 //     match pattern (the outermost .value elided), with a None arm for the unassigned case.
 //
-// The behaviors are pure, so there is no `fake`. Set / Map / Option values have no literal syntax, so
-// they cannot appear in `example` fixtures; correctness is checked by the JUnit smoke test, which
-// decodes JSON (arrays -> Set, objects -> Map) and reads results back through the encoder.
+// The behaviors are pure, so there is no `fake`, and every one of them carries its `example`s: a Set
+// is written as a list (duplicates collapse on decode, as they do at the boundary), a Map as its list
+// of (key, value) pairs, and an optional as the bare value or `None`. The JUnit smoke test still runs
+// one behavior end to end, decoding JSON (arrays -> Set, objects -> Map) through the derived codecs.
 //
 // exposing is omitted, so every generated class is public — the smoke test references them by name.
 module example.tagging
@@ -61,6 +64,12 @@ let normalizeLabels (input) = {
     LabelSet { labels = labels }
 }
 
+example normalizeLabels
+    | "case and spacing collapse into one label" :
+        (RawLabels { text = "Bug, bug , UI" })
+            -> LabelSet { labels = [ Label("bug"), Label("ui") ] }
+    | "blank pieces leave no labels" : (RawLabels { text = " , " }) -> NoLabels
+
 // === addLabel / removeLabel: Set insert / remove on the labels field ===
 // Constructor spread reuses every other field; only labels changes.
 behavior addLabel : (issue: Issue, label: Label) -> Issue
@@ -71,10 +80,43 @@ behavior removeLabel : (issue: Issue, label: Label) -> Issue
     constructs Issue
 let removeLabel (issue, label) = Issue { ...issue, labels = Set.remove(label, issue.labels) }
 
+// A Set fixture is a list; adding a label already carried leaves the set as it was, and the optional
+// assignee is written bare (present) or as `None`.
+example addLabel
+    | "a new label joins the set" :
+        (Issue { id = IssueId("i-1"), title = "crash on save", labels = [ Label("bug") ],
+            assignee = "kawasima" }, Label("ui"))
+        -> Issue { id = IssueId("i-1"), title = "crash on save",
+            labels = [ Label("bug"), Label("ui") ], assignee = "kawasima" }
+    | "a label already carried changes nothing" :
+        (Issue { id = IssueId("i-1"), title = "crash on save", labels = [ Label("bug") ],
+            assignee = None }, Label("bug"))
+        -> Issue { id = IssueId("i-1"), title = "crash on save", labels = [ Label("bug") ],
+            assignee = None }
+
+example removeLabel
+    | "the label leaves the set" :
+        (Issue { id = IssueId("i-1"), title = "crash on save",
+            labels = [ Label("bug"), Label("ui") ], assignee = None }, Label("ui"))
+        -> Issue { id = IssueId("i-1"), title = "crash on save", labels = [ Label("bug") ],
+            assignee = None }
+
 // === sharedLabels: the labels two issues have in common (Set intersection) ===
 behavior sharedLabels : (a: Issue, b: Issue) -> LabelSet
     constructs LabelSet
 let sharedLabels (a, b) = LabelSet { labels = Set.intersect(a.labels, b.labels) }
+
+example sharedLabels
+    | "only the labels both issues carry" :
+        (Issue { id = IssueId("i-1"), title = "a", labels = [ Label("bug"), Label("ui") ],
+            assignee = None },
+         Issue { id = IssueId("i-2"), title = "b", labels = [ Label("ui"), Label("docs") ],
+            assignee = None })
+        -> LabelSet { labels = [ Label("ui") ] }
+    | "nothing in common is an empty set" :
+        (Issue { id = IssueId("i-1"), title = "a", labels = [ Label("bug") ], assignee = None },
+         Issue { id = IssueId("i-2"), title = "b", labels = [ Label("docs") ], assignee = None })
+        -> LabelSet { labels = [] }
 
 // === assigneeOf: open the optional assignee with a Some(Newtype) pattern ===
 // Some's first written layer opens the element type directly, so Some(Assignee(name)) binds name to
@@ -89,13 +131,22 @@ let assigneeOf (issue) =
         | Some(Assignee(name)) -> Assigned { name = name }
         | None -> Unassigned
 
+example assigneeOf
+    | "an assigned issue names its assignee" :
+        (Issue { id = IssueId("i-1"), title = "a", labels = [ Label("bug") ],
+            assignee = "kawasima" })
+        -> Assigned { name = "kawasima" }
+    | "an unassigned issue takes the None arm" :
+        (Issue { id = IssueId("i-1"), title = "a", labels = [ Label("bug") ], assignee = None })
+        -> Unassigned
+
 // === countByLabel: how many issues carry each label (fold + Map.upsert) ===
 // Collect every label occurrence across the board as plain strings (Set.toList each issue's labels,
 // unwrap to the text, concatenate), then fold them into a Map<String, Int>, counting each key with
 // Map.upsert — seed 1 on first sight, +1 on every repeat. The empty-map seed's value type comes from
-// the binding's annotation `let counts: Map<String, Int>`: a written type is pushed into the value,
-// so a fold over an empty seed can be named on its own line instead of being inlined into the field
-// it feeds. The key is the label text (Label.value); a Map key is a String or String-backed newtype.
+// the helper's declared return type `Map<String, Int>`: a written type is pushed into the body, so a
+// fold over an empty seed can stand on its own rather than being inlined into the field it feeds. The
+// key is the label text (Label.value); a Map key is a String or a String-backed newtype.
 data LabelCounts = { counts: Map<String, Int> }
 
 behavior countByLabel : (board: Board) -> LabelCounts
@@ -105,8 +156,70 @@ behavior countByLabel : (board: Board) -> LabelCounts
 let labelKeys (issues: List<Issue>): List<String> =
     fold((acc, issue) -> acc ++ map(l -> l.value, Set.toList(issue.labels)), [], issues)
 
-let countByLabel (board) = {
-    let counts: Map<String, Int> =
-        fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), labelKeys(board.issues))
-    LabelCounts { counts = counts }
+// The counts themselves, shared with the ranking below. The helper's declared return type is pushed
+// into its body, so the empty-map seed takes its value type from `Map<String, Int>`.
+let labelCounts (issues: List<Issue>): Map<String, Int> =
+    fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), labelKeys(issues))
+
+let countByLabel (board) = LabelCounts { counts = labelCounts(board.issues) }
+
+// A Map fixture is its list of (key, value) pairs, as `Map.fromList` takes it.
+example countByLabel
+    | "each label counted across the board" :
+        (Board { issues =
+            [ Issue { id = IssueId("i-1"), title = "a", labels = [ Label("bug"), Label("ui") ],
+                assignee = None }
+            , Issue { id = IssueId("i-2"), title = "b", labels = [ Label("bug") ],
+                assignee = "kawasima" } ] })
+        -> LabelCounts { counts = [ ("bug", 2), ("ui", 1) ] }
+    | "an empty board counts nothing" : (Board { issues = [] }) -> LabelCounts { counts = [] }
+
+// === topLabels: the most-used labels, most frequent first ===
+// The ranking side of the same counts. `Map.toList` hands the counts over as `(label, count)` pairs;
+// a tuple type may be written in a helper signature, and `let (a, b) = e` opens one, so the entries
+// are read without leaving the pipe. `List.sortBy` + `List.reverse` order them by count, and
+// `List.take` keeps the head of the ranking. A tie falls back to the map's iteration order, which is
+// deterministic but unspecified — the example below avoids one.
+data LabelRanking = { labels: List<String> }
+
+behavior topLabels : (board: Board, n: Int) -> LabelRanking
+    constructs LabelRanking
+
+let entryLabel (e: (String, Int)): String = {
+    let (label, _) = e
+    label
 }
+
+let entryCount (e: (String, Int)): Int = {
+    let (_, count) = e
+    count
+}
+
+// The counts are named on their own line with their type: `Map.toList`'s parameter is generic, so
+// a fold over an empty seed feeding it directly would have nothing to fix its accumulator type.
+let topLabels (board, n) = {
+    let counts: Map<String, Int> = labelCounts(board.issues)
+    LabelRanking { labels =
+        Map.toList(counts)
+            |> List.sortBy(e -> entryCount(e))
+            |> List.reverse
+            |> List.take(n)
+            |> map(entryLabel)
+    }
+}
+
+example topLabels
+    | "the most-used label leads the ranking" :
+        (Board { issues =
+            [ Issue { id = IssueId("i-1"), title = "a", labels = [ Label("bug"), Label("ui") ],
+                assignee = None }
+            , Issue { id = IssueId("i-2"), title = "b", labels = [ Label("bug") ],
+                assignee = None } ] }, 1)
+        -> LabelRanking { labels = [ "bug" ] }
+    | "asking for more than there are gives every label" :
+        (Board { issues =
+            [ Issue { id = IssueId("i-1"), title = "a", labels = [ Label("bug"), Label("ui") ],
+                assignee = None }
+            , Issue { id = IssueId("i-2"), title = "b", labels = [ Label("bug") ],
+                assignee = None } ] }, 9)
+        -> LabelRanking { labels = [ "bug", "ui" ] }

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -548,14 +548,110 @@ public final class ExampleVerifier {
         return arm != null ? Type.ref(arm) : declared;
     }
 
+    /** The written expectation, rendered as it was written: a bare arm stays the arm name, anything
+     * else is its neutral form under that arm ({@code Out { n = 7 }}). */
     private String describeExpected(Ast.Expr expected) {
         String arm = expectedArm(expected);
-        return arm != null ? arm : String.valueOf(rawOrNull(expected));
+        if (expected instanceof Ast.Var) {
+            return arm;   // a bare arm asserts only the case, so there is no value to show
+        }
+        // Render it through the same encoder the actual goes through, so the two sides are written
+        // in one notation and can be read against each other; the fixture's own neutral form (which
+        // still holds e.g. a LocalDate where the encoder writes its ISO text) is the fallback.
+        Object built = buildExpected(expected);
+        Object neutral = built == null || arm == null ? rawOrNull(expected) : encodedOrNull(built, arm);
+        if (neutral == null) {
+            neutral = rawOrNull(expected);
+        }
+        if (neutral == null) {
+            return arm != null ? arm : "?";
+        }
+        return arm != null ? show(arm, neutral) : showValue(neutral);
     }
 
+    /** What actually came out, in the same notation: the case name plus the value the derived encoder
+     * writes, so the two sides of a mismatch can be read against each other. A value with no encoder
+     * (or one that fails to encode) falls back to its case name alone. */
     private String describeActual(Object result) {
         String name = simpleName(result);
-        return name.isEmpty() ? String.valueOf(result) : name;
+        if (name.isEmpty()) {
+            return String.valueOf(result);
+        }
+        Object encoded = encodedOrNull(result, name);
+        if (encoded != null) {
+            return show(name, encoded);
+        }
+        return isScalar(result) ? showValue(result) : name;
+    }
+
+    /** Whether a value is a neutral scalar, so it can be shown as written rather than by class name. */
+    private static boolean isScalar(Object v) {
+        return v instanceof String || v instanceof Long || v instanceof Boolean
+                || v instanceof BigDecimal || v instanceof java.time.LocalDate
+                || v instanceof java.time.LocalDateTime;
+    }
+
+    /** {@code result} through its class's derived {@code encoder()}, or null when it has none. */
+    private Object encodedOrNull(Object result, String name) {
+        try {
+            String pkg = importedPackages.getOrDefault(name, module.name());
+            Class<?> c = loader.loadClass(pkg + "." + name);
+            Object encoder = c.getMethod("encoder").invoke(null);
+            return net.unit8.raoh.encode.Encoder.class.getMethod("encode", Object.class)
+                    .invoke(encoder, result);
+        } catch (ReflectiveOperationException | RuntimeException e) {
+            return null;
+        }
+    }
+
+    /** A case name with its neutral value: a record's fields in braces, a newtype's value in parens,
+     * a unit case as the bare name. */
+    private String show(String name, Object neutral) {
+        if (neutral instanceof Map<?, ?> fields) {
+            if (fields.isEmpty()) {
+                return name;
+            }
+            StringBuilder sb = new StringBuilder(name).append(" { ");
+            boolean first = true;
+            for (Map.Entry<?, ?> e : fields.entrySet()) {
+                if (!first) {
+                    sb.append(", ");
+                }
+                first = false;
+                sb.append(e.getKey()).append(" = ").append(showValue(e.getValue()));
+            }
+            return sb.append(" }").toString();
+        }
+        return name + "(" + showValue(neutral) + ")";
+    }
+
+    /** A neutral value in the notation a fixture is written in: a quoted string, a list in brackets,
+     * a map as its list of pairs, a date as {@code Date("...")}. */
+    private String showValue(Object v) {
+        if (v == null) {
+            return "None";
+        }
+        if (v instanceof String s) {
+            return "\"" + s + "\"";
+        }
+        if (v instanceof java.time.LocalDate || v instanceof java.time.LocalDateTime) {
+            return (v instanceof java.time.LocalDate ? "Date(\"" : "DateTime(\"") + v + "\")";
+        }
+        if (v instanceof Map<?, ?> m) {
+            List<String> entries = new ArrayList<>();
+            for (Map.Entry<?, ?> e : m.entrySet()) {
+                entries.add("(" + showValue(e.getKey()) + ", " + showValue(e.getValue()) + ")");
+            }
+            return "[ " + String.join(", ", entries) + " ]";
+        }
+        if (v instanceof Iterable<?> it) {
+            List<String> elements = new ArrayList<>();
+            for (Object e : it) {
+                elements.add(showValue(e));
+            }
+            return elements.isEmpty() ? "[]" : "[ " + String.join(", ", elements) + " ]";
+        }
+        return String.valueOf(v);
     }
 
     private Object rawOrNull(Ast.Expr e) {
@@ -607,6 +703,15 @@ public final class ExampleVerifier {
                 }
                 yield out;
             }
+            // a `(key, value)` pair: only a `Map` field's entries are written this way, and `shaped`
+            // collects them into the map the decoder reads (a tuple is not a data field type itself).
+            case Ast.Tuple t -> {
+                List<Object> out = new ArrayList<>();
+                for (Ast.Expr el : t.elements()) {
+                    out.add(raw(el));
+                }
+                yield out;
+            }
             default -> throw new FixtureException("an example fixture must be a literal or a construction");
         };
     }
@@ -626,11 +731,26 @@ public final class ExampleVerifier {
     }
 
     private Object newtypeInner(Ast.Call c) {
+        if (c.fn().equals("Date") || c.fn().equals("DateTime")) {
+            // a written date: the decoders take the parsed temporal, not its text (a Date field's
+            // neutral form is a LocalDate), so the fixture hands over the same value the checker read
+            if (c.args().size() != 1 || !(c.args().get(0) instanceof Ast.StringLit lit)) {
+                throw new FixtureException("`" + c.fn() + "` takes one written string");
+            }
+            return TypeChecker.parseTemporal(c.fn(), lit.value(), c.pos());
+        }
         if (!isNewtype(c.fn())) {
             throw new FixtureException("`" + c.fn() + "` is not a newtype; a fixture cannot call it");
         }
         if (c.args().size() != 1) {
             throw new FixtureException("`" + c.fn() + "` takes one argument");
+        }
+        // a newtype over a temporal (`data 貸出日 = Date`) wraps the parsed value, so its written
+        // string is read here as it would be for a bare `Date("...")`
+        String base = newtypeBase(c.fn());
+        if (("Date".equals(base) || "DateTime".equals(base))
+                && c.args().get(0) instanceof Ast.StringLit lit) {
+            return TypeChecker.parseTemporal(base, lit.value(), c.pos());
         }
         return raw(c.args().get(0));
     }
@@ -639,9 +759,10 @@ public final class ExampleVerifier {
         if (!nd.spreads().isEmpty()) {
             throw new FixtureException("a `...spread` cannot be used in an example fixture");
         }
+        Map<String, Ast.TypeRef> declared = fieldTypes(nd.typeName());
         Map<String, Object> map = new LinkedHashMap<>();
         for (Ast.FieldInit fi : nd.inits()) {
-            Object v = raw(fi.value());
+            Object v = shaped(raw(fi.value()), declared.get(fi.name()));
             // `None` on a `T?` field yields a null; leave the key out so the optional decoder reads
             // it as absent (spec 8, absent -> None), the same neutral form as omitting the field.
             if (v == null) {
@@ -652,8 +773,60 @@ public final class ExampleVerifier {
         return map;
     }
 
+    /** A data's fields by name, following the `...includes` it composes in (spec §data). */
+    private Map<String, Ast.TypeRef> fieldTypes(String typeName) {
+        Map<String, Ast.TypeRef> out = new LinkedHashMap<>();
+        if (symbols.get(typeName) instanceof Ast.Data d) {
+            for (String inc : d.includes()) {
+                out.putAll(fieldTypes(inc));
+            }
+            for (Ast.Field f : d.fields()) {
+                out.put(f.name(), f.type());
+            }
+        }
+        return out;
+    }
+
+    /** Gives a fixture value the neutral shape its declared type decodes from. A {@code Map} field is
+     * written as a list of {@code (key, value)} pairs — Elm's {@code Dict.fromList}, and the same
+     * list literal a {@code Set} field takes — while the decoder wants a map, so the pairs are
+     * collected here. Everything else passes through; a {@code List} field written as a list stays
+     * one, since the declared type, not the literal, decides. */
+    private Object shaped(Object v, Ast.TypeRef type) {
+        if (type == null || v == null) {
+            return v;
+        }
+        if ("Map".equals(type.name()) && v instanceof List<?> entries) {
+            Ast.TypeRef value = type.arg();
+            Map<Object, Object> m = new LinkedHashMap<>();
+            for (Object entry : entries) {
+                if (!(entry instanceof List<?> pair) || pair.size() != 2) {
+                    throw new FixtureException("a `Map` fixture is a list of (key, value) pairs,"
+                            + " e.g. [ (\"apple\", 3) ]");
+                }
+                m.put(pair.get(0), shaped(pair.get(1), value));
+            }
+            return m;
+        }
+        if (("List".equals(type.name()) || "Set".equals(type.name())) && v instanceof List<?> elements) {
+            List<Object> out = new ArrayList<>(elements.size());
+            for (Object e : elements) {
+                out.add(shaped(e, type.arg()));
+            }
+            return out;
+        }
+        return v;
+    }
+
     private boolean isNewtype(String name) {
         return symbols.get(name) instanceof Ast.Data d && d.newtype();
+    }
+
+    /** The type a newtype wraps ({@code Date} for {@code data 貸出日 = Date}), or null. */
+    private String newtypeBase(String name) {
+        return symbols.get(name) instanceof Ast.Data d && d.newtype() && d.fields().size() == 1
+                ? d.fields().get(0).type().name()
+                : null;
     }
 
     private static Object negate(Object v) {

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -642,7 +642,7 @@ public final class ExampleVerifier {
             for (Map.Entry<?, ?> e : m.entrySet()) {
                 entries.add("(" + showValue(e.getKey()) + ", " + showValue(e.getValue()) + ")");
             }
-            return "[ " + String.join(", ", entries) + " ]";
+            return entries.isEmpty() ? "[]" : "[ " + String.join(", ", entries) + " ]";
         }
         if (v instanceof Iterable<?> it) {
             List<String> elements = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -218,6 +218,73 @@ public final class HelperInliner {
         }
     }
 
+    /** Keeps a helper's declared return type on the body spliced into the caller, as the annotation of
+     * a binding the body flows through ({@code let $r0: Map<String, Int> = <body> in $r0}). A declared
+     * return is a declaration into the body (spec §fn-declaration), and inlining is where it would
+     * otherwise be lost: at a call site that expects nothing concrete — a generic parameter such as
+     * {@code Map.toList}'s — the declaration is the only thing that can fix an empty-collection seed
+     * inside the body.
+     *
+     * <p>Only a collection-bearing return type is carried. A scalar return has nothing to fix, and
+     * leaving those bodies bare keeps a constant-foldable expression ({@code 金額(税込(100))}) a plain
+     * expression for the compile-time invariant check. A union return is left alone too: the binding
+     * would name one type where the body may produce several. */
+    private Ast.Expr keepDeclaredReturn(Ast.FnDef helper, Ast.Expr body, SourcePos pos, int k) {
+        Ast.RetType declared = helper.declaredReturn();
+        if (declared == null || declared.cases().size() != 1
+                || !carriesCollection(declared.cases().get(0))
+                || mentionsTypeVar(declared.cases().get(0))) {
+            return body;
+        }
+        String bound = "$r" + k;
+        return Ast.LetIn.annotated(bound, body, declared, new Ast.Var(bound, pos), pos);
+    }
+
+    /** Whether a written type has a collection anywhere inside it — the types whose element/value type
+     * an empty literal leaves open until something declares it. */
+    private static boolean carriesCollection(Ast.TypeRef ref) {
+        if (ref == null) {
+            return false;
+        }
+        if ("List".equals(ref.name()) || "Map".equals(ref.name()) || "Set".equals(ref.name())) {
+            return true;
+        }
+        if (carriesCollection(ref.arg())) {
+            return true;
+        }
+        if (ref.tupleElems() != null) {
+            for (Ast.TypeRef e : ref.tupleElems()) {
+                if (carriesCollection(e)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** Whether a written type has a type variable inside it. A generic declared return ({@code
+     * Map.upsert}'s {@code Map<'k, 'a>}) says nothing concrete at a call site, so it is not carried —
+     * the caller's own arguments are what fix those variables. */
+    private static boolean mentionsTypeVar(Ast.TypeRef ref) {
+        if (ref == null) {
+            return false;
+        }
+        if (ref.name() != null && ref.name().startsWith("'")) {
+            return true;
+        }
+        if (mentionsTypeVar(ref.arg())) {
+            return true;
+        }
+        if (ref.tupleElems() != null) {
+            for (Ast.TypeRef e : ref.tupleElems()) {
+                if (mentionsTypeVar(e)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     /** Rewrites every helper call in {@code e} to its inlined body. */
     public Ast.Expr inline(Ast.Expr e) {
         return switch (e) {
@@ -310,6 +377,7 @@ public final class HelperInliner {
                 SourcePos at = own.containsKey(helper.name()) ? null : call.pos();
                 Ast.Expr body = inline(rename(helper.body(), subst, fnParams, at));   // expand nested helpers too
                 scopedLambdas.keySet().forEach(helpers::remove);
+                body = keepDeclaredReturn(helper, body, call.pos(), k);
                 // wrap innermost-first so the value parameters bind in declared order
                 for (int i = letNames.size() - 1; i >= 0; i--) {
                     body = new Ast.LetIn(letNames.get(i), letValues.get(i), letTypes.get(i), body, call.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -31,7 +31,14 @@ public final class HelperInliner {
     private final Map<String, Ast.FnDef> helpers;   // prelude + module-own, keyed by name (inlining)
     private final Map<String, Ast.FnDef> own;       // the module's own helpers (standalone check)
     private final Set<String> recursive = new HashSet<>();   // own helpers on a call cycle (spec 13.1)
+    private final Map<String, LambdaOrigin> lambdaOrigins = new HashMap<>();   // $k_p -> where it was written
     private int counter = 0;
+
+    /** Where a lambda given to a function parameter was written: the parameter it fills, the helper
+     * that declares that parameter, and the lambda's own position. The lambda is inlined under a
+     * synthetic {@code $k_p} name, which must never reach a diagnostic — an error about it is
+     * reported against these instead. */
+    private record LambdaOrigin(String param, String owner, SourcePos pos) {}
 
     private HelperInliner(Map<String, Ast.FnDef> helpers, Map<String, Ast.FnDef> own) {
         this.helpers = helpers;
@@ -227,6 +234,20 @@ public final class HelperInliner {
                     yield new Ast.Call(call.fn(), args, call.pos());
                 }
                 if (args.size() != helper.params().size()) {
+                    LambdaOrigin origin = lambdaOrigins.get(helper.name());
+                    if (origin != null) {
+                        // the callee is a lambda the caller wrote, applied by the combinator it was
+                        // given to: report the parameter count against the lambda, not the synthetic
+                        // name it is inlined under.
+                        throw CompileException.of(
+                                Diagnostic.of(null, "check.fn.blockparam.arity").title("check.fn.title")
+                                        .at(origin.pos())
+                                        .args(origin.param(), origin.owner(), args.size(),
+                                                helper.params().size()).build(),
+                                "the block passed to `" + origin.param() + "` of `let " + origin.owner()
+                                        + "` takes " + args.size() + " argument(s) but is written with "
+                                        + helper.params().size());
+                    }
                     throw CompileException.of(
                             Diagnostic.of(null, "check.helper.arity").title("check.arity.title")
                                     .at(call.pos(), call.fn().length())
@@ -263,6 +284,7 @@ public final class HelperInliner {
                             // the lambda's body is caller code, so it is not renamed by this helper's
                             // substitution — only the enclosing helper body is.
                             scopedLambdas.put(f, new Ast.FnDef(f, lparams, null, null, lambda.body(), lambda.pos()));
+                            lambdaOrigins.put(f, new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
                         } else {
                             throw CompileException.of(
                                     Diagnostic.of(null, "check.fn.mustbenamed").title("check.fn.title")

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -3742,7 +3742,7 @@ public final class TypeChecker {
                     Diagnostic.of(null, "check.temporal.malformed").title("check.type.mismatch.title")
                             .at(pos, fn.length()).args(fn, text).build(),
                     "`" + text + "` is not a " + fn + " (expected "
-                            + (fn.equals("Date") ? "YYYY-MM-DD" : "YYYY-MM-DDThh:mm[:ss]") + ")");
+                            + (fn.equals("Date") ? "YYYY-MM-DD" : "YYYY-MM-DDTHH:mm[:ss]") + ")");
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -750,10 +750,33 @@ public final class TypeChecker {
         }
         for (int i = 0; i < declared.size(); i++) {
             if (declared.get(i) instanceof Type.FnOf fn0) {
-                checkFunctionArg(h, h.params().get(i).name(), (Type.FnOf) substitute(fn0, bind),
+                Type.FnOf want = (Type.FnOf) substitute(fn0, bind);
+                if (carriesBottom(want)) {
+                    // An empty-collection seed ([], Map.empty) binds the accumulator to a bottom, and
+                    // the step is what grows it to the concrete type — exactly the shape a fold over
+                    // an empty seed has (`Map.fold(step, [], m)`). Nothing concrete to check against
+                    // here; the inlined check, which sees the expected type pushed down, decides.
+                    continue;
+                }
+                checkFunctionArg(h, h.params().get(i).name(), want,
                         call.args().get(i), env, symbols, reqs, inliner);
             }
         }
+    }
+
+    /** Whether a step's signature still carries an empty-collection bottom in a parameter or in its
+     * result — the accumulator of a fold seeded with {@code []} / {@code Map.empty()}, which only the
+     * step itself grows to a concrete type. */
+    private static boolean carriesBottom(Type.FnOf fn) {
+        if (Type.mentions(fn.result(), TypeChecker::isBottom)) {
+            return true;
+        }
+        for (Type p : fn.params()) {
+            if (Type.mentions(p, TypeChecker::isBottom)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static void checkFunctionArg(Ast.FnDef h, String paramName, Type.FnOf want, Ast.Expr arg,
@@ -2478,7 +2501,8 @@ public final class TypeChecker {
             return typeOfOptionMatch(m, oo.element(), env, data, symbols, reqs, expected);
         }
         if (st instanceof Type.Union union) {
-            return typeOfCasesMatch(m, union.members(), "union " + union, st, env, data, symbols, reqs, expected);
+            return typeOfCasesMatch(m, union.members(), "union `" + Type.show(union) + "`",
+                    st, env, data, symbols, reqs, expected);
         }
         if (!(st instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.SumData sum)) {
             throw CompileException.of(
@@ -2885,6 +2909,10 @@ public final class TypeChecker {
                 arity(call, 0);
                 // empty set's element type fixed by context (ADR-0028); adopt an expected set type
                 yield expected instanceof Type.SetOf se ? se : Type.set(Type.NOTHING);
+            }
+            case "Date", "DateTime" -> {
+                arity(call, 1);
+                yield temporalLiteral(call);
             }
             case "Int.remainder" -> {
                 arity(call, 2);
@@ -3682,6 +3710,40 @@ public final class TypeChecker {
                         .args(subject, Localizable.of("kind.ordered.list"), Type.show(element))
                         .hint("check.ordered.hint").build(),
                 legacy);
+    }
+
+    /** A written date — {@code Date("2026-07-01")} / {@code DateTime("2026-07-01T09:00")}. The
+     * argument must be a string literal: the compiler parses it here, so a malformed date fails the
+     * build rather than a run (and an {@code example} fixture, which may only hold literals, can
+     * carry a date at all). A computed date comes from the boundary or from {@code Date.addDays},
+     * not from this form. */
+    private static Type temporalLiteral(Ast.Call call) {
+        boolean isDate = call.fn().equals("Date");
+        if (!(call.args().get(0) instanceof Ast.StringLit lit)) {
+            throw CompileException.of(
+                    Diagnostic.of(null, "check.temporal.literal").title("check.type.mismatch.title")
+                            .at(call.pos(), call.fn().length()).args(call.fn()).build(),
+                    "`" + call.fn() + "(...)` takes a written string, e.g. "
+                            + (isDate ? "Date(\"2026-07-01\")" : "DateTime(\"2026-07-01T09:00\")"));
+        }
+        parseTemporal(call.fn(), lit.value(), call.pos());
+        return isDate ? Type.DATE : Type.DATETIME;
+    }
+
+    /** Parses a written temporal, reporting a malformed one against {@code pos}. Returns the parsed
+     * value so the backend and the example verifier share this one reading of the text. */
+    public static Object parseTemporal(String fn, String text, SourcePos pos) {
+        try {
+            return fn.equals("Date")
+                    ? java.time.LocalDate.parse(text)
+                    : java.time.LocalDateTime.parse(text);
+        } catch (java.time.format.DateTimeParseException e) {
+            throw CompileException.of(
+                    Diagnostic.of(null, "check.temporal.malformed").title("check.type.mismatch.title")
+                            .at(pos, fn.length()).args(fn, text).build(),
+                    "`" + text + "` is not a " + fn + " (expected "
+                            + (fn.equals("Date") ? "YYYY-MM-DD" : "YYYY-MM-DDThh:mm[:ss]") + ")");
+        }
     }
 
     private static void arity(Ast.Call call, int n) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -821,7 +821,8 @@ final class BodyGen {
                     // find(p, xs) / sortBy(key, xs): the function is a value here (not inlined into a
                     // fold), so materialise it as an Fn, then pass the list. The list's element type
                     // gives the function's one parameter type.
-                    Type lt = TypeChecker.typeOf(call.args().get(1).toAst(), typesEnv(), data, symbols, reqSigs());
+                    Type lt = TypeChecker.typeOf(call.args().get(1).toAst(), typesEnvWithHelpers(),
+                            data, symbols, reqSigs());
                     Type elem = ((Type.ListOf) lt).element();
                     emitFunctionValue(call.args().get(0).toAst(), List.of(elem));   // Fn on the stack
                     genExpr(call.args().get(1));                                    // then the List
@@ -836,7 +837,8 @@ final class BodyGen {
                     // map(f, opt): materialise f as an Fn (its one parameter is the option's element
                     // type), then the option. `Option` is not surface-writable, so the rewrap into
                     // Some(f v) / None happens in the runtime kernel (Option.map), not in emitted code.
-                    Type ot = TypeChecker.typeOf(call.args().get(1).toAst(), typesEnv(), data, symbols, reqSigs());
+                    Type ot = TypeChecker.typeOf(call.args().get(1).toAst(), typesEnvWithHelpers(),
+                            data, symbols, reqSigs());
                     Type elem = ((Type.OptionOf) ot).element();
                     Type fnT = emitFunctionValue(call.args().get(0).toAst(), List.of(elem));  // Fn on the stack
                     genExpr(call.args().get(1));                                              // then the Option

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -861,6 +861,15 @@ final class BodyGen {
                     code.invokestatic(CD_Sets, "empty", MethodTypeDesc.of(CD_Set));
                     return expected instanceof Type.SetOf se ? se : Type.set(Type.NOTHING);
                 }
+                case "Date", "DateTime" -> {
+                    // a written date: the checker has already parsed the literal, so the text is
+                    // known good and this is a plain parse of a constant string.
+                    boolean isDate = call.fn().equals("Date");
+                    ClassDesc cd = isDate ? CD_LocalDate : CD_LocalDateTime;
+                    code.loadConstant(((Core.Str) call.args().get(0)).value());
+                    code.invokestatic(cd, "parse", MethodTypeDesc.of(cd, CD_CharSequence));
+                    return isDate ? Type.DATE : Type.DATETIME;
+                }
                 case "Int.divide", "Decimal.divide" -> {
                     if (call.args().size() == 4) {
                         return decimalDivide(call);

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -32,6 +32,7 @@ public final class AstBuilder {
     private int matchWholeCounter = 0;
     private int tupleCounter = 0;
     private int getterCounter = 0;
+    private int spreadCounter = 0;
 
     private AstBuilder(String source) {
         this.lines = new LineIndex(source);
@@ -581,9 +582,25 @@ public final class AstBuilder {
         String typeName = firstIdentText(n);
         List<Ast.FieldInit> inits = new ArrayList<>();
         List<String> spreads = new ArrayList<>();
+        // a spread naming a field path (`...c.address`) binds that path first, so the construction
+        // itself still spreads a plain local: `let $s0 = c.address in Address { ...$s0, ... }`
+        List<String> pathNames = new ArrayList<>();
+        List<Ast.Expr> pathValues = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             if (c.kind() == SyntaxKind.SPREAD_MEMBER) {
-                spreads.add(firstIdentText(c));
+                List<SyntaxToken> path = identTokens(c);
+                if (path.size() == 1) {
+                    spreads.add(path.get(0).text());
+                } else {
+                    String bound = "$s" + (spreadCounter++);
+                    Ast.Expr value = new Ast.Var(path.get(0).text(), posOf(path.get(0)));
+                    for (int i = 1; i < path.size(); i++) {
+                        value = new Ast.FieldAccess(value, path.get(i).text(), posOf(path.get(i)));
+                    }
+                    pathNames.add(bound);
+                    pathValues.add(value);
+                    spreads.add(bound);
+                }
             } else if (c.kind() == SyntaxKind.FIELD_INIT) {
                 String field = firstIdentText(c);
                 Optional<SyntaxNode> value = firstExprChildOpt(c);
@@ -593,7 +610,11 @@ public final class AstBuilder {
                 inits.add(new Ast.FieldInit(field, v, pos(c)));
             }
         }
-        return new Ast.NewData(typeName, inits, spreads, pos(n));
+        Ast.Expr built = new Ast.NewData(typeName, inits, spreads, pos(n));
+        for (int i = pathNames.size() - 1; i >= 0; i--) {
+            built = new Ast.LetIn(pathNames.get(i), pathValues.get(i), built, pos(n));
+        }
+        return built;
     }
 
     private Ast.Expr matchExpr(SyntaxNode n) {

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -283,6 +283,8 @@ check.import.notdefined=`{0}` is not defined in `{1}`.
 check.import.conflict=Imported `{0}` conflicts with a local definition.
 check.import.notstdfn=`{0}` is not a function in the standard-library module `{1}`.
 check.import.ambiguous=`{0}` is exposed from both `{1}` and `{2}` — call it qualified instead of importing both.
+check.temporal.literal=`{0}(...)` takes a written string, e.g. `Date("2026-07-01")` / `DateTime("2026-07-01T09:00")`.
+check.temporal.malformed=`{1}` is not a {0}. Write `Date("2026-07-01")` / `DateTime("2026-07-01T09:00")`.
 check.newtype.arity=`{0}` wraps one value, but is applied to {1} argument(s).
 check.helper.arity=Helper `let {0}` takes {1} argument(s), but is called with {2}.
 check.fn.mustbenamed=The function passed to `{0}` of `let {1}` must be a named function or a lambda.
@@ -320,6 +322,7 @@ parse.expr=I expected an expression here.
 parse.block.noresult=A block ends in one expression, which is its value; this one has only `let`/`require` lines. Layout does not end a statement, so a result on its own line may continue the line above.
 parse.orpattern=An or-pattern binds the sum type and cannot destructure a case's fields.
 parse.option.positional=Option's wrapped value is bound positionally: write `| Some v`, not `| Some as v`.
+parse.case.record.direct=A record's fields are destructured directly: write `| Some { field }`, not `| Some(Type { field })`. The parens open a newtype.
 
 # --- examples (E1901-E1907) ---
 check.example.title=EXAMPLE

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -5,8 +5,8 @@
 # --- 枠 ---
 diag.error.title=エラー
 diag.hint.label=ヒント:
-diag.diff.found=実際の型:
-diag.diff.expected=期待される型:
+diag.diff.found=実際:
+diag.diff.expected=期待:
 diag.suggestion=`{0}` の間違いではありませんか？
 
 # --- エラー見出し（仕様 22 章） ---
@@ -282,6 +282,8 @@ check.import.notdefined=`{0}` は `{1}` に定義されていません。
 check.import.conflict=import した `{0}` がローカルの定義と衝突しています。
 check.import.notstdfn=`{0}` は標準ライブラリのモジュール `{1}` の関数ではありません。
 check.import.ambiguous=`{0}` は `{1}` と `{2}` の両方から公開されています。両方を import せず、修飾して呼んでください。
+check.temporal.literal=`{0}(...)` は書かれた文字列を取ります（例: `Date("2026-07-01")` / `DateTime("2026-07-01T09:00")`）。
+check.temporal.malformed=`{1}` は {0} として読めません。`Date("2026-07-01")` / `DateTime("2026-07-01T09:00")` の形で書いてください。
 check.newtype.arity=`{0}` は値を1つ包みますが、{1} 個の引数で適用されています。
 check.helper.arity=ヘルパ `let {0}` は引数を {1} 個取りますが、{2} 個で呼ばれています。
 check.fn.mustbenamed=`let {1}` の `{0}` に渡す関数は、名前付き関数かラムダでなければなりません。
@@ -319,6 +321,7 @@ parse.expr=ここには式が必要です。
 parse.block.noresult=ブロックは最後に値となる式を1つ置きますが、このブロックには `let`／`require` の行しかありません。改行は文の区切りではないので、独立した行に書いた結果式が上の行の続きとして読まれることがあります。
 parse.orpattern=or パターンは直和型を束縛するため、ケースのフィールドを分解できません。
 parse.option.positional=Option の中身は位置で束縛します。`| Some as v` ではなく `| Some v` と書きます。
+parse.case.record.direct=レコードのフィールドは直接分解します。`| Some(型 { field })` ではなく `| Some { field }` と書いてください。括弧は newtype を開く形です。
 
 # --- examples (E1901-E1907) ---
 check.example.title=example

--- a/souther-compiler/src/main/resources/souther/list.sou
+++ b/souther-compiler/src/main/resources/souther/list.sou
@@ -57,6 +57,28 @@ let concat (xss: List<List<'a>>) = List.fold((acc, xs) -> acc ++ xs, [], xss)
 let member (e: 'a, xs: List<'a>) = List.fold((acc, x) -> acc || x == e, false, xs)
 let isEmpty (xs: List<'a>) = List.length(xs) == 0
 
+// `take` keeps the first `n` elements and `drop` skips them (Elm's `List.take` / `List.drop`). Both
+// clamp rather than fail: a count of 0 or less takes nothing / drops nothing, and a count past the
+// end takes the whole list / leaves it empty. They thread the same `(i, ys)` pair accumulator
+// `indexedMap` uses, keeping the elements whose index falls on the wanted side of `n`.
+let take (n: Int, xs: List<'a>) = {
+    let (_, out) = List.fold((acc, x) -> {
+        let (i, ys) = acc
+        let next = i + 1
+        if i < n then (next, ys ++ [x]) else (next, ys)
+    }, (0, []), xs)
+    out
+}
+
+let drop (n: Int, xs: List<'a>) = {
+    let (_, out) = List.fold((acc, x) -> {
+        let (i, ys) = acc
+        let next = i + 1
+        if i >= n then (next, ys ++ [x]) else (next, ys)
+    }, (0, []), xs)
+    out
+}
+
 // `distinct` keeps the first occurrence of each element and drops later duplicates, comparing by
 // value equality (Elm's List.Extra `unique`). It folds a pair of a `Set` of the elements seen so far
 // and the result list: an element already in the set is skipped, otherwise it joins both. Consulting

--- a/souther-compiler/src/test/java/souther/compiler/CompileDateLiteralTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDateLiteralTest.java
@@ -1,0 +1,145 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A written date: {@code Date("2026-07-01")} / {@code DateTime("2026-07-01T09:00")}. The argument is
+ * a string literal, parsed and checked when the module compiles, so a malformed date is a compile
+ * error rather than a run-time one. It is the form an {@code example} fixture needs — without it a
+ * behavior taking a date could not be examined at all.
+ */
+class CompileDateLiteralTest {
+
+    @Test
+    void aWrittenDateIsAValueAndFeedsDateArithmetic() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import Date ( addDays )
+
+                data In = { n: Int }
+                data Out = { start: Date, due: Date, at: DateTime }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out {
+                    start = Date("2026-07-01"),
+                    due = addDays(14, Date("2026-07-01")),
+                    at = DateTime("2026-07-01T09:00:00")
+                }
+                """), getClass().getClassLoader());
+
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("n", 1L));
+        Object out = Codecs.apply(
+                loader.loadClass("demo.Run$Impl").getConstructor().newInstance(), in);
+
+        Map<?, ?> m = (Map<?, ?>) Codecs.encode(loader, "demo.Out", out);
+        assertEquals("2026-07-01", m.get("start"));
+        assertEquals("2026-07-15", m.get("due"));
+        assertEquals("2026-07-01T09:00", m.get("at"));
+    }
+
+    @Test
+    void aDateFixtureExaminesADateDrivenBehavior() throws Exception {
+        // The payoff: the input and the expected output both carry dates, so the rule is fixed at
+        // compile time by its examples like any other behavior.
+        Compiler.compile("""
+                module demo
+
+                import Date ( daysBetween )
+
+                data Due = { on: Date }
+                data Overdue = { days: Int }
+                data OnTime
+
+                behavior check : (due: Due, today: Date) -> Overdue | OnTime
+                    constructs Overdue, OnTime
+
+                let check (due, today) = {
+                    let late = daysBetween(due.on, today)
+                    require late > 0 else OnTime
+                    Overdue { days = late }
+                }
+
+                example check
+                    | "past the due date" :
+                        (Due { on = Date("2026-07-01") }, Date("2026-07-25")) -> Overdue { days = 24 }
+                    | "on the due date" :
+                        (Due { on = Date("2026-07-25") }, Date("2026-07-25")) -> OnTime
+                """);
+    }
+
+    @Test
+    void aDateNewtypeTakesAWrittenDateInAFixture() throws Exception {
+        Compiler.compile("""
+                module demo
+
+                data 貸出日 = Date
+                data Loan = { on: 貸出日 }
+                data Echo = { on: 貸出日 }
+
+                behavior repeatBack : (l: Loan) -> Echo constructs Echo
+
+                let repeatBack (l) = Echo { on = l.on }
+
+                example repeatBack
+                    | "a written date survives the newtype" :
+                        (Loan { on = 貸出日("2026-07-01") }) -> Echo { on = 貸出日("2026-07-01") }
+                """);
+    }
+
+    @Test
+    void aMalformedDateIsACompileError() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data In = { n: Int }
+                data Out = { d: Date }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = Out { d = Date("2026-13-45") }
+                """));
+        assertTrue(e.getMessage().contains("2026-13-45"), e.getMessage());
+    }
+
+    @Test
+    void aDateMustBeWrittenNotComputed() {
+        // Only a literal: the point of the form is that the compiler can check it.
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data In = { s: String }
+                data Out = { d: Date }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = Out { d = Date(i.s) }
+                """));
+        assertTrue(e.getMessage().contains("Date"), e.getMessage());
+    }
+
+    @Test
+    void aWrittenDateWorksAtRunTimeThroughTheDecoder() throws Exception {
+        // The value the backend emits is the same LocalDate the boundary decodes.
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import Date ( daysBetween )
+
+                data In = { d: Date }
+                data Out = { gap: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out { gap = daysBetween(Date("2026-07-01"), i.d) }
+                """), getClass().getClassLoader());
+
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("d", LocalDate.parse("2026-07-11")));
+        Object out = Codecs.apply(
+                loader.loadClass("demo.Run$Impl").getConstructor().newInstance(), in);
+        assertEquals(10L, ((Map<?, ?>) Codecs.encode(loader, "demo.Out", out)).get("gap"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleMismatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleMismatchTest.java
@@ -81,6 +81,23 @@ class CompileExampleMismatchTest {
         assertTrue(rendered.contains("[ \"x\" ]"), rendered);
     }
 
+    /** An empty collection reads as `[]` on either side, whether it is a list, a set, or a map — the
+     * same form a fixture writes. */
+    @Test
+    void anEmptyCollectionReadsAsTheEmptyLiteral() {
+        String rendered = render("""
+                module demo
+                data In = { ns: List<Int> }
+                data Out = { counts: Map<String, Int>, tags: Set<String> }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = Out { counts = Map.empty(), tags = Set.empty() }
+                example run
+                    | "wrong on purpose" : (In { ns = [] })
+                        -> Out { counts = [ ("a", 1) ], tags = [ "x" ] }
+                """);
+        assertTrue(rendered.contains("counts = [], tags = []"), rendered);
+    }
+
     @Test
     void aDateShowsAsTheDateItIs() {
         String rendered = render("""

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleMismatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleMismatchTest.java
@@ -1,0 +1,99 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A failing {@code example} reports what came out against what was written. Both sides are rendered
+ * as values in the notation a fixture is written in — the arm name alone says nothing when the
+ * example fails inside one arm.
+ */
+class CompileExampleMismatchTest {
+
+    private static String render(String src) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        return new HumanRenderer(false).render(e.diagnostic(), null, Locale.ENGLISH);
+    }
+
+    @Test
+    void aWrongFieldValueShowsBothValues() {
+        String rendered = render("""
+                module demo
+                data In = { n: Int }
+                data Out = { n: Int }
+                behavior double : (i: In) -> Out constructs Out
+                let double (i) = Out { n = i.n * 2 }
+                example double
+                    | "twice" : (In { n = 3 }) -> Out { n = 7 }
+                """);
+        assertTrue(rendered.contains("Out { n = 6 }"), rendered);
+        assertTrue(rendered.contains("Out { n = 7 }"), rendered);
+    }
+
+    @Test
+    void aWrongArmStillShowsTheArm() {
+        String rendered = render("""
+                module demo
+                data In = { n: Int }
+                data Big = { n: Int }
+                data Small
+                behavior size : (i: In) -> Big | Small constructs Big, Small
+                let size (i) = {
+                    require i.n >= 10 else Small
+                    Big { n = i.n }
+                }
+                example size
+                    | "a small number is small" : (In { n = 3 }) -> Big { n = 3 }
+                """);
+        assertTrue(rendered.contains("Small"), rendered);
+        assertTrue(rendered.contains("Big { n = 3 }"), rendered);
+    }
+
+    @Test
+    void collectionsAndNewtypesReadAsTheyAreWritten() {
+        String rendered = render("""
+                module demo
+                data Sku = String
+                data In = { skus: List<Sku> }
+                data Out = { first: Sku, counts: Map<String, Int>, tags: Set<String> }
+                behavior run : (i: In) -> Out constructs Out, Sku
+                let run (i) = Out {
+                    first = Sku("apple"),
+                    counts = List.fold((acc, s) -> Map.upsert(s.value, 1, c -> c + 1, acc),
+                        Map.empty(), i.skus),
+                    tags = Set.fromList([ "x" ])
+                }
+                example run
+                    | "wrong on purpose" : (In { skus = [ Sku("apple"), Sku("apple") ] })
+                        -> Out { first = Sku("pear"), counts = [ ("apple", 1) ], tags = [ "y" ] }
+                """);
+        // both sides go through the derived encoder, which writes a newtype bare — so the two read
+        // against each other rather than in two different notations
+        assertTrue(rendered.contains("first = \"apple\""), rendered);
+        assertTrue(rendered.contains("first = \"pear\""), rendered);
+        assertTrue(rendered.contains("(\"apple\", 2)"), rendered);
+        assertTrue(rendered.contains("[ \"x\" ]"), rendered);
+    }
+
+    @Test
+    void aDateShowsAsTheDateItIs() {
+        String rendered = render("""
+                module demo
+                import Date ( addDays )
+                data In = { on: Date }
+                data Out = { due: Date }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = Out { due = addDays(14, i.on) }
+                example run
+                    | "two weeks on" : (In { on = Date("2026-07-01") }) -> Out { due = Date("2026-07-14") }
+                """);
+        assertTrue(rendered.contains("due = \"2026-07-15\""), rendered);
+        assertTrue(rendered.contains("due = \"2026-07-14\""), rendered);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperReturnPushdownTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperReturnPushdownTest.java
@@ -1,0 +1,135 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A helper's declared return type is a declaration into its body, and it stays one where the helper
+ * is inlined: a call site whose own expected type says nothing (a generic parameter such as
+ * {@code Map.toList}'s, or none at all) still fixes the accumulator of a fold over an empty seed in
+ * the helper's body.
+ */
+class CompileHelperReturnPushdownTest {
+
+    @Test
+    void aGenericCallSiteKeepsTheHelpersDeclaredReturn() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import List ( fold, map )
+
+                data In = { keys: List<String> }
+                data Out = { lines: List<String> }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let tally (keys: List<String>): Map<String, Int> =
+                    fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), keys)
+
+                let entryKey (e: (String, Int)): String = {
+                    let (k, _) = e
+                    k
+                }
+
+                let run (i) = Out { lines = map(entryKey, Map.toList(tally(i.keys))) }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("keys", List.of("a", "b", "a")));
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(2, ((List<?>) out.get("lines")).size());
+    }
+
+    @Test
+    void aListReturningHelperFeedsAGenericPosition() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import List ( fold, length )
+
+                data In = { ns: List<Int> }
+                data Out = { n: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let doubled (ns: List<Int>): List<Int> = fold((acc, n) -> acc ++ [n * 2], [], ns)
+
+                let run (i) = Out { n = length(List.distinct(doubled(i.ns))) }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("ns", List.of(1L, 1L, 2L)));
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(2L, out.get("n"));
+    }
+
+    /** {@code List.sortBy} takes its key as a real function value, so the backend re-types the list
+     * argument to learn the element type. That argument may hold a recursive helper call (the
+     * {@code foldFrom} a fold expands to), which it can only resolve with the recursive helpers'
+     * signatures in scope. */
+    @Test
+    void sortByOverAFoldedListResolvesTheRecursiveHelper() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import List ( fold, map )
+
+                data In = { keys: List<String> }
+                data Out = { ranked: List<String> }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let tally (keys: List<String>): Map<String, Int> =
+                    fold((acc, k) -> Map.upsert(k, 1, n -> n + 1, acc), Map.empty(), keys)
+
+                let entryKey (e: (String, Int)): String = {
+                    let (k, _) = e
+                    k
+                }
+
+                let entryCount (e: (String, Int)): Int = {
+                    let (_, c) = e
+                    c
+                }
+
+                let run (i) = Out { ranked =
+                    Map.toList(tally(i.keys))
+                        |> List.sortBy(e -> entryCount(e))
+                        |> List.reverse
+                        |> List.take(1)
+                        |> map(entryKey)
+                }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("keys", List.of("a", "b", "a")));
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(List.of("a"), out.get("ranked"), "the most frequent key leads the ranking");
+    }
+
+    @Test
+    void aLyingDeclaredReturnIsStillReportedAgainstTheHelper() {
+        // The push-down must not turn a wrong declaration into a diagnostic about a generated binding.
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data In = { n: Int }
+                data Out = { s: String }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let label (n: Int): String = n
+
+                let run (i) = Out { s = label(i.n) }
+                """));
+        assertTrue(e.getMessage().contains("label"), e.getMessage());
+        assertTrue(!e.getMessage().contains("$r"), "a generated binding name leaked: " + e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileLambdaArityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLambdaArityTest.java
@@ -1,0 +1,34 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** A lambda given to a combinator is registered under a synthetic name while it is inlined. A wrong
+ * number of parameters must be reported against the parameter it fills, not against that internal
+ * name. */
+class CompileLambdaArityTest {
+
+    @Test
+    void aLambdaWithTooManyParametersNamesTheCombinatorParameter() {
+        String src = """
+                module demo
+                data Names = { ns: List<String> }
+                data Count = { n: Int }
+                behavior count : (m: Names) -> Count constructs Count
+
+                let count (m) = Count { n = List.length(List.map((k, v) -> k, m.ns)) }
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        String rendered = new HumanRenderer(false).render(e.diagnostic(), null, Locale.ENGLISH);
+        assertFalse(rendered.contains("$"), "internal lambda name leaked:\n" + rendered);
+        assertTrue(rendered.contains("`f`"), rendered);
+        assertTrue(rendered.contains("let map"), rendered);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileListLibTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileListLibTest.java
@@ -346,6 +346,53 @@ class CompileListLibTest {
         assertEquals(true, encode(loader, Codecs.apply(behavior, oneIn)).get("unique"));
     }
 
+    /** {@code take}/{@code drop} cut the list at an index (Elm's List.take / List.drop), clamping at
+     * both ends: a non-positive count takes nothing, a count past the end takes everything. */
+    @Test
+    void takeAndDropCutTheListAndClamp() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import List ( take, drop )
+
+                data In = { ns: List<Int> }
+                data Out = {
+                    firstTwo: List<Int>
+                    , rest: List<Int>
+                    , none: List<Int>
+                    , all: List<Int>
+                    , beyond: List<Int>
+                    , dropAll: List<Int>
+                }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out {
+                    firstTwo = take(2, i.ns),
+                    rest = drop(2, i.ns),
+                    none = take(0, i.ns),
+                    all = drop(0, i.ns),
+                    beyond = take(99, i.ns),
+                    dropAll = drop(99, i.ns)
+                }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Map<?, ?> m = encode(loader, Codecs.apply(behavior, decodeIn(loader, List.of(1L, 2L, 3L, 4L))));
+
+        assertEquals(List.of(1L, 2L), m.get("firstTwo"));
+        assertEquals(List.of(3L, 4L), m.get("rest"));
+        assertEquals(List.of(), m.get("none"));
+        assertEquals(List.of(1L, 2L, 3L, 4L), m.get("all"));
+        assertEquals(List.of(1L, 2L, 3L, 4L), m.get("beyond"), "a count past the end takes everything");
+        assertEquals(List.of(), m.get("dropAll"), "dropping past the end leaves nothing");
+
+        // a negative count behaves as 0 on both sides, and an empty input stays empty
+        Map<?, ?> neg = encode(loader, Codecs.apply(behavior, decodeIn(loader, List.of())));
+        assertEquals(List.of(), neg.get("firstTwo"));
+        assertEquals(List.of(), neg.get("rest"));
+    }
+
     private static Object decodeIn(BytesClassLoader loader, List<Long> ns) throws Exception {
         return Codecs.decoded(loader, "demo.In", Map.of("ns", ns));
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileMapFixtureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileMapFixtureTest.java
@@ -1,0 +1,110 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code Map} in an {@code example} fixture is written as a list of key/value pairs — Elm's
+ * {@code Dict.fromList} and F#'s {@code Map.ofList}, and the same list literal a {@code Set} field
+ * already takes. Which of the two a list means is decided by the field's declared type, so a
+ * {@code List} field keeps reading as a list.
+ */
+class CompileMapFixtureTest {
+
+    @Test
+    void aMapFieldTakesAListOfPairsOnBothSides() {
+        Compiler.compile("""
+                module demo
+
+                data In = { names: List<String> }
+                data Out = { counts: Map<String, Int> }
+
+                behavior count : (i: In) -> Out constructs Out
+
+                let count (i) = Out {
+                    counts = List.fold((acc, n) -> Map.upsert(n, 1, c -> c + 1, acc), Map.empty(), i.names)
+                }
+
+                example count
+                    | "repeats are counted" : (In { names = [ "a", "a", "b" ] })
+                        -> Out { counts = [ ("a", 2), ("b", 1) ] }
+                    | "no names, no counts" : (In { names = [] }) -> Out { counts = [] }
+                """);
+    }
+
+    @Test
+    void aMapFixtureIsAlsoAnInput() {
+        Compiler.compile("""
+                module demo
+
+                data Stock = { onHand: Map<String, Int> }
+                data Level = { n: Int }
+
+                behavior lookUp : (s: Stock, sku: String) -> Level constructs Level
+
+                let lookUp (s, sku) = Level { n = Map.get(sku, s.onHand) |> Option.withDefault(0) }
+
+                example lookUp
+                    | "a stocked sku" : (Stock { onHand = [ ("apple", 3) ] }, "apple") -> Level { n = 3 }
+                    | "an unknown sku" : (Stock { onHand = [ ("apple", 3) ] }, "pear") -> Level { n = 0 }
+                """);
+    }
+
+    @Test
+    void aNewtypeKeyedMapTakesItsKeysAsWritten() {
+        Compiler.compile("""
+                module demo
+
+                data Sku = String
+                data Stock = { onHand: Map<Sku, Int> }
+                data Level = { n: Int }
+
+                behavior size : (s: Stock) -> Level constructs Level
+
+                let size (s) = Level { n = Map.size(s.onHand) }
+
+                example size
+                    | "two skus" : (Stock { onHand = [ (Sku("apple"), 3), (Sku("pear"), 1) ] })
+                        -> Level { n = 2 }
+                """);
+    }
+
+    @Test
+    void aListFieldStillReadsAsAList() {
+        // The list literal is not turned into a map where a List is declared.
+        Compiler.compile("""
+                module demo
+
+                data In = { ns: List<Int> }
+                data Out = { n: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out { n = List.length(i.ns) }
+
+                example run
+                    | "three" : (In { ns = [ 1, 2, 3 ] }) -> Out { n = 3 }
+                """);
+    }
+
+    @Test
+    void aMapEntryMustBeAPair() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data In = { counts: Map<String, Int> }
+                data Out = { n: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out { n = Map.size(i.counts) }
+
+                example run
+                    | "not pairs" : (In { counts = [ "a", "b" ] }) -> Out { n = 2 }
+                """));
+        assertTrue(e.getMessage().contains("(key, value)"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileMapLibTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileMapLibTest.java
@@ -146,6 +146,57 @@ class CompileMapLibTest {
         assertEquals(Map.of(), m.get("updated"), "update on an absent key of an empty map is empty");
     }
 
+    /** A {@code Map.fold} seeded with the empty list grows a list out of a map, the same shape
+     *  {@code List.fold} allows. The seed carries no element type of its own, so it takes the one
+     *  the result is used at — here the field the fold feeds. */
+    @Test
+    void foldGrowsAListFromAnEmptySeed() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import Map ( fold )
+
+                data In = { counts: Map<String, Int> }
+                data Out = { lines: List<String> }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out {
+                    lines = fold((acc, k, v) -> acc ++ [k ++ "=" ++ String.fromInt(v)], [], i.counts)
+                }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("counts", Map.of("a", 2L)));
+        Map<?, ?> m = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(java.util.List.of("a=2"), m.get("lines"));
+    }
+
+    /** The same fold named on its own line: the binding's written type fixes the seed instead. */
+    @Test
+    void foldGrowsAListFromAnEmptySeedUnderAnAnnotatedBinding() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import Map ( fold )
+
+                data In = { counts: Map<String, Int> }
+                data Out = { keys: List<String> }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = {
+                    let keys: List<String> = fold((acc, k, v) -> acc ++ [k], [], i.counts)
+                    Out { keys = keys }
+                }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("counts", Map.of("a", 2L)));
+        Map<?, ?> m = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(java.util.List.of("a"), m.get("keys"));
+    }
+
     /** upsert collapses insert-if-absent / modify-if-present: it applies the step to a present key
      *  and inserts the default for an absent one ([#stdlib-map]). */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileNestedSpreadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNestedSpreadTest.java
@@ -1,0 +1,66 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A spread may name a field path ({@code ...c.address}), not only a local. Rebuilding a record
+ * nested one level down is the ordinary "change one field of a sub-record" edit, and without this it
+ * takes a `let` binding to name the sub-record first.
+ */
+class CompileNestedSpreadTest {
+
+    @Test
+    void aSpreadTakesAFieldPath() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                data Address = { city: String, street: String }
+                data Customer = { name: String, address: Address }
+
+                behavior move : (c: Customer, city: String) -> Customer constructs Customer, Address
+
+                let move (c, city) = Customer { ...c, address = Address { ...c.address, city = city } }
+                """), getClass().getClassLoader());
+
+        Object in = Codecs.decoded(loader, "demo.Customer", Map.of(
+                "name", "A", "address", Map.of("city", "Tokyo", "street", "1-2-3")));
+        Class<?> impl = loader.loadClass("demo.Move$Impl");
+        Object out = impl.getMethod("apply", Object.class, Object.class)
+                .invoke(impl.getConstructor().newInstance(), in, "Osaka");
+
+        Map<?, ?> m = (Map<?, ?>) Codecs.encode(loader, "demo.Customer", out);
+        assertEquals("A", m.get("name"));
+        assertEquals(Map.of("city", "Osaka", "street", "1-2-3"), m.get("address"),
+                "the untouched field comes from the spread path");
+    }
+
+    @Test
+    void aDeeperPathAlsoSpreads() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                data Geo = { lat: String, lon: String }
+                data Address = { city: String, geo: Geo }
+                data Customer = { name: String, address: Address }
+                data Out = { geo: Geo }
+
+                behavior movePin : (c: Customer, lat: String) -> Out constructs Out, Geo
+
+                let movePin (c, lat) = Out { geo = Geo { ...c.address.geo, lat = lat } }
+                """), getClass().getClassLoader());
+
+        Object in = Codecs.decoded(loader, "demo.Customer", Map.of(
+                "name", "A",
+                "address", Map.of("city", "Tokyo", "geo", Map.of("lat", "1", "lon", "2"))));
+        Class<?> impl = loader.loadClass("demo.MovePin$Impl");
+        Object out = impl.getMethod("apply", Object.class, Object.class)
+                .invoke(impl.getConstructor().newInstance(), in, "9");
+
+        Map<?, ?> m = (Map<?, ?>) Codecs.encode(loader, "demo.Out", out);
+        assertEquals(Map.of("lat", "9", "lon", "2"), m.get("geo"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileOptionMatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileOptionMatchTest.java
@@ -146,6 +146,44 @@ class CompileOptionMatchTest {
         assertTrue(e.getMessage().contains("Some"), e.getMessage());
     }
 
+    private static final String RECORD_ELEMENT = """
+            module demo
+
+            data Booking = { member: String }
+            data Queue = { head: Booking? }
+            data Next = { member: String }
+            data Nobody
+
+            behavior peek : (q: Queue) -> Next | Nobody constructs Next, Nobody
+
+            let peek (q) =
+                match q.head with
+                    | Some { member } -> Next { member = member }
+                    | None -> Nobody
+            """;
+
+    @Test
+    void someDestructuresTheWrappedRecordsFields() throws Exception {
+        // A record element is opened by the same `{ field }` pattern a user case takes; the fields are
+        // read off the wrapped value, so no `.field` on a positional binding is needed.
+        BytesClassLoader loader =
+                new BytesClassLoader(Compiler.compile(RECORD_ELEMENT), getClass().getClassLoader());
+        Object queue = Codecs.decoded(loader, "demo.Queue", Map.of("head", Map.of("member", "m-1")));
+        Object behavior = loader.loadClass("demo.Peek$Impl").getConstructor().newInstance();
+        Map<?, ?> next = (Map<?, ?>) Codecs.encode(loader, "demo.Next", Codecs.apply(behavior, queue));
+        assertEquals("m-1", next.get("member"));
+    }
+
+    @Test
+    void aRecordNamedInsideSomeParensPointsAtTheFieldPattern() {
+        // `Some(Booking { member })` is not a second spelling: the parens open a newtype, a record is
+        // destructured directly. The error says which form to write.
+        String src = RECORD_ELEMENT.replace("| Some { member }", "| Some(Booking { member })");
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        assertTrue(e.getMessage().contains("{ member }") || e.getMessage().contains("{ field }"),
+                e.getMessage());
+    }
+
     @Test
     void someAndNoneCannotBeDeclaredAsUserData() {
         // Some/None are the built-in Option cases; declaring one as a data type is rejected, so a

--- a/souther-compiler/src/test/java/souther/compiler/CompileStringCharsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileStringCharsTest.java
@@ -1,10 +1,16 @@
 package souther.compiler;
 
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Character access without a {@code Char} type (Issue #52): a character is a length-1 {@code String}.
@@ -71,6 +77,24 @@ class CompileStringCharsTest {
         assertEquals(-1L, runInt(src, "parse", Map.of("s", "")));     // NotANumber
         assertEquals(-1L, runInt(src, "parse", Map.of("s", " 5")));   // surrounding space: NotANumber
         assertEquals(-1L, runInt(src, "parse", Map.of("s", "99999999999999999999")));  // > Int64: NotANumber
+    }
+
+    /** A wrong case name over the parse union names its members, not the type's internal form. */
+    @Test
+    void aWrongCaseOverTheParseUnionNamesItsMembers() {
+        String src = """
+                module demo
+                data In = { s: String }
+                data Out = Int
+                behavior parse : (i: In) -> Out constructs Out
+                let parse (i) = match String.toInt(i.s) with
+                    | Some n -> Out(n)
+                    | NotANumber -> Out(-1)
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        String rendered = new HumanRenderer(false).render(e.diagnostic(), null, Locale.ENGLISH);
+        assertTrue(rendered.contains("Int | NotANumber"), rendered);
+        assertFalse(rendered.contains("Union["), "internal type form leaked:\n" + rendered);
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileTupleAnnotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileTupleAnnotationTest.java
@@ -1,0 +1,89 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A helper parameter may be annotated with a tuple type. It reads the same as a function type's
+ * parameter list up to the closing paren, so the two are told apart by what follows it: `->` makes
+ * it a function type, anything else a tuple. This is what lets a domain consume {@code Map.toList},
+ * whose entries are {@code ('k, 'a)} pairs (destructured with {@code let (k, v) = e}).
+ */
+class CompileTupleAnnotationTest {
+
+    @Test
+    void aHelperTakesATupleParameter() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                data In = { counts: Map<String, Int> }
+                data Out = { lines: List<String> }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let entry (e: (String, Int)): String = {
+                    let (k, v) = e
+                    k ++ "=" ++ String.fromInt(v)
+                }
+
+                let run (i) = Out { lines = List.map(entry, Map.toList(i.counts)) }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("counts", Map.of("a", 2L)));
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(List.of("a=2"), out.get("lines"));
+    }
+
+    @Test
+    void aFunctionTypedParameterStillParses() throws Exception {
+        // The disambiguation must not break the existing form: `(Int) -> Bool` is a function type.
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                data In = { ns: List<Int> }
+                data Out = { n: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let countBy (p: (Int) -> Bool, xs: List<Int>): Int = List.length(List.filter(p, xs))
+
+                let run (i) = Out { n = countBy(x -> x > 1, i.ns) }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("ns", List.of(1L, 2L, 3L)));
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(2L, out.get("n"));
+    }
+
+    @Test
+    void aTupleReturnAnnotationParses() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                data In = { ns: List<Int> }
+                data Out = { lo: Int, hi: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let bounds (xs: List<Int>): (Int, Int) = (List.fold((a, x) -> if x < a then x else a, 0, xs),
+                    List.fold((a, x) -> if x > a then x else a, 0, xs))
+
+                let run (i) = {
+                    let (lo, hi) = bounds(i.ns)
+                    Out { lo = lo, hi = hi }
+                }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("ns", List.of(1L, 5L, 3L)));
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals(0L, out.get("lo"));
+        assertEquals(5L, out.get("hi"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/diag/DiagnosticHintArgsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/DiagnosticHintArgsTest.java
@@ -1,0 +1,102 @@
+package souther.compiler.diag;
+
+import souther.compiler.Compiler;
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** A hint carries placeholders of its own ({@code Add `constructs {1}` to `{0}`}). A site that names
+ * the hint without repeating the message's arguments used to render the placeholders verbatim, so a
+ * hint with no arguments of its own takes the diagnostic's. */
+class DiagnosticHintArgsTest {
+
+    private static String render(String src) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        return new HumanRenderer(false).render(e.diagnostic(), null, Locale.ENGLISH);
+    }
+
+    private static void assertNoPlaceholder(String rendered) {
+        for (int i = 0; i < 4; i++) {
+            assertFalse(rendered.contains("{" + i + "}"),
+                    "unsubstituted placeholder {" + i + "} in:\n" + rendered);
+        }
+    }
+
+    @Test
+    void anUnderDeclaredConstructsHintNamesTheCase() {
+        String rendered = render("""
+                module demo
+                data Response = { id: String }
+                data Empty
+                behavior make : (x: String) -> Response | Empty constructs Empty
+
+                let make (x) = if x == "" then Empty else Response { id = x }
+                """);
+        assertNoPlaceholder(rendered);
+        assertTrue(rendered.contains("constructs Response"), rendered);
+    }
+
+    @Test
+    void anOverDeclaredConstructsHintNamesTheCase() {
+        String rendered = render("""
+                module demo
+                data Amount = Int
+                data Line = { subtotal: Amount, shipping: Amount }
+                data Total = { amount: Amount }
+                behavior sum : (l: Line) -> Total constructs Total, Amount
+
+                let sum (l) = Total { amount = l.subtotal + l.shipping }
+                """);
+        assertNoPlaceholder(rendered);
+        assertTrue(rendered.contains("`Amount`"), rendered);
+    }
+
+    @Test
+    void aMissingFieldHintNamesTheField() {
+        String rendered = render("""
+                module demo
+                data Point = { x: Int, y: Int }
+                behavior make : (n: Int) -> Point constructs Point
+
+                let make (n) = Point { x = n }
+                """);
+        assertNoPlaceholder(rendered);
+        assertTrue(rendered.contains("`y`"), rendered);
+    }
+
+    @Test
+    void aMissingRequiresHintNamesTheDependency() {
+        String rendered = render("""
+                module demo
+                data Id = String
+                data Row = { id: Id }
+                behavior load : (id: Id) -> Row constructs Row
+                behavior run : (id: Id) -> Row
+
+                let run (id) = load(id)
+                """);
+        assertNoPlaceholder(rendered);
+        assertTrue(rendered.contains("requires load"), rendered);
+    }
+
+    @Test
+    void anUnusedRequiresHintNamesTheDependency() {
+        String rendered = render("""
+                module demo
+                data Id = String
+                data Row = { id: Id }
+                behavior load : (id: Id) -> Row constructs Row
+                behavior run : (id: Id) -> Row
+                    constructs Row
+                    requires load
+
+                let run (id, load) = Row { id = id }
+                """);
+        assertNoPlaceholder(rendered);
+        assertTrue(rendered.contains("`load`"), rendered);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -103,6 +103,24 @@ class FormatterTest {
                 "formatted output does not re-parse for " + source + ":\n" + formatted);
     }
 
+    /** A spread naming a field path keeps its path: `...c.address`, not `...c`. */
+    @Test
+    void aNestedSpreadPathSurvivesFormatting() {
+        String src = """
+                module demo
+
+                data Address = { city: String, street: String }
+                data Customer = { name: String, address: Address }
+
+                behavior move : (c: Customer, city: String) -> Customer constructs Customer, Address
+
+                let move (c, city) = Customer { ...c, address = Address { ...c.address, city = city } }
+                """;
+        String formatted = Formatter.format(src);
+        assertTrue(formatted.contains("...c.address"), formatted);
+        assertEquals(code(src), code(formatted));
+    }
+
     @Test
     void canonicalFormOfASmallModule() {
         String messy = "module demo\n\n\ndata Id=String\n  invariant length(value)>0\n"

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -581,7 +581,7 @@ public final class Formatter {
         List<Doc> members = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             if (c.kind() == SyntaxKind.SPREAD_MEMBER) {
-                members.add(concat(text("..."), text(firstIdent(c))));
+                members.add(concat(text("..."), text(identPath(c))));   // `...c` or `...c.address`
             } else if (c.kind() == SyntaxKind.FIELD_INIT) {
                 var value = firstExprChildOpt(c);
                 members.add(value.map(v -> concat(text(firstIdent(c)), text(" = "), expr(v)))
@@ -742,6 +742,20 @@ public final class Formatter {
             }
         }
         return out;
+    }
+
+    /** Every identifier of a node, dotted — a spread's field path ({@code c.address}). */
+    private String identPath(SyntaxNode n) {
+        List<String> parts = new ArrayList<>();
+        for (SyntaxElement e : n.children()) {
+            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
+                parts.add(t.text());
+            }
+        }
+        if (parts.isEmpty()) {
+            throw new IllegalStateException("no identifier in " + n.kind());
+        }
+        return String.join(".", parts);
     }
 
     private String firstIdent(SyntaxNode n) {

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -397,9 +397,12 @@ public final class CstParser {
         finish();
     }
 
-    /** A helper parameter's type: a function type when it opens with {@code (}, else an ordinary type. */
+    /** A helper parameter's type: a function type when it opens a parameter list ending in {@code ->},
+     * else an ordinary type — which may itself be a parenthesised tuple ({@code (String, Int)}, the
+     * entry type of {@code Map.toList}). Both start with {@code (} and read alike up to the closing
+     * paren, so the token after it decides. */
     private void paramType() {
-        if (at(SyntaxKind.LPAREN)) {
+        if (at(SyntaxKind.LPAREN) && atFnTypeParams()) {
             start(SyntaxKind.FN_TYPE);
             expect(SyntaxKind.LPAREN);
             if (!at(SyntaxKind.RPAREN)) {
@@ -525,6 +528,26 @@ public final class CstParser {
             typeRef();
         }
         finish();
+    }
+
+    /** Whether the parenthesised run at the cursor is a function type's parameter list: its closing
+     * paren is followed by {@code ->}. A tuple type is written the same way without the arrow. */
+    private boolean atFnTypeParams() {
+        int depth = 0;
+        for (int i = 0; ; i++) {
+            SyntaxKind k = nth(i);
+            if (k == SyntaxKind.EOF) {
+                return false;
+            }
+            if (k == SyntaxKind.LPAREN) {
+                depth++;
+            } else if (k == SyntaxKind.RPAREN) {
+                depth--;
+                if (depth == 0) {
+                    return nth(i + 1) == SyntaxKind.ARROW;
+                }
+            }
+        }
     }
 
     private void typeRef() {
@@ -937,7 +960,16 @@ public final class CstParser {
     private void casePattern() {
         expect(SyntaxKind.LPAREN);
         expect(SyntaxKind.IDENT);
-        if (at(SyntaxKind.LPAREN)) {
+        if (at(SyntaxKind.LBRACE)) {
+            // `Some(Booking { member })`: the parens open a *newtype*, so a record named in them has
+            // nothing to open. Its fields are destructured directly, as on a user case.
+            error("parse.case.record.direct",
+                    "a record's fields are destructured directly: write `| Some { field }`");
+            while (!at(SyntaxKind.RBRACE) && !at(SyntaxKind.EOF)) {
+                bump();
+            }
+            eat(SyntaxKind.RBRACE);
+        } else if (at(SyntaxKind.LPAREN)) {
             casePattern();
         }
         expect(SyntaxKind.RPAREN);
@@ -1003,6 +1035,11 @@ public final class CstParser {
             start(SyntaxKind.SPREAD_MEMBER);
             bump();   // ...
             expect(SyntaxKind.IDENT);
+            // a spread may name a field path (`...c.address`), not only a local
+            while (at(SyntaxKind.DOT) && nth(1) == SyntaxKind.IDENT) {
+                bump();   // .
+                bump();   // field
+            }
             finish();
         } else {
             start(SyntaxKind.FIELD_INIT);

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -129,7 +129,21 @@ public record Diagnostic(Severity severity,
 
         public Diagnostic build() {
             return new Diagnostic(severity, code, titleKey, region, List.copyOf(secondary),
-                    messageKey, args, null, diff, List.copyOf(notes), suggestion);
+                    messageKey, args, null, diff, List.copyOf(withMessageArgs(notes)), suggestion);
+        }
+
+        /** A hint's text is written against the same numbered arguments as the message it follows
+         * ({@code Add `constructs {1}` to `{0}`}), so a site that names the hint without repeating
+         * them takes the message's. A hint given arguments of its own keeps them. */
+        private List<Note> withMessageArgs(List<Note> notes) {
+            if (args.length == 0) {
+                return notes;
+            }
+            List<Note> filled = new ArrayList<>(notes.size());
+            for (Note n : notes) {
+                filled.add(n.args().length == 0 ? new Note(n.messageKey(), args) : n);
+            }
+            return filled;
         }
     }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -1611,6 +1611,10 @@ A behavior with a `+let+` implementation is evaluated (<<fn>>). An injected beha
 
 An input and an expected value are fixtures: literals, newtype applications, and record constructions. A `+?+` field takes a value directly (wrapped in `+Some+`) or `+None+` for empty, the same way a `+let+` body writes an optional (<<optional>>); omitting the field reads as `+None+` too. A row's argument is decoded into the behavior's parameter type through that type's derived Decoder (<<decoder>>), so a fixture that breaks an invariant is rejected (<<e1903>>).
 
+A collection field is written as a list, and its declared type says what the list means: a `+List+` field keeps its order and repeats, a `+Set+` field drops duplicates on decode (`+labels = [ Label("bug"), Label("bug") ]+` is one label), and a `+Map+` field takes its entries as `+(key, value)+` pairs — `+counts = [ ("bug", 2), ("ui", 1) ]+` — the form `+Map.fromList+` takes (<<stdlib-map>>). A `+Date+` / `+DateTime+` field takes a written temporal (`+Date("2026-07-25")+`, <<temporal-literal>>). This is what lets a rule over dates, sets, or maps be fixed by its examples rather than only by a hand-written test at the boundary.
+
+When a row does not hold, the diagnostic (<<e1905>>) shows what the behavior produced against what the row expects, both encoded through the data's derived Encoder (<<encoder>>) so the two read against each other.
+
 [#example-fakes]
 === Faking a requires dependency
 
@@ -1944,6 +1948,7 @@ Note that `+申請者.役職 == 一般社員+` cannot be written as a condition.
 map  filter  fold  all  any  length  get  indexedMap
 reverse  member  sum  product  concat  isEmpty  sort
 distinct  partition  groupBy  max  min  find  sortBy  allUniqueBy
+take  drop
 ----
 
 All are called through the qualifier `+List+` (<<stdlib>>). `+List.get+` returns `+Option<T>+`. `+List.map+` / `+List.filter+` / `+List.fold+` / `+List.all+` / `+List.any+` / `+List.indexedMap+` take a block (<<blocks>>). Import them as `+import List ( map, all )+` to write unqualified thereafter.
@@ -1963,6 +1968,8 @@ None of these is a compiler primitive. `+List.fold+` is a recursive `+let+` in `
 The lower row is also ported from Elm's List module; except `+sort+`, all are self-language `+let+`s derived from `+List.fold+`. `+reverse+` extends the seed to the front, `+sum+` / `+product+` fold numbers, `+concat+` folds with `{plus}{plus}` and flattens nesting (Elm's `+List.concat+`), and `+member+` folds with `+==+` so it works for comparable elements. `+isEmpty+` looks at length. Only `+sort+` is a primitive that cannot be derived from `+fold+` (as in Elm) — self-language sorting needs, besides comparison, a place to hold intermediate results, which `+fold+` does not give; it sorts by the element's natural order. Elements MUST be an ordered type (`+Int+` / `+String+` / `+Decimal+` / `+Date+` / `+DateTime+`; <<primitives>>), and passing a list of data or newtype to `+sort+` is a compile error (they have no ordering, so it is rejected up front rather than at runtime; to sort them, map to an ordered field first with `+List.map+`).
 
 The third row adds more of Elm's List module. `+distinct+` keeps the first occurrence of each element and drops later duplicates (Elm's `+List.Extra.unique+`), folding a `+Set+` of what it has seen; `+partition+` splits into `+(kept, rest)+` by a predicate; `+groupBy+` buckets elements into a `+Map<'k, List<'a>>+` by a key. These three are self-language `+let+`s that grow their result from within `+List.fold+`. `+max+` / `+min+` return the largest / smallest as an `+Option+` — `+None+` on an empty list — and compare by natural order, so like `+sort+` the element MUST be ordered (Elm's `+maximum+` / `+minimum+`); `+find+` returns the first element satisfying a predicate as an `+Option+`. `+sortBy(key, xs)+` orders by a projected ordered key rather than the element itself (F#/Elm `+List.sortBy+`): unlike `+sort+`, whose comparison is built in, its key is a runtime function value, so the sort carries an actual `+Fn+`. `+max+` / `+min+` / `+find+` / `+sortBy+` are primitives (they step outside `+fold+`); only Elm's `+List.head+` is still not ported — a domain reads the first element with `+List.get(0, xs)+`. `+allUniqueBy(key, xs)+` holds when the elements have distinct keys under `+key+` (Elm's `+List.Extra.allDifferentBy+`): the "this projection is a unique id" invariant, written as `+distinct+` of the projected keys compared against the length rather than by hand. Deriving from `+fold+` (through `+map+` / `+distinct+`), it may stand in an invariant, like `+distinct+` itself.
+
+`+take(n, xs)+` keeps the first `+n+` elements and `+drop(n, xs)+` skips them (Elm's `+List.take+` / `+List.drop+`) — the top-N of a ranking and the rest of it. Both clamp instead of failing: a count of 0 or less takes nothing / drops nothing, and a count past the end takes the whole list / leaves it empty. Like `+indexedMap+` they thread a pair accumulator `+(i, ys)+` through `+List.fold+` and keep the elements whose index falls on the wanted side of `+n+`.
 
 [#stdlib-map]
 === Map
@@ -2030,6 +2037,9 @@ not
 ----
 addDays  addMonths  addYears  daysBetween
 ----
+
+[#temporal-literal]
+A date is written `+Date("2026-07-25")+` and a date-time `+DateTime("2026-07-25T09:00")+`. The argument MUST be a written string: the compiler parses it where it stands, so a malformed date fails the build rather than a run, and an `+example+` fixture — which holds only written values (<<example-evaluable>>) — can carry a date at all. A computed date comes from the boundary or from the arithmetic below, not from this form.
 
 `+Date+` is a local calendar date (<<primitives>>). Calendar arithmetic is pure and belongs in the domain, not behind an injected behavior (<<injected-behavior>>) — only reading the *current* date needs the outside world. `+addDays(n, d)+` / `+addMonths(n, d)+` / `+addYears(n, d)+` shift `+d+` by `+n+` units (`+n+` may be negative), following `+java.time.LocalDate+`, which clamps the end of a month (`+addMonths(1, 2026-01-31)+` is `+2026-02-28+`). `+daysBetween(from, to)+` is the whole days from `+from+` to `+to+`, negative when `+to+` precedes `+from+`. The date operated on is last (<<pipe>>), so `+d |> Date.addDays(3)+` reads left to right.
 
@@ -2455,11 +2465,11 @@ Emitted when a row's expected arm is not one of the target behavior's output cas
 ----
 error E1905:
 This example does not hold.
-found: 提出済み
-expected: 却下
+found: 提出済み { 提出日時 = "2026-07-20T09:00" }
+expected: 却下 { 理由 = "high_cost" }
 ----
 
-Emitted when a row's evaluated result does not match the expected arm or value. Every failing row of a build is reported.
+Emitted when a row's evaluated result does not match the expected arm or value. Every failing row of a build is reported. Both sides are shown as values, encoded through the data's derived Encoder (<<encoder>>) — the arm name alone does not say what went wrong when a row fails inside one arm. A row that asserts only the arm (a bare case name, <<example-expected>>) shows just that name.
 
 [#e1906]
 === An examples file contains non-example declarations

--- a/specification.adoc
+++ b/specification.adoc
@@ -1282,6 +1282,8 @@ let 適用する (xs: List<Int>, p: (Int) -> Bool) = List.all(p, xs)
 
 The return type is inferred. However, a *recursive helper* MUST declare its return type — `+let 深さ (s: 社員): Int = ...+` — because the result type cannot be inferred through the cycle, and only with a declaration can a self-call be type-checked. The declaration is required only for a recursive helper. A non-recursive helper is inferred as before, and a `+let+` with a same-named behavior cannot write a return type (the type comes from the behavior).
 
+A written return type is a declaration into the body, and it stays one where the helper is expanded: it is pushed into the body at each call site, so a value only its context can type — an empty `+[]+` / `+Map.empty()+` / `+Set.empty()+`, or a `+fold+` over one — takes the declared element type even where the call site itself expects nothing concrete (a generic parameter such as `+Map.toList+`'s). This is the same direction a binding's `+let x: T = v+` has (<<block-expression>>).
+
 The body is an expression. `+{ ... }+` is a block expression (<<block-expression>>), written to place a `+let+` or `+require+`. `+let 正の数 (v: Int) = v >= 0+` and `+let 正の数 (v: Int) = { v >= 0 }+` are the same.
 
 `+=+` introduces a named definition. The bodies of an anonymous block (<<blocks>>) and a `+match+` case are introduced by `+->+` — the same symbol as the type arrow (as in F# and Elm). Binding a lambda to a named definition (`+let f = (x) -> ...+`) is not adopted.


### PR DESCRIPTION
Writing examples against the current language turned up eight places where a rule could not be written, or could not be examined once written. This closes them.

## Examples can carry the values they need

- **Written temporals.** `Date("2026-07-01")` / `DateTime("2026-07-01T09:00")` take a written string, parsed and checked where they stand — in a body or in a fixture. Before this, a behavior taking a `Date` could not have a single `example`.
- **`Map` fixtures.** A map field is written as its list of `(key, value)` pairs, the form `Map.fromList` takes (Elm's `Dict.fromList`, F#'s `Map.ofList`), and the same list literal a `Set` field already took. The declared type decides what a list means, so a `List` field still reads as a list.
- **E1905 shows values.** A failing row reported `found: Out` / `expected: Out` — the arm name on both sides. Both are now encoded through the derived encoder and shown as values.

## The language reaches what the standard library returns

- **Tuple annotations.** `let entry (e: (String, Int))` parses. The spec already allowed a tuple type in a helper signature; the parser read the leading paren as a function type's parameter list. The two are told apart by whether `->` follows the closing paren. Destructuring is unchanged — `let (k, v) = e`, no second spelling added.
- **`Map.fold` with an empty seed.** `Map.fold(step, [], m)` failed to type while `List.fold(step, [], xs)` passed: the pre-inline step check judged a step whose accumulator was still the seed's bottom. It now leaves that to the inlined check, which sees the pushed-down type.
- **Nested spread.** `Address { ...c.address, city = city }` — the ordinary "change one field of a sub-record" edit, which needed a `let` binding first.
- **`List.take` / `List.drop`.** Elm's, derived from `fold`, so a top-N is one call.

## Diagnostics stop leaking internals

- A hint with no arguments of its own takes the message's. Seven hints (E1002/E1005/E1006/E1305/E1602/E1603/E1606) rendered `{0}` / `{1}` verbatim.
- An anonymous union prints as `` `Int | NotANumber` ``, not `Union[members=[Int, NotANumber]]`.
- A lambda of the wrong arity is reported against the parameter it fills (`` `f` of `let map` ``), not against `$0_f`.
- A record named inside `Some(...)` points at `| Some { field }` — the form that already works, so no second spelling was added.

## Examples follow

`tagging` gains examples for every behavior (a set, a map, an optional assignee) plus `topLabels`, a ranking over `Map.toList` using the tuple annotation, `List.sortBy` and `List.take`; its header comment claiming sets and maps cannot appear in fixtures was stale. `inventory` gains `checkExpiry`, a best-before rule fixed by examples written with dates.

Spec updated for the fixture notation, written temporals, E1905, and `take`/`drop`.

## Verification

`mvn clean install` at the root: 792 compiler tests, 44 LSP tests, green. `examples/`: `mvn clean test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
