### PR TITLE
Read a field off the call that produced it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -149,9 +149,19 @@ public final class DataChecker {
      * meaningless and, left to codegen, would emit a duplicate JVM member — a duplicate method,
      * field, or implemented interface, i.e. a malformed class file. */
     static void rejectDuplicateNames(List<String> names, String where, SourcePos pos) {
+        rejectDuplicateNames(names, where, pos, n -> n);
+    }
+
+    /**
+     * As above, but two entries are the same when {@code identity} maps them to the same thing. A
+     * list of type names admits two spellings of one type — `Amount` an import brings in and
+     * `up.Amount` — and listing both is the duplicate that a spelling comparison would miss.
+     */
+    static void rejectDuplicateNames(List<String> names, String where, SourcePos pos,
+                                     java.util.function.UnaryOperator<String> identity) {
         Set<String> seen = new HashSet<>();
         for (String n : names) {
-            if (!seen.add(n)) {
+            if (!seen.add(identity.apply(n))) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.dup.name").title("check.duplicate.title")
                                 .at(pos).args(n, where).build(),

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -5,6 +5,7 @@ import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -224,8 +225,13 @@ public final class SpecChecker {
         // match `requires` gets (E1602/E1603). Injected behaviors still declare it: no body to infer
         // from, and it drives factory generation (spec 13.3).
         if (!spec.constructs().isEmpty()) {
+            // Both sides name types, and a type has one identity however it is written — `up.Amount`
+            // and an `Amount` an import brings in are the same one. So the sets are compared resolved,
+            // and each side keeps its own spelling in whatever it has to report.
+            Set<String> declared = canonicalConstructs(spec.constructs(), symbols);
+            Set<String> built = canonicalConstructs(constructed, symbols);
             for (String c : constructed) {
-                if (!spec.constructs().contains(c)) {
+                if (!declared.contains(canonicalConstruct(c, symbols))) {
                     throw CompileException.of(
                             Diagnostic.of("E1002", "e1002.msg").at(spec.pos())
                                     .args(spec.name(), c).hint("e1002.hint").build(),
@@ -233,13 +239,13 @@ public final class SpecChecker {
                                     + "` but does not declare `constructs " + c + "`.");
                 }
             }
-            for (String declared : spec.constructs()) {
-                if (!constructed.contains(declared)) {
+            for (String name : spec.constructs()) {
+                if (!built.contains(canonicalConstruct(name, symbols))) {
                     throw CompileException.of(
                             Diagnostic.of("E1006", "e1006.msg").at(spec.pos())
-                                    .args(spec.name(), declared).hint("e1006.hint").build(),
-                            "Behavior `" + spec.name() + "` declares `constructs " + declared
-                                    + "` but never builds " + declared + " — it passes an existing"
+                                    .args(spec.name(), name).hint("e1006.hint").build(),
+                            "Behavior `" + spec.name() + "` declares `constructs " + name
+                                    + "` but never builds " + name + " — it passes an existing"
                                     + " value through. Remove it from the `constructs` clause.");
                 }
             }
@@ -381,8 +387,10 @@ public final class SpecChecker {
             TypeName built = symbols.resolve(c);
             // What Java needs is a way in: the decoder, which a module publishes by exposing the type.
             // For a type of another module that is its own `exposing` to answer, not this one's.
+            // `exposed` lists this module's own names, so the resolved name is what to look up — a
+            // type of this module written through it (`down.Out`) is the same one as `Out`
             boolean buildable = symbols.isForeign(built)
-                    ? symbols.isExposed(built) : exposeAll || exposed.contains(c);
+                    ? symbols.isExposed(built) : exposeAll || exposed.contains(built.name());
             if (!buildable) {
                 throw CompileException.of(
                         Diagnostic.of("E1305", "e1305.msg").at(spec.pos())
@@ -471,6 +479,24 @@ public final class SpecChecker {
                     "only required behaviors can be called from a body; compose others with `>->`");
         }
         TypeChecker.forEachChild(e, c -> rejectNonRequiredCalls(c, allBehaviors, reqSigs));
+    }
+
+    /**
+     * The identity a written construction name stands for, so a `constructs` clause and a body are
+     * compared by type rather than by spelling. A name that denotes nothing here stands for itself:
+     * resolution is not this check's job, and the checks that own it report a better error.
+     */
+    static String canonicalConstruct(String written, Symbols symbols) {
+        TypeName resolved = symbols.resolve(written);
+        return resolved == null ? written : resolved.qualified();
+    }
+
+    private static Set<String> canonicalConstructs(Collection<String> written, Symbols symbols) {
+        Set<String> out = new HashSet<>();
+        for (String w : written) {
+            out.add(canonicalConstruct(w, symbols));
+        }
+        return out;
     }
 
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -221,7 +221,8 @@ public final class TypeChecker {
                 }
                 DataChecker.rejectDuplicateNames(outputCases, "the behavior output", spec.pos());
                 DataChecker.rejectDuplicateNames(spec.requires(), "`requires`", spec.pos());
-                DataChecker.rejectDuplicateNames(spec.constructs(), "`constructs`", spec.pos());
+                DataChecker.rejectDuplicateNames(spec.constructs(), "`constructs`", spec.pos(),
+                        n -> SpecChecker.canonicalConstruct(n, symbols));
             }
         }
         // A data is Java-buildable from outside iff the whole module is public (no `exposing`) or

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -312,22 +312,12 @@ public final class AstBuilder {
             List<String> constructs = new ArrayList<>();
             List<String> requires = new ArrayList<>();
             for (SyntaxNode clause : s.childNodes()) {
+                // either clause may name through a module, so the idents of one name are joined and
+                // a comma starts the next
                 if (clause.kind() == SyntaxKind.CONSTRUCTS_CLAUSE) {
-                    for (SyntaxToken t : identTokens(clause)) {
-                        constructs.add(t.text());
-                    }
+                    collectDottedNames(clause, constructs);
                 } else if (clause.kind() == SyntaxKind.REQUIRES_CLAUSE) {
-                    // a required behavior may be named through its module, so the idents of one
-                    // name are joined and a comma starts the next
-                    List<SyntaxElement> es = meaningful(clause);
-                    int[] at = {1};                       // past the `requires` keyword
-                    while (at[0] < es.size()) {
-                        if (isToken(es.get(at[0]), SyntaxKind.COMMA)) {
-                            at[0]++;
-                            continue;
-                        }
-                        requires.add(dottedName(es, at));
-                    }
+                    collectDottedNames(clause, requires);
                 }
             }
             return new Ast.SpecBehavior(name, params, ret, constructs, requires, pos);
@@ -745,6 +735,20 @@ public final class AstBuilder {
             sb.append('.').append(tokenText(es.get(at[0]++)));
         }
         return sb.toString();
+    }
+
+    /** The comma-separated names of a {@code constructs}/{@code requires} clause, each possibly
+     * qualified by its module. */
+    private void collectDottedNames(SyntaxNode clause, List<String> out) {
+        List<SyntaxElement> es = meaningful(clause);
+        int[] at = {1};                           // past the clause keyword
+        while (at[0] < es.size()) {
+            if (isToken(es.get(at[0]), SyntaxKind.COMMA)) {
+                at[0]++;
+                continue;
+            }
+            out.add(dottedName(es, at));
+        }
     }
 
     private Ast.Case matchCase(SyntaxNode n) {

--- a/souther-compiler/src/test/java/souther/compiler/CompileCallResultFieldAccessTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileCallResultFieldAccessTest.java
@@ -1,0 +1,143 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A field is read off whatever produced it, not only off a name: `f(x).field` parses, so a newtype can
+ * be opened on the call that builds it without an intervening `let` (issue #158).
+ */
+class CompileCallResultFieldAccessTest {
+
+    private static Object apply(BytesClassLoader loader, String cls, Object in) throws Exception {
+        Object b = loader.loadClass("demo." + cls + "$Impl").getConstructor().newInstance();
+        return Codecs.apply(b, in);
+    }
+
+    @Test
+    void aNewtypeIsOpenedOnTheCallThatBuildsIt() throws Exception {
+        String src = """
+                module demo
+                exposing ( Amount, In, Out, run )
+
+                data Amount = Int invariant value >= 0
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                let amountOf (i: In) = Amount(i.n)
+
+                behavior run : (i: In) -> Out constructs Out, Amount
+
+                let run (i) = Out { m = amountOf(i).value }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object out = apply(loader, "Run", Codecs.decoded(loader, "demo.In", java.util.Map.of("n", 7L)));
+
+        assertEquals(7L, out.getClass().getMethod("m").invoke(out));
+    }
+
+    @Test
+    void theChainKeepsGoingThroughSeveralFields() throws Exception {
+        String src = """
+                module demo
+                exposing ( In, Out, run )
+
+                data Address = { city: String }
+                data Person = { address: Address }
+                data In = { name: String }
+                data Out = { c: String }
+
+                let personOf (i: In) = Person { address = Address { city = i.name } }
+
+                behavior run : (i: In) -> Out constructs Out, Person, Address
+
+                let run (i) = Out { c = personOf(i).address.city }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object out = apply(loader, "Run", Codecs.decoded(loader, "demo.In", java.util.Map.of("name", "Kyoto")));
+
+        assertEquals("Kyoto", out.getClass().getMethod("c").invoke(out));
+    }
+
+    @Test
+    void anImportedTypesConstructorResultIsReachedInto() throws Exception {
+        String up = """
+                module up exposing ( Amount )
+
+                data Amount = Int invariant value >= 0
+                """;
+        String down = """
+                module down exposing ( In, Out, run )
+                import up ( Amount )
+
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                behavior run : (i: In) -> Out constructs Out, Amount
+
+                let run (i) = Out { m = Amount(i.n).value }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(
+                Compiler.compileModules(java.util.List.of(up, down)), getClass().getClassLoader());
+        Object b = loader.loadClass("down.Run$Impl").getConstructor().newInstance();
+        Object out = Codecs.apply(b, Codecs.decoded(loader, "down.In", java.util.Map.of("n", 3L)));
+
+        assertEquals(3L, out.getClass().getMethod("m").invoke(out));
+    }
+
+    @Test
+    void aMatchScrutineeReachesIntoACallResult() throws Exception {
+        String src = """
+                module demo
+                exposing ( In, Out, run )
+
+                data Held = { held: Int? }
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                let heldOf (i: In) = Held { held = i.n }
+
+                behavior run : (i: In) -> Out constructs Out, Held
+
+                let run (i) = Out { m = match heldOf(i).held with
+                    | Some v -> v
+                    | None -> 0
+                }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object out = apply(loader, "Run", Codecs.decoded(loader, "demo.In", java.util.Map.of("n", 5L)));
+
+        assertEquals(5L, out.getClass().getMethod("m").invoke(out));
+    }
+
+    /**
+     * A bare `.field` is a getter (ADR-0055) and `x.field` is a read, and the two are told apart by
+     * where they sit: a getter starts an expression, a read follows one. Extending the read to a call's
+     * result puts them next to each other in an argument list, where the comma still separates them.
+     */
+    @Test
+    void aBareGetterAfterACallArgumentStaysAGetter() throws Exception {
+        String src = """
+                module demo
+                exposing ( In, Out, run )
+                import List ( map, sum )
+
+                data Amount = Int invariant value >= 0
+                data In = { ns: List<Int> }
+                data Out = { m: Int }
+
+                let amountsOf (i: In) = map(n -> Amount(n), i.ns)
+                let pick (xs: List<Amount>, f: (Amount) -> Int) = map(f, xs)
+
+                behavior run : (i: In) -> Out constructs Out, Amount
+
+                let run (i) = Out { m = sum(pick(amountsOf(i), .value)) }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object out = apply(loader, "Run",
+                Codecs.decoded(loader, "demo.In", java.util.Map.of("ns", java.util.List.of(1L, 2L, 4L))));
+
+        assertEquals(7L, out.getClass().getMethod("m").invoke(out));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileQualifiedConstructsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQualifiedConstructsTest.java
@@ -1,0 +1,141 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A `constructs` clause names a type the way a type is named anywhere else, through its module when it
+ * is another module's. A qualified construction reports itself as `up.Amount`, so that is what the
+ * clause has to be able to say; before this it could only say the bare name an `import` brings in,
+ * which left a qualified construction impossible to declare.
+ */
+class CompileQualifiedConstructsTest {
+
+    private static final String UP = """
+            module up exposing ( Amount )
+
+            data Amount = Int invariant value >= 0
+            """;
+
+    private static Object run(String down, long n) throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(
+                Compiler.compileModules(List.of(UP, down)), CompileQualifiedConstructsTest.class.getClassLoader());
+        Object b = loader.loadClass("down.Run$Impl").getConstructor().newInstance();
+        return Codecs.apply(b, Codecs.decoded(loader, "down.In", Map.of("n", n)));
+    }
+
+    @Test
+    void aQualifiedConstructionIsDeclaredThroughItsModule() throws Exception {
+        Object out = run("""
+                module down exposing ( In, Out, run )
+
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                behavior run : (i: In) -> Out constructs Out, up.Amount
+
+                let run (i) = Out { m = up.Amount(i.n).value }
+                """, 4L);
+
+        assertEquals(4L, out.getClass().getMethod("m").invoke(out));
+    }
+
+    @Test
+    void theClauseMayNameThroughTheModuleWhileTheBodyUsesTheImportedName() throws Exception {
+        // the clause names a type, and `up.Amount` and an imported `Amount` are the same type, so
+        // which spelling each side uses is not something the check has an opinion about
+        Object out = run("""
+                module down exposing ( In, Out, run )
+                import up ( Amount )
+
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                behavior run : (i: In) -> Out constructs Out, up.Amount
+
+                let run (i) = Out { m = Amount(i.n).value }
+                """, 8L);
+
+        assertEquals(8L, out.getClass().getMethod("m").invoke(out));
+    }
+
+    @Test
+    void theClauseMayNameBareWhileTheBodyQualifies() throws Exception {
+        Object out = run("""
+                module down exposing ( In, Out, run )
+                import up ( Amount )
+
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                behavior run : (i: In) -> Out constructs Out, Amount
+
+                let run (i) = Out { m = up.Amount(i.n).value }
+                """, 9L);
+
+        assertEquals(9L, out.getClass().getMethod("m").invoke(out));
+    }
+
+    @Test
+    void namingOneTypeTwiceIsADuplicateHoweverItIsSpelled() {
+        String down = """
+                module down exposing ( In, Out, run )
+                import up ( Amount )
+
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                behavior run : (i: In) -> Out constructs Out, Amount, up.Amount
+
+                let run (i) = Out { m = Amount(i.n).value }
+                """;
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(UP, down)));
+
+        assertTrue(e.getMessage().contains("constructs"), e.getMessage());
+        assertTrue(e.getMessage().contains("Amount"), e.getMessage());
+    }
+
+    @Test
+    void anInjectedBehaviorMayQualifyATypeItsOwnModuleDeclares() {
+        // `Out` is exposed, so Java can build it. What answers that is the type, and the qualifier in
+        // front of it does not change which type it is.
+        String down = """
+                module down exposing ( In, Out, lookup )
+
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                behavior lookup : (i: In) -> Out constructs down.Out
+                """;
+
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(UP, down)));
+    }
+
+    @Test
+    void anImportedNameIsStillDeclaredBare() throws Exception {
+        Object out = run("""
+                module down exposing ( In, Out, run )
+                import up ( Amount )
+
+                data In = { n: Int }
+                data Out = { m: Int }
+
+                behavior run : (i: In) -> Out constructs Out, Amount
+
+                let run (i) = Out { m = Amount(i.n).value }
+                """, 6L);
+
+        assertEquals(6L, out.getClass().getMethod("m").invoke(out));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/cst/CstCallResultFieldAccessTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/cst/CstCallResultFieldAccessTest.java
@@ -1,0 +1,79 @@
+package souther.compiler.cst;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A field-access chain follows any identifier-led primary, not only a bare name (issue #158). What
+ * keeps it apart from the bare `.field` getter (ADR-0055) is where each sits: a getter opens an
+ * expression, a read follows one, and the two never compete for the same position.
+ */
+class CstCallResultFieldAccessTest {
+
+    private static SyntaxNode parsed(String body) {
+        String src = "module demo\n"
+                + "data In = { n: Int }\n"
+                + "data Out = { m: Int }\n"
+                + "let run (i) = " + body + "\n";
+        CstParser.Result r = CstParser.parse(src);
+        assertTrue(r.errors().isEmpty(), () -> "unexpected syntax errors: " + r.errors());
+        return r.root();
+    }
+
+    /** Every node of {@code kind} in the tree, outermost first. */
+    private static List<SyntaxNode> allOf(SyntaxNode n, SyntaxKind kind) {
+        List<SyntaxNode> out = new ArrayList<>();
+        if (n.kind() == kind) {
+            out.add(n);
+        }
+        for (SyntaxNode c : n.childNodes()) {
+            out.addAll(allOf(c, kind));
+        }
+        return out;
+    }
+
+    private static SyntaxNode onlyOf(SyntaxNode n, SyntaxKind kind) {
+        List<SyntaxNode> found = allOf(n, kind);
+        assertEquals(1, found.size(), () -> "expected one " + kind + ", found " + found.size());
+        return found.get(0);
+    }
+
+    @Test
+    void aCallResultCarriesTheFieldAccess() {
+        SyntaxNode access = onlyOf(parsed("amountOf(i).value"), SyntaxKind.FIELD_ACCESS);
+
+        assertEquals(SyntaxKind.CALL_EXPR, access.childNodes().get(0).kind());
+        assertEquals("amountOf(i).value", access.text().strip());
+    }
+
+    @Test
+    void aQualifiedCallIsTheCallAndNotAFieldReadOnTheModule() {
+        SyntaxNode access = onlyOf(parsed("up.amountOf(i).value"), SyntaxKind.FIELD_ACCESS);
+
+        // one FIELD_ACCESS only: `up.amountOf` is the call's name, so `.value` is the sole read
+        assertEquals(SyntaxKind.CALL_EXPR, access.childNodes().get(0).kind());
+        assertEquals("up.amountOf(i)", access.childNodes().get(0).text().strip());
+    }
+
+    @Test
+    void aBareGetterInArgumentPositionIsStillAGetter() {
+        SyntaxNode root = parsed("pick(amountsOf(i), .value)");
+
+        assertEquals(1, allOf(root, SyntaxKind.FIELD_GETTER).size(), "the `.value` argument is a getter");
+        assertEquals(0, allOf(root, SyntaxKind.FIELD_ACCESS).size(), "nothing is read off the call");
+    }
+
+    @Test
+    void aChainOfReadsFollowsACall() {
+        SyntaxNode outer = allOf(parsed("personOf(i).address.city"), SyntaxKind.FIELD_ACCESS).get(0);
+
+        assertEquals("personOf(i).address.city", outer.text().strip());
+        assertEquals(SyntaxKind.FIELD_ACCESS, outer.childNodes().get(0).kind());
+        assertEquals("personOf(i).address", outer.childNodes().get(0).text().strip());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -225,6 +225,24 @@ class FormatterTest {
     }
 
     @Test
+    void formattingKeepsAReadOffACallResult() {
+        // the read hangs off the call, so the formatter has to render the chain from its left operand
+        // rather than from a name (issue #158)
+        String source = "module demo\n"
+                + "data Amount = Int invariant value >= 0\n"
+                + "data In = { n: Int }\n"
+                + "data Out = { m: Int }\n"
+                + "let amountOf (i: In) = Amount(i.n)\n"
+                + "behavior run : (i: In) -> Out constructs Out, Amount\n"
+                + "let run (i) = Out { m=amountOf(i).value }\n";
+        String formatted = Formatter.format(source);
+        assertEquals(code(source), code(formatted), "the code token stream changed");
+        assertEquals(formatted, Formatter.format(formatted), "formatting is not idempotent");
+        assertTrue(formatted.contains("amountOf(i).value"), formatted);
+        assertTrue(CstParser.parse(formatted).errors().isEmpty(), "formatted output does not re-parse");
+    }
+
+    @Test
     void canonicalFormOfAnExample() {
         String messy = "module demo\n"
                 + "data M={ n:Int }\n"

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -358,8 +358,8 @@ public final class Formatter {
     }
 
     private Doc nameList(SyntaxNode clause) {
-        // a `requires` entry may name its behavior through a module, so the dots of one name are kept
-        // and only a comma starts the next
+        // an entry may name through a module, so the dots of one name are kept and only a comma
+        // starts the next
         List<Doc> names = new ArrayList<>();
         StringBuilder current = new StringBuilder();
         for (SyntaxElement e : meaningful(clause)) {

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -1155,35 +1155,39 @@ public final class CstParser {
         expect(SyntaxKind.RPAREN);
     }
 
-    /** An identifier-led primary: a call, a qualified call, a construction, or a field-access chain. */
+    /** An identifier-led primary: a call, a qualified call, a construction, or a bare variable —
+     * each of which a field-access chain may follow. */
     private void identExpr() {
-        // qualified call `Mod.name(args)`
         if (nth(1) == SyntaxKind.DOT && nth(2) == SyntaxKind.IDENT && nth(3) == SyntaxKind.LPAREN) {
+            // qualified call `Mod.name(args)`
             start(SyntaxKind.CALL_EXPR);
             bump();   // Mod
             bump();   // .
             bump();   // name
             argList();
             finish();
-            return;
-        }
-        // plain call `name(args)`
-        if (nth(1) == SyntaxKind.LPAREN) {
+        } else if (nth(1) == SyntaxKind.LPAREN) {
+            // plain call `name(args)`
             start(SyntaxKind.CALL_EXPR);
             bump();   // name
             argList();
             finish();
-            return;
-        }
-        // construction `Type { ... }` (unless suppressed, as in a match scrutinee)
-        if (!noConstruct && nth(1) == SyntaxKind.LBRACE) {
+        } else if (!noConstruct && nth(1) == SyntaxKind.LBRACE) {
+            // construction `Type { ... }` (unless suppressed, as in a match scrutinee)
             newDataExpr();
-            return;
+        } else {
+            start(SyntaxKind.VAR_EXPR);
+            bump();   // ident
+            finish();
         }
-        // a bare variable or a field-access chain `a.b.c`
-        start(SyntaxKind.VAR_EXPR);
-        bump();   // ident
-        finish();
+        fieldAccessChain();
+    }
+
+    /** {@code .a.b} following a primary. What precedes it is any ident-led expression, so a newtype is
+     * opened on the call that builds it (`amountOf(i).value`) rather than through a binding written to
+     * hold the result (issue #158). A qualified call is taken before this, so `Mod.name(args)` is that
+     * call and not a field `name` read off `Mod`. */
+    private void fieldAccessChain() {
         while (at(SyntaxKind.DOT) && nth(1) == SyntaxKind.IDENT) {
             int m = markForFieldAccess();
             wrap(m, SyntaxKind.FIELD_ACCESS);

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -341,23 +341,20 @@ public final class CstParser {
     }
 
     /** A {@code constructs}/{@code requires} clause: the keyword then a bare comma list of names,
-     * tolerating a trailing comma (which has no closing bracket to bound it). */
+     * tolerating a trailing comma (which has no closing bracket to bound it). Either clause names
+     * through a module, so a behavior declares what it builds and what it needs the same way it
+     * writes any other name. */
     private void nameClause(SyntaxKind kind) {
-        boolean dotted = kind == SyntaxKind.REQUIRES_CLAUSE;
         start(kind);
         bump();   // constructs / requires
         expect(SyntaxKind.IDENT);
-        if (dotted) {
-            caseNameTail();
-        }
+        caseNameTail();
         while (eat(SyntaxKind.COMMA)) {
             if (!at(SyntaxKind.IDENT)) {
                 break;   // a trailing comma is consumed and ends the list
             }
             bump();   // ident
-            if (dotted) {
-                caseNameTail();
-            }
+            caseNameTail();
         }
         finish();
     }

--- a/specification.adoc
+++ b/specification.adoc
@@ -732,6 +732,8 @@ Because a local shadowing a built-in value is always an error, using a *built-in
 [#field-visibility]
 === Field visibility
 
+A field is read as `+e.field+`, where `+e+` is a name, a call, or a construction, and `+.a.b+` chains from the left. So `+amountOf(i).value+` opens a newtype on the call that builds it, with no `+let+` written to hold the result. This never competes with the bare `+.field+` getter of <<blocks>>: a getter starts an expression, a read follows one.
+
 *Reading* a field is possible wherever that data's type is visible. Within the same module, any data of that module may be read. A data of another module may have its fields read if it is exposed with `+exposing+` — being importable means it is exposed. An exposed data has all fields readable (there is no per-field exposure). A behavior may read the fields of its input data even when they come from another module.
 
 What is constrained is *not reading but construction*. Reading a field and constructing a new value of that data are separate authorities, so allowing cross-boundary reads leaves the guarantee that no unvalidated value can be built (<<asymmetric-interop>>) intact. There is no need to define a getter-only behavior just to pass a value out (<<behavior-composition-unit>>).

--- a/specification.adoc
+++ b/specification.adoc
@@ -1188,6 +1188,8 @@ behavior applyChange : (input: ChangeEmailRequest) -> Member
 
 To construct multiple data, list them: `+constructs Member, AuditRecord+`.
 
+An entry names a type the way a type is named anywhere else, so a type another module declares may be written through it (`+constructs up.Amount+`) as well as under the name an `+import+` brings in. Which spelling the clause uses and which the body uses are independent — both name one type, and that is what E1002 and E1006 compare. Naming one type twice, however spelled, is a duplicate entry.
+
 The following count as data construction: a record literal (`+型名 { ... }+`), a sum data constructor, a unit data construction, and constructing a collection containing new data as elements. Returning an existing value unchanged does not count as construction.
 
 The built-in `+Some+` / `+None+` (<<algebraic-types>>) do not count as data construction. Option is not domain data but an auxiliary type and has no invariant, so <<invariant-on-construct>> has nothing to guard. So `+constructs+` is not required to put a value in a `+?+` field (<<optional>>) — and since Option cannot be written as a type, there is no way to declare `+constructs Some+` anyway (<<algebraic-types>>).


### PR DESCRIPTION
`f(x).field` did not parse, so opening a newtype the moment it is built took a `let` written to hold the result. Closes #158.

## What changed

A field-access chain was built only after a bare name. `identExpr`'s four branches — qualified call, call, construction, bare name — now fall through to one `fieldAccessChain`. `Ast.FieldAccess` and `Core.FieldAccess` already take an arbitrary target, so type checking and codegen are untouched.

It does not compete with the bare `.field` getter (ADR-0055): a getter starts an expression, a read follows one, and an argument list separates them with a comma. Checked for every position, including across a line break, where a read after a call now behaves as one after a name already did.

## The second commit

Writing the test for a construction reached into through its module turned up a gap of its own, unrelated to the parse: a construction written as `up.Amount(n)` reports itself as `up.Amount`, and `constructs` could not say that — the clause took a bare identifier, so the only route was an `import` and the unqualified name. Qualified references (ADR-0058) exist so an import is not required, and construction is guarded by declaration wherever the type is declared (ADR-0059); the two did not meet.

Admitting the qualified spelling alone would have been half a fix, so three things move with it:

- **E1002 / E1006** compared the written strings, so a clause naming `up.Amount` and a body building an imported `Amount` disagreed. Both sides are resolved before they are compared; each keeps its own spelling in what it reports.
- **`constructs Amount, up.Amount`** is now a duplicate entry. It named one type twice, and for an injected behavior it would have emitted that type's factory twice.
- **E1305** asked `exposed.contains(written)`, which said no to a type of this module written through it (`constructs down.Out`). It asks about the resolved name now.

## Verification

15 new tests: 9 for the read (4 at the parse level, including the getter positions; 5 compiling and running), 6 for `constructs` (all four spelling combinations, the duplicate, and the injected self-qualified case). The E1305 false positive and the missed duplicate were each seen failing before being fixed.

1177 compiler tests and 81 LSP tests pass, and souther-examples builds clean against this compiler.

The specification gains a paragraph in each of `[#field-visibility]` and `[#constructs]`. No ADR — both changes apply decisions already recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
