### PR TITLE
Walk a parenthesised run once instead of rescanning it

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/CompileDeepExpressionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDeepExpressionTest.java
@@ -6,6 +6,7 @@ import souther.compiler.diag.CompileException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -60,9 +61,42 @@ class CompileDeepExpressionTest {
         assertReportsDepth(() -> Compiler.compileModules(List.of(moduleWith(expr))));
     }
 
+    /**
+     * A nest is walked, not rescanned. The lambda lookahead reads the parenthesised run at every
+     * level of one, and deriving each token position from the cursor again made that cost the cube of
+     * the depth — this source took over two minutes, and where the stack ran out first it still took
+     * nine seconds to say so, which from the outside is a compiler that has hung. The stack here is
+     * large enough that the walk, not the depth limit, is what the time measures.
+     */
+    @Test
+    void aNestIsWalkedRatherThanRescannedAtEveryLevel() throws InterruptedException {
+        String expr = "(".repeat(5000) + "1" + ")".repeat(5000);
+
+        long started = System.nanoTime();
+        run(() -> Compiler.compile(moduleWith(expr)), 32 * 1024 * 1024);
+        long took = (System.nanoTime() - started) / 1_000_000;
+
+        assertTrue(took < 30_000, "compiling a 5000-deep nest took " + took + "ms");
+    }
+
     /** Runs {@code work} on a thread with {@link #STACK_BYTES} of stack and asserts it came back
      *  with a depth diagnostic rather than an {@code Error}. */
     private static void assertReportsDepth(Runnable work) throws InterruptedException {
+        Throwable thrown = run(work, STACK_BYTES);
+        assertNotNull(thrown, "a source this deep should not compile on a " + STACK_BYTES
+                + "-byte stack; the test no longer exercises the depth boundary");
+        assertInstanceOf(CompileException.class, thrown,
+                "expected a diagnostic, got " + thrown.getClass().getName());
+        assertTrue(thrown.getMessage().contains("deep"),
+                "expected a depth diagnostic, got: " + thrown.getMessage());
+    }
+
+    /**
+     * Runs {@code work} on a thread with {@code stackBytes} of stack and returns what it threw, or
+     * null where it returned. The wait is bounded: work that never comes back is a failure with a
+     * name on it, not a run that sits there.
+     */
+    private static Throwable run(Runnable work, int stackBytes) throws InterruptedException {
         AtomicReference<Throwable> caught = new AtomicReference<>();
         Thread t = new Thread(null, () -> {
             try {
@@ -70,16 +104,10 @@ class CompileDeepExpressionTest {
             } catch (Throwable x) {
                 caught.set(x);
             }
-        }, "deep-expression", STACK_BYTES);
+        }, "deep-expression", stackBytes);
         t.start();
-        t.join();
-
-        Throwable thrown = caught.get();
-        assertNotNull(thrown, "a source this deep should not compile on a " + STACK_BYTES
-                + "-byte stack; the test no longer exercises the depth boundary");
-        assertInstanceOf(CompileException.class, thrown,
-                "expected a diagnostic, got " + thrown.getClass().getName());
-        assertTrue(thrown.getMessage().contains("deep"),
-                "expected a depth diagnostic, got: " + thrown.getMessage());
+        t.join(120_000);
+        assertFalse(t.isAlive(), "the compile did not come back within 120s");
+        return caught.get();
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -1398,23 +1398,42 @@ public final class CstParser {
         return nth(1) != SyntaxKind.RPAREN && parenRunFollowedByArrow();
     }
 
-    /** Whether the parenthesised run at the cursor closes on a {@code )} that {@code ->} follows. */
+    /**
+     * Whether the parenthesised run at the cursor closes on a {@code )} that {@code ->} follows.
+     *
+     * <p>Walks the tokens from the cursor with one moving index rather than asking for the nth
+     * meaningful token each step: {@link #mi} counts from {@code pos} every time, which would make a
+     * run of length L cost L steps per token and the nest of runs in {@code ((((1))))} cost the cube
+     * of its depth. The lookahead runs at every level of the nest, so that is what it costs.
+     */
     private boolean parenRunFollowedByArrow() {
         int depth = 0;
-        for (int i = 0; ; i++) {
-            SyntaxKind k = nth(i);
+        for (int i = mi(0); i < tokens.size(); i++) {
+            SyntaxKind k = tokens.get(i).kind();
+            if (k.isTrivia()) {
+                continue;
+            }
             if (k == SyntaxKind.EOF) {
                 return false;
             }
             if (k == SyntaxKind.LPAREN) {
                 depth++;
-            } else if (k == SyntaxKind.RPAREN) {
-                depth--;
-                if (depth == 0) {
-                    return nth(i + 1) == SyntaxKind.ARROW;
-                }
+            } else if (k == SyntaxKind.RPAREN && --depth == 0) {
+                return kindAfter(i) == SyntaxKind.ARROW;
             }
         }
+        return false;
+    }
+
+    /** The kind of the first meaningful token after the one at {@code index}. */
+    private SyntaxKind kindAfter(int index) {
+        for (int i = index + 1; i < tokens.size(); i++) {
+            SyntaxKind k = tokens.get(i).kind();
+            if (!k.isTrivia()) {
+                return k;
+            }
+        }
+        return SyntaxKind.EOF;
     }
 
     private void error(String messageKey, String legacyMessage, Object... args) {


### PR DESCRIPTION
`CompileDeepExpressionTest` hangs, or takes 16 seconds where it does not.

## What it costs

Telling a lambda's parameter list from a parenthesised expression means reading ahead for the `)` that closes the run and the `->` that may follow it. `parenRunFollowedByArrow` asked for the *n*th meaningful token at each step, and `mi` counts from the cursor every time — so reading a run of length L takes L steps per token. The lookahead runs again at every level of a nest, which makes `((((1))))` cost the cube of its depth:

| depth | before | after |
|---|---|---|
| 1250 | 2.2s | 0.1s |
| 2500 | 16.5s | 0.1s |
| 5000 | 127.8s | 0.2s |

(whole-compile, on a 32MB stack so the walk rather than the depth limit is what is measured)

On the 256KB stack the test pins, the same source took 9.2s before the stack ran out and the depth diagnostic came back. How far 256KB goes depends on frame sizes, so on a run where it went further the compile carried on into the cube — which is the hang.

Every sample of the stack while it ran was in the same place:

```
souther.compiler.cst.CstParser.mi(CstParser.java:1371)
souther.compiler.cst.CstParser.nth(CstParser.java:1364)
souther.compiler.cst.CstParser.parenRunFollowedByArrow(CstParser.java:1405)
souther.compiler.cst.CstParser.isBlockParams(CstParser.java:1398)
souther.compiler.cst.CstParser.primaryExpr(CstParser.java:915)
```

## The fix

Walk the tokens from the cursor with one moving index, skipping trivia inline. `CompileDeepExpressionTest` drops from 16.1s to 0.1s.

The lookahead widened to a whole run in 162c8ac, when a parameter became a pattern rather than only a name. Before that it stopped at the first token that was not an identifier, so `((((` cost nothing to reject.

## The guard

The test's `join` is now bounded, so work that does not come back is a failure with a name on it rather than a run that sits there. A new case compiles a 5000-deep nest on a 32MB stack and holds it to 30s — verified to fail on the unfixed parser (`took 111940ms`) and to pass on the fixed one.

`mvn -o clean test`: compiler 1115, LSP 81, formatter 37, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
