### PR TITLE
Render a compile error in the build log, and name the file it came from

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,10 @@ The whole Maven wiring is just this (set once for all modules in `examples/pom.x
 end up in the artifact jar. With Gradle you use the same processor via an `annotationProcessor`
 dependency plus the `-Asouther.source` compiler arg.
 
+A compile error is reported the way the CLI reports it — the title, the position, the offending line
+with a caret, and the hint. `-Asouther.lang=en` picks the language of the message; without it the
+processor follows `SOUTHER_LANG` and then the JVM's default locale, as `souther --lang` does.
+
 ## Modules
 
 | Module | What it shows |

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -226,11 +226,25 @@ public final class Compiler {
 
     private static Map<String, byte[]> linking(List<String> sources, List<Diagnostic> warningsOut) {
         List<Ast.Module> allParsed = new ArrayList<>();
-        for (String s : sources) {
+        // Which source each module was read from, so an error can be traced back to a file.
+        Map<String, Integer> sourceOfModule = new LinkedHashMap<>();
+        // Modules an `examples for` file was merged into. Their examples come from another source, so
+        // an example failure names no file rather than quoting this one's line at that one's position.
+        Set<String> mergedExamples = new LinkedHashSet<>();
+        for (int i = 0; i < sources.size(); i++) {
             // A module linked by imports must be named; `null` forbids omitting the header here.
-            Ast.Module raw = CstFrontend.parse(s, null);
-            rejectReservedNamespace(raw);
-            allParsed.add(Exposing.rewrite(raw));
+            try {
+                Ast.Module raw = CstFrontend.parse(sources.get(i), null);
+                rejectReservedNamespace(raw);
+                Ast.Module rewritten = Exposing.rewrite(raw);
+                allParsed.add(rewritten);
+                if (rewritten.exampleFileTarget() == null) {
+                    // an `examples for X` file carries X's name; the module itself is the other source
+                    sourceOfModule.put(rewritten.name(), i);
+                }
+            } catch (CompileException e) {
+                throw e.inSource(i);
+            }
         }
         // An `examples for <module>` file contributes only examples: merge each into its target
         // module. It is never a module of its own, so it never enters `byName`.
@@ -241,6 +255,7 @@ public final class Compiler {
             if (m.exampleFileTarget() != null) {
                 attached.computeIfAbsent(m.exampleFileTarget(), k -> new ArrayList<>()).addAll(m.examples());
                 attachedFakes.computeIfAbsent(m.exampleFileTarget(), k -> new ArrayList<>()).addAll(m.fakes());
+                mergedExamples.add(m.exampleFileTarget());
             } else {
                 parsed.add(m);
             }
@@ -253,22 +268,31 @@ public final class Compiler {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.module.duplicate").title("check.module.title")
                                 .at(m.pos()).args(m.name()).build(),
-                        "duplicate module `" + m.name() + "`");
+                        "duplicate module `" + m.name() + "`")
+                        .inSource(sourceIndex(sourceOfModule, m.name()));
             }
         }
-        detectCycles(parsed, byName);
+        detectCycles(parsed, byName, sourceOfModule);
 
         // pass 1: derive each module's codecs, resolving imported types against the original defs
         Map<String, Ast.Module> derived = new LinkedHashMap<>();
         for (Ast.Module m : parsed) {
-            Ast.Module d = Deriver.derive(m, visibleDefs(m, byName));
-            derived.put(m.name(), HelperInliner.forModule(d).withInlinedInvariants(d));
+            try {
+                Ast.Module d = Deriver.derive(m, visibleDefs(m, byName));
+                derived.put(m.name(), HelperInliner.forModule(d).withInlinedInvariants(d));
+            } catch (CompileException e) {
+                throw e.inSource(sourceIndex(sourceOfModule, m.name()));
+            }
         }
         // pass 1.5: lower `金額(x)` newtype constructors to NewData (needs every module's defs, so
         // an imported newtype name resolves) before check and codegen see them
         for (Ast.Module original : parsed) {
             Ast.Module m = derived.get(original.name());
-            derived.put(original.name(), NewtypeDesugar.rewrite(m, visibleDefs(m, derived)));
+            try {
+                derived.put(original.name(), NewtypeDesugar.rewrite(m, visibleDefs(m, derived)));
+            } catch (CompileException e) {
+                throw e.inSource(sourceIndex(sourceOfModule, original.name()));
+            }
         }
         // `derived` is final from here, so what each module resolves against is resolved once, in the
         // pass that first needs it, and read again by the example pass. Resolving it up front instead
@@ -279,29 +303,45 @@ public final class Compiler {
         Map<String, byte[]> out = new LinkedHashMap<>();
         for (Ast.Module original : parsed) {
             Ast.Module m = derived.get(original.name());
-            Map<String, Ast.Def> symbols = visibleDefs(m, derived);
-            Map<String, Sig> importedSigs = importedBehaviorSigs(m, derived);
-            visible.put(original.name(), symbols);
-            imported.put(original.name(), importedSigs);
-            Set<String> importedInjected = importedInjectedBehaviors(m, derived);
-            m = injectRecursivePrelude(m);
-            Ast.Module lowered = Lower.run(m);
-            TypeChecker.Checked checked = TypeChecker.checkOrThrow(m, symbols, importedSigs, lowered);
-            warningsOut.addAll(checked.warnings());
-            out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs,
-                    importedInjected, checked));
+            try {
+                Map<String, Ast.Def> symbols = visibleDefs(m, derived);
+                Map<String, Sig> importedSigs = importedBehaviorSigs(m, derived);
+                visible.put(original.name(), symbols);
+                imported.put(original.name(), importedSigs);
+                Set<String> importedInjected = importedInjectedBehaviors(m, derived);
+                m = injectRecursivePrelude(m);
+                Ast.Module lowered = Lower.run(m);
+                TypeChecker.Checked checked = TypeChecker.checkOrThrow(m, symbols, importedSigs, lowered);
+                warningsOut.addAll(checked.warnings());
+                out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs,
+                        importedInjected, checked));
+            } catch (CompileException e) {
+                throw e.inSource(sourceIndex(sourceOfModule, original.name()));
+            }
         }
         // every module's classes are now present, so CTFE and example evaluation can resolve
         // cross-module references
         for (Ast.Module original : parsed) {
             Ast.Module m = derived.get(original.name());
             Map<String, Ast.Def> symbols = visible.get(original.name());
-            verifyConstConstructions(m, symbols, out);
-            Map<String, Sig> sigs =
-                    PipelineSigs.signatures(m, symbols, imported.get(original.name()));
-            ExampleVerifier.verify(m, symbols, sigs, importedPackages(m), out);
+            try {
+                verifyConstConstructions(m, symbols, out);
+                Map<String, Sig> sigs =
+                        PipelineSigs.signatures(m, symbols, imported.get(original.name()));
+                ExampleVerifier.verify(m, symbols, sigs, importedPackages(m), out);
+            } catch (CompileException e) {
+                throw e.inSource(mergedExamples.contains(original.name())
+                        ? -1 : sourceIndex(sourceOfModule, original.name()));
+            }
         }
         return out;
+    }
+
+    /** The source a module was read from, or {@code -1} when it cannot be named — an unknown module,
+     *  or one whose positions come from more than one file. */
+    private static int sourceIndex(Map<String, Integer> sourceOfModule, String moduleName) {
+        Integer index = sourceOfModule.get(moduleName);
+        return index == null ? -1 : index;
     }
 
     /**
@@ -713,16 +753,18 @@ public final class Compiler {
         return names;
     }
 
-    private static void detectCycles(List<Ast.Module> modules, Map<String, Ast.Module> byName) {
+    private static void detectCycles(List<Ast.Module> modules, Map<String, Ast.Module> byName,
+                                     Map<String, Integer> sourceOfModule) {
         Set<String> done = new HashSet<>();
         Set<String> stack = new HashSet<>();
         for (Ast.Module m : modules) {
-            visit(m.name(), byName, done, stack);
+            visit(m.name(), byName, done, stack, sourceOfModule);
         }
     }
 
     private static void visit(String name, Map<String, Ast.Module> byName,
-                              Set<String> done, Set<String> stack) {
+                              Set<String> done, Set<String> stack,
+                              Map<String, Integer> sourceOfModule) {
         if (done.contains(name)) {
             return;
         }
@@ -731,10 +773,12 @@ public final class Compiler {
         if (m != null) {
             for (Ast.Import imp : m.imports()) {
                 if (stack.contains(imp.module())) {
-                    throw new CompileException(imp.pos(), "E1501", "Cyclic module dependency detected.");
+                    // the `import` that closes the cycle is written in `m`, so that is the file to quote
+                    throw new CompileException(imp.pos(), "E1501", "Cyclic module dependency detected.")
+                            .inSource(sourceIndex(sourceOfModule, name));
                 }
                 if (byName.containsKey(imp.module())) {
-                    visit(imp.module(), byName, done, stack);
+                    visit(imp.module(), byName, done, stack, sourceOfModule);
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -324,14 +324,20 @@ public final class Compiler {
         for (Ast.Module original : parsed) {
             Ast.Module m = derived.get(original.name());
             Map<String, Ast.Def> symbols = visible.get(original.name());
+            int index = sourceIndex(sourceOfModule, original.name());
+            Map<String, Sig> sigs;
             try {
+                // both read the module's own defs and helper bodies, so their positions are this file's
                 verifyConstConstructions(m, symbols, out);
-                Map<String, Sig> sigs =
-                        PipelineSigs.signatures(m, symbols, imported.get(original.name()));
+                sigs = PipelineSigs.signatures(m, symbols, imported.get(original.name()));
+            } catch (CompileException e) {
+                throw e.inSource(index);
+            }
+            try {
                 ExampleVerifier.verify(m, symbols, sigs, importedPackages(m), out);
             } catch (CompileException e) {
-                throw e.inSource(mergedExamples.contains(original.name())
-                        ? -1 : sourceIndex(sourceOfModule, original.name()));
+                // a merged `examples for` file's rows are positioned in that file, not this one
+                throw e.inSource(mergedExamples.contains(original.name()) ? -1 : index);
             }
         }
         return out;

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -90,7 +90,7 @@ public final class Main {
                 System.out.println("wrote " + file);
             }
         } catch (CompileException e) {
-            reportCompileError(e, sources.size() == 1 ? sources.get(0) : null, render);
+            reportCompileError(e, sourceOf(sources, e), render);
             System.exit(1);
         } catch (IOException e) {
             System.err.println("io error: " + e.getMessage());
@@ -192,6 +192,20 @@ public final class Main {
             reportCompileError(e, firstSource(args), render);
             System.exit(1);
         }
+    }
+
+    /**
+     * The file whose line the error should quote: the only source of a single-file compile, or — when
+     * several were linked — the one the compiler was working on, which it tags the error with. Null
+     * when a multi-file error names no source, so the snippet is left out rather than quoting a line
+     * from the wrong file.
+     */
+    static Path sourceOf(List<Path> sources, CompileException e) {
+        if (sources.size() == 1) {
+            return sources.get(0);
+        }
+        int index = e.sourceIndex();
+        return index >= 0 && index < sources.size() ? sources.get(index) : null;
     }
 
     /** Renders a compile error: an Elm-style snippet (or JSON) in the chosen locale, or the legacy

--- a/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
+++ b/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
@@ -1,6 +1,9 @@
 package souther.compiler.apt;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.Messages;
+import souther.compiler.diag.SourceContext;
 import souther.compiler.Compiler;
 
 import javax.annotation.processing.AbstractProcessor;
@@ -17,6 +20,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -32,6 +36,11 @@ import java.util.stream.Stream;
  * {@code annotationProcessorPaths}, Gradle {@code annotationProcessor}, or plain
  * {@code javac -processorpath}). With no {@code souther.source} option it is a no-op, so it is
  * harmless to have on any classpath.
+ *
+ * <p>A compile error is rendered as the CLI renders it and handed to the {@code Messager}, so the
+ * build log carries the snippet and the hint rather than an exception's detail string.
+ * {@code -Asouther.lang=<tag>} chooses the language, defaulting the same way {@code souther --lang}
+ * does.
  */
 @SupportedAnnotationTypes("*")
 public final class SoutherProcessor extends AbstractProcessor {
@@ -45,7 +54,7 @@ public final class SoutherProcessor extends AbstractProcessor {
 
     @Override
     public Set<String> getSupportedOptions() {
-        return Set.of("souther.source");
+        return Set.of("souther.source", "souther.lang");
     }
 
     @Override
@@ -58,14 +67,16 @@ public final class SoutherProcessor extends AbstractProcessor {
             return false;   // not configured: no-op
         }
         done = true;
+        List<Source> sources = List.of();
         try {
-            List<String> sources = readSources(Path.of(configured));
+            sources = readSources(Path.of(configured));
             if (sources.isEmpty()) {
                 return false;
             }
-            Map<String, byte[]> classes = sources.size() == 1
-                    ? Compiler.compile(sources.get(0))
-                    : Compiler.compileModules(sources);
+            List<String> texts = sources.stream().map(Source::text).toList();
+            Map<String, byte[]> classes = texts.size() == 1
+                    ? Compiler.compile(texts.get(0))
+                    : Compiler.compileModules(texts);
             Filer filer = processingEnv.getFiler();
             for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
                 JavaFileObject file = filer.createClassFile(entry.getKey());
@@ -74,25 +85,54 @@ public final class SoutherProcessor extends AbstractProcessor {
                 }
             }
         } catch (CompileException e) {
-            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "souther: " + e.getMessage());
+            processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, render(e, sources));
         } catch (IOException e) {
             processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, "souther: io error: " + e.getMessage());
         }
         return false;
     }
 
+    /**
+     * The compile error as the CLI would print it: an Elm-style snippet in the chosen locale, with
+     * no color since this goes to a build log. The snippet comes from the source the compiler names
+     * — the only one, or the module it was working on when a module set is linked.
+     */
+    private String render(CompileException e, List<Source> sources) {
+        souther.compiler.diag.Diagnostic d = e.diagnostic();
+        if (d == null) {
+            return "souther: " + e.getMessage();   // not yet structured
+        }
+        Source origin = originOf(e, sources);
+        SourceContext src = origin == null ? null
+                : new SourceContext(origin.path().getFileName().toString(), origin.text());
+        Locale locale = Messages.resolveLocale(processingEnv.getOptions().get("souther.lang"));
+        return new HumanRenderer(false).render(d, src, locale);
+    }
+
+    /** The source the error came from, or null when it names none (so no line is quoted). */
+    private static Source originOf(CompileException e, List<Source> sources) {
+        if (sources.size() == 1) {
+            return sources.get(0);
+        }
+        int index = e.sourceIndex();
+        return index >= 0 && index < sources.size() ? sources.get(index) : null;
+    }
+
     /** Reads a single {@code .sou} file, or every {@code .sou} under a directory (path-sorted). */
-    private static List<String> readSources(Path path) throws IOException {
+    private static List<Source> readSources(Path path) throws IOException {
         if (Files.isDirectory(path)) {
             try (Stream<Path> walk = Files.walk(path)) {
                 List<Path> files = walk.filter(p -> p.toString().endsWith(".sou")).sorted().toList();
-                List<String> sources = new ArrayList<>();
+                List<Source> sources = new ArrayList<>();
                 for (Path file : files) {
-                    sources.add(Files.readString(file));
+                    sources.add(new Source(file, Files.readString(file)));
                 }
                 return sources;
             }
         }
-        return List.of(Files.readString(path));
+        return List.of(new Source(path, Files.readString(path)));
     }
+
+    /** A {@code .sou} file and its text. The path is kept so a diagnostic can quote the line. */
+    private record Source(Path path, String text) {}
 }

--- a/souther-compiler/src/test/java/souther/compiler/MultiFileDiagnosticOriginTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/MultiFileDiagnosticOriginTest.java
@@ -96,6 +96,33 @@ class MultiFileDiagnosticOriginTest {
     }
 
     @Test
+    void aConstantInvariantViolationNamesTheModuleEvenWithAnAttachedExampleFile() {
+        // a regex invariant is not discharged by the checker, so the constant is rejected by the
+        // compile-time evaluation that runs alongside the examples — the pass this test pins down
+        String target = """
+                module t
+                import String ( matches )
+                data メール = String
+                    invariant matches("[^@]+@[^@]+", value)
+                data Out = { v: メール }
+                behavior f : (n: Int) -> Out
+                    constructs Out, メール
+                let f (n) = Out { v = メール("not-an-email") }
+                """;
+        String examples = """
+                examples for t
+                example f
+                    | "one" : (1) -> Out { v = メール("a@b") }
+                """;
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(target, examples)));
+
+        assertEquals(0, e.sourceIndex(),
+                "the rejected construction is written in the module, not in the example file");
+    }
+
+    @Test
     void aFailingExampleInAMergedModuleNamesNoSource() {
         String target = """
                 module t

--- a/souther-compiler/src/test/java/souther/compiler/MultiFileDiagnosticOriginTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/MultiFileDiagnosticOriginTest.java
@@ -1,0 +1,159 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.SourceContext;
+import souther.compiler.diag.SourcePos;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An error in a multi-file compile says which file it came from. A position is a line and a column,
+ * so without the module it belongs to there is nothing to quote — the linker tags the error with the
+ * source it was compiling, and the caller turns that into the file it read.
+ */
+class MultiFileDiagnosticOriginTest {
+
+    private static final String A = """
+            module a exposing ( 従業員ID )
+            data 従業員ID = String
+            """;
+
+    private static final String B = """
+            module b
+            import a ( 従業員ID )
+            data Out = { v: Int }
+            behavior f : (who: 従業員ID) -> Out
+                constructs Out
+            let f (who) = Out { v = who }
+            """;
+
+    @Test
+    void theErrorIsTaggedWithTheSourceItCameFrom() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(A, B)));
+
+        assertEquals(1, e.sourceIndex(), "the error is in the second source");
+    }
+
+    @Test
+    void anErrorInTheFirstSourceIsTaggedToo() {
+        String broken = """
+                module a exposing ( 従業員ID )
+                data 従業員ID = String
+                data Bad = { v: Nonexistent }
+                """;
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(broken, B)));
+
+        assertEquals(0, e.sourceIndex());
+    }
+
+    @Test
+    void aSingleModuleCompileCarriesNoOrigin() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module solo
+                data Out = { v: Int }
+                behavior f : (s: String) -> Out
+                    constructs Out
+                let f (s) = Out { v = s }
+                """));
+
+        assertEquals(-1, e.sourceIndex(), "there is only one source; the caller knows which");
+    }
+
+    @Test
+    void aModuleWithAnAttachedExampleFileStillNamesItsOwnBodyError() {
+        String target = """
+                module t
+                data Out = { v: Int }
+                behavior f : (s: String) -> Out
+                    constructs Out
+                let f (s) = Out { v = s }
+                """;
+        String examples = """
+                examples for t
+                example f
+                    | "one" : ("a") -> Out { v = 1 }
+                """;
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(target, examples)));
+
+        assertEquals(0, e.sourceIndex(), "the type error is in the module's own body");
+    }
+
+    @Test
+    void aFailingExampleInAMergedModuleNamesNoSource() {
+        String target = """
+                module t
+                data Out = { v: Int }
+                behavior f : (n: Int) -> Out
+                    constructs Out
+                let f (n) = Out { v = n }
+                """;
+        String examples = """
+                examples for t
+                example f
+                    | "wrong" : (1) -> Out { v = 2 }
+                """;
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(target, examples)));
+
+        assertEquals(-1, e.sourceIndex(),
+                "the example was written in the other file, so neither file's line is quoted");
+    }
+
+    @Test
+    void theCliPicksTheFileTheErrorCameFrom(@TempDir Path dir) throws IOException {
+        Path a = dir.resolve("a.sou");
+        Path b = dir.resolve("b.sou");
+        Files.writeString(a, A);
+        Files.writeString(b, B);
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Main.compileToDir(List.of(a, b), dir.resolve("out")));
+
+        assertEquals(b, Main.sourceOf(List.of(a, b), e));
+    }
+
+    @Test
+    void anUntaggedMultiFileErrorStillRendersWithoutASnippet(@TempDir Path dir) {
+        Path a = dir.resolve("a.sou");
+        Path b = dir.resolve("b.sou");
+        CompileException untagged = new CompileException(new SourcePos(1, 1), "boom");
+
+        assertNull(Main.sourceOf(List.of(a, b), untagged));
+    }
+
+    @Test
+    void theRenderedErrorQuotesTheRightFile(@TempDir Path dir) throws IOException {
+        Path a = dir.resolve("a.sou");
+        Path b = dir.resolve("b.sou");
+        Files.writeString(a, A);
+        Files.writeString(b, B);
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Main.compileToDir(List.of(a, b), dir.resolve("out")));
+        Path source = Main.sourceOf(List.of(a, b), e);
+        String rendered = new HumanRenderer(false).render(e.diagnostic(),
+                new SourceContext(source.getFileName().toString(), Files.readString(source)),
+                Locale.ENGLISH);
+
+        assertTrue(rendered.contains("b.sou:6:"), rendered);
+        assertTrue(rendered.contains("let f (who) = Out { v = who }"), rendered);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorDiagnosticTest.java
@@ -1,0 +1,132 @@
+package souther.compiler.apt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A compile error found by the annotation processor reaches the build log as the same rendered
+ * diagnostic the CLI prints — title, position, source line with a caret, message, and hint — not as
+ * the exception's internal detail string.
+ */
+class SoutherProcessorDiagnosticTest {
+
+    @Test
+    void aTypeErrorIsRenderedWithItsSourceLine(@TempDir Path dir) throws IOException {
+        Path source = write(dir, "member.sou", """
+                module demo
+                data Out = { v: Int }
+                behavior f : (s: String) -> Out
+                    constructs Out
+                let f (s) = Out { v = s }
+                """);
+
+        String reported = compile(dir, source, "en");
+
+        assertTrue(reported.contains("member.sou:5:"), reported);          // which file, where
+        assertTrue(reported.contains("let f (s) = Out { v = s }"), reported);  // the offending line
+        assertTrue(reported.contains("^"), reported);                      // the caret under it
+        assertTrue(reported.contains("Int"), reported);                    // the found/expected block
+    }
+
+    @Test
+    void theMessageIsRenderedInTheChosenLanguage(@TempDir Path dir) throws IOException {
+        Path source = write(dir, "member.sou", """
+                module demo
+                data Out = { v: Int }
+                behavior f : (s: String) -> Out
+                    constructs Out
+                let f (s) = Out { v = s }
+                """);
+
+        String ja = compile(dir, source, "ja");
+
+        assertTrue(ja.contains("フィールド"), ja);
+    }
+
+    @Test
+    void aMultiFileModuleSetNamesTheFileTheErrorIsIn(@TempDir Path dir) throws IOException {
+        Path sources = Files.createDirectories(dir.resolve("souther"));
+        write(sources, "a.sou", """
+                module a exposing ( 従業員ID )
+                data 従業員ID = String
+                """);
+        write(sources, "b.sou", """
+                module b
+                import a ( 従業員ID )
+                data Out = { v: Int }
+                behavior f : (who: 従業員ID) -> Out
+                    constructs Out
+                let f (who) = Out { v = who }
+                """);
+
+        String reported = compile(dir, sources, "en");
+
+        assertTrue(reported.contains("b.sou:6:"), reported);
+        assertTrue(reported.contains("let f (who) = Out { v = who }"), reported);
+    }
+
+    @Test
+    void aSyntaxErrorIsRenderedTheSameWay(@TempDir Path dir) throws IOException {
+        Path source = write(dir, "broken.sou", """
+                module demo
+                data Out = { v: Int
+                """);
+
+        String reported = compile(dir, source, "en");
+
+        assertTrue(reported.contains("broken.sou:"), reported);
+        assertTrue(reported.contains("^"), reported);
+    }
+
+    /** Runs javac over one throwaway Java file with the processor pointed at {@code source}, and
+     *  returns what the processor reported. The compilation must fail. */
+    private static String compile(Path dir, Path source, String lang) throws IOException {
+        Path java = write(dir, "Dummy.java", "public class Dummy {}\n");
+        Path classes = Files.createDirectories(dir.resolve("classes"));
+        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> collected = new DiagnosticCollector<>();
+        boolean ok;
+        try (StandardJavaFileManager files =
+                     javac.getStandardFileManager(collected, null, StandardCharsets.UTF_8)) {
+            List<String> options = new ArrayList<>(List.of(
+                    "-processor", SoutherProcessor.class.getName(),
+                    "-Asouther.source=" + source,
+                    "-Asouther.lang=" + lang,
+                    "-d", classes.toString(),
+                    "-classpath", System.getProperty("java.class.path")));
+            ok = javac.getTask(null, files, collected, options,
+                    null, files.getJavaFileObjects(java)).call();
+        }
+        StringBuilder reported = new StringBuilder();
+        for (Diagnostic<? extends JavaFileObject> d : collected.getDiagnostics()) {
+            if (d.getKind() == Diagnostic.Kind.ERROR) {
+                reported.append(d.getMessage(Locale.ENGLISH)).append('\n');
+            }
+        }
+        assertFalse(ok, "the compilation should have failed: " + reported);
+        return reported.toString();
+    }
+
+    private static Path write(Path dir, String name, String content) throws IOException {
+        Path file = dir.resolve(name);
+        Files.writeString(file, content);
+        return file;
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
@@ -12,7 +12,12 @@ package souther.compiler.diag;
  */
 public class CompileException extends RuntimeException {
 
+    /** A position is a line and a column, so a compile that was handed several sources also has to
+     *  say which one — otherwise there is nothing to quote the line from. */
+    private static final int NO_SOURCE = -1;
+
     private final transient Diagnostic diagnostic;
+    private final int sourceIndex;
 
     public CompileException(SourcePos pos, String message) {
         this(pos, null, message);
@@ -24,8 +29,13 @@ public class CompileException extends RuntimeException {
 
     /** Throws with a fully structured diagnostic (a migrated site). */
     public CompileException(Diagnostic diagnostic, String legacyMessage) {
+        this(diagnostic, legacyMessage, NO_SOURCE);
+    }
+
+    private CompileException(Diagnostic diagnostic, String legacyMessage, int sourceIndex) {
         super(legacyMessage);
         this.diagnostic = diagnostic;
+        this.sourceIndex = sourceIndex;
     }
 
     /**
@@ -49,6 +59,25 @@ public class CompileException extends RuntimeException {
     /** The structured diagnostic behind this error, for a renderer. */
     public Diagnostic diagnostic() {
         return diagnostic;
+    }
+
+    /** Which of the sources a multi-module compile was handed this error came from, or {@code -1}
+     *  when it carries no origin (a single-source compile, where the caller knows). */
+    public int sourceIndex() {
+        return sourceIndex;
+    }
+
+    /**
+     * The same error, tagged with the source being compiled when it was thrown. The first tag wins:
+     * an inner phase that already named its source keeps it, so a surrounding loop may tag freely.
+     */
+    public CompileException inSource(int index) {
+        if (sourceIndex != NO_SOURCE || index < 0) {
+            return this;
+        }
+        CompileException tagged = new CompileException(diagnostic, getMessage(), index);
+        tagged.setStackTrace(getStackTrace());
+        return tagged;
     }
 
     private static String format(SourcePos pos, String code, String message) {

--- a/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
@@ -61,8 +61,13 @@ public class CompileException extends RuntimeException {
         return diagnostic;
     }
 
-    /** Which of the sources a multi-module compile was handed this error came from, or {@code -1}
-     *  when it carries no origin (a single-source compile, where the caller knows). */
+    /**
+     * Which of the sources a multi-module compile was handed this error came from, or {@code -1} when
+     * it names none. Untagged covers a single-source compile — where the caller knows the file — and
+     * an error a linked compile cannot pin on one source, such as a failing example the compiler
+     * merged in from an {@code examples for} file. A caller reads {@code -1} as "quote no line",
+     * never as "the first source".
+     */
     public int sourceIndex() {
         return sourceIndex;
     }


### PR DESCRIPTION
Fixes #93 and #94 together: the first is only worth having if the second holds, since a rendered
diagnostic with no file to quote is still a bare `line:col`.

## What changed

**The annotation processor renders the diagnostic** (#93). It caught a `CompileException` and passed
`e.getMessage()` — the internal detail string — to the `Messager`, so a Maven or Gradle build got one
line and none of the structure the compiler had already produced. It now runs the same
`HumanRenderer` the CLI runs, with no color (this goes to a log), and takes `-Asouther.lang=<tag>`
for the language, defaulting the way `souther --lang` does.

**A multi-file compile names its file** (#94). The CLI passed `null` for the source whenever it was
handed more than one file, so every diagnostic in a multi-module project lost its file name and its
snippet — `examples/ordering` alone has four `.sou` files. A `CompileException` now carries the index
of the source the linker was compiling; the CLI and the processor turn that into the file they read.
The tag is set once per phase loop and the first one wins, so an inner phase that already named its
source keeps it.

A module that had an `examples for` file merged into it holds positions from two sources. Its body
errors keep the module's own file; a failing example there names no source, because quoting this
file's line at the other file's position would point at the wrong code.

## Before / after

`mvn clean compile` on a module with a type error:

```
[ERROR] souther: 30:24 field `v` expects INT but got STRING
```

```
[ERROR] -- 型の不一致 ----------------------------------contact.sou:30:24

  30| let bad (s) = Broken { v = s }
                             ^

  フィールド `v` は Int を必要としますが、String です。

  実際:
      String
  期待:
      Int
```

The same on `examples/ordering` (four `.sou` files) now says `tax.sou:125:25` and quotes line 125;
before this it was a bare `125:25` with a blank snippet line.

## Tests

- `SoutherProcessorDiagnosticTest` drives javac in-process with the processor attached and reads what
  the `Messager` received: a type error with its snippet, the language option, a multi-file set that
  names the right file, and a syntax error.
- `MultiFileDiagnosticOriginTest` covers the tagging itself — which source an error is attributed to,
  a single-module compile carrying no origin, the CLI's file pick, and both `examples for` rules.

Full reactor green (souther-compiler 902, souther-lsp 46), `examples` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
