### PR TITLE
Let a behavior body give a `?` field its value

### DIFF
--- a/docs/adr/0011-option-never-unit-not-surface-types.md
+++ b/docs/adr/0011-option-never-unit-not-surface-types.md
@@ -1,6 +1,7 @@
 # ADR-0011: Option, Never, and Unit are not surface-writable types
 
-Status: Accepted
+Status: Accepted. Amended (decided 2026-07-28) — where an optional is made is now stated rather than
+left implicit, which is what issue #167 found: the compiler had implemented neither half of it.
 
 ## Context
 
@@ -10,9 +11,13 @@ Status: Accepted
 
 `Never` and `Unit` are reading concepts, not writable type names. `Option<T>` cannot be written as a type either; it appears only where a `T?` field desugars, as stdlib return types (`List.get` / `Map.get` / `List.find`), and as the argument/result of the `Option` module's functions (`Option.map` / `Option.withDefault`), which consume an inferred `Option` without the caller ever naming the type or building a `Some`. None of the three may appear in a behavior output.
 
+A model makes an optional in one place: a data construction giving a `?` field its value. A plain value written there is wrapped and `None` is the empty one, so the type is made without being named. Everywhere else a model reads an optional and passes it on.
+
 ## Consequences
 
 `Never` denotes an impossible case (an empty sum); a single-case output (`-> A`) reads as "the failure row is empty." `Unit` corresponds to the DSL's 単位型 but is always expressed as a field-less `data`, never as a written type. `Option` cannot appear in a behavior output because "might not be found" as a business result is a domain sum — `-> 会員 | 会員なし` — which reads closer to the DSL than `Option<会員>`. Allowing `Option` in output would also force `>->` routing to decide whether it consumes `Some` / `None` or treats `Option<会員>` as one case; saying it in business vocabulary removes the question.
+
+Making an optional at a construction is a rule about building a data, not a coercion applied wherever two shapes nearly line up, and the two differ in what they permit elsewhere. An expected optional reaches an expression only from a field's own type, since nowhere else in a model can `T?` be written, so no other position can produce one — a lambda handed to a stdlib combinator is typed with no expected type at all. A step for `List.filterMap` therefore still has to answer an optional it read, and absence that is a case of the model's own sum stays a case of that sum, projected to a list of nought or one for `List.concatMap` (issue #166). A coercion would accept a step answering a plain value, and `filterMap` would no longer be the combinator that drops anything. The lift does reach the branches of the value being given to the field, so a field can be given one thing or nothing by a rule; that is the same construction, written conditionally.
 
 `Some(T)` is the one exception to the rule that a sum case carries no payload (see ADR-0013). Because `Option` is built in, users cannot imitate the form. Building a `?` field needs no `constructs`: `Option` is an auxiliary type with no invariant, so closed construction (ADR-0002) has nothing to protect there — and there is no way to write `constructs Some` anyway, since `Option` is not a writable type. The wrapped value is taken out with `match`, positionally: `| Some v` binds `v` to the contained value, as F#'s `Some x` and Elm's `Just x` do (see ADR-0035). `as`, which binds the whole matched value everywhere else, is not used on `Some`.
 

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -408,7 +408,7 @@ public final class CallElaborator {
                 // a required behavior called inline (spec 12.2, 13): type it as its success case
                 ReqSig callee = ctx.reqs().get(call.fn());
                 if (callee == null) {
-                    Elaborator.optionIsRead(call.fn(), call.pos());
+                    Elaborator.optionCaseWritten(call.fn(), call.pos());
                     String qualified = Prelude.qualifiedFor(call.fn());
                     if (qualified != null) {
                         throw CompileException.of(

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -487,7 +487,8 @@ public final class DataChecker {
             }
             // push the field's declared type into the value expression, so a field initialised from a
             // fold over an empty-collection seed has its result pinned by the field type (issue #70)
-            Core value = Elaborator.elaborate(init.value(), env, ctx, ft);
+            Core value = Elaborator.liftIntoOption(
+                    Elaborator.elaborate(init.value(), env, ctx, ft), ft, ctx.symbols());
             elaborated.add(new Core.FieldInit(init.name(), value, init.pos()));
             Type vt = value.type();
             if (!TypeOps.assignable(vt, ft, ctx.symbols())) {   // a case value widens to its sum-typed field (spec 8.3)

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -165,7 +165,13 @@ public final class Elaborator {
                     throw new CompileException(v.pos(), "E1301",
                             "`null` is not part of the language. Use an optional field with `?`.");
                 }
-                optionIsRead(v.name(), v.pos());
+                // `None` where a `?` field is being given a value: the empty optional (spec 7.3).
+                // Only the field's own type puts it here — nothing else expects an optional, because
+                // nothing else can say `T?` (ADR-0011) — so this stays a construction rule.
+                if (v.name().equals("None") && expected instanceof Type.OptionOf) {
+                    yield new Core.OptionNone(expected, v.pos());
+                }
+                optionCaseWritten(v.name(), v.pos());
                 throw CompileException.of(
                         Diagnostic.of(null, "check.unknown.name.msg")
                                 .title("check.unknown.title")
@@ -193,8 +199,12 @@ public final class Elaborator {
             case Ast.Match m -> MatchElaborator.elaborateMatch(m, env, ctx, expected);
             case Ast.If iff -> {
                 Core cond = requireTyped(iff.cond(), Type.BOOL, env, ctx, "if condition");
-                Core then = elaborate(iff.then(), env, ctx, expected);
-                Core els = elaborate(iff.els(), env, ctx, expected);
+                // Each branch is lifted before the join, so a field taking `T?` can be given a value
+                // on one side and `None` on the other and still have one type (spec 7.3).
+                Core then = liftIntoOption(elaborate(iff.then(), env, ctx, expected), expected,
+                        ctx.symbols());
+                Core els = liftIntoOption(elaborate(iff.els(), env, ctx, expected), expected,
+                        ctx.symbols());
                 Type tt = then.type();
                 Type et = els.type();
                 Type joined = TypeOps.join(tt, et);
@@ -686,25 +696,54 @@ public final class Elaborator {
     }
 
     /**
-     * Rejects {@code Some} / {@code None} written in an expression (E1303). An optional reaches a
-     * model already made — a {@code ?} field, {@code Map.get}, {@code List.find} — and is passed on
-     * or matched; nothing in the language builds one, and neither does a Java binding, so the
-     * unknown-name and arbitrary-call reports both send the reader the wrong way (issue #166).
-     * Patterns do not come through here: {@code | Some v} is matched, not evaluated.
+     * Wraps a value being given to a {@code ?} field, so {@code Out { note = n }} puts {@code n}
+     * where an optional is asked for (spec 7.3). Construction is the one place this happens: an
+     * expected optional only ever arrives from a field's own type, because nowhere else in a model
+     * can {@code T?} be written (ADR-0011) — a lambda handed to a stdlib combinator is typed with no
+     * expected type at all ({@code HelperTyping}), so a step for {@code List.filterMap} still has to
+     * answer an optional of its own. That keeps this a rule about building a data rather than a
+     * coercion applied wherever two shapes nearly line up.
+     *
+     * <p>A value that is already the optional — read from another field, or {@code None} — is
+     * returned untouched, and so is one whose type has nothing to do with the field, which the
+     * caller then reports as the mismatch it is.
      */
-    static void optionIsRead(String name, SourcePos pos) {
-        if (!name.equals("Some") && !name.equals("None")) {
+    static Core liftIntoOption(Core value, Type expected, Symbols symbols) {
+        if (!(expected instanceof Type.OptionOf opt)
+                || TypeOps.assignable(value.type(), expected, symbols)
+                || !TypeOps.assignable(value.type(), opt.element(), symbols)) {
+            return value;
+        }
+        return new Core.OptionSome(value, expected, value.pos());
+    }
+
+    /**
+     * Rejects {@code Some} / {@code None} written where no {@code ?} field is being given a value
+     * (E1303). Giving a field its value is the one place an optional is made — the wrap is implicit
+     * and {@code None} is the empty one (spec 7.3) — and everywhere else an optional is read and
+     * passed on. Neither an unknown-name report nor an arbitrary-call report says that, and the
+     * latter sent the reader off to write a Java binding, which makes no optional either (issue
+     * #166). Patterns do not come through here: {@code | Some v} is matched, not evaluated.
+     */
+    static void optionCaseWritten(String name, SourcePos pos) {
+        boolean some = name.equals("Some");
+        if (!some && !name.equals("None")) {
             return;
         }
         throw CompileException.of(
-                Diagnostic.of("E1303", "e1303.msg").title("e1303.title")
-                        .at(pos, name.length()).args(name).hint("e1303.hint").build(),
-                "`" + name + "` is a built-in Option case: a model reads an optional (a `?` field,"
-                        + " `Map.get`, `List.find`) and passes it on, and never builds one. Where the"
-                        + " model owns the absence, make it a case of its own sum. Absence of that"
-                        + " kind does not reach `List.filterMap`, whose step has to answer an"
-                        + " optional: use `List.concatMap` over a step answering a list of nought or"
-                        + " one.");
+                Diagnostic.of("E1303", some ? "e1303.some" : "e1303.none").title("e1303.title")
+                        .at(pos, name.length())
+                        .hint(some ? "e1303.some.hint" : "e1303.none.hint").build(),
+                some
+                        ? "`Some(...)` is not a call: a value written into a `?` field is wrapped for"
+                                + " you, and that is the only place an optional is made. Where a `?`"
+                                + " field is being given a value, write the value on its own;"
+                                + " elsewhere an optional is only read, never made."
+                        : "`None` is the empty value of a `?` field, and nothing here is asking for"
+                                + " one. Where the model owns the absence, make it a case of its own"
+                                + " sum. Absence of that kind does not reach `List.filterMap`, whose"
+                                + " step has to answer an optional: use `List.concatMap` over a step"
+                                + " answering a list of nought or one.");
     }
 
     /** A best-effort caret width for {@code e}: the token length when the node is a leaf whose source

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -105,7 +105,9 @@ public final class MatchElaborator {
                 }
                 checkUnwrapAsserts(c, ctx.symbols());
             }
-            Core body = Elaborator.elaborate(c.body(), bound(env, c.binding(), bindType), ctx, expected);
+            Core body = Elaborator.liftIntoOption(
+                    Elaborator.elaborate(c.body(), bound(env, c.binding(), bindType), ctx, expected),
+                    expected, ctx.symbols());
             arms.add(new Core.Case(c.caseTypes(), c.binding(), body, bindType, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c);
         }
@@ -166,7 +168,9 @@ public final class MatchElaborator {
                                 .at(c.pos()).args(caseType).build(),
                         "`" + caseType + "` is matched by more than one case");
             }
-            Core body = Elaborator.elaborate(c.body(), bound(env, c.binding(), bind), ctx, expected);
+            Core body = Elaborator.liftIntoOption(
+                    Elaborator.elaborate(c.body(), bound(env, c.binding(), bind), ctx, expected),
+                    expected, ctx.symbols());
             arms.add(new Core.Case(c.caseTypes(), c.binding(), body, bind, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c);
         }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -544,6 +544,16 @@ final class BodyGen {
                     genExpr(iff.els(), expected);
                     code.labelBinding(end);
                 }
+                case Core.OptionSome s -> {
+                    // `Option.some` takes the value as an Object, so a primitive element boxes here
+                    // the way a list element does.
+                    genExpr(s.value());
+                    JvmTypes.box(code, s.value().type());
+                    code.invokestatic(CD_Option, "some",
+                            MethodTypeDesc.of(CD_Option, ConstantDescs.CD_Object), true);
+                }
+                case Core.OptionNone _ ->
+                        code.invokestatic(CD_Option, "none", MethodTypeDesc.of(CD_Option), true);
                 case Core.ListLit lit -> listLit(lit);
                 case Core.Tuple t -> tuple(t);
                 case Core.TupleGet tg -> tupleGet(tg);
@@ -1372,6 +1382,8 @@ final class BodyGen {
                 case Core.ListLit lit -> lit.elements().forEach(x -> collectFree(x, bound, free));
                 case Core.Tuple tup -> tup.elements().forEach(x -> collectFree(x, bound, free));
                 case Core.TupleGet tg -> collectFree(tg.tuple(), bound, free);
+                case Core.OptionSome s -> collectFree(s.value(), bound, free);
+                case Core.OptionNone _ -> { }
                 case Core.Int _ -> { }
                 case Core.Decimal _ -> { }
                 case Core.Str _ -> { }

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -67,6 +67,14 @@ public sealed interface Core {
 
     record ListLit(List<Core> elements, Type type, SourcePos pos) implements Core {}
 
+    /** A value given to a {@code ?} field, wrapped (spec 7.3). Construction of a data is the one
+     * place an optional is made, so this node has no surface form: {@code Some(...)} is not a call
+     * anyone can write, and the type it produces is never named (ADR-0011). */
+    record OptionSome(Core value, Type type, SourcePos pos) implements Core {}
+
+    /** {@code None} given to a {@code ?} field: the empty optional. */
+    record OptionNone(Type type, SourcePos pos) implements Core {}
+
     /** A tuple {@code (e1, e2, ...)} (ADR-0036); the backend emits it as an {@code Object[]}. */
     record Tuple(List<Core> elements, Type type, SourcePos pos) implements Core {}
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -20,7 +20,7 @@ e1101.title=INVARIANT TYPE MISMATCH
 e1201.title=NON-EXHAUSTIVE MATCH
 e1301.title=USE OF NULL
 e1302.title=USE OF EXCEPTIONS
-e1303.title=BUILDING AN OPTIONAL
+e1303.title=WRITING AN OPTION CASE
 e1305.title=UNCREATABLE INJECTED DATA
 e1401.title=ARBITRARY JAVA CALL
 e1501.title=CYCLIC IMPORT
@@ -97,9 +97,11 @@ e1602.hint=Add `requires {1}` to `behavior {2}`.
 e1603.msg=`behavior {0}` declares `requires {1}`, but `let {2}` never calls it.
 e1603.hint=Remove `{1}` from the `requires` clause.
 
-# `Some` / `None` written in an expression (E1303)
-e1303.msg=`{0}` is a built-in Option case. A model reads an optional — a `?` field, `Map.get`, `List.find` — and passes it on; it never builds one.
-e1303.hint=Where the model owns the absence, make it a case of its own sum. Absence of that kind does not reach `List.filterMap`, whose step has to answer an optional: use `List.concatMap` over a step answering a list of nought or one.
+# `Some` / `None` written where no `?` field is being given a value (E1303)
+e1303.some=`Some(...)` is not a call: a value written into a `?` field is wrapped for you, and that is the only place an optional is made.
+e1303.some.hint=Where a `?` field is being given a value, write the value on its own. Elsewhere an optional is only read — a `?` field, `Map.get`, `List.find` — never made.
+e1303.none=`None` is the empty value of a `?` field, and nothing here is asking for one.
+e1303.none.hint=Where the model owns the absence, make it a case of its own sum. Absence of that kind does not reach `List.filterMap`, whose step has to answer an optional: use `List.concatMap` over a step answering a list of nought or one.
 
 # injected behavior constructs an uncreatable data (E1305)
 e1305.msg=Injected behavior `{0}` declares `constructs {1}`, but {1} is neither a unit data nor exposed, so Java cannot build it.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -19,7 +19,7 @@ e1101.title=不変条件の型不一致
 e1201.title=網羅されていない match
 e1301.title=null の使用
 e1302.title=例外の使用
-e1303.title=オプショナルの構築
+e1303.title=Option のケース名の使用
 e1305.title=生成できない注入データ
 e1401.title=任意の Java 呼び出し
 e1501.title=循環 import
@@ -96,9 +96,11 @@ e1602.hint=`behavior {2}` に `requires {1}` を追加してください。
 e1603.msg=`behavior {0}` は `requires {1}` を宣言していますが、`let {2}` はそれを呼んでいません。
 e1603.hint=`requires` 句から `{1}` を外してください。
 
-# 式の中に書かれた `Some` / `None`（E1303）
-e1303.msg=`{0}` は組み込みの Option のケースです。モデルはオプショナル（`?` フィールド・`Map.get`・`List.find`）を読んで渡すだけで、自分では作りません。
-e1303.hint=不在がモデル自身のものなら、自分の sum のケースにしてください。その不在は step がオプショナルを返す `List.filterMap` には渡せないので、0個か1個のリストを返す step を `List.concatMap` に渡します。
+# `?` フィールドに値を与える場所以外で書かれた `Some` / `None`（E1303）
+e1303.some=`Some(...)` は呼び出しではありません。`?` フィールドに書いた値は自動で包まれ、そこがオプショナルの作られる唯一の場所です。
+e1303.some.hint=`?` フィールドに値を与える場所なら、値だけを書いてください。それ以外の場所では、オプショナル（`?` フィールド・`Map.get`・`List.find`）は読むだけで作りません。
+e1303.none=`None` は `?` フィールドの空の値ですが、ここではそれを求めているものがありません。
+e1303.none.hint=不在がモデル自身のものなら、自分の sum のケースにしてください。その不在は step がオプショナルを返す `List.filterMap` には渡せないので、0個か1個のリストを返す step を `List.concatMap` に渡します。
 
 # 注入 behavior が生成できないデータを構築（E1305）
 e1305.msg=注入 behavior `{0}` は `constructs {1}` を宣言していますが、{1} は unit data でも exposed でもないため、Java から生成できません。

--- a/souther-compiler/src/test/java/souther/compiler/CompileOptionalFieldConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileOptionalFieldConstructionTest.java
@@ -1,0 +1,195 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Giving a {@code ?} field a value from a behavior body (spec 7.3): a plain value is wrapped in
+ * {@code Some}, and {@code None} is the empty one. Both are construction — the one place an optional
+ * is made — so the type is still never named and {@code Some(...)} is still not a call anyone can
+ * write (ADR-0011, issue #167). {@link CompileOptionalFieldTest} covers the codec side of the same
+ * field.
+ */
+class CompileOptionalFieldConstructionTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Note = String
+            data In = { id: String, n: Note, keep: Bool }
+            data Out = { id: String, note: Note? }
+
+            behavior run : (i: In) -> Out constructs Out
+
+            let run (i) = %s
+            """;
+
+    private Map<?, ?> run(String body) throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(
+                Compiler.compile(MODULE.formatted(body)), getClass().getClassLoader());
+        Map<String, Object> input = new HashMap<>();
+        input.put("id", "x-1");
+        input.put("n", "hello");
+        input.put("keep", true);
+        Object in = Codecs.decoded(loader, "demo.In", input);
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        return (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+    }
+
+    @Test
+    void aPlainValueIsWrapped() throws Exception {
+        assertEquals("hello", run("Out { id = i.id, note = i.n }").get("note"));
+    }
+
+    @Test
+    void aConstructedValueIsWrapped() throws Exception {
+        // The value need not be read from somewhere: a newtype built here wraps the same way.
+        String src = """
+                module demo
+
+                data Note = String
+                data In = { id: String }
+                data Out = { id: String, note: Note? }
+
+                behavior run : (i: In) -> Out constructs Out, Note
+
+                let run (i) = Out { id = i.id, note = Note("fresh") }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("id", "x-1"));
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals("fresh", out.get("note"));
+    }
+
+    @Test
+    void noneIsTheEmptyOne() throws Exception {
+        Map<?, ?> out = run("Out { id = i.id, note = None }");
+        assertFalse(out.containsKey("note"), "an empty optional encodes to no key at all: " + out);
+    }
+
+    @Test
+    void anOptionalReadElsewhereStillPassesThrough() throws Exception {
+        // The form that already worked: the value is an optional to begin with, so nothing wraps it.
+        String src = """
+                module demo
+
+                data Note = String
+                data In = { id: String, note: Note? }
+                data Out = { id: String, note: Note? }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out { id = i.id, note = i.note }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("id", "x-1", "note", "kept"));
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+        assertEquals("kept", out.get("note"));
+    }
+
+    @Test
+    void aConditionalGivesTheFieldEitherOne() throws Exception {
+        // The shape the trick existed for: present or absent by a rule. Each branch is lifted before
+        // the two are joined, so the `if` has one type without either side naming it.
+        assertEquals("hello", run("Out { id = i.id, note = if i.keep then i.n else None }").get("note"));
+        Map<?, ?> dropped = run("Out { id = i.id, note = if i.keep then None else i.n }");
+        assertFalse(dropped.containsKey("note"), dropped.toString());
+    }
+
+    @Test
+    void aMatchArmGivesTheFieldEitherOne() throws Exception {
+        String src = """
+                module demo
+
+                data Note = String
+                data Present = { n: Note }
+                data Which = Absent | Present
+                data In = { id: String, which: Which }
+                data Out = { id: String, note: Note? }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out { id = i.id, note = match i.which with
+                                                         | Present { n } -> n
+                                                         | Absent        -> None }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object behavior = loader.loadClass("demo.Run" + "$Impl").getConstructor().newInstance();
+
+        Object present = Codecs.decoded(loader, "demo.In", Map.of("id", "x-1",
+                "which", Map.of("type", "Present", "n", "here")));
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, present));
+        assertEquals("here", out.get("note"));
+
+        Object absent = Codecs.decoded(loader, "demo.In", Map.of("id", "x-2",
+                "which", Map.of("type", "Absent")));
+        Map<?, ?> gone = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, absent));
+        assertFalse(gone.containsKey("note"), gone.toString());
+    }
+
+    @Test
+    void aStepForFilterMapStillHasToAnswerAnOptionalOfItsOwn() {
+        // The lift reaches branches, but only under a field: a lambda is typed with no expected type,
+        // so absence the model owns still does not become an optional here (issue #166).
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                import List ( filterMap )
+
+                data Note = String
+                data Issue = { id: String, n: Note, keep: Bool }
+                data In = { issues: List<Issue> }
+                data Out = { notes: List<Note> }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let run (i) = Out { notes = filterMap(x -> if x.keep then x.n else None, i.issues) }
+                """));
+        assertTrue(e.getMessage().contains("None") || e.getMessage().contains("filterMap"),
+                e.getMessage());
+    }
+
+    @Test
+    void noneOutsideAnOptionalFieldIsStillRejected() {
+        // The wrap is a construction rule, not a coercion: `None` means nothing where the field is
+        // not optional, and nothing where there is no field at all.
+        CompileException onField = assertThrows(CompileException.class,
+                () -> Compiler.compile(MODULE.formatted("Out { id = None, note = None }")));
+        assertEquals("E1303", onField.code(), onField.getMessage());
+
+        CompileException bare = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Note = String
+                data Out = { note: Note? }
+                behavior run : (o: Out) -> Out
+                let run (o) = None
+                """));
+        assertEquals("E1303", bare.code(), bare.getMessage());
+    }
+
+    @Test
+    void someIsStillNotACallAnyoneCanWrite() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compile(MODULE.formatted("Out { id = i.id, note = Some(i.n) }")));
+        assertEquals("E1303", e.code(), e.getMessage());
+    }
+
+    @Test
+    void aWrongTypeIsStillAWrongType() {
+        // The wrap is over the field's own element type; anything else is the mismatch it was.
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compile(MODULE.formatted("Out { id = i.id, note = i.id }")));
+        assertTrue(e.getMessage().contains("note"), e.getMessage());
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -2562,19 +2562,18 @@ Exceptions are not supported. Return a failure case in the output sum.
 ----
 
 [#e1303]
-=== Building an optional
+=== Writing an option case
 
 [,text]
 ----
 error E1303:
-`Some` is a built-in Option case. A model reads an optional — a `?` field, `Map.get`,
-`List.find` — and passes it on; it never builds one.
+`None` is the empty value of a `?` field, and nothing here is asking for one.
 Hint: Where the model owns the absence, make it a case of its own sum. Absence of that
 kind does not reach `List.filterMap`, whose step has to answer an optional: use
 `List.concatMap` over a step answering a list of nought or one.
 ----
 
-Reported where `+Some+` or `+None+` is written in an expression. A pattern is unaffected: `+| Some v+` matches an optional the model was given (<<optional>>, ADR-0011).
+Reported where `+Some+` or `+None+` is written outside the one place an optional is made — a `+?+` field being given a value, where a plain value is wrapped and `+None+` is the empty one (<<optional>>). `+Some(...)+` is never a call, since the wrap there is implicit. A pattern is unaffected: `+| Some v+` matches an optional the model was given (ADR-0011).
 
 [#e1401]
 === Arbitrary Java calls

--- a/specification.adoc
+++ b/specification.adoc
@@ -2564,6 +2564,21 @@ Exceptions are not supported. Return a failure case in the output sum.
 [#e1303]
 === Writing an option case
 
+Reported where `+Some+` or `+None+` is written outside the one place an optional is made — a `+?+` field being given a value, where a plain value is wrapped and `+None+` is the empty one (<<optional>>). The two names fail for different reasons and are reported apart.
+
+`+Some(...)+` is never a call, wherever it is written, because the wrap at the field is implicit:
+
+[,text]
+----
+error E1303:
+`Some(...)` is not a call: a value written into a `?` field is wrapped for you,
+and that is the only place an optional is made.
+Hint: Where a `?` field is being given a value, write the value on its own.
+Elsewhere an optional is only read — a `?` field, `Map.get`, `List.find` — never made.
+----
+
+`+None+` is a value, and the error is that this position is not asking for one:
+
 [,text]
 ----
 error E1303:
@@ -2573,7 +2588,7 @@ kind does not reach `List.filterMap`, whose step has to answer an optional: use
 `List.concatMap` over a step answering a list of nought or one.
 ----
 
-Reported where `+Some+` or `+None+` is written outside the one place an optional is made — a `+?+` field being given a value, where a plain value is wrapped and `+None+` is the empty one (<<optional>>). `+Some(...)+` is never a call, since the wrap there is implicit. A pattern is unaffected: `+| Some v+` matches an optional the model was given (ADR-0011).
+A pattern is unaffected by either: `+| Some v+` matches an optional the model was given (ADR-0011).
 
 [#e1401]
 === Arbitrary Java calls


### PR DESCRIPTION
Closes the folklore in issue #167, and corrects its premise on the way.

The issue reads the rule as "`None` is not a value a behavior body can write (ADR-0011)". ADR-0011 forbids naming the type `Option<T>` and calling `Some(...)`; it does not forbid `None`. Spec §optional has always said the opposite of what the compiler does:

> To put a value in a `?` field, write a `従業員ID` value directly and it is wrapped in `Some`; write `None` for empty.

Neither half was implemented. Measured on `develop`, a `?` field in a behavior body took an optional read from somewhere else, and `List.get(0, [x])` / `List.get(0, [])`, but refused both `i.n` and `None`. So the trick was not a loophole around a rule — it was the only way to reach a rule the compiler had never implemented, in **both** directions. #167 saw the absent half; the present half was equally broken.

## What this does

Implements the field-initialization rule as written. A value given to a `?` field is wrapped; `None` is the empty one.

The lift also reaches the branches of the value, because that is the shape the trick actually existed for:

```
Out { note = if i.keep then i.n else None }

Out { note = match i.which with
                 | Present { n } -> n
                 | Absent        -> None }
```

## Why this does not reopen #166

Construction is the only place an optional is made. An expected optional reaches an expression only from a field's own type — nowhere else in a model can `T?` be written (ADR-0011) — and `HelperTyping` types a lambda handed to a stdlib combinator with **no** expected type at all, then unifies the result afterwards. So a step for `List.filterMap` still has to answer an optional of its own, and absence the model owns still does not become one. There is a test pinning exactly that, so the boundary cannot drift.

This is why it is a construction rule and not a coercion: a coercion applied wherever two shapes nearly line up would let `filterMap(x -> x.id, xs)` through, and `filterMap` would stop being the combinator that drops anything.

## Diagnostics

E1303 (added in #172) now reports the two names apart, since they fail for different reasons:

- `Some(...)` — never a call, because the wrap at the field is implicit.
- `None` — the empty value of a `?` field; the error is that nothing here is asking for one. Keeps the `List.concatMap` hint for absence the model owns.

## Notes

- `List.get(0, [])` still compiles. It is an ordinary total call, not a loophole; nobody has a reason to write it now.
- Spec §optional needed no edit — it now describes what the compiler does. The E1303 catalog entry is updated.
- No ADR change: ADR-0011 already says wrapping in `Some`/`None` is not data construction and needs no `constructs`.
- Full suite green, and all of `souther-lang/examples` builds and tests against it. `crm` can drop its `List.get(0, [])` note in a follow-up.
