### PR TITLE
Wrap a collection in a newtype

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -833,7 +833,11 @@ public final class ExampleVerifier {
                 && c.args().get(0) instanceof Ast.StringLit lit) {
             return CallElaborator.parseTemporal(base, lit.value(), c.pos());
         }
-        return adjacentlyTagged(c.fn(), raw(c.args().get(0)));
+        // the argument is shaped against what the newtype wraps, the same way a record fixture
+        // shapes a field's value: a `Map` newtype's entry pairs become a map, a `Set` newtype's
+        // written list stays a list for its decoder to dedupe
+        return adjacentlyTagged(c.fn(),
+                shaped(raw(c.args().get(0)), shapeOf(newtypeBaseType(c.fn()))));
     }
 
     /**
@@ -980,8 +984,15 @@ public final class ExampleVerifier {
 
     /** The type a newtype wraps ({@code Date} for {@code data 貸出日 = Date}), or null. */
     private String newtypeBase(String name) {
+        Ast.TypeRef base = newtypeBaseType(name);
+        return base == null ? null : base.name();
+    }
+
+    /** The written form of what a newtype wraps, kept whole so a generic base
+     * ({@code data 在庫 = Map<商品ID, Int>}) keeps its type arguments. */
+    private Ast.TypeRef newtypeBaseType(String name) {
         return symbols.declaration(name) instanceof Ast.Data d && d.newtype() && d.fields().size() == 1
-                ? d.fields().get(0).type().name()
+                ? d.fields().get(0).type()
                 : null;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -325,6 +325,20 @@ public final class DataChecker {
                                   Map<String, Type> recursiveHelperFns) {
         Map<String, Type> fields = TypeOps.fieldTypes(ctx.data(), ctx.symbols());
 
+        // A newtype wraps one value and takes its representation, so there is nothing for it to be
+        // when the value is absent. Whether a value is present is a property of the place it is
+        // used, written there as `f: X?`. Read on the resolved type, so a data the author happens
+        // to have named `Option` is an ordinary named data here.
+        if (ctx.data().newtype() && fields.get("value") instanceof Type.OptionOf o) {
+            throw CompileException.of(
+                    Diagnostic.of(null, "check.newtype.optional").title("check.boundary.title")
+                            .at(fieldRegion(ctx.data(), "value"))
+                            .args(ctx.data().name(), Type.show(o.element()))
+                            .hint("check.newtype.optional.hint", ctx.data().name()).build(),
+                    "newtype `" + ctx.data().name() + "` cannot wrap an optional; write the `?` where"
+                            + " the value is used, on the field");
+        }
+
         for (Map.Entry<String, Type> e : fields.entrySet()) {
             if (SpecChecker.containsTuple(e.getValue())) {
                 throw CompileException.of(

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -166,13 +166,14 @@ public final class Deriver {
             Ast.Expr access = new Ast.FieldAccess(new Ast.Var("self", pos), single.getKey(), pos);
             return new Ast.EncoderDef("self", primRaw(single.getValue(), access, pos), pos);
         }
-        // a newtype over a non-primitive Y encodes self.value via Y's encoder — Y's representation,
-        // not `{value: ...}` (spec 8.7)
+        // a newtype over a non-primitive Y encodes self.value as Y writes itself — Y's
+        // representation, not `{value: ...}` (spec 8.7). Y is a named data, a sum, or a collection,
+        // so this is the same choice a field of type Y makes.
         if (d.newtype() && !isCase) {
             Map.Entry<String, Type> only = fields.entrySet().iterator().next();
             Ast.Expr access = new Ast.FieldAccess(new Ast.Var("self", pos), only.getKey(), pos);
-            String inner = ((Type.Ref) only.getValue()).name().qualified();
-            return new Ast.EncoderDef("self", new Ast.EncodeRaw(inner, access, pos), pos);
+            return new Ast.EncoderDef("self",
+                    rawForAccess(only.getValue(), access, d, only.getKey(), pos), pos);
         }
         List<Ast.RawEntry> entries = new ArrayList<>();
         for (Map.Entry<String, Type> f : fields.entrySet()) {
@@ -247,7 +248,7 @@ public final class Deriver {
         if (mo.key() == Type.STRING || mo.key() == Type.DATE || mo.key() == Type.DATETIME) {
             return new Ast.PrimDecRef(primKind(mo.key()), pos);
         }
-        throw noCodec(mo.key(), d, field, pos);
+        throw badMapKey(mo.key(), d, field, pos);
     }
 
     private static Ast.EncElem mapKeyEnc(Type.MapOf mo, Ast.Data d, String field, SourcePos pos) {
@@ -257,7 +258,30 @@ public final class Deriver {
         if (mo.key() == Type.STRING || mo.key() == Type.DATE || mo.key() == Type.DATETIME) {
             return new Ast.PrimEnc(primKind(mo.key()), pos);
         }
-        throw noCodec(mo.key(), d, field, pos);
+        throw badMapKey(mo.key(), d, field, pos);
+    }
+
+    /**
+     * A key that cannot key a JSON object. Derivation runs ahead of the checker that makes the same
+     * judgement on a data's fields, so it reports the same way rather than as a codec that gave up:
+     * the reader has to change the key type either way, and being told twice in two vocabularies
+     * helps nobody.
+     */
+    private static CompileException badMapKey(Type key, Ast.Data d, String field, SourcePos pos) {
+        return CompileException.of(
+                Diagnostic.of(null, "check.map.key.field").title("check.boundary.title")
+                        .at(pos).args(where(d, field), Type.show(key))
+                        .hint("check.map.key.field.hint").build(),
+                "a Map crossing the boundary at `" + where(d, field) + "` must be keyed by String, a"
+                        + " String-backed newtype (`data X = String`), Date or DateTime, got "
+                        + Type.show(key));
+    }
+
+    /** How to name the place a boundary complaint belongs to. A newtype's single field is implicit —
+     * the author wrote {@code data X = Y}, never a field called {@code value} — so it is named by
+     * the type alone. */
+    private static String where(Ast.Data d, String field) {
+        return d.newtype() ? d.name() : d.name() + "." + field;
     }
 
     /** The encoder for one element of a collection. A collection may hold a collection
@@ -293,15 +317,15 @@ public final class Deriver {
         if (t instanceof Type.TupleOf) {
             return CompileException.of(
                     Diagnostic.of(null, "check.derive.tuplefield").title("check.boundary.title")
-                            .at(pos).args(d.name(), field, Type.show(t)).build(),
-                    "field `" + field + "` of `" + d.name() + "` is " + Type.show(t) + ": a tuple has"
+                            .at(pos).args(where(d, field), Type.show(t)).build(),
+                    "`" + where(d, field) + "` is " + Type.show(t) + ": a tuple has"
                             + " no external representation, so no codec can be derived (ADR-0036)."
                             + " Use a named data.");
         }
         return CompileException.of(
                 Diagnostic.of(null, "check.derive.nocodec").title("check.boundary.title")
-                        .at(pos).args(d.name(), field, Type.show(t)).build(),
-                "no codec can be derived for field `" + field + "` of `" + d.name() + "`: "
+                        .at(pos).args(where(d, field), Type.show(t)).build(),
+                "no codec can be derived for `" + where(d, field) + "`: "
                         + Type.show(t) + " has no external representation");
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -238,9 +238,12 @@ public final class AstBuilder {
         }
         Optional<SyntaxNode> newtype = n.child(SyntaxKind.NEWTYPE_BODY);
         if (newtype.isPresent()) {
-            SyntaxToken inner = identTokens(newtype.get()).get(0);
-            Ast.TypeRef innerType = new Ast.TypeRef(inner.text(), null, posOf(inner));
-            List<Ast.Field> fields = List.of(new Ast.Field("value", innerType, posOf(inner)));
+            SyntaxNode inner = typeChild(newtype.get());
+            Ast.TypeRef innerType = typeRef(inner);
+            if (newtype.get().token(SyntaxKind.QUESTION).isPresent()) {
+                innerType = new Ast.TypeRef("Option", innerType, innerType.pos());   // `Y?` → Option<Y>
+            }
+            List<Ast.Field> fields = List.of(new Ast.Field("value", innerType, pos(inner)));
             return new Ast.Data(name, true, List.of(), fields, invariant,
                     Optional.empty(), Optional.empty(), pos);
         }

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -339,8 +339,10 @@ check.fn.annotation=The binding `{0}` is a function, and a function type may be 
 check.fn.annotation.hint=Remove the annotation.
 check.behavior.collision.data=behavior `{0}`''s first letter is capitalized to form the JVM class `{1}` (spec 19.5), which collides with data `{1}`; rename one so their class names differ.
 check.behavior.collision.behavior=behaviors `{0}` and `{1}` both capitalize to the same JVM class `{2}` (spec 19.5); rename one so their class names differ.
-check.derive.tuplefield=Field `{1}` of `{0}` is {2}: a tuple has no external representation, so no codec can be derived. Use a named data.
-check.derive.nocodec=No codec can be derived for field `{1}` of `{0}`: {2} has no external representation.
+check.derive.tuplefield=`{0}` is {1}: a tuple has no external representation, so no codec can be derived. Use a named data.
+check.derive.nocodec=No codec can be derived for `{0}`: {1} has no external representation.
+check.newtype.optional=`{0}` wraps `{1}?`, but a newtype wraps one value and takes its representation, so there is nothing for it to be when the value is absent.
+check.newtype.optional.hint=Wrap the value itself (`data {0} = ...`) and write the `?` where it is used, on the field.
 
 # --- syntax errors (lexer / parser) ---
 parse.title=SYNTAX ERROR
@@ -372,6 +374,9 @@ parse.block.noresult=A block ends in one expression, which is its value; this on
 parse.orpattern=An or-pattern binds the sum type and cannot destructure a case's fields.
 parse.option.positional=Option's wrapped value is bound positionally: write `| Some v`, not `| Some as v`.
 parse.case.record.direct=A record's fields are destructured directly: write `| Some { field }`, not `| Some(Type { field })`. The parens open a newtype.
+parse.newtype.tuple=A newtype takes the external representation of what it wraps, and a tuple has none. Wrap a named data instead.
+parse.newtype.fntype=A newtype takes the external representation of what it wraps, and a function has none.
+parse.sum.case.generic=A sum's cases are references to declared named data, so a case is never a generic type. Declare a data for it and name that.
 
 # --- examples (E1901-E1907) ---
 check.example.title=EXAMPLE

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -338,8 +338,10 @@ check.fn.annotation=束縛 `{0}` は関数です。関数型はヘルパの引�
 check.fn.annotation.hint=型注釈を外してください。
 check.behavior.collision.data=behavior `{0}` は先頭が大文字化され JVM クラス `{1}` になり（spec 19.5）、data `{1}` と衝突します。クラス名が異なるよう、どちらかをリネームしてください。
 check.behavior.collision.behavior=behavior `{0}` と `{1}` はどちらも先頭大文字化で同じ JVM クラス `{2}` になります（spec 19.5）。クラス名が異なるよう、どちらかをリネームしてください。
-check.derive.tuplefield=`{0}` のフィールド `{1}` は {2} です。タプルは外部表現を持たず codec を導出できません。名前付き data を使ってください。
-check.derive.nocodec=`{0}` のフィールド `{1}` の codec を導出できません。{2} は外部表現を持ちません。
+check.derive.tuplefield=`{0}` は {1} です。タプルは外部表現を持たず codec を導出できません。名前付き data を使ってください。
+check.derive.nocodec=`{0}` の codec を導出できません。{1} は外部表現を持ちません。
+check.newtype.optional=`{0}` は `{1}?` を包んでいますが、newtype が包むのは1つの値でその外部表現をそのまま受け取るため、値が無いときに何を表すかがありません。
+check.newtype.optional.hint=値そのものを包み（`data {0} = ...`）、`?` は使う側のフィールドに書いてください。
 
 # --- 構文エラー（レキサ／パーサ） ---
 parse.title=構文エラー
@@ -371,6 +373,9 @@ parse.block.noresult=ブロックは最後に値となる式を1つ置きます�
 parse.orpattern=or パターンは直和型を束縛するため、ケースのフィールドを分解できません。
 parse.option.positional=Option の中身は位置で束縛します。`| Some as v` ではなく `| Some v` と書きます。
 parse.case.record.direct=レコードのフィールドは直接分解します。`| Some(型 { field })` ではなく `| Some { field }` と書いてください。括弧は newtype を開く形です。
+parse.newtype.tuple=newtype は包んだ型の外部表現をそのまま受け取りますが、タプルには外部表現がありません。名前付きの data を包んでください。
+parse.newtype.fntype=newtype は包んだ型の外部表現をそのまま受け取りますが、関数には外部表現がありません。
+parse.sum.case.generic=sum のケースは宣言済みの名前付き data への参照なので、総称型がケースになることはありません。data を宣言してその名前を書いてください。
 
 # --- examples (E1901-E1907) ---
 check.example.title=example

--- a/souther-compiler/src/test/java/souther/compiler/CompileDeriveDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDeriveDiagnosticTest.java
@@ -17,7 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * A field the boundary cannot represent is reported on the field, in the type the author wrote.
  * The report used to name the codec that gave up ("cannot derive a list-element encoder for
  * ListOf[element=Ref[name=IssueId]]"), print the internal type, and point at the data's first line,
- * which says nothing about which of a dozen fields is the problem.
+ * which says nothing about which of a dozen fields is the problem. The place is named the way the
+ * boundary's other complaints name it, {@code データ.フィールド} — a newtype, whose single field is
+ * implicit, is named by the type alone.
  */
 class CompileDeriveDiagnosticTest {
 
@@ -40,14 +42,14 @@ class CompileDeriveDiagnosticTest {
         assertEquals(4, d.pos().line());
         String out = new HumanRenderer(false).render(d, new SourceContext("demo.sou", src),
                 Locale.ENGLISH);
-        assertTrue(out.contains("`entries`"), out);
+        assertTrue(out.contains("`集計.entries`"), out);
         assertTrue(out.contains("Map<String, (String, Int)>"), out);
         assertTrue(out.contains("Use a named data"), out);
 
         // the same three parts in Japanese: a locale must not lose the field or the type
         String ja = new HumanRenderer(false).render(d, new SourceContext("demo.sou", src),
                 Locale.JAPANESE);
-        assertTrue(ja.contains("フィールド `entries`"), ja);
+        assertTrue(ja.contains("`集計.entries`"), ja);
         assertTrue(ja.contains("Map<String, (String, Int)>"), ja);
     }
 
@@ -65,7 +67,7 @@ class CompileDeriveDiagnosticTest {
         assertEquals(4, d.pos().line());
         String out = new HumanRenderer(false).render(d, new SourceContext("demo.sou", src),
                 Locale.ENGLISH);
-        assertTrue(out.contains("`where`"), out);
+        assertTrue(out.contains("`座席.where`"), out);
         assertTrue(out.contains("(Int, Int)"), out);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileNewtypeCollectionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNewtypeCollectionTest.java
@@ -1,0 +1,253 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A newtype may wrap a collection: {@code data Tags = List<String>}. The base is written the way a
+ * type is written anywhere else, and the newtype keeps the bare external representation of what it
+ * wraps — a JSON array, not {@code {"value": [...]}}. A base with no external representation (a
+ * tuple, a function type, an optional) is refused where it is written.
+ */
+class CompileNewtypeCollectionTest {
+
+    private BytesClassLoader load(String src) {
+        return new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+    }
+
+    private Object apply(BytesClassLoader loader, String cls, Object in) throws Exception {
+        Object b = loader.loadClass("demo." + cls + "$Impl").getConstructor().newInstance();
+        return Codecs.apply(b, in);
+    }
+
+    @Test
+    void listNewtypeRoundTripsBare() throws Exception {
+        BytesClassLoader loader = load("""
+                module demo
+                data Tags = List<String>
+                """);
+
+        Object v = Codecs.decoded(loader, "demo.Tags", List.of("a", "b"));
+        assertEquals("demo.Tags", v.getClass().getName());
+        assertEquals(List.of("a", "b"), Codecs.encode(loader, "demo.Tags", v),
+                "the newtype reads and writes the list's representation, not `{value: [...]}`");
+    }
+
+    @Test
+    void setNewtypeRoundTripsBare() throws Exception {
+        BytesClassLoader loader = load("""
+                module demo
+                data Labels = Set<String>
+                """);
+
+        Object v = Codecs.decoded(loader, "demo.Labels", List.of("a", "b", "a"));
+        Object out = Codecs.encode(loader, "demo.Labels", v);
+        // a set crosses as a JSON array, so the encoded form is a list; only its membership is fixed
+        assertEquals(Set.of("a", "b"), Set.copyOf((List<?>) out));
+        assertEquals(2, ((List<?>) out).size(), "the duplicate is dropped on the way in");
+    }
+
+    @Test
+    void mapNewtypeRoundTripsBare() throws Exception {
+        BytesClassLoader loader = load("""
+                module demo
+                data Stock = Map<String, Int>
+                """);
+
+        Object v = Codecs.decoded(loader, "demo.Stock", Map.of("a", 3L));
+        assertEquals(Map.of("a", 3L), Codecs.encode(loader, "demo.Stock", v));
+    }
+
+    @Test
+    void newtypeOverAListOfNamedData() throws Exception {
+        // the element carries its own codec, so the newtype writes an array of the element's objects
+        BytesClassLoader loader = load("""
+                module demo
+                data Line = { sku: String, qty: Int }
+                data Lines = List<Line>
+                """);
+
+        Object v = Codecs.decoded(loader, "demo.Lines", List.of(Map.of("sku", "s-1", "qty", 2L)));
+        assertEquals(List.of(Map.of("sku", "s-1", "qty", 2L)), Codecs.encode(loader, "demo.Lines", v));
+    }
+
+    @Test
+    void collectionNewtypeCarriesAnInvariant() throws Exception {
+        BytesClassLoader loader = load("""
+                module demo
+                import List ( isEmpty )
+                data Tags = List<String>
+                    invariant isEmpty(value) == false
+                """);
+
+        assertEquals(List.of("a"), Codecs.encode(loader, "demo.Tags",
+                Codecs.decoded(loader, "demo.Tags", List.of("a"))));
+        assertEquals("Err", Codecs.decode(loader, "demo.Tags", List.of()).getClass().getSimpleName(),
+                "an empty list breaks the invariant, so the decode fails at the boundary");
+    }
+
+    @Test
+    void valueOpensTheWrappedCollection() throws Exception {
+        BytesClassLoader loader = load("""
+                module demo
+                import List ( length )
+                data Tags = List<String>
+
+                behavior countTags : (t: Tags) -> Int
+                let countTags (t) = length(t.value)
+                """);
+
+        assertEquals(2L, apply(loader, "CountTags", Codecs.decoded(loader, "demo.Tags", List.of("a", "b"))));
+    }
+
+    @Test
+    void aCollectionNewtypeIsAMatchableSumCase() throws Exception {
+        // a sum case may be a newtype over a collection, and the constructor pattern opens it
+        BytesClassLoader loader = load("""
+                module demo
+                import List ( length )
+                data Tags = List<String>
+                data Untagged
+                data Labelling = Tags | Untagged
+
+                behavior countTags : (l: Labelling) -> Int
+                let countTags (l) = match l with
+                    | Tags(xs) -> length(xs)
+                    | Untagged -> 0
+                """);
+
+        Object tagged = Codecs.decoded(loader, "demo.Labelling",
+                Map.of("type", "Tags", "value", List.of("a", "b")));
+        assertEquals(2L, apply(loader, "CountTags", tagged));
+        assertEquals(0L, apply(loader, "CountTags",
+                Codecs.decoded(loader, "demo.Labelling", Map.of("type", "Untagged"))));
+    }
+
+    @Test
+    void aCollectionNewtypeIsNotOrdered() {
+        // ordering needs an ordered base; a list is not one, so `<` has nothing to compare
+        String src = """
+                module demo
+                data Tags = List<String>
+
+                behavior before : (a: Tags, b: Tags) -> Bool
+                let before (a, b) = a < b
+                """;
+        assertThrows(CompileException.class, () -> Compiler.compile(src));
+    }
+
+    @Test
+    void aTupleBaseIsRejected() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Pair = (String, Int)
+                """));
+        assertEquals("parse.newtype.tuple", e.diagnostic().messageKey(), e.getMessage());
+    }
+
+    @Test
+    void aFunctionTypeBaseIsRejected() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Rule = (String) -> Bool
+                """));
+        assertEquals("parse.newtype.fntype", e.diagnostic().messageKey(), e.getMessage());
+    }
+
+    @Test
+    void anOptionBaseIsRejected() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Note = Option<String>
+                """));
+        assertEquals("check.newtype.optional", e.diagnostic().messageKey(), e.getMessage());
+    }
+
+    @Test
+    void anOptionalMarkOnTheBaseIsRejected() {
+        // `?` says the use site may omit the value; it is written on the field, not on the type
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Note = String?
+                """));
+        assertEquals("check.newtype.optional", e.diagnostic().messageKey(), e.getMessage());
+    }
+
+    @Test
+    void theOptionalComplaintNamesTheNewtypeAndPointsAtTheField() {
+        // both spellings reach the same report, because it is read off the resolved type rather
+        // than off the word that was written
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Note = String?
+                """));
+        assertTrue(e.getMessage().contains("Note"), e.getMessage());
+        assertFalse(e.getMessage().contains("`value`") || e.getMessage().contains("Note.value"),
+                "the author never wrote a field called `value`: " + e.getMessage());
+    }
+
+    @Test
+    void aGenericSumCaseIsRejected() {
+        // a sum case is a reference to a declared named data, so it is never a generic type
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data B
+                data X = List<String> | B
+                """));
+        assertEquals("parse.sum.case.generic", e.diagnostic().messageKey(), e.getMessage());
+    }
+
+    @Test
+    void aMapNewtypeKeyedOffTheBoundaryIsRejected() {
+        // a JSON object's keys are strings, so an Int-keyed map cannot cross as itself
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Stock = Map<Int, Int>
+                """));
+        assertEquals("check.map.key.field", e.diagnostic().messageKey(), e.getMessage());
+        assertTrue(e.getMessage().contains("`Stock`") && !e.getMessage().contains("Stock.value"),
+                "the complaint names the newtype, not a field the author never wrote: " + e.getMessage());
+    }
+
+    @Test
+    void anExampleFixtureConstructsAListNewtype() {
+        // the fixture is written as the constructor applied to the collection literal
+        Compiler.compile("""
+                module demo
+                import List ( length )
+                data Tags = List<String>
+
+                behavior countTags : (t: Tags) -> Int
+                let countTags (t) = length(t.value)
+
+                example countTags
+                  | (Tags(["a", "b"])) -> 2
+                """);
+    }
+
+    @Test
+    void anExampleFixtureConstructsAMapNewtype() {
+        // the argument is shaped against the newtype's own base, so a list of pairs becomes a Map
+        Compiler.compile("""
+                module demo
+                import Map ( size )
+                data Stock = Map<String, Int>
+
+                behavior lineCount : (s: Stock) -> Int
+                let lineCount (s) = size(s.value)
+
+                example lineCount
+                  | (Stock([("a", 3), ("b", 1)])) -> 2
+                """);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileQualifiedTypeRefTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQualifiedTypeRefTest.java
@@ -42,6 +42,17 @@ class CompileQualifiedTypeRefTest {
     }
 
     @Test
+    void aNewtypeWrapsAQualifiedType() {
+        // the newtype's base is written like a type anywhere else, so it reaches through a module
+        Map<String, byte[]> classes = Compiler.compileModules(List.of(A, """
+                module probe.c exposing ( Counted )
+                data Counted = probe.a.Amount
+                """));
+
+        assertTrue(classes.containsKey("probe.c.Counted"), classes.keySet().toString());
+    }
+
+    @Test
     void anImportedNameAndAQualifiedOneNameTheSameType() {
         Compiler.compileModules(List.of(A, """
                 module probe.c

--- a/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -163,6 +163,22 @@ class FormatterTest {
     }
 
     @Test
+    void formattingKeepsACollectionNewtypeBase() {
+        // the newtype body used to be one identifier, so the type arguments had nowhere to be
+        // written; dropping them would turn `List<String>` into a `List` with no element type
+        String source = "module demo\n"
+                + "data Tags = List<String>\n"
+                + "data Stock = Map<String, Int>\n"
+                + "data Labels = Set<String>\n";
+        String formatted = Formatter.format(source);
+        assertEquals(code(source), code(formatted), "the code token stream changed");
+        assertEquals(formatted, Formatter.format(formatted), "formatting is not idempotent");
+        assertTrue(formatted.contains("data Tags = List<String>"), formatted);
+        assertTrue(formatted.contains("data Stock = Map<String, Int>"), formatted);
+        assertTrue(CstParser.parse(formatted).errors().isEmpty(), "formatted output does not re-parse");
+    }
+
+    @Test
     void formattingKeepsALocalLetTypeAnnotation() {
         // the annotation is what pins an empty-collection value at the binding (issue #71); dropping it
         // would turn a compiling module into one that cannot infer the accumulator's type.

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -276,8 +276,8 @@ public final class Formatter {
         }
         var newtype = n.child(SyntaxKind.NEWTYPE_BODY);
         if (newtype.isPresent()) {
-            String inner = idents(newtype.get()).get(0).text();
-            return concat(text("data "), text(name), text(" = "), text(inner), nest(INDENT, concat(invariants)));
+            Doc inner = typeRef(typeChild(newtype.get()));
+            return concat(text("data "), text(name), text(" = "), inner, nest(INDENT, concat(invariants)));
         }
         return concat(text("data "), text(name));   // unit
     }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -355,6 +355,28 @@ class AnalyzerTest {
     }
 
     @Test
+    void renameEditsReachInsideACollectionNewtypeBase() {
+        // a newtype's base is a written type, so it may be a collection whose element names a data;
+        // renaming that data must reach the element inside `List<...>`
+        String a = "module a\n"
+                + "data Tag = { v: Int }\n"
+                + "data Tags = List<Tag>\n"
+                + "behavior f : (t: Tags) -> Tags\n"
+                + "let f (t) = t\n";
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a));
+
+        // cursor on the `data Tag` declaration (line 1, char 5)
+        java.util.Map<String, List<Range>> edits =
+                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph);
+
+        java.util.Set<Integer> lines = new java.util.HashSet<>();
+        for (Range r : edits.get("file:///a.sou")) {
+            lines.add(r.start().line());
+        }
+        assertTrue(lines.contains(2), "the element inside `List<Tag>` on line 2 is renamed: " + lines);
+    }
+
+    @Test
     void renameEditsIncludeExposingAndImportBindingSites() {
         String a = "module a exposing ( N )\ndata N = { v: Int }\n";
         String b = "module b\nimport a ( N )\nbehavior f : (n: N) -> N\nlet f (n) = n\n";

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -270,7 +270,8 @@ public final class CstParser {
         typeRef();
         eat(SyntaxKind.QUESTION);   // `Y?`, kept for the AST to read as Option<Y> and the checker to refuse
         if (at(SyntaxKind.PIPE)) {
-            error("parse.sum.case.generic", "a sum case is a declared named data");
+            error("parse.sum.case.generic",
+                    "a sum case must be a declared named data, so it cannot be a generic type");
         }
     }
 

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -238,7 +238,8 @@ public final class CstParser {
 
     /** {@code data X = A | B} is a sum; {@code data X = Y} (no {@code |}) is a newtype over Y. */
     private void sumOrNewtypeBody() {
-        // one or more names separated by `|` → sum; a lone name → newtype
+        // a sum case is always a bare, undotted, ungeneric name, so `|` at the second token is an
+        // exact test for a sum; anything else opens a newtype over a written type
         if (nth(1) == SyntaxKind.PIPE) {
             start(SyntaxKind.SUM_BODY);
             expect(SyntaxKind.IDENT);
@@ -248,8 +249,28 @@ public final class CstParser {
             finish();
         } else {
             start(SyntaxKind.NEWTYPE_BODY);
-            expect(SyntaxKind.IDENT);
+            newtypeBase();
             finish();
+        }
+    }
+
+    /** The type a newtype wraps. It is written like any other type, but it must have an external
+     * representation to hand up — the newtype takes it as its own — and it must be one type rather
+     * than a choice between several. A shape the parser can see is refused where it is written,
+     * ahead of the codec derivation that would otherwise report it as a field named {@code value};
+     * what only the resolved type tells apart is left to the checker. */
+    private void newtypeBase() {
+        if (at(SyntaxKind.LPAREN)) {
+            if (atFnTypeParams()) {
+                error("parse.newtype.fntype", "a function type cannot be a newtype's base");
+            } else {
+                error("parse.newtype.tuple", "a tuple cannot be a newtype's base");
+            }
+        }
+        typeRef();
+        eat(SyntaxKind.QUESTION);   // `Y?`, kept for the AST to read as Option<Y> and the checker to refuse
+        if (at(SyntaxKind.PIPE)) {
+            error("parse.sum.case.generic", "a sum case is a declared named data");
         }
     }
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -376,6 +376,7 @@ The full formal grammar (BNF) is deferred (<<future-work>>). The delimiters and 
 * `+?+` is a type postfix (`+従業員ID?+`) and desugars to `+Option<従業員ID>+` (<<optional>>).
 * `+.+` is field reference; `+...+` is spread (<<record-literal>>).
 * The type position admits: a named type, a stdlib generic type (such as `+List<T>+`), an anonymous output sum (`+A | B+`), and a postfix `+?+`. A function type `+(A) -> B+` is admitted only in a `+let+` argument position (<<fn-declaration>>).
+* A newtype's base (`+data X = Y+`) is a type position narrowed to what `+X+` can take as its own external representation: no tuple, no function type, and no `+?+` (<<newtype>>). A sum's cases are names of declared data, so a case is never generic: `+data X = List<A> | B+` is not a sum (<<sum-data>>, ADR-0013).
 
 [#external-representation]
 == External representation
@@ -475,6 +476,8 @@ Set<T>
 ----
 
 Collections are immutable. A `+List+` is ordered and may repeat; a `+Set+` is unordered with no duplicate elements, compared by value equality (<<primitives>>, ADR-0009); a `+Map+` is keyed by `+K+`, so a key carries its domain type (`+Map<商品ID, 在庫>+`; ADR-0040). Inside a behavior body `+K+` is any value type — `+List.groupBy+` keys by whatever the projection returns. A map that *crosses the boundary* — a data field, a behavior's input or output, at any depth — is a JSON object, whose keys are strings, so there `+K+` MUST be `+String+`, a String-backed newtype (`+data 商品ID = String+`), `+Date+` or `+DateTime+`. A newtype key is decoded into the key newtype (its invariant enforced, a bad key failing at that key's path) and encoded back bare; a temporal key is parsed from and written as its ISO 8601 form, the same representation a `+Date+` field has (`+{"2026-01-01": 300}+`). A `+Set+`'s external representation is a JSON array, deduplicated on decode (ADR-0039). An element may itself be a collection — `+Map<String, List<商品ID>>+` is what bucketing rows by a key produces (`+List.groupBy+`, <<stdlib-list>>) — and it crosses the boundary as the nested JSON its shape implies, decoded and encoded the same way at every depth.
+
+A collection MAY be what a newtype wraps (`+data タグ集合 = Set<タグ>+`, <<newtype>>), which names the collection itself and gives an invariant something to hold about it — that its elements are unique, that it is not empty. The newtype crosses the boundary as the collection's own representation, a JSON array or object, not as `+{"value": [...]}+`.
 
 Collections are *covariant* in their element. A case `+A+` may be used as its sum `+S+` (<<sum-data>>), so `+List<A>+` may be passed where `+List<S>+` is expected, `+Set<A>+` where `+Set<S>+` is expected, `+Map<String, A>+` where `+Map<String, S>+` is expected, and `+A?+` where `+S?+` is expected. This is sound because collections are immutable and there is no room to write a sibling case later. Covariance of mutable arrays (Java) is unsound because writes are a hole; that is the difference. This is the same position as Scala's immutable `+List+` and Kotlin's read-only `+List+`. Covariance applies only in the case→sum direction; sibling cases (`+A+` and `+B+`) are unrelated.
 
@@ -744,7 +747,7 @@ Structural intersection types (`+A & B+`, a type operator for "a value that is b
 [#newtype]
 === newtype (`+data X = Y+`)
 
-When the right-hand side is a single type name `+Y+`, `+X+` is a newtype wrapping `+Y+`. `+Y+` may be a primitive (`+String+` / `+Int+` / `+Date+`, etc.), a named data, or a sum. `+X+` is a distinct type from `+Y+` (nominally distinguished) with the same (bare) external representation as `+Y+`. The spec DSL's `+data X = Y+` (right-hand side a single name) is written directly.
+When the right-hand side is a single type rather than a `+{ ... }+` product or a `+|+` sum, `+X+` is a newtype wrapping that type `+Y+`. `+Y+` is written the way a type is written anywhere else: a primitive (`+String+` / `+Int+` / `+Date+`, etc.), a named data, a sum, or a collection (`+List<T>+` / `+Set<T>+` / `+Map<K, V>+`, <<collections>>), including a collection of any of these. `+X+` is a distinct type from `+Y+` (nominally distinguished) with the same (bare) external representation as `+Y+`. The spec DSL's `+data X = Y+` (right-hand side a single name) is written directly.
 
 [,text]
 ----
@@ -757,7 +760,13 @@ data 権限不足 = 役職
 
 // spec DSL: data 費用明細 = 費目 (費目 is a sum)
 data 費用明細 = 費目
+
+// a collection the domain has a name for, with an invariant on the collection itself
+data タグ集合 = Set<タグ>
+data 在庫 = Map<商品ID, Int>
 ----
+
+`+Y+` MUST have an external representation, since `+X+` takes it as its own: a tuple (<<tuple>>) and a function type (<<fn>>) are refused as a newtype's base, where they are written. `+Y+` MUST NOT be optional — neither `+data X = Y?+` nor `+data X = Option<Y>+` — because whether a value is present is a property of the place it is used, written there as `+f: X?+`. A `+Map+` that a newtype wraps crosses the boundary as a JSON object, so its key follows the same rule a field's does (<<collections>>).
 
 `+data X = Y+` is equivalent to having a single field `+value: Y+`. Construction applies the value to the type name, `+X(v)+` (`+金額(500)+`, `+会員ID("m-01")+`), equal to `+X { value = v }+`. Reference is `+x.value+`; an invariant refers to the inside as `+value+`. The difference from `+data X = { value: Y }+` (with braces) is *the external representation only*: `+data X = Y+` reads and writes `+Y+`'s representation bare (`+従業員ID+` is `+"e-01"+`), while `+data X = { value: Y }+` becomes an Object `+{"value": "e-01"}+`.
 


### PR DESCRIPTION
`data 商品ID = String` was writable and `data タグ集合 = Set<タグ>` was not. Neither the spec's `[#newtype]` enumeration nor ADR-0014 gives a reason — collections are simply absent from the list — so this removes an asymmetry the language could not explain, rather than serving a use case a product `data 袋 = { xs: List<金額> }` could not already serve. What the newtype adds over that product is the bare external representation: a JSON array, not `{"xs": [...]}`.

## What is writable now

```
data Tags   = List<String>
data 在庫    = Map<商品ID, Int>
data Lines  = List<Line>
data Counted = probe.a.Amount

data Tags = List<String>
    invariant isEmpty(value) == false
```

The invariant holds about the collection itself. `.value` opens it, a sum case that is a collection newtype destructures as `| Tags(xs)`, and an example fixture writes `Tags(["a", "b"])` or `在庫([("a", 3)])`.

## What is refused

A tuple base and a function-type base, in the parser, where they are written — a newtype takes the external representation of what it wraps, and neither has one. An optional base (`data X = Y?` and `data X = Option<Y>` alike) in the checker, on the resolved type, so the judgement does not hang on the word `Option`. And `data X = List<A> | B`, which used to fall through to top-level recovery.

## Two things this exposed

The formatter rebuilt the newtype body from its first identifier, which is an empty list once the body's child is a type node — an `IndexOutOfBoundsException` on every newtype declaration. Caught by the existing formatter tests.

A boundary complaint named ``field `value` of `X` ``, a field the author never wrote. The place is now named the way the boundary's other reports name it (`集計.entries`, or the type alone for a newtype), which also changes that wording for record fields. A map key that cannot key a JSON object now reports as the key it is, matching what `DataChecker` says about the same thing, instead of as a codec that gave up.

## Verification

`mvn clean test` — compiler 1075, LSP 67, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
