### PR TITLE
Make a nested sum a subtype of the sum it is a case of

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -152,6 +152,14 @@ final class ValueClassGen {
         }
         out.put(pkg + "." + sum.name(), build(cdX, cb -> {
             cb.withFlags(pub(sum.name()) | ClassFile.ACC_INTERFACE | ClassFile.ACC_ABSTRACT);
+            // A sum may itself be a case of another sum (spec 8.3), and then it carries that sum's
+            // interface as a product or unit case does. Only the direct link is recorded, which is
+            // all that is needed: interface inheritance carries it the rest of the way, so a leaf of
+            // this sum is a value of the outer one without being named there.
+            ClassDesc[] ifaces = caseInterfaces(sum.name());
+            if (ifaces.length > 0) {
+                cb.withInterfaceSymbols(ifaces);
+            }
             cb.with(PermittedSubclassesAttribute.ofSymbols(caseCds));
             sum.decoder().ifPresent(disc -> {
                 codec.emitCodecFactory(cb, "decoder", CD_RDecoder, cd(sum.name() + "$Dec"), CodecGen.decoderSig(cdX, true));

--- a/souther-compiler/src/test/java/souther/compiler/CompileNestedSumTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNestedSumTest.java
@@ -3,26 +3,28 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A sum may have a sum as a case — spec 8.3's 費用負担区分 = 自社負担 | 先方負担, where 自社負担 is
- * itself 立替 | 仮払い | 会社カード. The derived codecs used to reject that: a case had to be a
- * product or a unit, so the spec's own model would not compile.
+ * A sum may have a sum as a case — spec 8.3's model of who bears a cost, where the company's own
+ * share is itself one of three ways of paying. The derived codecs used to reject that: a case had to
+ * be a product or a unit, so the spec's own model would not compile.
  */
 class CompileNestedSumTest {
 
     private static final String MODULE = """
             module demo
 
-            data 立替
-            data 仮払い
-            data 会社カード
-            data 先方負担
-            data 自社負担     = 立替 | 仮払い | 会社カード
-            data 費用負担区分 = 自社負担 | 先方負担
+            data Reimbursement
+            data Advance
+            data CorporateCard
+            data Counterparty
+            data OwnCompany = Reimbursement | Advance | CorporateCard
+            data CostBearer = OwnCompany | Counterparty
             """;
 
     private BytesClassLoader loader() {
@@ -32,44 +34,119 @@ class CompileNestedSumTest {
     /**
      * The derived codec dispatches over the leaves, so a nested case is tagged directly. Tagging
      * the direct case instead put two levels on one "type" key: the encoder wrote
-     * {@code {type: 自社負担}}, which lost the leaf and which the decoder then rejected.
+     * {@code {type: OwnCompany}}, which lost the leaf and which the decoder then rejected.
      */
     @Test
     void aLeafOfANestedSumIsTaggedDirectly() throws Exception {
         BytesClassLoader loader = loader();
-        Object v = Codecs.decoded(loader, "demo.費用負担区分", Map.of("type", "立替"));
-        assertInstanceOf(loader.loadClass("demo.立替"), v);
+        Object v = Codecs.decoded(loader, "demo.CostBearer", Map.of("type", "Reimbursement"));
+        assertInstanceOf(loader.loadClass("demo.Reimbursement"), v);
     }
 
     @Test
     void aNestedSumRoundTrips() throws Exception {
         BytesClassLoader loader = loader();
 
-        java.lang.reflect.Constructor<?> c = loader.loadClass("demo.仮払い").getDeclaredConstructors()[0];
+        java.lang.reflect.Constructor<?> c = loader.loadClass("demo.Advance").getDeclaredConstructors()[0];
         c.setAccessible(true);
-        Object 仮払い = c.newInstance();
+        Object advance = c.newInstance();
 
-        Object back = Codecs.decoded(loader, "demo.費用負担区分", Codecs.encode(loader, "demo.費用負担区分", 仮払い));
-        assertInstanceOf(loader.loadClass("demo.仮払い"), back, "decode(encode(v)) == v (spec 11.3)");
+        Object back = Codecs.decoded(loader, "demo.CostBearer",
+                Codecs.encode(loader, "demo.CostBearer", advance));
+        assertInstanceOf(loader.loadClass("demo.Advance"), back, "decode(encode(v)) == v (spec 11.3)");
     }
 
     @Test
     void aDirectCaseOfTheOuterSumStillDecodes() throws Exception {
         BytesClassLoader loader = loader();
-        Object v = Codecs.decoded(loader, "demo.費用負担区分", Map.of("type", "先方負担"));
-        assertInstanceOf(loader.loadClass("demo.先方負担"), v);
+        Object v = Codecs.decoded(loader, "demo.CostBearer", Map.of("type", "Counterparty"));
+        assertInstanceOf(loader.loadClass("demo.Counterparty"), v);
+    }
+
+    /**
+     * The nested sum is a case of the outer one, so its class carries the outer interface — and by
+     * inheritance so does every leaf under it. Without that the two halves of the model disagree:
+     * the checker folds a nested sum to its leaves and accepts a {@code Reimbursement} where a
+     * {@code CostBearer} is expected, the derived codec dispatches over those same leaves, and the
+     * JVM then holds a {@code Reimbursement} that is not a {@code CostBearer} (issue #143).
+     */
+    @Test
+    void aNestedSumIsASubtypeOfTheSumItIsACaseOf() throws Exception {
+        BytesClassLoader loader = loader();
+        Class<?> outer = loader.loadClass("demo.CostBearer");
+
+        assertTrue(outer.isAssignableFrom(loader.loadClass("demo.OwnCompany")),
+                "the nested sum implements the sum that names it as a case");
+        assertTrue(outer.isAssignableFrom(loader.loadClass("demo.Reimbursement")),
+                "and so a leaf under it is one too");
+        assertEquals(Set.of(loader.loadClass("demo.OwnCompany"), loader.loadClass("demo.Counterparty")),
+                Set.of(outer.getPermittedSubclasses()),
+                "a Java switch over the outer sum can name both of its cases");
+    }
+
+    /**
+     * What the sealed hierarchy is for: a Java {@code switch} over the outer sum names its two cases
+     * and nothing else, and a leaf of the nested one arrives at the nested arm. javac accepted the
+     * source before the fix too — one interface type is never provably unrelated to another, and
+     * exhaustiveness is read off the permits list, which already named both — but no leaf could be
+     * handed to it, which is where it went wrong.
+     */
+    @Test
+    void aLeafReachesTheNestedArmOfAJavaSwitch() throws Exception {
+        Map<String, byte[]> classes = new java.util.HashMap<>(Compiler.compile(MODULE));
+        classes.put("demo.ReadBearer", Subclasses.compile(classes, "demo.ReadBearer", """
+                package demo;
+                public final class ReadBearer {
+                    public static String name(CostBearer v) {
+                        return switch (v) {
+                            case OwnCompany own -> "own";
+                            case Counterparty other -> "other";
+                        };
+                    }
+                }
+                """));
+        BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
+
+        java.lang.reflect.Constructor<?> c = loader.loadClass("demo.Reimbursement")
+                .getDeclaredConstructors()[0];
+        c.setAccessible(true);
+
+        assertEquals("own", loader.loadClass("demo.ReadBearer")
+                .getMethod("name", loader.loadClass("demo.CostBearer"))
+                .invoke(null, c.newInstance()));
+    }
+
+    /**
+     * The round trip the mismatch broke: a field typed as the outer sum puts a checkcast on the
+     * decoder's own output, so the encoder wrote a value its decoder could not read back.
+     */
+    @Test
+    void aFieldTypedAsTheOuterSumReadsBackWhatItWrote() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(MODULE + """
+                data Expense = { bearer: CostBearer }
+                """), getClass().getClassLoader());
+
+        Object written = Codecs.decoded(loader, "demo.Expense",
+                Map.of("bearer", Map.of("type", "Reimbursement")));
+
+        assertInstanceOf(loader.loadClass("demo.Expense"), written);
+        assertEquals(Map.of("bearer", Map.of("type", "Reimbursement")),
+                Codecs.encode(loader, "demo.Expense", written));
     }
 
     @Test
     void theOuterAndInnerSumAgreeOnTheTag() throws Exception {
         BytesClassLoader loader = loader();
 
-        java.lang.reflect.Constructor<?> c = loader.loadClass("demo.立替").getDeclaredConstructors()[0];
+        java.lang.reflect.Constructor<?> c = loader.loadClass("demo.Reimbursement")
+                .getDeclaredConstructors()[0];
         c.setAccessible(true);
-        Object 立替 = c.newInstance();
+        Object reimbursement = c.newInstance();
 
-        assertEquals("立替", ((Map<?, ?>) Codecs.encode(loader, "demo.費用負担区分", 立替)).get("type"));
-        assertEquals("立替", ((Map<?, ?>) Codecs.encode(loader, "demo.自社負担", 立替)).get("type"),
+        assertEquals("Reimbursement",
+                ((Map<?, ?>) Codecs.encode(loader, "demo.CostBearer", reimbursement)).get("type"));
+        assertEquals("Reimbursement",
+                ((Map<?, ?>) Codecs.encode(loader, "demo.OwnCompany", reimbursement)).get("type"),
                 "both levels tag the leaf, so a value encoded at one decodes at the other");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileSpecChapter23Test.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSpecChapter23Test.java
@@ -15,6 +15,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * a {@code List} of a sum could not derive an encoder, {@code ==} between two data was rejected,
  * and a sum with a sum as a case was refused — so the language's own worked example was not a
  * program. Kept verbatim from the spec so drift shows up here.
+ *
+ * <p>It is also where non-ASCII identifiers stay covered. A Souther name may be written in any
+ * script and the backend has to bring it to a JVM class name, so the fixtures elsewhere being
+ * English would otherwise leave that path untested. Keep this one as it is written.
  */
 class CompileSpecChapter23Test {
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -2253,6 +2253,8 @@ A single-value newtype over an ordered type implements `+Comparable+` against it
 
 Generated as a sealed interface and final implementation classes. If a case is a named data, its final class implements the sealed interface. A unit data is generated as a field-less final class (or singleton).
 
+A case may itself be a sum (<<sum-data>>), and then its interface extends the outer one. Only that one step is emitted: interface inheritance carries the rest, so a leaf is a value of every sum above it without being named in any of them. The relation has to exist because the rest of the language already reads it that way — the checker folds a nested sum to its leaves to judge a case, and the derived codec dispatches over those same leaves, so a decoder hands back a leaf where the outer sum is what was asked for.
+
 [#jvm-codec]
 === Decoder / Encoder
 


### PR DESCRIPTION
Fixes the round trip in #143 — a value the derived encoder wrote could not be read back by the derived decoder, out as a `ClassCastException` from generated bytecode rather than any diagnostic.

## What was wrong

`ValueClassGen.generateData` and `generateUnit` both take `caseInterfaces(name)` and hand it to `withInterfaceSymbols`. `generateSum` sets the flags, the permitted subclasses and the codec factories, and never did — so a sum that is itself a case of another sum carried no supertype:

```
先方負担 implements 費用負担区分     // a direct case, so it carries the interface
自社負担                            // implements nothing
立替     implements 自社負担         // and so is unrelated to 費用負担区分
```

Everything else already assumes that relation. `TypeOps.sumCases` folds a nested sum to its leaves, so the checker accepts a leaf where the outer sum is expected (ADR-0013). `Deriver.leafCases` folds the same way, so the encoder writes the leaf tag and the decoder returns the leaf. Put that leaf in a record whose field is typed as the outer sum and the decoder's own output meets a checkcast that fails.

There was a second consequence at the boundary: the outer sum's `PermittedSubclasses` named a class that was not a subtype, so a Java `switch` over it could be handed no leaf.

## The fix

`generateSum` carries the interfaces the other two generators carry. Only the direct case → sum link is recorded and only that is emitted; interface inheritance carries the rest, so a leaf is a value of every sum above it without being named in any of them.

A sum whose case comes from another module is refused before codegen (checked), so nothing here reaches into a class another module generated and ADR-0057 stands.

## Tests

Three, in `CompileNestedSumTest`: the subtype relation and the permits list, a field typed as the outer sum reading back what it wrote, and a leaf arriving at the nested arm of a Java `switch`.

That third one first only compiled the Java source, and passed without the fix — javac never rejects one interface type as a case label for another, and reads exhaustiveness off the permits list, which already named both cases. It now passes a leaf through the switch, which fails without the fix with `argument type mismatch`.

The spec's `jvm-sum` gains a paragraph.

## While here

The model in `CompileNestedSumTest` is now written in English (`CostBearer = OwnCompany | Counterparty`, leaves `Reimbursement` / `Advance` / `CorporateCard`), the examples having moved to their own repository. The non-ASCII identifiers a Souther name may be written with stay covered by `CompileSpecChapter23Test`, whose javadoc now says that is part of its job.

`mvn clean test`: souther-runtime 37, souther-compiler 1035, souther-lsp/cli 66, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
