### PR TITLE
Mark the classes, not the package

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
+++ b/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
@@ -9,7 +9,6 @@ import souther.compiler.meta.ModulePath;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
-import javax.annotation.processing.FilerException;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
@@ -91,24 +90,7 @@ public final class SoutherProcessor extends AbstractProcessor {
                     : Compiler.compileModules(texts, path);
             Filer filer = processingEnv.getFiler();
             for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
-                JavaFileObject file;
-                try {
-                    file = filer.createClassFile(entry.getKey());
-                } catch (FilerException e) {
-                    // This compilation already declares that file. The only generated class a
-                    // hand-written source can collide with is the package annotations, when Java in
-                    // the same package as the module carries a package-info.java of its own. Theirs
-                    // is the declaration; ours is skipped rather than failing the build — but the
-                    // nullness the generated types would have stated is then unstated, so say so.
-                    if (entry.getKey().endsWith(".package-info")) {
-                        processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING,
-                                "souther: `" + entry.getKey() + "` is declared by this compilation,"
-                                        + " so the generated `@NullMarked` was not written; add it"
-                                        + " there to keep the module's types non-null for Kotlin");
-                        continue;
-                    }
-                    throw e;
-                }
+                JavaFileObject file = filer.createClassFile(entry.getKey());
                 try (OutputStream out = file.openOutputStream()) {
                     out.write(entry.getValue());
                 }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -21,7 +21,6 @@ import java.lang.classfile.Label;
 import java.lang.classfile.MethodSignature;
 import java.lang.classfile.attribute.PermittedSubclassesAttribute;
 import java.lang.classfile.attribute.RuntimeInvisibleAnnotationsAttribute;
-import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
 import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
@@ -189,7 +188,6 @@ public final class Backend {
             }
         });
         Map<String, byte[]> out = new LinkedHashMap<>();
-        out.put(packageInfoName(module.name()), packageInfo(module.name()));
         behaviorResults.forEach((resultName, cases) ->
                 out.put(module.name() + "." + resultName, b.generateBehaviorResult(resultName, cases)));
         for (Ast.Def def : module.defs()) {
@@ -674,34 +672,6 @@ public final class Backend {
     /** The class a module's own declarations are published on. It carries nothing but them. */
     public static String moduleClassName(String moduleName) {
         return moduleName + ".$Module";
-    }
-
-    /** The class a package's annotations ride on, named as javac names the one it compiles from
-     * {@code package-info.java}. A module is a package (a class is {@code module + "." + name}), so
-     * there is one per module. */
-    public static String packageInfoName(String moduleName) {
-        return moduleName + ".package-info";
-    }
-
-    /**
-     * Emits {@link #packageInfoName} carrying JSpecify's {@code @NullMarked}: in this package a type
-     * that says nothing about null is not null.
-     *
-     * <p>That is what the generated code already is. Absence is {@code Option} and a failure is a case
-     * of the output union (spec 7.3, 12), so no accessor, factory or codec hands back a null. Saying
-     * it here is what lets a caller's compiler know: Kotlin reads the annotation off this class and
-     * types every generated accessor as non-null instead of falling back to a platform type, where a
-     * null check is neither required nor possible. It is read by name, so neither this compiler nor
-     * anything downstream needs the JSpecify jar on its classpath.
-     *
-     * <p>The class is shaped as javac shapes the one it compiles from a {@code package-info.java} —
-     * an abstract synthetic interface declaring nothing — since that is the shape every tool that
-     * reads package annotations expects to find.
-     */
-    public static byte[] packageInfo(String moduleName) {
-        return Descriptors.build(ClassDesc.of(packageInfoName(moduleName)), cb -> cb
-                .withFlags(ClassFile.ACC_INTERFACE | ClassFile.ACC_ABSTRACT | ClassFile.ACC_SYNTHETIC)
-                .with(RuntimeVisibleAnnotationsAttribute.of(Annotation.of(CD_NullMarked))));
     }
 
     /** Emits {@link #moduleClassName}, carrying {@code declarations}. What it says is the caller's;

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
@@ -1,8 +1,10 @@
 package souther.compiler.codegen;
 
+import java.lang.classfile.Annotation;
 import java.lang.classfile.ClassBuilder;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.ClassHierarchyResolver;
+import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
 import java.lang.classfile.attribute.SourceFileAttribute;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
@@ -35,16 +37,27 @@ final class Descriptors {
             }));
 
     /**
-     * Builds a class targeting Java 25 (spec 19.1).
+     * Builds a class targeting Java 25 (spec 19.1), carrying JSpecify's {@code @NullMarked}.
      *
      * <p>The version is pinned rather than left to {@link ClassFile#of}, which defaults to the
      * JDK running the compiler: the generated code would then track whatever JDK built it, and
      * two developers on different JDKs would emit mutually incompatible artifacts.
+     *
+     * <p>The marking says that in this class a type saying nothing about null is not null — which is
+     * what the generated code already is, since absence is {@code Option} and a failure is a case of
+     * the output union (spec 7.3, 12). Saying it is what lets a caller's compiler know: Kotlin reads
+     * the annotation off the class file and types every generated accessor as non-null instead of
+     * falling back to a platform type, where a null check is neither required nor possible. It rides
+     * on each class rather than on a {@code package-info} because a module's own package is where a
+     * consumer's hand-written {@code package-info.java} lives — theirs would be the declaration, and
+     * the marking would reach only the modules that own no Java of their own (issue #150). It is read
+     * by name, so neither this compiler nor anything downstream needs the JSpecify jar.
      */
     static byte[] build(ClassDesc cd, Consumer<ClassBuilder> handler) {
         return CF.build(cd, cb -> {
             cb.withVersion(ClassFile.JAVA_25_VERSION, 0);
             cb.with(SourceFileAttribute.of(sourceFileName(cd)));
+            cb.with(RuntimeVisibleAnnotationsAttribute.of(Annotation.of(CD_NullMarked)));
             handler.accept(cb);
         });
     }
@@ -78,7 +91,7 @@ final class Descriptors {
     static final ClassDesc CD_ResultOk = CD_Result.nested("Ok");
     static final ClassDesc CD_ResultErr = CD_Result.nested("Err");
     static final ClassDesc CD_Behavior = ClassDesc.of("souther.runtime.Behavior");
-    /** JSpecify's package annotation, referenced by name: the jar is on nobody's classpath. */
+    /** JSpecify's nullness annotation, referenced by name: the jar is on nobody's classpath. */
     static final ClassDesc CD_NullMarked = ClassDesc.of("org.jspecify.annotations.NullMarked");
     static final ClassDesc CD_Fn = ClassDesc.of("souther.runtime.Fn");
     static final MethodTypeDesc MTD_Fn_apply =

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -425,36 +425,59 @@ final class ValueClassGen {
         // Public for an exposed type: a behavior of another module may declare `constructs T`
         // (ADR-0002 never restricted that to T's own module), and this is the path it takes — the one
         // that runs the invariant. A type this module keeps to itself keeps its entry package-private.
-        cb.withMethodBody("__construct", MethodTypeDesc.of(CD_Result, fieldDescs(fields)),
-                ClassFile.ACC_STATIC | ctx.pub(data.name()), code -> {
-                    BodyGen gen = new BodyGen(ctx, code, data, cdName, 0);
-                    int slot = 0;
-                    for (Map.Entry<String, Type> f : fields.entrySet()) {
-                        gen.bind(f.getKey(), slot, f.getValue());
-                        slot += width(f.getValue());
-                    }
+        cb.withMethod("__construct", MethodTypeDesc.of(CD_Result, fieldDescs(fields)),
+                ClassFile.ACC_STATIC | ctx.pub(data.name()), mb -> {
+                    mb.with(SignatureAttribute.of(
+                            MethodSignature.parseFrom(constructSignature(fields, cdName))));
+                    mb.withCode(code -> {
+                        BodyGen gen = new BodyGen(ctx, code, data, cdName, 0);
+                        int slot = 0;
+                        for (Map.Entry<String, Type> f : fields.entrySet()) {
+                            gen.bind(f.getKey(), slot, f.getValue());
+                            slot += width(f.getValue());
+                        }
 
-                    for (Ast.Expr inv : TypeOps.effectiveInvariants(data, symbols)) {
-                        gen.expr(inv);
-                        Label ok = code.newLabel();
-                        code.ifne(ok);
-                        code.loadConstant("invariant violated on " + data.name());
-                        code.invokestatic(CD_Result, "err", MTD_Result_err, true);
+                        for (Ast.Expr inv : TypeOps.effectiveInvariants(data, symbols)) {
+                            gen.expr(inv);
+                            Label ok = code.newLabel();
+                            code.ifne(ok);
+                            code.loadConstant("invariant violated on " + data.name());
+                            code.invokestatic(CD_Result, "err", MTD_Result_err, true);
+                            code.areturn();
+                            code.labelBinding(ok);
+                        }
+
+                        code.new_(cdName);
+                        code.dup();
+                        int s = 0;
+                        for (Map.Entry<String, Type> f : fields.entrySet()) {
+                            load(code, s, f.getValue());
+                            s += width(f.getValue());
+                        }
+                        code.invokespecial(cdName, "<init>",
+                                MethodTypeDesc.of(ConstantDescs.CD_void, fieldDescs(fields)));
+                        code.invokestatic(CD_Result, "ok", MTD_Result_Object, true);
                         code.areturn();
-                        code.labelBinding(ok);
-                    }
-
-                    code.new_(cdName);
-                    code.dup();
-                    int s = 0;
-                    for (Map.Entry<String, Type> f : fields.entrySet()) {
-                        load(code, s, f.getValue());
-                        s += width(f.getValue());
-                    }
-                    code.invokespecial(cdName, "<init>",
-                            MethodTypeDesc.of(ConstantDescs.CD_void, fieldDescs(fields)));
-                    code.invokestatic(CD_Result, "ok", MTD_Result_Object, true);
-                    code.areturn();
+                    });
                 });
+    }
+
+    /**
+     * The generic {@code Signature} of {@code __construct}: {@code Result<T, String>}, where the
+     * failure side is the invariant message this method builds. Unlike a factory's, it is written
+     * whether or not a field is a container — the raw {@code Result} the descriptor names carries no
+     * type at all, and a Kotlin caller reads a raw type as a platform type, which is the one thing
+     * the rest of the class is marked to avoid (issue #150).
+     */
+    private String constructSignature(Map<String, Type> fields, ClassDesc cdName) {
+        StringBuilder sb = new StringBuilder("(");
+        for (Type t : fields.values()) {
+            String g = JvmTypes.genericSig(t, ctx);
+            sb.append(g != null ? g : jvmType(t).descriptorString());
+        }
+        return sb.append(")Lsouther/runtime/Result<")
+                .append(cdName.descriptorString())
+                .append(CD_String.descriptorString())
+                .append(">;").toString();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileNullMarkedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNullMarkedTest.java
@@ -8,6 +8,7 @@ import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.constant.ClassDesc;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -33,6 +34,10 @@ class CompileNullMarkedTest {
 
     @Test
     void everyGeneratedClassIsMarked() {
+        // the whole runtime-visible list, not just that the marking is among it: what a generated
+        // class states to a consumer's compiler is the boundary, and a second annotation arriving
+        // there is a decision to take rather than something to let through. The module's declarations
+        // ride on `$Module` as runtime-invisible for that reason.
         Map<String, byte[]> classes = Compiler.compile(SRC);
 
         assertTrue(classes.size() > 1, "there is more than one class to mark: " + classes.keySet());
@@ -45,8 +50,10 @@ class CompileNullMarkedTest {
     void noPackageInfoIsEmitted() {
         // a module's package is where a consumer's own package-info.java lives; the marking rides on
         // the classes so that declaration has nothing to collide with (issue #150)
-        assertTrue(Compiler.compile(SRC).keySet().stream().noneMatch(n -> n.endsWith(".package-info")),
-                "no package annotations are generated: " + Compiler.compile(SRC).keySet());
+        Set<String> emitted = Compiler.compile(SRC).keySet();
+
+        assertTrue(emitted.stream().noneMatch(n -> n.endsWith(".package-info")),
+                "no package annotations are generated: " + emitted);
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileNullMarkedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNullMarkedTest.java
@@ -3,8 +3,8 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import java.lang.classfile.ClassFile;
-import java.lang.classfile.ClassModel;
 import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
+import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.constant.ClassDesc;
 import java.util.List;
 import java.util.Map;
@@ -16,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Nothing generated is ever null: absence is {@code Option}, a failure is a case of the output union.
  * A consumer that reads nullness from the bytecode cannot know that unless the classes say so, and a
  * Kotlin caller that is told nothing falls back to platform types, where a null check is neither
- * required nor possible. So each generated package carries JSpecify's {@code @NullMarked}.
+ * required nor possible. So every generated class carries JSpecify's {@code @NullMarked}.
  */
 class CompileNullMarkedTest {
 
@@ -32,25 +32,25 @@ class CompileNullMarkedTest {
             """;
 
     @Test
-    void aModuleCarriesNullMarkedOnItsPackage() {
+    void everyGeneratedClassIsMarked() {
         Map<String, byte[]> classes = Compiler.compile(SRC);
 
-        byte[] bytes = classes.get("demo.package-info");
-        assertTrue(bytes != null, "the module's package is marked: " + classes.keySet());
-        assertEquals(List.of(NULL_MARKED), annotations(bytes));
+        assertTrue(classes.size() > 1, "there is more than one class to mark: " + classes.keySet());
+        for (Map.Entry<String, byte[]> e : classes.entrySet()) {
+            assertEquals(List.of(NULL_MARKED), annotations(e.getValue()), e.getKey());
+        }
     }
 
     @Test
-    void thePackageInfoIsShapedAsJavacWouldEmitOne() {
-        ClassModel model = ClassFile.of().parse(Compiler.compile(SRC).get("demo.package-info"));
-
-        assertEquals(ClassFile.ACC_INTERFACE | ClassFile.ACC_ABSTRACT | ClassFile.ACC_SYNTHETIC,
-                model.flags().flagsMask(), "an interface, abstract and synthetic, as javac emits");
-        assertTrue(model.methods().isEmpty() && model.fields().isEmpty(), "it declares nothing");
+    void noPackageInfoIsEmitted() {
+        // a module's package is where a consumer's own package-info.java lives; the marking rides on
+        // the classes so that declaration has nothing to collide with (issue #150)
+        assertTrue(Compiler.compile(SRC).keySet().stream().noneMatch(n -> n.endsWith(".package-info")),
+                "no package annotations are generated: " + Compiler.compile(SRC).keySet());
     }
 
     @Test
-    void eachModuleOfALinkedSetMarksItsOwnPackage() {
+    void eachModuleOfALinkedSetMarksItsOwnClasses() {
         Map<String, byte[]> classes = Compiler.compileModules(List.of("""
                 module shared.money exposing ( Amount )
                 data Amount = Int
@@ -60,8 +60,16 @@ class CompileNullMarkedTest {
                 data Line = { paid: Amount }
                 """));
 
-        assertEquals(List.of(NULL_MARKED), annotations(classes.get("shared.money.package-info")));
-        assertEquals(List.of(NULL_MARKED), annotations(classes.get("ordering.package-info")));
+        assertEquals(List.of(NULL_MARKED), annotations(classes.get("shared.money.Amount")));
+        assertEquals(List.of(NULL_MARKED), annotations(classes.get("ordering.Line")));
+    }
+
+    @Test
+    void constructHandsBackATypedResult() {
+        // `__construct` is public for an exposed type and is the path another module's `constructs`
+        // takes; a raw `Result` there is a platform type again to a Kotlin caller
+        assertEquals("(Ldemo/Amount;)Lsouther/runtime/Result<Ldemo/Receipt;Ljava/lang/String;>;",
+                methodSignature(Compiler.compile(SRC).get("demo.Receipt"), "__construct"));
     }
 
     /** The annotation types the class carries as runtime-visible — what a Kotlin compiler reads. */
@@ -70,5 +78,14 @@ class CompileNullMarkedTest {
                         .runtimeVisibleAnnotations())
                 .map(RuntimeVisibleAnnotationsAttribute::annotations).orElse(List.of())
                 .stream().map(a -> a.classSymbol()).toList();
+    }
+
+    /** The generic {@code Signature} of the named method, or null where it has none. */
+    private static String methodSignature(byte[] bytes, String method) {
+        return ClassFile.of().parse(bytes).methods().stream()
+                .filter(m -> m.methodName().stringValue().equals(method))
+                .findFirst().orElseThrow()
+                .findAttribute(java.lang.classfile.Attributes.signature())
+                .map(SignatureAttribute::signature).map(s -> s.stringValue()).orElse(null);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/apt/CrossProjectProcessorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/apt/CrossProjectProcessorTest.java
@@ -46,8 +46,8 @@ class CrossProjectProcessorTest {
                 """, List.of(libClasses));
 
         assertTrue(Files.exists(appClasses.resolve("app/order/Order.class")));
-        assertTrue(Files.exists(appClasses.resolve("app/order/package-info.class")),
-                "the package annotations go through the Filer with everything else");
+        assertTrue(Files.exists(appClasses.resolve("app/order/$Module.class")),
+                "the module's declarations go through the Filer with everything else");
         assertFalse(Files.exists(appClasses.resolve("shared/money/Amount.class")),
                 "the dependency's classes belong to its own build");
     }

--- a/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorPackageInfoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorPackageInfoTest.java
@@ -10,6 +10,9 @@ import javax.tools.JavaFileObject;
 import javax.tools.StandardJavaFileManager;
 import javax.tools.ToolProvider;
 import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
+import java.lang.constant.ClassDesc;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -17,19 +20,20 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * The generated package annotations (the {@code package-info} carrying {@code @NullMarked}) are the
- * one generated class a hand-written source can be holding the name of: Java written in the same
- * package as the module may declare a {@code package-info.java} of its own. That is a declaration in
- * this compilation, so it wins — but the module's types then say nothing about null, which is worth
- * a word rather than a silent difference or a failed build.
+ * Java written in the same package as the module may declare a {@code package-info.java} of its own —
+ * and in a project whose only Java is that file, it does. Nothing generated is named after it, so the
+ * declaration stands and the module's types are marked all the same (issue #150).
  */
 class SoutherProcessorPackageInfoTest {
 
+    private static final ClassDesc NULL_MARKED = ClassDesc.of("org.jspecify.annotations.NullMarked");
+
     @Test
-    void aHandWrittenPackageInfoWinsAndIsWarnedAbout(@TempDir Path dir) throws IOException {
+    void aHandWrittenPackageInfoCollidesWithNothing(@TempDir Path dir) throws IOException {
         Files.writeString(dir.resolve("module.sou"), """
                 module app.order
                 data Order = { id: String }
@@ -39,11 +43,12 @@ class SoutherProcessorPackageInfoTest {
 
         List<String> warnings = compile(dir, pkg.resolve("package-info.java"));
 
-        assertTrue(warnings.stream().anyMatch(w -> w.contains("app.order.package-info")
-                        && w.contains("@NullMarked")),
-                "the skipped marking is reported: " + warnings);
-        assertTrue(Files.exists(dir.resolve("classes/app/order/Order.class")),
-                "the rest of the module is emitted as usual");
+        assertTrue(warnings.stream().noneMatch(w -> w.contains("souther:")),
+                "the processor has nothing to report: " + warnings);
+        Path order = dir.resolve("classes/app/order/Order.class");
+        assertTrue(Files.exists(order), "the module is emitted as usual");
+        assertEquals(List.of(NULL_MARKED), annotations(Files.readAllBytes(order)),
+                "and its types are marked without the package saying anything");
     }
 
     /** Runs javac with the processor over {@code source}; the build must succeed. Returns its
@@ -71,5 +76,13 @@ class SoutherProcessorPackageInfoTest {
         }
         assertTrue(ok && errors.isEmpty(), "the build carries on: " + errors);
         return warnings;
+    }
+
+    /** The annotation types the class carries as runtime-visible — what a Kotlin compiler reads. */
+    private static List<ClassDesc> annotations(byte[] bytes) {
+        return ClassFile.of().parse(bytes).findAttribute(java.lang.classfile.Attributes
+                        .runtimeVisibleAnnotations())
+                .map(RuntimeVisibleAnnotationsAttribute::annotations).orElse(List.of())
+                .stream().map(a -> a.classSymbol()).toList();
     }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -2286,7 +2286,11 @@ The class-file version of the generated `+.class+` is fixed at Java 25 (major 69
 
 No generated value is ever null. Absence is `+Option+` (<<optional>>), a failure is a case of the output union (<<unmarked-sum>>), and a collection holds neither a null key nor a null value — so no accessor, factory, codec or `+apply+` hands one back.
 
-Each generated package carries JSpecify's `+@NullMarked+` on a `+package-info+` class emitted with it, and souther-runtime carries it on its own packages, so a consumer's compiler knows that too. It matters most where a compiler acts on it: Kotlin reads the annotation off the class file and types every generated accessor as non-null, where without it the type is a platform type and a null check is neither required nor possible. The annotation is read by name, so the JSpecify jar need not be on the consumer's classpath.
+Every generated class carries JSpecify's `+@NullMarked+`, and souther-runtime carries it on its own packages, so a consumer's compiler knows that too. It matters most where a compiler acts on it: Kotlin reads the annotation off the class file and types every generated accessor as non-null, where without it the type is a platform type and a null check is neither required nor possible. The annotation is read by name, so the JSpecify jar need not be on the consumer's classpath.
+
+It rides on each class rather than on a `+package-info+` of the module's package. That package is where a consumer's own `+package-info.java+` sits, and a generated class of the same name would lose to that declaration — the marking would then reach only the modules that own no Java of their own.
+
+A generated method whose descriptor names a generic type carries the `+Signature+` for it, so the type argument survives to a reader. `+__construct+` returns `+Result<T, String>+`; a raw `+Result+` would be a platform type again on the Kotlin side, where the class carrying it says everything else is not.
 
 The few places that do admit a null are annotated one by one — a `+java.util.Map+` implementation's `+get+`, which returns null for an absent key because that interface says so.
 


### PR DESCRIPTION
Fixes what issue #150 reports: the generated `@NullMarked` reaches almost no module, and writing it by hand does not stop the warning.

## The marking rides on each class

A module's package is where a consumer's own `package-info.java` sits — in a project whose only Java is that file, by construction. The generated `package-info` lost to that declaration, the marking was skipped, and the warning saying so kept printing after the consumer did what it asked, since it never read what the declared package already carried.

Every generated class carries the annotation instead. They all go through `Descriptors.build`, so it is one place, and it covers the `$`-named classes (`Foo$Dec`, `Foo$Enc`) that an enclosing-element rule would not. With nothing generated under that name any more, the `package-info` generation goes and the processor's `FilerException` handler goes with it — a collision there is now as much a build failure as any other.

Nobody is asked to write the annotation, so nobody needs the JSpecify jar on any classpath.

## `__construct` hands back a typed `Result`

It had no `Signature`, so `Result<T, E>` was raw — a platform type on the Kotlin side, in the one method a Java binding reaches for. It is public for an exposed data and is the path another module's `constructs` takes, so it gets the signature it returns: `Result<T, String>`, the failure side being the invariant message the method builds.

`$Dec.decode`'s raw `net.unit8.raoh.Result` is left alone: consumers reach it through the generic `decoder()`, so nothing sees it.

## Verification

Generated classes run through kotlinc 2.2.21, with the type forced out by mismatching it:

```
Probe.kt:4:18: error: initializer type mismatch: expected 'Int', actual 'String'.
    val x: Int = r.note()

Probe2.kt:5:18: error: initializer type mismatch: expected 'Int', actual 'Result<Receipt, String>'.
    val x: Int = Receipt.__construct(a, "note")
```

`String`, not `String!`; `Result<Receipt, String>`, not `Result<*, *>!`. No `package-info.class` among the output.

`mvn -o clean test`: compiler 1115, LSP 81, formatter 37, all green.

`BOUNDARY_VERSION` stays at 2 — no descriptor and no visibility changes, so a jar built before this still links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
