### PR TITLE
Say what closes construction, and stop citing an ADR that does not

### DIFF
--- a/docs/adr/0002-closed-construction-paths.md
+++ b/docs/adr/0002-closed-construction-paths.md
@@ -10,6 +10,29 @@ The spec DSL states, via parse-don't-validate, that "a validated email address i
 
 A value of `data T` can be produced only by: `T`'s derived decoder, the implementation (Souther `let` or injected Java) of a behavior whose construction set includes T, or compiler-generated code. The authority to construct is held by the *behavior*, not by its implementation. That set is written with `constructs` on the behavior; on an let-backed behavior it may be omitted and inferred from the visible body, while an injected behavior must declare it (no body to infer from, and it drives factory generation — ADR-0006, `[#java-base-class]`).
 
+## Why this is not a per-type choice
+
+The ML family makes opacity a decision the author writes per type. Elm's `exposing` distinguishes the
+type from its constructors — `module Dict exposing ( Dict, ... )` hides them, `module Maybe exposing
+( Maybe(..), ... )` shows them. F# and OCaml put the same choice in a separate signature (`.fsi` /
+`.mli`), where a discriminated union or record "must expose either all or none of their fields and
+constructors". In all three, a module may choose to hand out a raw constructor.
+
+Souther does not offer that choice, and the reason is the invariant. None of those languages attaches
+one to a type, so exposing a constructor there costs nothing but encapsulation. Here a constructor is
+the one place an invariant is checked, so a type that hands one out is a type whose invariant is
+advisory — and "a validated email address is guaranteed to be validated by its type" stops holding
+for the whole language, not just for that type.
+
+What F# programmers write by convention for exactly this reason — `type X = private ...` with a smart
+constructor returning a `Result` — is what Souther makes the only way. The guarantee is the same one;
+what changes is that it is not opt-in.
+
+Note what this decision does *not* say: nothing here restricts construction to the module that
+declares the type. A behavior in any module that declares `constructs T` is a declared path by this
+ADR. The compiler currently rejects that when `T` is imported, for a reason that lives in codegen
+rather than here (issue #121).
+
 ## Consequences
 
 Permission is always on the behavior's declaration. A helper `let` (one with no corresponding behavior) may also construct data, but it does not declare `constructs` itself — its construction set is inferred transitively and must be contained in the `constructs` of the behavior that calls it (otherwise E1002). Blocks work the same way, constructing under the enclosing behavior's authority. So refactoring an anonymous block out into a named helper `let` never changes whether a construction is allowed.
@@ -21,3 +44,5 @@ The guarantee is "no *unvalidated* value can be built," not "no value can be bui
 ## References
 
 - Specification: `[#closed-construction]`, `[#constructs]`, `[#java-base-class]`
+- Prior art: Elm `exposing (Dict)` vs `exposing (Maybe(..))` (elm/core), F# signature files and
+  `type X = private ...`, OCaml `.mli` abstract types

--- a/examples/ordering/src/main/souther/returns.sou
+++ b/examples/ordering/src/main/souther/returns.sou
@@ -3,11 +3,11 @@
 // second diamond, and neither costs anything at the call — a module is resolved once for the whole
 // compile, so `Amount` reaching here through billing is the same `Amount` billing states.
 //
-// What the depth costs is knowing which module may build what. Construction is closed to the module
-// that declares a type (ADR-0015): billing's `Amount` can be read here and cannot be constructed
-// here, however many modules import it. So this module reads the invoiced amount as an `Amount` and
-// states what it produces as a `Refund` of its own — a type returns declares, and therefore may
-// build. Writing `constructs Amount` instead compiles and then fails at run time inside the example:
+// What the depth costs is knowing which module may build what. A behavior constructs only what its
+// own module declares, so billing's `Amount` can be read here and cannot be built here, however many
+// modules import it. This module therefore reads the invoiced amount as an `Amount` and states what
+// it produces as a `Refund` of its own — a type returns declares, and therefore may build. Writing
+// `constructs Amount` instead used to compile and then fail at run time inside the example:
 //
 //     aborted: class example.returns.PlanRefund$Impl tried to access method
 //     'souther.runtime.Result example.billing.Amount.__construct(java.math.BigDecimal)'

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -362,11 +362,22 @@ public final class SpecChecker {
     }
 
     /**
-     * A behavior may only construct types its own module declares. Construction is closed to the
-     * declaring module (ADR-0015): the generated {@code __construct} is package-private, so a
-     * {@code constructs} naming an imported type compiles and then fails with an
-     * {@code IllegalAccessError} when the behavior runs (issue #113). Which module declares a name is
-     * known from the import list, so the clause is answered where it is written.
+     * A behavior may only construct types its own module declares.
+     *
+     * <p>What is decided is that construction goes through declared paths only (ADR-0002): a value of
+     * {@code T} comes from {@code T}'s decoder, from a behavior whose construction set includes it, or
+     * from generated code. That much is the language's guarantee and holds wherever the behavior is.
+     *
+     * <p>That those paths must be in {@code T}'s own module is <em>not</em> a decided rule — no ADR
+     * states it. It is where the compiler has arrived: the generated {@code __construct} is
+     * package-private, so a {@code constructs} naming an imported type compiled and then failed with
+     * an {@code IllegalAccessError} when the behavior ran. Rejecting the declaration turns that into
+     * a compile error (issue #113) and is right either way, because a declaration the runtime cannot
+     * honour should not compile. Whether it should be honoured instead — by emitting a construction
+     * path the declaring module opens — is open (issue #121).
+     *
+     * <p>Which module declares a name is known from the import list, so the clause is answered where
+     * it is written.
      */
     static void rejectImportedConstructs(Ast.SpecBehavior spec, Ast.Module module) {
         for (String constructed : spec.constructs()) {
@@ -380,7 +391,7 @@ public final class SpecChecker {
                                 .hint("check.constructs.imported.hint").build(),
                         "`behavior " + spec.name() + "` declares `constructs " + constructed
                                 + "`, but `" + constructed + "` is declared by `" + imp.module()
-                                + "`; construction is closed to the declaring module (ADR-0015)");
+                                + "`; a behavior constructs only what its own module declares");
             }
         }
     }

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -217,7 +217,7 @@ check.typearg.set=`Set` needs a type argument, e.g. `Set<String>`.
 check.typearg.option=`Option` needs a type argument.
 check.typearg.map=`Map` needs a value type, e.g. `Map<String, Int>`.
 check.constructs.imported=`{0}` declares `constructs {1}`, but `{1}` is declared by `{2}`.
-check.constructs.imported.hint=Construction is closed to the module that declares a type. Read the imported type and declare your own for what this behavior produces, or have `{2}` expose a behavior that builds it.
+check.constructs.imported.hint=A behavior constructs only what its own module declares. Read the imported type and declare your own for what this behavior produces, or have `{2}` expose a behavior that builds it.
 check.map.key.field=`{0}` crosses the boundary, so the Map it holds must be keyed by String, a String-backed newtype (`data X = String`), Date or DateTime, but is keyed by {1}.
 check.map.key.field.hint=A Map is a JSON object, whose keys are strings. Inside a behavior body a Map may be keyed by any value.
 check.map.key.param=Parameter `{0}` carries a Map keyed by {1}, which cannot cross the boundary.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -216,7 +216,7 @@ check.typearg.set=`Set` には型引数が必要です（例: `Set<String>`）�
 check.typearg.option=`Option` には型引数が必要です。
 check.typearg.map=`Map` には値の型が必要です（例: `Map<String, Int>`）。
 check.constructs.imported=`{0}` が `constructs {1}` を宣言していますが、`{1}` を宣言しているのは `{2}` です。
-check.constructs.imported.hint=型の構築はそれを宣言したモジュールに閉じています。import した型は読むだけにして、この behavior が生み出すものは自分のモジュールで宣言してください。あるいは `{2}` 側に、それを構築する behavior を用意してください。
+check.constructs.imported.hint=behavior が構築できるのは自分のモジュールが宣言した型だけです。import した型は読むだけにして、この behavior が生み出すものは自分のモジュールで宣言してください。あるいは `{2}` 側に、それを構築する behavior を用意してください。
 check.map.key.field=`{0}` は境界を越えるので、持っている Map のキーは String・String ベースの newtype（`data X = String`）・Date・DateTime のいずれかでなければなりませんが、{1} です。
 check.map.key.field.hint=Map の外部表現は JSON オブジェクトで、そのキーは文字列です。behavior の本体内であれば Map のキーは任意の値でかまいません。
 check.map.key.param=引数 `{0}` が持つ Map のキーが {1} で、境界を越えられません。


### PR DESCRIPTION
Groundwork for the module-system design review. No behaviour changes; what changes is what the reasoning says, and one wrong citation that I put there.

## Two rules that were being treated as one

**(a) Construction goes through declared paths.** ADR-0002. Settled — but the *reason* was never written, so it could not be told apart from an oversight.

The ML family makes opacity a per-type choice the author writes. Verified against the sources rather than recalled:

| | how a type hides its constructors |
|---|---|
| Elm | in the `exposing` list — `module Dict exposing ( Dict, … )` hides them, `module Maybe exposing ( Maybe(..), … )` shows them |
| F# | a `.fsi` signature; a union or record "must expose either all or none of their fields and constructors" |
| OCaml | an `.mli` signature that omits the representation |

Souther offers no such choice, and the reason is the invariant — which none of those languages attaches to a type. Here the constructor is the one place an invariant runs, so a type that hands one out has an advisory invariant, and "a validated email address is guaranteed to be validated by its type" stops holding for the whole language rather than for that type. What an F# programmer writes by convention for exactly this reason — `type X = private ...` with a smart constructor returning a `Result` — is what Souther makes the only way.

ADR-0002 now says that, with the sources.

**(b) Those paths must be in the type's own module.** No ADR says this, and this PR stops pretending one does.

## The citation I got wrong

#113's diagnostic read `construction is closed to the declaring module (ADR-0015)`. ADR-0015 is about *field reads*; its "construction is closed" means closed to ADR-0002's paths, not closed to a module. Neither ADR restricts construction by module — ADR-0002 says "a behavior whose construction set includes T", with no module qualifier.

I wrote that citation two days after writing ADR-0057, whose entire point was that a JVM claim had been standing in for a reason. Same failure, same week. It is removed from the diagnostic, its javadoc, the message catalog and the example's comment; each now states what is true — a behavior constructs only what its own module declares — without claiming a decision behind it.

**The check stays.** A declaration the runtime cannot honour should not compile, whichever way (b) is later decided.

## What is now open

#121 asks whether (b) should be a rule or should be lifted. Package-private `__construct` is a codegen choice, not a constraint, and (b) has a cost once a domain is split into contexts: a downstream context cannot originate a value in an upstream vocabulary — in `examples/ordering`, `returns` cannot state a refund as billing's `Amount`. The suggested escape ("have the declaring module expose a behavior that builds it") is the shape ADR-0005 rules out for getters, so (b) may have no sanctioned escape at all.

## Verification

```
mvn clean install -DskipTests && mvn test      # syntax 25, compiler 1065, LSP 66
mvn -f examples/pom.xml clean test             # all example projects
```

Both green. No test changed, because no behaviour did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
