### PR TITLE
Read only the imports a published module's declarations name

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/meta/PublishedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/PublishedModule.java
@@ -6,6 +6,8 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.frontend.CstFrontend;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -60,18 +62,15 @@ public record PublishedModule(Ast.Module module, Set<String> injectedBehaviors) 
         if (m.compat() != Backend.BOUNDARY_VERSION || m.header().isBlank()) {
             throw incompatible(m);
         }
-        StringBuilder source = new StringBuilder(m.header()).append('\n');
-        for (String line : m.imports()) {
-            source.append(line).append('\n');
-        }
+        StringBuilder declarations = new StringBuilder();
         Set<String> injected = new LinkedHashSet<>();
         for (String type : m.types()) {
-            source.append('\n').append(declaration(classes, m, type, moduleName + "." + type,
+            declarations.append('\n').append(declaration(classes, m, type, moduleName + "." + type,
                     Declarations::data)).append('\n');
         }
         for (String behavior : m.behaviors()) {
             String binaryName = moduleName + "." + Backend.behaviorClass(behavior);
-            source.append('\n')
+            declarations.append('\n')
                     .append(declaration(classes, m, behavior, binaryName,
                             Declarations::behaviorSignature))
                     .append('\n');
@@ -80,9 +79,98 @@ public record PublishedModule(Ast.Module module, Set<String> injectedBehaviors) 
             }
         }
         for (String helper : m.invariantHelpers()) {
-            source.append('\n').append(helper).append('\n');
+            declarations.append('\n').append(helper).append('\n');
         }
-        return new PublishedModule(CstFrontend.parse(source.toString(), null), injected);
+        StringBuilder source = new StringBuilder(m.header()).append('\n');
+        for (String line : m.imports()) {
+            source.append(line).append('\n');
+        }
+        source.append(declarations);
+        Ast.Module module = CstFrontend.parse(source.toString(), null);
+        // Which imports are needed is asked of the header and the declarations — everything that was
+        // published except the import lines themselves.
+        return new PublishedModule(
+                withNeededImports(module, m.header() + "\n" + declarations), injected);
+    }
+
+    /**
+     * {@code module} with the import lines its declarations do not need left out. A module's
+     * {@code let} bodies are not published, so an import only they used would otherwise be
+     * republished and every importing project would have to put that module on its path to read
+     * declarations that never mention it (issue #138).
+     *
+     * <p>Needed is decided on the words of the published text rather than on the parsed
+     * declarations. The text is exactly what an importing project reads, and a word is a word
+     * wherever it is written — in a field's type, a spread, an invariant, a helper an invariant
+     * calls, an exposed composition's output. A walk over the parsed forms would have to name every
+     * place a type can appear and would drop an import the day one is added; a word that is written
+     * nowhere cannot be referred to by anything.
+     */
+    private static Ast.Module withNeededImports(Ast.Module module, String declared) {
+        Set<String> written = new LinkedHashSet<>();
+        Set<String> qualifiers = new LinkedHashSet<>();
+        for (String word : words(declared)) {
+            written.add(word);
+            int dot = word.lastIndexOf('.');
+            if (dot > 0) {
+                qualifiers.add(word.substring(0, dot));
+            }
+        }
+        List<Ast.Import> needed = new ArrayList<>();
+        for (Ast.Import imp : module.imports()) {
+            if (!Collections.disjoint(written, imp.names())
+                    || qualifiers.contains(imp.module())
+                    || (imp.alias() != null && qualifiers.contains(imp.alias()))) {
+                needed.add(imp);
+            }
+        }
+        if (needed.size() == module.imports().size()) {
+            return module;
+        }
+        return new Ast.Module(module.name(), module.exposing(), module.exposedOutputs(), needed,
+                module.defs(), module.behaviors(), module.fns(), module.examples(), module.fakes(),
+                module.exampleFileTarget(), module.pos());
+    }
+
+    /**
+     * Every maximal run of name characters in {@code text}, a qualified name counting as one word.
+     * The dot joins a qualifier to what it qualifies, so it is part of a run; a dot that does not
+     * join two names is dropped from the ends, which is what makes the spread {@code ...Common}
+     * read as the name it spreads.
+     *
+     * <p>A run inside a string literal is a word here too: it costs an import that is kept, which is
+     * what was published anyway.
+     */
+    private static List<String> words(String text) {
+        List<String> words = new ArrayList<>();
+        int start = -1;
+        for (int i = 0; i <= text.length(); i++) {
+            boolean part = i < text.length()
+                    && (Character.isLetterOrDigit(text.charAt(i)) || text.charAt(i) == '_'
+                            || text.charAt(i) == '.');
+            if (part && start < 0) {
+                start = i;
+            } else if (!part && start >= 0) {
+                String word = trimDots(text.substring(start, i));
+                if (!word.isEmpty()) {
+                    words.add(word);
+                }
+                start = -1;
+            }
+        }
+        return words;
+    }
+
+    private static String trimDots(String word) {
+        int from = 0;
+        int to = word.length();
+        while (from < to && word.charAt(from) == '.') {
+            from++;
+        }
+        while (to > from && word.charAt(to - 1) == '.') {
+            to--;
+        }
+        return word.substring(from, to);
     }
 
     private static String declaration(Classes classes, SoutherModuleView m, String name,

--- a/souther-compiler/src/test/java/souther/compiler/CrossProjectImportTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CrossProjectImportTest.java
@@ -184,6 +184,80 @@ class CrossProjectImportTest {
         assertTrue(e.getMessage().contains("shared.money"), e.getMessage());
     }
 
+    /** A library's `let` bodies are not published, so an import only they needed is not part of what
+     * an importing project reads. Requiring it on the path would make a consumer carry a dependency
+     * nothing it can see mentions. */
+    @Test
+    void anImportOnlyAnUnpublishedLetNeededIsNotRequiredOnThePath() {
+        Map<String, byte[]> both = Compiler.compileModules(List.of("""
+                module shared.audit exposing ( Trail )
+                data Trail = String
+                """, """
+                module shared.billing exposing ( Invoice )
+                import shared.audit ( Trail )
+                data Invoice = { total: Int }
+                let describe (t: Trail) = t
+                """));
+        ModulePath billingOnly = name -> name.startsWith("shared.billing") ? both.get(name) : null;
+
+        Compiler.compileModules(List.of("""
+                module app.ledger
+                import shared.billing ( Invoice )
+                data Entry = { of: Invoice }
+                behavior record : (i: Invoice) -> Entry constructs Entry
+                let record (i) = Entry { of = i }
+                """), billingOnly);
+    }
+
+    /** A spread names a type without writing it as a field's type, so an import a published
+     * declaration needs is not always one a field mentions. It is still needed on the path. */
+    @Test
+    void anImportOnlySpreadIntoAPublishedDataIsStillRequired() {
+        Map<String, byte[]> both = Compiler.compileModules(List.of("""
+                module shared.base exposing ( Common )
+                data Common = { id: String }
+                """, """
+                module shared.billing exposing ( Invoice )
+                import shared.base ( Common )
+                data Invoice = { ...Common, total: Int }
+                """));
+        ModulePath billingOnly = name -> name.startsWith("shared.billing") ? both.get(name) : null;
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of("""
+                        module app.ledger
+                        import shared.billing ( Invoice )
+                        data Entry = { of: Invoice }
+                        """), billingOnly));
+
+        assertTrue(e.getMessage().contains("shared.billing"), e.getMessage());
+        assertTrue(e.getMessage().contains("shared.base"), e.getMessage());
+    }
+
+    /** An import that brings in no name is used through its alias alone. The alias is what the
+     * declarations write, so that is what says the import is needed. */
+    @Test
+    void anImportUsedOnlyThroughItsAliasIsStillRequired() {
+        Map<String, byte[]> both = Compiler.compileModules(List.of("""
+                module shared.audit exposing ( Trail )
+                data Trail = String
+                """, """
+                module shared.billing exposing ( Invoice )
+                import shared.audit as A
+                data Invoice = { trail: A.Trail }
+                """));
+        ModulePath billingOnly = name -> name.startsWith("shared.billing") ? both.get(name) : null;
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of("""
+                        module app.ledger
+                        import shared.billing ( Invoice )
+                        data Entry = { of: Invoice }
+                        """), billingOnly));
+
+        assertTrue(e.getMessage().contains("shared.audit"), e.getMessage());
+    }
+
     /** A module compiled here that is also on the path is refused: which one an import means would
      * be settled by nothing the author wrote. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/meta/PublishedModuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/PublishedModuleTest.java
@@ -74,6 +74,30 @@ class PublishedModuleTest {
         assertTrue(amount.invariant().isPresent(), "the invariant did not come back");
     }
 
+    /** An import comes back when a declaration names what it brings in, and not otherwise: the
+     * `let` that needed the other one is not part of what was published. */
+    @Test
+    void onlyTheImportsTheDeclarationsNameComeBack() {
+        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+                module shared.money exposing ( Amount )
+                data Amount = Int
+                """, """
+                module shared.audit exposing ( Trail )
+                data Trail = String
+                """, """
+                module shared.billing exposing ( Invoice )
+                import shared.money ( Amount )
+                import shared.audit ( Trail )
+                data Invoice = { total: Amount }
+                let describe (t: Trail) = t
+                """));
+
+        PublishedModule read = readBack("shared.billing", classes);
+
+        assertEquals(List.of("shared.money"),
+                read.module().imports().stream().map(Ast.Import::module).toList());
+    }
+
     /** No `let` comes back for any behavior, so which ones are injection targets cannot be read off
      * the module; it is carried beside it. */
     @Test

--- a/specification.adoc
+++ b/specification.adoc
@@ -281,6 +281,11 @@ not this compiler's is refused, naming the compiler that built it, rather than r
 misunderstood. A module compiled here SHALL NOT also be on the class path, and a module on the class
 path that needs one absent from it is reported against the path.
 
+A module on the class path needs another when what it declares names it — in a field's type, a
+spread, an invariant, a helper an invariant calls, or an exposed composition's output. A `+let+` body
+is not published, so an `+import+` only a `+let+` used is not one the importing project has to
+satisfy: a dependency's implementation-only dependencies need not be on the class path.
+
 [#qualified-reference]
 === Qualified reference
 


### PR DESCRIPTION
Fixes #138. A project depending on `shared.billing` no longer has to put `shared.audit` on its
class path when nothing `shared.billing` publishes mentions it.

## What changed

`PublishedModule.read` leaves out the import lines the restored declarations do not name. What a
module publishes is untouched, so `BOUNDARY_VERSION` does not move and jars already built stay
readable.

Which imports are needed is decided on the words of the published text — the header and the
declarations, everything an importing project reads except the import lines themselves. That text
is exactly what the other side sees, so a name written nowhere in it cannot be referred to by
anything. The alternative, walking the parsed declarations, would have to name every place a type
can appear and would drop an import the day another place is added; matching words only ever errs
toward keeping one.

The one thing that needed care was the spread: `.` joins a qualifier to what it qualifies, so it is
part of a word, which made `...Common` read as one word that matches nothing. Dots are dropped from
the ends of a word.

## Tests

- `anImportOnlyAnUnpublishedLetNeededIsNotRequiredOnThePath` — the issue's acceptance case. Fails
  before the change with `needs 'shared.audit'`.
- `anImportOnlySpreadIntoAPublishedDataIsStillRequired` — a spread names a type without writing it
  as a field's type. Dropping that import gets a crash instead of a diagnostic, which is how the
  word-splitting bug above was found.
- `anImportUsedOnlyThroughItsAliasIsStillRequired` — an import with no names, used through its
  alias. Removing the alias clause degrades the diagnostic to `needs 'A'`, so the test bites.
- `onlyTheImportsTheDeclarationsNameComeBack` — the read-back module's import list, directly.
- The existing `aDependencyOfADependencyThatIsAbsentNamesBothModules` holds the other side: a
  dependency the declarations do name is still reported when it is absent.

`mvn clean test`: 1247 tests, 0 failures, 0 errors.

## Not in here

A spread of a type that is not in scope throws a `NullPointerException` instead of reporting an
unknown type. It is a typo away in a single `.sou` and has nothing to do with the class path, so it
is #154 rather than part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
