### PR TITLE
Point the published POM and the security contact at the new home

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ security fixes.
 ## Reporting a vulnerability
 
 Please report a suspected vulnerability privately through GitHub's
-[private vulnerability reporting](https://github.com/kawasima/souther/security/advisories/new)
+[private vulnerability reporting](https://github.com/souther-lang/souther/security/advisories/new)
 (the repository's **Security** tab → **Report a vulnerability**). Do not open a public
 issue for a suspected vulnerability.
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <name>Souther</name>
     <description>Souther: a JVM language that turns SMDD spec models into implementation models.</description>
-    <url>https://github.com/kawasima/souther</url>
+    <url>https://github.com/souther-lang/souther</url>
 
     <licenses>
         <license>
@@ -39,9 +39,9 @@
     </modules>
 
     <scm>
-        <connection>scm:git:https://github.com/kawasima/souther.git</connection>
-        <developerConnection>scm:git:git@github.com:kawasima/souther.git</developerConnection>
-        <url>https://github.com/kawasima/souther</url>
+        <connection>scm:git:https://github.com/souther-lang/souther.git</connection>
+        <developerConnection>scm:git:git@github.com:souther-lang/souther.git</developerConnection>
+        <url>https://github.com/souther-lang/souther</url>
         <tag>HEAD</tag>
     </scm>
 


### PR DESCRIPTION
The repository moved to `souther-lang/souther`. GitHub redirects the old URLs, so nothing breaks — but two of the four references are not just links.

`pom.xml`: `<url>` and the three `<scm>` entries are published in the POM to Maven Central, where they are what a reader follows back to the source and what the Portal checks. These need to be right before the next `-Prelease deploy`.

`SECURITY.md`: where to report a vulnerability privately. Not a place to leave a redirect standing in for an address.

## What is deliberately unchanged

`<developers>` still points at `github.com/kawasima` — that is a person, not the repository. Same for the copyright line in the README.

The coordinates do not move. The groupId has been `org.souther-lang` since #68, so the Central namespace is verified by domain and does not care where the repository lives. Had it been `io.github.kawasima`, this move would have invalidated it.

`examples/README.md` and `examples/joboffer/pom.xml` mention `kawasima/validation-modeling`, which is a different repository and is not moving. The `kawasima` in the compiler tests and in `examples/issuetracker` is a person's name in a fixture.

## The release path is untouched

No workflow hardcodes the owner, and no workflow reads a secret at all — signing and publishing are done by hand from a local checkout, not by CI. So the move carries no credential with it and none has to be re-added. The Central account's credentials live in `~/.m2/settings.xml` and are per-account, not per-repository.

`softprops/action-gh-release` in `release.yml` uses the repository it runs in, so it follows the move on its own.

The one thing worth looking at in the org's settings is branch protection on `main` and `develop`, which is a repository setting rather than a secret.

`mvn clean test`: 1248 tests, all green; version consistency passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
