### PR TITLE
Say the module is missing, rather than the type it would have brought

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -104,7 +104,9 @@ public final class Compiler {
                     "an `examples for " + raw.exampleFileTarget() + "` file has no target module to attach to");
         }
         rejectReservedNamespace(raw);
-        Ast.Module module = Deriver.derive(Exposing.rewrite(raw));
+        Ast.Module exposed = Exposing.rewrite(raw);
+        rejectUserImports(exposed);
+        Ast.Module module = Deriver.derive(exposed);
         module = HelperInliner.forModule(module).withInlinedInvariants(module);
         module = NewtypeDesugar.rewrite(module, TypeChecker.symbols(module));
         module = Compiler.injectRecursivePrelude(module);
@@ -181,6 +183,25 @@ public final class Compiler {
             return boolean.class;
         }
         return v.getClass();   // String, BigDecimal
+    }
+
+    /**
+     * Rejects any import left after {@link Exposing#rewrite} — the standard-library lines are gone by
+     * then, so what remains names another module, and this path compiles one module alone. Without
+     * this the import is dropped and the failure surfaces later as a naming error on the first use of
+     * the imported type, which points at the wrong line and says the wrong thing.
+     */
+    private static void rejectUserImports(Ast.Module m) {
+        if (!m.imports().isEmpty()) {
+            throw unknownModule(m.imports().get(0));
+        }
+    }
+
+    private static CompileException unknownModule(Ast.Import imp) {
+        return CompileException.of(
+                Diagnostic.of(null, "check.import.unknownmodule").title("check.module.title")
+                        .at(imp.pos()).args(imp.module()).build(),
+                "unknown module `" + imp.module() + "`");
     }
 
     /** The namespace the compiler ships (souther.string/list/map/bool); a user module may not
@@ -852,10 +873,7 @@ public final class Compiler {
         for (Ast.Import imp : m.imports()) {
             Ast.Module src = registry.get(imp.module());
             if (src == null) {
-                throw CompileException.of(
-                        Diagnostic.of(null, "check.import.unknownmodule").title("check.module.title")
-                                .at(imp.pos()).args(imp.module()).build(),
-                        "unknown module `" + imp.module() + "`");
+                throw unknownModule(imp);
             }
             if (imp.alias() != null) {
                 checkAlias(imp, aliases, registry);

--- a/souther-compiler/src/test/java/souther/compiler/CompileModuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileModuleTest.java
@@ -75,4 +75,28 @@ class CompileModuleTest {
                 () -> Compiler.compileModules(List.of(a, b)));
         assertEquals("E1501", e.code());
     }
+
+    /** One module on its own has nothing to import from, so the import line is what is wrong. Left
+     * to fall through, the name would go missing and the report would land on its first use. */
+    @Test
+    void anImportInASingleSourceNamesAModuleThatIsNotThere() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module app.order
+                import shared.money ( Amount )
+                data Order = { total: Amount }
+                """));
+        assertTrue(e.getMessage().contains("shared.money"), e.getMessage());
+        assertTrue(e.getMessage().contains("unknown module"), e.getMessage());
+    }
+
+    /** A standard-library import is not a module import: it is stripped before that check. */
+    @Test
+    void aStandardLibraryImportInASingleSourceStillCompiles() {
+        Compiler.compile("""
+                module app.order
+                import String ( length )
+                data Code = String
+                    invariant length(value) > 0
+                """);
+    }
 }


### PR DESCRIPTION
The "cheap partial win" from #128, which stands on its own.

Compiling one source on its own (`Compiler.compile(String)`) dropped any module import, so the failure surfaced later as a naming error on the first use of the imported type:

```
-- NAMING ERROR ------------------------------order.sou:3:23
3| data Order = { total: Amount }
                         ^^^^^^
I cannot find a type named `Amount`.
```

The type is fine; there is nowhere for it to come from. `Exposing.rewrite` strips the standard-library import lines, so anything left after it names another module, and this path has no other module. It now reports the same `unknown module` the linking path reports, at the import line. The two call sites build that diagnostic through one method.

`mvn clean test`: 1207 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
