### PR TITLE
Give the seven message keys that render as themselves a message

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -212,7 +212,7 @@ public final class MatchElaborator {
         List<String> opened = new ArrayList<>();
         opened.add(c.caseTypes().get(0));
         opened.addAll(c.unwrapAsserts());
-        checkOpenedLayers(c, opened, symbols);
+        checkOpenedLayers(c, opened, symbols, true);
     }
 
     /** {@code Some(X(v))} opens the Option's element in the pattern. Unlike a user case, {@code Some}
@@ -228,21 +228,29 @@ public final class MatchElaborator {
         if (!elementName.equals(first)) {
             throw CompileException.of(
                     Diagnostic.of(null, "check.match.newtype.mismatch").title("check.match.title")
-                            .at(c.pos()).args(first, elementName).build(),
+                            .at(c.pos()).args("Some", elementName, first).build(),
                     "`Some` wraps `" + elementName + "`, not `" + first + "`");
         }
-        checkOpenedLayers(c, layers, symbols);
+        checkOpenedLayers(c, layers, symbols, false);
     }
 
-    static void checkOpenedLayers(Ast.Case c, List<String> opened, Symbols symbols) {
+    /** {@code firstOpensTheCase} says the first opened name is the arm's own case, which is where
+     * {@code | X as v} is the spelling to reach for when X turns out not to be a newtype. An inner
+     * layer (and Option's element) is reached through the case, so no such binding replaces it. */
+    static void checkOpenedLayers(Ast.Case c, List<String> opened, Symbols symbols,
+                                  boolean firstOpensTheCase) {
         for (int i = 0; i < opened.size(); i++) {
             String name = opened.get(i);
             TypeName layer = symbols.resolve(name);
             Type inner = layer == null ? null : TypeOps.newtypeInner(layer, symbols);
             if (inner == null) {
-                throw CompileException.of(
+                Diagnostic.Builder d =
                         Diagnostic.of(null, "check.match.newtype.notnewtype").title("check.match.title")
-                                .at(c.pos()).args(name).build(),
+                                .at(c.pos()).args(name);
+                if (i == 0 && firstOpensTheCase) {
+                    d = d.hint("check.match.newtype.notnewtype.hint");
+                }
+                throw CompileException.of(d.build(),
                         "`" + name + "` is not a newtype, so it cannot be opened with `" + name + "(...)`");
             }
             if (i + 1 < opened.size()) {
@@ -251,7 +259,7 @@ public final class MatchElaborator {
                 if (!innerName.equals(next)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.match.newtype.mismatch").title("check.match.title")
-                                    .at(c.pos()).args(next, innerName).build(),
+                                    .at(c.pos()).args(name, innerName, next).build(),
                             "`" + name + "` wraps `" + innerName + "`, not `" + next + "`");
                 }
             }

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -166,6 +166,10 @@ check.match.nocases=This `match` has no cases.
 check.match.option.orpattern=Or-patterns are not allowed in an Option match; use separate Some and None cases.
 check.match.option.notcase=`{0}` is not a case of Option; use Some or None.
 check.match.option.nopayload=`{0}` has no value, so it cannot be opened with `{0}(...)`.
+check.match.newtype.notnewtype=`{0}` is not a newtype, so a match case cannot open it with `{0}(...)`.
+check.match.newtype.notnewtype.hint=To bind the matched value itself, write `| {0} as v`.
+check.match.newtype.mismatch=`{0}` wraps `{1}`, not `{2}`.
+check.match.newtype.orpattern=An or-pattern binds the sum type, so it cannot open a case's value with `(...)`.
 
 # tuple pattern / field access
 check.tuple.pattern=A tuple pattern needs a tuple, but got {0}.
@@ -379,6 +383,7 @@ parse.module=A source file starts with a `module` declaration (or omit it in a s
 parse.topdef=A top-level definition starts with `data`, `behavior`, or `let`.
 parse.behavior.colon=A behavior signature uses `:` before its parameters: `behavior {0} : (...) -> ...`.
 parse.intrinsic.rettype=Intrinsic `{0}` must declare its return type: `let {0} (...) : <type> = intrinsic "<key>"`.
+parse.intrinsic.core=`intrinsic` is a core privilege: only a module in the reserved `souther` namespace declares one.
 parse.data.equals=data `{0}` needs `=` before its body: write `data {0} = ...`.
 parse.data.fields=data `{0}` must declare at least one field or spread.
 parse.tuple=A tuple type needs at least two elements; `(T)` is not a type.
@@ -395,6 +400,9 @@ parse.case.record.direct=A record's fields are destructured directly: write `| S
 parse.newtype.tuple=A newtype takes the external representation of what it wraps, and a tuple has none. Wrap a named data instead.
 parse.newtype.fntype=A newtype takes the external representation of what it wraps, and a function has none.
 parse.sum.case.generic=A sum's cases are references to declared named data, so a case is never a generic type. Declare a data for it and name that.
+parse.examples.for=An example-only file starts with the module its examples belong to: `examples for <module>`.
+parse.example.row=An `example` needs at least one `|` row.
+parse.fake.row=A `fake` needs at least one `|` row.
 
 # --- examples (E1901-E1907) ---
 check.example.title=EXAMPLE

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -165,6 +165,10 @@ check.match.nocases=この match にはケースがありません。
 check.match.option.orpattern=Option の match では or パターンを使えません。Some と None を別々のケースにしてください。
 check.match.option.notcase=`{0}` は Option のケースではありません。Some か None を使ってください。
 check.match.option.nopayload=`{0}` は値を持たないので、`{0}(...)` で分解できません。
+check.match.newtype.notnewtype=`{0}` は newtype ではないので、match のケースで `{0}(...)` と開くことはできません。
+check.match.newtype.notnewtype.hint=一致した値そのものを束縛するなら `| {0} as v` と書きます。
+check.match.newtype.mismatch=`{0}` が包むのは `{1}` であって `{2}` ではありません。
+check.match.newtype.orpattern=or パターンは直和型を束縛するため、ケースの値を `(...)` で開くことはできません。
 
 # タプルパターン／フィールドアクセス
 check.tuple.pattern=タプルパターンにはタプルが必要ですが、{0} が渡されました。
@@ -378,6 +382,7 @@ parse.module=ソースファイルは `module` 宣言から始めます（単一
 parse.topdef=トップレベルの定義は `data`・`behavior`・`let` のいずれかで始めます。
 parse.behavior.colon=behavior のシグネチャは引数の前に `:` を書きます: `behavior {0} : (...) -> ...`
 parse.intrinsic.rettype=intrinsic `{0}` は戻り値の型を宣言する必要があります: `let {0} (...) : <型> = intrinsic "<キー>"`
+parse.intrinsic.core=intrinsic はコアの特権です。予約された `souther` 名前空間のモジュールだけが宣言できます。
 parse.data.equals=data `{0}` は本体の前に `=` が必要です。`data {0} = ...` と書きます。
 parse.data.fields=data `{0}` は少なくとも1つのフィールドかスプレッドを宣言する必要があります。
 parse.tuple=タプル型は要素が2つ以上必要です。`(T)` は型ではありません。
@@ -394,6 +399,9 @@ parse.case.record.direct=レコードのフィールドは直接分解します�
 parse.newtype.tuple=newtype は包んだ型の外部表現をそのまま受け取りますが、タプルには外部表現がありません。名前付きの data を包んでください。
 parse.newtype.fntype=newtype は包んだ型の外部表現をそのまま受け取りますが、関数には外部表現がありません。
 parse.sum.case.generic=sum のケースは宣言済みの名前付き data への参照なので、総称型がケースになることはありません。data を宣言してその名前を書いてください。
+parse.examples.for=example だけのファイルは、その example が属するモジュールから始めます: `examples for <モジュール>`
+parse.example.row=example には `|` で始まる行が少なくとも1つ必要です。
+parse.fake.row=fake には `|` で始まる行が少なくとも1つ必要です。
 
 # --- examples (E1901-E1907) ---
 check.example.title=example

--- a/souther-compiler/src/test/java/souther/compiler/CompileMatchNewtypeUnwrapTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileMatchNewtypeUnwrapTest.java
@@ -1,12 +1,15 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Locale;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -126,6 +129,56 @@ class CompileMatchNewtypeUnwrapTest {
                     match m with
                         | アクティベート済み | 未アクティベート(a) -> a.value
                 """;
-        assertThrows(CompileException.class, () -> Compiler.compile(HEAD + body));
+        CompileException ex = assertThrows(CompileException.class, () -> Compiler.compile(HEAD + body));
+        assertTrue(render(ex).contains("or-pattern"), render(ex));
+    }
+
+    /** Every one of these rejections is read as rendered prose, and each of the three used to reach
+     *  the reader as its own message key. */
+    @Test
+    void eachRejectionRendersAsAMessage() {
+        String wrongInner = """
+                    match m with
+                        | アクティベート済み(ソース(s)) -> s
+                        | 未アクティベート(メールアドレス(s)) -> s
+                """;
+        String notNewtype = """
+                    match m with
+                        | アクティベート済み(メールアドレス(String(s))) -> s
+                        | 未アクティベート(メールアドレス(s)) -> s
+                """;
+        String orPattern = """
+                    match m with
+                        | アクティベート済み | 未アクティベート(a) -> a.value
+                """;
+        for (String body : new String[] {wrongInner, notNewtype, orPattern}) {
+            String rendered = render(assertThrows(CompileException.class,
+                    () -> Compiler.compile(HEAD + body)));
+            assertFalse(rendered.contains("check.match.newtype"), rendered);
+        }
+    }
+
+    @Test
+    void openingAPrimitiveCaseSaysHowToBindItInstead() {
+        // `Int` heads a primitive union case, so it is bound with `as`, not opened with `(...)`
+        CompileException ex = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module p exposing ( run, In, Out )
+                data In = { a: Int, b: Int }
+                data Out = { r: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let q = match Int.divide(i.a, i.b) with
+                        | DivisionByZero -> 0
+                        | Int(n) -> n
+                    Out { r = q }
+                }
+                """));
+        String rendered = render(ex);
+        assertTrue(rendered.contains("`Int` is not a newtype"), rendered);
+        assertTrue(rendered.contains("| Int as v"), rendered);
+    }
+
+    private static String render(CompileException ex) {
+        return new HumanRenderer(false).render(ex.diagnostic(), null, Locale.ENGLISH);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/diag/MessageCatalogFormatTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/MessageCatalogFormatTest.java
@@ -7,6 +7,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -16,8 +18,10 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Every message in the catalog is a {@link java.text.MessageFormat} pattern, where a lone {@code '}
@@ -79,6 +83,82 @@ class MessageCatalogFormatTest {
             highest = Math.max(highest, Integer.parseInt(m.group(1)));
         }
         return highest + 1;
+    }
+
+    /**
+     * A key the compiler names but the catalog does not define renders as the key itself, so the
+     * reader gets {@code check.match.newtype.notnewtype} where the message belongs. Nothing else
+     * catches it: the site compiles, and the text is only read when that diagnostic fires.
+     *
+     * <p>The keys are collected from the sources rather than from the call sites, because a key is
+     * also passed to the parser's and the AST builder's own {@code error(...)} helpers, and those
+     * sites are invisible to a scan for {@code Diagnostic.of}. A string literal counts as a key when
+     * it is shaped like one and its first segment is one the catalog already uses — so the very
+     * first key of a brand-new namespace is the one case this does not see.
+     */
+    @Test
+    void everyKeyTheCompilerNamesIsInTheCatalog() throws IOException {
+        Set<String> defined = keysOf("/souther/compiler/diag/messages.properties");
+        Set<String> namespaces = new TreeSet<>();
+        for (String key : defined) {
+            namespaces.add(key.substring(0, key.indexOf('.')));
+        }
+        Set<String> named = new TreeSet<>();
+        for (Path source : mainSources()) {
+            Matcher m = KEY_LITERAL.matcher(Files.readString(source, StandardCharsets.UTF_8));
+            while (m.find()) {
+                String key = m.group(1);
+                if (namespaces.contains(key.substring(0, key.indexOf('.')))) {
+                    named.add(key);
+                }
+            }
+        }
+        assertFalse(named.isEmpty(), "found no message keys at all — the source scan missed the tree");
+        named.removeAll(defined);
+        assertEquals(Set.of(), named);
+    }
+
+    @Test
+    void bothCatalogsDefineTheSameKeys() throws IOException {
+        Set<String> english = keysOf("/souther/compiler/diag/messages.properties");
+        Set<String> japanese = keysOf("/souther/compiler/diag/messages_ja.properties");
+        Set<String> onlyEnglish = new TreeSet<>(english);
+        onlyEnglish.removeAll(japanese);
+        Set<String> onlyJapanese = new TreeSet<>(japanese);
+        onlyJapanese.removeAll(english);
+        assertEquals(Set.of(), onlyEnglish, "defined in English only");
+        assertEquals(Set.of(), onlyJapanese, "defined in Japanese only");
+    }
+
+    private static final Pattern KEY_LITERAL =
+            Pattern.compile("\"([a-z][a-z0-9]*(?:\\.[a-z0-9]+)+)\"");
+
+    private static Set<String> keysOf(String resource) throws IOException {
+        Properties catalog = new Properties();
+        try (InputStream in = MessageCatalogFormatTest.class.getResourceAsStream(resource)) {
+            catalog.load(new InputStreamReader(in, StandardCharsets.UTF_8));
+        }
+        return new TreeSet<>(catalog.stringPropertyNames());
+    }
+
+    /** Every module's main sources. The test runs in its own module directory, so the repo root is
+     *  that directory's parent, and any module may name a message key. */
+    private static List<Path> mainSources() throws IOException {
+        Path module = Path.of("").toAbsolutePath();
+        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
+                ? module.getParent() : module;
+        List<Path> sources = new ArrayList<>();
+        try (Stream<Path> modules = Files.list(repo)) {
+            for (Path root : modules.map(m -> m.resolve(Path.of("src", "main", "java"))).toList()) {
+                if (!Files.isDirectory(root)) {
+                    continue;
+                }
+                try (Stream<Path> walk = Files.walk(root)) {
+                    walk.filter(p -> p.toString().endsWith(".java")).forEach(sources::add);
+                }
+            }
+        }
+        return sources;
     }
 
     @Test


### PR DESCRIPTION
Fixes the three `check.match.newtype.*` keys reported in #168, and four more in the same state that the issue's count did not reach.

## What was wrong

`check.match.newtype.notnewtype`, `check.match.newtype.mismatch` and `check.match.newtype.orpattern` have no entry in either catalog, so the reader gets the key where the message belongs:

```
-- MATCH ERROR ---------------------------------
8|         | Int(n) -> n
             ^
check.match.newtype.notnewtype
```

`parse.examples.for`, `parse.example.row`, `parse.fake.row` and `parse.intrinsic.core` are undefined too. A scan for `Diagnostic.of(...)` does not see them: `CstParser` and `AstBuilder` pass a key to their own `error(...)` helper.

## What this changes

Both catalogs gain the seven keys. The same repro now reads:

```
-- MATCH ERROR -----------------------------------p.sou:8:11

8|         | Int(n) -> n
             ^

`Int` is not a newtype, so a match case cannot open it with `Int(...)`.
Hint: To bind the matched value itself, write `| Int as v`.
```

`check.match.newtype.mismatch` took the written name and the actual inner type, but not the type doing the wrapping, so its text could not say whether `Some` or a user newtype is the wrapper. It now takes all three. The hint is attached only where the first opened name is the arm's own case, since an inner layer and Option's element are not reached with `as`.

## Keeping it from recurring

`MessageCatalogFormatTest` gains two tests: every key the sources name is defined, and the two catalogs define the same key set. Keys are collected from the source text — a literal shaped like a key whose first segment is a namespace the catalog already uses — rather than from the call sites, so a key reaching a diagnostic through a helper is counted. The one case this does not see is the first key of a brand-new namespace, and the javadoc says so. Cross-checked against a scan of the call sites themselves: both find exactly this set.

Reverting the catalog additions fails the two new catalog tests (listing all seven) and two of the rendering tests. With them, the reactor is green (1161 compiler tests, 81 LSP), and `souther-examples` builds and passes against the installed SNAPSHOT.

Refs #168