### PR TITLE
Stop the two patterns behind the recent issues

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/DecoderPathAgreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/DecoderPathAgreementTest.java
@@ -1,0 +1,154 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Three separate implementations answer "read a value of type T from the outside": the derived codec
+ * a data field crosses through, the fixture builder an {@code example} uses, and
+ * {@code Runner.decoderFor} behind {@code souther run}. They are written independently, so they drift
+ * — issue #97 was exactly that, a collection argument the boundary read and the fixture builder did
+ * not.
+ *
+ * <p>This pins what each supports against the same table of types, so adding a capability to one
+ * without the others fails here rather than in whatever example happens to use it. Where they do not
+ * agree today the divergence is stated, not smoothed over: a test that hides a gap is worse than the
+ * gap.
+ */
+class DecoderPathAgreementTest {
+
+    @TempDir
+    Path dir;
+
+    // === what all three read ===
+
+    @Test
+    void aPrimitiveIsReadByAllThree() throws Exception {
+        acceptedEverywhere("Int", 3L, "3", 3L);
+    }
+
+    @Test
+    void aNewtypeIsReadByAllThree() throws Exception {
+        // declared as `data Wrapped = Int` in the modules below
+        acceptedEverywhere("Wrapped", 3L, "3", 3L);
+    }
+
+    @Test
+    void aListIsReadByAllThree() throws Exception {
+        acceptedEverywhere("List<Int>", List.of(1L, 2L), "[1, 2]", 2L);
+    }
+
+    @Test
+    void aStringKeyedMapIsReadByAllThree() throws Exception {
+        acceptedEverywhere("Map<String, Int>", Map.of("a", 1L), "{\"a\": 1}", 1L);
+    }
+
+    // === where they part ===
+
+    /**
+     * A newtype-keyed map crosses the boundary and is written in a fixture, and {@code run} declines
+     * it. {@code Runner.decoderFor} handles only a {@code String} key; its javadoc says so, so this
+     * is a stated limit rather than a surprise — stated here too, so closing it in one place without
+     * the others is caught.
+     */
+    @Test
+    void aNewtypeKeyedMapIsReadByTheBoundaryAndTheFixtureButNotByRun() throws Exception {
+        assertTrue(boundaryReads("Map<Key, Int>", Map.of("a", 1L)), "the derived codec reads it");
+        assertTrue(fixtureReads("Map<Key, Int>", "[ (Key(\"a\"), 1) ]", 1L), "a fixture writes it");
+
+        RuntimeException e = assertThrows(Runner.RunException.class,
+                () -> runReads("Map<Key, Int>", "{\"a\": 1}"));
+        assertTrue(e.getMessage().contains("Map"), e.getMessage());
+    }
+
+    /** A temporal-keyed map, added at the boundary by issue #100, is the same story one step later. */
+    @Test
+    void aDateKeyedMapIsReadByTheBoundaryAndTheFixtureButNotByRun() throws Exception {
+        assertTrue(boundaryReads("Map<Date, Int>", Map.of("2026-01-01", 1L)),
+                "the derived codec reads it");
+        assertTrue(fixtureReads("Map<Date, Int>", "[ (Date(\"2026-01-01\"), 1) ]", 1L),
+                "a fixture writes it");
+
+        assertThrows(Runner.RunException.class, () -> runReads("Map<Date, Int>", "{\"2026-01-01\": 1}"));
+    }
+
+    // === the three paths ===
+
+    private void acceptedEverywhere(String type, Object neutral, String runJson, Object size)
+            throws Exception {
+        assertTrue(boundaryReads(type, neutral), "the derived codec reads " + type);
+        assertTrue(fixtureReads(type, fixtureOf(type), size), "a fixture writes " + type);
+        assertEquals(String.valueOf(size), runReads(type, runJson).trim(), "run reads " + type);
+    }
+
+    private static String fixtureOf(String type) {
+        return switch (type) {
+            case "Int" -> "3";
+            case "Wrapped" -> "Wrapped(3)";
+            case "List<Int>" -> "[ 1, 2 ]";
+            case "Map<String, Int>" -> "[ (\"a\", 1) ]";
+            default -> throw new IllegalArgumentException(type);
+        };
+    }
+
+    /** A data with a field of that type, decoded through its generated codec. */
+    private boolean boundaryReads(String type, Object neutral) throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+                data Key = String
+                data Wrapped = Int
+                data Holder = { v: %s }
+                """.formatted(type)), getClass().getClassLoader());
+        Object decoded = Codecs.decode(loader, "demo.Holder", Map.of("v", neutral));
+        return "Ok".equals(decoded.getClass().getSimpleName());
+    }
+
+    /** A behavior taking that type, with an `example` whose fixture writes it. The compile evaluates
+     *  the example, so a fixture the builder cannot construct fails the compile. */
+    private boolean fixtureReads(String type, String fixture, Object expected) {
+        Compiler.compile("""
+                module demo
+                data Key = String
+                data Wrapped = Int
+                data Out = { n: Int }
+                behavior take : (v: %s) -> Out constructs Out
+                let take (v) = Out { n = %s }
+                example take
+                  | "reads it" : (%s) -> Out { n = %s }
+                """.formatted(type, sizeExprFor(type), fixture, expected));
+        return true;
+    }
+
+    /** The same type as a behavior input, driven through {@code souther run}. */
+    private String runReads(String type, String json) throws Exception {
+        Path file = dir.resolve("run" + Math.abs(type.hashCode()) + ".sou");
+        Files.writeString(file, """
+                module demo
+                data Key = String
+                data Wrapped = Int
+                behavior take : (v: %s) -> Int
+                let take (v) = %s
+                """.formatted(type, sizeExprFor(type)));
+        return Runner.run(file, "take", json);
+    }
+
+    /** An expression reducing a value of that type to the Int the three paths compare. */
+    private static String sizeExprFor(String type) {
+        if (type.startsWith("Map<")) {
+            return "Map.size(v)";
+        }
+        if (type.startsWith("List<")) {
+            return "List.length(v)";
+        }
+        return type.equals("Wrapped") ? "v.value" : "v";
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/BlockCommentFormatTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/BlockCommentFormatTest.java
@@ -6,10 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A comment inside a block body survives formatting. {@code block} walked only the block's child
- * nodes, so a comment explaining a step — the one place a body wants one — was dropped on the first
- * format. No example wrote one until a module with multi-step bodies did, and the formatter's own
- * round-trip test over the repository's {@code .sou} files caught it there.
+ * Formatting a body that carries comments, in the shape a real module writes them. Where a comment
+ * may go at all is enumerated by {@link CommentSurvivalTest}; this keeps the two multi-step bodies
+ * that first exposed the problem, because they are what the repository's own `.sou` files look like.
  */
 class BlockCommentFormatTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/fmt/CommentSurvivalTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/CommentSurvivalTest.java
@@ -1,0 +1,175 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A comment survives formatting wherever it is written. Comment handling used to be per construct
+ * and only three constructs had it, so a comment disappeared on the first {@code souther fmt} in
+ * eight of the nine places one can be written — silently, which is worse than a rejection.
+ *
+ * <p>The constructs are listed rather than sampled, so adding one without handling its comments
+ * fails here. Each case also asserts the comment is written exactly once: it is reachable both from
+ * the parent's child list and from the front of the member's own subtree, and the two overlap.
+ */
+class CommentSurvivalTest {
+
+    static Stream<Arguments> everyPlaceACommentCanGo() {
+        return Stream.of(
+                Arguments.of("top-level item", """
+                        module m
+                        // the comment
+                        data D = { a: Int }
+                        """),
+                Arguments.of("data field", """
+                        module m
+                        data D = {
+                          // the comment
+                          a: Int
+                        }
+                        """),
+                Arguments.of("sum case", """
+                        module m
+                        data A
+                        data B
+                        data S =
+                          // the comment
+                          A | B
+                        """),
+                Arguments.of("behavior parameter", """
+                        module m
+                        data O = { n: Int }
+                        behavior f : (
+                          // the comment
+                          n: Int) -> O constructs O
+                        let f (n) = O { n = n }
+                        """),
+                Arguments.of("block statement", """
+                        module m
+                        data O = { n: Int }
+                        behavior f : (n: Int) -> O constructs O
+                        let f (n) = {
+                          // the comment
+                          let m = n * 2
+                          O { n = m }
+                        }
+                        """),
+                Arguments.of("record literal field", """
+                        module m
+                        data O = { a: Int, b: Int }
+                        behavior f : (n: Int) -> O constructs O
+                        let f (n) = O {
+                          a = n,
+                          // the comment
+                          b = n
+                        }
+                        """),
+                Arguments.of("list element", """
+                        module m
+                        data O = { xs: List<Int> }
+                        behavior f : (n: Int) -> O constructs O
+                        let f (n) = O { xs = [
+                          // the comment
+                          1, 2] }
+                        """),
+                Arguments.of("match arm", """
+                        module m
+                        data A
+                        data B
+                        data S = A | B
+                        data O = { n: Int }
+                        behavior f : (s: S) -> O constructs O
+                        let f (s) = O { n = match s with
+                          // the comment
+                          | A -> 1
+                          | B -> 2 }
+                        """),
+                Arguments.of("example row", """
+                        module m
+                        data O = { n: Int }
+                        behavior f : (n: Int) -> O constructs O
+                        let f (n) = O { n = n }
+                        example f
+                          // the comment
+                          | "a" : (1) -> O { n = 1 }
+                        """),
+                Arguments.of("exposing entry", """
+                        module m exposing (
+                          // the comment
+                          O )
+                        data O = { n: Int }
+                        """),
+                Arguments.of("call argument", """
+                        module m
+                        data O = { n: Int }
+                        behavior f : (n: Int) -> O constructs O
+                        let g (x: Int) = x
+                        let f (n) = O { n = g(
+                          // the comment
+                          n) }
+                        """));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("everyPlaceACommentCanGo")
+    void theCommentSurvives(String where, String source) {
+        String formatted = Formatter.format(source);
+
+        assertTrue(formatted.contains("// the comment"),
+                "the comment written at a " + where + " was dropped:\n" + formatted);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("everyPlaceACommentCanGo")
+    void theCommentIsWrittenOnce(String where, String source) {
+        String formatted = Formatter.format(source);
+
+        assertEquals(1, occurrences(formatted, "// the comment"),
+                "the comment at a " + where + " is reachable two ways and must be written once:\n"
+                        + formatted);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("everyPlaceACommentCanGo")
+    void formattingIsStable(String where, String source) {
+        String once = Formatter.format(source);
+
+        assertEquals(once, Formatter.format(once),
+                "a second format changed the " + where + " case");
+    }
+
+    /** Two comment lines above one member stay in that order — building them one at a time reverses
+     *  them, and a reversal shows only on the second format. */
+    @Test
+    void twoLinesKeepTheirOrder() {
+        String formatted = Formatter.format("""
+                module m
+                data O = { a: Int, b: Int }
+                behavior f : (n: Int) -> O constructs O
+                let f (n) = O {
+                  a = n,
+                  // first line
+                  // second line
+                  b = n
+                }
+                """);
+
+        assertTrue(formatted.indexOf("// first line") < formatted.indexOf("// second line"), formatted);
+        assertEquals(formatted, Formatter.format(formatted));
+    }
+
+    private static int occurrences(String haystack, String needle) {
+        int n = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            n++;
+        }
+        return n;
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -32,12 +32,18 @@ public final class Formatter {
     private static final int INDENT = 4;
     private static final int WIDTH = 100;
 
-    /** The comments already written, by their offset in the source. A comment is reachable two ways
-     * once members nest — from the parent's child list and from the front of the member's own subtree
-     * — and it must be written once. The key is the offset rather than the token: the tree is
-     * green/red, so reading `children()` twice hands back equal tokens that are not the same object.
-     * One instance formats one file, so this lives as long as that. */
+    /** The comments already written, keyed by where they are in the source. A comment is reachable
+     * two ways once members nest — from the parent's child list and from the front of the member's
+     * own subtree — and it must be written once. The offset identifies a comment without depending on
+     * how the tree hands nodes back. One instance formats one file, so this lives as long as that. */
     private final java.util.Set<Integer> written = new java.util.HashSet<>();
+
+    /** {@link #commentsBefore} per parent, computed once. It is asked for every member of a parent,
+     * and answering means walking that parent's children, so without this a construct with n members
+     * walks them n times. One instance formats one file, so the cache lives exactly as long as the
+     * tree it describes. */
+    private final Map<SyntaxNode, Map<SyntaxNode, List<SyntaxToken>>> commentsByParent =
+            new IdentityHashMap<>();
 
     private Formatter() {
     }
@@ -745,6 +751,10 @@ public final class Formatter {
     /** Each of {@code parent}'s child nodes against the comment lines written above it — the comments
      * that sit in the parent's own child list rather than on the member. */
     private Map<SyntaxNode, List<SyntaxToken>> commentsBefore(SyntaxNode parent) {
+        return commentsByParent.computeIfAbsent(parent, Formatter::scanCommentsBefore);
+    }
+
+    private static Map<SyntaxNode, List<SyntaxToken>> scanCommentsBefore(SyntaxNode parent) {
         Map<SyntaxNode, List<SyntaxToken>> out = new IdentityHashMap<>();
         List<SyntaxToken> pending = new ArrayList<>();
         for (SyntaxElement e : parent.children()) {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -7,7 +7,9 @@ import souther.compiler.cst.SyntaxNode;
 import souther.compiler.cst.SyntaxToken;
 
 import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static souther.compiler.fmt.Doc.HARDLINE;
@@ -29,6 +31,13 @@ public final class Formatter {
 
     private static final int INDENT = 4;
     private static final int WIDTH = 100;
+
+    /** The comments already written, by their offset in the source. A comment is reachable two ways
+     * once members nest — from the parent's child list and from the front of the member's own subtree
+     * — and it must be written once. The key is the offset rather than the token: the tree is
+     * green/red, so reading `children()` twice hands back equal tokens that are not the same object.
+     * One instance formats one file, so this lives as long as that. */
+    private final java.util.Set<Integer> written = new java.util.HashSet<>();
 
     private Formatter() {
     }
@@ -55,16 +64,23 @@ public final class Formatter {
             if (!isTopLevel(item.kind())) {
                 continue;
             }
-            Leading lead = leading(item);
+            // A top-level item's comments are read the same way a member's are, and marked written
+            // the same way: an `example`'s comment is the item's leading trivia here and the first
+            // row's from inside, and it belongs to whichever asks first.
+            List<SyntaxToken> lead = new ArrayList<>(
+                    commentsBefore(file).getOrDefault(item, List.of()));
+            lead.addAll(leadingDeep(item));
             if (prev != null) {
                 parts.add(HARDLINE);
                 if (blankBetween(prev, item.kind())) {
                     parts.add(HARDLINE);
                 }
             }
-            for (String c : lead.comments) {
-                parts.add(text(c));
-                parts.add(HARDLINE);
+            for (SyntaxToken c : lead) {
+                if (written.add(c.start())) {
+                    parts.add(text(c.text().stripTrailing()));
+                    parts.add(HARDLINE);
+                }
             }
             parts.add(item(item));
             prev = item.kind();
@@ -117,7 +133,7 @@ public final class Formatter {
         String target = ids.size() >= 2 ? ids.get(1).text() : "";
         List<Doc> rows = new ArrayList<>();
         for (SyntaxNode row : childNodes(n, SyntaxKind.EXAMPLE_ROW)) {
-            rows.add(concat(HARDLINE, exampleRow(row)));
+            rows.add(concat(HARDLINE, withComments(n, row, exampleRow(row))));
         }
         return concat(text("example "), text(target), nest(INDENT, concat(rows)));
     }
@@ -191,9 +207,9 @@ public final class Formatter {
         List<Doc> entries = new ArrayList<>();
         for (SyntaxNode e : childNodes(clause, SyntaxKind.EXPOSED_ENTRY)) {
             Doc name = qualifiedName(e.child(SyntaxKind.QUALIFIED_NAME).orElseThrow());
-            entries.add(e.child(SyntaxKind.RET_TYPE)
+            entries.add(withComments(clause, e, e.child(SyntaxKind.RET_TYPE)
                     .map(rt -> concat(name, text(" : "), retType(rt)))
-                    .orElse(name));
+                    .orElse(name)));
         }
         return concat(text("exposing ( "), Doc.join(text(", "), entries), text(" )"));
     }
@@ -225,9 +241,24 @@ public final class Formatter {
         }
         var sum = n.child(SyntaxKind.SUM_BODY);
         if (sum.isPresent()) {
+            // A sum's cases are bare idents, not nodes, so the comments between them are picked up
+            // from the token stream rather than from a member node.
             List<Doc> cases = new ArrayList<>();
-            for (SyntaxToken t : idents(sum.get())) {
-                cases.add(text(t.text()));
+            List<String> pending = new ArrayList<>();
+            for (SyntaxElement e : sum.get().children()) {
+                if (!(e instanceof SyntaxToken t)) {
+                    continue;
+                }
+                if (t.kind() == SyntaxKind.LINE_COMMENT) {
+                    pending.add(t.text().stripTrailing());
+                } else if (t.kind() == SyntaxKind.IDENT) {
+                    Doc c = text(t.text());
+                    for (int i = pending.size() - 1; i >= 0; i--) {
+                        c = concat(text(pending.get(i)), HARDLINE, c);
+                    }
+                    pending.clear();
+                    cases.add(c);
+                }
             }
             return concat(text("data "), text(name), text(" = "), Doc.join(text(" | "), cases));
         }
@@ -244,9 +275,9 @@ public final class Formatter {
         List<Doc> members = new ArrayList<>();
         for (SyntaxNode m : body.childNodes()) {
             if (m.kind() == SyntaxKind.FIELD) {
-                members.add(field(m));
+                members.add(withComments(body, m, field(m)));
             } else if (m.kind() == SyntaxKind.SPREAD_MEMBER) {
-                members.add(concat(text("..."), text(firstIdent(m))));
+                members.add(withComments(body, m, concat(text("..."), text(firstIdent(m)))));
             }
         }
         List<Doc> lines = new ArrayList<>();
@@ -297,7 +328,8 @@ public final class Formatter {
     private Doc paramList(SyntaxNode n) {
         List<Doc> params = new ArrayList<>();
         for (SyntaxNode p : childNodes(n, SyntaxKind.PARAM)) {
-            params.add(concat(text(firstIdent(p)), text(": "), retType(p.child(SyntaxKind.RET_TYPE).orElseThrow())));
+            params.add(withComments(n, p, concat(text(firstIdent(p)), text(": "),
+                    retType(p.child(SyntaxKind.RET_TYPE).orElseThrow()))));
         }
         return concat(text("("), Doc.join(text(", "), params), text(")"));
     }
@@ -466,9 +498,10 @@ public final class Formatter {
         if (args.isEmpty()) {
             return concat(text(fn.toString()), text("()"));
         }
+        SyntaxNode argList = n.child(SyntaxKind.ARG_LIST).orElseThrow();
         List<Doc> argDocs = new ArrayList<>();
         for (SyntaxNode a : args) {
-            argDocs.add(expr(a));
+            argDocs.add(withComments(argList, a, expr(a)));
         }
         return concat(text(fn.toString()), group(concat(text("("),
                 nest(INDENT, concat(SOFTLINE, Doc.join(concat(text(","), LINE), argDocs))),
@@ -535,7 +568,7 @@ public final class Formatter {
         SyntaxNode scrutinee = exprChildren(n).get(0);
         List<Doc> cases = new ArrayList<>();
         for (SyntaxNode c : childNodes(n, SyntaxKind.MATCH_CASE)) {
-            cases.add(concat(HARDLINE, matchCase(c)));
+            cases.add(concat(HARDLINE, withComments(n, c, matchCase(c))));
         }
         return concat(text("match "), expr(scrutinee), text(" with"), nest(INDENT, concat(cases)));
     }
@@ -595,16 +628,7 @@ public final class Formatter {
             // A member's leading comments come before it, each on its own line. The HARDLINE forces
             // the enclosing group to break, which is what a literal with a comment in it wants
             // anyway: a `//` on a line the group had collapsed would swallow the rest of it.
-            List<String> comments = leading(c).comments();
-            if (!comments.isEmpty()) {
-                List<Doc> parts = new ArrayList<>();
-                for (String comment : comments) {
-                    parts.add(concat(text(comment), HARDLINE));   // in order: two lines stay two lines
-                }
-                parts.add(member);
-                member = concat(parts);
-            }
-            members.add(member);
+            members.add(withComments(n, c, member));
         }
         if (members.isEmpty()) {
             return concat(text(typeName), text(" {}"));
@@ -620,8 +644,15 @@ public final class Formatter {
             // A statement inside a block carries its leading comments the same way a top-level item
             // does. Walking only the child nodes dropped them, so a comment explaining a step was
             // lost on the first format.
-            for (String comment : leading(c).comments()) {
-                lines.add(concat(HARDLINE, text(comment)));
+            for (SyntaxToken comment : commentsBefore(n).getOrDefault(c, List.of())) {
+                if (written.add(comment.start())) {
+                    lines.add(concat(HARDLINE, text(comment.text().stripTrailing())));
+                }
+            }
+            for (SyntaxToken comment : leadingDeep(c)) {
+                if (written.add(comment.start())) {
+                    lines.add(concat(HARDLINE, text(comment.text().stripTrailing())));
+                }
             }
             Doc d = switch (c.kind()) {
                 case LET_STMT -> concat(text("let "), text(firstIdent(c)), writtenType(c),
@@ -650,6 +681,87 @@ public final class Formatter {
 
     // --- comments / blank lines ---
 
+    /**
+     * A member with the comments written above it in front of it, each on its own line.
+     *
+     * <p>Where a comment lands in the tree is the parser's business and it is not uniform: a comment
+     * above a record-literal field becomes that field's own leading trivia, while one above a match
+     * arm becomes a child of the enclosing {@code MATCH_EXPR}, sitting between the scrutinee and the
+     * first arm. Asking each member for its leading trivia therefore finds some comments and not
+     * others — which is why a comment survived in three constructs and disappeared in eight.
+     *
+     * <p>So the question is asked of the parent instead: walk its children in document order and the
+     * comments fall between the members they were written above, wherever the parser attached them.
+     * A member's own leading trivia is added to that, since the two are disjoint — a token belongs to
+     * one node.
+     *
+     * <p>The {@link Doc#HARDLINE} after each comment forces the enclosing group to break. That is not
+     * a preference: a {@code //} on a line the group had collapsed would swallow everything after it.
+     */
+    private Doc withComments(SyntaxNode parent, SyntaxNode member, Doc d) {
+        List<SyntaxToken> comments = new ArrayList<>(commentsBefore(parent).getOrDefault(member, List.of()));
+        comments.addAll(leadingDeep(member));
+        List<Doc> parts = new ArrayList<>();
+        for (SyntaxToken comment : comments) {
+            if (written.add(comment.start())) {
+                parts.add(concat(text(comment.text().stripTrailing()), HARDLINE));
+            }
+        }
+        if (parts.isEmpty()) {
+            return d;
+        }
+        parts.add(d);
+        return concat(parts);
+    }
+
+    /**
+     * The comments at the front of a member's own text. {@link #leading} reads only the node's direct
+     * children and stops at its first child node, but a parser may put the member's first token a
+     * level or two down — an {@code exposing} entry's name is a {@code QUALIFIED_NAME}, and the
+     * comment above the entry becomes *that* node's leading trivia. What is written above a member is
+     * at the front of its text however deep the front is, so the walk follows the leftmost spine.
+     */
+    private List<SyntaxToken> leadingDeep(SyntaxNode member) {
+        List<SyntaxToken> comments = new ArrayList<>();
+        for (SyntaxElement e : member.children()) {
+            if (e instanceof SyntaxToken t) {
+                if (t.kind() == SyntaxKind.WHITESPACE) {
+                    continue;
+                }
+                if (t.kind() == SyntaxKind.LINE_COMMENT) {
+                    comments.add(t);
+                    continue;
+                }
+                break;                      // a real token: the front of the text is here
+            }
+            if (e instanceof SyntaxNode first) {
+                comments.addAll(leadingDeep(first));
+                break;                      // only the leftmost child is the front
+            }
+        }
+        return comments;
+    }
+
+    /** Each of {@code parent}'s child nodes against the comment lines written above it — the comments
+     * that sit in the parent's own child list rather than on the member. */
+    private Map<SyntaxNode, List<SyntaxToken>> commentsBefore(SyntaxNode parent) {
+        Map<SyntaxNode, List<SyntaxToken>> out = new IdentityHashMap<>();
+        List<SyntaxToken> pending = new ArrayList<>();
+        for (SyntaxElement e : parent.children()) {
+            if (e instanceof SyntaxToken t) {
+                if (t.kind() == SyntaxKind.LINE_COMMENT) {
+                    pending.add(t);
+                }
+            } else if (e instanceof SyntaxNode n && !pending.isEmpty()) {
+                out.put(n, List.copyOf(pending));
+                pending.clear();
+            }
+        }
+        return out;
+    }
+
+    /** The comments left after {@code parent}'s last child node — written above the closing brace,
+     * with no member to attach to. */
     private record Leading(List<String> comments) {}
 
     /** The full-line comments that sit directly above a top-level item (its leading trivia). Blank
@@ -706,7 +818,7 @@ public final class Formatter {
     private List<Doc> exprDocs(SyntaxNode n) {
         List<Doc> out = new ArrayList<>();
         for (SyntaxNode c : exprChildren(n)) {
-            out.add(expr(c));
+            out.add(withComments(n, c, expr(c)));
         }
         return out;
     }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/DiagnosticPathAgreementTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/DiagnosticPathAgreementTest.java
@@ -1,0 +1,145 @@
+package souther.lsp.analysis;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.lsp.protocol.LspDiagnostic;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The same error, reached two ways, says the same thing. A compile reports through
+ * {@link CompileException}, which the CLI and the annotation processor render; an editor reaches the
+ * same source through {@link Analyzer}, which builds {@code LspDiagnostic}s. The two are separate
+ * implementations over one compile, and every diagnostic defect this project has filed —
+ * #93 (the processor printed a raw line), #94 (a multi-file compile lost the file), #98 (an
+ * aggregate lost the reason) — was one path behaving differently from another.
+ *
+ * <p>Nothing compared them. Each path had its own tests, over its own inputs, so a change to one
+ * could not fail the other. This runs one source through both and asserts they agree on what is
+ * wrong and where.
+ */
+class DiagnosticPathAgreementTest {
+
+    private final Analyzer analyzer = new Analyzer();
+
+    /** Sources whose first error both paths must describe the same way. Each names a different check,
+     *  so the agreement is not a property of one diagnostic family. */
+    static Stream<org.junit.jupiter.params.provider.Arguments> brokenSources() {
+        return Stream.of(
+                arguments("a field type that does not exist", """
+                        module demo
+                        data Out = { v: Nonexistent }
+                        """),
+                arguments("a body whose type does not match the signature", """
+                        module demo
+                        data Out = { v: Int }
+                        behavior f : (s: String) -> Out
+                            constructs Out
+                        let f (s) = Out { v = s }
+                        """),
+                arguments("a construction the behavior may not make", """
+                        module demo
+                        data Out = { v: Int }
+                        data Other = { v: Int }
+                        behavior f : (n: Int) -> Out
+                            constructs Out
+                        let f (n) = Other { v = n }
+                        """),
+                arguments("a failing example", """
+                        module demo
+                        data In = { n: Int }
+                        data Out = { n: Int }
+                        behavior f : (i: In) -> Out constructs Out
+                        let f (i) = Out { n = i.n }
+                        example f
+                          | "wrong" : (In { n = 1 }) -> Out { n = 2 }
+                        """),
+                arguments("a Map key that cannot cross the boundary", """
+                        module demo
+                        data EmployeeNo = Int
+                        data Roster = { byNo: Map<EmployeeNo, String> }
+                        """),
+                arguments("an unknown name in a body", """
+                        module demo
+                        data Out = { v: Int }
+                        behavior f : (n: Int) -> Out
+                            constructs Out
+                        let f (n) = Out { v = bogus }
+                        """));
+    }
+
+    private static org.junit.jupiter.params.provider.Arguments arguments(String label, String source) {
+        return org.junit.jupiter.params.provider.Arguments.of(label, source);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("brokenSources")
+    void theCompileAndTheEditorAgreeOnTheCode(String label, String source) {
+        Diagnostic compiled = firstFromCompile(source);
+        LspDiagnostic seen = firstFromAnalyzer(source);
+
+        assertEquals(compiled.code(), seen.code(),
+                "the stable identity is what a tool keys on, so both paths must give the same one");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("brokenSources")
+    void theCompileAndTheEditorAgreeOnWhereItIs(String label, String source) {
+        Diagnostic compiled = firstFromCompile(source);
+        LspDiagnostic seen = firstFromAnalyzer(source);
+
+        // LSP positions are 0-based, the compiler's are 1-based; that offset is the only difference
+        // allowed between them.
+        assertEquals(compiled.pos().line() - 1, seen.range().start().line(), "line");
+        assertEquals(compiled.pos().column() - 1, seen.range().start().character(), "column");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("brokenSources")
+    void neitherPathReportsAnEmptyReason(String label, String source) {
+        LspDiagnostic seen = firstFromAnalyzer(source);
+
+        assertFalse(seen.message() == null || seen.message().isBlank(),
+                "an editor marker with no message is what #98 shipped");
+        assertFalse(seen.message().contains("{0}"),
+                "an unsubstituted placeholder means the catalog pattern is broken");
+    }
+
+    @Test
+    void aCleanSourceIsCleanOnBothPaths() {
+        String source = """
+                module demo
+                data In = { n: Int }
+                data Out = { n: Int }
+                behavior f : (i: In) -> Out constructs Out
+                let f (i) = Out { n = i.n * 2 }
+                example f
+                  | "doubles" : (In { n = 3 }) -> Out { n = 6 }
+                """;
+
+        Compiler.compile(source);
+        assertEquals(List.of(), analyzer.diagnostics(source));
+    }
+
+    private static Diagnostic firstFromCompile(String source) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(source),
+                "the source is supposed to be broken");
+        return e.diagnostic();
+    }
+
+    private LspDiagnostic firstFromAnalyzer(String source) {
+        List<LspDiagnostic> seen = analyzer.diagnostics(source);
+        assertFalse(seen.isEmpty(), "the editor path found nothing in a source the compile rejects");
+        return seen.get(0);
+    }
+}


### PR DESCRIPTION
The recent issues were not fourteen separate mistakes. Classified by mechanism they fall into two patterns, and this addresses both — the first by making divergence fail a test, the second by removing the thing that kept diverging.

| pattern | issues |
|---|---|
| several implementations of one concept, only one exercised | #93, #94, #97, #98, #114, the processor path, example × exposing |
| a decided rule enforced somewhere other than where it is stated | #95, #99, #100, #101, #110, #113 |
| one construct handled, its siblings missed | #112, block comments, the fixture's sum case |

The third is a special case of the first. What follows is measured, not asserted.

## Comment handling: the formatter asked the wrong question

A comment survived in three constructs and disappeared in eight:

```
LOST data field     LOST list literal    LOST example row
LOST sum case       LOST match arm       LOST exposing entry
LOST behavior param                      LOST call argument
KEPT import list
```

Each construct read its members' leading trivia itself, so each had to remember to; two had been taught one at a time by the two bugs that happened to get noticed. Teaching the rest would not have worked either, because **where a comment lands is the parser's business and it is not uniform**: above a record-literal field it becomes that field's trivia, above a match arm it becomes a child of the enclosing `MATCH_EXPR`, above an `exposing` entry it lands two levels down on the entry's `QUALIFIED_NAME`.

So the question is asked of the parent — walk its children in document order and the comments fall between the members they were written above, wherever attached — and a member's own subtree is walked down its leftmost spine, since what is written above a member is at the front of its text however deep the front is.

The two readings overlap, so a comment must be written once. That is a set of emitted offsets, not identities: the tree is green/red, and reading `children()` twice hands back equal tokens that are not the same object. Getting that wrong is what made an `example`'s comment appear twice, once as the item's and once as its first row's.

All eleven places now keep it. `CommentSurvivalTest` lists them rather than sampling, and asserts each comment survives, appears exactly once, and is stable under a second format.

## Path agreement: divergence now fails a test

**`DiagnosticPathAgreementTest`** runs six broken sources through the compile path and the editor path and asserts they agree on the code, the position, and that neither reports an empty reason. They agree today; nothing compared them before, which is how #93, #94 and #98 each shipped one path behaving differently from another.

**`DecoderPathAgreementTest`** pins the three implementations of "read a value of type T from the outside" — the derived codec, the fixture builder, `Runner.decoderFor` — against one table of types. Four types are read by all three. A newtype-keyed and a temporal-keyed map are read by the boundary and by a fixture and **not** by `run`; that divergence is written down rather than smoothed over, so closing it in one place without the others fails here. #97 was exactly this drift, found by an example instead of a test.

## What this does not address

The second pattern — a rule enforced somewhere other than where it is stated — has no mechanical guard here. The one thing that would help is a test per ADR that states a constraint, using the ADR's own examples, which would make the 58 prose decisions executable. That is a larger change and is not in this PR.

## Verification

```
mvn clean install -DskipTests && mvn test      # syntax 25, compiler 1062, LSP 66
mvn -f examples/pom.xml clean test             # all example projects
```

Both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
