### PR TITLE
Declare a unit by naming it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/frontend/CstFrontend.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/CstFrontend.java
@@ -32,7 +32,7 @@ public final class CstFrontend {
         if (!result.errors().isEmpty()) {
             throw firstError(source, result.errors().get(0));
         }
-        return AstBuilder.build(result.root(), source, defaultModuleName);
+        return ImplicitUnits.expand(AstBuilder.build(result.root(), source, defaultModuleName));
     }
 
     /** As {@link #parse(String, String)} with the default module name {@code Main}. */
@@ -57,7 +57,8 @@ public final class CstFrontend {
         if (!result.errors().isEmpty()) {
             throw firstError(source, result.errors().get(0));
         }
-        Ast.Module module = AstBuilder.build(result.root(), source, defaultModuleName);
+        Ast.Module module = ImplicitUnits.expand(
+                AstBuilder.build(result.root(), source, defaultModuleName));
         String header = "module " + module.name();   // a source with no header is named for its file
         List<String> imports = new ArrayList<>();
         Map<String, String> defs = new LinkedHashMap<>();
@@ -72,6 +73,11 @@ public final class CstFrontend {
                 case FN_DEF -> fns.put(AstBuilder.firstIdentText(n), n.text().strip());
                 default -> { /* examples and fakes are not declarations to publish */ }
             }
+        }
+        // a unit only named (spec 8.4) has no slice of its own; what it declares is its name, so
+        // that is what an importing project reads back
+        for (Ast.Def def : module.defs()) {
+            defs.computeIfAbsent(def.name(), name -> "data " + name);
         }
         return new Parsed(module, new Slices(header, imports, defs, behaviors, fns));
     }

--- a/souther-compiler/src/main/java/souther/compiler/frontend/ImplicitUnits.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/ImplicitUnits.java
@@ -1,0 +1,110 @@
+package souther.compiler.frontend;
+
+import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.SourcePos;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Declares the unit data a module only names. A name written where a module introduces a type — a
+ * sum's case list, a behavior's output, a composition's declared output — and declared nowhere is a
+ * data with no fields, and the name alone is its declaration (spec 8.4). Without this,
+ * {@code data Terms = Net15 | Net30} needed a {@code data Net15} line that repeated the name and
+ * said nothing else.
+ *
+ * <p>Everywhere else a type is referred to, not introduced: a parameter type, a field's type,
+ * {@code constructs}, {@code requires}, a match arm, a decoder variant. A name unknown there is
+ * still unknown, and reported as before.
+ *
+ * <p>Whether a name is declared is answered inside the module: its own definitions and the names its
+ * imports list. A sum's case is module-local anyway (E1606), so nothing on the class path can
+ * change the answer. A qualified name ({@code inventory.在庫不足}) refers to another module by
+ * writing it, so it is never introduced here.
+ */
+public final class ImplicitUnits {
+
+    private ImplicitUnits() {
+    }
+
+    /** Names that mean something without a declaration: the primitives and library namespaces, the
+     * runtime's arithmetic failure cases, and Option's two cases (which a module may not declare). */
+    private static final Set<String> BUILT_IN = builtIn();
+
+    private static Set<String> builtIn() {
+        Set<String> names = new HashSet<>(Prelude.qualifiers());
+        names.add("Raw");
+        names.add("DivisionByZero");
+        names.add("NotANumber");
+        names.add("Some");
+        names.add("None");
+        return names;
+    }
+
+    /** {@code module} with a unit data added for each name it introduces and does not declare. */
+    public static Ast.Module expand(Ast.Module module) {
+        Set<String> declared = new HashSet<>();
+        for (Ast.Def def : module.defs()) {
+            declared.add(def.name());
+        }
+        for (Ast.Import imp : module.imports()) {
+            declared.addAll(imp.names());
+        }
+
+        Map<String, Ast.UnitData> added = new LinkedHashMap<>();
+        for (Ast.Def def : module.defs()) {
+            if (def instanceof Ast.SumData sum) {
+                // a case list carries names, not type nodes, so the sum's own position is the unit's
+                for (String caseName : sum.cases()) {
+                    introduce(caseName, sum.pos(), declared, added);
+                }
+            }
+        }
+        for (Ast.BehaviorDef behavior : module.behaviors()) {
+            switch (behavior) {
+                case Ast.SpecBehavior spec -> introduceAll(spec.ret(), declared, added);
+                case Ast.PipeBehavior pipe -> introduceAll(pipe.declaredOut(), declared, added);
+            }
+        }
+        for (Ast.RetType output : module.exposedOutputs().values()) {
+            introduceAll(output, declared, added);
+        }
+
+        if (added.isEmpty()) {
+            return module;
+        }
+        List<Ast.Def> defs = new ArrayList<>(module.defs());
+        defs.addAll(added.values());
+        return new Ast.Module(module.name(), module.exposing(), module.exposedOutputs(),
+                module.imports(), defs, module.behaviors(), module.fns(), module.examples(),
+                module.fakes(), module.exampleFileTarget(), module.pos());
+    }
+
+    private static void introduceAll(Ast.RetType output, Set<String> declared,
+                                     Map<String, Ast.UnitData> added) {
+        if (output == null) {
+            return;
+        }
+        for (Ast.TypeRef ref : output.cases()) {
+            if (ref.arg() == null && ref.tupleElems() == null) {
+                introduce(ref.name(), ref.pos(), declared, added);
+            }
+        }
+    }
+
+    private static void introduce(String name, SourcePos pos,
+                                  Set<String> declared, Map<String, Ast.UnitData> added) {
+        if (declared.contains(name) || added.containsKey(name)
+                || name.indexOf('.') >= 0                  // qualified: another module declares it
+                || name.startsWith("'")                    // a type variable, written in the core
+                || BUILT_IN.contains(name)) {
+            return;
+        }
+        added.put(name, new Ast.UnitData(name, pos));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileImplicitUnitDataTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImplicitUnitDataTest.java
@@ -1,0 +1,182 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A case name written where a module introduces a type — a sum's case list, a behavior's output —
+ * needs no separate {@code data} declaration when it carries no fields: the name alone declares the
+ * unit (spec 8.4). Before this, {@code data Terms = Net15 | Net30} demanded a {@code data Net15}
+ * line that repeated the name and said nothing else.
+ *
+ * <p>Everywhere else a type is referred to rather than introduced, and an unknown name there is
+ * still unknown.
+ */
+class CompileImplicitUnitDataTest {
+
+    private BytesClassLoader loader(String source) {
+        return new BytesClassLoader(Compiler.compile(source), getClass().getClassLoader());
+    }
+
+    @Test
+    void anUndeclaredCaseOfASumIsAUnitData() throws Exception {
+        BytesClassLoader loader = loader("""
+                module demo
+
+                data Terms = Net15 | Net30 | EndOfNextMonth
+                """);
+
+        Object v = Codecs.decoded(loader, "demo.Terms", Map.of("type", "Net30"));
+        assertInstanceOf(loader.loadClass("demo.Net30"), v);
+    }
+
+    @Test
+    void anUndeclaredCaseOfABehaviorOutputIsAUnitData() throws Exception {
+        BytesClassLoader loader = loader("""
+                module demo
+
+                data Cart = { n: Int }
+                data Priced = { total: Int }
+
+                behavior quote : (c: Cart) -> Priced | EmptyCart
+                    constructs Priced, EmptyCart
+
+                let quote (c) = {
+                    require c.n >= 1 else EmptyCart
+                    Priced { total = c.n }
+                }
+                """);
+
+        Object cart = Codecs.decoded(loader, "demo.Cart", Map.of("n", 0L));
+        Object behavior = loader.loadClass("demo.Quote$Impl").getConstructor().newInstance();
+        Object out = behavior.getClass().getMethod("apply", Object.class).invoke(behavior, cart);
+
+        assertInstanceOf(loader.loadClass("demo.EmptyCart"), out);
+    }
+
+    /** A single output type is an output all the same: a behavior whose result carries nothing
+     * declares that result by naming it. */
+    @Test
+    void anUndeclaredSingleOutputTypeIsAUnitData() throws Exception {
+        BytesClassLoader loader = loader("""
+                module demo
+
+                data Cart = { n: Int }
+
+                behavior close : (c: Cart) -> Closed constructs Closed
+                let close (c) = Closed
+                """);
+
+        Object cart = Codecs.decoded(loader, "demo.Cart", Map.of("n", 1L));
+        Object behavior = loader.loadClass("demo.Close$Impl").getConstructor().newInstance();
+        Object out = behavior.getClass().getMethod("apply", Object.class).invoke(behavior, cart);
+
+        assertInstanceOf(loader.loadClass("demo.Closed"), out);
+    }
+
+    /** A composition produces what its stages produce, so a name only it declares is a case nothing
+     * can return. Reading it as a unit is what lets the mismatch be reported (E1604) rather than the
+     * name being called unknown. */
+    @Test
+    void aCaseOnlyAnExposedCompositionNamesIsAMismatch() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo exposing ( process : Doubled | Refused )
+
+                data Amount = Int
+                data Doubled = Int
+
+                behavior guard : (a: Amount) -> Amount
+                let guard (a) = a
+
+                behavior toDoubled : (a: Amount) -> Doubled constructs Doubled
+                let toDoubled (a) = Doubled { value = a.value }
+
+                behavior process = guard >-> toDoubled
+                """));
+
+        assertEquals("E1604", e.code());
+    }
+
+    @Test
+    void anUndeclaredParameterTypeIsStillUnknown() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data Out = { n: Int }
+
+                behavior f : (c: Basket) -> Out constructs Out
+                let f (c) = Out { n = 1 }
+                """));
+
+        assertTrue(e.getMessage().contains("Basket"), e.getMessage());
+    }
+
+    @Test
+    void anUndeclaredNameInConstructsIsStillUnknown() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data Cart = { n: Int }
+                data Out = { n: Int }
+
+                behavior f : (c: Cart) -> Out constructs Out, Refused
+                let f (c) = Out { n = 1 }
+                """));
+
+        assertTrue(e.getMessage().contains("Refused"), e.getMessage());
+    }
+
+    /** A qualified name says which module declares it, so it is a reference wherever it is written. */
+    @Test
+    void anUnresolvedQualifiedOutputCaseIsStillUnknown() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of("""
+                        module up exposing ( Amount )
+                        data Amount = Int
+                        """, """
+                        module down
+                        import up ( Amount )
+
+                        data Out = { n: Int }
+
+                        behavior f : (a: up.Amount) -> Out | up.Refused constructs Out
+                        let f (a) = Out { n = a.value }
+                        """)));
+
+        assertTrue(e.getMessage().contains("Refused"), e.getMessage());
+    }
+
+    /** An imported name is declared — by the module it came from. Introducing one here would give a
+     * second type of the same name, and the value would be of the wrong one. */
+    @Test
+    void anImportedUnitIsNotDeclaredAgainHere() throws Exception {
+        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+                module up exposing ( Done )
+                data Done
+                """, """
+                module down
+                import up ( Done )
+
+                data Cart = { n: Int }
+
+                behavior finish : (c: Cart) -> Done constructs Done
+                let finish (c) = Done
+                """));
+
+        BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
+        Object cart = Codecs.decoded(loader, "down.Cart", Map.of("n", 1L));
+        Object behavior = loader.loadClass("down.Finish$Impl").getConstructor().newInstance();
+        Object out = behavior.getClass().getMethod("apply", Object.class).invoke(behavior, cart);
+
+        assertEquals("up.Done", out.getClass().getName());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CrossProjectImportTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CrossProjectImportTest.java
@@ -206,4 +206,31 @@ class CrossProjectImportTest {
                     | "an amount becomes an order" : (Amount(5)) -> Order { total = Amount(5) }
                 """), published(LIBRARY));
     }
+
+    /** A unit the library only named in a sum (spec 8.4) is one of its declarations like any other,
+     * so it is published on its class and read back here — the consumer builds it by name. */
+    @Test
+    void aUnitOnlyNamedByASumIsPublishedToo() throws Exception {
+        ModulePath path = published("""
+                module shared.terms exposing ( Terms, Net30 )
+                data Terms = Net15 | Net30
+                """);
+
+        Map<String, byte[]> app = Compiler.compileModules(List.of("""
+                module app.billing
+                import shared.terms ( Terms, Net30 )
+                data Req = { n: Int }
+                behavior pick : (r: Req) -> Terms constructs Net30
+                let pick (r) = Net30
+                """), path);
+
+        Map<String, byte[]> both = new LinkedHashMap<>(app);
+        both.put("shared.terms.Terms", path.bytes("shared.terms.Terms"));
+        both.put("shared.terms.Net30", path.bytes("shared.terms.Net30"));
+        BytesClassLoader loader = new BytesClassLoader(both, getClass().getClassLoader());
+        Object impl = loader.loadClass("app.billing.Pick$Impl").getDeclaredConstructor().newInstance();
+
+        Object out = Codecs.apply(impl, Codecs.decoded(loader, "app.billing.Req", Map.of("n", 1L)));
+        assertEquals("shared.terms.Net30", out.getClass().getName());
+    }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -37,11 +37,11 @@ Each construct of the spec DSL maps to Souther as follows.
 |===
 | Spec DSL | Souther
 
-| `+data 金額 = 整数 // 0以上+` | `+data 金額 = Int  invariant value >= 0+` (newtype; <<newtype>>)
+| `+data 金額 = 整数 // 0以上+` | `+data Amount = Int  invariant value >= 0+` (newtype; <<newtype>>)
 
 | `+data X = A OR B+` (A, B are named data) | `+data X = A \| B+` (sum; cases are existing named data)
 
-| `+data 立替 = 単位型+` | `+data 立替+` (data with no fields)
+| `+data 立替 = 単位型+` | `+data Reimbursement+` (data with no fields; a case named in a sum or a behavior output needs no declaration, <<unit-data>>)
 
 | `+data X = A AND b+` (A is a record, b is an added item) | `+data X = { ...A, b: B }+` (field composition)
 
@@ -49,7 +49,7 @@ Each construct of the spec DSL maps to Souther as follows.
 
 | `+behavior f = In -> Out+` (Out has multiple success states) | `+behavior f : (...) -> Out1 \| Out2+` (bare sum)
 
-| `+behavior f = In -> Out OR 失敗+` | `+behavior f : (...) -> Out \| 失敗+` (a failure is just data; departure from the mainline is decided by composition)
+| `+behavior f = In -> Out OR 失敗+` | `+behavior f : (...) -> Out \| Rejected+` (a failure is just data; departure from the mainline is decided by composition)
 
 | `+f >-> g+` | `+f >-> g+`
 
@@ -650,24 +650,24 @@ The spec DSL's `+OR+` maps to a sum. *A case MAY reference an already-defined na
 [,text]
 ----
 // spec DSL: data 出張申請 = 申請準備中 OR 提出済み OR 事前承認待ち OR 事前承認済み
-data 出張申請 =
-    申請準備中
-  | 提出済み
-  | 事前承認待ち
-  | 事前承認済み
+data BusinessTrip =
+    Drafting
+  | Submitted
+  | AwaitingPreapproval
+  | Preapproved
 ----
 
 Nested sums MAY be written directly.
 
 [,text]
 ----
-data 費用負担区分 = 自社負担 | 先方負担
-data 自社負担     = 立替 | 仮払い | 会社カード
+data CostBearer = OwnCompany | Counterparty
+data OwnCompany = Reimbursement | Advance | CorporateCard
 ----
 
-A case is always a reference to a separately declared named data. An inline record MUST NOT be written in a case position. The spec DSL is the same: a case is always declared separately (for `+data 役職 = 管理職 OR 一般社員+`, `+data 管理職 = レベル+` / `+data 一般社員 = 単位型+`).
+A case names a data; an inline record MUST NOT be written in a case position. A case that carries fields is declared separately, as the spec DSL declares it (for `+data 役職 = 管理職 OR 一般社員+`, `+data Manager = { level: Level }+`). A case declared nowhere carries no fields, and the case list is its declaration (<<unit-data>>).
 
-*A case value is a value of its sum.* As in functional languages, a value of a case type (e.g. `+提出済み+`) may be used transparently wherever its sum type (`+出張申請+`) is expected — field assignment, argument, or return value. Only the upward direction (case→sum) is allowed; the downward direction (sum→specific case) requires `+match+`. A nested sum (`+data 自社負担 = 立替 | 仮払い+` being a case of `+費用負担区分+`) is decided the same way, folding to the leaf case.
+*A case value is a value of its sum.* As in functional languages, a value of a case type (e.g. `+Submitted+`) may be used transparently wherever its sum type (`+BusinessTrip+`) is expected — field assignment, argument, or return value. Only the upward direction (case→sum) is allowed; the downward direction (sum→specific case) requires `+match+`. A nested sum (`+data OwnCompany = Reimbursement | Advance+` being a case of `+CostBearer+`) is decided the same way, folding to the leaf case.
 
 [#unit-data]
 === Unit data
@@ -677,14 +677,31 @@ A data with no fields is declared with no body. It corresponds to the spec DSL's
 [,text]
 ----
 // spec DSL: data 立替 = 単位型
-data 立替
-data 仮払い
-data 会社カード
-data 先方負担
-data 一般社員
+data Reimbursement
+data Advance
+data CorporateCard
+data Counterparty
+data Staff
 ----
 
-Unit data appear frequently as sum cases (such as `+一般社員+` in `+data 役職 = 管理職 | 一般社員+`).
+Unit data appear frequently as sum cases (such as `+Staff+` in `+data Role = Manager | Staff+`).
+
+A unit written where a module *introduces* a type needs no declaration of its own: the name alone declares it. Three positions introduce a type — a sum's case list (<<sum-data>>), a behavior's output (<<behavior-io>>), and the output declared for a `+>->+` composition, written either on the composition or in `+exposing+` (<<declared-composition-output>>).
+
+[,text]
+----
+data CostBearer = OwnCompany | Counterparty
+data OwnCompany = Reimbursement | Advance | CorporateCard
+// Reimbursement, Advance, CorporateCard and Counterparty are units; nothing else declares them
+
+behavior quote : (c: Cart) -> PricedCart | EmptyCart     // EmptyCart is a unit
+----
+
+Everywhere else a type is *referred to*, and a name nothing declares is unknown there and reported: a parameter type, a field's type, `+constructs+`, `+requires+`, a `+match+` arm, a codec variant, a `+let+`'s declared return type.
+
+Whether a name is declared is answered within the module — its own declarations and the names its `+import+` lines list. A qualified name (`+inventory.InsufficientStock+`) names another module's declaration, so it is a reference wherever it is written. A sum's case is module-local in any event (<<e1606>>).
+
+The explicit declaration stays available, and is how a case that carries a comment of its own is written.
 
 A unit data MUST NOT carry an `+invariant+`: it has no field for one to observe and no value it could reject (<<invariant-declaration>>). Writing one is a compile error rather than a clause with no effect. A data written with an empty body (`+data T = { }+`) is a product with no fields, not a unit, and its `+invariant+` is checked as any other product's is.
 
@@ -693,10 +710,10 @@ A unit data value is constructed by *writing the name directly* (as a zero-argum
 [,text]
 ----
 // construct a unit in an implementation (let). Requires the behavior's constructs (§2.1, §12.3)
-[先方費用負担 | 費用負担が先方]     // 先方費用負担 is a unit, constructed by name alone
+[CounterpartyBorne | bearer == Counterparty]     // CounterpartyBorne is a unit, constructed by name alone
 ----
 
-This is a guard comprehension (<<stdlib-list>>): it yields one `+先方費用負担+` if the condition holds, an empty list otherwise.
+This is a guard comprehension (<<stdlib-list>>): it yields one `+CounterpartyBorne+` if the condition holds, an empty list otherwise.
 
 A bare identifier in an expression resolves as: a variable if a bound local exists; otherwise a built-in value (such as `+None+`; <<algebraic-types>>); otherwise the construction of a unit data of the same name; otherwise undefined. Souther does not distinguish identifiers syntactically by case (so that Japanese business vocabulary can be used as identifiers), so this resolution is done in the symbol table.
 


### PR DESCRIPTION
`data Terms = Net15 | Net30 | EndOfNextMonth` did not compile without a `data Net15` line above it that repeated the name and said nothing else. In souther-examples, 30 of the 49 field-less data are that repetition.

A name written where a module **introduces** a type, and declared nowhere, is now a unit data — the name alone declares it. Three positions introduce a type:

- a sum's case list, `data Terms = Net15 | Net30`
- a behavior's output, `behavior quote : (c: Cart) -> PricedCart | EmptyCart` (a single output type included)
- the output declared for a `>->` composition, on the composition or in `exposing`

Everywhere else a type is referred to rather than introduced — a parameter type, a field's type, `constructs`, `requires`, a match arm, a codec variant, a `let`'s declared return type — and a name nothing declares is still unknown there.

Whether a name is declared is answered inside the module: its own definitions and the names its imports list. A sum's case is module-local anyway (E1606), so nothing on the class path changes the answer, and a qualified name refers to another module by writing it.

The cost is that a mistyped case name is a new unit rather than an error at the sum, as it is in Elm and F#. It surfaces where the case is used: a `match` arm naming the intended case is not a case of the sum, and an output union a behavior cannot produce is E1604.

## Notes

- The pass runs in `CstFrontend`, the one place every entry builds its AST.
- A unit only named has no source slice, so `data <name>` is filed as its declaration. Without it the module metadata carries a null and another project cannot import the type; `CrossProjectImportTest` covers the jar round trip.
- Introducing at a composition's declared output turns `unknown type Refused` into E1604 — a composition returns what its stages return, so a case only the signature names is a mismatch, and E1604 says that.

## Spec

`<<sum-data>>` no longer says a case is always a reference to a separately declared data; `<<unit-data>>` states the introduction and reference positions. Identifiers in the sections touched are now English (`BusinessTrip`, `CostBearer`, `OwnCompany`, `Reimbursement`); the `// spec DSL:` lines quote the book and stay Japanese.

## Testing

`mvn clean test` — compiler 1056, LSP 66, BUILD SUCCESS. `CompileImplicitUnitDataTest` is new (8 tests); each of the four behaviour-changing ones was watched failing first, for its own reason (`unknown case Net15`, `unknown type EmptyCart`, `unknown type Closed`, E1604 reported as null).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
