### PR TITLE
Settle a helper's parameter type before its call is expanded

### DIFF
--- a/docs/adr/0066-a-helper-is-typed-by-its-body.md
+++ b/docs/adr/0066-a-helper-is-typed-by-its-body.md
@@ -30,7 +30,9 @@ The measured migration cost is zero lines. Of the 240 helper `let`s in the bundl
 
 Where the body leaves a parameter open the report names the parameter and labels the use that named no type. The "used at conflicting types" error of ADR-0050 no longer exists: with no call sites read, there is nothing to conflict, and a body that uses the parameter at two types is an ordinary type error at the second use.
 
-What a helper settles about itself does not yet reach its expansion: the binding a call inlines to carries only a written parameter type, so a body-determined sum narrows to the argument's case there (#178). The type a resolved parameter has cannot be written onto a surface tree, which is what that needs.
+What a helper settles about itself reaches its expansion (#178). The settled type is written back onto the parameter, as a reference that carries what it denotes and no surface text at all. ADR-0067 is what makes that possible: everything downstream of `Resolve` reads what a reference denotes rather than how it was spelled, so a type with no spelling is as good as a written one, and the type-to-surface writer this looked like it needed is not needed. The inliner then carries it onto the binding the call becomes, like any written type, and a `match` on a body-determined sum sees the sum rather than the case the caller passed.
+
+Settling happens before a helper call is expanded, which is twice: once before the data invariants are inlined, and once before the bodies are lowered. The two are separate points in the pipeline because an importer reads an included data's invariant through the symbol table and must find it already expanded. Settling is idempotent, so running it at both is running it once at each place it is needed.
 
 The rule that reads the body is deliberately small, and every gap in it is closed by annotating. When names and types resolve through one implementation (#177 steps 2 and 4), a built-in's parameter types become readable the same way a declared one is, and the gap closes without the rule changing.
 

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -117,13 +117,15 @@ public final class Compiler {
         // later pass reads is a name that already says which module declares it.
         Ast.Module named = Resolve.module(exposed);
         Ast.Module module = Deriver.derive(named);
-        module = HelperInliner.forModule(module).withInlinedInvariants(module);
+        module = HelperInliner.withSettledInvariants(module, TypeChecker.symbols(module));
         module = NewtypeDesugar.rewrite(module, TypeChecker.symbols(module));
         module = Compiler.injectRecursivePrelude(module);
-        Ast.Module lowered = Lower.run(module);
-        // the module no longer changes, so its symbol table is built once and shared by the check,
-        // the constant verification, and the example run
+        // the module's definitions no longer change, so its symbol table is built once and shared by
+        // the settling, the check, the constant verification, and the example run
         Symbols symbols = TypeChecker.symbols(module);
+        Lower.Lowered lowering = Lower.run(module, symbols, Map.of(), Set.of());
+        module = lowering.settled();
+        Ast.Module lowered = lowering.lowered();
         TypeChecker.Checked checked = TypeChecker.checkOrThrow(module, symbols, Map.of(), Set.of(), lowered);
         warningsOut.addAll(checked.warnings());
         Map<String, byte[]> out = Backend.generate(lowered, checked);
@@ -386,7 +388,7 @@ public final class Compiler {
         for (Ast.Module m : toDerive) {
             try {
                 Ast.Module d = Deriver.derive(m, visibleDefs(m, byName));
-                derived.put(m.name(), HelperInliner.forModule(d).withInlinedInvariants(d));
+                derived.put(m.name(), HelperInliner.withSettledInvariants(d, visibleDefs(d, byName)));
             } catch (CompileException e) {
                 throw e.inSource(sourceIndex(sourceOfModule, m.name()));
             }
@@ -417,7 +419,9 @@ public final class Compiler {
                 imported.put(original.name(), importedSigs);
                 Set<String> importedInjected = importedInjectedBehaviors(m, derived, injectedElsewhere);
                 m = injectRecursivePrelude(m);
-                Ast.Module lowered = Lower.run(m);
+                Lower.Lowered lowering = Lower.run(m, symbols, importedSigs, importedInjected);
+                m = lowering.settled();
+                Ast.Module lowered = lowering.lowered();
                 TypeChecker.Checked checked = TypeChecker.checkOrThrow(m, symbols, importedSigs, importedInjected, lowered);
                 warningsOut.addAll(checked.warnings());
                 out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs,
@@ -708,7 +712,7 @@ public final class Compiler {
                 continue;   // its names did not resolve, so there is nothing to derive from
             }
             Ast.Module d = Deriver.derive(m, visibleDefs(m, byName));
-            d = HelperInliner.forModule(d).withInlinedInvariants(d);
+            d = HelperInliner.withSettledInvariants(d, visibleDefs(d, byName));
             derived.put(m.name(), NewtypeDesugar.rewrite(d, visibleDefs(d, derived)));
         }
         Map<String, byte[]> out = new LinkedHashMap<>();
@@ -723,7 +727,7 @@ public final class Compiler {
             }
             try {
                 Ast.Module d = Deriver.derive(original, visibleDefs(original, byName));
-                d = HelperInliner.forModule(d).withInlinedInvariants(d);
+                d = HelperInliner.withSettledInvariants(d, visibleDefs(d, byName));
                 derived.put(original.name(), d);   // visible to its own newtype constructors during desugar
                 Ast.Module m = NewtypeDesugar.rewrite(d, visibleDefs(d, derived));
                 derived.put(original.name(), m);
@@ -731,7 +735,9 @@ public final class Compiler {
                 Map<String, Sig> importedSigs = importedBehaviorSigs(m, derived);
                 Set<String> importedInjected = importedInjectedBehaviors(m, derived, injectedElsewhere);
                 m = injectRecursivePrelude(m);
-                Ast.Module lowered = Lower.run(m);
+                Lower.Lowered lowering = Lower.run(m, symbols, importedSigs, importedInjected);
+                m = lowering.settled();
+                Ast.Module lowered = lowering.lowered();
                 TypeChecker.CheckResult result0 =
                         TypeChecker.checkAndElaborate(m, symbols, importedSigs, importedInjected, lowered);
                 List<Diagnostic> typeErrors = result0.diagnostics();

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -288,6 +288,16 @@ public interface Ast {
             return new TypeRef(name, arg, tupleElems, type, pos);
         }
 
+        /**
+         * A reference nobody wrote: it carries what it denotes and no surface text. A helper
+         * parameter whose type its body settles is written back as one (issue #178) — the type is
+         * decided, and there is no source it stands for. Everything downstream of {@code Resolve}
+         * reads {@link #denotes()}, so a reference with a decided type is as good as a written one.
+         */
+        public static TypeRef of(Type type, SourcePos pos) {
+            return new TypeRef(null, null, null, type, pos);
+        }
+
         /** A tuple type is the nameless form; a named ref that also carries {@code tupleElems}
          *  (a {@code Map} carrying its key) is not a tuple. */
         public boolean isTuple() {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -149,11 +149,30 @@ public final class HelperInliner {
     }
 
     /**
+     * Settles the helper parameter types the author left unwritten, then inlines the helper calls in
+     * every data's {@code invariant}.
+     *
+     * <p>The two go together: expanding a call carries the parameter's type onto the binding the call
+     * becomes, so a type settled afterwards would never reach this expansion (issue #178). An
+     * invariant is inlined well before the module is lowered — an importer reads an included data's
+     * invariant through the symbol table, so it must already be expanded there — which is why the
+     * settling is done here as well as in {@link Lower}. It is idempotent: a parameter already typed
+     * is left alone, and {@code Lower} settles what only the fully desugared module can determine.
+     *
+     * <p>An invariant is pure and cannot call an injected behavior (spec §invariant-expressions), so
+     * nothing here needs the injected signatures to settle the helpers an invariant reaches.
+     */
+    public static Ast.Module withSettledInvariants(Ast.Module m, Symbols symbols) {
+        Ast.Module settled = HelperParams.settle(m, symbols, Map.of());
+        return forModule(settled).withInlinedInvariants(settled);
+    }
+
+    /**
      * Inlines helper calls inside every data's {@code invariant}, so a rule named with a {@code let}
      * (e.g. {@code invariant 正の数(value)}) expands to its body before the invariant is type-checked
      * or emitted — the same lowering a behavior body gets (spec 12.5, §invariant-expressions).
      */
-    public Ast.Module withInlinedInvariants(Ast.Module m) {
+    Ast.Module withInlinedInvariants(Ast.Module m) {
         List<Ast.Def> defs = new ArrayList<>();
         for (Ast.Def def : m.defs()) {
             if (def instanceof Ast.Data d && d.invariant().isPresent()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -1,0 +1,424 @@
+package souther.compiler.check;
+
+import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
+import souther.compiler.types.Type;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Settles the type of every helper parameter the author left unwritten, reading it off the helper's
+ * own body (spec 13.1, issue #176) and writing it back onto the parameter (issue #178).
+ *
+ * <p>Writing it back is what makes the type reach the helper's expansion. A helper call is rewritten
+ * to {@code let $k_p = arg in <body>} carrying the parameter's type onto the binding, so a value the
+ * helper knows to be a sum is not narrowed to the case the caller passed when the body is re-checked
+ * inline. That happens in {@link Lower}, before the type checker runs, so a type the checker settles
+ * would arrive too late — the type is settled here instead, on the tree, and the inliner reads it
+ * like any written one. The type is written as a reference with no surface text (see
+ * {@link Ast.TypeRef#of}): what a parameter denotes is decided, and no source stands for it.
+ *
+ * <p>Settling is best-effort and reports nothing. A parameter its body does not determine is left as
+ * it was, for {@link HelperTyping} to report where it reports today — so a helper that cannot be
+ * typed still names the use that left it open, and one broken helper still does not hide the errors
+ * in the rest of the module.
+ */
+final class HelperParams {
+
+    private HelperParams() {}
+
+    /**
+     * {@code module} with each settleable helper parameter carrying the type its body gives it. One
+     * helper's settled type can settle the next one's — {@code describe}'s parameter is determined
+     * only by passing it to {@code hold}, whose own parameter the body settles — so the rounds run
+     * until nothing new is settled.
+     */
+    static Ast.Module settle(Ast.Module module, Symbols symbols, Map<String, ReqSig> reqSigs) {
+        Ast.Module current = module;
+        while (true) {
+            Ast.Module next = settleOnce(current, symbols, reqSigs);
+            if (next == current) {
+                return current;
+            }
+            current = next;
+        }
+    }
+
+    /** One round: returns {@code m} itself when no parameter was settled. */
+    private static Ast.Module settleOnce(Ast.Module m, Symbols symbols, Map<String, ReqSig> reqSigs) {
+        if (!hasOpenParam(m)) {
+            return m;   // nothing to settle: don't build the inliner (it scans the whole prelude)
+        }
+        HelperInliner inliner = HelperInliner.forModule(m);
+        Set<String> recursive = inliner.recursiveHelpers();
+        Map<String, Type> recursiveHelperFns;
+        try {
+            recursiveHelperFns = HelperTyping.recursiveHelperSigs(inliner, symbols);
+        } catch (CompileException _) {
+            // a recursive helper that does not declare its types is reported by the check; here it
+            // only means calls to it name no types.
+            recursiveHelperFns = Map.of();
+        }
+        Map<String, Ast.FnDef> settled = new LinkedHashMap<>();
+        for (Ast.FnDef h : inliner.helpers().values()) {
+            if (recursive.contains(h.name())) {
+                continue;   // a recursive helper is not inlined and declares its parameters (spec 13.1)
+            }
+            Ast.FnDef s = settle(h, inliner, symbols, reqSigs, recursiveHelperFns);
+            if (s != null) {
+                settled.put(h.name(), s);
+            }
+        }
+        if (settled.isEmpty()) {
+            return m;
+        }
+        List<Ast.FnDef> fns = new ArrayList<>();
+        for (Ast.FnDef fn : m.fns()) {
+            fns.add(settled.getOrDefault(fn.name(), fn));
+        }
+        return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), m.defs(),
+                m.behaviors(), fns, m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
+    }
+
+    /** Whether any fn of {@code m} writes a parameter without a type — behaviors included, whose
+     * parameters are typed from the behavior rather than settled, so this only over-approximates. */
+    private static boolean hasOpenParam(Ast.Module m) {
+        for (Ast.FnDef fn : m.fns()) {
+            for (Ast.FnParam p : fn.params()) {
+                if (p.type() == null) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** {@code h} with its determinable parameters typed, or null when none of them is. */
+    private static Ast.FnDef settle(Ast.FnDef h, HelperInliner inliner, Symbols symbols,
+                                    Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns) {
+        List<Integer> open = new ArrayList<>();
+        Map<String, Type> env = new HashMap<>();
+        Ast.Expr body;
+        try {
+            for (int i = 0; i < h.params().size(); i++) {
+                Ast.FnParam p = h.params().get(i);
+                if (p.type() == null) {
+                    open.add(i);
+                } else {
+                    env.put(p.name(), TypeOps.resolveParamType(p.type(), symbols));
+                }
+            }
+            if (open.isEmpty()) {
+                return null;
+            }
+            body = inliner.inline(h.body());
+        } catch (CompileException _) {
+            return null;   // a written type or a call that does not resolve; the check reports it
+        }
+        Map<Integer, Type> found =
+                determine(h, open, env, body, symbols, reqSigs, recursiveHelperFns, new HashMap<>());
+        if (found.isEmpty()) {
+            return null;
+        }
+        List<Ast.FnParam> params = new ArrayList<>();
+        for (int i = 0; i < h.params().size(); i++) {
+            Ast.FnParam p = h.params().get(i);
+            Type t = found.get(i);
+            params.add(t == null ? p
+                    : new Ast.FnParam(p.name(),
+                            new Ast.RetType(List.of(Ast.TypeRef.of(t, p.pos())), p.pos()),
+                            p.typeFromPattern(), p.pos()));
+        }
+        return new Ast.FnDef(h.name(), params, h.declaredReturn(), h.intrinsicKey(), h.body(),
+                h.partial(), h.pos());
+    }
+
+    /**
+     * The type {@code body} gives each of {@code open}, by index. A parameter a later round settles
+     * can settle an earlier one — {@code f(x, y)} where {@code y}'s type follows from {@code x}'s —
+     * so the rounds run to a fixpoint. {@code env} is completed as they are found, and
+     * {@code openUses} collects, for each parameter still open, a use of it that named no type.
+     */
+    static Map<Integer, Type> determine(Ast.FnDef h, List<Integer> open, Map<String, Type> env,
+                                        Ast.Expr body, Symbols symbols, Map<String, ReqSig> reqSigs,
+                                        Map<String, Type> recursiveHelperFns,
+                                        Map<Integer, Ast.Var> openUses) {
+        BodyTyping typing = new BodyTyping(symbols, reqSigs, recursiveHelperFns);
+        Map<Integer, Type> found = new LinkedHashMap<>();
+        List<Integer> value = new ArrayList<>();
+        for (int idx : open) {
+            // a function-typed parameter is annotated, not settled (spec 13.1); reading a value type
+            // off one would hide the report that says so.
+            if (!isApplied(body, h.params().get(idx).name())) {
+                value.add(idx);
+            }
+        }
+        boolean progress = true;
+        while (progress) {
+            progress = false;
+            for (int idx : value) {
+                String name = h.params().get(idx).name();
+                if (env.containsKey(name)) {
+                    continue;
+                }
+                Type t = typing.typeOf(name, body, env);
+                if (t == null) {
+                    openUses.put(idx, typing.openUse());
+                } else {
+                    env.put(name, t);
+                    found.put(idx, t);
+                    progress = true;
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Whether {@code name} is applied in {@code e} — the shape only a function parameter has. A
+     * binding that rebinds the name hides its body: an inner {@code let f = (x) -> ...} applied there
+     * is not this parameter.
+     */
+    static boolean isApplied(Ast.Expr e, String name) {
+        if (e instanceof Ast.Call call && call.fn().equals(name)) {
+            return true;
+        }
+        boolean[] found = {false};
+        forEachInScope(e, name, c -> {
+            if (!found[0]) {
+                found[0] = isApplied(c, name);
+            }
+        });
+        return found[0];
+    }
+
+    /**
+     * Walks the children of {@code e} that {@code name} still means the parameter in. A binder that
+     * rebinds the name — a {@code let}, a lambda parameter, a {@code match} arm's binding — hides
+     * what it binds over, so a same-named local is not read as the parameter.
+     */
+    static void forEachInScope(Ast.Expr e, String name, java.util.function.Consumer<Ast.Expr> f) {
+        switch (e) {
+            case Ast.LetIn li -> {
+                f.accept(li.value());
+                if (!li.name().equals(name)) {
+                    f.accept(li.body());
+                }
+            }
+            case Ast.Block b -> {
+                if (!b.params().contains(name)) {
+                    f.accept(b.body());
+                }
+            }
+            case Ast.Match m -> {
+                f.accept(m.scrutinee());
+                for (Ast.Case c : m.cases()) {
+                    if (!name.equals(c.binding())) {
+                        f.accept(c.body());
+                    }
+                }
+            }
+            default -> TypeChecker.forEachChild(e, f);
+        }
+    }
+
+    /**
+     * One parameter's type read out of the helper's body. The whole body is read, so a position after
+     * a use that named no type still determines it; the order the body is written decides only which
+     * of several determining positions wins.
+     *
+     * <p>It answers with a type or with nothing; it never reports a type error. A type the rest of the
+     * body disagrees with is reported by the standalone check that follows, at the position of the
+     * disagreement, so type errors keep coming from one place ({@link Elaborator}). Where nothing
+     * names a type, {@link #openUse()} is a use that named none, for the report to point at.
+     */
+    private static final class BodyTyping {
+        private final Symbols symbols;
+        private final CheckContext ctx;
+        private final Map<String, ReqSig> reqSigs;
+        private final Map<String, Type> recursiveHelperFns;
+        private Type pinned;
+        private Ast.Var openUse;
+
+        BodyTyping(Symbols symbols, Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns) {
+            this.symbols = symbols;
+            this.ctx = new CheckContext(symbols, null, reqSigs);
+            this.reqSigs = reqSigs;
+            this.recursiveHelperFns = recursiveHelperFns;
+        }
+
+        /** The type {@code body} gives {@code name}, or null when it gives none. */
+        Type typeOf(String name, Ast.Expr body, Map<String, Type> env) {
+            this.pinned = null;
+            this.openUse = null;
+            visit(body, env, name);
+            return pinned;
+        }
+
+        /** A use of the parameter that named no type, from the last {@link #typeOf} that found none. */
+        Ast.Var openUse() {
+            return openUse;
+        }
+
+        private void visit(Ast.Expr e, Map<String, Type> env, String name) {
+            if (pinned != null) {
+                return;
+            }
+            switch (e) {
+                case Ast.LetIn li -> {
+                    visitLet(li, env, name);
+                    return;
+                }
+                case Ast.Binary bin -> {
+                    if (bin.op() == Ast.BinOp.AND || bin.op() == Ast.BinOp.OR) {
+                        if (isParam(bin.left(), name) || isParam(bin.right(), name)) {
+                            pin(Type.BOOL);
+                        }
+                    } else if (isParam(bin.left(), name)) {
+                        pin(typed(bin.right(), env));
+                    } else if (isParam(bin.right(), name)) {
+                        pin(typed(bin.left(), env));
+                    }
+                }
+                case Ast.If iff -> {
+                    if (isParam(iff.cond(), name)) {
+                        pin(Type.BOOL);
+                    }
+                }
+                case Ast.Call call -> pinFromCall(call, name);
+                case Ast.NewData nd -> pinFromInits(nd.typeName(), nd.inits(), name);
+                case Ast.Var v when v.name().equals(name) -> {
+                    if (openUse == null) {
+                        openUse = v;   // a use of the parameter that no enclosing position typed
+                    }
+                }
+                default -> { }
+            }
+            if (pinned != null) {
+                return;
+            }
+            forEachInScope(e, name, c -> visit(c, env, name));
+        }
+
+        /**
+         * A {@code let} demands a type of its value: the one written on it, or the callee's declared
+         * parameter type, which the inliner carries onto the binding a helper call becomes. Where it
+         * demands none, the constraint passes along the binding: {@code let y = x in y * 2} types
+         * {@code x} through {@code y}, which is the shape a call to another body-typed helper inlines
+         * to. A binding of the parameter's own name shadows it, so its body is not walked for it.
+         */
+        private void visitLet(Ast.LetIn li, Map<String, Type> env, String name) {
+            Type demanded = li.declaredType() == null ? null
+                    : TypeOps.resolveParamType(li.declaredType(), symbols);
+            if (isParam(li.value(), name)) {
+                pin(demanded);
+                if (pinned != null) {
+                    return;
+                }
+                Ast.Var use = openUse;
+                visit(li.body(), env, li.name());   // the binding stands for the parameter
+                openUse = use;                      // its uses are the binding's, not the parameter's
+                if (pinned != null) {
+                    return;
+                }
+            }
+            visit(li.value(), env, name);
+            if (pinned != null || li.name().equals(name)) {
+                return;
+            }
+            Type bound = demanded != null ? demanded : carried(li, env);
+            Map<String, Type> inner = env;
+            if (bound != null) {
+                inner = new HashMap<>(env);
+                inner.put(li.name(), bound);
+            }
+            visit(li.body(), inner, name);
+        }
+
+        /** The type a binding carries into its body, or null where this scope cannot type its value. */
+        private Type carried(Ast.LetIn li, Map<String, Type> env) {
+            Type value = typed(li.value(), env);
+            return value == null ? null : Elaborator.carriedType(li, value, symbols);
+        }
+
+        /** The parameter passed where a callee declares the type of that argument. */
+        private void pinFromCall(Ast.Call call, String name) {
+            List<Type> params = calleeParams(call.fn());
+            if (params == null || params.size() != call.args().size()) {
+                return;
+            }
+            for (int i = 0; i < call.args().size(); i++) {
+                if (isParam(call.args().get(i), name)) {
+                    pin(params.get(i));
+                    return;
+                }
+            }
+        }
+
+        /** The parameter written as a field of a construction takes that field's type. */
+        private void pinFromInits(Ast.Name typeName, List<Ast.FieldInit> inits, String name) {
+            if (!(symbols.get(typeName.denotes()) instanceof Ast.Data data)) {
+                return;
+            }
+            for (Ast.FieldInit init : inits) {
+                if (isParam(init.value(), name)) {
+                    pin(TypeOps.fieldType(data, init.name(), symbols));
+                    return;
+                }
+            }
+        }
+
+        /**
+         * The parameter types {@code fn} declares, or null when nothing here declares them. A helper
+         * that annotates its parameters has already been inlined into this body, where its annotation
+         * is on the binding the call became, and a newtype's constructor {@code X(v)} has already been
+         * desugared to a construction; what is left to read is an injected behavior, a recursive
+         * helper and an intrinsic. A built-in that is neither an intrinsic nor a self-hosted helper
+         * states its parameter types only inside {@link CallElaborator}, so an argument of one is not
+         * read here — the parameter is annotated instead.
+         */
+        private List<Type> calleeParams(String fn) {
+            ReqSig req = reqSigs.get(fn);
+            if (req != null) {
+                return req.params();
+            }
+            if (recursiveHelperFns.get(fn) instanceof Type.FnOf sig) {
+                return sig.params();
+            }
+            Prelude.IntrinsicSig intrinsic = Prelude.intrinsics().get(fn);
+            return intrinsic == null ? null : intrinsic.params();
+        }
+
+        private boolean isParam(Ast.Expr e, String name) {
+            return e instanceof Ast.Var v && v.name().equals(name);
+        }
+
+        /**
+         * {@code t} taken as the parameter's type, unless it is one nothing concrete follows from: a
+         * function type (which must be written), a signature's type variable, or the bottom an empty
+         * collection carries — each of those leaves the parameter as open as it was.
+         */
+        private void pin(Type t) {
+            if (t == null || t instanceof Type.FnOf || Type.mentions(t, x -> x instanceof Type.Var)
+                    || Type.mentions(t, BottomInfer::isBottom)) {
+                return;
+            }
+            pinned = t;
+        }
+
+        /** The type of a neighbouring expression, or null where this scope cannot type it. */
+        private Type typed(Ast.Expr e, Map<String, Type> env) {
+            try {
+                return Elaborator.typeOf(e, env, ctx);
+            } catch (CompileException _) {
+                return null;
+            }
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -7,6 +7,7 @@ import souther.compiler.types.Type;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,10 +90,21 @@ final class HelperParams {
                 m.behaviors(), fns, m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
     }
 
-    /** Whether any fn of {@code m} writes a parameter without a type — behaviors included, whose
-     * parameters are typed from the behavior rather than settled, so this only over-approximates. */
+    /**
+     * Whether {@code m} has a helper parameter with no type written on it — the only thing there is
+     * to settle. A behavior's implementation is not a helper: its parameters are typed from the
+     * behavior and carry no type of their own, so counting them would answer yes for every module
+     * that implements a behavior and this would never skip anything.
+     */
     private static boolean hasOpenParam(Ast.Module m) {
+        Set<String> behaviors = new HashSet<>();
+        for (Ast.BehaviorDef b : m.behaviors()) {
+            behaviors.add(b.name());
+        }
         for (Ast.FnDef fn : m.fns()) {
+            if (behaviors.contains(fn.name())) {
+                continue;
+            }
             for (Ast.FnParam p : fn.params()) {
                 if (p.type() == null) {
                     return true;

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -61,8 +61,11 @@ final class HelperParams {
         try {
             recursiveHelperFns = HelperTyping.recursiveHelperSigs(inliner, symbols);
         } catch (CompileException _) {
-            // a recursive helper that does not declare its types is reported by the check; here it
-            // only means calls to it name no types.
+            // One recursive helper that does not declare its types costs the signatures of all of
+            // them, which is not observable: the check builds this same map outside its recovery, so
+            // the module is abandoned on that error before any helper is typed. If that map is ever
+            // made recoverable, this has to be made per-helper along with it — otherwise a helper
+            // this leaves unsettled is reported as undetermined on top of the real error.
             recursiveHelperFns = Map.of();
         }
         Map<String, Ast.FnDef> settled = new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
@@ -137,9 +136,9 @@ public final class HelperTyping {
      * generics, so there is nothing to generalise an open parameter into, and the annotation is what
      * states the type instead.
      *
-     * <p>A parameter a later round settles can settle an earlier one — {@code f(x, y)} where
-     * {@code y}'s type follows from {@code x}'s — so the rounds run to a fixpoint. Failing that, the
-     * report names the use that named no type.
+     * <p>{@link HelperParams} settles these types before the module is lowered, and writes what it
+     * settles back onto the parameter — so what reaches here open is what it could not settle. Reading
+     * it again is what turns "not settled" into a report that names the use that named no type.
      */
     private static void typeFromBody(Ast.FnDef h, List<Integer> open, Map<String, Type> env,
             Ast.Expr body, Symbols symbols, Map<String, ReqSig> reqSigs,
@@ -151,7 +150,7 @@ public final class HelperTyping {
         // where it is written — is reported as the function it is.
         for (int idx : open) {
             Ast.FnParam p = h.params().get(idx);
-            if (isApplied(body, p.name())) {
+            if (HelperParams.isApplied(body, p.name())) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.helper.fnparam").title("check.helper.title")
                                 .at(p.pos(), p.name().length()).args(h.name(), p.name()).build(),
@@ -160,25 +159,8 @@ public final class HelperTyping {
                                 + " type (spec 13.1)");
             }
         }
-        BodyTyping typing = new BodyTyping(symbols, reqSigs, recursiveHelperFns);
         Map<Integer, Ast.Var> openUses = new HashMap<>();
-        boolean progress = true;
-        while (progress) {
-            progress = false;
-            for (int idx : open) {
-                String name = h.params().get(idx).name();
-                if (env.containsKey(name)) {
-                    continue;
-                }
-                Type t = typing.typeOf(name, body, env);
-                if (t == null) {
-                    openUses.put(idx, typing.openUse());
-                } else {
-                    env.put(name, t);
-                    progress = true;
-                }
-            }
-        }
+        HelperParams.determine(h, open, env, body, symbols, reqSigs, recursiveHelperFns, openUses);
         for (int idx : open) {
             Ast.FnParam p = h.params().get(idx);
             if (env.containsKey(p.name())) {
@@ -192,249 +174,6 @@ public final class HelperTyping {
             throw CompileException.of(d.build(),
                     "helper `let " + h.name() + "` parameter `" + p.name() + "` is not determined by"
                             + " its body; annotate it with its type (spec 13.1)");
-        }
-    }
-
-    /**
-     * Whether {@code name} is applied in {@code e} — the shape only a function parameter has. A
-     * binding that rebinds the name hides its body: an inner {@code let f = (x) -> ...} applied there
-     * is not this parameter. ({@link #collectCalls} answers the same question for the recursive-helper
-     * call graph, where the names are helper names rather than a local, so it does not follow scopes.)
-     */
-    private static boolean isApplied(Ast.Expr e, String name) {
-        if (e instanceof Ast.Call call && call.fn().equals(name)) {
-            return true;
-        }
-        boolean[] found = {false};
-        forEachInScope(e, name, c -> {
-            if (!found[0]) {
-                found[0] = isApplied(c, name);
-            }
-        });
-        return found[0];
-    }
-
-    /**
-     * Walks the children of {@code e} that {@code name} still means the parameter in. A binder that
-     * rebinds the name — a {@code let}, a lambda parameter, a {@code match} arm's binding — hides
-     * what it binds over, so a same-named local is not read as the parameter.
-     */
-    private static void forEachInScope(Ast.Expr e, String name, java.util.function.Consumer<Ast.Expr> f) {
-        switch (e) {
-            case Ast.LetIn li -> {
-                f.accept(li.value());
-                if (!li.name().equals(name)) {
-                    f.accept(li.body());
-                }
-            }
-            case Ast.Block b -> {
-                if (!b.params().contains(name)) {
-                    f.accept(b.body());
-                }
-            }
-            case Ast.Match m -> {
-                f.accept(m.scrutinee());
-                for (Ast.Case c : m.cases()) {
-                    if (!name.equals(c.binding())) {
-                        f.accept(c.body());
-                    }
-                }
-            }
-            default -> TypeChecker.forEachChild(e, f);
-        }
-    }
-
-    /**
-     * One parameter's type read out of the helper's body. The whole body is read, so a position after
-     * a use that named no type still determines it; the order the body is written decides only which
-     * of several determining positions wins.
-     *
-     * <p>It answers with a type or with nothing; it never reports a type error. A type the rest of the
-     * body disagrees with is reported by the standalone check that follows, at the position of the
-     * disagreement, so type errors keep coming from one place ({@link Elaborator}). Where nothing
-     * names a type, {@link #openUse()} is a use that named none, for the report to point at.
-     */
-    private static final class BodyTyping {
-        private final Symbols symbols;
-        private final CheckContext ctx;
-        private final Map<String, ReqSig> reqSigs;
-        private final Map<String, Type> recursiveHelperFns;
-        private Type pinned;
-        private Ast.Var openUse;
-
-        BodyTyping(Symbols symbols, Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns) {
-            this.symbols = symbols;
-            this.ctx = new CheckContext(symbols, null, reqSigs);
-            this.reqSigs = reqSigs;
-            this.recursiveHelperFns = recursiveHelperFns;
-        }
-
-        /** The type {@code body} gives {@code name}, or null when it gives none. */
-        Type typeOf(String name, Ast.Expr body, Map<String, Type> env) {
-            this.pinned = null;
-            this.openUse = null;
-            visit(body, env, name);
-            return pinned;
-        }
-
-        /** A use of the parameter that named no type, from the last {@link #typeOf} that found none. */
-        Ast.Var openUse() {
-            return openUse;
-        }
-
-        private void visit(Ast.Expr e, Map<String, Type> env, String name) {
-            if (pinned != null) {
-                return;
-            }
-            switch (e) {
-                case Ast.LetIn li -> {
-                    visitLet(li, env, name);
-                    return;
-                }
-                case Ast.Binary bin -> {
-                    if (bin.op() == Ast.BinOp.AND || bin.op() == Ast.BinOp.OR) {
-                        if (isParam(bin.left(), name) || isParam(bin.right(), name)) {
-                            pin(Type.BOOL);
-                        }
-                    } else if (isParam(bin.left(), name)) {
-                        pin(typed(bin.right(), env));
-                    } else if (isParam(bin.right(), name)) {
-                        pin(typed(bin.left(), env));
-                    }
-                }
-                case Ast.If iff -> {
-                    if (isParam(iff.cond(), name)) {
-                        pin(Type.BOOL);
-                    }
-                }
-                case Ast.Call call -> pinFromCall(call, name);
-                case Ast.NewData nd -> pinFromInits(nd.typeName(), nd.inits(), name);
-                case Ast.Var v when v.name().equals(name) -> {
-                    if (openUse == null) {
-                        openUse = v;   // a use of the parameter that no enclosing position typed
-                    }
-                }
-                default -> { }
-            }
-            if (pinned != null) {
-                return;
-            }
-            forEachInScope(e, name, c -> visit(c, env, name));
-        }
-
-        /**
-         * A {@code let} demands a type of its value: the one written on it, or the callee's declared
-         * parameter type, which the inliner carries onto the binding a helper call becomes. Where it
-         * demands none, the constraint passes along the binding: {@code let y = x in y * 2} types
-         * {@code x} through {@code y}, which is the shape a call to another body-typed helper inlines
-         * to. A binding of the parameter's own name shadows it, so its body is not walked for it.
-         */
-        private void visitLet(Ast.LetIn li, Map<String, Type> env, String name) {
-            Type demanded = li.declaredType() == null ? null
-                    : TypeOps.resolveParamType(li.declaredType(), symbols);
-            if (isParam(li.value(), name)) {
-                pin(demanded);
-                if (pinned != null) {
-                    return;
-                }
-                Ast.Var use = openUse;
-                visit(li.body(), env, li.name());   // the binding stands for the parameter
-                openUse = use;                      // its uses are the binding's, not the parameter's
-                if (pinned != null) {
-                    return;
-                }
-            }
-            visit(li.value(), env, name);
-            if (pinned != null || li.name().equals(name)) {
-                return;
-            }
-            Type bound = demanded != null ? demanded : carried(li, env);
-            Map<String, Type> inner = env;
-            if (bound != null) {
-                inner = new HashMap<>(env);
-                inner.put(li.name(), bound);
-            }
-            visit(li.body(), inner, name);
-        }
-
-        /** The type a binding carries into its body, or null where this scope cannot type its value. */
-        private Type carried(Ast.LetIn li, Map<String, Type> env) {
-            Type value = typed(li.value(), env);
-            return value == null ? null : Elaborator.carriedType(li, value, symbols);
-        }
-
-        /** The parameter passed where a callee declares the type of that argument. */
-        private void pinFromCall(Ast.Call call, String name) {
-            List<Type> params = calleeParams(call.fn());
-            if (params == null || params.size() != call.args().size()) {
-                return;
-            }
-            for (int i = 0; i < call.args().size(); i++) {
-                if (isParam(call.args().get(i), name)) {
-                    pin(params.get(i));
-                    return;
-                }
-            }
-        }
-
-        /** The parameter written as a field of a construction takes that field's type. */
-        private void pinFromInits(Ast.Name typeName, List<Ast.FieldInit> inits, String name) {
-            if (!(symbols.get(typeName.denotes()) instanceof Ast.Data data)) {
-                return;
-            }
-            for (Ast.FieldInit init : inits) {
-                if (isParam(init.value(), name)) {
-                    pin(TypeOps.fieldType(data, init.name(), symbols));
-                    return;
-                }
-            }
-        }
-
-        /**
-         * The parameter types {@code fn} declares, or null when nothing here declares them. A helper
-         * that annotates its parameters has already been inlined into this body, where its annotation
-         * is on the binding the call became, and a newtype's constructor {@code X(v)} has already been
-         * desugared to a construction; what is left to read is an injected behavior, a recursive
-         * helper and an intrinsic. A built-in that is neither an intrinsic nor a self-hosted helper
-         * states its parameter types only inside {@link CallElaborator}, so an argument of one is not
-         * read here — the parameter is annotated instead.
-         */
-        private List<Type> calleeParams(String fn) {
-            ReqSig req = reqSigs.get(fn);
-            if (req != null) {
-                return req.params();
-            }
-            if (recursiveHelperFns.get(fn) instanceof Type.FnOf sig) {
-                return sig.params();
-            }
-            Prelude.IntrinsicSig intrinsic = Prelude.intrinsics().get(fn);
-            return intrinsic == null ? null : intrinsic.params();
-        }
-
-        private boolean isParam(Ast.Expr e, String name) {
-            return e instanceof Ast.Var v && v.name().equals(name);
-        }
-
-        /**
-         * {@code t} taken as the parameter's type, unless it is one nothing concrete follows from: a
-         * function type (which must be written), a signature's type variable, or the bottom an empty
-         * collection carries — each of those leaves the parameter as open as it was.
-         */
-        private void pin(Type t) {
-            if (t == null || t instanceof Type.FnOf || isOpen(t)
-                    || Type.mentions(t, BottomInfer::isBottom)) {
-                return;
-            }
-            pinned = t;
-        }
-
-        /** The type of a neighbouring expression, or null where this scope cannot type it. */
-        private Type typed(Ast.Expr e, Map<String, Type> env) {
-            try {
-                return Elaborator.typeOf(e, env, ctx);
-            } catch (CompileException _) {
-                return null;
-            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InjectionSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InjectionSigs.java
@@ -1,0 +1,53 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.types.Type;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The signatures of the behaviors a module injects (spec 13.2): a {@code behavior} declared with no
+ * matching {@code let} here, plus the ones an imported module declared and this one names (spec
+ * 14.3). A call to any of them is typed from its declaration, so both the settling of helper
+ * parameter types (before the module is lowered) and the type check itself read the same map.
+ */
+final class InjectionSigs {
+
+    private InjectionSigs() {}
+
+    /**
+     * Builds the map. Whether a behavior is an injection target is decided the same way in both
+     * callers — it is a {@code SpecBehavior} this module writes no {@code let} for. A local behavior
+     * of the same name as an imported one wins; the imported signature only fills a name this module
+     * does not declare.
+     */
+    static Map<String, ReqSig> of(Ast.Module module, Symbols symbols,
+                                  Map<String, Sig> importedSigs, Set<String> importedInjected) {
+        Set<String> implemented = new HashSet<>();
+        for (Ast.FnDef fn : module.fns()) {
+            implemented.add(fn.name());
+        }
+        Map<String, ReqSig> sigs = new HashMap<>();
+        for (Ast.BehaviorDef b : module.behaviors()) {
+            if (b instanceof Ast.SpecBehavior spec && !implemented.contains(spec.name())) {
+                List<Type> params = new ArrayList<>();
+                for (Ast.Param p : spec.params()) {
+                    params.add(TypeOps.successType(p.type(), symbols));
+                }
+                sigs.put(spec.name(), new ReqSig(params, TypeOps.successType(spec.ret(), symbols)));
+            }
+        }
+        for (String name : importedInjected) {
+            Sig sig = importedSigs.get(name);
+            if (sig != null) {
+                sigs.putIfAbsent(name, new ReqSig(sig.ins(), sig.out()));
+            }
+        }
+        return sigs;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -1,10 +1,12 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -27,9 +29,37 @@ public final class Lower {
 
     private Lower() {}
 
-    /** Returns {@code module} with each behavior-implementing fn body inlined and every list
-     * comprehension (in a body or a data invariant) desugared to an {@code if}. */
-    public static Ast.Module run(Ast.Module module) {
+    /**
+     * The two trees this stage answers with: the surface module it settled helper parameter types on,
+     * and the lowered module the backend emits from. The type check reads both — the surface one for
+     * the declarations, the lowered one for the bodies — so they must be the same settling, which is
+     * why they are handed back together rather than settled again downstream.
+     */
+    public record Lowered(Ast.Module settled, Ast.Module lowered) {}
+
+    /**
+     * Settles the helper parameter types the author left unwritten, then returns {@code module} with
+     * each behavior-implementing fn body inlined and every list comprehension (in a body or a data
+     * invariant) desugared to an {@code if}.
+     *
+     * <p>Settling comes first because inlining is what carries a parameter's type onto the binding a
+     * call becomes (issue #178): a type settled after this stage would never reach the expansion.
+     */
+    public static Lowered run(Ast.Module module, Symbols symbols,
+                              Map<String, Sig> importedSigs, Set<String> importedInjected) {
+        Map<String, ReqSig> reqSigs;
+        try {
+            reqSigs = InjectionSigs.of(module, symbols, importedSigs, importedInjected);
+        } catch (CompileException _) {
+            // a signature that does not build is reported by the check that follows; settling reads
+            // what it can and leaves the rest for the annotation rule.
+            reqSigs = Map.of();
+        }
+        Ast.Module settled = HelperParams.settle(module, symbols, reqSigs);
+        return new Lowered(settled, lower(settled));
+    }
+
+    private static Ast.Module lower(Ast.Module module) {
         HelperInliner inliner = HelperInliner.forModule(module);
         Set<String> behaviorNames = new HashSet<>();
         for (Ast.BehaviorDef b : module.behaviors()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -262,7 +262,12 @@ public final class TypeChecker {
         }
         // Injection targets (spec 13.2): a SpecBehavior with no matching fn. Its name and success
         // type let a fn call it inline (spec 12.2); it is the "required" behavior of the old form.
-        Map<String, ReqSig> reqSigs = new HashMap<>();
+        // An imported injection target is one here too (spec 14.3): the module that names it injects
+        // and binds it, whether it named it as a `>->` stage or as a `requires` dependency. Its
+        // signature comes from the module that declared it; a local behavior of the same name wins.
+        // The same map is built before the module is lowered, where a helper's parameter type is
+        // settled from a call to an injected behavior (issue #178), so it is built in one place.
+        Map<String, ReqSig> reqSigs = InjectionSigs.of(module, symbols, importedSigs, importedInjected);
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (b instanceof Ast.SpecBehavior spec && !fns.containsKey(spec.name())) {
                 // `requires` names what an implementation calls (12.6), and an injection target has
@@ -277,21 +282,7 @@ public final class TypeChecker {
                                     + " (spec 13.2); it cannot declare `requires` — the behavior that"
                                     + " calls or composes it does");
                 }
-                List<Type> reqParams = new ArrayList<>();
-                for (Ast.Param p : spec.params()) {
-                    reqParams.add(TypeOps.successType(p.type(), symbols));
-                }
-                reqSigs.put(spec.name(), new ReqSig(reqParams, TypeOps.successType(spec.ret(), symbols)));
                 SpecChecker.checkInjectionConstructs(spec, symbols, exposeAll, exposed);
-            }
-        }
-        // An imported injection target is one here too (spec 14.3): the module that names it injects and
-        // binds it, whether it named it as a `>->` stage or as a `requires` dependency. Its signature
-        // comes from the module that declared it; a local behavior of the same name wins.
-        for (String name : importedInjected) {
-            Sig sig = importedSigs.get(name);
-            if (sig != null) {
-                reqSigs.putIfAbsent(name, new ReqSig(sig.ins(), sig.out()));
             }
         }
         // Fail-fast with the reqSigs it reads: a `requires` that named something else leaves the call

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleTest.java
@@ -269,12 +269,15 @@ class CompileExampleTest {
         module = souther.compiler.check.Resolve.module(module,
                 souther.compiler.check.TypeChecker.symbols(module));
         module = souther.compiler.derive.Deriver.derive(module);
-        module = souther.compiler.check.HelperInliner.forModule(module)
-                .withInlinedInvariants(module);
+        module = souther.compiler.check.HelperInliner.withSettledInvariants(
+                module, souther.compiler.check.TypeChecker.symbols(module));
         module = souther.compiler.check.NewtypeDesugar.rewrite(module,
                 souther.compiler.check.TypeChecker.symbols(module));
-        var lowered = souther.compiler.check.Lower.run(module);
         var symbols = souther.compiler.check.TypeChecker.symbols(module);
+        var lowering = souther.compiler.check.Lower.run(
+                module, symbols, java.util.Map.of(), java.util.Set.of());
+        module = lowering.settled();
+        var lowered = lowering.lowered();
         var checked = souther.compiler.check.TypeChecker
                 .checkAndElaborate(module, symbols, java.util.Map.of(), java.util.Set.of(), lowered)
                 .checked();

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperBodyTypingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperBodyTypingTest.java
@@ -4,6 +4,8 @@ import souther.compiler.diag.CompileException;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -366,6 +368,39 @@ class CompileHelperBodyTypingTest {
                 """;
         assertTrue(Compiler.compile(src).containsKey("demo.F"),
                 "the determined type reaches the expansion inside the invariant");
+    }
+
+    @Test
+    void aRecursiveHelperMissingItsTypesIsTheOnlyThingReported() {
+        // Settling reads the recursive helpers' signatures, and one that does not declare its types
+        // costs it all of them — so `describe`, which is determined only by a call to the recursive
+        // helper that IS declared, is left unsettled. That is not observable: the check builds the
+        // same map outside its recovery and abandons the module on the same error. Holding it here
+        // means making that map recoverable cannot quietly add a second, derived report about
+        // `describe` on top of the real one.
+        String src = """
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                data U = A | B
+                data X = Int
+                partial let validRecursive (v: U): Int = match v with
+                        | A as a -> a.x
+                        | B as b -> b.y
+                partial let brokenRecursive (x) = brokenRecursive(x)
+                let describe (v) = {
+                    let n = validRecursive(v)
+                    match v with
+                        | A as a -> a.x + n
+                        | B as b -> b.y
+                }
+                behavior f : (a: A) -> X constructs X
+                let f (a) = X(describe(a))
+                """;
+        assertEquals(List.of("check.rechelper.return"),
+                Compiler.diagnoseModules(java.util.Map.of("demo.sou", src)).get("demo.sou").stream()
+                        .map(souther.compiler.diag.Diagnostic::messageKey).toList(),
+                "the undeclared recursive helper is reported, and nothing else is");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperBodyTypingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperBodyTypingTest.java
@@ -289,6 +289,86 @@ class CompileHelperBodyTypingTest {
     }
 
     @Test
+    void aBodyDeterminedTypeReachesTheExpansion() throws Exception {
+        // `v` is the value of `W`'s `u` field, so the body determines it as the sum `U` — and that is
+        // the type the binding the call expands to carries, rather than the case the caller passed.
+        String src = """
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                data U = A | B
+                data W = { u: U }
+                data X = Int
+                behavior f : (a: A) -> X constructs X, W
+                let describe (v) = {
+                    let w = W { u = v }
+                    match v with
+                        | A as a -> a.x
+                        | B as b -> b.y
+                }
+                let f (a) = X(describe(a))
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object behavior = loader.loadClass("demo.F$Impl").getConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.A", java.util.Map.of("x", 7L));
+        assertEquals(7L, Codecs.encode(loader, "demo.X", Codecs.apply(behavior, in)));
+    }
+
+    @Test
+    void aBodyDeterminedTypeTypesTheNextHelpersParameter() {
+        // `hold`'s parameter is determined by its body, and `describe`'s only comes from passing it to
+        // `hold` — so one helper's determined type has to be settled before the next one is read.
+        String src = """
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                data U = A | B
+                data W = { u: U }
+                data X = Int
+                behavior f : (a: A) -> X constructs X, W
+                let hold (v) = W { u = v }
+                let describe (w) = {
+                    let kept = hold(w)
+                    match w with
+                        | A as a -> a.x
+                        | B as b -> b.y
+                }
+                let f (a) = X(describe(a))
+                """;
+        assertTrue(Compiler.compile(src).containsKey("demo.F"),
+                "`hold`'s determined parameter type types `describe`'s");
+    }
+
+    @Test
+    void aBodyDeterminedTypeReachesAnInvariantsExpansionToo() {
+        // An invariant is expanded from a helper as a body is, and earlier in the pipeline — an
+        // importer reads an included data's invariant already expanded. `w` is determined as `U` by
+        // the call to `size`, and that is what the binding in the invariant's expansion carries.
+        String src = """
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                data U = A | B
+                data X = Int
+                partial let size (v: U): Int = match v with
+                        | A as a -> a.x
+                        | B as b -> b.y
+                let describe (w) = {
+                    let n = size(w)
+                    match w with
+                        | A as a -> a.x + n
+                        | B as b -> b.y
+                }
+                data V = { a: A }
+                    invariant describe(a) > 0
+                behavior f : (v: V) -> X constructs X
+                let f (v) = X(v.a.x)
+                """;
+        assertTrue(Compiler.compile(src).containsKey("demo.F"),
+                "the determined type reaches the expansion inside the invariant");
+    }
+
+    @Test
     void anAnnotatedHelperIsUnchanged() {
         String src = """
                 module demo

--- a/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
@@ -5,6 +5,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Lower;
 import souther.compiler.check.Resolve;
+import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.codegen.Backend;
 import souther.compiler.derive.Deriver;
@@ -30,9 +31,11 @@ class CompileTypeVariableTest {
     /** Compiles a core (reserved-namespace) module directly, bypassing the user-facing guard. */
     private static Map<String, byte[]> compileCore(String src) {
         Ast.Module m = Deriver.derive(Resolve.module(CstFrontend.parse(src)));
-        Ast.Module lowered = Lower.run(m);
+        Symbols symbols = TypeChecker.symbols(m);
+        Lower.Lowered lowering = Lower.run(m, symbols, Map.of(), Set.of());
+        Ast.Module lowered = lowering.lowered();
         TypeChecker.Checked checked =
-                TypeChecker.checkOrThrow(m, TypeChecker.symbols(m), Map.of(), Set.of(), lowered);
+                TypeChecker.checkOrThrow(lowering.settled(), symbols, Map.of(), Set.of(), lowered);
         return Backend.generate(lowered, checked);
     }
 


### PR DESCRIPTION
Closes #178 (the default branch is `main`, so this will not close it automatically — close by hand after merge).

## What was wrong

ADR-0066 gives a helper a type of its own: its parameter types come from its body rather than from its call sites. That type stopped at the helper.

Expanding a call rewrites `describe(a)` to `let $k_v = a in <body>` and carries the parameter's declared type onto the binding, so a value the helper knows to be a sum is not narrowed to the case the caller passed. A body-determined parameter had nothing written, so the narrowing happened:

```
let describe (v) = {
    let w = W { u = v }          -- v is U, the type of W's `u`
    match v with
        | A as a -> a.x
        | B as b -> b.y
}
let f (a) = X(describe(a))       -- rejected: match needs a sum, but A was passed
```

The type was settled by the type check; expansion happens before it. So what the check settled could never reach an expansion.

## What this does

Settles the type on the tree instead, in a new `HelperParams` pass, writing it back onto the parameter.

The issue expected this to need a type-to-surface writer — resolution run backwards. It does not. Since ADR-0067 everything downstream of `Resolve` reads what a reference denotes rather than how it was spelled, so the settled type goes on as an `Ast.TypeRef` that carries a denotation and no surface text at all. `HelperInliner` reads it like any written type and needed no change.

Settling runs before each of the two points a helper call is expanded — before the data invariants are inlined, and before the bodies are lowered. Those are separate points because an importer reads an included data's invariant through the symbol table and must find it already expanded. It is idempotent, and one helper's settled type can settle the next one's, so it runs to a fixpoint.

It reports nothing. A parameter its body does not determine is left as it was, and `HelperTyping` reports it exactly where it reported before — the report still labels the use that left the parameter open, and one unsettleable helper still does not hide the errors in the rest of the module.

`Lower.run` now answers with both trees, so a caller that lowers a module and then checks it cannot check the unsettled one by accident.

The first commit moves the injected-behavior signature map out of the type check into `InjectionSigs`, so settling and checking read the same one.

## Measured

- 1316 tests pass on a clean build.
- souther-lang/examples builds unchanged: migration cost zero lines.

Three tests added: the issue's own program (run end to end, not just compiled), one helper settling the next helper's parameter, and the same shape reached through a data invariant — which was a second instance of the bug, found while checking whether this fix covered it.

ADR-0066's Consequences recorded #178 as open; that paragraph is replaced with what now happens. No new ADR and no spec change: the language is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
