### PR TITLE
Typed Core IR: the checker produces it, the backend reads it

### DIFF
--- a/docs/adr/0021-compiler-layers-core-ir.md
+++ b/docs/adr/0021-compiler-layers-core-ir.md
@@ -4,24 +4,30 @@ Status: Accepted; implemented (supersedes the MVP "no separate IR" stance record
 
 Implemented: the **Lower** stage (`check/Lower.java`) inlines each behavior body once —
 both the type checker's body check and the backend consume it, so the backend no longer
-inlines — and desugars list comprehensions. A structural **Core IR** (`core/Core.java`)
-carries the lowered behavior-body language; the backend emits every expression from Core
-(`genExpr`), and the AST `expr` is a thin `Core.of`
-adapter kept for the codec paths, which are still AST-level.
+inlines — and desugars list comprehensions. A **Core IR** (`core/Core.java`) carries the
+lowered behavior-body language, and the backend emits every expression from Core.
 
-Core is **structural, not typed**: the backend infers types as it emits. One consequence
-is that the closure path (a runtime-selected function) asks the type checker — which works
-on the AST — whether a `let` value is such a function and for its parameter types, reaching
-it through `Core.toAst()`. This is a genuine dependency of the untyped design, not an
-unfinished migration: current generics are monomorphized by inline expansion (no typed IR
-needed), and the JVM erases generics and boxes collection elements regardless, so a typed
-Core buys little for them. A typed Core IR is deferred until a real need appears — recursive
-generics lowered to shared methods, or an optimization that needs types on nodes.
+Core is **typed**: every node carries the type the checker decided for it. The type checker
+produces Core as it types a body (`TypeChecker.elaborate`), and it is the only producer —
+the backend translates nothing itself. This reverses the original stance, which deferred a
+typed Core until "a real need appears — recursive generics lowered to shared methods, or an
+optimization that needs types on nodes". The need that arrived was a third one: with an
+untyped Core the emitter inferred types again as it emitted, so every improvement to
+inference had to be made in both places, and a miss in the second copy surfaced as a codegen
+crash rather than a type error. Issues #70, #71, #74 and #80 each paid that cost before #81
+removed the second copy.
 
-The normative specification (`[#compiler-pipeline]`, `[#ast-tracking]`) still holds: Core
-is a structural lowering of behavior bodies with no type reification, so "no separate IR" in
-the sense of a typed/reified representation remains accurate; the pipeline text is revised
-when a typed Core lands, not ahead of it.
+What the emitter no longer does: resolve a recursive helper call's type variables
+(`pinResultTypeVars`, `unify`, `resolveStepBinding`, `substitute`), ask whether a `let` value
+is a runtime-selected function and what its parameter types are, re-derive a case binding's
+type, a lambda body's result type, or a combinator argument's element type. Each is read off
+the node. `Core.toAst()` is gone with the closure path that needed it, and so is `Core.of`:
+the codec emitters, which are still AST-level, elaborate their expressions through the
+checker at the environment their slots hold, rather than translating them untyped.
+
+The normative specification (`[#compiler-pipeline]`, `[#ast-tracking]`) is revised with this
+change: Core is a typed lowering of behavior bodies, so "no separate IR" no longer describes
+the pipeline.
 
 ## Context
 
@@ -49,8 +55,8 @@ The "no IR" stance has three costs that now bite:
 ## Decision
 
 The compiler is defined as an explicit layered pipeline with a **Core IR** for
-behavior bodies. (As implemented the Core IR is structural, not typed; a typed Core IR
-is deferred — see the implementation note above.)
+behavior bodies. (As implemented the Core IR is typed and the type checker produces it —
+see the implementation note above.)
 
 1. **Parse** — source to surface AST. Only concrete-syntax desugars that need no types.
 2. **Resolve** — import/`exposing` name resolution (today `Exposing`).

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -79,21 +79,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!-- The emitter reads the type the checker put on each Core node; where it still
-                         synthesises one itself, this makes a disagreement fail the test rather than
-                         surface later as a codegen crash (issue #81). -->
-                    <systemPropertyVariables>
-                        <souther.core.checkTypes>true</souther.core.checkTypes>
-                    </systemPropertyVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -79,4 +79,21 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- The emitter reads the type the checker put on each Core node; where it still
+                         synthesises one itself, this makes a disagreement fail the test rather than
+                         surface later as a codegen crash (issue #81). -->
+                    <systemPropertyVariables>
+                        <souther.core.checkTypes>true</souther.core.checkTypes>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -77,8 +77,10 @@ public final class Compiler {
         module = NewtypeDesugar.rewrite(module, TypeChecker.symbols(module));
         module = Compiler.injectRecursivePrelude(module);
         Ast.Module lowered = Lower.run(module);
-        warningsOut.addAll(TypeChecker.checkOrThrow(module, TypeChecker.symbols(module), Map.of(), lowered));
-        Map<String, byte[]> out = Backend.generate(lowered);
+        TypeChecker.Checked checked =
+                TypeChecker.checkOrThrow(module, TypeChecker.symbols(module), Map.of(), lowered);
+        warningsOut.addAll(checked.warnings());
+        Map<String, byte[]> out = Backend.generate(lowered, checked);
         verifyConstConstructions(module, TypeChecker.symbols(module), out);
         Map<String, Ast.Def> symbols = TypeChecker.symbols(module);
         ExampleVerifier.verify(module, symbols, TypeChecker.signatures(module, symbols), Map.of(), out);
@@ -239,8 +241,10 @@ public final class Compiler {
             Set<String> importedInjected = importedInjectedBehaviors(m, derived);
             m = injectRecursivePrelude(m);
             Ast.Module lowered = Lower.run(m);
-            warningsOut.addAll(TypeChecker.checkOrThrow(m, symbols, importedSigs, lowered));
-            out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs, importedInjected));
+            TypeChecker.Checked checked = TypeChecker.checkOrThrow(m, symbols, importedSigs, lowered);
+            warningsOut.addAll(checked.warnings());
+            out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs,
+                    importedInjected, checked));
         }
         // every module's classes are now present, so CTFE and example evaluation can resolve
         // cross-module references
@@ -344,7 +348,9 @@ public final class Compiler {
                 Set<String> importedInjected = importedInjectedBehaviors(m, derived);
                 m = injectRecursivePrelude(m);
                 Ast.Module lowered = Lower.run(m);
-                List<Diagnostic> typeErrors = TypeChecker.check(m, symbols, importedSigs, lowered);
+                TypeChecker.CheckResult result0 =
+                        TypeChecker.checkAndElaborate(m, symbols, importedSigs, lowered);
+                List<Diagnostic> typeErrors = result0.diagnostics();
                 if (!typeErrors.isEmpty()) {
                     // a type-invalid module must not reach codegen; report every error and skip it,
                     // so its importers are skipped too rather than compiled against a broken module.
@@ -352,7 +358,8 @@ public final class Compiler {
                     failed.add(original.name());
                     continue;
                 }
-                out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs, importedInjected));
+                out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs,
+                        importedInjected, result0.checked()));
                 verifyConstConstructions(m, symbols, out);
                 Map<String, TypeChecker.Sig> sigs =
                         TypeChecker.signatures(m, symbols, importedBehaviorSigs(m, derived));

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -65,6 +65,13 @@ public final class Lower {
                 module.examples(), module.fakes(), module.exampleFileTarget(), module.pos());
     }
 
+    /** Desugars one expression the way a body is desugared, for the paths that hold a single
+     * expression rather than a module: the codec emitters, whose decoders and encoders are still
+     * AST-level, run their expressions through this before they are typed and emitted. */
+    public static Ast.Expr desugarExpr(Ast.Expr e) {
+        return desugar(e);
+    }
+
     /** Post-order rewrite: desugar the children first, then the node itself if it is a comprehension. */
     private static Ast.Expr desugar(Ast.Expr e) {
         Ast.Expr mapped = Ast.mapChildren(e, Lower::desugar);

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -454,10 +454,16 @@ public final class TypeChecker {
             // inlined at its call sites and never emitted on its own, so its standalone check expands
             // its body here; a recursive helper hides its own parameters from helper resolution while
             // that expansion runs (foldFrom's `step` is a parameter, not a same-named user helper).
-            Ast.Expr lowered = recursive ? loweredBodies.get(h.name()) : null;
             Ast.Expr body = recursive
-                    ? (lowered != null ? lowered : inliner.inlineRecursiveBody(h))
+                    ? loweredBodies.get(h.name())
                     : inliner.inline(h.body());
+            if (recursive && body == null) {
+                // Lower keeps every recursive helper as a fn of the lowered module, and the backend
+                // emits from that same list, so a recursive helper without a lowered body would leave
+                // the backend a method to emit and no elaborated body to emit it from.
+                throw new IllegalStateException(
+                        "recursive helper `" + h.name() + "` has no lowered body");
+            }
             // a helper that returns a function (e.g. `let adder (n) = (x) -> x + n`) has no application
             // here to infer the lambda's parameter types from; it is checked where it is inlined and
             // applied (spec §blocks).
@@ -479,8 +485,8 @@ public final class TypeChecker {
             Type declaredReturn = h.declaredReturn() == null ? null : successType(h.declaredReturn(), symbols);
             Core elaboratedBody = elaborate(body, tenv, null, symbols, reqSigs, declaredReturn);
             Type bodyType = elaboratedBody.type();
-            if (lowered != null) {
-                elaborated.helpers.put(h.name(), elaboratedBody);
+            if (recursive) {
+                elaborated.helpers.put(h.name(), elaboratedBody);   // the backend emits this
             }
             // a declared return type — required on a recursive helper, allowed on any helper — must
             // match the body; a lying annotation is not silently ignored.
@@ -2361,8 +2367,9 @@ public final class TypeChecker {
                 yield new Core.ListLit(elements, Type.list(elem), lit.pos());
             }
             case Ast.ListComp comp -> {
-                // A comprehension never reaches the backend — the Lower stage rewrites it to an `if`
-                // before a body is emitted. It still types here, on the pre-lowering paths (a helper's
+                // A comprehension never reaches the backend: the Lower stage rewrites it to an `if`
+                // before a body is emitted, and the codec emitters desugar the expression they hold
+                // before elaborating it. It still types here, on the pre-lowering paths (a helper's
                 // standalone check), so the node produced is a type carrier, not something to emit.
                 for (Ast.Expr g : comp.guards()) {
                     requireType(g, Type.BOOL, env, data, symbols, reqs, "guard of a comprehension");

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -2267,7 +2267,7 @@ public final class TypeChecker {
                 Map<String, Type> inner = new HashMap<>(env);
                 inner.put(li.name(), bindType);
                 Core body = elaborate(li.body(), inner, data, symbols, reqs, expected);
-                yield new Core.LetIn(li.name(), value, li.annotation(), body, body.type(), li.pos());
+                yield new Core.LetIn(li.name(), value, body, body.type(), li.pos());
             }
             // reached only where a block escapes: it may be passed as an argument, or bound to a
             // `let` and applied, but it is not a value that can be returned or stored, because that
@@ -2911,13 +2911,25 @@ public final class TypeChecker {
             cores[i] = c;
         }
 
-        /** The elaborated arguments. An argument no typing rule reaches — the bare rounding mode of
-         * {@code divide}, which is a built-in identifier rather than an expression (spec 18.3) — is
-         * carried in its untyped form. */
+        /** Records argument {@code i} as carrying no type: it is not an expression at all, but a
+         * built-in identifier the call reads by name — the rounding mode of {@code divide}
+         * (spec 18.3), which {@code requireRoundingMode} has already checked is one. The emitter
+         * reads its name and never asks for its type. */
+        void untyped(int i) {
+            Ast.Var name = (Ast.Var) args.get(i);
+            cores[i] = new Core.Var(name.name(), null, name.pos());
+        }
+
+        /** The elaborated arguments. Every argument must have been reached: a rule that yields a type
+         * without touching one of its arguments would leave the emitter a node with no type. */
         List<Core> cores() {
             List<Core> out = new ArrayList<>();
             for (int i = 0; i < cores.length; i++) {
-                out.add(cores[i] != null ? cores[i] : Core.of(args.get(i)));
+                if (cores[i] == null) {
+                    throw new IllegalStateException(
+                            "argument " + (i + 1) + " was never typed at " + args.get(i).pos());
+                }
+                out.add(cores[i]);
             }
             return out;
         }
@@ -3069,6 +3081,8 @@ public final class TypeChecker {
                 // so accept it rather than demand the bottom. Otherwise the key must match.
                 if (!isBottom(mo.key())) {
                     ca.require(0, mo.key(), "key of Map.get");
+                } else {
+                    ca.type(0);   // nothing to check it against yet, but the key is still typed
                 }
                 yield Type.option(mo.value());
             }
@@ -3087,6 +3101,7 @@ public final class TypeChecker {
             }
             case "Date", "DateTime" -> {
                 arity(call, 1);
+                ca.type(0);   // the literal text, which temporalLiteral parses
                 yield temporalLiteral(call);
             }
             case "Int.remainder" -> {
@@ -3103,6 +3118,7 @@ public final class TypeChecker {
                     ca.require(1, Type.DECIMAL, "argument 2 of divide");
                     ca.require(2, Type.INT, "scale of divide");
                     requireRoundingMode(args.get(3));
+                    ca.untyped(3);   // a built-in identifier, not an expression
                     yield Type.union(new java.util.LinkedHashSet<>(List.of("Decimal", "DivisionByZero")));
                 }
                 arity(call, 2);
@@ -3797,7 +3813,7 @@ public final class TypeChecker {
                 Map<String, Type> inner = new HashMap<>(env);
                 inner.put(li.name(), bound.type());
                 Core body = elaborateFunctionValue(li.body(), paramTypes, inner, data, symbols, reqs);
-                yield new Core.LetIn(li.name(), bound, li.annotation(), body, body.type(), li.pos());
+                yield new Core.LetIn(li.name(), bound, body, body.type(), li.pos());
             }
             default -> elaborate(value, env, data, symbols, reqs);
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -35,18 +35,34 @@ public final class TypeChecker {
     }
 
     /**
+     * What a successful check produced for the backend (issue #81): the Core of every body it typed,
+     * carrying the type decided for each node, plus the warnings the check raised. The backend emits
+     * from these rather than translating the AST and inferring the same types a second time.
+     */
+    public record Checked(Map<String, Core> behaviorBodies, Map<String, Core> recursiveHelpers,
+                          List<Diagnostic> warnings) {}
+
+    /** The bodies elaborated so far, filled as the check walks them. */
+    private static final class Elaborated {
+        private final Map<String, Core> behaviors = new LinkedHashMap<>();
+        private final Map<String, Core> helpers = new LinkedHashMap<>();
+    }
+
+    /**
      * Type-checks {@code module} and, if any error was found, throws the first — the fail-fast entry
      * point for the CLI and the annotation processor, which stop at the first error. The recovering
      * {@link #check(Ast.Module, Map, Map, Ast.Module)} collects every error for the LSP instead.
      */
-    public static List<Diagnostic> checkOrThrow(Ast.Module module, Map<String, Ast.Def> symbols,
+    public static Checked checkOrThrow(Ast.Module module, Map<String, Ast.Def> symbols,
                                                 Map<String, Sig> importedSigs, Ast.Module lowered) {
         List<Diagnostic> warnings = new ArrayList<>();
-        List<CompileException> errors = checkCollecting(module, symbols, importedSigs, lowered, warnings);
+        Elaborated elaborated = new Elaborated();
+        List<CompileException> errors =
+                checkCollecting(module, symbols, importedSigs, lowered, warnings, elaborated);
         if (!errors.isEmpty()) {
             throw errors.get(0);   // the original exception, so its rendered message is unchanged
         }
-        return warnings;
+        return new Checked(elaborated.behaviors, elaborated.helpers, warnings);
     }
 
     /** Every error found in {@code module}, recovering past each so the whole module is checked; the
@@ -54,10 +70,10 @@ public final class TypeChecker {
      * check would have thrown), deduped. */
     private static List<CompileException> checkCollecting(Ast.Module module, Map<String, Ast.Def> symbols,
                                                           Map<String, Sig> importedSigs, Ast.Module lowered,
-                                                          List<Diagnostic> warnings) {
+                                                          List<Diagnostic> warnings, Elaborated elaborated) {
         List<CompileException> errors = new ArrayList<>();
         try {
-            checkRecovering(module, symbols, importedSigs, lowered, errors, warnings);
+            checkRecovering(module, symbols, importedSigs, lowered, errors, warnings, elaborated);
         } catch (CompileException e) {
             // A structural / prerequisite check (a duplicate name, an `exposing` violation, a module
             // cycle) is fail-fast: it can leave later phases without the state they read, so its first
@@ -108,13 +124,24 @@ public final class TypeChecker {
      */
     public static List<Diagnostic> check(Ast.Module module, Map<String, Ast.Def> symbols,
                              Map<String, Sig> importedSigs, Ast.Module lowered) {
+        return checkAndElaborate(module, symbols, importedSigs, lowered).diagnostics();
+    }
+
+    /** The diagnostics of a recovering check together with what it elaborated — the entry point for a
+     * multi-module compile, which reports every module's errors and emits only the clean ones. */
+    public record CheckResult(List<Diagnostic> diagnostics, Checked checked) {}
+
+    public static CheckResult checkAndElaborate(Ast.Module module, Map<String, Ast.Def> symbols,
+                                                Map<String, Sig> importedSigs, Ast.Module lowered) {
         List<Diagnostic> out = new ArrayList<>();
         List<Diagnostic> warnings = new ArrayList<>();
-        for (CompileException e : checkCollecting(module, symbols, importedSigs, lowered, warnings)) {
+        Elaborated elaborated = new Elaborated();
+        for (CompileException e : checkCollecting(module, symbols, importedSigs, lowered, warnings,
+                elaborated)) {
             out.add(e.diagnostic());
         }
         out.addAll(warnings);
-        return out;
+        return new CheckResult(out, new Checked(elaborated.behaviors, elaborated.helpers, warnings));
     }
 
     /**
@@ -126,7 +153,8 @@ public final class TypeChecker {
      */
     private static void checkRecovering(Ast.Module module, Map<String, Ast.Def> symbols,
                                         Map<String, Sig> importedSigs, Ast.Module lowered,
-                                        List<CompileException> errors, List<Diagnostic> warnings) {
+                                        List<CompileException> errors, List<Diagnostic> warnings,
+                                        Elaborated elaborated) {
         Map<String, Ast.Expr> loweredBodies = new HashMap<>();
         for (Ast.FnDef fn : lowered.fns()) {
             loweredBodies.put(fn.name(), fn.body());
@@ -263,7 +291,8 @@ public final class TypeChecker {
         // Helper fns (no matching behavior) are expanded inline at each call site (spec 12.5); a
         // helper is checked standalone against its own declared parameter types (spec 13.1). Recovered
         // so a broken helper does not hide the behavior-body errors checked below.
-        collect(errors, () -> checkHelpers(inliner, symbols, reqSigs, recursiveHelperFns, module));
+        collect(errors, () -> checkHelpers(inliner, symbols, reqSigs, recursiveHelperFns, module,
+                loweredBodies, elaborated));
         // Recursion is total by default (spec §fn-declaration): a non-`partial` recursive helper must
         // be structurally recursive, so its examples terminate at compile time.
         collect(errors, () -> TotalityChecker.check(inliner));
@@ -275,8 +304,10 @@ public final class TypeChecker {
             if (b instanceof Ast.SpecBehavior spec) {
                 Ast.FnDef fn = fns.get(spec.name());
                 if (fn != null) {
-                    collect(errors, () -> checkSpecFn(spec, fn, loweredBodies.get(spec.name()), symbols,
-                            allBehaviors, reqSigs, inliner, recursiveHelperFns, recHelperConstructs, warnings));
+                    collect(errors, () -> elaborated.behaviors.put(fn.name(),
+                            checkSpecFn(spec, fn, loweredBodies.get(spec.name()), symbols,
+                            allBehaviors, reqSigs, inliner, recursiveHelperFns, recHelperConstructs,
+                            warnings)));
                 }
             }
         }
@@ -377,7 +408,8 @@ public final class TypeChecker {
      */
     private static void checkHelpers(HelperInliner inliner, Map<String, Ast.Def> symbols,
                                      Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns,
-                                     Ast.Module module) {
+                                     Ast.Module module, Map<String, Ast.Expr> loweredBodies,
+                                     Elaborated elaborated) {
         // Call sites that inference reads argument types from, built once for the whole module (each is
         // a top-level fn body with the environment its parameters bind).
         List<CallScope> callScopes = inferenceScopes(module, symbols);
@@ -416,9 +448,16 @@ public final class TypeChecker {
                     env.put(h.params().get(idx).name(), types.get(idx));
                 }
             }
-            // a recursive helper hides its own parameters from helper resolution while its body is
-            // expanded (foldFrom's `step` is a parameter, not a same-named user helper).
-            Ast.Expr body = recursive ? inliner.inlineRecursiveBody(h) : inliner.inline(h.body());
+            // A recursive helper survives to the backend as a method on `$Fns`, so it is typed on the
+            // body the Lower stage produced — the same tree the backend emits — and the Core this
+            // check produces is what the backend emits from (issue #81). A non-recursive helper is
+            // inlined at its call sites and never emitted on its own, so its standalone check expands
+            // its body here; a recursive helper hides its own parameters from helper resolution while
+            // that expansion runs (foldFrom's `step` is a parameter, not a same-named user helper).
+            Ast.Expr lowered = recursive ? loweredBodies.get(h.name()) : null;
+            Ast.Expr body = recursive
+                    ? (lowered != null ? lowered : inliner.inlineRecursiveBody(h))
+                    : inliner.inline(h.body());
             // a helper that returns a function (e.g. `let adder (n) = (x) -> x + n`) has no application
             // here to infer the lambda's parameter types from; it is checked where it is inlined and
             // applied (spec §blocks).
@@ -438,7 +477,11 @@ public final class TypeChecker {
             // push a declared return type into the body so an empty-collection body (Map.empty(), [])
             // takes the declared element/value type rather than a bottom
             Type declaredReturn = h.declaredReturn() == null ? null : successType(h.declaredReturn(), symbols);
-            Type bodyType = typeOf(body, tenv, null, symbols, reqSigs, declaredReturn);
+            Core elaboratedBody = elaborate(body, tenv, null, symbols, reqSigs, declaredReturn);
+            Type bodyType = elaboratedBody.type();
+            if (lowered != null) {
+                elaborated.helpers.put(h.name(), elaboratedBody);
+            }
             // a declared return type — required on a recursive helper, allowed on any helper — must
             // match the body; a lying annotation is not silently ignored.
             if (declaredReturn != null) {
@@ -822,7 +865,7 @@ public final class TypeChecker {
         }
     }
 
-    private static void checkSpecFn(Ast.SpecBehavior spec, Ast.FnDef fn, Ast.Expr inlinedBody,
+    private static Core checkSpecFn(Ast.SpecBehavior spec, Ast.FnDef fn, Ast.Expr inlinedBody,
                                     Map<String, Ast.Def> symbols, Set<String> allBehaviors,
                                     Map<String, ReqSig> reqSigs, HelperInliner inliner,
                                     Map<String, Type> recursiveHelperFns,
@@ -896,7 +939,8 @@ public final class TypeChecker {
 
         // push the declared output type into the body so a body that is directly an empty collection
         // (or a construction whose field is one) takes the declared type rather than a bottom
-        Type rt = typeOf(body, tenv, null, symbols, reqSigs, output);
+        Core elaboratedBody = elaborate(body, tenv, null, symbols, reqSigs, output);
+        Type rt = elaboratedBody.type();
         if (!assignable(rt, output, symbols)) {
             throw CompileException.of(
                     Diagnostic.of(null, "check.behavior.return").title("check.type.mismatch.title")
@@ -968,6 +1012,7 @@ public final class TypeChecker {
         if (!inv.errors().isEmpty()) {
             throw inv.errors().get(0);
         }
+        return elaboratedBody;
     }
 
     /**
@@ -1918,11 +1963,13 @@ public final class TypeChecker {
         checkConstruction(c.typeName(), c.inits(), c.spreads(), c.pos(), fields, env, data, symbols, NO_REQS);
     }
 
-    private static void checkConstruction(String typeName, List<Ast.FieldInit> inits, List<String> spreads,
+    private static List<Core.FieldInit> checkConstruction(String typeName, List<Ast.FieldInit> inits,
+                                          List<String> spreads,
                                           SourcePos pos, Map<String, Type> fields, Map<String, Type> env,
                                           Ast.Data data, Map<String, Ast.Def> symbols,
                                           Map<String, ReqSig> reqs) {
         Map<String, Ast.FieldInit> byName = new HashMap<>();
+        List<Core.FieldInit> elaborated = new ArrayList<>();
         for (Ast.FieldInit init : inits) {
             if (byName.put(init.name(), init) != null) {
                 throw CompileException.of(
@@ -1939,7 +1986,9 @@ public final class TypeChecker {
             }
             // push the field's declared type into the value expression, so a field initialised from a
             // fold over an empty-collection seed has its result pinned by the field type (issue #70)
-            Type vt = typeOf(init.value(), env, data, symbols, reqs, ft);
+            Core value = elaborate(init.value(), env, data, symbols, reqs, ft);
+            elaborated.add(new Core.FieldInit(init.name(), value, init.pos()));
+            Type vt = value.type();
             if (!assignable(vt, ft, symbols)) {   // a case value widens to its sum-typed field (spec 8.3)
                 throw CompileException.of(
                         Diagnostic.of(null, "check.field.type").title("check.type.mismatch.title")
@@ -1980,6 +2029,7 @@ public final class TypeChecker {
                                 + f.getValue());
             }
         }
+        return elaborated;
     }
 
     private static void checkEncoder(Ast.EncoderDef enc, Ast.Data data, Map<String, Ast.Def> symbols) {
@@ -2111,33 +2161,54 @@ public final class TypeChecker {
         return typeOf(e, env, data, symbols, reqs, null);
     }
 
-    // Bidirectional typing: {@code expected} is the type this expression is checked against, pushed
-    // down from the surrounding context (a declared field type, a declared return type). It may be
-    // {@code null} — no context — in which case this behaves exactly as pure bottom-up synthesis.
-    // Only a few arms consume it: the empty-collection leaves ([], Map.empty, Set.empty) adopt it,
-    // and a generic call pre-binds its result-type variables from it, so a fold whose seed is an
-    // empty collection has its accumulator pinned by context before the step is checked.
+    /** The type of {@code e}, discarding the Core the elaboration produced — for the checks that ask
+     * only whether an expression types (a decoder, an invariant, a helper's standalone check). */
     public static Type typeOf(Ast.Expr e, Map<String, Type> env, Ast.Data data,
                               Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs, Type expected) {
+        return elaborate(e, env, data, symbols, reqs, expected).type();
+    }
+
+    public static Core elaborate(Ast.Expr e, Map<String, Type> env, Ast.Data data,
+                                 Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs) {
+        return elaborate(e, env, data, symbols, reqs, null);
+    }
+
+    /**
+     * Types {@code e} and produces the Core node for it, carrying the type this decided (issue #81).
+     * The backend emits from what this returns instead of inferring the same types a second time.
+     *
+     * <p>Bidirectional typing: {@code expected} is the type this expression is checked against, pushed
+     * down from the surrounding context (a declared field type, a declared return type). It may be
+     * {@code null} — no context — in which case this behaves exactly as pure bottom-up synthesis.
+     * Only a few arms consume it: the empty-collection leaves ([], Map.empty, Set.empty) adopt it,
+     * and a generic call pre-binds its result-type variables from it, so a fold whose seed is an
+     * empty collection has its accumulator pinned by context before the step is checked.
+     */
+    public static Core elaborate(Ast.Expr e, Map<String, Type> env, Ast.Data data,
+                                 Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs, Type expected) {
         return switch (e) {
-            case Ast.IntLit _ -> Type.INT;
-            case Ast.DecimalLit _ -> Type.DECIMAL;
-            case Ast.StringLit _ -> Type.STRING;
-            case Ast.BoolLit _ -> Type.BOOL;
+            case Ast.IntLit x -> new Core.Int(x.value(), Type.INT, x.pos());
+            case Ast.DecimalLit x -> new Core.Decimal(x.value(), Type.DECIMAL, x.pos());
+            case Ast.StringLit x -> new Core.Str(x.value(), Type.STRING, x.pos());
+            case Ast.BoolLit x -> new Core.Bool(x.value(), Type.BOOL, x.pos());
             case Ast.Tuple tup -> {
                 // A pushed-down tuple type reaches each element, so a written `(Set<Int>, List<Int>)`
                 // fixes the empty collections the tuple seeds rather than leaving them bottoms (#74).
                 List<Type> want = expected instanceof Type.TupleOf te
                         && te.elements().size() == tup.elements().size() ? te.elements() : null;
-                List<Type> elems = new ArrayList<>();
+                List<Core> elems = new ArrayList<>();
+                List<Type> elemTypes = new ArrayList<>();
                 for (int i = 0; i < tup.elements().size(); i++) {
-                    elems.add(typeOf(tup.elements().get(i), env, data, symbols, reqs,
-                            want == null ? null : want.get(i)));
+                    Core el = elaborate(tup.elements().get(i), env, data, symbols, reqs,
+                            want == null ? null : want.get(i));
+                    elems.add(el);
+                    elemTypes.add(el.type());
                 }
-                yield Type.tuple(elems);
+                yield new Core.Tuple(elems, Type.tuple(elemTypes), tup.pos());
             }
             case Ast.TupleGet tg -> {
-                Type tt = typeOf(tg.tuple(), env, data, symbols, reqs);
+                Core tuple = elaborate(tg.tuple(), env, data, symbols, reqs);
+                Type tt = tuple.type();
                 if (!(tt instanceof Type.TupleOf to)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.tuple.pattern").title("check.type.mismatch.title")
@@ -2151,10 +2222,12 @@ public final class TypeChecker {
                             "this pattern binds " + tg.arity()
                                     + " name(s) but the tuple has " + to.elements().size() + " element(s)");
                 }
-                yield to.elements().get(tg.index());
+                yield new Core.TupleGet(tuple, tg.index(), tg.arity(),
+                        to.elements().get(tg.index()), tg.pos());
             }
             case Ast.Neg neg -> {
-                Type t = typeOf(neg.operand(), env, data, symbols, reqs);
+                Core operand = elaborate(neg.operand(), env, data, symbols, reqs);
+                Type t = operand.type();
                 if (t != Type.INT && t != Type.DECIMAL) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.neg.msg")
@@ -2164,10 +2237,11 @@ public final class TypeChecker {
                                     .build(),
                             "unary minus needs an Int or Decimal, got " + t);
                 }
-                yield t;
+                yield new Core.Neg(operand, t, neg.pos());
             }
             case Ast.LetIn li -> {
                 Type annotation = annotatedType(li, symbols);
+                Core value;
                 Type bindType;
                 if (isFunctionSelection(li.value())) {
                     // a lambda bound to a local that could not be inlined (e.g. chosen by an `if`):
@@ -2177,20 +2251,23 @@ public final class TypeChecker {
                         throw functionAnnotation(li);   // no ordinary type describes a function value
                     }
                     List<Type> paramTypes = inferFnParamTypes(li.name(), li.body(), env, data, symbols, reqs);
-                    bindType = typeFunctionValue(li.value(), paramTypes, env, data, symbols, reqs);
+                    value = elaborateFunctionValue(li.value(), paramTypes, env, data, symbols, reqs);
+                    bindType = value.type();
                 } else if (annotation != null) {
                     // the written type is the value's expected type, so an empty collection bound here
                     // takes its element/value type from the annotation rather than staying a bottom
-                    Type valueType = typeOf(li.value(), env, data, symbols, reqs, annotation);
-                    checkLetAnnotation(li, annotation, valueType, symbols);
+                    value = elaborate(li.value(), env, data, symbols, reqs, annotation);
+                    checkLetAnnotation(li, annotation, value.type(), symbols);
                     bindType = annotation;
                 } else {
-                    bindType = carriedType(li, typeOf(li.value(), env, data, symbols, reqs), symbols);
+                    value = elaborate(li.value(), env, data, symbols, reqs);
+                    bindType = carriedType(li, value.type(), symbols);
                 }
                 // the binding is visible only inside the body, so a sibling branch cannot see it
                 Map<String, Type> inner = new HashMap<>(env);
                 inner.put(li.name(), bindType);
-                yield typeOf(li.body(), inner, data, symbols, reqs, expected);
+                Core body = elaborate(li.body(), inner, data, symbols, reqs, expected);
+                yield new Core.LetIn(li.name(), value, li.annotation(), body, body.type(), li.pos());
             }
             // reached only where a block escapes: it may be passed as an argument, or bound to a
             // `let` and applied, but it is not a value that can be returned or stored, because that
@@ -2203,11 +2280,11 @@ public final class TypeChecker {
             case Ast.Var v -> {
                 Type t = env.get(v.name());
                 if (t != null) {
-                    yield t;
+                    yield new Core.Var(v.name(), t, v.pos());
                 }
                 // a bare name that isn't a local is a unit-data value (spec 8.4)
                 if (symbols.get(v.name()) instanceof Ast.UnitData) {
-                    yield Type.ref(v.name());
+                    yield new Core.Var(v.name(), Type.ref(v.name()), v.pos());
                 }
                 if (v.name().equals("null")) {
                     throw new CompileException(v.pos(), "E1301",
@@ -2222,9 +2299,9 @@ public final class TypeChecker {
                                 .build(),
                         "unknown identifier `" + v.name() + "`" + Suggest.hint(v.name(), env.keySet()));
             }
-            case Ast.FieldAccess fa -> typeOfFieldAccess(fa, env, data, symbols, reqs);
-            case Ast.Call call -> typeOfCall(call, env, data, symbols, reqs, expected);
-            case Ast.Binary bin -> typeOfBinary(bin, env, data, symbols, reqs);
+            case Ast.FieldAccess fa -> elaborateFieldAccess(fa, env, data, symbols, reqs);
+            case Ast.Call call -> elaborateCall(call, env, data, symbols, reqs, expected);
+            case Ast.Binary bin -> elaborateBinary(bin, env, data, symbols, reqs);
             case Ast.NewData nd -> {
                 if (!(symbols.get(nd.typeName()) instanceof Ast.Data owner)) {
                     throw CompileException.of(
@@ -2232,26 +2309,29 @@ public final class TypeChecker {
                                     .at(nd.pos(), nd.typeName().length()).args(nd.typeName()).build(),
                             "cannot construct `" + nd.typeName() + "`");
                 }
-                checkConstruction(nd.typeName(), nd.inits(), nd.spreads(), nd.pos(),
-                        fieldTypes(owner, symbols), env, data, symbols, reqs);
-                yield Type.ref(nd.typeName());
+                List<Core.FieldInit> inits = checkConstruction(nd.typeName(), nd.inits(), nd.spreads(),
+                        nd.pos(), fieldTypes(owner, symbols), env, data, symbols, reqs);
+                yield new Core.NewData(nd.typeName(), inits, nd.spreads(),
+                        Type.ref(nd.typeName()), nd.pos());
             }
-            case Ast.Match m -> typeOfMatch(m, env, data, symbols, reqs, expected);
+            case Ast.Match m -> elaborateMatch(m, env, data, symbols, reqs, expected);
             case Ast.If iff -> {
-                requireType(iff.cond(), Type.BOOL, env, data, symbols, reqs, "if condition");
-                Type tt = typeOf(iff.then(), env, data, symbols, reqs, expected);
-                Type et = typeOf(iff.els(), env, data, symbols, reqs, expected);
+                Core cond = requireTyped(iff.cond(), Type.BOOL, env, data, symbols, reqs, "if condition");
+                Core then = elaborate(iff.then(), env, data, symbols, reqs, expected);
+                Core els = elaborate(iff.els(), env, data, symbols, reqs, expected);
+                Type tt = then.type();
+                Type et = els.type();
                 Type empty = absorbBottom(tt, et);   // one case may be `[]`, or a tuple of them (ADR-0028)
                 if (empty != null) {
-                    yield empty;
+                    yield new Core.If(cond, then, els, empty, iff.pos());
                 }
                 if (tt.equals(et)) {
-                    yield tt;
+                    yield new Core.If(cond, then, els, tt, iff.pos());
                 }
                 if (isDataLike(tt) && isDataLike(et)) {
                     Set<String> names = new HashSet<>(namesOf(tt));
                     names.addAll(namesOf(et));
-                    yield Type.union(names);
+                    yield new Core.If(cond, then, els, Type.union(names), iff.pos());
                 }
                 throw CompileException.of(
                         Diagnostic.of(null, "check.if.msg")
@@ -2268,22 +2348,38 @@ public final class TypeChecker {
             case Ast.ListLit lit -> {
                 if (lit.elements().isEmpty()) {
                     // `[]`: element type fixed by context (ADR-0028); adopt an expected list type
-                    yield expected instanceof Type.ListOf le ? le : Type.EMPTY_LIST;
+                    yield new Core.ListLit(List.of(),
+                            expected instanceof Type.ListOf le ? le : Type.EMPTY_LIST, lit.pos());
                 }
+                List<Core> elements = new ArrayList<>();
                 Type elem = null;
                 for (Ast.Expr el : lit.elements()) {
-                    Type t = typeOf(el, env, data, symbols, reqs);
-                    elem = elem == null ? t : unifyElem(elem, t, lit.pos());
+                    Core c = elaborate(el, env, data, symbols, reqs);
+                    elements.add(c);
+                    elem = elem == null ? c.type() : unifyElem(elem, c.type(), lit.pos());
                 }
-                yield Type.list(elem);
+                yield new Core.ListLit(elements, Type.list(elem), lit.pos());
             }
             case Ast.ListComp comp -> {
+                // A comprehension never reaches the backend — the Lower stage rewrites it to an `if`
+                // before a body is emitted. It still types here, on the pre-lowering paths (a helper's
+                // standalone check), so the node produced is a type carrier, not something to emit.
                 for (Ast.Expr g : comp.guards()) {
                     requireType(g, Type.BOOL, env, data, symbols, reqs, "guard of a comprehension");
                 }
-                yield Type.list(typeOf(comp.element(), env, data, symbols, reqs));
+                Core element = elaborate(comp.element(), env, data, symbols, reqs);
+                yield new Core.ListLit(List.of(element), Type.list(element.type()), comp.pos());
             }
         };
+    }
+
+    /** Elaborates {@code e} and checks it against {@code expected}, returning its Core. The check is
+     * bottom-up, as {@link #requireType} is: the expected type is not pushed into the expression. */
+    private static Core requireTyped(Ast.Expr e, Type expected, Map<String, Type> env, Ast.Data data,
+                                     Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs, String what) {
+        Core c = elaborate(e, env, data, symbols, reqs);
+        requireType(e, c.type(), expected, symbols, what);
+        return c;
     }
 
     /** Refines the type-variable bindings from a function argument's actual result: where the
@@ -2494,14 +2590,16 @@ public final class TypeChecker {
                 "list elements disagree on type: " + a + " vs " + b);
     }
 
-    private static Type typeOfMatch(Ast.Match m, Map<String, Type> env, Ast.Data data,
-                                    Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs, Type expected) {
-        Type st = typeOf(m.scrutinee(), env, data, symbols, reqs);
+    private static Core elaborateMatch(Ast.Match m, Map<String, Type> env, Ast.Data data,
+                                       Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs,
+                                       Type expected) {
+        Core scrutinee = elaborate(m.scrutinee(), env, data, symbols, reqs);
+        Type st = scrutinee.type();
         if (st instanceof Type.OptionOf oo) {
-            return typeOfOptionMatch(m, oo.element(), env, data, symbols, reqs, expected);
+            return elaborateOptionMatch(m, scrutinee, oo.element(), env, data, symbols, reqs, expected);
         }
         if (st instanceof Type.Union union) {
-            return typeOfCasesMatch(m, union.members(), "union `" + Type.show(union) + "`",
+            return elaborateCasesMatch(m, scrutinee, union.members(), "union `" + Type.show(union) + "`",
                     st, env, data, symbols, reqs, expected);
         }
         if (!(st instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.SumData sum)) {
@@ -2510,7 +2608,7 @@ public final class TypeChecker {
                             .at(m.pos(), 5).args(Type.show(st)).build(),
                     "match requires a sum-typed value, got " + st);
         }
-        return typeOfCasesMatch(m, new HashSet<>(sum.cases()), "data `" + sum.name() + "`",
+        return elaborateCasesMatch(m, scrutinee, new HashSet<>(sum.cases()), "data `" + sum.name() + "`",
                 st, env, data, symbols, reqs, expected);
     }
 
@@ -2518,10 +2616,12 @@ public final class TypeChecker {
      * A single-case case binds that case's type; an or-pattern ({@code A | B}) binds {@code scrutinee}
      * (the sum type), since no one case type fits all its alternatives. Every case must be covered
      * exactly once (E1201; a second cover is an overlap error). */
-    private static Type typeOfCasesMatch(Ast.Match m, Set<String> cases, String what, Type scrutinee,
+    private static Core elaborateCasesMatch(Ast.Match m, Core scrutineeCore, Set<String> cases,
+                                        String what, Type scrutinee,
                                         Map<String, Type> env, Ast.Data data, Map<String, Ast.Def> symbols,
                                         Map<String, ReqSig> reqs, Type expected) {
         Set<String> covered = new HashSet<>();
+        List<Core.Case> arms = new ArrayList<>();
         Type branchType = null;
         for (Ast.Case c : m.cases()) {
             for (String caseName : c.caseTypes()) {
@@ -2548,8 +2648,9 @@ public final class TypeChecker {
                 }
                 checkUnwrapAsserts(c, symbols);
             }
-            branchType = mergeBranch(m, branchType,
-                    typeOf(c.body(), bound(env, c.binding(), bindType), data, symbols, reqs, expected), c);
+            Core body = elaborate(c.body(), bound(env, c.binding(), bindType), data, symbols, reqs, expected);
+            arms.add(new Core.Case(c.caseTypes(), c.binding(), body, bindType, c.pos()));
+            branchType = mergeBranch(m, branchType, body.type(), c);
         }
         List<String> missing = new ArrayList<>();
         for (String caseName : cases) {
@@ -2567,14 +2668,16 @@ public final class TypeChecker {
                             .at(m.pos(), 5).build(),
                     "match has no cases");
         }
-        return branchType;
+        return new Core.Match(scrutineeCore, arms, branchType, m.pos());
     }
 
     /** Match over {@code Option<element>}: cases are {@code Some} (binds the element) and
      * {@code None}; both must be present (spec 16.3). */
-    private static Type typeOfOptionMatch(Ast.Match m, Type element, Map<String, Type> env, Ast.Data data,
+    private static Core elaborateOptionMatch(Ast.Match m, Core scrutineeCore, Type element,
+                                          Map<String, Type> env, Ast.Data data,
                                           Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs, Type expected) {
         Set<String> covered = new HashSet<>();
+        List<Core.Case> arms = new ArrayList<>();
         Type branchType = null;
         for (Ast.Case c : m.cases()) {
             if (c.caseTypes().size() != 1) {
@@ -2607,8 +2710,9 @@ public final class TypeChecker {
                                 .at(c.pos()).args(caseType).build(),
                         "`" + caseType + "` is matched by more than one case");
             }
-            branchType = mergeBranch(m, branchType,
-                    typeOf(c.body(), bound(env, c.binding(), bind), data, symbols, reqs, expected), c);
+            Core body = elaborate(c.body(), bound(env, c.binding(), bind), data, symbols, reqs, expected);
+            arms.add(new Core.Case(c.caseTypes(), c.binding(), body, bind, c.pos()));
+            branchType = mergeBranch(m, branchType, body.type(), c);
         }
         List<String> missing = new ArrayList<>();
         for (String caseName : List.of("Some", "None")) {
@@ -2619,7 +2723,7 @@ public final class TypeChecker {
         if (!missing.isEmpty()) {
             throw nonExhaustive(m.pos(), "Option", missing);
         }
-        return branchType;
+        return new Core.Match(scrutineeCore, arms, branchType, m.pos());
     }
 
     /** The type a match case binds. A primitive-named case (e.g. {@code Int} in {@code Int |
@@ -2733,13 +2837,14 @@ public final class TypeChecker {
     }
 
 
-    private static Type typeOfFieldAccess(Ast.FieldAccess fa, Map<String, Type> env, Ast.Data data,
+    private static Core elaborateFieldAccess(Ast.FieldAccess fa, Map<String, Type> env, Ast.Data data,
                                           Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs) {
-        Type target = typeOf(fa.target(), env, data, symbols, reqs);
+        Core targetCore = elaborate(fa.target(), env, data, symbols, reqs);
+        Type target = targetCore.type();
         if (target instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data owner) {
             Type ft = fieldTypes(owner, symbols).get(fa.field());
             if (ft != null) {
-                return ft;
+                return new Core.FieldAccess(targetCore, fa.field(), ft, fa.pos());
             }
         }
         throw CompileException.of(
@@ -2748,7 +2853,77 @@ public final class TypeChecker {
                 "cannot access field `" + fa.field() + "` on this value");
     }
 
-    private static Type typeOfCall(Ast.Call call, Map<String, Type> env, Ast.Data data,
+    private static Core elaborateCall(Ast.Call call, Map<String, Type> env, Ast.Data data,
+                                      Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs,
+                                      Type expected) {
+        CallArgs ca = new CallArgs(call.args(), env, data, symbols, reqs);
+        Type result = typeOfCall(ca, call, env, data, symbols, reqs, expected);
+        return new Core.Call(call.fn(), ca.cores(), result, call.pos());
+    }
+
+    /**
+     * The arguments of one call, each elaborated once, as the call's typing rule reaches it. A rule
+     * types its arguments in its own order and shape — some through a required type, a step through
+     * the accumulator the other arguments fixed — so the Core for each argument is collected here
+     * rather than by a separate walk that would have to reconstruct that context.
+     */
+    private static final class CallArgs {
+        private final List<Ast.Expr> args;
+        private final Core[] cores;
+        private final Map<String, Type> env;
+        private final Ast.Data data;
+        private final Map<String, Ast.Def> symbols;
+        private final Map<String, ReqSig> reqs;
+
+        CallArgs(List<Ast.Expr> args, Map<String, Type> env, Ast.Data data,
+                 Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs) {
+            this.args = args;
+            this.cores = new Core[args.size()];
+            this.env = env;
+            this.data = data;
+            this.symbols = symbols;
+            this.reqs = reqs;
+        }
+
+        /** The type of argument {@code i}, elaborated with no expected type (bottom-up). */
+        Type type(int i) {
+            Core c = elaborate(args.get(i), env, data, symbols, reqs);
+            cores[i] = c;
+            return c.type();
+        }
+
+        /** Argument {@code i} checked against {@code expected}, as {@link #requireType} does. */
+        void require(int i, Type expected, String what) {
+            Core c = elaborate(args.get(i), env, data, symbols, reqs);
+            cores[i] = c;
+            requireType(args.get(i), c.type(), expected, symbols, what);
+        }
+
+        /** Argument {@code i} as a block (or a function value standing in for one), returning the
+         * result type the block yields at {@code paramTypes}. */
+        Type block(int i, String fnName, List<Type> paramTypes) {
+            Core c = elaborateBlockArg(fnName, args.get(i), paramTypes, env, data, symbols, reqs);
+            cores[i] = c;
+            return ((Type.FnOf) c.type()).result();
+        }
+
+        void put(int i, Core c) {
+            cores[i] = c;
+        }
+
+        /** The elaborated arguments. An argument no typing rule reaches — the bare rounding mode of
+         * {@code divide}, which is a built-in identifier rather than an expression (spec 18.3) — is
+         * carried in its untyped form. */
+        List<Core> cores() {
+            List<Core> out = new ArrayList<>();
+            for (int i = 0; i < cores.length; i++) {
+                out.add(cores[i] != null ? cores[i] : Core.of(args.get(i)));
+            }
+            return out;
+        }
+    }
+
+    private static Type typeOfCall(CallArgs ca, Ast.Call call, Map<String, Type> env, Ast.Data data,
                                    Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs, Type expected) {
         List<Ast.Expr> args = call.args();
         // A shipped intrinsic behaves like a built-in: check the call against its declared signature
@@ -2765,7 +2940,7 @@ public final class TypeChecker {
             }
             Map<String, Type> bindings = new HashMap<>();
             for (int i = 0; i < args.size(); i++) {
-                Type argType = typeOf(args.get(i), env, data, symbols, reqs);
+                Type argType = ca.type(i);
                 unify(intrinsic.params().get(i), argType, bindings, symbols, call.pos(),
                         "argument " + (i + 1) + " of " + call.fn());
             }
@@ -2789,19 +2964,19 @@ public final class TypeChecker {
         return switch (call.fn()) {
             case "String.length" -> {
                 arity(call, 1);
-                requireType(args.get(0), Type.STRING, env, data, symbols, reqs, "argument of String.length");
+                ca.require(0, Type.STRING, "argument of String.length");
                 yield Type.INT;
             }
             case "String.toInt" -> {
                 arity(call, 1);
-                requireType(args.get(0), Type.STRING, env, data, symbols, reqs, "argument of String.toInt");
+                ca.require(0, Type.STRING, "argument of String.toInt");
                 // a non-numeric string produces the NotANumber case; a primitive-headed union a core
                 // declaration cannot name, so this stays a built-in like Int.divide
                 yield Type.union(new java.util.LinkedHashSet<>(List.of("Int", "NotANumber")));
             }
             case "List.length" -> {
                 arity(call, 1);
-                Type t = typeOf(args.get(0), env, data, symbols, reqs);
+                Type t = ca.type(0);
                 if (!(t instanceof Type.ListOf)) {
                     throw expects(call.pos(), "List.length", "kind.list", t,
                             "argument of List.length must be a List but is " + t);
@@ -2810,7 +2985,7 @@ public final class TypeChecker {
             }
             case "List.max", "List.min" -> {
                 arity(call, 1);
-                Type t = typeOf(args.get(0), env, data, symbols, reqs);
+                Type t = ca.type(0);
                 if (!(t instanceof Type.ListOf lo)) {
                     throw expects(call.pos(), call.fn(), "kind.list", t,
                             "argument of " + call.fn() + " must be a List but is " + t);
@@ -2828,12 +3003,12 @@ public final class TypeChecker {
             }
             case "List.find" -> {
                 arity(call, 2);   // find(p, xs): predicate first, list last (F#/Elm order)
-                Type t = typeOf(args.get(1), env, data, symbols, reqs);
+                Type t = ca.type(1);
                 if (!(t instanceof Type.ListOf lo)) {
                     throw expects(call.pos(), "List.find", "kind.list", t,
                             "List.find expects a List, got " + t);
                 }
-                Type pr = blockType(call.fn(), args.get(0), List.of(lo.element()), env, data, symbols, reqs);
+                Type pr = ca.block(0, call.fn(), List.of(lo.element()));
                 if (pr != Type.BOOL) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.fn.predicatebool").title("check.fn.title")
@@ -2844,24 +3019,24 @@ public final class TypeChecker {
             }
             case "Option.map" -> {
                 arity(call, 2);   // map(f, opt): function first, option last (F#/Elm order)
-                Type t = typeOf(args.get(1), env, data, symbols, reqs);
+                Type t = ca.type(1);
                 if (!(t instanceof Type.OptionOf oo)) {
                     throw expects(call.pos(), "Option.map", "kind.option", t,
                             "Option.map expects an Option, got " + t);
                 }
                 // `f` sees the contained value; the option's element type gives its one parameter type.
                 // The result re-wraps `f`'s return, so the whole call is `Option<'b>`.
-                Type r = blockType(call.fn(), args.get(0), List.of(oo.element()), env, data, symbols, reqs);
+                Type r = ca.block(0, call.fn(), List.of(oo.element()));
                 yield Type.option(r);
             }
             case "List.sortBy" -> {
                 arity(call, 2);   // sortBy(key, xs): key first, list last (F#/Elm order)
-                Type t = typeOf(args.get(1), env, data, symbols, reqs);
+                Type t = ca.type(1);
                 if (!(t instanceof Type.ListOf lo)) {
                     throw expects(call.pos(), "List.sortBy", "kind.list", t,
                             "List.sortBy expects a List, got " + t);
                 }
-                Type keyT = blockType(call.fn(), args.get(0), List.of(lo.element()), env, data, symbols, reqs);
+                Type keyT = ca.block(0, call.fn(), List.of(lo.element()));
                 if (!isBottom(keyT) && !isOrdered(keyT)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.ordered.key").title("check.type.mismatch.title")
@@ -2874,17 +3049,17 @@ public final class TypeChecker {
             }
             case "List.get" -> {
                 arity(call, 2);
-                Type first = typeOf(args.get(1), env, data, symbols, reqs);   // get(index, xs): list last
+                Type first = ca.type(1);   // get(index, xs): list last
                 if (!(first instanceof Type.ListOf lo)) {
                     throw expects(call.pos(), "List.get", "kind.list", first,
                             "List.get expects a List, got " + first);
                 }
-                requireType(args.get(0), Type.INT, env, data, symbols, reqs, "index of List.get");
+                ca.require(0, Type.INT, "index of List.get");
                 yield Type.option(lo.element());
             }
             case "Map.get" -> {
                 arity(call, 2);
-                Type first = typeOf(args.get(1), env, data, symbols, reqs);   // get(key, m): map last
+                Type first = ca.type(1);   // get(key, m): map last
                 if (!(first instanceof Type.MapOf mo)) {
                     throw expects(call.pos(), "Map.get", "kind.map", first,
                             "Map.get expects a Map, got " + first);
@@ -2893,7 +3068,7 @@ public final class TypeChecker {
                 // the block growing it — `Map.get(k, acc)` in a groupBy fold — supplies the real key,
                 // so accept it rather than demand the bottom. Otherwise the key must match.
                 if (!isBottom(mo.key())) {
-                    requireType(args.get(0), mo.key(), env, data, symbols, reqs, "key of Map.get");
+                    ca.require(0, mo.key(), "key of Map.get");
                 }
                 yield Type.option(mo.value());
             }
@@ -2916,23 +3091,23 @@ public final class TypeChecker {
             }
             case "Int.remainder" -> {
                 arity(call, 2);
-                requireType(args.get(0), Type.INT, env, data, symbols, reqs, "argument 1 of remainder");
-                requireType(args.get(1), Type.INT, env, data, symbols, reqs, "argument 2 of remainder");
+                ca.require(0, Type.INT, "argument 1 of remainder");
+                ca.require(1, Type.INT, "argument 2 of remainder");
                 // partial: a zero divisor produces the DivisionByZero case (spec 18.2)
                 yield Type.union(new java.util.LinkedHashSet<>(List.of("Int", "DivisionByZero")));
             }
             case "Int.divide", "Decimal.divide" -> {
                 if (args.size() == 4) {
                     // Decimal divide states its rounding: divide(a, b, scale, mode) (spec 18.3)
-                    requireType(args.get(0), Type.DECIMAL, env, data, symbols, reqs, "argument 1 of divide");
-                    requireType(args.get(1), Type.DECIMAL, env, data, symbols, reqs, "argument 2 of divide");
-                    requireType(args.get(2), Type.INT, env, data, symbols, reqs, "scale of divide");
+                    ca.require(0, Type.DECIMAL, "argument 1 of divide");
+                    ca.require(1, Type.DECIMAL, "argument 2 of divide");
+                    ca.require(2, Type.INT, "scale of divide");
                     requireRoundingMode(args.get(3));
                     yield Type.union(new java.util.LinkedHashSet<>(List.of("Decimal", "DivisionByZero")));
                 }
                 arity(call, 2);
-                requireType(args.get(0), Type.INT, env, data, symbols, reqs, "argument 1 of divide");
-                requireType(args.get(1), Type.INT, env, data, symbols, reqs, "argument 2 of divide");
+                ca.require(0, Type.INT, "argument 1 of divide");
+                ca.require(1, Type.INT, "argument 2 of divide");
                 yield Type.union(new java.util.LinkedHashSet<>(List.of("Int", "DivisionByZero")));
             }
             default -> {
@@ -2962,7 +3137,7 @@ public final class TypeChecker {
                             "result of " + call.fn());
                     for (int i = 0; i < args.size(); i++) {
                         if (!(fn.params().get(i) instanceof Type.FnOf)) {
-                            Type at = typeOf(args.get(i), env, data, symbols, reqs);
+                            Type at = ca.type(i);
                             unify(fn.params().get(i), at, bind, symbols, call.pos(), "argument " + (i + 1));
                         }
                     }
@@ -2974,7 +3149,7 @@ public final class TypeChecker {
                     try {
                         for (int i = 0; i < args.size(); i++) {
                             if (fn.params().get(i) instanceof Type.FnOf fp0) {
-                                resolveStepBinding(call.fn(), fp0, args.get(i), bind, env, data, symbols, reqs);
+                                ca.put(i, resolveStepBinding(call.fn(), fp0, args.get(i), bind, env, data, symbols, reqs));
                             }
                         }
                     } catch (CompileException stepError) {
@@ -3000,8 +3175,7 @@ public final class TypeChecker {
                     }
                     for (int i = 0; i < args.size(); i++) {
                         if (!(fn.params().get(i) instanceof Type.FnOf)) {
-                            requireType(args.get(i), substitute(fn.params().get(i), bind), env, data,
-                                    symbols, reqs, "argument " + (i + 1) + " of " + call.fn());
+                            ca.require(i, substitute(fn.params().get(i), bind), "argument " + (i + 1) + " of " + call.fn());
                         }
                     }
                     yield substitute(fn.result(), bind);
@@ -3039,8 +3213,7 @@ public final class TypeChecker {
                 }
                 arity(call, callee.params().size());
                 for (int i = 0; i < callee.params().size(); i++) {
-                    requireType(args.get(i), callee.params().get(i), env, data, symbols, reqs,
-                            "argument " + (i + 1) + " of " + call.fn());
+                    ca.require(i, callee.params().get(i), "argument " + (i + 1) + " of " + call.fn());
                 }
                 yield callee.success();
             }
@@ -3061,13 +3234,15 @@ public final class TypeChecker {
         return Optional.empty();
     }
 
-    private static Type typeOfBinary(Ast.Binary bin, Map<String, Type> env, Ast.Data data,
+    private static Core elaborateBinary(Ast.Binary bin, Map<String, Type> env, Ast.Data data,
                                      Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs) {
         return switch (bin.op()) {
             case AND, OR -> {
-                requireType(bin.left(), Type.BOOL, env, data, symbols, reqs, "operand of logical operator");
-                requireType(bin.right(), Type.BOOL, env, data, symbols, reqs, "operand of logical operator");
-                yield Type.BOOL;
+                Core left = requireTyped(bin.left(), Type.BOOL, env, data, symbols, reqs,
+                        "operand of logical operator");
+                Core right = requireTyped(bin.right(), Type.BOOL, env, data, symbols, reqs,
+                        "operand of logical operator");
+                yield new Core.Binary(bin.op(), left, right, Type.BOOL, bin.pos());
             }
             case LT, LE, GT, GE -> {
                 // The ordered primitives: Int numerically, String lexicographically, Decimal by
@@ -3076,8 +3251,10 @@ public final class TypeChecker {
                 // LocalDateTime are Comparable, so it orders them too. A single-value newtype over an
                 // ordered type is ordered by that value; the operands stay the same newtype (nominal),
                 // except that a bare literal takes the other side's newtype from context.
-                Type lt = typeOf(bin.left(), env, data, symbols, reqs);
-                Type rt = typeOf(bin.right(), env, data, symbols, reqs);
+                Core left = elaborate(bin.left(), env, data, symbols, reqs);
+                Core right = elaborate(bin.right(), env, data, symbols, reqs);
+                Type lt = left.type();
+                Type rt = right.type();
                 if (!orderedComparable(lt, rt, bin.left(), bin.right(), symbols)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.compare.ordered").title("check.type.mismatch.title")
@@ -3086,28 +3263,32 @@ public final class TypeChecker {
                                     + " String, Decimal, Date, DateTime, or a newtype over one of these),"
                                     + " got " + lt + " and " + rt);
                 }
-                yield Type.BOOL;
+                yield new Core.Binary(bin.op(), left, right, Type.BOOL, bin.pos());
             }
             case ADD, SUB, MUL, DIV -> {
                 // `+ - * /` work on two Int or two Decimal operands (spec 18.1). Int aborts on
                 // overflow and `/` aborts on a zero divisor; Decimal `/` rounds by the default
                 // scale/mode. Case handling for a zero divisor is the `divide`/`remainder` functions.
-                Type lt = typeOf(bin.left(), env, data, symbols, reqs);
-                Type rt = typeOf(bin.right(), env, data, symbols, reqs);
+                Core left = elaborate(bin.left(), env, data, symbols, reqs);
+                Core right = elaborate(bin.right(), env, data, symbols, reqs);
+                Type lt = left.type();
+                Type rt = right.type();
                 boolean addSub = bin.op() == Ast.BinOp.ADD || bin.op() == Ast.BinOp.SUB;
                 // Closed newtype arithmetic (spec §newtype-arithmetic): `+`/`-` over a single-value
                 // numeric newtype yield that newtype. The result is re-wrapped and its invariant re-checked at construction,
                 // which a behavior's guard discharges. The operands are the same newtype, or a newtype
                 // with a bare literal of its base (as for comparison).
                 if (addSub && arithClosedNewtype(lt, rt, bin.left(), bin.right(), symbols)) {
-                    yield closedNewtypeArithResult(lt, rt, symbols);
+                    yield new Core.Binary(bin.op(), left, right,
+                            closedNewtypeArithResult(lt, rt, symbols), bin.pos());
                 }
                 // Scalar newtype arithmetic: `*`/`/` scale a numeric newtype by a plain Int/Decimal of
                 // the same base (`金額 * 2`), staying in the newtype — the dimension is unchanged.
                 // `金額 * 金額` and `金額 * 数量` (a dimension change / units, not modeled) fall through
                 // to the base path below, an error.
                 if (!addSub && scalarNewtypeArith(lt, rt, bin.op(), symbols)) {
-                    yield closedNewtypeArithResult(lt, rt, symbols);
+                    yield new Core.Binary(bin.op(), left, right,
+                            closedNewtypeArithResult(lt, rt, symbols), bin.pos());
                 }
                 if (lt != Type.INT && lt != Type.DECIMAL) {
                     throw CompileException.of(
@@ -3116,15 +3297,17 @@ public final class TypeChecker {
                             "operand of arithmetic must be Int or Decimal, got " + lt);
                 }
                 requireType(bin.right(), rt, lt, symbols, "operand of arithmetic");   // rt reused, no re-type
-                yield lt;
+                yield new Core.Binary(bin.op(), left, right, lt, bin.pos());
             }
             case CONCAT -> {
                 // `++` is Elm's appendable operator: two strings concatenate to a string, two lists to
                 // a list (spec 18.1). Strings are checked first, before the empty-list absorption below.
-                Type lraw = typeOf(bin.left(), env, data, symbols, reqs);
-                Type rraw = typeOf(bin.right(), env, data, symbols, reqs);
+                Core left = elaborate(bin.left(), env, data, symbols, reqs);
+                Core right = elaborate(bin.right(), env, data, symbols, reqs);
+                Type lraw = left.type();
+                Type rraw = right.type();
                 if (lraw == Type.STRING && rraw == Type.STRING) {
-                    yield Type.STRING;
+                    yield new Core.Binary(bin.op(), left, right, Type.STRING, bin.pos());
                 }
                 // A bottom operand ({@code Nothing}) is a list read from an accumulator an empty
                 // collection seed grows — the value at a key of a `Map.empty`-seeded fold, whose element
@@ -3145,11 +3328,14 @@ public final class TypeChecker {
                                     .build(),
                             "`++` needs two lists or two strings, got " + lt + " and " + rt);
                 }
-                yield Type.list(unifyElem(lo.element(), ro.element(), bin.pos()));
+                yield new Core.Binary(bin.op(), left, right,
+                        Type.list(unifyElem(lo.element(), ro.element(), bin.pos())), bin.pos());
             }
             case EQ, NE -> {
-                Type lt = typeOf(bin.left(), env, data, symbols, reqs);
-                Type rt = typeOf(bin.right(), env, data, symbols, reqs);
+                Core left = elaborate(bin.left(), env, data, symbols, reqs);
+                Core right = elaborate(bin.right(), env, data, symbols, reqs);
+                Type lt = left.type();
+                Type rt = right.type();
                 // two values of the same data compare by their fields (spec 16.2); across different
                 // types there is nothing to compare. An operand may be the scalar empty-collection
                 // bottom (`Nothing`) when it reads an accumulator a `[]` seed grows — the `e` in
@@ -3182,7 +3368,7 @@ public final class TypeChecker {
                                     .build(),
                             "cannot compare " + lt + " with " + rt);
                 }
-                yield Type.BOOL;
+                yield new Core.Binary(bin.op(), left, right, Type.BOOL, bin.pos());
             }
         };
     }
@@ -3337,14 +3523,16 @@ public final class TypeChecker {
      * the way. Shared by the checker's call typing and the backend's step materialization, so the two
      * resolve identically.
      */
-    public static void resolveStepBinding(String fnName, Type.FnOf declaredStep, Ast.Expr stepArg,
+    public static Core resolveStepBinding(String fnName, Type.FnOf declaredStep, Ast.Expr stepArg,
                                           Map<String, Type> bind, Map<String, Type> env, Ast.Data data,
                                           Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs) {
         Type.FnOf narrow = (Type.FnOf) substitute(declaredStep, bind);
+        Core narrowCore = null;
         Type narrowGot = null;
         CompileException narrowFailed = null;
         try {
-            narrowGot = blockType(fnName, stepArg, narrow.params(), env, data, symbols, reqs);
+            narrowCore = elaborateBlockArg(fnName, stepArg, narrow.params(), env, data, symbols, reqs);
+            narrowGot = ((Type.FnOf) narrowCore.type()).result();
         } catch (CompileException e) {
             narrowFailed = e;
         }
@@ -3352,7 +3540,7 @@ public final class TypeChecker {
             refineBottom(declaredStep.result(), narrowGot, bind);
             Type want = substitute(declaredStep.result(), bind);
             if (want instanceof Type.Var || assignable(narrowGot, want, symbols)) {
-                return;   // the narrow accumulator is a fixpoint
+                return narrowCore;   // the narrow accumulator is a fixpoint
             }
         }
         // The step matches on, or grows the accumulator into, the sum the seed's case belongs to.
@@ -3361,11 +3549,12 @@ public final class TypeChecker {
             if (sum != null) {
                 Map<String, Type> widened = new HashMap<>(bind);
                 widened.put(accVar.name(), sum);
-                Type got = blockType(fnName, stepArg,
+                Core widenedCore = elaborateBlockArg(fnName, stepArg,
                         ((Type.FnOf) substitute(declaredStep, widened)).params(), env, data, symbols, reqs);
+                Type got = ((Type.FnOf) widenedCore.type()).result();
                 if (assignable(got, sum, symbols)) {
                     bind.put(accVar.name(), sum);
-                    return;
+                    return widenedCore;   // the step is emitted at the widened accumulator
                 }
             }
         }
@@ -3380,13 +3569,16 @@ public final class TypeChecker {
                         + ", but the accumulator is " + Type.show(substitute(declaredStep.result(), bind)));
     }
 
-    private static Type blockType(String fnName, Ast.Expr arg, List<Type> paramTypes,
+    /** Elaborates a block argument at {@code paramTypes}; the node it returns carries the
+     * {@link Type.FnOf} of the block — the parameter types the call fixed, and the body's result. */
+    private static Core elaborateBlockArg(String fnName, Ast.Expr arg, List<Type> paramTypes,
                                   Map<String, Type> env, Ast.Data data,
                                   Map<String, Ast.Def> symbols, Map<String, ReqSig> reqs) {
         if (!(arg instanceof Ast.Block block)) {
             // a function-typed value — a helper's function parameter (spec §fn-declaration) —
             // stands in for a block: check its shape and yield its result type.
-            if (typeOf(arg, env, data, symbols, reqs) instanceof Type.FnOf fn) {
+            Core value = elaborate(arg, env, data, symbols, reqs);
+            if (value.type() instanceof Type.FnOf fn) {
                 if (fn.params().size() != paramTypes.size()) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.fn.callarity").title("check.fn.title")
@@ -3406,7 +3598,7 @@ public final class TypeChecker {
                                         + fn.params().get(i));
                     }
                 }
-                return fn.result();
+                return value;
             }
             throw CompileException.of(
                     Diagnostic.of(null, "check.fn.expectsblock").title("check.fn.title")
@@ -3425,7 +3617,8 @@ public final class TypeChecker {
         for (int i = 0; i < paramTypes.size(); i++) {
             inner.put(block.params().get(i), paramTypes.get(i));
         }
-        return typeOf(block.body(), inner, data, symbols, reqs);
+        Core body = elaborate(block.body(), inner, data, symbols, reqs);
+        return new Core.Block(block.params(), body, Type.fn(paramTypes, body.type()), block.pos());
     }
 
     /** Whether an expression bound to a {@code let} is a function value: a lambda, or an {@code if}
@@ -3565,7 +3758,7 @@ public final class TypeChecker {
     /** Types a function value against inferred parameter types: a lambda binds its parameters and
      * yields {@code FnOf(params, resultOfBody)}; an {@code if} requires both branches to be the same
      * function type (spec §blocks). */
-    private static Type typeFunctionValue(Ast.Expr value, List<Type> paramTypes, Map<String, Type> env,
+    private static Core elaborateFunctionValue(Ast.Expr value, List<Type> paramTypes, Map<String, Type> env,
                                           Ast.Data data, Map<String, Ast.Def> symbols,
                                           Map<String, ReqSig> reqs) {
         return switch (value) {
@@ -3581,27 +3774,32 @@ public final class TypeChecker {
                 for (int i = 0; i < paramTypes.size(); i++) {
                     inner.put(b.params().get(i), paramTypes.get(i));
                 }
-                yield Type.fn(paramTypes, typeOf(b.body(), inner, data, symbols, reqs));
+                Core body = elaborate(b.body(), inner, data, symbols, reqs);
+                yield new Core.Block(b.params(), body, Type.fn(paramTypes, body.type()), b.pos());
             }
             case Ast.If iff -> {
-                requireType(iff.cond(), Type.BOOL, env, data, symbols, reqs, "if condition");
-                Type t = typeFunctionValue(iff.then(), paramTypes, env, data, symbols, reqs);
-                Type f = typeFunctionValue(iff.els(), paramTypes, env, data, symbols, reqs);
+                Core cond = requireTyped(iff.cond(), Type.BOOL, env, data, symbols, reqs, "if condition");
+                Core then = elaborateFunctionValue(iff.then(), paramTypes, env, data, symbols, reqs);
+                Core els = elaborateFunctionValue(iff.els(), paramTypes, env, data, symbols, reqs);
+                Type t = then.type();
+                Type f = els.type();
                 if (!t.equals(f)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.fn.branchtypes").title("check.fn.title")
                                     .at(iff.pos(), 2).args(Type.show(t), Type.show(f)).build(),
                             "the two branches produce different function types: " + t + " vs " + f);
                 }
-                yield t;
+                yield new Core.If(cond, then, els, t, iff.pos());
             }
             case Ast.LetIn li -> {
                 // a capture binding around the function (e.g. `let $n = 5 in (x) -> x + $n`)
+                Core bound = elaborate(li.value(), env, data, symbols, reqs);
                 Map<String, Type> inner = new HashMap<>(env);
-                inner.put(li.name(), typeOf(li.value(), env, data, symbols, reqs));
-                yield typeFunctionValue(li.body(), paramTypes, inner, data, symbols, reqs);
+                inner.put(li.name(), bound.type());
+                Core body = elaborateFunctionValue(li.body(), paramTypes, inner, data, symbols, reqs);
+                yield new Core.LetIn(li.name(), bound, li.annotation(), body, body.type(), li.pos());
             }
-            default -> typeOf(value, env, data, symbols, reqs);
+            default -> elaborate(value, env, data, symbols, reqs);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -46,13 +46,23 @@ public final class Backend {
 
     private final CodecGen codec;
     private final ValueClassGen value;
+    /** The checker's elaborated bodies: what this emits from (issue #81). */
+    private final TypeChecker.Checked checked;
 
-    private Backend(CodegenContext ctx) {
+    private Backend(CodegenContext ctx, TypeChecker.Checked checked) {
         this.ctx = ctx;
         this.pkg = ctx.pkg;
         this.symbols = ctx.symbols;
         this.codec = new CodecGen(ctx);
         this.value = new ValueClassGen(ctx, codec);
+        this.checked = checked;
+    }
+
+    /** The elaborated body of {@code name}, or — until the remaining slices of issue #81 land — the
+     * untyped translation of {@code body}, which the emitter types itself. */
+    private Core body(Map<String, Core> elaborated, String name, Ast.Expr body) {
+        Core core = elaborated.get(name);
+        return core != null ? core : Core.of(body);
     }
 
     /** {@code ACC_PUBLIC} when the name is exposed (or the module exposes all), else 0. */
@@ -60,30 +70,42 @@ public final class Backend {
         return ctx.pub(name);
     }
 
+    /** A checked module with no elaborated body: every body falls back to {@link Core#of} and the
+     * emitter's own synthesis. The remaining slices of issue #81 remove that fallback. */
+    private static final TypeChecker.Checked NO_ELABORATION =
+            new TypeChecker.Checked(Map.of(), Map.of(), List.of());
+
     public static Map<String, byte[]> generate(Ast.Module module) {
-        return generate(module, TypeChecker.symbols(module), Map.of());
+        return generate(module, NO_ELABORATION);
+    }
+
+    public static Map<String, byte[]> generate(Ast.Module module, TypeChecker.Checked checked) {
+        return generate(module, TypeChecker.symbols(module), Map.of(), Map.of(), Set.of(), checked);
     }
 
     public static Map<String, byte[]> generate(Ast.Module module, Map<String, Ast.Def> symbols,
                                                Map<String, String> typePackage) {
-        return generate(module, symbols, typePackage, Map.of(), Set.of());
+        return generate(module, symbols, typePackage, Map.of(), Set.of(), NO_ELABORATION);
     }
 
     public static Map<String, byte[]> generate(Ast.Module module, Map<String, Ast.Def> symbols,
                                                Map<String, String> typePackage,
                                                Map<String, TypeChecker.Sig> importedSigs) {
-        return generate(module, symbols, typePackage, importedSigs, Set.of());
+        return generate(module, symbols, typePackage, importedSigs, Set.of(), NO_ELABORATION);
     }
 
     /** Generates a module's classes. {@code symbols} covers own plus imported definitions;
      * {@code typePackage} maps an imported type or behavior name to its declaring module (spec 4);
      * {@code importedSigs} carries imported behaviors' signatures so a composition can name one as
      * a stage (spec 14); {@code importedInjected} are imported injection-target behaviors, which a
-     * composition here inherits as requirements to inject and bind (spec 13.2, 14.3). */
+     * composition here inherits as requirements to inject and bind (spec 13.2, 14.3);
+     * {@code checked} carries the type checker's elaborated bodies, which is what the emitter reads
+     * instead of inferring types again (issue #81). */
     public static Map<String, byte[]> generate(Ast.Module module, Map<String, Ast.Def> symbols,
                                                Map<String, String> typePackage,
                                                Map<String, TypeChecker.Sig> importedSigs,
-                                               Set<String> importedInjected) {
+                                               Set<String> importedInjected,
+                                               TypeChecker.Checked checked) {
         Map<String, List<String>> caseToSums = new HashMap<>();
         for (Ast.Def def : module.defs()) {
             if (def instanceof Ast.SumData sum) {
@@ -109,7 +131,7 @@ public final class Backend {
         }
         CodegenContext ctx = new CodegenContext(module.name(), symbols, caseToSums, typePackage,
                 module.exposing().isEmpty(), exposed, recHelpers);
-        Backend b = new Backend(ctx);
+        Backend b = new Backend(ctx, checked);
         // A behavior's class capitalizes its first letter (spec 19.5). Data names are already
         // capitalized, so `behavior quote` producing `data Quote` would generate two classes named
         // `Quote`. Reject the collision here rather than let one silently overwrite the other.
@@ -316,7 +338,8 @@ public final class Backend {
                     // a recursive helper declares its return type; thread it so a tail-position fold
                     // over an empty seed materialises its step at the declared type, not a bottom (#70)
                     Type helperReturn = h.declaredReturn() == null ? null : successType(h.declaredReturn());
-                    gen.emitTail(Core.of(h.body()), cdFns, Set.of(), Map.of(), helperReturn);
+                    gen.emitTail(body(checked.recursiveHelpers(), h.name(), h.body()),
+                            cdFns, Set.of(), Map.of(), helperReturn);
                 });
             }
         });
@@ -702,7 +725,8 @@ public final class Backend {
                 }
                 // thread the behavior's declared output so a tail-position fold over an empty seed
                 // materialises its step at the output type, not a bottom (issue #70)
-                gen.emitTail(Core.of(fn.body()), cdB, requiredNames, requiredSuccess, successType(spec.ret()));
+                gen.emitTail(body(checked.behaviorBodies(), fn.name(), fn.body()),
+                        cdB, requiredNames, requiredSuccess, successType(spec.ret()));
             });
             if (n != 1) {
                 List<Type> pts = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -58,6 +58,17 @@ public final class Backend {
         this.checked = checked;
     }
 
+    /** The body the checker elaborated for {@code name}. Codegen runs only on a module that type
+     * checked, and the check elaborates every body the backend emits, so a missing one is a compiler
+     * invariant violation rather than something to emit around. */
+    private static Core elaborated(Map<String, Core> bodies, String name) {
+        Core body = bodies.get(name);
+        if (body == null) {
+            throw new IllegalStateException("no elaborated body for `" + name + "`");
+        }
+        return body;
+    }
+
     /** {@code ACC_PUBLIC} when the name is exposed (or the module exposes all), else 0. */
     private int pub(String name) {
         return ctx.pub(name);
@@ -311,7 +322,7 @@ public final class Backend {
                     // a recursive helper declares its return type; thread it so a tail-position fold
                     // over an empty seed materialises its step at the declared type, not a bottom (#70)
                     Type helperReturn = h.declaredReturn() == null ? null : successType(h.declaredReturn());
-                    gen.emitTail(checked.recursiveHelpers().get(h.name()),
+                    gen.emitTail(elaborated(checked.recursiveHelpers(), h.name()),
                             cdFns, Set.of(), Map.of(), helperReturn);
                 });
             }
@@ -698,7 +709,7 @@ public final class Backend {
                 }
                 // thread the behavior's declared output so a tail-position fold over an empty seed
                 // materialises its step at the output type, not a bottom (issue #70)
-                gen.emitTail(checked.behaviorBodies().get(fn.name()),
+                gen.emitTail(elaborated(checked.behaviorBodies(), fn.name()),
                         cdB, requiredNames, requiredSuccess, successType(spec.ret()));
             });
             if (n != 1) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -58,40 +58,13 @@ public final class Backend {
         this.checked = checked;
     }
 
-    /** The elaborated body of {@code name}, or — until the remaining slices of issue #81 land — the
-     * untyped translation of {@code body}, which the emitter types itself. */
-    private Core body(Map<String, Core> elaborated, String name, Ast.Expr body) {
-        Core core = elaborated.get(name);
-        return core != null ? core : Core.of(body);
-    }
-
     /** {@code ACC_PUBLIC} when the name is exposed (or the module exposes all), else 0. */
     private int pub(String name) {
         return ctx.pub(name);
     }
 
-    /** A checked module with no elaborated body: every body falls back to {@link Core#of} and the
-     * emitter's own synthesis. The remaining slices of issue #81 remove that fallback. */
-    private static final TypeChecker.Checked NO_ELABORATION =
-            new TypeChecker.Checked(Map.of(), Map.of(), List.of());
-
-    public static Map<String, byte[]> generate(Ast.Module module) {
-        return generate(module, NO_ELABORATION);
-    }
-
     public static Map<String, byte[]> generate(Ast.Module module, TypeChecker.Checked checked) {
         return generate(module, TypeChecker.symbols(module), Map.of(), Map.of(), Set.of(), checked);
-    }
-
-    public static Map<String, byte[]> generate(Ast.Module module, Map<String, Ast.Def> symbols,
-                                               Map<String, String> typePackage) {
-        return generate(module, symbols, typePackage, Map.of(), Set.of(), NO_ELABORATION);
-    }
-
-    public static Map<String, byte[]> generate(Ast.Module module, Map<String, Ast.Def> symbols,
-                                               Map<String, String> typePackage,
-                                               Map<String, TypeChecker.Sig> importedSigs) {
-        return generate(module, symbols, typePackage, importedSigs, Set.of(), NO_ELABORATION);
     }
 
     /** Generates a module's classes. {@code symbols} covers own plus imported definitions;
@@ -338,7 +311,7 @@ public final class Backend {
                     // a recursive helper declares its return type; thread it so a tail-position fold
                     // over an empty seed materialises its step at the declared type, not a bottom (#70)
                     Type helperReturn = h.declaredReturn() == null ? null : successType(h.declaredReturn());
-                    gen.emitTail(body(checked.recursiveHelpers(), h.name(), h.body()),
+                    gen.emitTail(checked.recursiveHelpers().get(h.name()),
                             cdFns, Set.of(), Map.of(), helperReturn);
                 });
             }
@@ -725,7 +698,7 @@ public final class Backend {
                 }
                 // thread the behavior's declared output so a tail-position fold over an empty seed
                 // materialises its step at the output type, not a bottom (issue #70)
-                gen.emitTail(body(checked.behaviorBodies(), fn.name(), fn.body()),
+                gen.emitTail(checked.behaviorBodies().get(fn.name()),
                         cdB, requiredNames, requiredSuccess, successType(spec.ret()));
             });
             if (n != 1) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -3,6 +3,7 @@ package souther.compiler.codegen;
 import souther.compiler.diag.CompileException;
 import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
+import souther.compiler.check.Lower;
 import souther.compiler.check.Type;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.core.Core;
@@ -149,10 +150,13 @@ final class BodyGen {
         }
 
         /** Elaborates an AST expression at this body's environment — the codec emitters hold AST and
-         * build the Core nodes they pass back in. {@code expected} is the type the position wants, as
-         * the checker pushes a field's declared type into its initialiser. */
+         * build the Core nodes they pass back in. It is desugared first, by the same Lower rewrite a
+         * body gets, so a surface form with no Core node of its own (a comprehension) reaches the
+         * emitter in the shape it emits from. {@code expected} is the type the position wants, as the
+         * checker pushes a field's declared type into its initialiser. */
         Core elaborate(Ast.Expr e, Type expected) {
-            return TypeChecker.elaborate(e, typesEnvWithHelpers(), data, symbols, reqSigs(), expected);
+            return TypeChecker.elaborate(Lower.desugarExpr(e), typesEnvWithHelpers(), data, symbols,
+                    reqSigs(), expected);
         }
 
         private void emitFieldRead(CodeBuilder code, String ownerName, String field, Type ft) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -34,20 +34,6 @@ import static souther.compiler.codegen.JvmTypes.*;
  */
 final class BodyGen {
 
-    /**
-     * Whether to check what this emitter synthesises against the type the checker put on the node
-     * (issue #81). The node's type is what the emitter uses either way; this only decides whether a
-     * disagreement is reported. It is on in the compiler's own test runs (surefire sets the property),
-     * where a divergence means the emitter's remaining synthesis is wrong and should be found here
-     * rather than as a crash. The synthesis goes away with the last slice of #81, and this with it.
-     *
-     * <p>The check is assignability, not equality: the emitter's synthesis is allowed to be the
-     * narrower of the two, because it reads one branch where the checker merged both — an {@code if}
-     * over two cases of a sum is {@code 管理職} here and {@code 一般社員 | 管理職} there. What it may
-     * not be is a type the checker's decision does not admit.
-     */
-    private static final boolean CHECK_TYPES = Boolean.getBoolean("souther.core.checkTypes");
-
     private final CodegenContext ctx;
     /** Aliases of {@link CodegenContext#pkg}/{@link CodegenContext#symbols}, read as bare names. */
     private final String pkg;
@@ -152,12 +138,21 @@ final class BodyGen {
         }
 
         /**
-         * Emits an AST expression by lowering it to Core and emitting that (ADR-0021). The behavior
-         * body is already Core by the time it reaches the backend; this adapter remains for the codec
-         * paths (encoder/decoder), which still hold AST expressions.
+         * Emits an AST expression: the codec emitters (decoder, encoder) and a data's invariant are
+         * AST-level, so their expressions are elaborated here, at the environment the slots hold,
+         * before they are emitted. The types come from the checker either way — a behavior body
+         * arrives already elaborated, and these are elaborated on the spot — so there is one
+         * implementation of inference and the emitter reads its decisions (issue #81).
          */
         Type expr(Ast.Expr e) {
-            return genExpr(Core.of(e));
+            return genExpr(elaborate(e, null));
+        }
+
+        /** Elaborates an AST expression at this body's environment — the codec emitters hold AST and
+         * build the Core nodes they pass back in. {@code expected} is the type the position wants, as
+         * the checker pushes a field's declared type into its initialiser. */
+        Core elaborate(Ast.Expr e, Type expected) {
+            return TypeChecker.elaborate(e, typesEnvWithHelpers(), data, symbols, reqSigs(), expected);
         }
 
         private void emitFieldRead(CodeBuilder code, String ownerName, String field, Type ft) {
@@ -297,22 +292,19 @@ final class BodyGen {
                         // call an injected required behavior; requiredCall handles both the unary
                         // Behavior contract and a multi-input base (issue #57), leaving the success
                         // value cast on the stack
-                        Type letType = requiredCall(call);
+                        Type letType = call.type();
+                        requiredCall(call);
                         int vSlot = slot(letType);
                         store(code, vSlot, letType);
                         bind(li.name(), vSlot, letType);
                     } else {
-                        // Type inference for a closure lives in the checker (AST); Core is untyped, so
-                        // the backend reaches it through toAst rather than re-deriving types.
-                        Ast.Expr valueAst = li.value().toAst();
-                        Type vt;
-                        if (TypeChecker.isFunctionSelection(valueAst)) {
-                            // a lambda chosen at runtime (e.g. by an `if`) — a first-class Fn (spec §blocks)
-                            List<Type> paramTypes = TypeChecker.inferFnParamTypes(
-                                    li.name(), li.body().toAst(), typesEnv(), data, symbols);
-                            vt = emitFunctionValue(valueAst, paramTypes);
+                        Type vt = li.value().type();
+                        if (vt instanceof Type.FnOf fn) {
+                            // a lambda chosen at runtime (e.g. by an `if`) — a first-class Fn
+                            // (spec §blocks), at the parameter types the checker inferred for it
+                            emitFunctionValue(li.value(), fn.params());
                         } else {
-                            vt = genExpr(li.value(), letExpected(li));
+                            genExpr(li.value(), vt);
                         }
                         int slot = slot(vt);
                         store(code, slot, vt);
@@ -409,54 +401,39 @@ final class BodyGen {
          * adopts a pushed-down list type, as {@code Map.empty}/{@code Set.empty} do and as the checker
          * already does: a written {@code let xs: List<Int> = []} otherwise emits at {@code List<_>},
          * and reading an element back unboxes the bottom (issue #74). */
-        private Type listLit(Core.ListLit lit, Type expected) {
+        private void listLit(Core.ListLit lit) {
             code.new_(CD_ArrayList);
             code.dup();
             code.invokespecial(CD_ArrayList, "<init>", MTD_void);
-            Type elem = null;
             for (Core el : lit.elements()) {
                 code.dup();
-                Type t = genExpr(el);
-                box(code, t);
+                box(code, genExpr(el));
                 code.invokevirtual(CD_ArrayList, "add", MTD_ArrayList_add);
                 code.pop();
-                elem = t;
             }
             code.invokestatic(CD_List, "copyOf", MTD_List_copyOf, true);
-            if (elem != null) {
-                return Type.list(elem);
-            }
-            return expected instanceof Type.ListOf le ? le : Type.EMPTY_LIST;   // `[]` (ADR-0028)
         }
 
         /** Builds a tuple {@code (e1, e2, ...)} as an {@code Object[]}, boxing each element (ADR-0036).
          * A pushed-down tuple type reaches each element, as it does in the checker, so a written
          * {@code (Map<String, Int>, List<String>)} seed materialises at those types (issue #74). */
-        private Type tuple(Core.Tuple t, Type expected) {
-            List<Type> want = expected instanceof Type.TupleOf te
-                    && te.elements().size() == t.elements().size() ? te.elements() : null;
-            List<Type> elems = new ArrayList<>();
+        private void tuple(Core.Tuple t) {
             pushInt(code, t.elements().size());
             code.anewarray(CD_Object);
             for (int i = 0; i < t.elements().size(); i++) {
                 code.dup();
                 pushInt(code, i);
-                Type et = genExpr(t.elements().get(i), want == null ? null : want.get(i));
-                box(code, et);
+                box(code, genExpr(t.elements().get(i)));
                 code.aastore();
-                elems.add(et);
             }
-            return Type.tuple(elems);
         }
 
         /** Reads a tuple element by index: {@code arr[i]}, cast back to the element's type. */
-        private Type tupleGet(Core.TupleGet tg) {
-            Type tt = genExpr(tg.tuple());
-            Type et = ((Type.TupleOf) tt).elements().get(tg.index());
+        private void tupleGet(Core.TupleGet tg) {
+            genExpr(tg.tuple());
             pushInt(code, tg.index());
             code.aaload();
-            castFromObject(code, et);
-            return et;
+            castFromObject(code, tg.type());
         }
 
         /** Whether {@code t} still carries the empty-collection bottom {@link Type#NOTHING} — an
@@ -491,94 +468,70 @@ final class BodyGen {
 
         /**
          * Emits {@code e} and yields its type: the one the checker decided, read off the node
-         * (issue #81). A node the checker did not produce — a codec expression, which is still
-         * AST-level — has no type, and the synthesis below stands in for it.
+         * (issue #81). Nothing here derives a type of its own — where a type drives the emission
+         * (which instruction, which descriptor, which slot), it is read from the node that carries it.
+         *
+         * <p>{@code expected} mirrors the checker's bidirectional pass (issue #70): it is pushed into
+         * a fold call so codegen materialises the step closure at the same accumulator type the
+         * checker validated. Only the passthrough arms (if/let/match/call) forward it.
          */
         Type genExpr(Core e, Type expected) {
-            Type synthesised = genExprSynth(e, expected);
             if (e.type() == null) {
-                return synthesised;
+                throw new IllegalStateException("this node reached the emitter untyped: "
+                        + e.getClass().getSimpleName() + " at " + e.pos());
             }
-            if (CHECK_TYPES && !TypeChecker.assignable(synthesised, e.type(), symbols)) {
-                throw new IllegalStateException("the checker typed this " + Type.show(e.type())
-                        + " but the emitter synthesised " + Type.show(synthesised)
-                        + " at " + e.pos() + " (" + e.getClass().getSimpleName() + ")");
-            }
-            return e.type();
-        }
-
-        // {@code expected} mirrors the checker's bidirectional pass (issue #70): it is pushed into a
-        // fold call so codegen materialises the step closure at the same accumulator type the checker
-        // validated, when an empty-collection seed would otherwise leave that type a bottom. Only the
-        // passthrough arms (if/let/match/call) forward it; every other arm ignores it.
-        private Type genExprSynth(Core e, Type expected) {
             emitLine(e);
-            return switch (e) {
-                case Core.Int x -> {
-                    code.loadConstant(x.value());
-                    yield Type.INT;
-                }
+            switch (e) {
+                case Core.Int x -> code.loadConstant(x.value());
                 case Core.Decimal x -> {
                     code.new_(CD_BigDecimal);
                     code.dup();
                     code.loadConstant(x.value().toString());
                     code.invokespecial(CD_BigDecimal, "<init>",
                             MethodTypeDesc.of(ConstantDescs.CD_void, CD_String));
-                    yield Type.DECIMAL;
                 }
-                case Core.Str x -> {
-                    code.loadConstant(x.value());
-                    yield Type.STRING;
-                }
+                case Core.Str x -> code.loadConstant(x.value());
                 case Core.Bool x -> {
                     if (x.value()) code.iconst_1(); else code.iconst_0();
-                    yield Type.BOOL;
                 }
                 case Core.Var v -> {
                     Var var = env.get(v.name());
                     if (var != null) {
                         load(code, var.slot(), var.type());
-                        yield var.type();
-                    }
-                    if (symbols.get(v.name()) instanceof Ast.UnitData) {
+                    } else if (symbols.get(v.name()) instanceof Ast.UnitData) {
                         ClassDesc cdU = cd(v.name());
                         code.new_(cdU);
                         code.dup();
                         code.invokespecial(cdU, "<init>", MTD_void);
-                        yield Type.ref(v.name());
+                    } else {
+                        throw new CompileException(v.pos(), "unbound identifier `" + v.name() + "`");
                     }
-                    throw new CompileException(v.pos(), "unbound identifier `" + v.name() + "`");
                 }
                 case Core.Neg n -> {
-                    Type t = genExpr(n.operand());
-                    if (t == Type.DECIMAL) {
+                    if (genExpr(n.operand()) == Type.DECIMAL) {
                         code.invokevirtual(CD_BigDecimal, "negate", MethodTypeDesc.of(CD_BigDecimal));
                     } else {
                         code.lneg();               // Int is carried as a long
                     }
-                    yield t;
                 }
                 case Core.FieldAccess fa -> {
                     Type targetType = genExpr(fa.target());
                     Ast.Data owner = (Ast.Data) symbols.get(((Type.Ref) targetType).name());
-                    Type ft = fieldTypes(owner).get(fa.field());
-                    emitFieldRead(code, owner.name(), fa.field(), ft);
-                    yield ft;
+                    emitFieldRead(code, owner.name(), fa.field(), fa.type());
                 }
                 case Core.If iff -> {
                     genExpr(iff.cond());
                     Label elseL = code.newLabel();
                     Label end = code.newLabel();
                     code.ifeq(elseL);
-                    Type tt = genExpr(iff.then(), expected);
+                    genExpr(iff.then(), expected);
                     code.goto_(end);
                     code.labelBinding(elseL);
                     genExpr(iff.els(), expected);
                     code.labelBinding(end);
-                    yield tt;
                 }
-                case Core.ListLit lit -> listLit(lit, expected);
-                case Core.Tuple t -> tuple(t, expected);
+                case Core.ListLit lit -> listLit(lit);
+                case Core.Tuple t -> tuple(t);
                 case Core.TupleGet tg -> tupleGet(tg);
                 case Core.Binary bin -> binary(bin);
                 case Core.NewData nd -> newData(nd);
@@ -586,55 +539,38 @@ final class BodyGen {
                 case Core.Call c -> call(c, expected);
                 case Core.LetIn li -> {
                     // a `let` outside tail position: bind, then value the body
-                    Type vt;
-                    if (li.value().type() instanceof Type.FnOf fn) {
-                        // a lambda chosen at runtime (e.g. by an `if`): a first-class Fn (spec §blocks).
-                        // Its parameter types are the ones the checker inferred from the applications
-                        // in the body, read off the node (issue #81).
-                        vt = emitFunctionValue(li.value(), fn.params());
-                    } else if (li.value().type() == null
-                            && TypeChecker.isFunctionSelection(li.value().toAst())) {
-                        // an untyped node (a codec expression): the checker is asked, as before
-                        List<Type> paramTypes = TypeChecker.inferFnParamTypes(
-                                li.name(), li.body().toAst(), typesEnv(), data, symbols);
-                        vt = emitFunctionValue(li.value().toAst(), paramTypes);
+                    Type vt = li.value().type();
+                    if (vt instanceof Type.FnOf fn) {
+                        // a lambda chosen at runtime (e.g. by an `if`): a first-class Fn (spec §blocks),
+                        // at the parameter types the checker inferred from its applications
+                        emitFunctionValue(li.value(), fn.params());
                     } else {
-                        vt = genExpr(li.value(), letExpected(li));
+                        genExpr(li.value(), vt);
                     }
                     int s = slot(vt);
                     store(code, s, vt);
                     bind(li.name(), s, vt);
-                    yield genExpr(li.body(), expected);
+                    genExpr(li.body(), expected);
                 }
                 // a block has no value of its own; it is inlined by the call it is passed to
                 case Core.Block b -> throw new CompileException(b.pos(), "a block is not a value");
-            };
-        }
-
-        /** The type a binding's value is emitted at: the one the checker decided for it, so an
-         * empty-collection value materialises at the type the context pinned rather than a bottom
-         * (issue #71). A node the checker did not produce falls back to the written annotation. */
-        private Type letExpected(Core.LetIn li) {
-            if (li.value().type() != null) {
-                return li.value().type();
             }
-            return li.annotation() == null ? null : successType(li.annotation());
+            return e.type();
         }
 
-        private Type match(Core.Match m, Type expected) {
+        private void match(Core.Match m, Type expected) {
             Type st = genExpr(m.scrutinee());
             int sSlot = slot(st);
             store(code, sSlot, st);
             Type element = st instanceof Type.OptionOf oo ? oo.element() : null;
             Label end = code.newLabel();
-            Type branchType = null;
             for (Core.Case c : m.cases()) {
                 Label nextCase = code.newLabel();
                 // A case binding is scoped to its arm: save any outer binding it shadows and restore it
                 // after the arm, or a later arm reusing the name would resolve to this arm's slot.
                 Var prevBinding = c.binding() != null ? env.get(c.binding()) : null;
                 emitCaseGuard(c, sSlot, st, element, nextCase);
-                branchType = genExpr(c.body(), expected);
+                genExpr(c.body(), expected);
                 if (c.binding() != null) {
                     restore(c.binding(), prevBinding);
                 }
@@ -643,7 +579,6 @@ final class BodyGen {
             }
             emitMatchFallthrough();
             code.labelBinding(end);
-            return branchType;
         }
 
         /** Emits {@code match} in tail position: each arm body is emitted through {@link #emitTail}, so
@@ -699,7 +634,7 @@ final class BodyGen {
                 code.ifeq(nextCase);
                 if (c.binding() != null) {
                     // a data case binds the instance; a primitive case (e.g. Int) unboxes the value
-                    Type bt = c.bindType() != null ? c.bindType() : TypeChecker.caseBindType(cases.get(0));
+                    Type bt = c.bindType();   // what the checker narrowed the scrutinee to here
                     code.aload(sSlot);
                     int bslot = slot(bt);
                     unbox(code, bt, bslot);
@@ -731,7 +666,7 @@ final class BodyGen {
             code.athrow();
         }
 
-        private Type newData(Core.NewData nd) {
+        private void newData(Core.NewData nd) {
             Ast.Data owner = (Ast.Data) symbols.get(nd.typeName());
             Map<String, Type> flds = fieldTypes(owner);
             ClassDesc cdType = cd(nd.typeName());
@@ -743,14 +678,13 @@ final class BodyGen {
                 emitFieldValues(flds, nd.inits(), nd.spreads());
                 emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                 finishInvariantConstruct(cdType, flds);
-                return Type.ref(nd.typeName());
+                return;
             }
             code.new_(cdType);
             code.dup();
             emitFieldValues(flds, nd.inits(), nd.spreads());
             code.invokespecial(cdType, "<init>",
                     MethodTypeDesc.of(ConstantDescs.CD_void, fieldDescs(flds)));
-            return Type.ref(nd.typeName());
         }
 
         /** Emits the checked-construction tail — {@code __construct(fields) -> Result}, {@code orThrow}
@@ -819,137 +753,98 @@ final class BodyGen {
             code.l2i();
         }
 
-        private Type call(Core.Call call, Type expected) {
+        private void call(Core.Call call, Type expected) {
             Prelude.IntrinsicSig intrinsic = Prelude.intrinsics().get(call.fn());
             if (intrinsic != null) {
-                return Intrinsics.emit(this, intrinsic.key(), call);
+                Intrinsics.emit(this, intrinsic.key(), call);
+                return;
             }
             switch (call.fn()) {
                 case "String.length" -> {
                     genExpr(call.args().get(0));
                     code.invokevirtual(CD_String, "length", MethodTypeDesc.of(ConstantDescs.CD_int));
                     code.i2l();
-                    return Type.INT;
                 }
                 case "String.toInt" -> {
                     // Strings.toInt returns a boxed Long or NotANumber.INSTANCE — the Int | NotANumber
                     // union, carried as Object (like intDivide's DivisionByZero result).
                     genExpr(call.args().get(0));
                     code.invokestatic(CD_Strings, "toInt", MethodTypeDesc.of(CD_Object, CD_String));
-                    return Type.union(new java.util.LinkedHashSet<>(java.util.List.of("Int", "NotANumber")));
                 }
                 case "List.length" -> {
                     genExpr(call.args().get(0));
                     code.invokeinterface(CD_List, "size", MTD_size);
                     code.i2l();
-                    return Type.INT;
                 }
                 case "List.get" -> {
-                    Type ct = genExpr(call.args().get(1));      // get(index, xs): list then index (Lists.get)
-                    genExpr(call.args().get(0));                // long index
+                    genExpr(call.args().get(1));      // get(index, xs): list then index (Lists.get)
+                    genExpr(call.args().get(0));      // long index
                     code.invokestatic(CD_Lists, "get",
                             MethodTypeDesc.of(CD_Option, CD_List, ConstantDescs.CD_long));
-                    return Type.option(((Type.ListOf) ct).element());
                 }
                 case "List.max", "List.min" -> {
-                    Type ct = genExpr(call.args().get(0));
+                    genExpr(call.args().get(0));
                     code.invokestatic(CD_Lists, bareOp(call.fn()),   // "max" / "min"
                             MethodTypeDesc.of(CD_Option, CD_List));
-                    return Type.option(((Type.ListOf) ct).element());
                 }
                 case "List.find", "List.sortBy" -> {
                     // find(p, xs) / sortBy(key, xs): the function is a value here (not inlined into a
                     // fold), so materialise it as an Fn, then pass the list. The list's element type
                     // gives the function's one parameter type.
-                    Type lt = argType(call, 1);
-                    Type elem = ((Type.ListOf) lt).element();
-                    emitFunction(call.args().get(0), List.of(elem));   // Fn on the stack
-                    genExpr(call.args().get(1));                                    // then the List
+                    Type elem = ((Type.ListOf) call.args().get(1).type()).element();
+                    emitFunctionValue(call.args().get(0), List.of(elem));   // Fn on the stack
+                    genExpr(call.args().get(1));                            // then the List
                     if (call.fn().equals("List.find")) {
                         code.invokestatic(CD_Lists, "find", MethodTypeDesc.of(CD_Option, CD_Fn, CD_List));
-                        return Type.option(elem);
+                    } else {
+                        code.invokestatic(CD_Lists, "sortBy", MethodTypeDesc.of(CD_List, CD_Fn, CD_List));
                     }
-                    code.invokestatic(CD_Lists, "sortBy", MethodTypeDesc.of(CD_List, CD_Fn, CD_List));
-                    return Type.list(elem);
                 }
                 case "Option.map" -> {
                     // map(f, opt): materialise f as an Fn (its one parameter is the option's element
                     // type), then the option. `Option` is not surface-writable, so the rewrap into
                     // Some(f v) / None happens in the runtime kernel (Option.map), not in emitted code.
-                    Type ot = argType(call, 1);
-                    Type elem = ((Type.OptionOf) ot).element();
-                    Type fnT = emitFunction(call.args().get(0), List.of(elem));  // Fn on the stack
-                    genExpr(call.args().get(1));                                              // then the Option
+                    Type elem = ((Type.OptionOf) call.args().get(1).type()).element();
+                    emitFunctionValue(call.args().get(0), List.of(elem));   // Fn on the stack
+                    genExpr(call.args().get(1));                            // then the Option
                     code.invokestatic(CD_Options, "map", MethodTypeDesc.of(CD_Option, CD_Fn, CD_Option));
-                    return Type.option(((Type.FnOf) fnT).result());   // the option rewraps f's return type
                 }
                 case "Map.get" -> {
-                    Type ct = genExpr(call.args().get(1));      // get(key, m): map then key (Maps.get)
-                    genExpr(call.args().get(0));                // key (a reference)
+                    genExpr(call.args().get(1));      // get(key, m): map then key (Maps.get)
+                    genExpr(call.args().get(0));      // key (a reference)
                     code.invokestatic(CD_Maps, "get",
                             MethodTypeDesc.of(CD_Option, CD_Map, ConstantDescs.CD_Object));
-                    return Type.option(((Type.MapOf) ct).value());
                 }
-                case "Map.empty" -> {
-                    code.invokestatic(CD_Maps, "empty", MethodTypeDesc.of(CD_Map));
-                    // key/value fixed by context, like `[]` — adopt the pushed-down type as the checker
-                    // does, or a written seed type would be lost here and the fold's accumulator
-                    // re-derived at a bottom (issue #74)
-                    return expected instanceof Type.MapOf me ? me : Type.map(Type.NOTHING, Type.NOTHING);
-                }
-                case "Set.empty" -> {
-                    code.invokestatic(CD_Sets, "empty", MethodTypeDesc.of(CD_Set));
-                    return expected instanceof Type.SetOf se ? se : Type.set(Type.NOTHING);
-                }
+                case "Map.empty" -> code.invokestatic(CD_Maps, "empty", MethodTypeDesc.of(CD_Map));
+                case "Set.empty" -> code.invokestatic(CD_Sets, "empty", MethodTypeDesc.of(CD_Set));
                 case "Date", "DateTime" -> {
                     // a written date: the checker has already parsed the literal, so the text is
                     // known good and this is a plain parse of a constant string.
-                    boolean isDate = call.fn().equals("Date");
-                    ClassDesc cd = isDate ? CD_LocalDate : CD_LocalDateTime;
+                    ClassDesc cd = call.fn().equals("Date") ? CD_LocalDate : CD_LocalDateTime;
                     code.loadConstant(((Core.Str) call.args().get(0)).value());
                     code.invokestatic(cd, "parse", MethodTypeDesc.of(cd, CD_CharSequence));
-                    return isDate ? Type.DATE : Type.DATETIME;
                 }
                 case "Int.divide", "Decimal.divide" -> {
                     if (call.args().size() == 4) {
-                        return decimalDivide(call);
+                        decimalDivide(call);
+                    } else {
+                        intDivide(call, true);
                     }
-                    return intDivide(call, true);
                 }
-                case "Int.remainder" -> {
-                    return intDivide(call, false);
-                }
+                case "Int.remainder" -> intDivide(call, false);
                 default -> {
                     Var fv = env.get(call.fn());
                     if (fv != null && fv.type() instanceof Type.FnOf fnType) {
-                        return applyFn(call, fv, fnType);
+                        applyFn(call, fnType);
+                    } else if (ctx.recursiveHelpers.containsKey(call.fn())) {
+                        recursiveHelperCall(call);
+                    } else if (reqNames.contains(call.fn())) {
+                        requiredCall(call);
+                    } else {
+                        throw new CompileException(call.pos(), "unknown function `" + call.fn() + "`");
                     }
-                    Ast.FnDef rec = ctx.recursiveHelpers.get(call.fn());
-                    if (rec != null) {
-                        return recursiveHelperCall(call, rec, expected);
-                    }
-                    if (reqNames.contains(call.fn())) {
-                        return requiredCall(call);
-                    }
-                    throw new CompileException(call.pos(), "unknown function `" + call.fn() + "`");
                 }
             }
-        }
-
-        /** The type of a call's argument: the checker's, or — for a node it did not produce — inferred
-         * from the AST as before. */
-        private Type argType(Core.Call call, int i) {
-            Core arg = call.args().get(i);
-            return arg.type() != null ? arg.type()
-                    : TypeChecker.typeOf(arg.toAst(), typesEnvWithHelpers(), data, symbols, reqSigs());
-        }
-
-        /** Materialises a function argument as an {@code Fn}, from its node when the checker produced
-         * one and from the AST otherwise. */
-        private Type emitFunction(Core value, List<Type> paramTypes) {
-            return value.type() != null
-                    ? emitFunctionValue(value, paramTypes)
-                    : emitFunctionValue(value.toAst(), paramTypes);
         }
 
         /** Calls a recursive helper as a static method on {@code $Fns} (spec 13.1): each argument is
@@ -958,36 +853,23 @@ final class BodyGen {
          * A function parameter is passed as a first-class {@code Fn} value (a closure): the argument
          * block is materialised rather than evaluated as a plain value, and an {@code Fn} is already a
          * reference, so it fits the {@code Object} slot without boxing. */
-        private Type recursiveHelperCall(Core.Call call, Ast.FnDef h, Type expected) {
-            if (call.type() != null && allArgsTyped(call)) {
-                // The checker resolved this call's type variables when it typed it — the accumulator a
-                // fold's step runs at, the result the caller casts to — and left the decision on the
-                // nodes, so nothing is resolved a second time here (issue #81).
-                for (Core arg : call.args()) {
-                    if (arg.type() instanceof Type.FnOf fn) {
-                        if (stepNeverRuns(fn)) {
-                            code.aconst_null();
-                        } else {
-                            emitFunctionValue(arg, fn.params());
-                        }
-                    } else {
-                        box(code, genExpr(arg));
-                    }
-                }
-                invokeRecursiveHelper(call);
-                castFromObject(code, call.type());
-                return call.type();
-            }
-            return recursiveHelperCallSynth(call, h, expected);
-        }
-
-        private static boolean allArgsTyped(Core.Call call) {
+        private void recursiveHelperCall(Core.Call call) {
+            // The checker resolved this call's type variables when it typed it — the accumulator a
+            // fold's step runs at, the result the caller casts to — and left the decision on the
+            // nodes, so nothing is resolved a second time here (issue #81).
             for (Core arg : call.args()) {
-                if (arg.type() == null) {
-                    return false;
+                if (arg.type() instanceof Type.FnOf fn) {
+                    if (stepNeverRuns(fn)) {
+                        code.aconst_null();
+                    } else {
+                        emitFunctionValue(arg, fn.params());
+                    }
+                } else {
+                    box(code, genExpr(arg));
                 }
             }
-            return true;
+            invokeRecursiveHelper(call);
+            castFromObject(code, call.type());
         }
 
         /**
@@ -1014,61 +896,6 @@ final class BodyGen {
                     MethodTypeDesc.of(CD_Object, params));
         }
 
-        /** The pre-#81 path: resolve the helper's type variables here, for a call whose nodes the
-         * checker did not produce (a codec expression). */
-        private Type recursiveHelperCallSynth(Core.Call call, Ast.FnDef h, Type expected) {
-            // Resolve the helper's type variables from the value arguments, so a function argument is
-            // materialised at concrete parameter types — foldFrom's step is `(acc, x)` at the seed's
-            // and the list element's types — matching how the checker typed this call. A monomorphic
-            // helper leaves the bindings empty and every type is already concrete.
-            List<Type> declared = new ArrayList<>();
-            for (Ast.FnParam p : h.params()) {
-                declared.add(TypeChecker.resolveParamType(p.type(), symbols));
-            }
-            Map<String, Type> bind = new HashMap<>();
-            // Pin the result-type variables from the expected type first (issue #70), through the same
-            // best-effort helper the checker's call typing uses, so a fold with a Map.empty()/[] seed
-            // materialises its step closure at the accumulator type the context fixed, not a bottom.
-            if (h.declaredReturn() != null) {
-                TypeChecker.pinResultTypeVars(successType(h.declaredReturn()), expected, bind, symbols,
-                        call.pos(), "result of " + call.fn());
-            }
-            for (int i = 0; i < call.args().size(); i++) {
-                if (!(declared.get(i) instanceof Type.FnOf)) {
-                    Type at = TypeChecker.typeOf(call.args().get(i).toAst(), typesEnvWithHelpers(), data, symbols, reqSigs());
-                    TypeChecker.unify(declared.get(i), at, bind, symbols, call.pos(), "argument " + (i + 1));
-                }
-            }
-            // Resolve the accumulator type for each function argument exactly as the checker did — an
-            // empty-collection seed's bottom refined from the step's result, a case-seeded accumulator
-            // widened to its sum only when the step needs it — so the closure is materialised at the
-            // same types the checker validated.
-            for (int i = 0; i < call.args().size(); i++) {
-                if (declared.get(i) instanceof Type.FnOf fn0
-                        && call.args().get(i).toAst() instanceof Ast.Block) {
-                    TypeChecker.resolveStepBinding(call.fn(), fn0, call.args().get(i).toAst(), bind,
-                            typesEnvWithHelpers(), data, symbols, reqSigs());
-                }
-            }
-            for (int i = 0; i < call.args().size(); i++) {
-                Type pi = TypeChecker.substitute(declared.get(i), bind);
-                if (pi instanceof Type.FnOf fn) {
-                    if (stepNeverRuns(fn)) {
-                        code.aconst_null();
-                    } else {
-                        emitFunctionValue(call.args().get(i).toAst(), fn.params());
-                    }
-                } else {
-                    Type at = genExpr(call.args().get(i));
-                    box(code, at);
-                }
-            }
-            invokeRecursiveHelper(call);
-            Type rt = TypeChecker.substitute(successType(h.declaredReturn()), bind);
-            castFromObject(code, rt);
-            return rt;
-        }
-
         /** The operation name from a qualified builtin call ({@code "List.max"} → {@code "max"}). */
         private static String bareOp(String fn) {
             int dot = fn.indexOf('.');
@@ -1077,7 +904,7 @@ final class BodyGen {
 
         /** {@code divide}/{@code remainder} on Int: a zero divisor takes the DivisionByZero case,
          * otherwise the quotient/remainder is boxed (spec 18.2). */
-        private Type intDivide(Core.Call call, boolean divide) {
+        private void intDivide(Core.Call call, boolean divide) {
             genExpr(call.args().get(0));
             int aSlot = slot(Type.INT);
             code.lstore(aSlot);
@@ -1102,12 +929,11 @@ final class BodyGen {
             code.labelBinding(zero);
             code.getstatic(CD_DivisionByZero, "INSTANCE", CD_DivisionByZero);
             code.labelBinding(end);
-            return Type.union(new java.util.LinkedHashSet<>(java.util.List.of("Int", "DivisionByZero")));
         }
 
         /** {@code divide(a, b, scale, mode)} on Decimal: a zero divisor takes the DivisionByZero
          * case, otherwise {@code a.divide(b, scale, RoundingMode.mode)} (spec 18.3). */
-        private Type decimalDivide(Core.Call call) {
+        private void decimalDivide(Core.Call call) {
             genExpr(call.args().get(0));
             int aSlot = slot(Type.DECIMAL);
             code.astore(aSlot);
@@ -1130,12 +956,11 @@ final class BodyGen {
             code.labelBinding(zero);
             code.getstatic(CD_DivisionByZero, "INSTANCE", CD_DivisionByZero);
             code.labelBinding(end);
-            return Type.union(new java.util.LinkedHashSet<>(java.util.List.of("Decimal", "DivisionByZero")));
         }
 
         /** Emits an inline call to an injected required behavior, leaving its success value on
          * the stack cast to the success type (spec 12.2, 13). */
-        private Type requiredCall(Core.Call call) {
+        private void requiredCall(Core.Call call) {
             Type success = reqSuccess.get(call.fn());
             if (ctx.isMultiArgRequired(call.fn())) {
                 // 2+ inputs: the required behavior is its own base class, called with a typed
@@ -1149,7 +974,7 @@ final class BodyGen {
                 }
                 code.invokevirtual(ctx.cdBehavior(call.fn()), "apply", desc);
                 stackCast(success);
-                return success;
+                return;
             }
             code.aload(0);
             code.getfield(cdName, call.fn(), CD_Behavior);
@@ -1161,7 +986,6 @@ final class BodyGen {
             }
             code.invokeinterface(CD_Behavior, "apply", MTD_apply);
             stackCast(success);
-            return success;
         }
 
         /** Casts the {@code Object} on the stack to {@code type}, unboxing primitives. */
@@ -1177,19 +1001,17 @@ final class BodyGen {
             }
         }
 
-        private Type binary(Core.Binary bin) {
+        private void binary(Core.Binary bin) {
             switch (bin.op()) {
                 case AND -> {
                     genExpr(bin.left());
                     genExpr(bin.right());
                     code.iand();
-                    return Type.BOOL;
                 }
                 case OR -> {
                     genExpr(bin.left());
                     genExpr(bin.right());
                     code.ior();
-                    return Type.BOOL;
                 }
                 // `+ - * /` work on two Int or two Decimal operands (spec 18.1). Int aborts on
                 // overflow, and `/` aborts on a zero divisor; Decimal does not overflow, and its `/`
@@ -1221,28 +1043,23 @@ final class BodyGen {
                         };
                         code.invokestatic(CD_IntMath, m, MTD_intExact);
                     }
-                    // Closed `+`/`-`: re-wrap the base result into the operand's newtype (the checker
-                    // has already validated admissibility, so this only picks the result newtype).
-                    Type nt = TypeChecker.closedNewtypeArithResult(lraw, rraw, symbols);
-                    return nt != null ? wrapNewtypeValue(((Type.Ref) nt).name(), t) : t;
+                    // Closed `+`/`-` and scalar `*`/`/` stay in the newtype: when the checker typed
+                    // this expression as one, re-wrap the base value it left on the stack.
+                    if (bin.type() instanceof Type.Ref ref) {
+                        wrapNewtypeValue(ref.name(), t);
+                    }
                 }
                 case CONCAT -> {
                     Type lt = genExpr(bin.left());
-                    Type rt = genExpr(bin.right());
+                    genExpr(bin.right());
                     // `++` over two strings is Elm's appendable on String; the checker guarantees both
                     // sides are String here, so emit `a.concat(b)` rather than the list join.
                     if (lt == Type.STRING) {
                         code.invokevirtual(CD_String, "concat",
                                 MethodTypeDesc.of(CD_String, CD_String));
-                        return Type.STRING;
+                    } else {
+                        code.invokestatic(CD_Lists, "concat", MTD_Lists_concat);
                     }
-                    code.invokestatic(CD_Lists, "concat", MTD_Lists_concat);
-                    // the empty list contributes no element type; take the result's from the other
-                    // side, so a `[] ++ [x]` chain does not leave the element as `Nothing` (ADR-0028)
-                    if (lt.equals(Type.EMPTY_LIST)) {
-                        return rt;
-                    }
-                    return lt;
                 }
                 default -> {
                     // A single-value newtype compares by its underlying value: open each operand to
@@ -1263,7 +1080,7 @@ final class BodyGen {
                         code.invokeinterface(CD_Comparable, "compareTo", MTD_compareTo_Object);
                         code.iconst_0();
                         comparisonMaterialize(bin.op(), false);
-                        return Type.BOOL;
+                        return;
                     }
                     if (lt == Type.STRING) {
                         code.invokevirtual(CD_String, "equals",
@@ -1272,7 +1089,7 @@ final class BodyGen {
                             code.iconst_1();
                             code.ixor();
                         }
-                        return Type.BOOL;
+                        return;
                     }
                     if (lt == Type.DECIMAL) {
                         emitDecimalEquals(code);          // by value, ignoring scale (spec 7.1)
@@ -1280,7 +1097,7 @@ final class BodyGen {
                             code.iconst_1();
                             code.ixor();
                         }
-                        return Type.BOOL;
+                        return;
                     }
                     if (isReference(lt)) {
                         // a data (or any boxed value) compares by its fields — the generated
@@ -1290,10 +1107,9 @@ final class BodyGen {
                             code.iconst_1();
                             code.ixor();
                         }
-                        return Type.BOOL;
+                        return;
                     }
                     comparisonMaterialize(bin.op(), lt == Type.INT);
-                    return Type.BOOL;
                 }
             }
         }
@@ -1342,6 +1158,9 @@ final class BodyGen {
         private Map<String, Type> typesEnvWithHelpers() {
             Map<String, Type> t = typesEnv();
             ctx.recursiveHelpers.forEach((name, h) -> {
+                if (t.containsKey(name)) {
+                    return;   // a local of the same name shadows the helper, as it does in the checker
+                }
                 List<Type> params = new ArrayList<>();
                 for (Ast.FnParam p : h.params()) {
                     params.add(TypeChecker.resolveParamType(p.type(), symbols));
@@ -1351,51 +1170,21 @@ final class BodyGen {
             return t;
         }
 
-        /** Emits a function value — a lambda, or an {@code if} that selects one — leaving an
-         * {@link souther.runtime.Fn} on the stack (spec §blocks). */
-        private Type emitFunctionValue(Ast.Expr value, List<Type> paramTypes) {
-            return switch (value) {
-                case Ast.Block b -> emitLambda(b, paramTypes);
-                case Ast.If iff -> {
-                    expr(iff.cond());
-                    Label elseL = code.newLabel();
-                    Label end = code.newLabel();
-                    code.ifeq(elseL);
-                    Type t = emitFunctionValue(iff.then(), paramTypes);
-                    code.goto_(end);
-                    code.labelBinding(elseL);
-                    emitFunctionValue(iff.els(), paramTypes);
-                    code.labelBinding(end);
-                    yield t;
-                }
-                case Ast.LetIn li -> {
-                    // a capture binding around the function: bind it here so the lambda captures it
-                    Type vt = expr(li.value());
-                    int s = slot(vt);
-                    store(code, s, vt);
-                    bind(li.name(), s, vt);
-                    yield emitFunctionValue(li.body(), paramTypes);
-                }
-                default -> expr(value);
-            };
-        }
-
         /** Emits a function value from its elaborated node: the parameter and result types are the
          * ones the checker decided, so nothing is inferred here (issue #81). */
-        private Type emitFunctionValue(Core value, List<Type> paramTypes) {
-            return switch (value) {
+        private void emitFunctionValue(Core value, List<Type> paramTypes) {
+            switch (value) {
                 case Core.Block b -> emitLambda(b, paramTypes);
                 case Core.If iff -> {
                     genExpr(iff.cond());
                     Label elseL = code.newLabel();
                     Label end = code.newLabel();
                     code.ifeq(elseL);
-                    Type t = emitFunctionValue(iff.then(), paramTypes);
+                    emitFunctionValue(iff.then(), paramTypes);
                     code.goto_(end);
                     code.labelBinding(elseL);
                     emitFunctionValue(iff.els(), paramTypes);
                     code.labelBinding(end);
-                    yield t;
                 }
                 case Core.LetIn li -> {
                     // a capture binding around the function: bind it here so the lambda captures it
@@ -1403,43 +1192,21 @@ final class BodyGen {
                     int s = slot(vt);
                     store(code, s, vt);
                     bind(li.name(), s, vt);
-                    yield emitFunctionValue(li.body(), paramTypes);
+                    emitFunctionValue(li.body(), paramTypes);
                 }
                 default -> genExpr(value);
-            };
-        }
-
-        /** As {@link #emitLambda(Ast.Block, List)}, from the elaborated block: its body is emitted
-         * from Core and its result type read off the node rather than inferred again. */
-        private Type emitLambda(Core.Block block, List<Type> paramTypes) {
-            Type resultType = block.type() instanceof Type.FnOf fn
-                    ? fn.result()
-                    : TypeChecker.typeOf(block.toAst(), lambdaEnv(block.params(), paramTypes), data,
-                            symbols, reqSigs());
-            return emitLambda(block.params(), block.body(), paramTypes, resultType,
-                    freeVars((Ast.Block) block.toAst()));
+            }
         }
 
         /** Compiles a lambda to a synthetic {@code Fn} class and emits {@code new} of it, passing the
-         * captured free variables (and any injected behaviors it calls) to its constructor. */
-        private Type emitLambda(Ast.Block block, List<Type> paramTypes) {
-            Type resultType = TypeChecker.typeOf(block.body(),
-                    lambdaEnv(block.params(), paramTypes), data, symbols, reqSigs());
-            return emitLambda(block.params(), Core.of(block.body()), paramTypes, resultType,
-                    freeVars(block));
+         * captured free variables (and any injected behaviors it calls) to its constructor. Its
+         * parameter and result types are the ones the checker put on the block (issue #81). */
+        private void emitLambda(Core.Block block, List<Type> paramTypes) {
+            emitLambda(block.params(), block.body(), paramTypes,
+                    ((Type.FnOf) block.type()).result(), freeVars(block));
         }
 
-        /** The enclosing environment with a lambda's parameters bound, for the paths that still infer
-         * a lambda body's result type. */
-        private Map<String, Type> lambdaEnv(List<String> params, List<Type> paramTypes) {
-            Map<String, Type> inner = typesEnvWithHelpers();
-            for (int i = 0; i < paramTypes.size(); i++) {
-                inner.put(params.get(i), paramTypes.get(i));
-            }
-            return inner;
-        }
-
-        private Type emitLambda(List<String> params, Core body, List<Type> paramTypes,
+        private void emitLambda(List<String> params, Core body, List<Type> paramTypes,
                                 Type resultType, List<String> free) {
             List<String> valueNames = new ArrayList<>();
             List<Type> valueTypes = new ArrayList<>();
@@ -1471,12 +1238,12 @@ final class BodyGen {
             }
             code.invokespecial(cd, "<init>",
                     MethodTypeDesc.of(ConstantDescs.CD_void, ctorDescs.toArray(new ClassDesc[0])));
-            return Type.fn(paramTypes, resultType);
         }
 
         /** Applies a first-class function value: {@code f.apply(new Object[]{args...})}, then casts
          * the {@code Object} result back to the function's result type. */
-        private Type applyFn(Core.Call call, Var fv, Type.FnOf fnType) {
+        private void applyFn(Core.Call call, Type.FnOf fnType) {
+            Var fv = env.get(call.fn());
             load(code, fv.slot(), fv.type());   // the Fn receiver
             pushInt(code, call.args().size());
             code.anewarray(CD_Object);
@@ -1489,48 +1256,47 @@ final class BodyGen {
             }
             code.invokeinterface(CD_Fn, "apply", MTD_Fn_apply);
             stackCast(fnType.result());   // Object result -> the function's result type
-            return fnType.result();
         }
 
         /** The free variables of a lambda: names its body reads that are bound in the enclosing
          * scope (so must be captured), in first-seen order. */
-        private List<String> freeVars(Ast.Block block) {
+        private List<String> freeVars(Core.Block block) {
             LinkedHashSet<String> free = new LinkedHashSet<>();
             collectFree(block.body(), new HashSet<>(block.params()), free);
             return new ArrayList<>(free);
         }
 
-        private void collectFree(Ast.Expr e, Set<String> bound, LinkedHashSet<String> free) {
+        private void collectFree(Core e, Set<String> bound, LinkedHashSet<String> free) {
             switch (e) {
-                case Ast.Var v -> maybeFree(v.name(), bound, free);
-                case Ast.Call c -> {
+                case Core.Var v -> maybeFree(v.name(), bound, free);
+                case Core.Call c -> {
                     maybeFree(c.fn(), bound, free);   // an applied function value is captured too
                     c.args().forEach(a -> collectFree(a, bound, free));
                 }
-                case Ast.FieldAccess fa -> collectFree(fa.target(), bound, free);
-                case Ast.Binary bin -> {
+                case Core.FieldAccess fa -> collectFree(fa.target(), bound, free);
+                case Core.Binary bin -> {
                     collectFree(bin.left(), bound, free);
                     collectFree(bin.right(), bound, free);
                 }
-                case Ast.Neg neg -> collectFree(neg.operand(), bound, free);
-                case Ast.NewData nd -> {
+                case Core.Neg neg -> collectFree(neg.operand(), bound, free);
+                case Core.NewData nd -> {
                     nd.inits().forEach(i -> collectFree(i.value(), bound, free));
-                    nd.spreads().forEach(s -> maybeFree(s, bound, free));
+                    nd.spreads().forEach(sp -> maybeFree(sp, bound, free));
                 }
-                case Ast.If iff -> {
+                case Core.If iff -> {
                     collectFree(iff.cond(), bound, free);
                     collectFree(iff.then(), bound, free);
                     collectFree(iff.els(), bound, free);
                 }
-                case Ast.LetIn li -> {
+                case Core.LetIn li -> {
                     collectFree(li.value(), bound, free);
                     Set<String> inner = new HashSet<>(bound);
                     inner.add(li.name());
                     collectFree(li.body(), inner, free);
                 }
-                case Ast.Match m -> {
+                case Core.Match m -> {
                     collectFree(m.scrutinee(), bound, free);
-                    for (Ast.Case c : m.cases()) {
+                    for (Core.Case c : m.cases()) {
                         Set<String> inner = bound;
                         if (c.binding() != null) {
                             inner = new HashSet<>(bound);
@@ -1539,22 +1305,18 @@ final class BodyGen {
                         collectFree(c.body(), inner, free);
                     }
                 }
-                case Ast.Block b -> {
+                case Core.Block b -> {
                     Set<String> inner = new HashSet<>(bound);
                     inner.addAll(b.params());
                     collectFree(b.body(), inner, free);
                 }
-                case Ast.ListLit lit -> lit.elements().forEach(x -> collectFree(x, bound, free));
-                case Ast.Tuple tup -> tup.elements().forEach(x -> collectFree(x, bound, free));
-                case Ast.TupleGet tg -> collectFree(tg.tuple(), bound, free);
-                case Ast.ListComp comp -> {
-                    collectFree(comp.element(), bound, free);
-                    comp.guards().forEach(g -> collectFree(g, bound, free));
-                }
-                case Ast.IntLit _ -> { }
-                case Ast.DecimalLit _ -> { }
-                case Ast.StringLit _ -> { }
-                case Ast.BoolLit _ -> { }
+                case Core.ListLit lit -> lit.elements().forEach(x -> collectFree(x, bound, free));
+                case Core.Tuple tup -> tup.elements().forEach(x -> collectFree(x, bound, free));
+                case Core.TupleGet tg -> collectFree(tg.tuple(), bound, free);
+                case Core.Int _ -> { }
+                case Core.Decimal _ -> { }
+                case Core.Str _ -> { }
+                case Core.Bool _ -> { }
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -34,6 +34,20 @@ import static souther.compiler.codegen.JvmTypes.*;
  */
 final class BodyGen {
 
+    /**
+     * Whether to check what this emitter synthesises against the type the checker put on the node
+     * (issue #81). The node's type is what the emitter uses either way; this only decides whether a
+     * disagreement is reported. It is on in the compiler's own test runs (surefire sets the property),
+     * where a divergence means the emitter's remaining synthesis is wrong and should be found here
+     * rather than as a crash. The synthesis goes away with the last slice of #81, and this with it.
+     *
+     * <p>The check is assignability, not equality: the emitter's synthesis is allowed to be the
+     * narrower of the two, because it reads one branch where the checker merged both — an {@code if}
+     * over two cases of a sum is {@code 管理職} here and {@code 一般社員 | 管理職} there. What it may
+     * not be is a type the checker's decision does not admit.
+     */
+    private static final boolean CHECK_TYPES = Boolean.getBoolean("souther.core.checkTypes");
+
     private final CodegenContext ctx;
     /** Aliases of {@link CodegenContext#pkg}/{@link CodegenContext#symbols}, read as bare names. */
     private final String pkg;
@@ -177,7 +191,8 @@ final class BodyGen {
         /** Generates a synthetic {@code Fn} class for an escaping lambda: captured free variables become
          * {@code final} fields set by the constructor, and the body compiles into {@code apply}, which
          * unboxes its arguments from the {@code Object[]} and boxes its result (spec §blocks). */
-        private byte[] generateLambdaClass(ClassDesc cd, Ast.Block block, List<Type> paramTypes,
+        private byte[] generateLambdaClass(ClassDesc cd, List<String> params, Core body,
+                                           List<Type> paramTypes,
                                            Type resultType, List<String> valueNames, List<Type> valueTypes,
                                            List<String> injectedNames, Map<String, Type> reqSuccess,
                                            Map<String, List<Type>> reqParams) {
@@ -237,7 +252,7 @@ final class BodyGen {
                         pushInt(code, i);
                         code.aaload();
                         unbox(code, pt, s);
-                        g.bind(block.params().get(i), s, pt);
+                        g.bind(params.get(i), s, pt);
                     }
                     for (int i = 0; i < valueNames.size(); i++) {
                         Type ct = valueTypes.get(i);
@@ -247,7 +262,7 @@ final class BodyGen {
                         store(code, s, ct);
                         g.bind(valueNames.get(i), s, ct);
                     }
-                    Type rt = g.expr(block.body());
+                    Type rt = g.genExpr(body);
                     box(code, rt);
                     code.areturn();
                 });
@@ -474,11 +489,29 @@ final class BodyGen {
             return genExpr(e, null);
         }
 
+        /**
+         * Emits {@code e} and yields its type: the one the checker decided, read off the node
+         * (issue #81). A node the checker did not produce — a codec expression, which is still
+         * AST-level — has no type, and the synthesis below stands in for it.
+         */
+        Type genExpr(Core e, Type expected) {
+            Type synthesised = genExprSynth(e, expected);
+            if (e.type() == null) {
+                return synthesised;
+            }
+            if (CHECK_TYPES && !TypeChecker.assignable(synthesised, e.type(), symbols)) {
+                throw new IllegalStateException("the checker typed this " + Type.show(e.type())
+                        + " but the emitter synthesised " + Type.show(synthesised)
+                        + " at " + e.pos() + " (" + e.getClass().getSimpleName() + ")");
+            }
+            return e.type();
+        }
+
         // {@code expected} mirrors the checker's bidirectional pass (issue #70): it is pushed into a
         // fold call so codegen materialises the step closure at the same accumulator type the checker
         // validated, when an empty-collection seed would otherwise leave that type a bottom. Only the
         // passthrough arms (if/let/match/call) forward it; every other arm ignores it.
-        Type genExpr(Core e, Type expected) {
+        private Type genExprSynth(Core e, Type expected) {
             emitLine(e);
             return switch (e) {
                 case Core.Int x -> {
@@ -554,14 +587,17 @@ final class BodyGen {
                 case Core.LetIn li -> {
                     // a `let` outside tail position: bind, then value the body
                     Type vt;
-                    // Type inference for a closure lives in the checker (AST); Core is untyped, so
-                    // the backend reaches it through toAst rather than re-deriving types.
-                    Ast.Expr valueAst = li.value().toAst();
-                    if (TypeChecker.isFunctionSelection(valueAst)) {
-                        // a lambda chosen at runtime (e.g. by an `if`): a first-class Fn (spec §blocks)
+                    if (li.value().type() instanceof Type.FnOf fn) {
+                        // a lambda chosen at runtime (e.g. by an `if`): a first-class Fn (spec §blocks).
+                        // Its parameter types are the ones the checker inferred from the applications
+                        // in the body, read off the node (issue #81).
+                        vt = emitFunctionValue(li.value(), fn.params());
+                    } else if (li.value().type() == null
+                            && TypeChecker.isFunctionSelection(li.value().toAst())) {
+                        // an untyped node (a codec expression): the checker is asked, as before
                         List<Type> paramTypes = TypeChecker.inferFnParamTypes(
                                 li.name(), li.body().toAst(), typesEnv(), data, symbols);
-                        vt = emitFunctionValue(valueAst, paramTypes);
+                        vt = emitFunctionValue(li.value().toAst(), paramTypes);
                     } else {
                         vt = genExpr(li.value(), letExpected(li));
                     }
@@ -575,9 +611,13 @@ final class BodyGen {
             };
         }
 
-        /** The type a binding's value is emitted at when the source annotated it (issue #71) — the same
-         * pin the checker applied, so an empty-collection value materialises at the written type. */
+        /** The type a binding's value is emitted at: the one the checker decided for it, so an
+         * empty-collection value materialises at the type the context pinned rather than a bottom
+         * (issue #71). A node the checker did not produce falls back to the written annotation. */
         private Type letExpected(Core.LetIn li) {
+            if (li.value().type() != null) {
+                return li.value().type();
+            }
             return li.annotation() == null ? null : successType(li.annotation());
         }
 
@@ -659,7 +699,7 @@ final class BodyGen {
                 code.ifeq(nextCase);
                 if (c.binding() != null) {
                     // a data case binds the instance; a primitive case (e.g. Int) unboxes the value
-                    Type bt = TypeChecker.caseBindType(cases.get(0));
+                    Type bt = c.bindType() != null ? c.bindType() : TypeChecker.caseBindType(cases.get(0));
                     code.aload(sSlot);
                     int bslot = slot(bt);
                     unbox(code, bt, bslot);
@@ -821,10 +861,9 @@ final class BodyGen {
                     // find(p, xs) / sortBy(key, xs): the function is a value here (not inlined into a
                     // fold), so materialise it as an Fn, then pass the list. The list's element type
                     // gives the function's one parameter type.
-                    Type lt = TypeChecker.typeOf(call.args().get(1).toAst(), typesEnvWithHelpers(),
-                            data, symbols, reqSigs());
+                    Type lt = argType(call, 1);
                     Type elem = ((Type.ListOf) lt).element();
-                    emitFunctionValue(call.args().get(0).toAst(), List.of(elem));   // Fn on the stack
+                    emitFunction(call.args().get(0), List.of(elem));   // Fn on the stack
                     genExpr(call.args().get(1));                                    // then the List
                     if (call.fn().equals("List.find")) {
                         code.invokestatic(CD_Lists, "find", MethodTypeDesc.of(CD_Option, CD_Fn, CD_List));
@@ -837,10 +876,9 @@ final class BodyGen {
                     // map(f, opt): materialise f as an Fn (its one parameter is the option's element
                     // type), then the option. `Option` is not surface-writable, so the rewrap into
                     // Some(f v) / None happens in the runtime kernel (Option.map), not in emitted code.
-                    Type ot = TypeChecker.typeOf(call.args().get(1).toAst(), typesEnvWithHelpers(),
-                            data, symbols, reqSigs());
+                    Type ot = argType(call, 1);
                     Type elem = ((Type.OptionOf) ot).element();
-                    Type fnT = emitFunctionValue(call.args().get(0).toAst(), List.of(elem));  // Fn on the stack
+                    Type fnT = emitFunction(call.args().get(0), List.of(elem));  // Fn on the stack
                     genExpr(call.args().get(1));                                              // then the Option
                     code.invokestatic(CD_Options, "map", MethodTypeDesc.of(CD_Option, CD_Fn, CD_Option));
                     return Type.option(((Type.FnOf) fnT).result());   // the option rewraps f's return type
@@ -898,6 +936,22 @@ final class BodyGen {
             }
         }
 
+        /** The type of a call's argument: the checker's, or — for a node it did not produce — inferred
+         * from the AST as before. */
+        private Type argType(Core.Call call, int i) {
+            Core arg = call.args().get(i);
+            return arg.type() != null ? arg.type()
+                    : TypeChecker.typeOf(arg.toAst(), typesEnvWithHelpers(), data, symbols, reqSigs());
+        }
+
+        /** Materialises a function argument as an {@code Fn}, from its node when the checker produced
+         * one and from the AST otherwise. */
+        private Type emitFunction(Core value, List<Type> paramTypes) {
+            return value.type() != null
+                    ? emitFunctionValue(value, paramTypes)
+                    : emitFunctionValue(value.toAst(), paramTypes);
+        }
+
         /** Calls a recursive helper as a static method on {@code $Fns} (spec 13.1): each argument is
          * evaluated and boxed, the {@code invokestatic} returns {@code Object}, and the result is cast
          * back to the helper's declared return type. A self- or mutual call reaches here the same way.
@@ -905,6 +959,64 @@ final class BodyGen {
          * block is materialised rather than evaluated as a plain value, and an {@code Fn} is already a
          * reference, so it fits the {@code Object} slot without boxing. */
         private Type recursiveHelperCall(Core.Call call, Ast.FnDef h, Type expected) {
+            if (call.type() != null && allArgsTyped(call)) {
+                // The checker resolved this call's type variables when it typed it — the accumulator a
+                // fold's step runs at, the result the caller casts to — and left the decision on the
+                // nodes, so nothing is resolved a second time here (issue #81).
+                for (Core arg : call.args()) {
+                    if (arg.type() instanceof Type.FnOf fn) {
+                        if (stepNeverRuns(fn)) {
+                            code.aconst_null();
+                        } else {
+                            emitFunctionValue(arg, fn.params());
+                        }
+                    } else {
+                        box(code, genExpr(arg));
+                    }
+                }
+                invokeRecursiveHelper(call);
+                castFromObject(code, call.type());
+                return call.type();
+            }
+            return recursiveHelperCallSynth(call, h, expected);
+        }
+
+        private static boolean allArgsTyped(Core.Call call) {
+            for (Core arg : call.args()) {
+                if (arg.type() == null) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /**
+         * Whether a step closure would never be applied: one of its parameters is the bare bottom, so
+         * it is the element of an empty-literal list and there are no elements — {@code foldFrom} over
+         * {@code []} yields the seed. Such a step is passed as a null {@code Fn} rather than
+         * materialised, since materialising it would unbox the bottom element (as {@code acc + x}
+         * does with {@code x}) and crash. An empty *seed* (a {@code List<Nothing>} accumulator) is a
+         * reference and still materialises.
+         */
+        private static boolean stepNeverRuns(Type.FnOf fn) {
+            for (Type p : fn.params()) {
+                if (p instanceof Type.Nothing) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void invokeRecursiveHelper(Core.Call call) {
+            ClassDesc[] params = new ClassDesc[call.args().size()];
+            java.util.Arrays.fill(params, CD_Object);
+            code.invokestatic(ClassDesc.of(pkg + ".$Fns"), CodegenContext.recursiveHelperMethod(call.fn()),
+                    MethodTypeDesc.of(CD_Object, params));
+        }
+
+        /** The pre-#81 path: resolve the helper's type variables here, for a call whose nodes the
+         * checker did not produce (a codec expression). */
+        private Type recursiveHelperCallSynth(Core.Call call, Ast.FnDef h, Type expected) {
             // Resolve the helper's type variables from the value arguments, so a function argument is
             // materialised at concrete parameter types — foldFrom's step is `(acc, x)` at the seed's
             // and the list element's types — matching how the checker typed this call. A monomorphic
@@ -941,16 +1053,7 @@ final class BodyGen {
             for (int i = 0; i < call.args().size(); i++) {
                 Type pi = TypeChecker.substitute(declared.get(i), bind);
                 if (pi instanceof Type.FnOf fn) {
-                    boolean stepDead = false;
-                    for (Type p : fn.params()) {
-                        stepDead |= p instanceof Type.Nothing;   // an element of an empty-literal list
-                    }
-                    if (stepDead) {
-                        // A step parameter is a bare Nothing: it is the element of an empty-literal
-                        // list, so there are no elements and the step never runs — foldFrom over `[]`
-                        // yields the seed. Pass a null Fn rather than materialise a closure that would
-                        // unbox the bottom element (as `acc + x` does with `x`) and crash. An empty
-                        // *seed* (a `List<Nothing>` accumulator) is a reference and still materialises.
+                    if (stepNeverRuns(fn)) {
                         code.aconst_null();
                     } else {
                         emitFunctionValue(call.args().get(i).toAst(), fn.params());
@@ -960,10 +1063,7 @@ final class BodyGen {
                     box(code, at);
                 }
             }
-            ClassDesc[] params = new ClassDesc[call.args().size()];
-            java.util.Arrays.fill(params, CD_Object);
-            code.invokestatic(ClassDesc.of(pkg + ".$Fns"), CodegenContext.recursiveHelperMethod(call.fn()),
-                    MethodTypeDesc.of(CD_Object, params));
+            invokeRecursiveHelper(call);
             Type rt = TypeChecker.substitute(successType(h.declaredReturn()), bind);
             castFromObject(code, rt);
             return rt;
@@ -1280,19 +1380,71 @@ final class BodyGen {
             };
         }
 
+        /** Emits a function value from its elaborated node: the parameter and result types are the
+         * ones the checker decided, so nothing is inferred here (issue #81). */
+        private Type emitFunctionValue(Core value, List<Type> paramTypes) {
+            return switch (value) {
+                case Core.Block b -> emitLambda(b, paramTypes);
+                case Core.If iff -> {
+                    genExpr(iff.cond());
+                    Label elseL = code.newLabel();
+                    Label end = code.newLabel();
+                    code.ifeq(elseL);
+                    Type t = emitFunctionValue(iff.then(), paramTypes);
+                    code.goto_(end);
+                    code.labelBinding(elseL);
+                    emitFunctionValue(iff.els(), paramTypes);
+                    code.labelBinding(end);
+                    yield t;
+                }
+                case Core.LetIn li -> {
+                    // a capture binding around the function: bind it here so the lambda captures it
+                    Type vt = genExpr(li.value());
+                    int s = slot(vt);
+                    store(code, s, vt);
+                    bind(li.name(), s, vt);
+                    yield emitFunctionValue(li.body(), paramTypes);
+                }
+                default -> genExpr(value);
+            };
+        }
+
+        /** As {@link #emitLambda(Ast.Block, List)}, from the elaborated block: its body is emitted
+         * from Core and its result type read off the node rather than inferred again. */
+        private Type emitLambda(Core.Block block, List<Type> paramTypes) {
+            Type resultType = block.type() instanceof Type.FnOf fn
+                    ? fn.result()
+                    : TypeChecker.typeOf(block.toAst(), lambdaEnv(block.params(), paramTypes), data,
+                            symbols, reqSigs());
+            return emitLambda(block.params(), block.body(), paramTypes, resultType,
+                    freeVars((Ast.Block) block.toAst()));
+        }
+
         /** Compiles a lambda to a synthetic {@code Fn} class and emits {@code new} of it, passing the
          * captured free variables (and any injected behaviors it calls) to its constructor. */
         private Type emitLambda(Ast.Block block, List<Type> paramTypes) {
+            Type resultType = TypeChecker.typeOf(block.body(),
+                    lambdaEnv(block.params(), paramTypes), data, symbols, reqSigs());
+            return emitLambda(block.params(), Core.of(block.body()), paramTypes, resultType,
+                    freeVars(block));
+        }
+
+        /** The enclosing environment with a lambda's parameters bound, for the paths that still infer
+         * a lambda body's result type. */
+        private Map<String, Type> lambdaEnv(List<String> params, List<Type> paramTypes) {
             Map<String, Type> inner = typesEnvWithHelpers();
             for (int i = 0; i < paramTypes.size(); i++) {
-                inner.put(block.params().get(i), paramTypes.get(i));
+                inner.put(params.get(i), paramTypes.get(i));
             }
-            Type resultType = TypeChecker.typeOf(block.body(), inner, data, symbols, reqSigs());
+            return inner;
+        }
 
+        private Type emitLambda(List<String> params, Core body, List<Type> paramTypes,
+                                Type resultType, List<String> free) {
             List<String> valueNames = new ArrayList<>();
             List<Type> valueTypes = new ArrayList<>();
             List<String> injectedNames = new ArrayList<>();
-            for (String c : freeVars(block)) {
+            for (String c : free) {
                 if (env.containsKey(c)) {
                     valueNames.add(c);
                     valueTypes.add(env.get(c).type());
@@ -1302,7 +1454,7 @@ final class BodyGen {
             }
             String className = pkg + ".$Fn" + ctx.nextLambdaId();
             ClassDesc cd = ClassDesc.of(className);
-            ctx.addSynth(className, generateLambdaClass(cd, block, paramTypes, resultType,
+            ctx.addSynth(className, generateLambdaClass(cd, params, body, paramTypes, resultType,
                     valueNames, valueTypes, injectedNames, reqSuccess, reqParams));
 
             code.new_(cd);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -798,11 +798,13 @@ final class CodecGen {
      */
     private void emitConstructCall(CodeBuilder code, BodyGen gen, ClassDesc cdName, Ast.Construct construct,
                                    Map<String, Type> fields) {
-        // The decoder is still AST-level; translate its field inits to Core so the shared
-        // emitFieldValues consumes one representation (ADR-0021).
+        // The decoder is still AST-level; elaborate its field inits so the shared emitFieldValues
+        // consumes one representation, with the type the checker decides for each (ADR-0021, #81).
+        // The field's declared type is pushed in, as the checker does when it checks a construction.
         List<Core.FieldInit> inits = new ArrayList<>();
         for (Ast.FieldInit init : construct.inits()) {
-            inits.add(new Core.FieldInit(init.name(), Core.of(init.value()), init.pos()));
+            inits.add(new Core.FieldInit(init.name(),
+                    gen.elaborate(init.value(), fields.get(init.name())), init.pos()));
         }
         gen.emitFieldValues(fields, inits, construct.spreads());
         code.invokestatic(cdName, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(fields)));

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -1,5 +1,6 @@
 package souther.compiler.core;
 
+import souther.compiler.check.Type;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.ast.Ast;
 
@@ -16,13 +17,22 @@ import java.util.List;
  * own node here, so the backend only emits. Later slices add explicit nodes for {@code match}
  * lowering and closure conversion, and drop the corresponding special cases from the emitter.
  *
- * <p>Core is structural, not typed: the backend infers types as it emits, as it does from the AST
- * today. A surface-only node (a list comprehension) never appears — the Lower stage has already
+ * <p>Every node carries {@link #type()}: the type the checker decided for it (issue #81). The
+ * checker produces Core as it types a body — {@code TypeChecker.elaborate} — so the backend reads
+ * the decision instead of inferring it a second time. A node built by {@link #of} instead of by the
+ * checker has a {@code null} type: the codec emitters are still AST-level and reach the shared value
+ * emitter through {@code of}, and the backend falls back to its own synthesis for those. That
+ * fallback is what the remaining slices of #81 remove.
+ *
+ * <p>A surface-only node (a list comprehension) never appears — the Lower stage has already
  * rewritten it — so translating one is a compiler bug, not a case to handle.
  */
 public sealed interface Core {
 
     SourcePos pos();
+
+    /** The type the checker decided for this expression, or {@code null} on a node {@link #of} built. */
+    Type type();
 
     /**
      * Rebuilds the equivalent surface expression. Two callers need AST rather than Core: the codec
@@ -75,78 +85,92 @@ public sealed interface Core {
         return out;
     }
 
-    record Int(long value, SourcePos pos) implements Core {}
+    record Int(long value, Type type, SourcePos pos) implements Core {}
 
-    record Decimal(BigDecimal value, SourcePos pos) implements Core {}
+    record Decimal(BigDecimal value, Type type, SourcePos pos) implements Core {}
 
-    record Str(String value, SourcePos pos) implements Core {}
+    record Str(String value, Type type, SourcePos pos) implements Core {}
 
-    record Bool(boolean value, SourcePos pos) implements Core {}
+    record Bool(boolean value, Type type, SourcePos pos) implements Core {}
 
-    record Var(String name, SourcePos pos) implements Core {}
+    record Var(String name, Type type, SourcePos pos) implements Core {}
 
-    record Neg(Core operand, SourcePos pos) implements Core {}
+    record Neg(Core operand, Type type, SourcePos pos) implements Core {}
 
-    record FieldAccess(Core target, String field, SourcePos pos) implements Core {}
+    record FieldAccess(Core target, String field, Type type, SourcePos pos) implements Core {}
 
-    record Binary(Ast.BinOp op, Core left, Core right, SourcePos pos) implements Core {}
+    record Binary(Ast.BinOp op, Core left, Core right, Type type, SourcePos pos) implements Core {}
 
     /** A call to a builtin, an injected behavior, or an intrinsic (a helper fn is already inlined). */
-    record Call(String fn, List<Core> args, SourcePos pos) implements Core {}
+    record Call(String fn, List<Core> args, Type type, SourcePos pos) implements Core {}
 
-    record If(Core cond, Core then, Core els, SourcePos pos) implements Core {}
+    record If(Core cond, Core then, Core els, Type type, SourcePos pos) implements Core {}
 
     /** {@code annotation} is the type the source wrote on the binding ({@code let x: T = e}), or null.
-     * Core carries no types of its own; this is the written annotation, kept so the backend materialises
-     * an empty-collection value at the type the checker pinned it to rather than re-deriving a bottom.
+     * It is kept for the backend's fallback path, which re-derives the value's type; a node the
+     * checker produced carries the decided type on {@code value} instead.
      * A type that helper inlining put on a binding is not an annotation and does not come along. */
-    record LetIn(String name, Core value, Ast.RetType annotation, Core body, SourcePos pos)
+    record LetIn(String name, Core value, Ast.RetType annotation, Core body, Type type, SourcePos pos)
             implements Core {
 
-        LetIn(String name, Core value, Core body, SourcePos pos) {
-            this(name, value, null, body, pos);
+        LetIn(String name, Core value, Core body, Type type, SourcePos pos) {
+            this(name, value, null, body, type, pos);
         }
     }
 
     /** A second-class block: a step passed to a recursive combinator, or an escaping lambda a {@code
-     * let} binds (a closure). Kept as its own node until closure conversion gets an explicit Core form. */
-    record Block(List<String> params, Core body, SourcePos pos) implements Core {}
+     * let} binds (a closure). Kept as its own node until closure conversion gets an explicit Core form.
+     * Its {@code type} is the {@link Type.FnOf} the checker gave it — the parameter types the context
+     * fixed, and the body's result type. */
+    record Block(List<String> params, Core body, Type type, SourcePos pos) implements Core {}
 
-    record ListLit(List<Core> elements, SourcePos pos) implements Core {}
+    record ListLit(List<Core> elements, Type type, SourcePos pos) implements Core {}
 
     /** A tuple {@code (e1, e2, ...)} (ADR-0036); the backend emits it as an {@code Object[]}. */
-    record Tuple(List<Core> elements, SourcePos pos) implements Core {}
+    record Tuple(List<Core> elements, Type type, SourcePos pos) implements Core {}
 
     /** Reads a tuple element by index (a {@code let (x, y) = t} destructure); {@code arity} is the
      * pattern's name count, checked against the tuple's size (ADR-0036). */
-    record TupleGet(Core tuple, int index, int arity, SourcePos pos) implements Core {}
+    record TupleGet(Core tuple, int index, int arity, Type type, SourcePos pos) implements Core {}
 
     record FieldInit(String name, Core value, SourcePos pos) {}
 
-    record NewData(String typeName, List<FieldInit> inits, List<String> spreads, SourcePos pos)
-            implements Core {}
+    record NewData(String typeName, List<FieldInit> inits, List<String> spreads, Type type,
+                   SourcePos pos) implements Core {}
 
-    record Case(List<String> caseTypes, String binding, Core body, SourcePos pos) {}
+    /** {@code bindType} is the type the case binding takes inside the arm — the case type a union
+     * narrows to, or the element a {@code Some x} opens (null on a node {@link #of} built). */
+    record Case(List<String> caseTypes, String binding, Core body, Type bindType, SourcePos pos) {
 
-    record Match(Core scrutinee, List<Case> cases, SourcePos pos) implements Core {}
+        Case(List<String> caseTypes, String binding, Core body, SourcePos pos) {
+            this(caseTypes, binding, body, null, pos);
+        }
+    }
 
-    /** Translates a lowered behavior body (helpers inlined, surface forms desugared) to Core. */
-    static Core of(Ast.Expr e) {
+    record Match(Core scrutinee, List<Case> cases, Type type, SourcePos pos) implements Core {}
+
+    /**
+     * Translates a lowered behavior body to Core without types, for the AST-level codec emitters.
+     * The behavior and helper bodies the backend emits come from the checker instead, with the type
+     * it decided on every node (issue #81).
+     */
+    public static Core of(Ast.Expr e) {
         return switch (e) {
-            case Ast.IntLit x -> new Int(x.value(), x.pos());
-            case Ast.DecimalLit x -> new Decimal(x.value(), x.pos());
-            case Ast.StringLit x -> new Str(x.value(), x.pos());
-            case Ast.BoolLit x -> new Bool(x.value(), x.pos());
-            case Ast.Var x -> new Var(x.name(), x.pos());
-            case Ast.Neg n -> new Neg(of(n.operand()), n.pos());
-            case Ast.FieldAccess fa -> new FieldAccess(of(fa.target()), fa.field(), fa.pos());
-            case Ast.Binary b -> new Binary(b.op(), of(b.left()), of(b.right()), b.pos());
-            case Ast.If iff -> new If(of(iff.cond()), of(iff.then()), of(iff.els()), iff.pos());
-            case Ast.LetIn li -> new LetIn(li.name(), of(li.value()), li.annotation(), of(li.body()), li.pos());
-            case Ast.Block bl -> new Block(bl.params(), of(bl.body()), bl.pos());
-            case Ast.ListLit l -> new ListLit(ofAll(l.elements()), l.pos());
-            case Ast.Tuple t -> new Tuple(ofAll(t.elements()), t.pos());
-            case Ast.TupleGet tg -> new TupleGet(of(tg.tuple()), tg.index(), tg.arity(), tg.pos());
+            case Ast.IntLit x -> new Int(x.value(), null, x.pos());
+            case Ast.DecimalLit x -> new Decimal(x.value(), null, x.pos());
+            case Ast.StringLit x -> new Str(x.value(), null, x.pos());
+            case Ast.BoolLit x -> new Bool(x.value(), null, x.pos());
+            case Ast.Var x -> new Var(x.name(), null, x.pos());
+            case Ast.Neg n -> new Neg(of(n.operand()), null, n.pos());
+            case Ast.FieldAccess fa -> new FieldAccess(of(fa.target()), fa.field(), null, fa.pos());
+            case Ast.Binary b -> new Binary(b.op(), of(b.left()), of(b.right()), null, b.pos());
+            case Ast.If iff -> new If(of(iff.cond()), of(iff.then()), of(iff.els()), null, iff.pos());
+            case Ast.LetIn li -> new LetIn(li.name(), of(li.value()), li.annotation(), of(li.body()),
+                    null, li.pos());
+            case Ast.Block bl -> new Block(bl.params(), of(bl.body()), null, bl.pos());
+            case Ast.ListLit l -> new ListLit(ofAll(l.elements()), null, l.pos());
+            case Ast.Tuple t -> new Tuple(ofAll(t.elements()), null, t.pos());
+            case Ast.TupleGet tg -> new TupleGet(of(tg.tuple()), tg.index(), tg.arity(), null, tg.pos());
             case Ast.NewData nd -> ofNewData(nd);
             case Ast.Match m -> ofMatch(m);
             case Ast.Call c -> ofCall(c);
@@ -156,7 +180,7 @@ public sealed interface Core {
     }
 
     private static Core ofCall(Ast.Call c) {
-        return new Call(c.fn(), ofAll(c.args()), c.pos());
+        return new Call(c.fn(), ofAll(c.args()), null, c.pos());
     }
 
     private static Core ofNewData(Ast.NewData nd) {
@@ -164,7 +188,7 @@ public sealed interface Core {
         for (Ast.FieldInit i : nd.inits()) {
             inits.add(new FieldInit(i.name(), of(i.value()), i.pos()));
         }
-        return new NewData(nd.typeName(), inits, nd.spreads(), nd.pos());
+        return new NewData(nd.typeName(), inits, nd.spreads(), null, nd.pos());
     }
 
     private static Core ofMatch(Ast.Match m) {
@@ -172,7 +196,7 @@ public sealed interface Core {
         for (Ast.Case c : m.cases()) {
             cases.add(new Case(c.caseTypes(), c.binding(), of(c.body()), c.pos()));
         }
-        return new Match(of(m.scrutinee()), cases, m.pos());
+        return new Match(of(m.scrutinee()), cases, null, m.pos());
     }
 
     private static List<Core> ofAll(List<Ast.Expr> es) {

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -5,7 +5,6 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.ast.Ast;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -18,72 +17,21 @@ import java.util.List;
  * lowering and closure conversion, and drop the corresponding special cases from the emitter.
  *
  * <p>Every node carries {@link #type()}: the type the checker decided for it (issue #81). The
- * checker produces Core as it types a body — {@code TypeChecker.elaborate} — so the backend reads
- * the decision instead of inferring it a second time. A node built by {@link #of} instead of by the
- * checker has a {@code null} type: the codec emitters are still AST-level and reach the shared value
- * emitter through {@code of}, and the backend falls back to its own synthesis for those. That
- * fallback is what the remaining slices of #81 remove.
+ * checker is the only producer of Core — it builds the tree as it types a body
+ * ({@code TypeChecker.elaborate}) — so the backend reads those decisions instead of inferring the
+ * same types a second time. The one node with no type is the rounding mode of {@code divide}, a
+ * built-in identifier the emitter reads by name rather than as a value (spec 18.3).
  *
  * <p>A surface-only node (a list comprehension) never appears — the Lower stage has already
- * rewritten it — so translating one is a compiler bug, not a case to handle.
+ * rewritten it.
  */
 public sealed interface Core {
 
     SourcePos pos();
 
-    /** The type the checker decided for this expression, or {@code null} on a node {@link #of} built. */
+    /** The type the checker decided for this expression (null only on a built-in identifier
+     * the emitter reads by name — see the class comment). */
     Type type();
-
-    /**
-     * Rebuilds the equivalent surface expression. Two callers need AST rather than Core: the codec
-     * emitter, which is AST-level, reaches the shared value emitter through {@code Core.of} then here;
-     * and the backend's closure path, which asks the type checker (AST-based) about a runtime-selected
-     * function, since Core is untyped. {@code of} and {@code toAst} round-trip.
-     */
-    default Ast.Expr toAst() {
-        return switch (this) {
-            case Int x -> new Ast.IntLit(x.value(), x.pos());
-            case Decimal x -> new Ast.DecimalLit(x.value(), x.pos());
-            case Str x -> new Ast.StringLit(x.value(), x.pos());
-            case Bool x -> new Ast.BoolLit(x.value(), x.pos());
-            case Var x -> new Ast.Var(x.name(), x.pos());
-            case Neg n -> new Ast.Neg(n.operand().toAst(), n.pos());
-            case FieldAccess fa -> new Ast.FieldAccess(fa.target().toAst(), fa.field(), fa.pos());
-            case Binary b -> new Ast.Binary(b.op(), b.left().toAst(), b.right().toAst(), b.pos());
-            case Call c -> new Ast.Call(c.fn(), toAstAll(c.args()), c.pos());
-            case If iff -> new Ast.If(iff.cond().toAst(), iff.then().toAst(), iff.els().toAst(), iff.pos());
-            case LetIn li -> li.annotation() == null
-                    ? new Ast.LetIn(li.name(), li.value().toAst(), li.body().toAst(), li.pos())
-                    : Ast.LetIn.annotated(li.name(), li.value().toAst(), li.annotation(),
-                            li.body().toAst(), li.pos());
-            case Block bl -> new Ast.Block(bl.params(), bl.body().toAst(), bl.pos());
-            case ListLit l -> new Ast.ListLit(toAstAll(l.elements()), l.pos());
-            case Tuple t -> new Ast.Tuple(toAstAll(t.elements()), t.pos());
-            case TupleGet tg -> new Ast.TupleGet(tg.tuple().toAst(), tg.index(), tg.arity(), tg.pos());
-            case NewData nd -> {
-                List<Ast.FieldInit> inits = new ArrayList<>();
-                for (FieldInit i : nd.inits()) {
-                    inits.add(new Ast.FieldInit(i.name(), i.value().toAst(), i.pos()));
-                }
-                yield new Ast.NewData(nd.typeName(), inits, nd.spreads(), nd.pos());
-            }
-            case Match m -> {
-                List<Ast.Case> cases = new ArrayList<>();
-                for (Case c : m.cases()) {
-                    cases.add(new Ast.Case(c.caseTypes(), c.binding(), c.body().toAst(), c.pos()));
-                }
-                yield new Ast.Match(m.scrutinee().toAst(), cases, m.pos());
-            }
-        };
-    }
-
-    private static List<Ast.Expr> toAstAll(List<Core> cs) {
-        List<Ast.Expr> out = new ArrayList<>();
-        for (Core c : cs) {
-            out.add(c.toAst());
-        }
-        return out;
-    }
 
     record Int(long value, Type type, SourcePos pos) implements Core {}
 
@@ -106,17 +54,10 @@ public sealed interface Core {
 
     record If(Core cond, Core then, Core els, Type type, SourcePos pos) implements Core {}
 
-    /** {@code annotation} is the type the source wrote on the binding ({@code let x: T = e}), or null.
-     * It is kept for the backend's fallback path, which re-derives the value's type; a node the
-     * checker produced carries the decided type on {@code value} instead.
-     * A type that helper inlining put on a binding is not an annotation and does not come along. */
-    record LetIn(String name, Core value, Ast.RetType annotation, Core body, Type type, SourcePos pos)
-            implements Core {
-
-        LetIn(String name, Core value, Core body, Type type, SourcePos pos) {
-            this(name, value, null, body, type, pos);
-        }
-    }
+    /** A local binding. What the source wrote as its type — {@code let x: T = e} — is already in
+     * {@code value}'s type: the checker pushed the annotation into the value when it typed it, so an
+     * empty collection bound here materialises at the written type rather than a bottom (issue #71). */
+    record LetIn(String name, Core value, Core body, Type type, SourcePos pos) implements Core {}
 
     /** A second-class block: a step passed to a recursive combinator, or an escaping lambda a {@code
      * let} binds (a closure). Kept as its own node until closure conversion gets an explicit Core form.
@@ -139,71 +80,9 @@ public sealed interface Core {
                    SourcePos pos) implements Core {}
 
     /** {@code bindType} is the type the case binding takes inside the arm — the case type a union
-     * narrows to, or the element a {@code Some x} opens (null on a node {@link #of} built). */
-    record Case(List<String> caseTypes, String binding, Core body, Type bindType, SourcePos pos) {
-
-        Case(List<String> caseTypes, String binding, Core body, SourcePos pos) {
-            this(caseTypes, binding, body, null, pos);
-        }
-    }
+     * narrows to, or the element a {@code Some x} opens. */
+    record Case(List<String> caseTypes, String binding, Core body, Type bindType, SourcePos pos) {}
 
     record Match(Core scrutinee, List<Case> cases, Type type, SourcePos pos) implements Core {}
 
-    /**
-     * Translates a lowered behavior body to Core without types, for the AST-level codec emitters.
-     * The behavior and helper bodies the backend emits come from the checker instead, with the type
-     * it decided on every node (issue #81).
-     */
-    public static Core of(Ast.Expr e) {
-        return switch (e) {
-            case Ast.IntLit x -> new Int(x.value(), null, x.pos());
-            case Ast.DecimalLit x -> new Decimal(x.value(), null, x.pos());
-            case Ast.StringLit x -> new Str(x.value(), null, x.pos());
-            case Ast.BoolLit x -> new Bool(x.value(), null, x.pos());
-            case Ast.Var x -> new Var(x.name(), null, x.pos());
-            case Ast.Neg n -> new Neg(of(n.operand()), null, n.pos());
-            case Ast.FieldAccess fa -> new FieldAccess(of(fa.target()), fa.field(), null, fa.pos());
-            case Ast.Binary b -> new Binary(b.op(), of(b.left()), of(b.right()), null, b.pos());
-            case Ast.If iff -> new If(of(iff.cond()), of(iff.then()), of(iff.els()), null, iff.pos());
-            case Ast.LetIn li -> new LetIn(li.name(), of(li.value()), li.annotation(), of(li.body()),
-                    null, li.pos());
-            case Ast.Block bl -> new Block(bl.params(), of(bl.body()), null, bl.pos());
-            case Ast.ListLit l -> new ListLit(ofAll(l.elements()), null, l.pos());
-            case Ast.Tuple t -> new Tuple(ofAll(t.elements()), null, t.pos());
-            case Ast.TupleGet tg -> new TupleGet(of(tg.tuple()), tg.index(), tg.arity(), null, tg.pos());
-            case Ast.NewData nd -> ofNewData(nd);
-            case Ast.Match m -> ofMatch(m);
-            case Ast.Call c -> ofCall(c);
-            case Ast.ListComp _ -> throw new IllegalStateException(
-                    "a list comprehension must be lowered to an `if` before Core translation");
-        };
-    }
-
-    private static Core ofCall(Ast.Call c) {
-        return new Call(c.fn(), ofAll(c.args()), null, c.pos());
-    }
-
-    private static Core ofNewData(Ast.NewData nd) {
-        List<FieldInit> inits = new ArrayList<>();
-        for (Ast.FieldInit i : nd.inits()) {
-            inits.add(new FieldInit(i.name(), of(i.value()), i.pos()));
-        }
-        return new NewData(nd.typeName(), inits, nd.spreads(), null, nd.pos());
-    }
-
-    private static Core ofMatch(Ast.Match m) {
-        List<Case> cases = new ArrayList<>();
-        for (Ast.Case c : m.cases()) {
-            cases.add(new Case(c.caseTypes(), c.binding(), of(c.body()), c.pos()));
-        }
-        return new Match(of(m.scrutinee()), cases, null, m.pos());
-    }
-
-    private static List<Core> ofAll(List<Ast.Expr> es) {
-        List<Core> out = new ArrayList<>();
-        for (Ast.Expr e : es) {
-            out.add(of(e));
-        }
-        return out;
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleTest.java
@@ -173,8 +173,9 @@ class CompileExampleTest {
                 souther.compiler.check.TypeChecker.symbols(module));
         var lowered = souther.compiler.check.Lower.run(module);
         var symbols = souther.compiler.check.TypeChecker.symbols(module);
-        souther.compiler.check.TypeChecker.check(module, symbols, java.util.Map.of(), lowered);
-        var classes = souther.compiler.codegen.Backend.generate(lowered);
+        var checked = souther.compiler.check.TypeChecker
+                .checkAndElaborate(module, symbols, java.util.Map.of(), lowered).checked();
+        var classes = souther.compiler.codegen.Backend.generate(lowered, checked);
         var sigs = souther.compiler.check.TypeChecker.signatures(module, symbols);
         var fails = ExampleVerifier.check(module, symbols, sigs, java.util.Map.of(), classes);
         assertEquals(2, fails.size());

--- a/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
@@ -28,8 +28,10 @@ class CompileTypeVariableTest {
     /** Compiles a core (reserved-namespace) module directly, bypassing the user-facing guard. */
     private static Map<String, byte[]> compileCore(String src) {
         Ast.Module m = Deriver.derive(CstFrontend.parse(src));
-        TypeChecker.check(m);
-        return Backend.generate(Lower.run(m));
+        Ast.Module lowered = Lower.run(m);
+        TypeChecker.Checked checked =
+                TypeChecker.checkOrThrow(m, TypeChecker.symbols(m), Map.of(), lowered);
+        return Backend.generate(lowered, checked);
     }
 
     @Test

--- a/specification.adoc
+++ b/specification.adoc
@@ -2164,18 +2164,18 @@ The model author does not write this type name in Souther source; they only writ
 ----
 Source -> Lexer -> Parser -> AST
   -> Derive (fill decoder/encoder into the AST from a data's shape)
-  -> Lower (behavior / let bodies -> Core IR: helper inlining, desugaring)
-  -> Type Check
+  -> Lower (behavior / let bodies: helper inlining, desugaring)
+  -> Type Check -> Core IR (typed: the checker produces it as it types a body)
        name resolution / construction-authority check / requirement-set check and composition inference / exhaustiveness check / invariant type check
   -> ClassFile Backend -> .class (direct bytecode generation)
 ----
 
-Behavior and `+let+` bodies are lowered to a Core IR — helper inlining and surface desugaring happen once here — and the backend emits from it. Data definitions and derived decoders / encoders stay at the AST level; there is no separate Domain IR / Decoder IR / Encoder IR. Type checking verifies construction authority, requirement sets, exhaustiveness, and invariants together: the surface checks read the AST, and the body check reads the lowered Core. The backend generates `+.class+` with the Class-File API (`+java.lang.classfile+`) and does not go through javac.
+Behavior and `+let+` bodies are lowered — helper inlining and surface desugaring happen once here — and then typed. The type checker produces the Core IR as it types a body: every Core node carries the type decided for it, and the backend emits from that rather than inferring types a second time. Data definitions and derived decoders / encoders stay at the AST level, and their expressions are typed the same way where the backend emits them; there is no separate Domain IR / Decoder IR / Encoder IR. Type checking verifies construction authority, requirement sets, exhaustiveness, and invariants together: the surface checks read the AST, and the body check reads the lowered form. The backend generates `+.class+` with the Class-File API (`+java.lang.classfile+`) and does not go through javac.
 
 [#ast-tracking]
 == Information tracked by the AST and backend
 
-Apart from the Core IR that behavior and `+let+` bodies are lowered to (<<compiler-pipeline>>), the compiler keeps no separate intermediate representation; the following is held as the AST and the type-check results.
+Apart from the typed Core IR the type checker produces for behavior and `+let+` bodies (<<compiler-pipeline>>), the compiler keeps no separate intermediate representation; the following is held as the AST and the type-check results.
 
 [#ast-nodes]
 === AST definition nodes


### PR DESCRIPTION
Closes #81 (needs a manual `gh issue close` — the default branch is `main`, so a PR into `develop` does not fire it).

Core was structural and untyped (ADR-0021), so `BodyGen` inferred types again as it emitted. Every improvement to inference had to be made twice, and a miss in the second copy surfaced as a codegen crash rather than a type error — #70, #71, #74 and #80 each paid that cost.

## What changed

`TypeChecker.elaborate` types an expression and produces its Core, carrying the decided type on every node. `typeOf` is `elaborate(...).type()`, so the twenty-odd callers that only want a type — the decoder, invariant, example and helper checks — are unchanged. The checker is now Core's only producer: it hands the backend a `Checked` with the elaborated body of each behavior and recursive helper, and `Core.of` / `Core.toAst()` are gone.

`checkHelpers` now types a recursive helper on the body the Lower stage produced, which is the tree the backend emits. Until now it typed a second inlining of its own — structurally equal, but a different object graph.

The codec emitters and a data's invariant are still AST-level; they elaborate through the checker at the environment their slots hold, so every node reaching the emitter carries a type. An untyped one is a compiler error rather than a silent fallback, and so is a call whose typing rule yields a type without touching one of its arguments (`Map.get` over a bottom-keyed accumulator was one). The single deliberate exception is the rounding mode of `divide` — a built-in identifier the emitter reads by name, not a value.

`BodyGen` no longer computes types at all. Gone: the accumulator resolution around a recursive helper call (`pinResultTypeVars`, `unify`, `resolveStepBinding`, `substitute`), the closure path's `isFunctionSelection` / `inferFnParamTypes`, `caseBindType`, the annotation read behind a `let`'s expected type, the re-typing of `List.find` / `sortBy` / `Option.map` arguments, a lambda body's result type, and `closedNewtypeArithResult`. Every emitter is void; where a type drives the emission — which instruction, which descriptor, which slot, which newtype to re-wrap into — it is read from the node. The file is 552 lines shorter.

## What the investigation changed about the plan

The issue named recursive generics lowered to shared methods as the hardest part. It was already resolved: `checkHelpers` and `Backend` both type a helper body at its declared signature through `resolveParamType`, so `'acc` stays a type variable on both sides and one type per node suffices. The call site carries the substituted result; the shared body stays generic.

## Migration

The first commit lands the elaboration with the emitter still synthesising types beside it, checked against each other in the test runs (assignability, not equality — the emitter reads one branch where the checker merged both). The second commit deletes the synthesis. Nothing from the first commit was rewritten by the second.

## Verification

```
mvn -o clean test                    # compiler 797, LSP 44 — green
mvn -o -f examples/pom.xml verify    # all example modules green
```

ADR-0021 and the specification's pipeline section are revised: the Core IR is typed and the type checker produces it. The ADR had deferred a typed Core until "recursive generics lowered to shared methods, or an optimization that needs types on nodes"; the need that arrived was a third one it did not list — inference maintained in two places, where the second copy is discovered by a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
