### PR TITLE
Let an example expect a case of a named sum output

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -751,11 +751,8 @@ public final class ExampleVerifier {
     }
 
     private Set<TypeName> outCases(Type out) {
-        if (out instanceof Type.Union u) {
-            return u.members();
-        }
-        if (out instanceof Type.Ref r) {
-            return Set.of(r.name());
+        if (out instanceof Type.Union || out instanceof Type.Ref) {
+            return TypeOps.leafCases(out, symbols);
         }
         return Set.of();
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Compile-time evaluation of {@code example}s: an example that holds compiles, one that
@@ -114,6 +116,104 @@ class CompileExampleTest {
         // Both rows fail; the build reports the aggregate (E1905) mentioning the extra failure.
         CompileException e = err(bad);
         assertEquals("E1905", e.diagnostic().code());
+    }
+
+    /** A behavior whose output is a sum written under its own name, so a row's expected arm is a
+     *  case of that sum rather than a member of a written case list. */
+    private static final String NAMED_SUM = """
+            module tiering
+            data Small = { n: Int }
+            data Large = { n: Int }
+            data Elsewhere = { n: Int }
+            data Tier = Small | Large
+            data Reading = { n: Int }
+
+            behavior tierOf : (r: Reading) -> Tier constructs Small, Large
+
+            let tierOf (r) = if r.n > 10 then Large { n = r.n } else Small { n = r.n }
+            """;
+
+    @Test
+    void aCaseOfANamedSumOutputIsAWritableExpectedArm() {
+        String model = NAMED_SUM + """
+                example tierOf
+                  | "over the line"  : (Reading { n = 20 }) -> Large
+                  | "under the line" : (Reading { n = 1 })  -> Small { n = 1 }
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(model));
+    }
+
+    @Test
+    void theWrongCaseOfANamedSumOutputStillFailsTheExample() {
+        String bad = NAMED_SUM + """
+                example tierOf
+                  | (Reading { n = 20 }) -> Small
+                """;
+        assertEquals("E1905", err(bad).diagnostic().code());
+    }
+
+    @Test
+    void aCaseOutsideTheNamedSumIsE1904() {
+        String bad = NAMED_SUM + """
+                example tierOf
+                  | (Reading { n = 20 }) -> Elsewhere
+                """;
+        CompileException e = err(bad);
+        assertEquals("E1904", e.diagnostic().code());
+        // the hint names the cases, not the sum, since those are what a row may expect
+        String hint = String.valueOf(e.diagnostic().notes().get(0).args()[0]);
+        assertTrue(hint.contains("Small") && hint.contains("Large"), hint);
+        assertFalse(hint.contains("Tier"), hint);
+    }
+
+    @Test
+    void theSumItselfIsNotAnExpectedArm() {
+        // `Tier` names no case, so a row expecting it asserts nothing a result could be
+        String bad = NAMED_SUM + """
+                example tierOf
+                  | (Reading { n = 20 }) -> Tier
+                """;
+        assertEquals("E1904", err(bad).diagnostic().code());
+    }
+
+    @Test
+    void aLeafOfANestedNamedSumOutputIsAWritableExpectedArm() {
+        String model = """
+                module nesting
+                data Approved = { n: Int }
+                data Rejected = { n: Int }
+                data Pending = { n: Int }
+                data Decided = Approved | Rejected
+                data Outcome = Decided | Pending
+                data Reading = { n: Int }
+
+                behavior decide : (r: Reading) -> Outcome constructs Approved, Pending
+
+                let decide (r) = if r.n > 10 then Approved { n = r.n } else Pending { n = r.n }
+
+                example decide
+                  | "over the line"  : (Reading { n = 20 }) -> Approved
+                  | "under the line" : (Reading { n = 1 })  -> Pending
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(model));
+    }
+
+    @Test
+    void aUnitCaseOfANamedSumOutputIsAWritableExpectedArm() {
+        String model = """
+                module ranking
+                data Tier = Bronze | Silver
+                data Reading = { n: Int }
+
+                behavior rankOf : (r: Reading) -> Tier constructs Bronze, Silver
+
+                let rankOf (r) = if r.n > 10 then Silver else Bronze
+
+                example rankOf
+                  | "over the line"  : (Reading { n = 20 }) -> Silver
+                  | "under the line" : (Reading { n = 1 })  -> Bronze
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(model));
     }
 
     @Test

--- a/specification.adoc
+++ b/specification.adoc
@@ -1760,6 +1760,8 @@ The expected side asserts at one of two granularities.
 * A bare type name (`+-> 提出済み+`) asserts only the *arm* — which case of the output sum the result is — and ignores its fields.
 * A construction (`+-> 却下 { 理由 = "high_cost" }+`), a newtype application (`+-> 金額(0)+`), or a literal asserts the *whole value* by structural equality.
 
+The cases a row may name are the output's cases whether the output is written as a case list (`+-> 提出済み | 却下+`) or under the sum's own name (`+-> 審査結果+`, <<sum-data>>) — a case stands where a value of its sum is expected here as everywhere else. A sum among those cases contributes its own cases, so a row names a leaf. The sum's name is not itself an expected arm: it says which cases are possible, not which one this input yields (<<e1904>>).
+
 Types make totality and the case set exhaustive (<<match>>, <<unmarked-sum>>); an `+example+` fixes the value rule for a representative input — which arm, or which value, a given input yields.
 
 [#example-evaluable]


### PR DESCRIPTION
Fixes the E1904 in #157.

## Root cause

`ExampleVerifier.outCases` read the behavior's output type as a name rather than a set of cases:

```java
if (out instanceof Type.Ref r) {
    return Set.of(r.name());   // a `-> Tier` output yields {Tier}
}
```

So a row expecting `Large` was rejected, and the hint asked for `Tier` — which has no value of its own. A written case list (`-> Small | Large`) landed on the `Type.Union` branch, whose members already are the cases, which is why spelling the cases out in the signature was the only way to make examples writable.

The rest of the language reads a sum's cases with `TypeOps.leafCases`; that is what lets a case stand where its sum is expected (`TypeOps.assignable`). The example verifier had its own notion that never consulted `Symbols`.

## Change

`outCases` delegates to `TypeOps.leafCases`. A nested sum folds to its leaves, so a row names a leaf. The sum's own name is not in the set — it says which cases are possible, not which one an input yields, so `-> Tier` as an expected value stays E1904.

The check is not loosened: a case outside the sum is still E1904 (now with the cases in the hint), and a wrong case or a wrong field value is still E1905.

## Tests

Six tests in `CompileExampleTest`, all failing before the change:

- a case of a named sum output is a writable expected arm (bare, and as a full value)
- the wrong case still fails the example (E1905)
- a case outside the sum is E1904, and the hint names the cases rather than the sum
- the sum itself is not an expected arm
- a leaf of a nested named sum is writable
- a unit case of a named sum is writable

Full reactor build green (1140 compiler tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
