### PR TITLE
Say what to write instead of an optional a model cannot name

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -408,6 +408,7 @@ public final class CallElaborator {
                 // a required behavior called inline (spec 12.2, 13): type it as its success case
                 ReqSig callee = ctx.reqs().get(call.fn());
                 if (callee == null) {
+                    Elaborator.optionIsRead(call.fn(), call.pos());
                     String qualified = Prelude.qualifiedFor(call.fn());
                     if (qualified != null) {
                         throw CompileException.of(

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -165,6 +165,7 @@ public final class Elaborator {
                     throw new CompileException(v.pos(), "E1301",
                             "`null` is not part of the language. Use an optional field with `?`.");
                 }
+                optionIsRead(v.name(), v.pos());
                 throw CompileException.of(
                         Diagnostic.of(null, "check.unknown.name.msg")
                                 .title("check.unknown.title")
@@ -682,6 +683,27 @@ public final class Elaborator {
                             .build(),
                     what + " must be " + expected + " but is " + actual);
         }
+    }
+
+    /**
+     * Rejects {@code Some} / {@code None} written in an expression (E1303). An optional reaches a
+     * model already made — a {@code ?} field, {@code Map.get}, {@code List.find} — and is passed on
+     * or matched; nothing in the language builds one, and neither does a Java binding, so the
+     * unknown-name and arbitrary-call reports both send the reader the wrong way (issue #166).
+     * Patterns do not come through here: {@code | Some v} is matched, not evaluated.
+     */
+    static void optionIsRead(String name, SourcePos pos) {
+        if (!name.equals("Some") && !name.equals("None")) {
+            return;
+        }
+        throw CompileException.of(
+                Diagnostic.of("E1303", "e1303.msg").title("e1303.title")
+                        .at(pos, name.length()).args(name).hint("e1303.hint").build(),
+                "`" + name + "` is a built-in Option case: a model reads an optional (a `?` field,"
+                        + " `Map.get`, `List.find`) and passes it on, and never builds one. Where the"
+                        + " model owns the absence, make it a case of its own sum; a step for"
+                        + " `List.filterMap` can answer a list of nought or one instead, joined with"
+                        + " `List.concatMap`.");
     }
 
     /** A best-effort caret width for {@code e}: the token length when the node is a leaf whose source

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -701,9 +701,10 @@ public final class Elaborator {
                         .at(pos, name.length()).args(name).hint("e1303.hint").build(),
                 "`" + name + "` is a built-in Option case: a model reads an optional (a `?` field,"
                         + " `Map.get`, `List.find`) and passes it on, and never builds one. Where the"
-                        + " model owns the absence, make it a case of its own sum; a step for"
-                        + " `List.filterMap` can answer a list of nought or one instead, joined with"
-                        + " `List.concatMap`.");
+                        + " model owns the absence, make it a case of its own sum. Absence of that"
+                        + " kind does not reach `List.filterMap`, whose step has to answer an"
+                        + " optional: use `List.concatMap` over a step answering a list of nought or"
+                        + " one.");
     }
 
     /** A best-effort caret width for {@code e}: the token length when the node is a leaf whose source

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -465,10 +465,12 @@ public final class AstBuilder {
      */
     private Ast.TypeRef optional(List<Ast.TypeRef> cases, SourcePos pos) {
         if (!isReservedNamespace(moduleName)) {
-            throw error(pos, "parse.optional.core",
+            throw errorWithHint(pos, "parse.optional.core", "parse.optional.core.hint",
                     "an optional type `T?` may be written only on a data field, or in the core (the"
                             + " reserved `souther` namespace); a user model never names an optional"
-                            + " elsewhere (ADR-0011)");
+                            + " elsewhere (ADR-0011). On the result of a helper, leave the type off and"
+                            + " the optional is inferred; where the model owns the absence, answer a"
+                            + " list of nought or one and use `List.concatMap`");
         }
         if (cases.size() > 1) {
             throw error(pos, "parse.optional.sum",
@@ -1198,6 +1200,15 @@ public final class AstBuilder {
     private CompileException error(SourcePos pos, String messageKey, String legacyMessage, Object... args) {
         return CompileException.of(
                 Diagnostic.of(null, messageKey).title("parse.title").at(pos).args(args).build(),
+                legacyMessage);
+    }
+
+    /** As {@link #error}, with a hint under it naming the way out. */
+    private CompileException errorWithHint(SourcePos pos, String messageKey, String hintKey,
+                                           String legacyMessage, Object... args) {
+        return CompileException.of(
+                Diagnostic.of(null, messageKey).title("parse.title").at(pos).args(args)
+                        .hint(hintKey).build(),
                 legacyMessage);
     }
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -99,7 +99,7 @@ e1603.hint=Remove `{1}` from the `requires` clause.
 
 # `Some` / `None` written in an expression (E1303)
 e1303.msg=`{0}` is a built-in Option case. A model reads an optional — a `?` field, `Map.get`, `List.find` — and passes it on; it never builds one.
-e1303.hint=Where the model owns the absence, make it a case of its own sum. A step for `List.filterMap` can answer a list of nought or one instead, joined with `List.concatMap`.
+e1303.hint=Where the model owns the absence, make it a case of its own sum. Absence of that kind does not reach `List.filterMap`, whose step has to answer an optional: use `List.concatMap` over a step answering a list of nought or one.
 
 # injected behavior constructs an uncreatable data (E1305)
 e1305.msg=Injected behavior `{0}` declares `constructs {1}`, but {1} is neither a unit data nor exposed, so Java cannot build it.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -20,6 +20,7 @@ e1101.title=INVARIANT TYPE MISMATCH
 e1201.title=NON-EXHAUSTIVE MATCH
 e1301.title=USE OF NULL
 e1302.title=USE OF EXCEPTIONS
+e1303.title=BUILDING AN OPTIONAL
 e1305.title=UNCREATABLE INJECTED DATA
 e1401.title=ARBITRARY JAVA CALL
 e1501.title=CYCLIC IMPORT
@@ -95,6 +96,10 @@ e1602.msg=`let {0}` calls `{1}`, which has no implementation, but `behavior {2}`
 e1602.hint=Add `requires {1}` to `behavior {2}`.
 e1603.msg=`behavior {0}` declares `requires {1}`, but `let {2}` never calls it.
 e1603.hint=Remove `{1}` from the `requires` clause.
+
+# `Some` / `None` written in an expression (E1303)
+e1303.msg=`{0}` is a built-in Option case. A model reads an optional — a `?` field, `Map.get`, `List.find` — and passes it on; it never builds one.
+e1303.hint=Where the model owns the absence, make it a case of its own sum. A step for `List.filterMap` can answer a list of nought or one instead, joined with `List.concatMap`.
 
 # injected behavior constructs an uncreatable data (E1305)
 e1305.msg=Injected behavior `{0}` declares `constructs {1}`, but {1} is neither a unit data nor exposed, so Java cannot build it.
@@ -377,6 +382,7 @@ parse.data.fields=data `{0}` must declare at least one field or spread.
 parse.tuple=A tuple type needs at least two elements; `(T)` is not a type.
 parse.typevar.core=A type variable `{0}` is only allowed in the core (the reserved `souther` namespace); a user model stays bounded.
 parse.optional.core=An optional type `T?` may be written on a data field, or in the core (the reserved `souther` namespace); a user model never names an optional elsewhere.
+parse.optional.core.hint=On the result of a helper, leave the type off and the optional is inferred. Where the model owns the absence, answer a list of nought or one and use `List.concatMap`.
 parse.optional.sum=`?` marks a single type optional, but it follows a sum of {0} cases.
 parse.vpipe.right=The right side of `|>` must be a function call or a function name.
 parse.expr=I expected an expression here.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -98,7 +98,7 @@ e1603.hint=`requires` 句から `{1}` を外してください。
 
 # 式の中に書かれた `Some` / `None`（E1303）
 e1303.msg=`{0}` は組み込みの Option のケースです。モデルはオプショナル（`?` フィールド・`Map.get`・`List.find`）を読んで渡すだけで、自分では作りません。
-e1303.hint=不在がモデル自身のものなら、自分の sum のケースにしてください。`List.filterMap` に渡す step なら、0個か1個のリストを返して `List.concatMap` で繋ぐ形にもできます。
+e1303.hint=不在がモデル自身のものなら、自分の sum のケースにしてください。その不在は step がオプショナルを返す `List.filterMap` には渡せないので、0個か1個のリストを返す step を `List.concatMap` に渡します。
 
 # 注入 behavior が生成できないデータを構築（E1305）
 e1305.msg=注入 behavior `{0}` は `constructs {1}` を宣言していますが、{1} は unit data でも exposed でもないため、Java から生成できません。

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -19,6 +19,7 @@ e1101.title=不変条件の型不一致
 e1201.title=網羅されていない match
 e1301.title=null の使用
 e1302.title=例外の使用
+e1303.title=オプショナルの構築
 e1305.title=生成できない注入データ
 e1401.title=任意の Java 呼び出し
 e1501.title=循環 import
@@ -94,6 +95,10 @@ e1602.msg=`let {0}` は実装のない `{1}` を呼んでいますが、`behavio
 e1602.hint=`behavior {2}` に `requires {1}` を追加してください。
 e1603.msg=`behavior {0}` は `requires {1}` を宣言していますが、`let {2}` はそれを呼んでいません。
 e1603.hint=`requires` 句から `{1}` を外してください。
+
+# 式の中に書かれた `Some` / `None`（E1303）
+e1303.msg=`{0}` は組み込みの Option のケースです。モデルはオプショナル（`?` フィールド・`Map.get`・`List.find`）を読んで渡すだけで、自分では作りません。
+e1303.hint=不在がモデル自身のものなら、自分の sum のケースにしてください。`List.filterMap` に渡す step なら、0個か1個のリストを返して `List.concatMap` で繋ぐ形にもできます。
 
 # 注入 behavior が生成できないデータを構築（E1305）
 e1305.msg=注入 behavior `{0}` は `constructs {1}` を宣言していますが、{1} は unit data でも exposed でもないため、Java から生成できません。
@@ -376,6 +381,7 @@ parse.data.fields=data `{0}` は少なくとも1つのフィールドかスプ�
 parse.tuple=タプル型は要素が2つ以上必要です。`(T)` は型ではありません。
 parse.typevar.core=型変数 `{0}` は core（予約された `souther` 名前空間）でのみ使えます。ユーザーのモデルは有界のままです。
 parse.optional.core=オプショナル型 `T?` は data のフィールド、または core（予約された `souther` 名前空間）でのみ書けます。ユーザーのモデルはそれ以外の場所でオプショナルを名前で呼びません。
+parse.optional.core.hint=ヘルパーの戻り型なら、型を書かなければオプショナルのまま推論されます。不在がモデル自身のものなら、0個か1個のリストを返して `List.concatMap` を使ってください。
 parse.optional.sum=`?` は単一の型をオプショナルにしますが、{0} ケースの sum に付いています。
 parse.vpipe.right=`|>` の右辺は関数呼び出しか関数名でなければなりません。
 parse.expr=ここには式が必要です。

--- a/souther-compiler/src/main/resources/souther/list.sou
+++ b/souther-compiler/src/main/resources/souther/list.sou
@@ -151,8 +151,13 @@ let groupBy (key: ('a) -> 'k, xs: List<'a>) =
 // with an optional, and only what is there joins the result. This is how an optional field becomes a
 // plain list — `filterMap(i -> i.assignee, issues)` — without the caller writing a sentinel value to
 // filter on afterwards. `f`'s result type is written `'b?`, an optional in a signature, which is a
-// core privilege like the type variables around it: the caller's lambda returns an optional it read
-// (a `?` field, `Map.get`, `List.find`) and never names the type (ADR-0011).
+// core privilege like the type variables around it: the caller's step returns an optional it read
+// (a `?` field, `Map.get`, `List.find`) and never names the type (ADR-0011). The step can be named
+// as well as written inline — a helper that leaves its result type off has the optional inferred.
+//
+// So `filterMap` serves the absence a model reads. Absence the model owns — a sum case with nothing
+// to give — cannot reach it, because nothing but the core builds an optional; that projection answers
+// a list of nought or one and `concatMap` joins them (issue #166).
 let filterMap (f: ('a) -> 'b?, xs: List<'a>) =
     List.fold((acc, x) ->
         match f(x) with

--- a/souther-compiler/src/test/java/souther/compiler/CompileFilterMapTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFilterMapTest.java
@@ -1,10 +1,13 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.SourceContext;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -107,6 +110,58 @@ class CompileFilterMapTest {
                 let run (o) = o
                 """));
         assertTrue(e.getMessage().contains("optional"), e.getMessage());
+    }
+
+    @Test
+    void theOptionalInASignatureErrorSaysWhatToWriteInstead() {
+        // The rule alone left no way forward: the model wrote the annotation because it wanted a
+        // step for filterMap, and both ways to get one are ways of not writing the type (issue #166).
+        String src = """
+                module demo
+
+                data Name = String
+                data Issue = { id: String, assignee: Name? }
+
+                behavior run : (i: Issue) -> Issue
+
+                let pick (x: Issue): Name? = x.assignee
+                let run (i) = i
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        String out = new HumanRenderer(false).render(e.diagnostic(),
+                new SourceContext("demo.sou", src), Locale.ENGLISH);
+        assertTrue(out.contains("concatMap"), out);
+    }
+
+    @Test
+    void aHelperWithAnInferredResultIsAStep() throws Exception {
+        // The step can be named: a helper leaves its result type off and the optional is inferred,
+        // so factoring the projection out of the lambda does not need `Name?` to be writable.
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                import List ( filterMap )
+
+                data Name = String
+                data Issue = { id: String, assignee: Name? }
+                data In = { issues: List<Issue> }
+                data Out = { names: List<Name> }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let assigneeOf (x: Issue) = x.assignee
+
+                let run (i) = Out { names = filterMap(assigneeOf, i.issues) }
+                """), getClass().getClassLoader());
+
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("issues", List.of(
+                Map.of("id", "i-1", "assignee", "kawasima"),
+                Map.of("id", "i-2"),
+                Map.of("id", "i-3", "assignee", "aoyagi"))));
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+
+        assertEquals(List.of("kawasima", "aoyagi"), out.get("names"));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileOptionMatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileOptionMatchTest.java
@@ -1,12 +1,16 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.SourceContext;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -201,5 +205,57 @@ class CompileOptionMatchTest {
                 """;
         CompileException b = assertThrows(CompileException.class, () -> Compiler.compile(noneSrc));
         assertTrue(b.getMessage().contains("None"), b.getMessage());
+    }
+
+    @Test
+    void someCannotBeBuilt() {
+        // An optional is read, never built: `Some(x)` is not a call the model can write. It used to
+        // land on E1401 and advise a Java binding, which is the wrong way out (issue #166).
+        String src = """
+                module demo
+                data Id = String
+                data Trip = { id: Id }
+                behavior f : (t: Trip) -> Trip
+                let f (t) = Some(t.id)
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        assertEquals("E1303", e.code(), e.getMessage());
+        String out = new HumanRenderer(false).render(e.diagnostic(),
+                new SourceContext("demo.sou", src), Locale.ENGLISH);
+        assertTrue(out.contains("Some"), out);
+        assertFalse(out.contains("Java"), "a Java binding does not build an optional either: " + out);
+    }
+
+    @Test
+    void noneCannotBeWritten() {
+        String src = """
+                module demo
+                data Id = String
+                data Trip = { id: Id }
+                behavior f : (t: Trip) -> Trip
+                let f (t) = None
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        assertEquals("E1303", e.code(), e.getMessage());
+        String out = new HumanRenderer(false).render(e.diagnostic(),
+                new SourceContext("demo.sou", src), Locale.ENGLISH);
+        assertTrue(out.contains("None"), out);
+    }
+
+    @Test
+    void theHintPointsAtASumOfTheModelsOwn() {
+        // Where the absence is the model's own, the way out is a case of its own sum or a 0-or-1
+        // list, not a way to name `Option`.
+        String src = """
+                module demo
+                data Id = String
+                data Trip = { id: Id }
+                behavior f : (t: Trip) -> Trip
+                let f (t) = None
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        String out = new HumanRenderer(false).render(e.diagnostic(),
+                new SourceContext("demo.sou", src), Locale.ENGLISH);
+        assertTrue(out.contains("concatMap"), out);
     }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -2561,6 +2561,20 @@ error E1302:
 Exceptions are not supported. Return a failure case in the output sum.
 ----
 
+[#e1303]
+=== Building an optional
+
+[,text]
+----
+error E1303:
+`Some` is a built-in Option case. A model reads an optional — a `?` field, `Map.get`,
+`List.find` — and passes it on; it never builds one.
+Hint: Where the model owns the absence, make it a case of its own sum. A step for
+`List.filterMap` can answer a list of nought or one instead, joined with `List.concatMap`.
+----
+
+Reported where `+Some+` or `+None+` is written in an expression. A pattern is unaffected: `+| Some v+` matches an optional the model was given (<<optional>>, ADR-0011).
+
 [#e1401]
 === Arbitrary Java calls
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -2569,8 +2569,9 @@ Exceptions are not supported. Return a failure case in the output sum.
 error E1303:
 `Some` is a built-in Option case. A model reads an optional — a `?` field, `Map.get`,
 `List.find` — and passes it on; it never builds one.
-Hint: Where the model owns the absence, make it a case of its own sum. A step for
-`List.filterMap` can answer a list of nought or one instead, joined with `List.concatMap`.
+Hint: Where the model owns the absence, make it a case of its own sum. Absence of that
+kind does not reach `List.filterMap`, whose step has to answer an optional: use
+`List.concatMap` over a step answering a list of nought or one.
 ----
 
 Reported where `+Some+` or `+None+` is written in an expression. A pattern is unaffected: `+| Some v+` matches an optional the model was given (<<optional>>, ADR-0011).


### PR DESCRIPTION
Issue #166 reports `List.filterMap` as unreachable from a model. It is not. A step can be an inline lambda (`filterMap(x -> x.assignee, issues)`), and it can also be named — a helper that leaves its result type off has the optional inferred, and `filterMap(assigneeOf, issues)` compiles and runs. The repro in the issue failed because it wrote the annotation, not because the function has no callers.

What is genuinely blocked is narrower: absence the model owns. A case of the model's own sum has nothing that turns it into an optional, so that projection answers a list of nought or one and `concatMap` joins them — which is what `crm` does. That is ADR-0011 working as decided, so the language is unchanged here. The issue's proposal — letting the step answer a 0-or-1 list — would make `filterMap` a second name for `concatMap` without adding reach.

What was wrong is that neither diagnostic on the path said any of this.

- `T?` in a signature stated the rule and stopped. It now carries a hint naming both ways out.
- `Some(x)` / `None` in an expression landed on E1401 and advised writing a Java binding, which builds no optional either. New code **E1303** says an optional is read — a `?` field, `Map.get`, `List.find` — and never built, and points at the model's own sum. Patterns are untouched: `| Some v` matches an optional the model was given.

E1303 also fires on `Trip { approver = None }` in a behavior body, which spec §optional shows as ordinary construction but the compiler has never accepted. That divergence is issue #167's to settle, so the hint here deliberately says nothing about the field case.

Tests: the two new diagnostics, plus a regression guard that compiles *and runs* `filterMap` with a named helper step, so the route the docs now point at cannot rot. Full suite green; the `crm` example builds and tests against the change.

Docs: `list.sou` states which absence `filterMap` serves, and the spec catalog gains E1303. The overstated comments in `souther-lang/examples` are corrected in a companion PR.