### PR TITLE
Refuse a data with an empty body

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -8,6 +8,7 @@ import souther.compiler.cst.SyntaxNode;
 import souther.compiler.cst.SyntaxToken;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 
 import java.math.BigDecimal;
@@ -233,7 +234,7 @@ public final class AstBuilder {
             if (includes.isEmpty() && fields.isEmpty()) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.data.emptybody").title("check.data.invalid.title")
-                                .at(pos(product.get())).args(name)
+                                .at(bodyRegion(product.get())).args(name)
                                 .hint("check.data.emptybody.hint", name).build(),
                         "data `" + name + "` has an empty body");
             }
@@ -1154,6 +1155,14 @@ public final class AstBuilder {
 
     private SourcePos posOf(SyntaxToken t) {
         return lines.posOf(t.start());
+    }
+
+    /** The whole `{ ... }` of a body, so an error about the body underlines both braces. */
+    private Region bodyRegion(SyntaxNode body) {
+        SourcePos open = pos(body);
+        return body.token(SyntaxKind.RBRACE)
+                .map(close -> new Region(open, lines.posOf(close.end())))
+                .orElseGet(() -> Region.point(open));
     }
 
     // --- literal decoding ---

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -227,6 +227,16 @@ public final class AstBuilder {
                     fields.add(field(member));
                 }
             }
+            // `data T = { }` names a type with one value, which is what a unit data is — but it is
+            // built as `T {}` where a unit is built by name, so the two spellings mean the same
+            // thing and reject each other's construction. One way to write it (spec §unit-data).
+            if (includes.isEmpty() && fields.isEmpty()) {
+                throw CompileException.of(
+                        Diagnostic.of(null, "check.data.emptybody").title("check.data.invalid.title")
+                                .at(pos(product.get())).args(name)
+                                .hint("check.data.emptybody.hint", name).build(),
+                        "data `" + name + "` has an empty body");
+            }
             return new Ast.Data(name, false, includes, fields, invariant,
                     Optional.empty(), Optional.empty(), pos);
         }

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -197,6 +197,9 @@ check.invariant.invalid.title=INVALID INVARIANT
 check.invariant.partial=The invariant of `{0}` calls the `partial` helper `{1}`, which may not terminate; an invariant is checked at construction time and must terminate, so only a total helper may appear in it.
 check.invariant.construct=The invariant of `{0}` constructs `{1}`, but an invariant may not construct a data — it observes the value being built, it does not build another.
 check.invariant.onunit=`{0}` is a unit data, so it has no field for this invariant to observe and nothing it could reject. Drop the clause, or give `{0}` the field the constraint is about.
+check.data.invalid.title=INVALID DATA
+check.data.emptybody=data `{0}` has an empty body, which names a type with one value — that is a unit data, and it is written without a body.
+check.data.emptybody.hint=Write `data {0}` and build it by name, or give `{0}` the fields it holds.
 
 # module / exposing
 check.module.title=MODULE ERROR

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -196,6 +196,9 @@ check.invariant.invalid.title=不正な不変条件
 check.invariant.partial=`{0}` の不変条件が `partial` ヘルパ `{1}` を呼んでいます。停止するとは限らないため使えません。不変条件は構築時に検査され停止する必要があるので、呼べるのは total なヘルパだけです。
 check.invariant.construct=`{0}` の不変条件が `{1}` を構築していますが、不変条件はデータを構築できません。構築される値を観測するだけで、別の値を作ってはいけません。
 check.invariant.onunit=`{0}` は単位データなので、この不変条件が観測するフィールドがなく、拒める値もありません。この句を削除するか、制約の対象となるフィールドを `{0}` に持たせてください。
+check.data.invalid.title=不正なデータ定義
+check.data.emptybody=データ `{0}` の本体が空です。これは値がひとつだけの型、つまり単位データであり、単位データは本体を書かずに宣言します。
+check.data.emptybody.hint=`data {0}` と書いて名前だけで構築するか、`{0}` が持つフィールドを与えてください。
 
 # モジュール／exposing
 check.module.title=モジュールのエラー

--- a/souther-compiler/src/test/java/souther/compiler/CompileNewtypeComparisonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNewtypeComparisonTest.java
@@ -25,8 +25,8 @@ class CompileNewtypeComparisonTest {
                 invariant value >= 0
 
             data 見積 = { 額: 金額, 予算: 金額 }
-            data 予算内 = { }
-            data 予算超過 = { }
+            data 予算内
+            data 予算超過
             """;
 
     private String result(String body, long amount, long budget) throws Exception {
@@ -45,8 +45,8 @@ class CompileNewtypeComparisonTest {
     void sameNewtypeComparisonReadsTheUnderlyingValue() throws Exception {
         String body = """
                 let 判定 (m) = {
-                    require m.額 <= m.予算 else 予算超過 { }
-                    予算内 { }
+                    require m.額 <= m.予算 else 予算超過
+                    予算内
                 }
                 """;
         assertEquals("demo.予算内", result(body, 50, 100));
@@ -57,8 +57,8 @@ class CompileNewtypeComparisonTest {
     void bareLiteralIsTakenAsTheNewtype() throws Exception {
         String body = """
                 let 判定 (m) = {
-                    require m.額 <= 100 else 予算超過 { }
-                    予算内 { }
+                    require m.額 <= 100 else 予算超過
+                    予算内
                 }
                 """;
         assertEquals("demo.予算内", result(body, 100, 0));   // boundary: 100 <= 100
@@ -69,8 +69,8 @@ class CompileNewtypeComparisonTest {
     void equalityAcceptsABareLiteral() throws Exception {
         String body = """
                 let 判定 (m) = {
-                    require m.額 == 0 else 予算超過 { }
-                    予算内 { }
+                    require m.額 == 0 else 予算超過
+                    予算内
                 }
                 """;
         assertEquals("demo.予算内", result(body, 0, 0));
@@ -85,8 +85,8 @@ class CompileNewtypeComparisonTest {
                 behavior 判定 : (d: 明細) -> 予算内 | 予算超過
                     constructs 予算内, 予算超過
                 let 判定 (d) = {
-                    require d.額 <= d.個数 else 予算超過 { }
-                    予算内 { }
+                    require d.額 <= d.個数 else 予算超過
+                    予算内
                 }
                 """;
         assertThrows(CompileException.class, () -> Compiler.compile(model));
@@ -99,8 +99,8 @@ class CompileNewtypeComparisonTest {
                 behavior 判定 : (m: 見積, 限度: Int) -> 予算内 | 予算超過
                     constructs 予算内, 予算超過
                 let 判定 (m, 限度) = {
-                    require m.額 <= 限度 else 予算超過 { }
-                    予算内 { }
+                    require m.額 <= 限度 else 予算超過
+                    予算内
                 }
                 """;
         assertThrows(CompileException.class, () -> Compiler.compile(model));
@@ -113,8 +113,8 @@ class CompileNewtypeComparisonTest {
                 behavior 判定 : (m: 見積) -> 予算内 | 予算超過
                     constructs 予算内, 予算超過
                 let 判定 (m) = {
-                    require m.額.value <= 100 else 予算超過 { }
-                    予算内 { }
+                    require m.額.value <= 100 else 予算超過
+                    予算内
                 }
                 """;
         assertDoesNotThrow(() -> Compiler.compile(model));

--- a/souther-compiler/src/test/java/souther/compiler/CompileUnitValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileUnitValueTest.java
@@ -1,10 +1,13 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.SourceContext;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -107,6 +110,28 @@ class CompileUnitValueTest {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
         assertTrue(e.getMessage().contains("empty body"), e.getMessage());
         assertEquals(2, e.pos().line(), "must point at the body");
+        assertEquals(13, e.pos().column(), "must start at the opening brace");
+        String out = new HumanRenderer(false)
+                .render(e.diagnostic(), new SourceContext("demo.sou", src), Locale.ENGLISH);
+        assertTrue(out.contains("^^"), out);   // the whole `{}`, not just the opening brace
+    }
+
+    /** A body written open is still underlined from its opening brace: the region spans to the
+     *  closing brace wherever it sits, and the renderer draws one caret across lines. */
+    @Test
+    void anEmptyBodySpanningLinesIsUnderlinedFromItsBrace() {
+        String src = """
+                module demo
+                data Mark = {
+                }
+                data Out = { s: String }
+                behavior k : (n: Int) -> Out constructs Out
+                let k (n) = Out { s = "x" }
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        assertTrue(e.getMessage().contains("empty body"), e.getMessage());
+        assertEquals(2, e.pos().line(), "must point at the opening brace");
+        assertEquals(1, e.diagnostic().region().caretWidth(), "a multi-line region draws one caret");
     }
 
     /** A spread body is a body: what it includes decides the fields, and an empty one cannot be

--- a/souther-compiler/src/test/java/souther/compiler/CompileUnitValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileUnitValueTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -92,19 +93,33 @@ class CompileUnitValueTest {
         assertThrows(CompileException.class, () -> Compiler.compile(src));
     }
 
-    /** The sibling shape still behaves: a data written with an empty body is a product with no
-     *  fields, not a unit, and its invariant goes through the ordinary path. */
+    /** An empty body names a type with one value, which is what a unit data is, so it is the second
+     *  way to write one — and the two reject each other's construction. Only the unit form remains. */
     @Test
-    void anEmptyProductBodyStillTypeChecksItsInvariant() {
+    void anEmptyProductBodyIsRefused() {
         String src = """
                 module demo
                 data Mark = {}
-                    invariant nonexistent > 0
                 data Out = { s: String }
                 behavior k : (n: Int) -> Out constructs Out
                 let k (n) = Out { s = "x" }
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertTrue(e.getMessage().contains("nonexistent"), e.getMessage());
+        assertTrue(e.getMessage().contains("empty body"), e.getMessage());
+        assertEquals(2, e.pos().line(), "must point at the body");
+    }
+
+    /** A spread body is a body: what it includes decides the fields, and an empty one cannot be
+     *  written any more, so this stays a data with fields. */
+    @Test
+    void aSpreadOnlyBodyIsStillAProduct() {
+        String src = """
+                module demo
+                data Base = { s: String }
+                data Mark = { ...Base }
+                behavior k : (n: Int) -> Mark constructs Mark
+                let k (n) = Mark { s = "x" }
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(src));
     }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -711,7 +711,9 @@ Whether a name is declared is answered within the module — its own declaration
 
 The explicit declaration stays available, and is how a case that carries a comment of its own is written.
 
-A unit data MUST NOT carry an `+invariant+`: it has no field for one to observe and no value it could reject (<<invariant-declaration>>). Writing one is a compile error rather than a clause with no effect. A data written with an empty body (`+data T = { }+`) is a product with no fields, not a unit, and its `+invariant+` is checked as any other product's is.
+A unit data MUST NOT carry an `+invariant+`: it has no field for one to observe and no value it could reject (<<invariant-declaration>>). Writing one is a compile error rather than a clause with no effect.
+
+A data body MUST NOT be empty: `+data T = { }+` names a type with one value, which is what a unit data is, so it is a second spelling of one. The two are not interchangeable where it counts — an empty product is built as `+T {}+` and a unit by its name alone — so the declaration form silently decides how the value is written. Writing it is a compile error naming the unit form. A body of spreads alone (`+data T = { ...共通項目 }+`) is not empty: what it includes gives it its fields (<<field-spread>>).
 
 A unit data value is constructed by *writing the name directly* (as a zero-argument constructor becomes a value in functional languages). An empty record such as `+T {}+` is not used.
 


### PR DESCRIPTION
`data T = { }` names a type with one value, which is what a unit data is. Both spellings were accepted, and they are not interchangeable where it counts.

## What the two forms actually do

Measured against `develop`:

| | `data Yes = {}` | `data Yes` (or an undeclared case name) |
|---|---|---|
| built as `Yes {}` | yes | `cannot construct Yes` |
| built as `Yes` | `unknown identifier Yes` | yes |
| as a `match` pattern | same | same |
| as a sum case | same | same |
| as a field type | yes | `has no decoder` |

So a reader of `data Answer = Yes | No` cannot tell how to construct `Yes` without going to look at whether it happens to be declared with an empty body — and each form rejects the other's syntax with a diagnostic that does not mention the other form.

The one capability the empty product has and the unit lacks is standing as a field type. That is a field of a type carrying no information, and the specification (§7) states that Unit "is never provided as a way to write a field" — the empty body was a back door to what was deliberately not offered.

`data T = {} invariant false` also compiles: an invariant with no field to observe, checked at construction, so every construction of the type aborts. Nothing reports it.

## Nothing used it

No `.sou` in this repository, in the standard library, or in `souther-lang/examples` writes an empty body. The two Java tests that did were the ones pinning the form: one asserting the empty body's invariant is checked, and one using empty products where unit data was meant.

The specification sentence describing the form was added a day ago (0ddf29e) as a side note explaining why the new unit-invariant rule did not touch it — it recorded what the parser happened to do, not a decision.

## Change

The empty body is refused in `AstBuilder.dataDef`, beside the rule that refuses an invariant on a unit, since both are well-formedness rules about the shape of a declaration and need no type information. The message names the unit form:

```
-- INVALID DATA --------------------------------
2| data Mark = {}
              ^^
data `Mark` has an empty body, which names a type with one value — that is a
unit data, and it is written without a body.
Hint: Write `data Mark` and build it by name, or give `Mark` the fields it holds.
```

A body of spreads alone (`data T = { ...共通項目 }`) is not empty: what it includes gives it its fields. With the leaf form gone, nothing an include names can be empty either, so the syntactic check is enough.

The CST parser still accepts the form — only the AST refuses it — so the formatter and the language server keep working on half-written source.

## Verification

- Full reactor build green (1135 compiler tests).
- `souther-lang/examples` builds and passes against this compiler (`clean test`, all modules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
