### PR TITLE
Look for a constant's invariant check under the module that declares the type

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -156,7 +156,8 @@ public final class Compiler {
         for (DataChecker.ConstCheck c : checks) {
             boolean holds;
             try {
-                Class<?> ctfe = Class.forName(module.name() + "." + c.typeName() + "$Ctfe", true, loader);
+                Class<?> ctfe = Class.forName(
+                        c.type().module() + "." + c.type().name() + "$Ctfe", true, loader);
                 holds = (boolean) ctfe.getMethod("check", paramClass(c.value())).invoke(null, c.value());
             } catch (ReflectiveOperationException | LinkageError _) {
                 continue;   // cannot evaluate at compile time; the run-time check still applies

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -26,8 +26,11 @@ public final class DataChecker {
 
     private DataChecker() {}
 
-    /** A constant newtype construction to verify after codegen: its wrapped constant and its site. */
-    public record ConstCheck(String typeName, Object value, SourcePos pos) {}
+    /** A constant newtype construction to verify after codegen: its wrapped constant and its site.
+     * {@code type} says which module declared it — the check runs that module's generated class, not
+     * one named after the module the construction is written in. {@code typeName} is what was
+     * written, which is what the message quotes. */
+    public record ConstCheck(String typeName, TypeName type, Object value, SourcePos pos) {}
 
     /**
      * Every {@code 金額(constant)} in the module: a newtype construction whose argument folds to a
@@ -45,7 +48,8 @@ public final class DataChecker {
     private static void collectConstChecks(Ast.Expr e, Symbols symbols, List<ConstCheck> out) {
         if (e instanceof Ast.NewData nd && symbols.declaration(nd.typeName()) instanceof Ast.Data nt
                 && nt.newtype() && isInvariantBearing(nd.typeName(), symbols)) {
-            CallElaborator.newtypeConstantArg(nd).ifPresent(v -> out.add(new ConstCheck(nd.typeName(), v, nd.pos())));
+            CallElaborator.newtypeConstantArg(nd).ifPresent(v ->
+                    out.add(new ConstCheck(nd.typeName(), symbols.resolve(nd.typeName()), v, nd.pos())));
         }
         TypeChecker.forEachChild(e, c -> collectConstChecks(c, symbols, out));
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileConstructsImportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileConstructsImportedTest.java
@@ -106,6 +106,43 @@ class CompileConstructsImportedTest {
         assertTrue(aborted.getMessage().contains("Amount"), aborted.getMessage());
     }
 
+    /** A constant argument is checked where it is written, whichever module declared the type: the
+     * verdict a local newtype gets at compile time is the verdict an imported one gets. The
+     * invariant here is one only the compile-time evaluation can decide — an interval invariant
+     * would be settled earlier, by the discharge analysis, and say nothing about this path. */
+    @Test
+    void aConstantViolatingAnImportedInvariantIsACompileError() {
+        String up = """
+                module up exposing ( Email )
+                import String ( contains )
+                data Email = String
+                    invariant contains("@", value)
+                """;
+
+        Compiler.compileModules(List.of(up, """
+                module down
+                import up ( Email )
+
+                data Req = { n: Int }
+
+                behavior mint : (r: Req) -> Email constructs Email
+                let mint (r) = Email("a@b.com")
+                """));
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(up, """
+                        module down
+                        import up ( Email )
+
+                        data Req = { n: Int }
+
+                        behavior mint : (r: Req) -> Email constructs Email
+                        let mint (r) = Email("nope")
+                        """)));
+
+        assertTrue(e.getMessage().contains("Email"), e.getMessage());
+    }
+
     /** A type its module keeps to itself has no entry to build with. A value of it still arrives —
      * through a field of a data that module does expose — and reading it is all this module can do. */
     @Test


### PR DESCRIPTION
Fixes the silent skip described in #132.

`verifyConstConstructions` built the CTFE class name from the module the construction is written in (`Compiler.java:159`), and `DataChecker.ConstCheck` carried only the written type name. A constant construction of a newtype imported from another module looked for `<consuming module>.<Type>$Ctfe`, which does not exist; the `ClassNotFoundException` was swallowed by the catch that exists for invariants which genuinely cannot be evaluated at compile time, so the construction fell through to the run-time check with nothing said.

`ConstCheck` now carries the resolved `TypeName` alongside the written name, and the lookup uses the declaring module.

The regression test uses a `contains` invariant. An interval invariant such as `value >= 0` is settled earlier by the discharge analysis, which reports it and never reaches this path, so it would pass whether or not the bug is fixed.

`mvn clean test`: 1205 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
