### PR TITLE
Four diagnostics the deeper examples turned up

### DIFF
--- a/examples/ordering/src/main/souther/returns.sou
+++ b/examples/ordering/src/main/souther/returns.sou
@@ -197,13 +197,13 @@ let planRefund (accepted, reconciliation, unitPrices, invoiceNo, invoicedGross, 
     let gross = Decimal.fromInt(agreedValue(reconciliation, unitPrices))
     let fee = Decimal.multiply(gross, restockingRate)
     let net = Decimal.max(0.0m, Decimal.subtract(gross, fee))
-    // `withinInvoiced` reads billing's Amount and compares against it. Reading across a module is
-    // what importing is for; building across one is what ADR-0015 closes.
     RefundPlan {
         rma = accepted.rma,
         invoiceNo = invoiceNo,
         refund = Refund(net),
         restockingFee = Refund(Decimal.min(fee, gross)),
+        // reads billing's Amount and compares against it. Reading across a module is what
+        // importing is for; building across one is what ADR-0015 closes.
         withinInvoiced = Decimal.compare(net, invoicedGross.value) <= 0,
         repeatReturn = Set.fold((acc, sku) -> acc || member(sku, previousSkus), false, accepted.skus),
         recentRmas = take(3, reverse(history))

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -322,6 +322,8 @@ public final class Compiler {
         }
         // every module's classes are now present, so CTFE and example evaluation can resolve
         // cross-module references
+        List<Diagnostic> exampleFailures = new ArrayList<>();
+        List<Integer> exampleSources = new ArrayList<>();
         for (Ast.Module original : parsed) {
             Ast.Module m = derived.get(original.name());
             Map<String, Ast.Def> symbols = visible.get(original.name());
@@ -334,12 +336,19 @@ public final class Compiler {
             } catch (CompileException e) {
                 throw e.inSource(index);
             }
-            try {
-                ExampleVerifier.verify(m, symbols, sigs, importedPackages(m), out);
-            } catch (CompileException e) {
+            // Every module's examples are evaluated before any failure is thrown, so a change to a
+            // widely-imported data says how far it reaches in one compile rather than one module per
+            // round (issue #114). A module whose own compile failed never gets here, so what is
+            // collected is only ever a stale or wrong example, never a knock-on of a broken type.
+            for (Diagnostic d : ExampleVerifier.check(m, symbols, sigs, importedPackages(m), out)) {
+                exampleFailures.add(d);
                 // a merged `examples for` file's rows are positioned in that file, not this one
-                throw e.inSource(mergedExamples.contains(original.name()) ? -1 : index);
+                exampleSources.add(mergedExamples.contains(original.name()) ? -1 : index);
             }
+        }
+        if (!exampleFailures.isEmpty()) {
+            throw CompileException.ofAllInSources(exampleFailures, exampleSources,
+                    ExampleVerifier.legacySummary(exampleFailures));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -86,6 +86,15 @@ public final class ExampleVerifier {
                 failures.size() + " examples do not hold; " + legacyOf(first));
     }
 
+    /** The one-line form for a set of failures gathered across modules: the count, then the first
+     * one's reason, matching what a single module's aggregate says. */
+    public static String legacySummary(List<Diagnostic> failures) {
+        Diagnostic first = failures.get(0);
+        return failures.size() == 1
+                ? legacyOf(first)
+                : failures.size() + " examples do not hold; " + legacyOf(first);
+    }
+
     /** A one-line message for a failing example, used where only the legacy string is shown (the LSP
      * surfaces this rather than the rendered catalog message). */
     private static String legacyOf(Diagnostic d) {

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -846,9 +846,7 @@ public final class ExampleVerifier {
         Map<String, Ast.TypeRef> declared = fieldTypes(nd.typeName());
         Map<String, Object> map = new LinkedHashMap<>();
         for (Ast.FieldInit fi : nd.inits()) {
-            Ast.TypeRef declaredType = declared.get(fi.name());
-            Object v = shaped(raw(fi.value()),
-                    declaredType == null ? null : TypeOps.resolveType(declaredType, symbols));
+            Object v = shaped(raw(fi.value()), shapeOf(declared.get(fi.name())));
             // `None` on a `T?` field yields a null; leave the key out so the optional decoder reads
             // it as absent (spec 8, absent -> None), the same neutral form as omitting the field.
             if (v == null) {
@@ -858,6 +856,29 @@ public final class ExampleVerifier {
         }
         tagged(nd.typeName(), map);
         return map;
+    }
+
+    /**
+     * The declared type of a field, used only to shape the written value (a map's entry pairs, a
+     * set's list). It is best-effort on purpose: the {@code TypeRef} comes from the module that
+     * declares the data, which may name a type this module never imported — building a
+     * {@code TaxBreakdown} fixture does not require its {@code rate}'s type to be in scope here. That
+     * resolution failing is not the author's problem and, worse, carries the *declaring* file's
+     * position, which rendered against this file pointed at an unrelated line (issue #110).
+     *
+     * <p>An unshaped value still reaches the decoder, which accepts it or reports at the fixture's own
+     * row. A type this module genuinely may not name is caught where it is written, by
+     * {@code newtypeInner}.
+     */
+    private Type shapeOf(Ast.TypeRef declaredType) {
+        if (declaredType == null) {
+            return null;
+        }
+        try {
+            return TypeOps.resolveType(declaredType, symbols);
+        } catch (CompileException e) {
+            return null;
+        }
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -90,7 +90,7 @@ public final class Main {
                 System.out.println("wrote " + file);
             }
         } catch (CompileException e) {
-            reportCompileError(e, sourceOf(sources, e), render);
+            reportCompileError(e, sources, render);
             System.exit(1);
         } catch (IOException e) {
             System.err.println("io error: " + e.getMessage());
@@ -189,7 +189,7 @@ public final class Main {
             System.err.println(e.localized(Messages.resolveLocale(render.lang)));
             System.exit(e.exitCode);
         } catch (CompileException e) {
-            reportCompileError(e, firstSource(args), render);
+            reportCompileError(e, firstSource(args) == null ? List.of() : List.of(firstSource(args)), render);
             System.exit(1);
         }
     }
@@ -201,34 +201,47 @@ public final class Main {
      * from the wrong file.
      */
     static Path sourceOf(List<Path> sources, CompileException e) {
+        return sourceOf(sources, e, 0);
+    }
+
+    /** The file the {@code i}-th diagnostic should quote. */
+    static Path sourceOf(List<Path> sources, CompileException e, int i) {
         if (sources.size() == 1) {
             return sources.get(0);
         }
-        int index = e.sourceIndex();
+        int index = e.sourceIndexOf(i);
         return index >= 0 && index < sources.size() ? sources.get(index) : null;
+    }
+
+    /** A file as a snippet source, or null when it cannot be read — a snippet-less rendering is the
+     *  honest fallback. */
+    private static SourceContext read(Path source) {
+        if (source == null) {
+            return null;
+        }
+        try {
+            return new SourceContext(source.getFileName().toString(), Files.readString(source));
+        } catch (IOException ignore) {
+            return null;
+        }
     }
 
     /** Renders a compile error: an Elm-style snippet (or JSON) in the chosen locale, or the legacy
      * one-line form when the error is not yet structured. An error that carries several diagnostics
      * — every failing {@code example} row — prints each, so none of the reasons is lost. */
-    private static void reportCompileError(CompileException e, Path source, RenderOptions render) {
+    private static void reportCompileError(CompileException e, List<Path> sources, RenderOptions render) {
         if (e.diagnostic() == null) {
             System.err.println(e.getMessage());
             return;
         }
-        SourceContext src = null;
-        if (source != null) {
-            try {
-                src = new SourceContext(source.getFileName().toString(), Files.readString(source));
-            } catch (IOException ignore) {
-                // Fall back to a snippet-less rendering.
-            }
-        }
         Locale locale = Messages.resolveLocale(render.lang);
         DiagnosticRenderer renderer = render.json()
                 ? new JsonRenderer() : new HumanRenderer(render.useColor());
-        for (Diagnostic d : e.diagnostics()) {
-            System.err.println(renderer.render(d, src, locale));
+        List<Diagnostic> ds = e.diagnostics();
+        for (int i = 0; i < ds.size(); i++) {
+            // Each diagnostic quotes its own file: a compile that reports several modules at once has
+            // one per module, and they do not share a source.
+            System.err.println(renderer.render(ds.get(i), read(sourceOf(sources, e, i)), locale));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
+++ b/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
@@ -104,24 +104,27 @@ public final class SoutherProcessor extends AbstractProcessor {
         if (e.diagnostic() == null) {
             return List.of("souther: " + e.getMessage());   // not yet structured
         }
-        Source origin = originOf(e, sources);
-        SourceContext src = origin == null ? null
-                : new SourceContext(origin.path().getFileName().toString(), origin.text());
         Locale locale = Messages.resolveLocale(processingEnv.getOptions().get("souther.lang"));
         HumanRenderer renderer = new HumanRenderer(false);
         List<String> reported = new ArrayList<>();
-        for (souther.compiler.diag.Diagnostic d : e.diagnostics()) {
-            reported.add(renderer.render(d, src, locale));
+        List<souther.compiler.diag.Diagnostic> ds = e.diagnostics();
+        for (int i = 0; i < ds.size(); i++) {
+            // Each diagnostic quotes its own file; a compile reporting several modules at once has
+            // one per module.
+            Source origin = originOf(e, sources, i);
+            SourceContext src = origin == null ? null
+                    : new SourceContext(origin.path().getFileName().toString(), origin.text());
+            reported.add(renderer.render(ds.get(i), src, locale));
         }
         return reported;
     }
 
     /** The source the error came from, or null when it names none (so no line is quoted). */
-    private static Source originOf(CompileException e, List<Source> sources) {
+    private static Source originOf(CompileException e, List<Source> sources, int i) {
         if (sources.size() == 1) {
             return sources.get(0);
         }
-        int index = e.sourceIndex();
+        int index = e.sourceIndexOf(i);
         return index >= 0 && index < sources.size() ? sources.get(index) : null;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -259,7 +259,7 @@ public final class Elaborator {
         Core targetCore = elaborate(fa.target(), env, ctx);
         Type target = targetCore.type();
         if (target instanceof Type.Ref ref && ctx.symbols().get(ref.name()) instanceof Ast.Data owner) {
-            Type ft = TypeOps.fieldTypes(owner, ctx.symbols()).get(fa.field());
+            Type ft = TypeOps.fieldType(owner, fa.field(), ctx.symbols());
             if (ft != null) {
                 return new Core.FieldAccess(targetCore, fa.field(), ft, fa.pos());
             }
@@ -272,7 +272,7 @@ public final class Elaborator {
             List<String> without = new ArrayList<>();
             for (String c : cases) {
                 if (!(ctx.symbols().get(c) instanceof Ast.Data cd)
-                        || !TypeOps.fieldTypes(cd, ctx.symbols()).containsKey(fa.field())) {
+                        || !TypeOps.hasField(cd, fa.field(), ctx.symbols())) {
                     without.add(c);
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -361,6 +361,30 @@ public final class SpecChecker {
         }
     }
 
+    /**
+     * A behavior may only construct types its own module declares. Construction is closed to the
+     * declaring module (ADR-0015): the generated {@code __construct} is package-private, so a
+     * {@code constructs} naming an imported type compiles and then fails with an
+     * {@code IllegalAccessError} when the behavior runs (issue #113). Which module declares a name is
+     * known from the import list, so the clause is answered where it is written.
+     */
+    static void rejectImportedConstructs(Ast.SpecBehavior spec, Ast.Module module) {
+        for (String constructed : spec.constructs()) {
+            for (Ast.Import imp : module.imports()) {
+                if (!imp.names().contains(constructed)) {
+                    continue;
+                }
+                throw CompileException.of(
+                        Diagnostic.of(null, "check.constructs.imported").title("check.boundary.title")
+                                .at(spec.pos()).args(spec.name(), constructed, imp.module())
+                                .hint("check.constructs.imported.hint").build(),
+                        "`behavior " + spec.name() + "` declares `constructs " + constructed
+                                + "`, but `" + constructed + "` is declared by `" + imp.module()
+                                + "`; construction is closed to the declaring module (ADR-0015)");
+            }
+        }
+    }
+
     private static boolean refHasTuple(Ast.TypeRef ref) {
         return ref.isTuple() || (ref.arg() != null && refHasTuple(ref.arg()));
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -215,6 +215,7 @@ public final class TypeChecker {
                 SpecChecker.rejectAnonymousUnionParams(spec);
                 SpecChecker.rejectTupleIO(spec);
                 SpecChecker.rejectNonBoundaryMapKeyIO(spec, symbols);
+                SpecChecker.rejectImportedConstructs(spec, module);
                 List<String> outputCases = new ArrayList<>();
                 for (Ast.TypeRef t : spec.ret().cases()) {
                     outputCases.add(t.name());

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -337,6 +337,45 @@ public final class TypeOps {
         return types;
     }
 
+    /**
+     * The resolved type of one field, or null when the data has no such field. Reading a field is not
+     * a reason to resolve the data's other fields: a module that imports a data to read one `Int` out
+     * of it would otherwise need every sibling field's type in scope, and the failure would carry the
+     * declaring module's position (issue #110). The duplicate-field checks {@link #fieldTypes} makes
+     * belong to the declaring module's own check, which has already run.
+     */
+    public static Type fieldType(Ast.Data data, String field, Map<String, Ast.Def> symbols) {
+        for (Ast.Field f : data.fields()) {
+            if (f.name().equals(field)) {
+                return resolveType(f.type(), symbols);
+            }
+        }
+        for (String inc : data.includes()) {
+            if (symbols.get(inc) instanceof Ast.Data included) {
+                Type t = fieldType(included, field, symbols);
+                if (t != null) {
+                    return t;
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Whether a data has a field of that name, without resolving any type. */
+    public static boolean hasField(Ast.Data data, String field, Map<String, Ast.Def> symbols) {
+        for (Ast.Field f : data.fields()) {
+            if (f.name().equals(field)) {
+                return true;
+            }
+        }
+        for (String inc : data.includes()) {
+            if (symbols.get(inc) instanceof Ast.Data included && hasField(included, field, symbols)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /** All invariants that apply to a data: included data's invariants first, then its own. */
     public static List<Ast.Expr> effectiveInvariants(Ast.Data data, Map<String, Ast.Def> symbols) {
         List<Ast.Expr> invs = new ArrayList<>();

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -216,6 +216,8 @@ check.typearg.list=`List` needs a type argument, e.g. `List<Int>`.
 check.typearg.set=`Set` needs a type argument, e.g. `Set<String>`.
 check.typearg.option=`Option` needs a type argument.
 check.typearg.map=`Map` needs a value type, e.g. `Map<String, Int>`.
+check.constructs.imported=`{0}` declares `constructs {1}`, but `{1}` is declared by `{2}`.
+check.constructs.imported.hint=Construction is closed to the module that declares a type. Read the imported type and declare your own for what this behavior produces, or have `{2}` expose a behavior that builds it.
 check.map.key.field=`{0}` crosses the boundary, so the Map it holds must be keyed by String, a String-backed newtype (`data X = String`), Date or DateTime, but is keyed by {1}.
 check.map.key.field.hint=A Map is a JSON object, whose keys are strings. Inside a behavior body a Map may be keyed by any value.
 check.map.key.param=Parameter `{0}` carries a Map keyed by {1}, which cannot cross the boundary.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -138,7 +138,7 @@ kind.ordered.list=a list of ordered values (Int, String, Decimal, Date, DateTime
 check.expects=`{0}` expects {1}, but got {2}.
 check.ordered=`{0}` needs {1}, but the element is {2}.
 check.ordered.hint=Map to an ordered field first, then sort or compare that.
-check.ordered.key=`{0}`'s key must be an ordered value, but it returns {1}.
+check.ordered.key=`{0}`''s key must be an ordered value, but it returns {1}.
 
 # duplicates
 check.duplicate.title=DUPLICATE DEFINITION
@@ -199,16 +199,16 @@ check.invariant.construct=The invariant of `{0}` constructs `{1}`, but an invari
 
 # module / exposing
 check.module.title=MODULE ERROR
-check.exposing.granular=`exposing` is type-granular: a data's `decoder`/`encoder` are always public once the data is exposed. Write `{0}`, not `{1}`.
-check.exposing.imported=`exposing` names `{0}`, which is imported into this module, not defined here; `exposing` lists a module's own definitions and does not re-export imported names.
+check.exposing.granular=`exposing` is type-granular: a data''s `decoder`/`encoder` are always public once the data is exposed. Write `{0}`, not `{1}`.
+check.exposing.imported=`exposing` names `{0}`, which is imported into this module, not defined here; `exposing` lists a module''s own definitions and does not re-export imported names.
 check.exposing.notdefined=`exposing` names `{0}`, which is not a data or behavior of this module.
 check.inject.requires=behavior `{0}` has no `let`, so it is an injection target; it cannot declare `requires` — the behavior that calls or composes it does.
 
 # a type that must not cross the decoder/encoder boundary
 check.boundary.title=BOUNDARY TYPE
 check.param.union=parameter `{0}` has an anonymous union type `{1}`; a parameter type must be a single named type — declare `data ... = {1}` and take that name.
-check.param.tuple=parameter `{0}` is a tuple; a tuple has no external representation and cannot cross the boundary, so a behavior's input must be a named data.
-check.output.tuple=behavior `{0}` outputs a tuple; a tuple cannot cross the boundary, so a behavior's output must be a named data or a sum of them.
+check.param.tuple=parameter `{0}` is a tuple; a tuple has no external representation and cannot cross the boundary, so a behavior''s input must be a named data.
+check.output.tuple=behavior `{0}` outputs a tuple; a tuple cannot cross the boundary, so a behavior''s output must be a named data or a sum of them.
 
 # missing type argument on a collection type
 check.typearg.title=MISSING TYPE ARGUMENT
@@ -232,7 +232,7 @@ check.sum.title=SUM DEFINITION
 check.codec.title=CODEC
 check.sum.unknowncase=Unknown case `{0}` in sum `{1}`.
 check.expr.toodeep=An expression in this source nests too deeply for the compiler to walk. Name its parts with `let` to flatten it.
-check.sum.cycle=Sum `{0}` contains itself through {1}. A sum's cases are the values it can be, so one of them cannot be the sum itself.
+check.sum.cycle=Sum `{0}` contains itself through {1}. A sum''s cases are the values it can be, so one of them cannot be the sum itself.
 check.sum.optioncase=`{0}` is a built-in Option case and cannot be declared as a data type.
 check.codec.notcase=`{0}` is not a case of `{1}`.
 check.codec.needdecoder=Case `{0}` needs a decoder.
@@ -274,14 +274,14 @@ check.fn.argnotvalue=Argument {1} of `{0}` is `{2}`, which takes a function: pas
 check.fn.argnotvalue.hint=Write `{0}({3})`.
 check.fn.argnotfn=Argument {1} of `{0}` is `{2}`, which does not take a function: a lambda or a field getter cannot be written here.
 check.fn.callarity=`{0}` calls its function with {1} argument(s), but the function takes {2}.
-check.fn.argtype=`{0}`'s element type {1} is not acceptable to the function, which takes {2}.
+check.fn.argtype=`{0}`''s element type {1} is not acceptable to the function, which takes {2}.
 check.fn.expectsblock=`{0}` expects a block, e.g. `{0}((acc, x) -> ..., seed, xs)`.
 check.fn.blockarity=This block takes {0} parameter(s), but got {1}.
 check.fn.noinfer=Cannot infer the type of the function `{0}`: apply it (as `{0}(x)`) at least once so its parameter types are known. A function passed on rather than applied — e.g. to a combinator — must be written inline (`map(xs, x -> ...)`).
 check.fn.difftypes=The function `{0}` is applied with different argument types: {1} vs {2}.
 check.fn.lambdaarity=This lambda takes {0} parameter(s), but is applied with {1}.
 check.fn.branchtypes=The two branches produce different function types: {0} vs {1}.
-check.fn.predicatebool=`{0}`'s predicate must return Bool, but returns {1}.
+check.fn.predicatebool=`{0}`''s predicate must return Bool, but returns {1}.
 
 # remaining
 check.impl.compose=`let {0}` cannot implement the composition `behavior {0}`, which is already its own implementation.
@@ -291,8 +291,8 @@ check.field.tuple=A tuple cannot be a data field (`{0}.{1}`): a tuple has no ext
 check.spread.provides=The spread provides `{0}` as {1}, but `{2}` needs {3}.
 check.codec.elemenc=The element encoder {0} does not match the element type {1}.
 check.match.branchtypes=The match branches disagree: {0} vs {1}.
-check.fold.shape=A fold seeded with an empty collection must grow a value of that collection's shape, but its block returns {0}.
-check.fold.acctype=A fold's block must return the accumulator type {0}, but got {1}.
+check.fold.shape=A fold seeded with an empty collection must grow a value of that collection''s shape, but its block returns {0}.
+check.fold.acctype=A fold''s block must return the accumulator type {0}, but got {1}.
 check.stdlib.notfunction=`{0}` is not a standard-library function.
 check.generic.arg={0}: expected {1}, but got {2}.
 
@@ -319,7 +319,7 @@ check.helper.arity=Helper `let {0}` takes {1} argument(s), but is called with {2
 check.fn.recursivelambda=The lambda bound to `{0}` refers to itself; a recursive lambda would not bottom out when expanded inline.
 check.fn.annotation=The binding `{0}` is a function, and a function type may be written only in a helper parameter.
 check.fn.annotation.hint=Remove the annotation.
-check.behavior.collision.data=behavior `{0}`'s first letter is capitalized to form the JVM class `{1}` (spec 19.5), which collides with data `{1}`; rename one so their class names differ.
+check.behavior.collision.data=behavior `{0}`''s first letter is capitalized to form the JVM class `{1}` (spec 19.5), which collides with data `{1}`; rename one so their class names differ.
 check.behavior.collision.behavior=behaviors `{0}` and `{1}` both capitalize to the same JVM class `{2}` (spec 19.5); rename one so their class names differ.
 check.derive.tuplefield=Field `{1}` of `{0}` is {2}: a tuple has no external representation, so no codec can be derived. Use a named data.
 check.derive.nocodec=No codec can be derived for field `{1}` of `{0}`: {2} has no external representation.
@@ -379,7 +379,7 @@ check.totality.toocomplex=Recursion {0} is too complex to prove total by size-ch
 # --- invariant discharge (E2010 error, E2011 warning) ---
 check.invariant.title=INVARIANT
 check.invariant.violation=Constructing `{0}` here violates its invariant on a reachable path: the guards force a value the invariant rejects. Fix the value, or guard the path so the violating case cannot reach here.
-check.invariant.unproven=Constructing `{0}` here may violate its invariant: the guards do not establish it. Guard it with `require`, or reify the relation into `{0}`'s (or an input's) invariant so it is assumed here.
+check.invariant.unproven=Constructing `{0}` here may violate its invariant: the guards do not establish it. Guard it with `require`, or reify the relation into `{0}`''s (or an input''s) invariant so it is assumed here.
 check.invariant.reify=If a relation between inputs guarantees this, declare it as an `invariant` on the input data so it is checked once at its boundary and assumed here.
 
 # --- fake (E1908-E1909, test doubles for injected dependencies) ---

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -215,6 +215,8 @@ check.typearg.list=`List` には型引数が必要です（例: `List<Int>`）�
 check.typearg.set=`Set` には型引数が必要です（例: `Set<String>`）。
 check.typearg.option=`Option` には型引数が必要です。
 check.typearg.map=`Map` には値の型が必要です（例: `Map<String, Int>`）。
+check.constructs.imported=`{0}` が `constructs {1}` を宣言していますが、`{1}` を宣言しているのは `{2}` です。
+check.constructs.imported.hint=型の構築はそれを宣言したモジュールに閉じています。import した型は読むだけにして、この behavior が生み出すものは自分のモジュールで宣言してください。あるいは `{2}` 側に、それを構築する behavior を用意してください。
 check.map.key.field=`{0}` は境界を越えるので、持っている Map のキーは String・String ベースの newtype（`data X = String`）・Date・DateTime のいずれかでなければなりませんが、{1} です。
 check.map.key.field.hint=Map の外部表現は JSON オブジェクトで、そのキーは文字列です。behavior の本体内であれば Map のキーは任意の値でかまいません。
 check.map.key.param=引数 `{0}` が持つ Map のキーが {1} で、境界を越えられません。

--- a/souther-compiler/src/test/java/souther/compiler/CompileConstructsImportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileConstructsImportedTest.java
@@ -1,0 +1,89 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A behavior may not declare {@code constructs} for a type another module declares. Construction is
+ * closed to the declaring module (ADR-0015), so the generated {@code __construct} is package-private
+ * and the call fails with an {@code IllegalAccessError} at run time. The declaration is decidable
+ * where it is written — the type's declaring module against the behavior's own — so it is rejected
+ * there (issue #113).
+ */
+class CompileConstructsImportedTest {
+
+    private static final String UP = """
+            module up exposing ( Amount )
+            data Amount = Int
+            """;
+
+    @Test
+    void constructingAnImportedTypeIsRejected() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(UP, """
+                        module down
+                        import up ( Amount )
+
+                        data Plan = { total: Amount }
+
+                        behavior makePlan : (n: Int) -> Plan
+                            constructs Plan, Amount
+                        let makePlan (n) = Plan { total = Amount(n) }
+                        """)));
+
+        assertTrue(e.getMessage().contains("Amount"), e.getMessage());
+        assertTrue(e.getMessage().contains("up"), "it names the module that declares it: " + e.getMessage());
+    }
+
+    @Test
+    void constructingTheModulesOwnTypesIsFine() {
+        Compiler.compileModules(List.of(UP, """
+                module down
+                import up ( Amount )
+
+                data Plan = { total: Amount, note: Note }
+                data Note = String
+
+                behavior makePlan : (n: Int, a: Amount) -> Plan
+                    constructs Plan, Note
+                let makePlan (n, a) = Plan { total = a, note = Note("x") }
+                """));
+    }
+
+    @Test
+    void anImportedTypeMayStillBeReadAndPassedThrough() {
+        // reading across a module is what importing is for; only building across one is closed
+        Compiler.compileModules(List.of(UP, """
+                module down
+                import up ( Amount )
+
+                data Out = { doubled: Int }
+
+                behavior twice : (a: Amount) -> Out
+                    constructs Out
+                let twice (a) = Out { doubled = a.value * 2 }
+                """));
+    }
+
+    @Test
+    void anInjectedBehaviorCannotConstructAnImportedTypeEither() {
+        // the injected case has its own rule about exposure (E1305); this one is about ownership
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(UP, """
+                        module down
+                        import up ( Amount )
+
+                        data Plan = { total: Amount }
+
+                        behavior readPlan : (n: Int) -> Plan
+                            constructs Plan, Amount
+                        """)));
+
+        assertTrue(e.getMessage().contains("Amount"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileImportedFieldReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImportedFieldReadTest.java
@@ -1,0 +1,117 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Reading one field of an imported data needs that field's type in scope, not every field's. Typing
+ * a field access resolved the owner's whole field map, so a module reading `breakdown.net` — an
+ * `Int` — was made to import the type of a field it never touches, and the error carried the
+ * *declaring* file's position, which rendered against the reading file pointed at an unrelated line
+ * (issue #110).
+ */
+class CompileImportedFieldReadTest {
+
+    private static final String UP = """
+            module up exposing ( Rate, Box )
+            data Rate = Decimal
+            data Box =
+                { n: Int
+                , rate: Rate
+                }
+            """;
+
+    @Test
+    void readingAFieldDoesNotRequireASiblingFieldsTypeInScope() {
+        Compiler.compileModules(List.of(UP, """
+                module down
+                import up ( Box )
+
+                data Out = { doubled: Int }
+
+                behavior twice : (b: Box) -> Out constructs Out
+                let twice (b) = Out { doubled = b.n * 2 }
+                """));
+    }
+
+    @Test
+    void readingTheFieldWhoseTypeIsMissingStillReportsIt() {
+        // the sibling is fine to leave out; the field actually read is not
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(UP, """
+                        module down
+                        import up ( Box )
+
+                        data Out = { r: Rate }
+
+                        behavior pick : (b: Box) -> Out constructs Out
+                        let pick (b) = Out { r = b.rate }
+                        """)));
+
+        assertTrue(e.getMessage().contains("Rate"), e.getMessage());
+    }
+
+    @Test
+    void aFieldTheDataDoesNotHaveIsStillRejected() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(UP, """
+                        module down
+                        import up ( Box )
+
+                        data Out = { n: Int }
+
+                        behavior pick : (b: Box) -> Out constructs Out
+                        let pick (b) = Out { n = b.missing }
+                        """)));
+
+        assertTrue(e.getMessage().contains("missing"), e.getMessage());
+    }
+
+    private static final String SPREAD_UP = """
+            module up exposing ( Rate, Common, Box )
+            data Rate = Decimal
+            data Common = { n: Int }
+            data Box =
+                { ...Common
+                , rate: Rate
+                }
+            """;
+
+    @Test
+    void aFieldReachedThroughASpreadIsFoundWhenTheIncludedDataIsInScope() {
+        Compiler.compileModules(List.of(SPREAD_UP, """
+                module down
+                import up ( Common, Box )
+
+                data Out = { doubled: Int }
+
+                behavior twice : (b: Box) -> Out constructs Out
+                let twice (b) = Out { doubled = b.n * 2 }
+                """));
+    }
+
+    /** The remaining half of the same over-reach, recorded rather than fixed: a field spread in from
+     *  another data still needs that data in scope, because the reader walks the includes through its
+     *  own symbol table and cannot see a name it did not import. Answering it needs the declaring
+     *  module's symbols, which the field-access check does not have. */
+    @Test
+    void aSpreadInFieldStillNeedsTheIncludedDataImported() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(SPREAD_UP, """
+                        module down
+                        import up ( Box )
+
+                        data Out = { doubled: Int }
+
+                        behavior twice : (b: Box) -> Out constructs Out
+                        let twice (b) = Out { doubled = b.n * 2 }
+                        """)));
+
+        assertTrue(e.getMessage().contains("n"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileMultiModuleExampleFailuresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileMultiModuleExampleFailuresTest.java
@@ -1,0 +1,120 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A change to a widely-imported data breaks examples in every module that writes a fixture of it, and
+ * all of them are reported in one compile. Each module used to throw as it was reached, so learning
+ * how far a one-field change reached took as many edit-and-recompile rounds as there were modules
+ * (issue #114) — the question an author has after touching a shared type is exactly the one those
+ * rounds withheld.
+ *
+ * <p>Each diagnostic carries the source it came from, so a renderer quotes each module's own file
+ * rather than the first one's.
+ */
+class CompileMultiModuleExampleFailuresTest {
+
+    /** `Line` gains a field none of the three downstream fixtures writes. */
+    private static final String SHARED = """
+            module shared exposing ( Line, total )
+            data Line = { sku: String, qty: Int, weight: Int }
+            data Bag = { lines: List<Line> }
+            data Sum = { n: Int }
+            behavior total : (b: Bag) -> Sum constructs Sum
+            let total (b) = Sum { n = List.length(b.lines) }
+            example total
+              | "counts" : (Bag { lines = [ Line { sku = "a", qty = 1 } ] }) -> Sum { n = 1 }
+            """;
+    private static final String ONE = """
+            module one
+            import shared ( Line )
+            data OneOut = { n: Int }
+            behavior one : (l: Line) -> OneOut constructs OneOut
+            let one (l) = OneOut { n = l.qty }
+            example one
+              | "reads the qty" : (Line { sku = "a", qty = 2 }) -> OneOut { n = 2 }
+            """;
+    private static final String TWO = """
+            module two
+            import shared ( Line )
+            data TwoOut = { s: String }
+            behavior two : (l: Line) -> TwoOut constructs TwoOut
+            let two (l) = TwoOut { s = l.sku }
+            example two
+              | "reads the sku" : (Line { sku = "b", qty = 1 }) -> TwoOut { s = "b" }
+            """;
+
+    @Test
+    void everyModuleWithAStaleFixtureIsReportedInOneCompile() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(SHARED, ONE, TWO)));
+
+        assertEquals(3, e.diagnostics().size(),
+                "one row per module, not the first module's alone: " + e.diagnostics().size());
+        for (Diagnostic d : e.diagnostics()) {
+            assertEquals("E1903", d.code());
+        }
+    }
+
+    @Test
+    void eachDiagnosticNamesTheSourceItCameFrom() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(SHARED, ONE, TWO)));
+
+        Set<Integer> named = java.util.stream.IntStream.range(0, e.diagnostics().size())
+                .mapToObj(e::sourceIndexOf)
+                .collect(Collectors.toSet());
+
+        assertEquals(Set.of(0, 1, 2), named,
+                "three modules, three sources — a renderer quotes each one's own file");
+    }
+
+    @Test
+    void aSingleModuleFailureStillNamesItsOwnSource() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(SHARED, """
+                        module clean
+                        import shared ( Line )
+                        data CleanOut = { n: Int }
+                        behavior clean : (l: Line) -> CleanOut constructs CleanOut
+                        let clean (l) = CleanOut { n = l.qty }
+                        """)));
+
+        assertEquals(1, e.diagnostics().size());
+        assertEquals(0, e.sourceIndex(), "the stale fixture is in the first source");
+    }
+
+    @Test
+    void everyModulesExamplesHoldingIsStillASuccessfulCompile() {
+        Compiler.compileModules(List.of("""
+                module shared exposing ( Line )
+                data Line = { sku: String, qty: Int }
+                """, """
+                module one
+                import shared ( Line )
+                data OneOut = { n: Int }
+                behavior one : (l: Line) -> OneOut constructs OneOut
+                let one (l) = OneOut { n = l.qty }
+                example one
+                  | "reads the qty" : (Line { sku = "a", qty = 2 }) -> OneOut { n = 2 }
+                """));
+    }
+
+    @Test
+    void theOneLineMessageCountsThemAll() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(SHARED, ONE, TWO)));
+
+        assertTrue(e.getMessage().contains("3 examples do not hold"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/diag/MessageCatalogFormatTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/MessageCatalogFormatTest.java
@@ -1,0 +1,79 @@
+package souther.compiler.diag;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Every message in the catalog is a {@link java.text.MessageFormat} pattern, where a lone {@code '}
+ * opens a quoted run and {@code ''} is the apostrophe itself. A message that writes {@code a data's}
+ * therefore quotes the whole rest of itself: the apostrophe disappears and every {@code {n}} after it
+ * renders literally, as the placeholder rather than the value.
+ *
+ * <p>Nothing caught that, because a message is only read when its diagnostic fires and the result is
+ * prose nobody diffs. This renders each one with stand-in arguments and fails on any placeholder that
+ * survived.
+ */
+class MessageCatalogFormatTest {
+
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\{(\\d)}");
+
+    @Test
+    void everyEnglishMessageSubstitutesAllOfItsArguments() throws IOException {
+        assertEquals(List.of(), unsubstituted("/souther/compiler/diag/messages.properties", Locale.ENGLISH));
+    }
+
+    @Test
+    void everyJapaneseMessageSubstitutesAllOfItsArguments() throws IOException {
+        assertEquals(List.of(),
+                unsubstituted("/souther/compiler/diag/messages_ja.properties", Locale.JAPANESE));
+    }
+
+    /** The keys whose rendering still contains a {@code {n}} — one per line, so a failure names them
+     *  all rather than the first. */
+    private static List<String> unsubstituted(String resource, Locale locale) throws IOException {
+        Properties catalog = new Properties();
+        try (InputStream in = MessageCatalogFormatTest.class.getResourceAsStream(resource)) {
+            catalog.load(new InputStreamReader(in, StandardCharsets.UTF_8));
+        }
+        List<String> broken = new ArrayList<>();
+        for (String key : catalog.stringPropertyNames()) {
+            String template = catalog.getProperty(key);
+            int arity = arityOf(template);
+            if (arity == 0) {
+                continue;
+            }
+            Object[] args = new Object[arity];
+            for (int i = 0; i < arity; i++) {
+                args[i] = "<arg" + i + ">";
+            }
+            String rendered = Messages.get(key, locale, args);
+            if (PLACEHOLDER.matcher(rendered).find()) {
+                broken.add(key + " -> " + rendered);
+            }
+        }
+        broken.sort(String::compareTo);
+        return broken;
+    }
+
+    /** One past the highest argument index the pattern names. */
+    private static int arityOf(String template) {
+        Matcher m = PLACEHOLDER.matcher(template);
+        int highest = -1;
+        while (m.find()) {
+            highest = Math.max(highest, Integer.parseInt(m.group(1)));
+        }
+        return highest + 1;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/BlockCommentFormatTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/BlockCommentFormatTest.java
@@ -38,6 +38,73 @@ class BlockCommentFormatTest {
                 formatted);
     }
 
+    private static final String IN_A_LITERAL = """
+            module demo
+
+            data In = { n: Int }
+            data Out = { a: Int, b: Int }
+
+            behavior run : (i: In) -> Out constructs Out
+
+            let run (i) = Out {
+                a = i.n,
+                // why b is not simply a again
+                b = i.n * 2
+            }
+            """;
+
+    @Test
+    void aCommentInsideARecordLiteralIsKept() {
+        String formatted = Formatter.format(IN_A_LITERAL);
+
+        assertTrue(formatted.contains("// why b is not simply a again"), formatted);
+    }
+
+    @Test
+    void aCommentForcesTheLiteralToBreak() {
+        // a `//` on a line the group had collapsed would swallow the rest of it, so the literal that
+        // holds one is laid out a member per line
+        String formatted = Formatter.format(IN_A_LITERAL);
+
+        int comment = formatted.indexOf("// why b is not simply a again");
+        int b = formatted.indexOf("b = i.n * 2");
+        assertTrue(comment < b, formatted);
+        assertTrue(formatted.substring(comment, b).contains("\n"),
+                "the member starts on its own line: " + formatted);
+    }
+
+    @Test
+    void twoCommentLinesKeepTheirOrder() {
+        // each is prepended to the member, so building them one at a time reverses them — and a
+        // reversal only shows on the second format, which is what the idempotency check catches
+        String formatted = Formatter.format("""
+                module demo
+
+                data In = { n: Int }
+                data Out = { a: Int, b: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out {
+                    a = i.n,
+                    // first line of the reason
+                    // second line of the reason
+                    b = i.n * 2
+                }
+                """);
+
+        assertTrue(formatted.indexOf("// first line of the reason")
+                < formatted.indexOf("// second line of the reason"), formatted);
+        assertEquals(formatted, Formatter.format(formatted), "a second format changes nothing");
+    }
+
+    @Test
+    void formattingIsStableOverALiteralComment() {
+        String once = Formatter.format(IN_A_LITERAL);
+
+        assertEquals(once, Formatter.format(once), "a second format changes nothing");
+    }
+
     @Test
     void formattingIsStableOverABlockComment() {
         String once = Formatter.format(SOURCE);

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -582,13 +582,29 @@ public final class Formatter {
         String typeName = firstIdent(n);
         List<Doc> members = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
+            Doc member;
             if (c.kind() == SyntaxKind.SPREAD_MEMBER) {
-                members.add(concat(text("..."), text(identPath(c))));   // `...c` or `...c.address`
+                member = concat(text("..."), text(identPath(c)));   // `...c` or `...c.address`
             } else if (c.kind() == SyntaxKind.FIELD_INIT) {
                 var value = firstExprChildOpt(c);
-                members.add(value.map(v -> concat(text(firstIdent(c)), text(" = "), expr(v)))
-                        .orElse(text(firstIdent(c))));   // shorthand `field`
+                member = value.map(v -> concat(text(firstIdent(c)), text(" = "), expr(v)))
+                        .orElse(text(firstIdent(c)));   // shorthand `field`
+            } else {
+                continue;
             }
+            // A member's leading comments come before it, each on its own line. The HARDLINE forces
+            // the enclosing group to break, which is what a literal with a comment in it wants
+            // anyway: a `//` on a line the group had collapsed would swallow the rest of it.
+            List<String> comments = leading(c).comments();
+            if (!comments.isEmpty()) {
+                List<Doc> parts = new ArrayList<>();
+                for (String comment : comments) {
+                    parts.add(concat(text(comment), HARDLINE));   // in order: two lines stay two lines
+                }
+                parts.add(member);
+                member = concat(parts);
+            }
+            members.add(member);
         }
         if (members.isEmpty()) {
             return concat(text(typeName), text(" {}"));

--- a/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
@@ -24,7 +24,9 @@ public class CompileException extends RuntimeException {
     private static final int NO_SOURCE = -1;
 
     private final transient List<Diagnostic> diagnostics;
-    private final int sourceIndex;
+    /** One entry per diagnostic: which source it came from, or {@link #NO_SOURCE}. A compile that
+     *  reports several modules at once has a diagnostic per module, and each quotes its own file. */
+    private final transient List<Integer> sources;
 
     public CompileException(SourcePos pos, String message) {
         this(pos, null, message);
@@ -40,9 +42,13 @@ public class CompileException extends RuntimeException {
     }
 
     private CompileException(List<Diagnostic> diagnostics, String legacyMessage, int sourceIndex) {
+        this(diagnostics, legacyMessage, java.util.Collections.nCopies(diagnostics.size(), sourceIndex));
+    }
+
+    private CompileException(List<Diagnostic> diagnostics, String legacyMessage, List<Integer> sources) {
         super(legacyMessage);
         this.diagnostics = diagnostics;
-        this.sourceIndex = sourceIndex;
+        this.sources = sources;
     }
 
     /**
@@ -69,6 +75,24 @@ public class CompileException extends RuntimeException {
         Diagnostic first = diagnostics.get(0);
         return new CompileException(List.copyOf(diagnostics),
                 format(first.pos(), first.code(), legacyBody), NO_SOURCE);
+    }
+
+    /**
+     * Several errors found across several sources, each tagged with the source it came from —
+     * a multi-module compile reporting every module's failing examples rather than the first
+     * module's. {@code sources} has one entry per diagnostic.
+     */
+    public static CompileException ofAllInSources(List<Diagnostic> diagnostics, List<Integer> sources,
+                                                  String legacyBody) {
+        if (diagnostics == null || diagnostics.isEmpty()) {
+            throw new IllegalArgumentException("a compile error carries at least one diagnostic");
+        }
+        if (sources.size() != diagnostics.size()) {
+            throw new IllegalArgumentException("one source per diagnostic");
+        }
+        Diagnostic first = diagnostics.get(0);
+        return new CompileException(List.copyOf(diagnostics),
+                format(first.pos(), first.code(), legacyBody), List.copyOf(sources));
     }
 
     public SourcePos pos() {
@@ -103,7 +127,13 @@ public class CompileException extends RuntimeException {
      * never as "the first source".
      */
     public int sourceIndex() {
-        return sourceIndex;
+        return sources.isEmpty() ? NO_SOURCE : sources.get(0);
+    }
+
+    /** Which source the {@code i}-th of {@link #diagnostics()} came from, or {@code -1} when it names
+     *  none. A renderer walking the list quotes each diagnostic's own file. */
+    public int sourceIndexOf(int i) {
+        return sources == null || i >= sources.size() ? NO_SOURCE : sources.get(i);
     }
 
     /**
@@ -111,10 +141,11 @@ public class CompileException extends RuntimeException {
      * an inner phase that already named its source keeps it, so a surrounding loop may tag freely.
      */
     public CompileException inSource(int index) {
-        if (sourceIndex != NO_SOURCE || index < 0) {
-            return this;
+        if (index < 0 || sources.stream().allMatch(src -> src != NO_SOURCE)) {
+            return this;   // already named, or nothing to name it with
         }
-        CompileException tagged = new CompileException(diagnostics, getMessage(), index);
+        List<Integer> filled = sources.stream().map(src -> src == NO_SOURCE ? index : src).toList();
+        CompileException tagged = new CompileException(diagnostics, getMessage(), filled);
         tagged.setStackTrace(getStackTrace());
         return tagged;
     }


### PR DESCRIPTION
Closes #110, #112, #113, #114. Every one was found by the order-to-cash example set (#115), and each is verified against it here now that it is on develop.

## What changed

**#113 — `constructs` of a type another module declares.** Construction is closed to the declaring module (ADR-0015), so the generated `__construct` is package-private and the call failed at run time:

```
aborted: class example.returns.PlanRefund$Impl tried to access method
'souther.runtime.Result example.billing.Amount.__construct(java.math.BigDecimal)'
```

Which module declares a name is in the import list, so the clause is answered where it is written, naming the owner and the two ways out. Without an `example` covering that behavior it would have reached production instead.

**#114 — one module's failing examples per compile.** A multi-module compile threw at the first module that had any, so adding a field to a data six modules import took six edit-and-recompile rounds to learn how far it reached — while the extent was knowable the first time, since every module had compiled and only its fixtures were stale. The same change now reports 18 rows across six modules in one compile.

Carrying several modules' diagnostics means the source can no longer be a property of the exception: `CompileException` holds one source per diagnostic, and the CLI and the annotation processor quote each diagnostic's own file. `sourceIndex()` still answers for the first, so single-diagnostic callers are unchanged.

**#110 — an unknown type reported at an unrelated line.** The reported half of a wider problem. Typing a field access resolved the owner's *whole* field map, so reading one `Int` out of an imported data made the reader import types it never touches — `example.billing` reads `breakdown.net` and was made to import `TaxRate` because `TaxBreakdown` has one alongside. The field's `TypeRef` belongs to the declaring module, so the failure carried that file's position, and rendered against the reading file it landed on a comment:

```
-- NAMING ERROR ---------------------------billing.sou:63:13
63| // read: `Date` offers addDays / addMonths / addYears / daysBetween and no part
                ^^^^^^^
I cannot find a type named `TaxRate`.
```

Resolving only the field asked for drops the requirement and the misplaced position together. The same source now reports at the fixture that actually names `TaxRate`.

Half of the over-reach remains, recorded as a test rather than fixed: a field spread in through `...Common` still needs `Common` in scope. Answering that needs the declaring module's symbols, which this check does not have.

**#112 — a comment inside a record literal.** The other half of the block-body case. A literal joins its members inside a `group` that collapses when it fits, and a `//` on a collapsed line would swallow the rest, so the comment is emitted with a `HARDLINE` that forces the break. Two comment lines have to stay in order — prepending them one at a time reverses them, and a reversal shows only on the *second* format.

## One more, found on the way

Twelve English catalog messages wrote an ordinary possessive — `a data's`, `a fold's block` — and a lone `'` opens a quoted run in a MessageFormat pattern, so each quoted the rest of itself:

```
behavior `plan`s first letter is capitalized to form the JVM class `{1}`
(spec 19.5), which collides with data `{1}`; rename one
```

Seven lost their arguments outright; five lost only the apostrophe. `MessageCatalogFormatTest` renders every message in both catalogs with stand-in arguments and fails on any placeholder that survived, so this cannot come back. It surfaced while writing the two-module repro for #113 — the collision message was the first thing the repro printed.

## Verification

```
mvn clean install -DskipTests && mvn test      # syntax 25, compiler 1019, LSP 47
mvn -f examples/pom.xml clean test             # all example projects
```

Both green. #110, #113 and #114 were each reproduced against `examples/ordering` before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
