### PR TITLE
Make the compiler a set of questions it can be asked

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -272,31 +272,7 @@ public final class Compiler {
     public static Map<String, List<Diagnostic>> diagnoseModules(Map<String, String> sourcesById,
                                                                 Set<String> brokenModuleNames,
                                                                 ModulePath path) {
-        Compilation compilation =
-                Compilation.ofDocuments(sourcesById, brokenModuleNames, path);
-        compilation.answerEverything();
-
-        Map<String, List<Diagnostic>> result = new LinkedHashMap<>();
-        for (String id : sourcesById.keySet()) {
-            result.put(id, new ArrayList<>());
-        }
-        // Every report lands on the source it is about — an error in an imported module on that
-        // module's document, an `examples for` file's failing row on that file — which is what the
-        // reports carry with them. A report about something the caller did not hand over (a module
-        // read off the path) has nowhere to go and is left out.
-        for (Db.Found found : compilation.db().allReports()) {
-            String id = found.sourceId() != null ? found.sourceId()
-                    : compilation.sourceIdOf(found.module());
-            List<Diagnostic> on = id == null ? null : result.get(id);
-            if (on != null) {
-                on.add(found.report().diagnostic());
-            }
-        }
-        Map<String, List<Diagnostic>> published = new LinkedHashMap<>();
-        for (Map.Entry<String, List<Diagnostic>> e : result.entrySet()) {
-            published.put(e.getKey(), List.copyOf(e.getValue()));
-        }
-        return published;
+        return Compilation.ofDocuments(sourcesById, brokenModuleNames, path).diagnostics();
     }
     /** The module name from a source's {@code module <name>} header, for identifying a source that will
      * not parse (so its importers can be skipped, and the LSP can map a broken file to its module).

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -1,38 +1,18 @@
 package souther.compiler;
 
-import souther.compiler.types.TypeName;
-import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
-import souther.compiler.ast.Ast;
 import souther.compiler.diag.Diagnostic;
-import souther.compiler.diag.Region;
-import souther.compiler.diag.SourcePos;
-import souther.compiler.check.Exposing;
-import souther.compiler.check.HelperInliner;
-import souther.compiler.check.Lower;
-import souther.compiler.check.DataChecker;
-import souther.compiler.check.NewtypeDesugar;
-import souther.compiler.check.Resolve;
-import souther.compiler.check.PipelineSigs;
-import souther.compiler.check.Sig;
-import souther.compiler.check.TypeChecker;
-import souther.compiler.codegen.Backend;
-import souther.compiler.meta.ModuleMetadata;
 import souther.compiler.meta.ModulePath;
-import souther.compiler.meta.PublishedModule;
-import souther.compiler.frontend.CstFrontend;
-import souther.compiler.derive.Deriver;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Db;
+import souther.compiler.query.Report;
+import souther.compiler.query.Output;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -100,149 +80,70 @@ public final class Compiler {
                         + " name its parts with `let` to flatten it");
     }
 
+    /**
+     * Compiles one self-contained source by asking one compilation for its classes.
+     *
+     * <p>This differs from {@link #linking} in what it lets a source be, not in what it does with
+     * it: a source with no {@code module} header takes a name, and a failing example is reported
+     * with its own position rather than tagged with the file it came from, because there is only
+     * the one.
+     */
     private static Map<String, byte[]> compiling(String source, String defaultModuleName,
                                                  List<Diagnostic> warningsOut) {
-        CstFrontend.Parsed parsed = CstFrontend.parseWithSlices(source, defaultModuleName);
-        Ast.Module raw = parsed.module();
-        if (raw.exampleFileTarget() != null) {
-            throw CompileException.of(
-                    Diagnostic.of("E1907", "check.example.notarget").title("check.example.title")
-                            .at(raw.pos()).args(raw.exampleFileTarget()).build(),
-                    "an `examples for " + raw.exampleFileTarget() + "` file has no target module to attach to");
-        }
-        rejectReservedNamespace(raw);
-        Ast.Module exposed = Exposing.rewrite(raw);
-        rejectUserImports(exposed);
-        // Every written name is resolved here, before anything reads the tree (issue #177): what a
-        // later pass reads is a name that already says which module declares it.
-        Ast.Module named = Resolve.module(exposed);
-        Ast.Module module = Deriver.derive(named);
-        module = HelperInliner.withSettledInvariants(module, TypeChecker.symbols(module));
-        module = NewtypeDesugar.rewrite(module, TypeChecker.symbols(module));
-        module = Compiler.injectRecursivePrelude(module);
-        // the module's definitions no longer change, so its symbol table is built once and shared by
-        // the settling, the check, the constant verification, and the example run
-        Symbols symbols = TypeChecker.symbols(module);
-        Lower.Lowered lowering = Lower.run(module, symbols, Map.of(), Set.of());
-        module = lowering.settled();
-        Ast.Module lowered = lowering.lowered();
-        TypeChecker.Checked checked = TypeChecker.checkOrThrow(module, symbols, Map.of(), Set.of(), lowered);
-        warningsOut.addAll(checked.warnings());
-        Map<String, byte[]> out = Backend.generate(lowered, checked);
-        Map<String, Sig> sigs = PipelineSigs.signatures(module, symbols);
-        // the declarations go on the classes before anything loads them, so what a jar carries is
-        // the same bytes this compile checked
-        ModuleMetadata.stamp(out, raw, parsed.slices(), sigs, injectedNames(raw));
-        verifyConstConstructions(module, symbols, out, Compiler.class.getClassLoader());
-        ExampleVerifier.verify(module, symbols, sigs, out);
-        return out;
+        return classesOf(compiled(source, defaultModuleName, warningsOut));
     }
 
     /**
-     * Adds the prelude recursive helpers a module reaches (e.g. {@code souther.list}'s {@code
-     * foldFrom}) to the module as its own fns, under their qualified names. A recursive prelude helper
-     * cannot be inlined — it would expand forever — so it is emitted as one of the module's methods,
-     * the same as a module-own recursive helper. Only the reached ones are injected; a module that
-     * never folds gets none.
+     * The compilation of one self-contained source, driven to completion, with the first error
+     * raised. A caller that wants more than the classes — what a module declares, what a behavior's
+     * signature is — asks the compilation rather than parsing the source a second time.
      */
-    private static Ast.Module injectRecursivePrelude(Ast.Module module) {
-        Map<String, Ast.FnDef> injected = HelperInliner.forModule(module).injectedRecursiveHelpers();
-        if (injected.isEmpty()) {
-            return module;
-        }
-        List<Ast.FnDef> fns = new ArrayList<>(module.fns());
-        fns.addAll(injected.values());
-        return new Ast.Module(module.name(), module.exposing(), module.exposedOutputs(),
-                module.imports(), module.defs(), module.behaviors(), fns, module.examples(),
-                module.fakes(), module.exampleFileTarget(), module.pos());
+    public static Compilation compiled(String source, String defaultModuleName) {
+        return compiled(source, defaultModuleName, new ArrayList<>());
     }
 
-    /**
-     * Runs each constant newtype construction ({@code 金額(500)}) through its generated
-     * {@code $Ctfe.check} (compile-time function evaluation): the same invariant bytecode that
-     * {@code __construct} runs, so a violation becomes a compile error instead of a run-time abort
-     * (ADR-0032). A check that cannot be loaded or run here — e.g. a lambda-bearing invariant whose
-     * runtime class is absent from this classpath — is left to the run-time check.
-     */
-    private static void verifyConstConstructions(Ast.Module module, Symbols symbols,
-                                                 Map<String, byte[]> classes, ClassLoader parent) {
-        List<DataChecker.ConstCheck> checks = DataChecker.constNewtypeChecks(module, symbols);
-        if (checks.isEmpty()) {
-            return;
+    private static Compilation compiled(String source, String defaultModuleName,
+                                        List<Diagnostic> warningsOut) {
+        Compilation compilation = Compilation.ofSource(source, defaultModuleName);
+        Db db = compilation.db();
+
+        CompileException structural = compilation.firstError(compilation.structuralReports());
+        if (structural != null) {
+            throw structural;
         }
-        MemoryClassLoader loader = new MemoryClassLoader(classes, parent);
-        for (DataChecker.ConstCheck c : checks) {
-            boolean holds;
-            try {
-                Class<?> ctfe = Class.forName(
-                        c.type().module() + "." + c.type().name() + "$Ctfe", true, loader);
-                holds = (boolean) ctfe.getMethod("check", paramClass(c.value())).invoke(null, c.value());
-            } catch (ReflectiveOperationException | LinkageError _) {
-                continue;   // cannot evaluate at compile time; the run-time check still applies
+
+        db.ask(new Output.All());
+        CompileException failed = compilation.firstError(db.allReports());
+        if (failed != null) {
+            throw failed;
+        }
+        for (String module : compilation.modules()) {
+            if (!db.ask(new Output.ConstConstructions(module)).present()) {
+                CompileException bad = compilation.firstError(db.allReports());
+                if (bad != null) {
+                    throw bad;
+                }
             }
-            if (!holds) {
-                String shown = c.typeName() + "("
-                        + (c.value() instanceof String s ? "\"" + s + "\"" : c.value()) + ")";
-                throw CompileException.of(
-                        Diagnostic.of(null, "check.const.invariant").title("check.construct.title")
-                                .at(c.pos()).args(shown).build(),
-                        "`" + shown + "` violates its invariant.");
+            List<Diagnostic> failures = new ArrayList<>();
+            for (String id : compilation.exampleSourcesOf(module)) {
+                for (Report failure : db.ask(new Output.Examples(module, id)).reports()) {
+                    failures.add(failure.diagnostic());
+                }
+            }
+            if (failures.size() == 1) {
+                throw CompileException.of(failures.get(0),
+                        ExampleVerifier.legacySummary(failures));
+            }
+            if (!failures.isEmpty()) {
+                throw CompileException.ofAll(failures, ExampleVerifier.legacySummary(failures));
             }
         }
+        warningsOut.addAll(compilation.warnings(db.allReports()));
+        return compilation;
     }
 
-    private static Class<?> paramClass(Object v) {
-        if (v instanceof Long) {
-            return long.class;
-        }
-        if (v instanceof Boolean) {
-            return boolean.class;
-        }
-        return v.getClass();   // String, BigDecimal
-    }
-
-    /**
-     * Rejects any import left after {@link Exposing#rewrite} — the standard-library lines are gone by
-     * then, so what remains names another module, and this path compiles one module alone. Without
-     * this the import is dropped and the failure surfaces later as a naming error on the first use of
-     * the imported type, which points at the wrong line and says the wrong thing.
-     */
-    private static void rejectUserImports(Ast.Module m) {
-        if (!m.imports().isEmpty()) {
-            throw unknownModule(m.imports().get(0));
-        }
-    }
-
-    private static CompileException unknownModule(Ast.Import imp) {
-        return CompileException.of(
-                Diagnostic.of(null, "check.import.unknownmodule").title("check.module.title")
-                        .at(imp.pos()).args(imp.module()).build(),
-                "unknown module `" + imp.module() + "`");
-    }
-
-    /** The namespace the compiler ships (souther.string/list/map/bool); a user module may not
-     * take a reserved name, or it could grant itself the core's privileges (ADR-0028). */
-    private static final String RESERVED_NAMESPACE = "souther";
-
-    private static void rejectReservedNamespace(Ast.Module m) {
-        String n = m.name();
-        if (n.equals(RESERVED_NAMESPACE) || n.startsWith(RESERVED_NAMESPACE + ".")) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.module.reserved").title("check.module.title")
-                            .at(m.pos()).args(n).build(),
-                    "module `" + n + "` is in the reserved `" + RESERVED_NAMESPACE + "` namespace: the"
-                            + " compiler ships souther.string / souther.list / souther.map / souther.bool,"
-                            + " and a user module cannot take a reserved name.");
-        }
-        // The short qualifiers are how the standard library is reached (`List.map`, `import String`);
-        // a user module by one of these names would shadow the library and could not be imported.
-        if (Prelude.isQualifier(n)) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.module.qualifier").title("check.module.title")
-                            .at(m.pos()).args(n).build(),
-                    "module `" + n + "` uses a name reserved for the standard-library qualifier `" + n
-                            + "` (as in `" + n + ".…` / `import " + n + " { … }`); pick another module name.");
-        }
+    private static Map<String, byte[]> classesOf(Compilation compilation) {
+        return new LinkedHashMap<>(compilation.classes());
     }
 
     /** Compiles a set of modules together, resolving explicit imports and rejecting cycles. */
@@ -282,310 +183,58 @@ public final class Compiler {
         }
     }
 
+    /**
+     * Links a set of sources by asking one compilation for its classes.
+     *
+     * <p>What is left here is only what a batch compile decides and an editor decides differently:
+     * that a structural problem stops everything, that the first error is raised rather than
+     * collected, and that every module's examples are evaluated before any failing one is reported
+     * (issue #114) — so a change to a widely-imported data says how far it reaches in one compile.
+     */
     private static Map<String, byte[]> linking(List<String> sources, ModulePath path,
                                                List<Diagnostic> warningsOut) {
-        List<Ast.Module> allParsed = new ArrayList<>();
-        // Which source each module was read from, so an error can be traced back to a file.
-        Map<String, Integer> sourceOfModule = new LinkedHashMap<>();
-        // Modules an `examples for` file was merged into. Their examples come from another source, so
-        // an example failure names no file rather than quoting this one's line at that one's position.
-        Set<String> mergedExamples = new LinkedHashSet<>();
-        // What each module declared, as written, so its declarations can be published with it.
-        Map<String, CstFrontend.Parsed> asWritten = new LinkedHashMap<>();
-        for (int i = 0; i < sources.size(); i++) {
-            // A module linked by imports must be named; `null` forbids omitting the header here.
-            try {
-                CstFrontend.Parsed parsed = CstFrontend.parseWithSlices(sources.get(i), null);
-                Ast.Module raw = parsed.module();
-                rejectReservedNamespace(raw);
-                Ast.Module rewritten = Exposing.rewrite(raw);
-                allParsed.add(rewritten);
-                if (rewritten.exampleFileTarget() == null) {
-                    // an `examples for X` file carries X's name; the module itself is the other source
-                    sourceOfModule.put(rewritten.name(), i);
-                    asWritten.put(raw.name(), parsed);
-                }
-            } catch (CompileException e) {
-                throw e.inSource(i);
-            }
-        }
-        // An `examples for <module>` file contributes only examples: merge each into its target
-        // module. It is never a module of its own, so it never enters `byName`.
-        List<Ast.Module> parsed = new ArrayList<>();
-        Map<String, List<Ast.Example>> attached = new LinkedHashMap<>();
-        Map<String, List<Ast.Fake>> attachedFakes = new LinkedHashMap<>();
-        for (Ast.Module m : allParsed) {
-            if (m.exampleFileTarget() != null) {
-                attached.computeIfAbsent(m.exampleFileTarget(), k -> new ArrayList<>()).addAll(m.examples());
-                attachedFakes.computeIfAbsent(m.exampleFileTarget(), k -> new ArrayList<>()).addAll(m.fakes());
-                mergedExamples.add(m.exampleFileTarget());
-            } else {
-                parsed.add(m);
-            }
-        }
-        parsed = mergeAttachedExamples(parsed, attached, attachedFakes);
+        Compilation compilation = Compilation.ofSources(sources, path);
+        Db db = compilation.db();
 
-        Map<String, Ast.Module> byName = new LinkedHashMap<>();
-        for (Ast.Module m : parsed) {
-            if (byName.put(m.name(), m) != null) {
-                throw CompileException.of(
-                        Diagnostic.of(null, "check.module.duplicate").title("check.module.title")
-                                .at(m.pos()).args(m.name()).build(),
-                        "duplicate module `" + m.name() + "`")
-                        .inSource(sourceIndex(sourceOfModule, m.name()));
-            }
+        CompileException structural = compilation.firstError(compilation.structuralReports());
+        if (structural != null) {
+            throw structural;
         }
-        // A module these sources import but do not contain is looked for among the projects this one
-        // depends on. From here it is a module like any other, except that it is not in `parsed`:
-        // nothing generates it, runs its examples or reports its warnings — its jar already did.
-        Map<String, Set<String>> injectedElsewhere = new LinkedHashMap<>();
-        for (Ast.Module m : parsed) {
-            if (PublishedModule.read(m.name(), path.declarations()) != null) {
-                throw shadowsPath(m.name()).inSource(sourceIndex(sourceOfModule, m.name()));
-            }
-        }
-        List<Ast.Module> fromPath = readFromPath(parsed, byName, path, injectedElsewhere);
 
-        // A qualified behavior reference needs no import line (spec §qualified-reference); this is
-        // where not writing one becomes the same thing as writing it, so everything downstream — the
-        // imported signatures, the injected set, the class each name comes from — reads one shape.
-        List<Ast.Module> bound = new ArrayList<>();
-        for (Ast.Module m : parsed) {
-            bound.add(bindQualifiedBehaviors(m, byName));
+        Map<String, byte[]> out = new LinkedHashMap<>(db.ask(new Output.All()).value());
+        CompileException failed = compilation.firstError(db.allReports());
+        if (failed != null) {
+            throw failed;
         }
-        parsed = bound;
-        byName.clear();
-        for (Ast.Module m : fromPath) {
-            byName.put(m.name(), m);
-        }
-        for (Ast.Module m : parsed) {
-            byName.put(m.name(), m);
-        }
-        detectCycles(parsed, byName, sourceOfModule);
 
-        // pass 0: resolve every written name, in the module that wrote it (issue #177). A module off
-        // the path is resolved too — its declarations are read by the modules being compiled, and a
-        // spread or a case inside one means what its own module says it means.
-        Map<String, Ast.Module> named = new LinkedHashMap<>();
-        for (Ast.Module m : byName.values()) {
-            try {
-                named.put(m.name(), Resolve.module(m, visibleDefs(m, byName)));
-            } catch (CompileException e) {
-                throw e.inSource(sourceIndex(sourceOfModule, m.name()));
-            }
-        }
-        byName.clear();
-        byName.putAll(named);
-        parsed = reread(parsed, byName);
-        fromPath = reread(fromPath, byName);
-
-        // pass 1: derive each module's codecs, resolving imported types against the original defs.
-        // A module off the path is derived the same way, so what an import resolves against here is
-        // what it would have resolved against where it was compiled.
-        List<Ast.Module> toDerive = new ArrayList<>(fromPath);
-        toDerive.addAll(parsed);
-        Map<String, Ast.Module> derived = new LinkedHashMap<>();
-        for (Ast.Module m : toDerive) {
-            try {
-                Ast.Module d = Deriver.derive(m, visibleDefs(m, byName));
-                derived.put(m.name(), HelperInliner.withSettledInvariants(d, visibleDefs(d, byName)));
-            } catch (CompileException e) {
-                throw e.inSource(sourceIndex(sourceOfModule, m.name()));
-            }
-        }
-        // pass 1.5: lower `金額(x)` newtype constructors to NewData (needs every module's defs, so
-        // an imported newtype name resolves) before check and codegen see them
-        for (Ast.Module original : toDerive) {
-            Ast.Module m = derived.get(original.name());
-            try {
-                derived.put(original.name(), NewtypeDesugar.rewrite(m, visibleDefs(m, derived)));
-            } catch (CompileException e) {
-                throw e.inSource(sourceIndex(sourceOfModule, original.name()));
-            }
-        }
-        // `derived` is final from here, so what each module resolves against is resolved once, in the
-        // pass that first needs it, and read again by the example pass. Resolving it up front instead
-        // would move an unresolvable import ahead of an earlier module's type error in the report.
-        Map<String, Symbols> visible = new LinkedHashMap<>();
-        Map<String, Map<String, Sig>> imported = new LinkedHashMap<>();
-        // pass 2: type-check and generate against the derived (codec-bearing) defs
-        Map<String, byte[]> out = new LinkedHashMap<>();
-        for (Ast.Module original : parsed) {
-            Ast.Module m = derived.get(original.name());
-            try {
-                Symbols symbols = visibleDefs(m, derived);
-                Map<String, Sig> importedSigs = importedBehaviorSigs(m, derived);
-                visible.put(original.name(), symbols);
-                imported.put(original.name(), importedSigs);
-                Set<String> importedInjected = importedInjectedBehaviors(m, derived, injectedElsewhere);
-                m = injectRecursivePrelude(m);
-                Lower.Lowered lowering = Lower.run(m, symbols, importedSigs, importedInjected);
-                m = lowering.settled();
-                Ast.Module lowered = lowering.lowered();
-                TypeChecker.Checked checked = TypeChecker.checkOrThrow(m, symbols, importedSigs, importedInjected, lowered);
-                warningsOut.addAll(checked.warnings());
-                out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs,
-                        importedInjected, checked));
-            } catch (CompileException e) {
-                throw e.inSource(sourceIndex(sourceOfModule, original.name()));
-            }
-        }
-        // every module's classes are now present, so CTFE and example evaluation can resolve
-        // cross-module references — including into a dependency, whose classes come off the same
-        // path its declarations were read from
-        ClassLoader fromDependencies = path.loader(Compiler.class.getClassLoader());
+        // Every module's classes are now present, so a constant construction and an example can
+        // resolve a cross-module reference — including into a dependency, whose classes come off the
+        // same path its declarations were read from.
         List<Diagnostic> exampleFailures = new ArrayList<>();
         List<Integer> exampleSources = new ArrayList<>();
-        for (Ast.Module original : parsed) {
-            Ast.Module m = derived.get(original.name());
-            Symbols symbols = visible.get(original.name());
-            int index = sourceIndex(sourceOfModule, original.name());
-            Map<String, Sig> sigs;
-            try {
-                // both read the module's own defs and helper bodies, so their positions are this file's
-                sigs = PipelineSigs.signatures(m, symbols, imported.get(original.name()));
-                // as in the single-module path: the declarations go on before anything loads a class
-                CstFrontend.Parsed written = java.util.Objects.requireNonNull(
-                        asWritten.get(original.name()),
-                        () -> "nothing was read for module " + original.name() + " to publish");
-                ModuleMetadata.stamp(out, written.module(), written.slices(), sigs,
-                        injectedNames(written.module()));
-                verifyConstConstructions(m, symbols, out, fromDependencies);
-            } catch (CompileException e) {
-                throw e.inSource(index);
+        for (String module : compilation.modules()) {
+            if (!db.ask(new Output.ConstConstructions(module)).present()) {
+                CompileException bad = compilation.firstError(db.allReports());
+                if (bad != null) {
+                    throw bad;
+                }
+                continue;
             }
-            // Every module's examples are evaluated before any failure is thrown, so a change to a
-            // widely-imported data says how far it reaches in one compile rather than one module per
-            // round (issue #114). A module whose own compile failed never gets here, so what is
-            // collected is only ever a stale or wrong example, never a knock-on of a broken type.
-            for (Diagnostic d : ExampleVerifier.check(m, symbols, sigs, out, fromDependencies)) {
-                exampleFailures.add(d);
-                // a merged `examples for` file's rows are positioned in that file, not this one
-                exampleSources.add(mergedExamples.contains(original.name()) ? -1 : index);
+            for (String id : compilation.exampleSourcesOf(module)) {
+                for (Report failure : db.ask(new Output.Examples(module, id)).reports()) {
+                    exampleFailures.add(failure.diagnostic());
+                    // a row from an `examples for` file is positioned in that file, not this one
+                    exampleSources.add(compilation.sourceIndexOfId(id));
+                }
             }
         }
+        warningsOut.addAll(compilation.warnings(db.allReports()));
         if (!exampleFailures.isEmpty()) {
             throw CompileException.ofAllInSources(exampleFailures, exampleSources,
                     ExampleVerifier.legacySummary(exampleFailures));
         }
         return out;
     }
-
-    /**
-     * The modules {@code parsed} reaches that are not among {@code parsed} themselves, read from
-     * {@code path} and added to {@code byName}. A name that is not a compiled Souther module there
-     * is left out, so an import of something genuinely absent is still reported as unknown where it
-     * is written rather than here.
-     *
-     * <p>A module read this way brings its own reaches with it, so a dependency of a dependency
-     * arrives too. Which of its behaviors are injection targets is collected into
-     * {@code injectedOut}: no {@code let} is published, so that cannot be read off the module here
-     * the way it is read off a source.
-     */
-    private static List<Ast.Module> readFromPath(List<Ast.Module> parsed,
-                                                 Map<String, Ast.Module> byName, ModulePath path,
-                                                 Map<String, Set<String>> injectedOut) {
-        PublishedModule.Classes classes = path.declarations();
-        List<Ast.Module> found = new ArrayList<>();
-        // What is waiting to be read, and — for one a module off the path needs — which module needs
-        // it, so an incomplete path is reported as that rather than as an import nobody wrote.
-        Deque<String> pending = new ArrayDeque<>();
-        Map<String, String> neededBy = new LinkedHashMap<>();
-        parsed.forEach(m -> pending.addAll(reaches(m)));
-        Set<String> tried = new HashSet<>();
-        while (!pending.isEmpty()) {
-            String name = pending.poll();
-            if (byName.containsKey(name) || !tried.add(name)) {
-                continue;
-            }
-            PublishedModule published = PublishedModule.read(name, classes);
-            if (published == null) {
-                if (neededBy.containsKey(name) && !Prelude.isQualifier(name)) {
-                    throw pathIncomplete(name, neededBy.get(name));
-                }
-                continue;   // written in a source being compiled: still that import's own error
-            }
-            rejectReservedNamespace(published.module());
-            Ast.Module m = Exposing.rewrite(published.module());
-            found.add(m);
-            byName.put(name, m);
-            injectedOut.put(name, published.injectedBehaviors());
-            for (String reach : reaches(m)) {
-                neededBy.putIfAbsent(reach, name);
-                pending.add(reach);
-            }
-        }
-        return found;
-    }
-
-    /**
-     * A module on the path names another that is not there. The import is written in a module this
-     * project does not have, so quoting it would point at a line of a file nobody here can open: what
-     * is wrong is the path, and the message says which two modules it is between.
-     */
-    private static CompileException pathIncomplete(String missing, String needer) {
-        return CompileException.of(
-                Diagnostic.of(null, "check.module.pathincomplete").title("check.module.title")
-                        .args(missing, needer).hint("check.module.pathincomplete.hint", missing).build(),
-                "module `" + needer + "` needs `" + missing + "`, which is not on the path either");
-    }
-
-    /**
-     * A module being compiled here has the name of one already on the path. Which one an import means
-     * would be decided by nothing the author wrote, and the two would be different types under one
-     * name — the same reason two sources may not share a name.
-     */
-    private static CompileException shadowsPath(String name) {
-        return CompileException.of(
-                Diagnostic.of(null, "check.module.shadowspath").title("check.module.title")
-                        .args(name).hint("check.module.shadowspath.hint", name).build(),
-                "module `" + name + "` is compiled here and is also on the path");
-    }
-
-    /**
-     * Every module name {@code m} names: the ones it imports, the qualifier of every type it writes
-     * with one, and the qualifier of every behavior it names that way — a {@code >->} stage or a
-     * {@code requires}. Neither kind of qualified reference needs an import line, so reading only the
-     * import lines would leave a module it reaches unread. This runs before the qualified behavior
-     * references are rewritten to imports, because that rewrite is what needs the module read.
-     */
-    private static Set<String> reaches(Ast.Module m) {
-        Set<String> names = new LinkedHashSet<>();
-        Map<String, String> aliases = new HashMap<>();
-        for (Ast.Import imp : m.imports()) {
-            names.add(imp.module());
-            if (imp.alias() != null) {
-                aliases.put(imp.alias(), imp.module());
-            }
-        }
-        List<String> written = new ArrayList<>();
-        for (Ast.TypeRef ref : typeRefs(m)) {
-            written.add(ref.name());
-        }
-        for (Ast.BehaviorDef b : m.behaviors()) {
-            switch (b) {
-                case Ast.PipeBehavior pipe -> written.addAll(pipe.stages());
-                case Ast.SpecBehavior spec -> written.addAll(spec.requires());
-            }
-        }
-        for (String name : written) {
-            int dot = name.lastIndexOf('.');
-            if (dot > 0) {
-                String qualifier = name.substring(0, dot);
-                names.add(aliases.getOrDefault(qualifier, qualifier));
-            }
-        }
-        names.remove(m.name());
-        return names;
-    }
-
-    /** The source a module was read from, or {@code -1} when it cannot be named — an unknown module,
-     *  or one whose positions come from more than one file. */
-    private static int sourceIndex(Map<String, Integer> sourceOfModule, String moduleName) {
-        Integer index = sourceOfModule.get(moduleName);
-        return index == null ? -1 : index;
-    }
-
     /**
      * Links a module set like {@link #compileModules}, but collects diagnostics per source — keyed by
      * the caller's id (the LSP passes a document URI) — instead of throwing on the first error. This is
@@ -623,214 +272,32 @@ public final class Compiler {
     public static Map<String, List<Diagnostic>> diagnoseModules(Map<String, String> sourcesById,
                                                                 Set<String> brokenModuleNames,
                                                                 ModulePath path) {
+        Compilation compilation =
+                Compilation.ofDocuments(sourcesById, brokenModuleNames, path);
+        compilation.answerEverything();
+
         Map<String, List<Diagnostic>> result = new LinkedHashMap<>();
         for (String id : sourcesById.keySet()) {
             result.put(id, new ArrayList<>());
         }
-
-        // Parse each source, splitting real modules from `examples for` files. A parse-stage error
-        // (a type variable in a user module, say) is recorded against that source's id.
-        Map<String, Ast.Module> moduleById = new LinkedHashMap<>();
-        Map<String, Ast.Module> exampleFileById = new LinkedHashMap<>();
-        Set<String> failed = new HashSet<>(brokenModuleNames);   // module names whose source is broken
-        for (Map.Entry<String, String> e : sourcesById.entrySet()) {
-            try {
-                Ast.Module raw = CstFrontend.parse(e.getValue(), null);
-                if (raw.exampleFileTarget() != null) {
-                    exampleFileById.put(e.getKey(), raw);
-                } else {
-                    rejectReservedNamespace(raw);
-                    moduleById.put(e.getKey(), Exposing.rewrite(raw));
-                }
-            } catch (CompileException ex) {
-                result.get(e.getKey()).add(ex.diagnostic());
-                String name = moduleNameFromHeader(e.getValue());
-                if (name != null) {
-                    failed.add(name);   // a source that will not parse cannot satisfy an importer
-                }
+        // Every report lands on the source it is about — an error in an imported module on that
+        // module's document, an `examples for` file's failing row on that file — which is what the
+        // reports carry with them. A report about something the caller did not hand over (a module
+        // read off the path) has nowhere to go and is left out.
+        for (Db.Found found : compilation.db().allReports()) {
+            String id = found.sourceId() != null ? found.sourceId()
+                    : compilation.sourceIdOf(found.module());
+            List<Diagnostic> on = id == null ? null : result.get(id);
+            if (on != null) {
+                on.add(found.report().diagnostic());
             }
         }
-
-        // Index modules by name, tracking the source id each name came from; a duplicate name is an
-        // error on the offending source.
-        Map<String, Ast.Module> byName = new LinkedHashMap<>();
-        Map<String, String> idByName = new LinkedHashMap<>();
-        for (Map.Entry<String, Ast.Module> e : moduleById.entrySet()) {
-            Ast.Module m = e.getValue();
-            if (byName.containsKey(m.name())) {
-                result.get(e.getKey()).add(Diagnostic.of(null, "check.module.duplicate")
-                        .title("check.module.title").at(m.pos()).args(m.name()).build());
-                continue;
-            }
-            byName.put(m.name(), m);
-            idByName.put(m.name(), e.getKey());
-        }
-
-        // A module the workspace imports but does not contain is read from the path, so an import the
-        // build resolves is not reported here as unknown. A path that cannot be read leaves the
-        // workspace as it was: the author is editing a source, not a dependency.
-        Map<String, Set<String>> injectedElsewhere = new LinkedHashMap<>();
-        List<Ast.Module> fromPath;
-        try {
-            fromPath = readFromPath(new ArrayList<>(byName.values()), byName, path, injectedElsewhere);
-        } catch (CompileException _) {
-            fromPath = List.of();
-        }
-
-        // Names are resolved before anything reads a tree (issue #177). A module whose name resolves
-        // to nothing is reported and skipped, so an editor still gets every other module's errors.
-        Map<String, Ast.Module> named = new LinkedHashMap<>();
-        for (Ast.Module m : byName.values()) {
-            if (failed.contains(m.name()) || importsAnyFailed(m, failed)) {
-                named.put(m.name(), m);
-                continue;   // an importer of a broken module is skipped, not cascaded
-            }
-            try {
-                named.put(m.name(), Resolve.module(m, visibleDefs(m, byName)));
-            } catch (CompileException e) {
-                // The tree stays unresolved, so nothing may derive from it — including a module read
-                // off the class path, which has no source to report against but still cannot be used.
-                named.put(m.name(), m);
-                failed.add(m.name());
-                String id = idByName.get(m.name());
-                if (id != null) {
-                    result.get(id).add(e.diagnostic());
-                }
-            }
-        }
-        byName.clear();
-        byName.putAll(named);
-        fromPath = reread(fromPath, byName);
-
-        List<Ast.Module> order = dependencyOrder(byName, idByName, result);
-
-        // Compile each module (no example evaluation yet). Retain the derived module and its resolution
-        // context so examples can be evaluated afterwards, once every module's bytecode is present.
-        Map<String, Ast.Module> derived = new LinkedHashMap<>();
-        for (Ast.Module m : fromPath) {
-            if (failed.contains(m.name())) {
-                continue;   // its names did not resolve, so there is nothing to derive from
-            }
-            Ast.Module d = Deriver.derive(m, visibleDefs(m, byName));
-            d = HelperInliner.withSettledInvariants(d, visibleDefs(d, byName));
-            derived.put(m.name(), NewtypeDesugar.rewrite(d, visibleDefs(d, derived)));
-        }
-        Map<String, byte[]> out = new LinkedHashMap<>();
-        Map<String, VerifyContext> ready = new LinkedHashMap<>();
-        for (Ast.Module original : order) {
-            if (failed.contains(original.name())) {
-                continue;   // its error is already reported; its tree was not resolved past it
-            }
-            if (importsAnyFailed(original, failed)) {
-                failed.add(original.name());
-                continue;   // an importer of a broken module is skipped, not cascaded
-            }
-            try {
-                Ast.Module d = Deriver.derive(original, visibleDefs(original, byName));
-                d = HelperInliner.withSettledInvariants(d, visibleDefs(d, byName));
-                derived.put(original.name(), d);   // visible to its own newtype constructors during desugar
-                Ast.Module m = NewtypeDesugar.rewrite(d, visibleDefs(d, derived));
-                derived.put(original.name(), m);
-                Symbols symbols = visibleDefs(m, derived);
-                Map<String, Sig> importedSigs = importedBehaviorSigs(m, derived);
-                Set<String> importedInjected = importedInjectedBehaviors(m, derived, injectedElsewhere);
-                m = injectRecursivePrelude(m);
-                Lower.Lowered lowering = Lower.run(m, symbols, importedSigs, importedInjected);
-                m = lowering.settled();
-                Ast.Module lowered = lowering.lowered();
-                TypeChecker.CheckResult result0 =
-                        TypeChecker.checkAndElaborate(m, symbols, importedSigs, importedInjected, lowered);
-                List<Diagnostic> typeErrors = result0.diagnostics();
-                if (!typeErrors.isEmpty()) {
-                    // a type-invalid module must not reach codegen; report every error and skip it,
-                    // so its importers are skipped too rather than compiled against a broken module.
-                    result.get(idByName.get(original.name())).addAll(typeErrors);
-                    failed.add(original.name());
-                    continue;
-                }
-                out.putAll(Backend.generate(lowered, symbols, importedPackages(m), importedSigs,
-                        importedInjected, result0.checked()));
-                verifyConstConstructions(m, symbols, out, Compiler.class.getClassLoader());
-                Map<String, Sig> sigs =
-                        PipelineSigs.signatures(m, symbols, importedBehaviorSigs(m, derived));
-                ready.put(original.name(), new VerifyContext(m, symbols, sigs));
-            } catch (CompileException e) {
-                result.get(idByName.get(original.name())).add(e.diagnostic());
-                failed.add(original.name());
-            }
-        }
-
-        // Fakes from `examples for` files are shared with the target module (its own examples may use
-        // them), so gather them per target before evaluating any examples.
-        Map<String, List<Ast.Fake>> attachedFakes = new LinkedHashMap<>();
-        for (Ast.Module f : exampleFileById.values()) {
-            attachedFakes.computeIfAbsent(f.exampleFileTarget(), k -> new ArrayList<>()).addAll(f.fakes());
-        }
-
-        // A module's own inline examples, attributed to the module's source.
-        for (Map.Entry<String, VerifyContext> e : ready.entrySet()) {
-            VerifyContext ctx = e.getValue();
-            List<Ast.Fake> fakes = mergedFakes(ctx.module().fakes(), attachedFakes.get(e.getKey()));
-            result.get(idByName.get(e.getKey())).addAll(evaluate(ctx, ctx.module().examples(), fakes, out));
-        }
-
-        // Each `examples for` file's examples, attributed to that file — a target that is absent (not
-        // merely broken) is E1907.
-        for (Map.Entry<String, Ast.Module> e : exampleFileById.entrySet()) {
-            Ast.Module f = e.getValue();
-            VerifyContext ctx = ready.get(f.exampleFileTarget());
-            if (ctx == null) {
-                if (!byName.containsKey(f.exampleFileTarget())) {
-                    result.get(e.getKey()).add(Diagnostic.of("E1907", "check.example.notarget")
-                            .title("check.example.title").at(f.pos()).args(f.exampleFileTarget()).build());
-                }
-                continue;
-            }
-            List<Ast.Fake> fakes = mergedFakes(ctx.module().fakes(), attachedFakes.get(f.exampleFileTarget()));
-            result.get(e.getKey()).addAll(evaluate(ctx, f.examples(), fakes, out));
-        }
-
-        Map<String, List<Diagnostic>> frozen = new LinkedHashMap<>();
+        Map<String, List<Diagnostic>> published = new LinkedHashMap<>();
         for (Map.Entry<String, List<Diagnostic>> e : result.entrySet()) {
-            frozen.put(e.getKey(), List.copyOf(e.getValue()));
+            published.put(e.getKey(), List.copyOf(e.getValue()));
         }
-        return frozen;
+        return published;
     }
-
-    /** The resolution context a module's examples evaluate against, retained from its compile pass. */
-    private record VerifyContext(Ast.Module module, Symbols symbols, Map<String, Sig> sigs) {}
-
-    /** Evaluates {@code examples} against {@code ctx}'s module (its defs and bytecode), using
-     * {@code fakes} for any {@code requires} dependencies; returns one diagnostic per failing row. */
-    private static List<Diagnostic> evaluate(VerifyContext ctx, List<Ast.Example> examples,
-                                             List<Ast.Fake> fakes, Map<String, byte[]> classes) {
-        Ast.Module m = ctx.module();
-        Ast.Module toCheck = new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
-                m.defs(), m.behaviors(), m.fns(), examples, fakes, m.exampleFileTarget(), m.pos());
-        // An `examples for` file is parsed on its own and attached here, so its rows have not been
-        // through the resolve pass; the module's own rows have, and a resolved name is left alone.
-        return ExampleVerifier.check(Resolve.module(toCheck, ctx.symbols()), ctx.symbols(),
-                ctx.sigs(), classes);
-    }
-
-    private static List<Ast.Fake> mergedFakes(List<Ast.Fake> own, List<Ast.Fake> attached) {
-        if (attached == null || attached.isEmpty()) {
-            return own;
-        }
-        List<Ast.Fake> all = new ArrayList<>(own);
-        all.addAll(attached);
-        return all;
-    }
-
-    private static boolean importsAnyFailed(Ast.Module m, Set<String> failed) {
-        for (Ast.Import imp : m.imports()) {
-            if (failed.contains(imp.module())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
     /** The module name from a source's {@code module <name>} header, for identifying a source that will
      * not parse (so its importers can be skipped, and the LSP can map a broken file to its module).
      * {@code null} if no header token is found. */
@@ -839,535 +306,6 @@ public final class Compiler {
                 .compile("(?m)^\\s*module\\s+([\\p{L}\\p{N}_.]+)").matcher(source);
         return mt.find() ? mt.group(1) : null;
     }
-
-    /** Modules in dependency order (each module after the modules it imports). A cycle is E1501,
-     * recorded on the source of the module where the back edge is found; cyclic modules are left out
-     * of the order. */
-    private static List<Ast.Module> dependencyOrder(Map<String, Ast.Module> byName,
-                                                    Map<String, String> idByName,
-                                                    Map<String, List<Diagnostic>> result) {
-        List<Ast.Module> order = new ArrayList<>();
-        Set<String> done = new HashSet<>();
-        Set<String> onStack = new LinkedHashSet<>();
-        for (Ast.Module m : byName.values()) {
-            orderVisit(m.name(), byName, idByName, done, onStack, order, result);
-        }
-        return order;
-    }
-
-    private static void orderVisit(String name, Map<String, Ast.Module> byName, Map<String, String> idByName,
-                                   Set<String> done, Set<String> onStack, List<Ast.Module> order,
-                                   Map<String, List<Diagnostic>> result) {
-        if (done.contains(name)) {
-            return;
-        }
-        Ast.Module m = byName.get(name);
-        if (m == null) {
-            return;
-        }
-        onStack.add(name);
-        for (Ast.Import imp : m.imports()) {
-            if (onStack.contains(imp.module())) {
-                result.get(idByName.get(name)).add(
-                        new CompileException(imp.pos(), "E1501", "Cyclic module dependency detected.")
-                                .diagnostic());
-                onStack.remove(name);
-                done.add(name);
-                return;   // leave the cyclic module out of the order
-            }
-            if (byName.containsKey(imp.module())) {
-                orderVisit(imp.module(), byName, idByName, done, onStack, order, result);
-            }
-        }
-        onStack.remove(name);
-        done.add(name);
-        order.add(m);
-    }
-
-    /** Rebuilds each module with the examples and fakes from its attached {@code examples for} files
-     * appended; an attached file whose target module is absent is E1907. */
-    private static List<Ast.Module> mergeAttachedExamples(
-            List<Ast.Module> modules, Map<String, List<Ast.Example>> attached,
-            Map<String, List<Ast.Fake>> attachedFakes) {
-        if (attached.isEmpty() && attachedFakes.isEmpty()) {
-            return modules;
-        }
-        List<Ast.Module> out = new ArrayList<>();
-        for (Ast.Module m : modules) {
-            List<Ast.Example> extra = attached.remove(m.name());
-            List<Ast.Fake> extraFakes = attachedFakes.remove(m.name());
-            if ((extra == null || extra.isEmpty()) && (extraFakes == null || extraFakes.isEmpty())) {
-                out.add(m);
-                continue;
-            }
-            List<Ast.Example> mergedEx = new ArrayList<>(m.examples());
-            if (extra != null) {
-                mergedEx.addAll(extra);
-            }
-            List<Ast.Fake> mergedFk = new ArrayList<>(m.fakes());
-            if (extraFakes != null) {
-                mergedFk.addAll(extraFakes);
-            }
-            out.add(new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
-                    m.defs(), m.behaviors(), m.fns(), mergedEx, mergedFk, m.exampleFileTarget(), m.pos()));
-        }
-        String orphan = !attached.isEmpty() ? attached.keySet().iterator().next()
-                : (!attachedFakes.isEmpty() ? attachedFakes.keySet().iterator().next() : null);
-        if (orphan != null) {
-            throw CompileException.of(
-                    Diagnostic.of("E1907", "check.example.notarget").title("check.example.title")
-                            .at((SourcePos) null).args(orphan).build(),
-                    "an `examples for " + orphan + "` file names a module that is not being compiled");
-        }
-        return out;
-    }
-
-    /** Signatures of the behaviors {@code m} imports from other modules (spec 4, 14), so a
-     * composition here can name one as a stage. The declaring module's own signatures are computed
-     * against its visible defs; a behavior it in turn imports is out of scope for now. */
-    private static Map<String, Sig> importedBehaviorSigs(
-            Ast.Module m, Map<String, Ast.Module> registry) {
-        Map<String, Sig> result = new HashMap<>();
-        Map<String, String> fromModule = new HashMap<>();   // bare name → the module it came from
-        Map<String, Map<String, Sig>> sigsOf = new HashMap<>();
-        for (BehaviorRef ref : behaviorRefs(m, registry)) {
-            Ast.Module src = registry.get(ref.module());
-            if (!behaviorNames(src).contains(ref.name())) {
-                continue;   // a type import, or a name the module does not declare
-            }
-            // The declaring module may itself import the behaviors its definitions compose (an
-            // import chain deeper than one hop), so seed its own imported signatures when computing
-            // its signatures — recursively, up the graph. Cycles are already rejected, so this ends.
-            Map<String, Sig> srcSigs = sigsOf.computeIfAbsent(ref.module(), name ->
-                    PipelineSigs.signatures(src, visibleDefs(src, registry),
-                            importedBehaviorSigs(src, registry)));
-            Sig sig = srcSigs.get(ref.name());
-            if (sig == null) {
-                continue;
-            }
-            String earlier = fromModule.put(ref.name(), ref.module());
-            if (earlier != null && !earlier.equals(ref.module())) {
-                throw behaviorCollision(ref, earlier);
-            }
-            result.put(ref.name(), sig);
-        }
-        return result;
-    }
-
-    /**
-     * Rewrites every qualified behavior reference in {@code m} — a {@code >->} stage or a
-     * {@code requires} naming another module's behavior — to the bare name, and records the module it
-     * came from as an import. A behavior's name is a member name in the generated class, so the bare
-     * form is what the rest of the compiler needs; the qualifier only says which module to take it
-     * from, which is exactly what an import says.
-     */
-    private static Ast.Module bindQualifiedBehaviors(Ast.Module m, Map<String, Ast.Module> registry) {
-        Map<String, String> qualifiers = new HashMap<>();
-        for (Ast.Import imp : m.imports()) {
-            if (imp.alias() != null) {
-                qualifiers.put(imp.alias(), imp.module());
-            }
-        }
-        Map<String, Set<String>> taken = new LinkedHashMap<>();   // module → names it already brings
-        for (Ast.Import imp : m.imports()) {
-            taken.computeIfAbsent(imp.module(), k -> new LinkedHashSet<>()).addAll(imp.names());
-        }
-        Map<String, Set<String>> added = new LinkedHashMap<>();
-        Map<String, SourcePos> at = new LinkedHashMap<>();
-        List<Ast.BehaviorDef> behaviors = new ArrayList<>();
-        boolean rewrote = false;
-        for (Ast.BehaviorDef b : m.behaviors()) {
-            switch (b) {
-                case Ast.PipeBehavior pipe -> {
-                    List<String> stages = new ArrayList<>();
-                    for (String stage : pipe.stages()) {
-                        stages.add(bind(stage, qualifiers, registry, m, pipe.pos(), taken, added, at));
-                    }
-                    rewrote |= !stages.equals(pipe.stages());
-                    behaviors.add(new Ast.PipeBehavior(pipe.name(), stages, pipe.declaredOut(), pipe.pos()));
-                }
-                case Ast.SpecBehavior spec -> {
-                    List<String> requires = new ArrayList<>();
-                    for (String req : spec.requires()) {
-                        requires.add(bind(req, qualifiers, registry, m, spec.pos(), taken, added, at));
-                    }
-                    rewrote |= !requires.equals(spec.requires());
-                    behaviors.add(new Ast.SpecBehavior(spec.name(), spec.params(), spec.ret(),
-                            spec.constructs(), requires, spec.pos()));
-                }
-            }
-        }
-        if (!rewrote) {
-            return m;
-        }
-        List<Ast.Import> imports = new ArrayList<>(m.imports());
-        for (Map.Entry<String, Set<String>> e : added.entrySet()) {
-            imports.add(new Ast.Import(e.getKey(), null, List.copyOf(e.getValue()), at.get(e.getKey())));
-        }
-        return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), imports, m.defs(),
-                behaviors, m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
-    }
-
-    /** One written behavior name: the bare form it binds to, collecting the import it needs. */
-    private static String bind(String written, Map<String, String> qualifiers,
-                               Map<String, Ast.Module> registry, Ast.Module m, SourcePos pos,
-                               Map<String, Set<String>> taken, Map<String, Set<String>> added,
-                               Map<String, SourcePos> at) {
-        int dot = written.lastIndexOf('.');
-        if (dot < 0) {
-            return written;
-        }
-        String bare = written.substring(dot + 1);
-        // `X.decoder` / `X.encoder` name a codec, not a behavior of a module called X — a stage that
-        // writes one gets its own answer (spec 14.1), which reading it as an import would hide, and
-        // would hide the more so where a module happens to be named like the type.
-        if (bare.equals("decoder") || bare.equals("encoder")) {
-            return written;
-        }
-        String qualifier = written.substring(0, dot);
-        if (Prelude.isQualifier(qualifier)) {
-            return written;   // a standard-library qualifier: the stage names a function, not a behavior
-        }
-        String target = qualifiers.getOrDefault(qualifier, qualifier);
-        if (target.equals(m.name())) {
-            return bare;      // this module, named through itself
-        }
-        if (!registry.containsKey(target)) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.qualified.unknownmodule").title("check.module.title")
-                            .at(pos).args(qualifier, bare).build(),
-                    "no module named `" + qualifier + "`");
-        }
-        if (!taken.getOrDefault(target, Set.of()).contains(bare)) {
-            added.computeIfAbsent(target, k -> new LinkedHashSet<>()).add(bare);
-            at.putIfAbsent(target, pos);
-        }
-        return bare;
-    }
-
-    /** A behavior of another module named here, and where. */
-    private record BehaviorRef(String module, String name, SourcePos pos) {}
-
-    /** Every behavior of another module that {@code m} names. A qualified reference has already
-     * become an import by here ({@link #bindQualifiedBehaviors}), so the imports are the whole list. */
-    private static List<BehaviorRef> behaviorRefs(Ast.Module m, Map<String, Ast.Module> registry) {
-        List<BehaviorRef> refs = new ArrayList<>();
-        for (Ast.Import imp : m.imports()) {
-            if (registry.containsKey(imp.module())) {
-                for (String name : imp.names()) {
-                    refs.add(new BehaviorRef(imp.module(), name, imp.pos()));
-                }
-            }
-        }
-        return refs;
-    }
-
-    /**
-     * The same bare behavior name arrived from two modules. Unlike a type, a behavior name is also a
-     * member name in the generated class — an injected behavior is a field, and a stage that is one
-     * becomes a field here too — so the two cannot both be reached, qualified or not.
-     */
-    private static CompileException behaviorCollision(BehaviorRef ref, String earlier) {
-        return CompileException.of(
-                Diagnostic.of(null, "check.import.behaviordup").title("check.module.title")
-                        .at(ref.pos()).args(ref.name(), earlier, ref.module())
-                        .hint("check.import.behaviordup.hint", ref.name()).build(),
-                "behavior `" + ref.name() + "` is named from both `" + earlier + "` and `"
-                        + ref.module() + "`; one behavior name is one injected field, so this module"
-                        + " cannot take both");
-    }
-
-    private static Set<String> behaviorNames(Ast.Module m) {
-        Set<String> names = new HashSet<>();
-        for (Ast.BehaviorDef b : m.behaviors()) {
-            names.add(b.name());
-        }
-        return names;
-    }
-
-    /** The behaviors {@code m} imports that are injection targets in their declaring module (a
-     * SpecBehavior with no fn — spec 13.2). A composition here that names one as a stage inherits
-     * it as an inferred requirement, so the consuming module injects and binds it (spec 14.3). */
-    private static Set<String> importedInjectedBehaviors(Ast.Module m, Map<String, Ast.Module> registry,
-                                                         Map<String, Set<String>> injectedElsewhere) {
-        Set<String> result = new HashSet<>();
-        for (BehaviorRef ref : behaviorRefs(m, registry)) {
-            // A module off the path published which of its behaviors are injection targets, because
-            // the fn that decides is not published with it.
-            Set<String> injected = injectedElsewhere.containsKey(ref.module())
-                    ? injectedElsewhere.get(ref.module())
-                    : injectedNames(registry.get(ref.module()));
-            if (injected.contains(ref.name())) {
-                result.add(ref.name());
-            }
-        }
-        return result;
-    }
-
-    /** The injection-target behaviors of a module: a SpecBehavior with no matching fn (spec 13.2). */
-    private static Set<String> injectedNames(Ast.Module m) {
-        Set<String> fnNames = new HashSet<>();
-        for (Ast.FnDef f : m.fns()) {
-            fnNames.add(f.name());
-        }
-        Set<String> injected = new HashSet<>();
-        for (Ast.BehaviorDef b : m.behaviors()) {
-            if (b instanceof Ast.SpecBehavior && !fnNames.contains(b.name())) {
-                injected.add(b.name());
-            }
-        }
-        return injected;
-    }
-
-    /** The same modules, as {@code byName} now holds them — a list rebuilt after a pass replaced
-     * every module in the registry. */
-    private static List<Ast.Module> reread(List<Ast.Module> modules, Map<String, Ast.Module> byName) {
-        List<Ast.Module> out = new ArrayList<>();
-        for (Ast.Module m : modules) {
-            out.add(byName.get(m.name()));
-        }
-        return out;
-    }
-
-    /** What each bare name means in {@code m} — its own definitions plus the imported ones — paired
-     * with the registry a qualified reference resolves against. Each import is validated against the
-     * source module's {@code exposing}. */
-    private static Symbols visibleDefs(Ast.Module m, Map<String, Ast.Module> registry) {
-        Map<String, TypeName> scope = new HashMap<>();
-        for (String name : TypeChecker.ownDefs(m).keySet()) {
-            scope.put(name, new TypeName(m.name(), name));
-        }
-        Set<String> own = Set.copyOf(scope.keySet());
-        // Which import brought each name in, so a second one naming it is reported against that
-        // import rather than against a local definition the module may not have (issue #101).
-        Map<String, Ast.Import> from = new HashMap<>();
-        Map<String, String> aliases = new HashMap<>();
-        for (Ast.Import imp : m.imports()) {
-            Ast.Module src = registry.get(imp.module());
-            if (src == null) {
-                throw unknownModule(imp);
-            }
-            if (imp.alias() != null) {
-                checkAlias(imp, aliases, registry);
-                aliases.put(imp.alias(), imp.module());
-            }
-            Map<String, Ast.Def> srcDefs = TypeChecker.ownDefs(src);
-            Set<String> exposed = exposedBaseNames(src);
-            for (String name : imp.names()) {
-                if (!exposed.contains(name)) {
-                    throw CompileException.of(
-                            Diagnostic.of(null, "check.import.notexposed").title("check.module.title")
-                                    .at(imp.pos()).args(name, imp.module()).build(),
-                            "`" + name + "` is not exposed by `" + imp.module() + "`");
-                }
-                Ast.Def d = srcDefs.get(name);
-                if (d == null) {
-                    // a behavior import is resolved separately (importedBehaviorSigs); it is not a
-                    // data Def, so it does not go into the symbols map.
-                    if (behaviorNames(src).contains(name)) {
-                        continue;
-                    }
-                    throw CompileException.of(
-                            Diagnostic.of(null, "check.import.notdefined").title("check.module.title")
-                                    .at(imp.pos()).args(name, imp.module()).build(),
-                            "`" + name + "` is not defined in `" + imp.module() + "`");
-                }
-                if (scope.put(name, new TypeName(imp.module(), name)) != null) {
-                    throw importCollision(name, imp, own.contains(name) ? null : from.get(name));
-                }
-                from.put(name, imp);
-            }
-        }
-        return Symbols.of(m, registry, scope, aliases);
-    }
-
-    /**
-     * An alias must be a qualifier nothing else already is: another alias, a module in this
-     * compilation, or a standard-library qualifier ({@code List}, {@code String}). Left to win
-     * silently it would take over what {@code List.map} or {@code billing.Amount} means in this
-     * module, which is the opposite of what naming a module locally is for.
-     */
-    private static void checkAlias(Ast.Import imp, Map<String, String> aliases,
-                                   Map<String, Ast.Module> registry) {
-        String taken = aliases.containsKey(imp.alias()) ? aliases.get(imp.alias())
-                : registry.containsKey(imp.alias()) ? imp.alias()
-                : Prelude.isQualifier(imp.alias()) ? "souther" : null;
-        if (taken != null) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.import.aliastaken").title("check.module.title")
-                            .at(imp.pos()).args(imp.alias(), taken)
-                            .hint("check.import.aliastaken.hint").build(),
-                    "the alias `" + imp.alias() + "` is already how `" + taken + "` is named here");
-        }
-    }
-
-    /**
-     * The name arrived twice. {@code earlier} is the import that already brought it in, or null when
-     * the module defines it itself. Either way the way out is inside the module: keep at most one of
-     * them bare and name the other through its module (spec §qualified-reference), so the message names
-     * both modules and leaves the choice of which one to import to the module.
-     */
-    private static CompileException importCollision(String name, Ast.Import imp, Ast.Import earlier) {
-        if (earlier == null) {
-            return CompileException.of(
-                    Diagnostic.of(null, "check.import.conflict").title("check.module.title")
-                            .at(imp.pos()).args(name)
-                            .hint("check.import.conflict.hint").build(),
-                    "imported `" + name + "` conflicts with a local definition");
-        }
-        Diagnostic.Builder b = Diagnostic.of(null, "check.import.duplicate").title("check.module.title")
-                .at(imp.pos()).args(name, earlier.module(), imp.module())
-                .secondary(Region.point(earlier.pos()), "check.import.duplicate.first", name,
-                        earlier.module());
-        return CompileException.of(
-                (earlier.module().equals(imp.module())
-                        ? b.hint("check.import.duplicate.same.hint")
-                        : b.hint("check.import.duplicate.hint", name, imp.module())).build(),
-                "`" + name + "` is imported from both `" + earlier.module() + "` and `"
-                        + imp.module() + "`; one name cannot stand for two types");
-    }
-
-    /** Maps each imported type name to its declaring module, for cross-package class references. */
-    private static Map<String, String> importedPackages(Ast.Module m) {
-        Map<String, String> pkg = new HashMap<>();
-        for (Ast.Import imp : m.imports()) {
-            for (String name : imp.names()) {
-                pkg.put(name, imp.module());
-            }
-        }
-        return pkg;
-    }
-
-    /** The base type names a module exposes (dropping any {@code .decoder}/{@code .encoder} member). */
-    private static Set<String> exposedBaseNames(Ast.Module m) {
-        Set<String> names = new HashSet<>();
-        for (String e : m.exposing()) {
-            int dot = e.indexOf('.');
-            names.add(dot < 0 ? e : e.substring(0, dot));
-        }
-        return names;
-    }
-
-    private static void detectCycles(List<Ast.Module> modules, Map<String, Ast.Module> byName,
-                                     Map<String, Integer> sourceOfModule) {
-        Map<String, List<Dependency>> deps = new LinkedHashMap<>();
-        for (Ast.Module m : modules) {
-            deps.put(m.name(), dependencies(m, byName.keySet()));
-        }
-        Set<String> done = new HashSet<>();
-        Set<String> stack = new HashSet<>();
-        for (Ast.Module m : modules) {
-            visit(m.name(), byName, deps, done, stack, sourceOfModule);
-        }
-    }
-
-    /** One module reaching another, and where it does so. */
-    private record Dependency(String module, SourcePos pos) {}
-
-    /**
-     * Every module {@code m} depends on: the ones it imports, plus the ones it names in a qualified
-     * type reference. A qualified reference needs no {@code import} (spec 4), so reading only the
-     * import lines would let a dependency cycle through unseen — and a cycle is rejected whichever
-     * way it is written.
-     */
-    private static List<Dependency> dependencies(Ast.Module m, Set<String> modules) {
-        List<Dependency> deps = new ArrayList<>();
-        Map<String, String> qualifiers = new HashMap<>();
-        for (Ast.Import imp : m.imports()) {
-            deps.add(new Dependency(imp.module(), imp.pos()));
-            if (imp.alias() != null) {
-                qualifiers.put(imp.alias(), imp.module());
-            }
-        }
-        for (Ast.TypeRef ref : typeRefs(m)) {
-            int dot = ref.name().lastIndexOf('.');
-            if (dot < 0) {
-                continue;
-            }
-            String qualifier = ref.name().substring(0, dot);
-            String target = qualifiers.getOrDefault(qualifier, qualifier);
-            if (modules.contains(target) && !target.equals(m.name())) {
-                deps.add(new Dependency(target, ref.pos()));
-            }
-        }
-        return deps;
-    }
-
-    /** Every type written in {@code m}: its data's fields, and its behaviors' and fns' signatures. */
-    private static List<Ast.TypeRef> typeRefs(Ast.Module m) {
-        List<Ast.TypeRef> refs = new ArrayList<>();
-        for (Ast.Def def : m.defs()) {
-            if (def instanceof Ast.Data d) {
-                for (Ast.Field f : d.fields()) {
-                    collectTypeRefs(f.type(), refs);
-                }
-            }
-        }
-        for (Ast.BehaviorDef b : m.behaviors()) {
-            if (b instanceof Ast.SpecBehavior spec) {
-                for (Ast.Param p : spec.params()) {
-                    collectRetType(p.type(), refs);
-                }
-                collectRetType(spec.ret(), refs);
-            } else if (b instanceof Ast.PipeBehavior pipe) {
-                collectRetType(pipe.declaredOut(), refs);
-            }
-        }
-        for (Ast.FnDef fn : m.fns()) {
-            for (Ast.FnParam p : fn.params()) {
-                if (p.type() instanceof Ast.RetType rt) {
-                    collectRetType(rt, refs);
-                } else if (p.type() instanceof Ast.FnType ft) {
-                    ft.params().forEach(pt -> collectRetType(pt, refs));
-                    collectRetType(ft.result(), refs);
-                }
-            }
-            collectRetType(fn.declaredReturn(), refs);
-        }
-        return refs;
-    }
-
-    private static void collectRetType(Ast.RetType ret, List<Ast.TypeRef> refs) {
-        if (ret != null) {
-            ret.cases().forEach(c -> collectTypeRefs(c, refs));
-        }
-    }
-
-    private static void collectTypeRefs(Ast.TypeRef ref, List<Ast.TypeRef> refs) {
-        if (ref == null) {
-            return;
-        }
-        if (ref.name() != null) {
-            refs.add(ref);
-        }
-        collectTypeRefs(ref.arg(), refs);
-        if (ref.tupleElems() != null) {
-            ref.tupleElems().forEach(e -> collectTypeRefs(e, refs));
-        }
-    }
-
-    private static void visit(String name, Map<String, Ast.Module> byName,
-                              Map<String, List<Dependency>> deps,
-                              Set<String> done, Set<String> stack,
-                              Map<String, Integer> sourceOfModule) {
-        if (done.contains(name)) {
-            return;
-        }
-        stack.add(name);
-        for (Dependency dep : deps.getOrDefault(name, List.of())) {
-            if (stack.contains(dep.module())) {
-                // the reference that closes the cycle is written in `name`, so that is the file to quote
-                throw new CompileException(dep.pos(), "E1501", "Cyclic module dependency detected.")
-                        .inSource(sourceIndex(sourceOfModule, name));
-            }
-            if (byName.containsKey(dep.module())) {
-                visit(dep.module(), byName, deps, done, stack, sourceOfModule);
-            }
-        }
-        stack.remove(name);
-        done.add(name);
-    }
-
     /** Compiles source and writes each generated class under {@code outDir}. */
     public static void compileToDir(String source, Path outDir) throws IOException {
         for (Map.Entry<String, byte[]> entry : compile(source).entrySet()) {

--- a/souther-compiler/src/main/java/souther/compiler/MemoryClassLoader.java
+++ b/souther-compiler/src/main/java/souther/compiler/MemoryClassLoader.java
@@ -9,14 +9,14 @@ import java.util.function.Supplier;
  * unknown to the parent loader. Used to run generated code without writing {@code .class} files:
  * the compiler's compile-time {@code $Ctfe.check} evaluation and {@link Runner}'s behavior driving.
  */
-final class MemoryClassLoader extends ClassLoader {
+public final class MemoryClassLoader extends ClassLoader {
 
     private final Map<String, byte[]> classes;
     /** Classes defined on the fly (a multi-argument fake's base subclass; issue #57), cached so a name
      * is never defined twice — which would be a {@code LinkageError}. */
     private final Map<String, Class<?>> defined = new HashMap<>();
 
-    MemoryClassLoader(Map<String, byte[]> classes, ClassLoader parent) {
+    public MemoryClassLoader(Map<String, byte[]> classes, ClassLoader parent) {
         super(parent);
         this.classes = classes;
     }

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -6,7 +6,7 @@ import souther.compiler.check.PipelineSigs;
 import souther.compiler.check.Resolve;
 import souther.compiler.check.Sig;
 import souther.compiler.types.Type;
-import souther.compiler.check.TypeChecker;
+import souther.compiler.query.Compilation;
 import souther.compiler.diag.Messages;
 import souther.compiler.frontend.CstFrontend;
 
@@ -152,10 +152,13 @@ public final class Runner {
         String source = read(file);
         String moduleName = moduleName(file);
 
-        Map<String, byte[]> classes = Compiler.compile(source, moduleName);
-        Ast.Module module = Resolve.module(CstFrontend.parse(source, moduleName));
-        Symbols symbols = TypeChecker.symbols(module);
-        Map<String, Sig> sigs = PipelineSigs.signatures(module, symbols);
+        // One compilation answers all of it. Re-reading the source here to find the behavior and
+        // its signature would resolve every name a second time, against a tree this compile has
+        // already produced.
+        Compilation compilation = Compiler.compiled(source, moduleName);
+        Map<String, byte[]> classes = compilation.classes();
+        Ast.Module module = compilation.module(compilation.modules().get(0));
+        Map<String, Sig> sigs = compilation.signatures(module.name());
 
         Ast.BehaviorDef spec = resolveBehavior(module, behaviorName);
         Sig sig = sigs.get(spec.name());

--- a/souther-compiler/src/main/java/souther/compiler/check/Registry.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Registry.java
@@ -1,0 +1,77 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Where the declarations of a compilation are read from. {@link Symbols} answers what a name means
+ * here; this answers what any module declares, which is the part that is not about "here" at all.
+ *
+ * <p>Three questions, and no more: a module's definitions, what it exposes, and which modules there
+ * are. Keeping it to that is the point — a registry that handed out {@code Ast.Module} would let a
+ * caller reach a module's behaviors, examples or fns and so depend on which pass had last rewritten
+ * it, which is how a definition's meaning came to depend on the whole compile.
+ */
+public interface Registry {
+
+    /** Every definition of one module, keyed by the name written there. Empty when this compilation
+     * has no such module. */
+    Map<String, Ast.Def> declaredIn(String moduleName);
+
+    /** The base type names {@code moduleName} exposes, with any {@code .decoder} / {@code .encoder}
+     * member dropped. Empty when this compilation has no such module. */
+    Set<String> exposedBy(String moduleName);
+
+    /** Every module name in this compilation. A qualifier is one of these or an import alias. */
+    Set<String> moduleNames();
+
+    /** Nothing is declared anywhere — for signatures written over primitives and type variables. */
+    static Registry empty() {
+        return of(Map.of());
+    }
+
+    /** The declarations of a fixed set of modules. Each module's definitions are worked out on
+     * first use, so a compilation that never reaches a module never reads it. */
+    static Registry of(Map<String, Ast.Module> modules) {
+        return new Registry() {
+            private final Map<String, Map<String, Ast.Def>> defs = new HashMap<>();
+            private final Map<String, Set<String>> exposed = new HashMap<>();
+
+            @Override
+            public Map<String, Ast.Def> declaredIn(String moduleName) {
+                return defs.computeIfAbsent(moduleName, name -> {
+                    Ast.Module m = modules.get(name);
+                    return m == null ? Map.of() : TypeChecker.ownDefs(m);
+                });
+            }
+
+            @Override
+            public Set<String> exposedBy(String moduleName) {
+                return exposed.computeIfAbsent(moduleName, name -> {
+                    Ast.Module m = modules.get(name);
+                    return m == null ? Set.of() : baseNames(m.exposing());
+                });
+            }
+
+            @Override
+            public Set<String> moduleNames() {
+                return modules.keySet();
+            }
+        };
+    }
+
+    /** An {@code exposing} list as the type names it names: {@code Amount.decoder} exposes
+     * {@code Amount}. */
+    static Set<String> baseNames(Iterable<String> exposing) {
+        Set<String> names = new LinkedHashSet<>();
+        for (String e : exposing) {
+            int dot = e.indexOf('.');
+            names.add(dot < 0 ? e : e.substring(0, dot));
+        }
+        return Set.copyOf(names);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
@@ -27,10 +28,30 @@ import java.util.Map;
 public final class Resolve {
 
     private final Symbols symbols;
+    /** Every name this pass answered, in the order it met them. */
+    private final List<Denotation> denotations = new ArrayList<>();
 
     private Resolve(Symbols symbols) {
         this.symbols = symbols;
     }
+
+    /**
+     * One written name and what it turned out to denote, where it was written.
+     *
+     * <p>This is the pass's other product. Working out what a name means is a traversal of the whole
+     * module, and an editor asking "what is under the cursor" or "where else is this named" is asking
+     * about the answers that traversal already gave. Collecting them here is what keeps the editor
+     * from walking the tree again with a rule of its own — which, before this, is how renaming a
+     * type could rewrite the tail of a qualified reference to a different module's type.
+     *
+     * @param written the name as the source wrote it, bare or qualified
+     * @param denotes what it names
+     * @param pos where the written name starts
+     */
+    public record Denotation(String written, TypeName denotes, SourcePos pos) {}
+
+    /** A resolved module together with every name the pass answered in it. */
+    public record Resolved(Ast.Module module, List<Denotation> denotations) {}
 
     /** {@code m} with every name it writes resolved against its own definitions — a module compiled
      * with nothing else in sight. */
@@ -40,6 +61,11 @@ public final class Resolve {
 
     /** {@code m} with every name it writes resolved against {@code symbols}. */
     public static Ast.Module module(Ast.Module m, Symbols symbols) {
+        return resolving(m, symbols).module();
+    }
+
+    /** As {@link #module(Ast.Module, Symbols)}, keeping what each name was answered with. */
+    public static Resolved resolving(Ast.Module m, Symbols symbols) {
         Resolve r = new Resolve(symbols);
         List<Ast.Def> defs = new ArrayList<>();
         for (Ast.Def def : m.defs()) {
@@ -84,8 +110,10 @@ public final class Resolve {
         for (Map.Entry<String, Ast.RetType> e : m.exposedOutputs().entrySet()) {
             exposedOutputs.put(e.getKey(), r.retType(e.getValue()));
         }
-        return new Ast.Module(m.name(), m.exposing(), exposedOutputs, m.imports(), defs,
-                behaviors, fns, examples, fakes, m.exampleFileTarget(), m.pos());
+        return new Resolved(
+                new Ast.Module(m.name(), m.exposing(), exposedOutputs, m.imports(), defs,
+                        behaviors, fns, examples, fakes, m.exampleFileTarget(), m.pos()),
+                List.copyOf(r.denotations));
     }
 
     private Ast.FnDef fn(Ast.FnDef f) {
@@ -155,7 +183,15 @@ public final class Resolve {
             }
         }
         Ast.TypeRef resolved = new Ast.TypeRef(ref.name(), arg, elems, ref.pos());
-        return resolved.denoting(TypeOps.denoted(resolved, symbols));
+        Ast.TypeRef denoted = resolved.denoting(TypeOps.denoted(resolved, symbols));
+        // A reference with no name is a tuple or a container shape, which names no declaration.
+        if (denoted.name() != null && denoted.pos() != null) {
+            TypeName names = symbols.resolve(denoted.name());
+            if (names != null) {
+                denotations.add(new Denotation(denoted.name(), names, denoted.pos()));
+            }
+        }
+        return denoted;
     }
 
     // --- definitions ---
@@ -347,7 +383,7 @@ public final class Resolve {
         if (denoted == null) {
             throw TypeOps.unknownType(n.written(), n.pos(), symbols);
         }
-        return n.denoting(denoted);
+        return answered(n.denoting(denoted));
     }
 
     /** The names a {@code match} arm may write: a declared case, a primitive heading a union
@@ -372,6 +408,15 @@ public final class Resolve {
         if (denoted == null) {
             throw TypeOps.unknownType(n.written(), n.pos(), symbols);
         }
-        return n.denoting(denoted);
+        return answered(n.denoting(denoted));
+    }
+
+    /** Records what a name was answered with, and hands it back. A name with no position was
+     * synthesized by an earlier pass rather than written, so there is nothing to point at. */
+    private Ast.Name answered(Ast.Name n) {
+        if (n.pos() != null) {
+            denotations.add(new Denotation(n.written(), n.denotes(), n.pos()));
+        }
+        return n;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -30,28 +30,26 @@ import java.util.Set;
 public final class Symbols {
 
     private final String module;
-    /** Every module in this compilation, by name. The module being compiled is among them. */
-    private final Map<String, Ast.Module> registry;
+    /** Where the declarations of this compilation are read from. */
+    private final Registry registry;
     /** What a bare name means here: this module's own definitions plus the imported ones. */
     private final Map<String, TypeName> scope;
-    /** A qualifier a reference may carry → the module it names. Holds every module in the
-     * compilation under its own name, plus each {@code import ... as} alias. */
-    private final Map<String, String> qualifiers;
-    /** Per-module definitions, built on first use so a module's own errors are still reported while
-     * that module is being compiled rather than pulled forward into an unrelated one. */
-    private final Map<String, Map<String, Ast.Def>> declared = new HashMap<>();
+    /** Each {@code import ... as} alias → the module it names. A module of the compilation is also
+     * a qualifier under its own name, which {@link #moduleOfQualifier} reads off the registry
+     * rather than listing here — listing it would mean naming every module up front. */
+    private final Map<String, String> aliases;
 
-    private Symbols(String module, Map<String, Ast.Module> registry,
-                    Map<String, TypeName> scope, Map<String, String> qualifiers) {
+    private Symbols(String module, Registry registry,
+                    Map<String, TypeName> scope, Map<String, String> aliases) {
         this.module = module;
         this.registry = registry;
         this.scope = scope;
-        this.qualifiers = qualifiers;
+        this.aliases = aliases;
     }
 
     /** No module at all — for signatures written over primitives and type variables only. */
     public static Symbols none() {
-        return new Symbols("", Map.of(), Map.of(), Map.of());
+        return new Symbols("", Registry.empty(), Map.of(), Map.of());
     }
 
     /** A lone module, compiled with nothing else in sight: bare names are its own definitions. */
@@ -60,19 +58,22 @@ public final class Symbols {
         for (String name : TypeChecker.ownDefs(m).keySet()) {
             scope.put(name, new TypeName(m.name(), name));
         }
-        return new Symbols(m.name(), Map.of(m.name(), m), scope, Map.of(m.name(), m.name()));
+        return new Symbols(m.name(), Registry.of(Map.of(m.name(), m)), scope, Map.of());
     }
 
     /** A module compiled against a registry: {@code scope} is what its bare names mean (own plus
      * imported) and {@code aliases} maps each {@code import ... as} alias to its module. */
     public static Symbols of(Ast.Module m, Map<String, Ast.Module> registry,
                              Map<String, TypeName> scope, Map<String, String> aliases) {
-        Map<String, String> qualifiers = new HashMap<>();
-        for (String name : registry.keySet()) {
-            qualifiers.put(name, name);
-        }
-        qualifiers.putAll(aliases);
-        return new Symbols(m.name(), registry, scope, qualifiers);
+        return of(m.name(), Registry.of(registry), scope, aliases);
+    }
+
+    /** As {@link #of(Ast.Module, Map, Map, Map)}, over a registry that reads its declarations
+     * however it likes — the form a query-backed compilation uses, where a module's definitions are
+     * asked for one at a time rather than held in a map. */
+    public static Symbols of(String module, Registry registry,
+                             Map<String, TypeName> scope, Map<String, String> aliases) {
+        return new Symbols(module, registry, scope, Map.copyOf(aliases));
     }
 
     /** The module being compiled. */
@@ -133,7 +134,7 @@ public final class Symbols {
         if (dot < 0) {
             return scope.get(written);
         }
-        String target = qualifiers.get(written.substring(0, dot));
+        String target = moduleOfQualifier(written.substring(0, dot));
         if (target == null) {
             return null;
         }
@@ -145,12 +146,18 @@ public final class Symbols {
      * when it names none. Used to tell "unknown module" apart from "unknown type in a known
      * module". */
     public String moduleOfQualifier(String qualifier) {
-        return qualifiers.get(qualifier);
+        String alias = aliases.get(qualifier);
+        if (alias != null) {
+            return alias;
+        }
+        return registry.moduleNames().contains(qualifier) ? qualifier : null;
     }
 
     /** Every qualifier a reference may carry here — what a "did you mean" may offer for one. */
     public Set<String> qualifiers() {
-        return qualifiers.keySet();
+        Set<String> all = new LinkedHashSet<>(registry.moduleNames());
+        all.addAll(aliases.keySet());
+        return all;
     }
 
     /** Whether {@code name} is reachable here as a bare name. */
@@ -182,13 +189,7 @@ public final class Symbols {
 
     /** Every definition of one module, keyed by the name written there. */
     public Map<String, Ast.Def> declaredIn(String moduleName) {
-        Map<String, Ast.Def> defs = declared.get(moduleName);
-        if (defs == null) {
-            Ast.Module m = registry.get(moduleName);
-            defs = m == null ? Map.of() : TypeChecker.ownDefs(m);
-            declared.put(moduleName, defs);
-        }
-        return defs;
+        return registry.declaredIn(moduleName);
     }
 
     /** Whether the module that declares {@code name} exposes it — its own names always count. */
@@ -201,16 +202,6 @@ public final class Symbols {
         if (moduleName.equals(module)) {
             return true;   // a module reaches its own definitions whether it exposes them or not
         }
-        Ast.Module m = registry.get(moduleName);
-        if (m == null) {
-            return false;
-        }
-        for (String exposed : m.exposing()) {
-            int dot = exposed.indexOf('.');
-            if (name.equals(dot < 0 ? exposed : exposed.substring(0, dot))) {
-                return true;
-            }
-        }
-        return false;
+        return registry.exposedBy(moduleName).contains(name);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -49,15 +49,36 @@ public final class TypeChecker {
     public static Checked checkOrThrow(Ast.Module module, Symbols symbols,
                                                 Map<String, Sig> importedSigs, Set<String> importedInjected,
                                                 Ast.Module lowered) {
+        Reported reported =
+                checkReporting(module, symbols, importedSigs, importedInjected, lowered);
+        if (!reported.errors().isEmpty()) {
+            // the original exception, so its rendered message is unchanged
+            throw reported.errors().get(0);
+        }
+        return reported.checked();
+    }
+
+    /**
+     * A recovering check that keeps each error as the exception it was raised as, together with
+     * what the check elaborated.
+     *
+     * <p>The other two entry points are this one with a decision attached: {@link #checkOrThrow}
+     * raises the first error, {@link #checkAndElaborate} hands back the diagnostics. A caller that
+     * reports without throwing but must still be able to raise exactly what a batch compile would
+     * have raised — a query — needs the exceptions themselves, because a diagnostic does not carry
+     * the English body a throw site passed alongside it.
+     */
+    public record Reported(List<CompileException> errors, Checked checked) {}
+
+    public static Reported checkReporting(Ast.Module module, Symbols symbols,
+                                          Map<String, Sig> importedSigs, Set<String> importedInjected,
+                                          Ast.Module lowered) {
         List<Diagnostic> warnings = new ArrayList<>();
         Elaborated elaborated = new Elaborated();
         List<CompileException> errors =
                 checkCollecting(module, symbols, importedSigs, importedInjected, lowered, warnings,
                         elaborated);
-        if (!errors.isEmpty()) {
-            throw errors.get(0);   // the original exception, so its rendered message is unchanged
-        }
-        return new Checked(elaborated.behaviors, elaborated.helpers, warnings);
+        return new Reported(errors, new Checked(elaborated.behaviors, elaborated.helpers, warnings));
     }
 
     /** Every error found in {@code module}, recovering past each so the whole module is checked; the
@@ -132,15 +153,14 @@ public final class TypeChecker {
     public static CheckResult checkAndElaborate(Ast.Module module, Symbols symbols,
                                                 Map<String, Sig> importedSigs, Set<String> importedInjected,
                                                 Ast.Module lowered) {
+        Reported reported =
+                checkReporting(module, symbols, importedSigs, importedInjected, lowered);
         List<Diagnostic> out = new ArrayList<>();
-        List<Diagnostic> warnings = new ArrayList<>();
-        Elaborated elaborated = new Elaborated();
-        for (CompileException e : checkCollecting(module, symbols, importedSigs, importedInjected, lowered,
-                warnings, elaborated)) {
+        for (CompileException e : reported.errors()) {
             out.add(e.diagnostic());
         }
-        out.addAll(warnings);
-        return new CheckResult(out, new Checked(elaborated.behaviors, elaborated.helpers, warnings));
+        out.addAll(reported.checked().warnings());
+        return new CheckResult(out, reported.checked());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/meta/ModulePath.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/ModulePath.java
@@ -47,17 +47,26 @@ public interface ModulePath {
     /** The classes on an ordinary class path: directories and jars, read in order. Nothing is held
      * open between reads, so a path can be built as often as a compile is run. */
     static ModulePath ofClassPath(List<Path> entries) {
-        List<Path> path = List.copyOf(entries);
-        return binaryName -> {
+        return new ClassPath(List.copyOf(entries));
+    }
+
+    /**
+     * A class path, by its entries. It is a value rather than a lambda so that two paths over the
+     * same entries are the same path: a language server rebuilds one on every request, and a
+     * compilation it wants to keep between edits has to be able to tell that nothing moved.
+     */
+    record ClassPath(List<Path> entries) implements ModulePath {
+        @Override
+        public byte[] bytes(String binaryName) {
             String resource = binaryName.replace('.', '/') + ".class";
-            for (Path entry : path) {
+            for (Path entry : entries) {
                 byte[] bytes = read(entry, resource);
                 if (bytes != null) {
                     return bytes;
                 }
             }
             return null;
-        };
+        }
     }
 
     /** One class path entry's copy of {@code resource}, or null when it has none. An entry that is

--- a/souther-compiler/src/main/java/souther/compiler/query/Answer.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Answer.java
@@ -1,0 +1,84 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.CompileException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * What a {@link Key} answers: a value, or nothing, and whatever the attempt had to report.
+ *
+ * <p>Nothing throws to report. A question the compiler cannot answer — a name that denotes nothing,
+ * a module whose type check failed — comes back absent, carrying the reports that say why, and a
+ * key that asked it sees the absence and decides for itself whether it can still answer. That is
+ * what lets one set of queries serve both a batch compile, which stops at the first error, and an
+ * editor, which wants every module's errors at once: the difference is what the caller does with
+ * what it collected, not which code ran.
+ *
+ * <p>An absent answer is not the same as an error. A warning rides on a present answer, and a key
+ * may be absent with nothing to say, because something it read was absent and has already reported.
+ *
+ * @param value the answer, or {@code null} when the question could not be answered
+ * @param reports what this attempt found, errors and warnings alike
+ */
+public record Answer<T>(T value, List<Report> reports) {
+
+    public Answer {
+        reports = List.copyOf(reports);
+    }
+
+    public static <T> Answer<T> of(T value) {
+        return new Answer<>(value, List.of());
+    }
+
+    public static <T> Answer<T> of(T value, List<Report> reports) {
+        return new Answer<>(value, reports);
+    }
+
+    public static <T> Answer<T> absent() {
+        return new Answer<>(null, List.of());
+    }
+
+    public static <T> Answer<T> absent(Report... reports) {
+        return new Answer<>(null, Arrays.asList(reports));
+    }
+
+    public static <T> Answer<T> absent(List<Report> reports) {
+        return new Answer<>(null, reports);
+    }
+
+    /** The absent answer for a pass that threw — the bridge for a pass that has not stopped
+     * throwing yet. */
+    public static <T> Answer<T> absent(CompileException e) {
+        return new Answer<>(null, Report.of(e));
+    }
+
+    /** Whether the question was answered. A caller that reads {@link #value} without asking this is
+     * saying the absence cannot happen; where it can, ask. */
+    public boolean present() {
+        return value != null;
+    }
+
+    /** Whether anything this answer carries is an error. A present answer may still have one — a
+     * pass that recovered and went on. */
+    public boolean hasError() {
+        return reports.stream().anyMatch(Report::isError);
+    }
+
+    /** This answer's reports followed by {@code more} — for a key that says something of its own on
+     * top of what it read. */
+    public List<Report> and(List<Report> more) {
+        if (more.isEmpty()) {
+            return reports;
+        }
+        List<Report> all = new ArrayList<>(reports);
+        all.addAll(more);
+        return List.copyOf(all);
+    }
+
+    /** The same reports with a different value — for a key that answers from what it read. */
+    public <U> Answer<U> with(U value) {
+        return new Answer<>(value, reports);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1,0 +1,247 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Lower;
+import souther.compiler.check.PipelineSigs;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeChecker;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What the code in a module comes to: the signatures of the behaviors it declares and of the ones
+ * it borrows, the bodies with their helper calls expanded, and the result of checking them.
+ */
+public final class Bodies {
+
+    private Bodies() {}
+
+    /** The behaviors of a module that are injection targets — declared with a spec and no fn, so
+     * something else supplies the body. */
+    public record Injected(String name) implements Key<Set<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Set<String>> compute(Db db) {
+            Front.FromPath.Of path = db.ask(new Front.FromPath()).value();
+            if (path != null && path.injected().containsKey(name)) {
+                // A module off the path published which of its behaviors are injection targets,
+                // because the fn that decides is not published with it.
+                return Answer.of(path.injected().get(name));
+            }
+            Ast.Module m = db.ask(new Front.Available(name)).value();
+            if (m == null) {
+                return Answer.of(Set.of());
+            }
+            Set<String> fns = new LinkedHashSet<>();
+            for (Ast.FnDef f : m.fns()) {
+                fns.add(f.name());
+            }
+            Set<String> injected = new LinkedHashSet<>();
+            for (Ast.BehaviorDef b : m.behaviors()) {
+                if (b instanceof Ast.SpecBehavior && !fns.contains(b.name())) {
+                    injected.add(b.name());
+                }
+            }
+            return Answer.of(Ordered.set(injected));
+        }
+    }
+
+    /** The signatures of the behaviors a module declares. */
+    public record Signatures(String name) implements Key<Map<String, Sig>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Sig>> compute(Db db) {
+            Answer<Ast.Module> desugared = db.ask(new Shapes.Desugared(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> imported = db.ask(new Imported(name));
+            if (!desugared.present() || !scope.present() || !imported.present()) {
+                return Answer.absent();
+            }
+            try {
+                return Answer.of(PipelineSigs.signatures(desugared.value(), scope.value(),
+                        imported.value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /**
+     * The signatures of the behaviors a module borrows from others, under the bare names it reaches
+     * them by. A qualified behavior reference has already become an import, so the imports are the
+     * whole list.
+     */
+    public record Imported(String name) implements Key<Map<String, Sig>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Sig>> compute(Db db) {
+            Ast.Module m = db.ask(new Front.Available(name)).value();
+            if (m == null) {
+                return Answer.absent();
+            }
+            Map<String, Sig> result = new LinkedHashMap<>();
+            Map<String, String> fromModule = new LinkedHashMap<>();   // bare name → its module
+            for (Ast.Import imp : m.imports()) {
+                Ast.Module src = db.ask(new Front.Available(imp.module())).value();
+                if (src == null) {
+                    continue;   // the unknown module is reported where the scope is worked out
+                }
+                Set<String> declared = Names.behaviorNames(src);
+                for (String bare : imp.names()) {
+                    if (!declared.contains(bare)) {
+                        continue;   // a type import, or a name the module does not declare
+                    }
+                    Map<String, Sig> sigs = db.ask(new Signatures(imp.module())).value();
+                    Sig sig = sigs == null ? null : sigs.get(bare);
+                    if (sig == null) {
+                        continue;
+                    }
+                    String earlier = fromModule.put(bare, imp.module());
+                    if (earlier != null && !earlier.equals(imp.module())) {
+                        return Answer.absent(collision(bare, earlier, imp));
+                    }
+                    result.put(bare, sig);
+                }
+            }
+            return Answer.of(Ordered.map(result));
+        }
+
+        /**
+         * The same bare behavior name arrived from two modules. Unlike a type, a behavior name is
+         * also a member name in the generated class — an injected behavior is a field, and a stage
+         * that is one becomes a field here too — so the two cannot both be reached.
+         */
+        private Report collision(String bare, String earlier, Ast.Import imp) {
+            return Report.raised(
+                    Diagnostic.of(null, "check.import.behaviordup").title("check.module.title")
+                            .at(imp.pos()).args(bare, earlier, imp.module())
+                            .hint("check.import.behaviordup.hint", bare).build(),
+                    "behavior `" + bare + "` is named from both `" + earlier + "` and `"
+                            + imp.module() + "`; one behavior name is one injected field, so this"
+                            + " module cannot take both");
+        }
+    }
+
+    /** The behaviors a module borrows that are injection targets where they are declared, so a
+     * composition here inherits them as requirements of its own. */
+    public record ImportedInjected(String name) implements Key<Set<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Set<String>> compute(Db db) {
+            Ast.Module m = db.ask(new Front.Available(name)).value();
+            if (m == null) {
+                return Answer.of(Set.of());
+            }
+            Set<String> result = new LinkedHashSet<>();
+            for (Ast.Import imp : m.imports()) {
+                Set<String> injected = db.ask(new Injected(imp.module())).value();
+                if (injected == null) {
+                    continue;
+                }
+                for (String bare : imp.names()) {
+                    if (injected.contains(bare)) {
+                        result.add(bare);
+                    }
+                }
+            }
+            return Answer.of(Ordered.set(result));
+        }
+    }
+
+    /**
+     * A module with every helper call expanded into the body that called it, and with the parameter
+     * types those expansions settled written back into the declarations.
+     */
+    public record Lowering(String name) implements Key<Lower.Lowered> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Lower.Lowered> compute(Db db) {
+            Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> imported = db.ask(new Imported(name));
+            Answer<Set<String>> injected = db.ask(new ImportedInjected(name));
+            if (!prepared.present() || !scope.present() || !imported.present()
+                    || !injected.present()) {
+                return Answer.absent();
+            }
+            try {
+                return Answer.of(Lower.run(prepared.value(), scope.value(), imported.value(),
+                        injected.value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /**
+     * The result of type-checking a module. Absent when anything in it is wrong: a module that does
+     * not check must not reach codegen, and an importer of it is skipped rather than compiled
+     * against a broken module.
+     *
+     * <p>Warnings ride on a present answer, which is how an invariant-discharge warning reaches the
+     * author of a module that compiled.
+     */
+    public record Checked(String name) implements Key<TypeChecker.Checked> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<TypeChecker.Checked> compute(Db db) {
+            Answer<Lower.Lowered> lowering = db.ask(new Lowering(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> imported = db.ask(new Imported(name));
+            Answer<Set<String>> injected = db.ask(new ImportedInjected(name));
+            if (!lowering.present() || !scope.present() || !imported.present()
+                    || !injected.present()) {
+                return Answer.absent();
+            }
+            TypeChecker.Reported reported;
+            try {
+                reported = TypeChecker.checkReporting(lowering.value().settled(), scope.value(),
+                        imported.value(), injected.value(), lowering.value().lowered());
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+            List<Report> reports = new ArrayList<>();
+            for (CompileException e : reported.errors()) {
+                reports.addAll(Report.of(e));
+            }
+            for (Diagnostic warning : reported.checked().warnings()) {
+                reports.add(Report.of(warning));
+            }
+            return reported.errors().isEmpty()
+                    ? Answer.of(reported.checked(), reports)
+                    : Answer.absent(reports);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -95,6 +95,12 @@ public final class Bodies {
 
         @Override
         public Answer<Map<String, Sig>> compute(Db db) {
+            // A module in a cycle borrows a signature from a module that borrows one from it. This
+            // is where that would be asked, so this is where it stops; the cycle itself is reported
+            // by Names.InCycle.
+            if (Names.cyclic(db, name)) {
+                return Answer.absent();
+            }
             Ast.Module m = db.ask(new Front.Available(name)).value();
             if (m == null) {
                 return Answer.absent();

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -74,6 +74,22 @@ public final class Compilation {
         return c;
     }
 
+    /**
+     * The same workspace after an edit: every source as it now reads, and which modules the caller
+     * is still holding back.
+     *
+     * <p>Nothing is thrown away. A source whose text is unchanged is unchanged, and an answer that
+     * comes out the same as before leaves everything that read it alone — so what this costs is what
+     * the edit actually reached.
+     */
+    public void update(Map<String, String> byId, Set<String> broken) {
+        for (Map.Entry<String, String> e : byId.entrySet()) {
+            db.set(new Front.Text(e.getKey()), e.getValue());
+        }
+        db.set(new Front.Ids(), List.copyOf(byId.keySet()));
+        db.set(new Front.Broken(), Set.copyOf(broken));
+    }
+
     /** A compile of one of the compiler's own core sources, which may take a reserved name. */
     public static Compilation ofCoreSource(String source) {
         Compilation c = ofSource(source, null);

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -1,0 +1,239 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Sig;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.meta.ModulePath;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * One compile, as a set of questions that can be asked of it.
+ *
+ * <p>A caller sets the sources and then asks: for the classes, for a module's errors, for what a
+ * name denotes. What it does with an error is its own — the batch compiler raises the first, an
+ * editor publishes them all per file — and that decision is the only thing that differs between
+ * them. Nothing here runs a pipeline; asking a question is what makes the work that answers it
+ * happen, and only that work.
+ */
+public final class Compilation {
+
+    private final Db db = new Db();
+    /** Which source each id was, for a caller that names sources by index. */
+    private final Map<String, Integer> indexOfId = new LinkedHashMap<>();
+
+    private Compilation() {}
+
+    /** A compile of several sources named by their position, the way a build hands them over. An
+     * import naming no module among them is resolved against {@code path}. */
+    public static Compilation ofSources(List<String> sources, ModulePath path) {
+        Compilation c = new Compilation();
+        List<String> ids = new ArrayList<>();
+        for (int i = 0; i < sources.size(); i++) {
+            String id = String.valueOf(i);
+            ids.add(id);
+            c.indexOfId.put(id, i);
+            c.db.set(new Front.Text(id), sources.get(i));
+        }
+        c.db.set(new Front.Ids(), List.copyOf(ids));
+        c.db.set(new Front.Path(), path);
+        return c;
+    }
+
+    /** A compile of one self-contained source. A source with no {@code module} header takes
+     * {@code defaultModuleName}, which a set of linked sources cannot allow: a module reached by an
+     * import has to be named. */
+    public static Compilation ofSource(String source, String defaultModuleName) {
+        Compilation c = ofSources(List.of(source), ModulePath.EMPTY);
+        c.db.set(new Front.DefaultName(), defaultModuleName);
+        // There is only one source, so an error carries no origin: the caller knows which file it
+        // handed over, and a rendered index would be a file number nobody asked for.
+        c.indexOfId.clear();
+        return c;
+    }
+
+    /**
+     * A compile of a workspace, where each source is named by the caller — a document URI.
+     * {@code broken} names the modules whose sources the caller held back because they will not
+     * parse, so an importer of one is left alone rather than told the module is unknown.
+     */
+    public static Compilation ofDocuments(Map<String, String> byId, Set<String> broken,
+                                          ModulePath path) {
+        Compilation c = new Compilation();
+        for (Map.Entry<String, String> e : byId.entrySet()) {
+            c.db.set(new Front.Text(e.getKey()), e.getValue());
+        }
+        c.db.set(new Front.Ids(), List.copyOf(byId.keySet()));
+        c.db.set(new Front.Broken(), Set.copyOf(broken));
+        c.db.set(new Front.Path(), path);
+        return c;
+    }
+
+    /** A compile of one of the compiler's own core sources, which may take a reserved name. */
+    public static Compilation ofCoreSource(String source) {
+        Compilation c = ofSource(source, null);
+        c.db.set(new Front.Core(), Boolean.TRUE);
+        return c;
+    }
+
+    /** Every class this compilation generated. */
+    public Map<String, byte[]> classes() {
+        Map<String, byte[]> all = db.ask(new Output.All()).value();
+        return all == null ? Map.of() : all;
+    }
+
+    /** A module as everything below the check reads it — derived, desugared, and carrying the
+     * recursive prelude helpers it reaches. */
+    public Ast.Module module(String name) {
+        return db.ask(new Shapes.Prepared(name)).value();
+    }
+
+    /** The signatures of the behaviors {@code module} declares. */
+    public Map<String, Sig> signatures(String module) {
+        Map<String, Sig> sigs = db.ask(new Bodies.Signatures(module)).value();
+        return sigs == null ? Map.of() : sigs;
+    }
+
+    /** Every source id this compilation was given, in order. */
+    public List<String> sourceIds() {
+        List<String> ids = db.ask(new Front.Ids()).value();
+        return ids == null ? List.of() : ids;
+    }
+
+    /**
+     * Answers everything there is to answer about these sources — the classes, the constant
+     * constructions, the examples — without deciding anything about what was found. A caller that
+     * wants every problem at once asks for this and then reads {@link Db#allReports()}.
+     */
+    public void answerEverything() {
+        structuralReports();
+        db.ask(new Output.All());
+        for (String module : modules()) {
+            db.ask(new Output.ConstConstructions(module));
+            for (String id : exampleSourcesOf(module)) {
+                db.ask(new Output.Examples(module, id));
+            }
+        }
+    }
+
+    /** The sources that wrote any of {@code module}'s example rows, in order. */
+    public List<String> exampleSourcesOf(String module) {
+        List<String> origins = db.ask(new Front.ExampleOrigins(module)).value();
+        if (origins == null) {
+            return List.of();
+        }
+        List<String> distinct = new ArrayList<>();
+        for (String id : origins) {
+            if (!distinct.contains(id)) {
+                distinct.add(id);
+            }
+        }
+        return distinct;
+    }
+
+    public Db db() {
+        return db;
+    }
+
+    /** The names of the modules these sources declare, in the order the sources were given. */
+    public List<String> modules() {
+        List<String> declared = db.ask(new Front.Declared()).value();
+        return declared == null ? List.of() : declared;
+    }
+
+    /** Which source declares {@code module}, as the index a diagnostic names, or -1 when this
+     * compilation names its sources some other way. */
+    public int sourceIndexOf(String module) {
+        Front.Layout.Of layout = db.ask(new Front.Layout()).value();
+        String id = layout == null ? null : layout.idOfModule().get(module);
+        Integer index = id == null ? null : indexOfId.get(id);
+        return index == null ? -1 : index;
+    }
+
+    /** The index a diagnostic names for a source id, or -1 when this compilation names its sources
+     * some other way. */
+    public int sourceIndexOfId(String id) {
+        Integer index = indexOfId.get(id);
+        return index == null ? -1 : index;
+    }
+
+    /** The id of the source that declares {@code module}, or null when nothing here does. */
+    public String sourceIdOf(String module) {
+        Front.Layout.Of layout = db.ask(new Front.Layout()).value();
+        return layout == null ? null : layout.idOfModule().get(module);
+    }
+
+    /**
+     * The problems that stop this compilation before any module is looked at: a source that names a
+     * module twice, one that shadows a module already on the path, and a cycle among them.
+     *
+     * <p>These come first because each one makes "which module is this name" unanswerable, and
+     * every question below that is about a name.
+     */
+    public List<Db.Found> structuralReports() {
+        List<Db.Found> found = new ArrayList<>();
+        Answer<Front.Layout.Of> layout = db.ask(new Front.Layout());
+        for (Report report : layout.reports()) {
+            found.add(new Db.Found(null, null, report));
+        }
+        for (String id : sourceIds()) {
+            for (Report report : db.ask(new Front.Declares(id)).reports()) {
+                found.add(new Db.Found(null, id, report));
+            }
+            for (Report report : db.ask(new Front.AttachedTo(id)).reports()) {
+                found.add(new Db.Found(null, id, report));
+            }
+        }
+        Map<String, Report> shadows = db.ask(new Front.Shadows()).value();
+        if (shadows != null) {
+            shadows.forEach((module, report) -> found.add(new Db.Found(module, null, report)));
+        }
+        Map<String, Report> cycles = db.ask(new Names.Cycles()).value();
+        if (cycles != null) {
+            cycles.forEach((module, report) -> found.add(new Db.Found(module, null, report)));
+        }
+        return found;
+    }
+
+    /** Everything reported in answering {@code key} and everything that answering it needed. */
+    public List<Db.Found> reportsUnder(Key<?> key) {
+        return db.reportsUnder(key);
+    }
+
+    /** The first error among {@code found}, as the exception the pass raised, tagged with the source
+     * it belongs to — or null when nothing there is an error. */
+    public CompileException firstError(List<Db.Found> found) {
+        for (Db.Found f : found) {
+            if (f.report().isError()) {
+                return f.report().asException().inSource(indexOf(f));
+            }
+        }
+        return null;
+    }
+
+    /** Which source a report belongs to: the one it named, or the one that declares the module it
+     * was about, or none. */
+    public int indexOf(Db.Found found) {
+        if (found.sourceId() != null) {
+            Integer index = indexOfId.get(found.sourceId());
+            return index == null ? -1 : index;
+        }
+        return found.module() == null ? -1 : sourceIndexOf(found.module());
+    }
+
+    /** The warnings among {@code found}, in order. */
+    public List<Diagnostic> warnings(List<Db.Found> found) {
+        List<Diagnostic> warnings = new ArrayList<>();
+        for (Db.Found f : found) {
+            if (!f.report().isError()) {
+                warnings.add(f.report().diagnostic());
+            }
+        }
+        return warnings;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -270,11 +270,6 @@ public final class Compilation {
         return published;
     }
 
-    /** Everything reported in answering {@code key} and everything that answering it needed. */
-    public List<Db.Found> reportsUnder(Key<?> key) {
-        return db.reportsUnder(key);
-    }
-
     /** The first error among {@code found}, as the exception the pass raised, tagged with the source
      * it belongs to — or null when nothing there is an error. */
     public CompileException firstError(List<Db.Found> found) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -8,6 +8,7 @@ import souther.compiler.meta.ModulePath;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -26,6 +27,8 @@ public final class Compilation {
     private final Db db = new Db();
     /** Which source each id was, for a caller that names sources by index. */
     private final Map<String, Integer> indexOfId = new LinkedHashMap<>();
+    /** The sources this compilation currently has, so one that goes away can be forgotten. */
+    private final Set<String> held = new LinkedHashSet<>();
 
     private Compilation() {}
 
@@ -71,6 +74,7 @@ public final class Compilation {
         c.db.set(new Front.Ids(), List.copyOf(byId.keySet()));
         c.db.set(new Front.Broken(), Set.copyOf(broken));
         c.db.set(new Front.Path(), path);
+        c.held.addAll(byId.keySet());
         return c;
     }
 
@@ -83,11 +87,34 @@ public final class Compilation {
      * the edit actually reached.
      */
     public void update(Map<String, String> byId, Set<String> broken) {
+        // A source that is gone is forgotten, along with the module it declared. Which module that
+        // was has to be read before the layout is told the source is gone.
+        for (String gone : List.copyOf(held)) {
+            if (!byId.containsKey(gone)) {
+                db.forget(gone, moduleDeclaredBy(gone));
+                held.remove(gone);
+            }
+        }
         for (Map.Entry<String, String> e : byId.entrySet()) {
             db.set(new Front.Text(e.getKey()), e.getValue());
         }
         db.set(new Front.Ids(), List.copyOf(byId.keySet()));
         db.set(new Front.Broken(), Set.copyOf(broken));
+        held.addAll(byId.keySet());
+    }
+
+    /** The module {@code id} declares, as this compilation currently has it. */
+    private String moduleDeclaredBy(String id) {
+        Front.Layout.Of layout = db.ask(new Front.Layout()).value();
+        if (layout == null) {
+            return null;
+        }
+        for (Map.Entry<String, String> e : layout.idOfModule().entrySet()) {
+            if (e.getValue().equals(id)) {
+                return e.getKey();
+            }
+        }
+        return null;
     }
 
     /** A compile of one of the compiler's own core sources, which may take a reserved name. */
@@ -205,13 +232,13 @@ public final class Compilation {
                 found.add(new Db.Found(null, id, report));
             }
         }
-        Map<String, Report> shadows = db.ask(new Front.Shadows()).value();
-        if (shadows != null) {
-            shadows.forEach((module, report) -> found.add(new Db.Found(module, null, report)));
-        }
-        Map<String, Report> cycles = db.ask(new Names.Cycles()).value();
-        if (cycles != null) {
-            cycles.forEach((module, report) -> found.add(new Db.Found(module, null, report)));
+        for (String module : modules()) {
+            for (Report report : db.ask(new Front.ShadowsPath(module)).reports()) {
+                found.add(new Db.Found(module, null, report));
+            }
+            for (Report report : db.ask(new Names.InCycle(module)).reports()) {
+                found.add(new Db.Found(module, null, report));
+            }
         }
         return found;
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -216,6 +216,33 @@ public final class Compilation {
         return found;
     }
 
+    /**
+     * Every problem these sources have, on the source it belongs to. A source with none maps to an
+     * empty list.
+     *
+     * <p>Where a report goes is the report's to say, not this method's: an error in an imported
+     * module lands on that module's document however far away it was asked for, and a failing
+     * example row lands on the file the row was written in. A report about something the caller does
+     * not have — a module read off the path — has nowhere to go and is left out.
+     */
+    public Map<String, List<Diagnostic>> diagnostics() {
+        answerEverything();
+        Map<String, List<Diagnostic>> byId = new LinkedHashMap<>();
+        for (String id : sourceIds()) {
+            byId.put(id, new ArrayList<>());
+        }
+        for (Db.Found found : db.allReports()) {
+            String id = found.sourceId() != null ? found.sourceId() : sourceIdOf(found.module());
+            List<Diagnostic> on = id == null ? null : byId.get(id);
+            if (on != null) {
+                on.add(found.report().diagnostic());
+            }
+        }
+        Map<String, List<Diagnostic>> published = new LinkedHashMap<>();
+        byId.forEach((id, found) -> published.put(id, List.copyOf(found)));
+        return published;
+    }
+
     /** Everything reported in answering {@code key} and everything that answering it needed. */
     public List<Db.Found> reportsUnder(Key<?> key) {
         return db.reportsUnder(key);

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -13,21 +13,43 @@ import java.util.Set;
 
 /**
  * The store a compilation's questions are asked of: it answers a {@link Key} by running it once,
- * keeping the answer, and handing the same answer to everyone who asks again.
+ * keeps the answer, and hands the same answer to everyone who asks again.
  *
  * <p>It also watches. While a key is being answered, every key it asks is recorded against it, so
- * afterwards the graph knows what each answer was built from. That record is what an editor's
- * recompile will read to find the answers an edit can have changed, and it is what makes a question
- * that depends on itself visible at the moment it happens rather than as a stack overflow.
+ * afterwards the graph knows what each answer was built from. That is what makes a question
+ * depending on itself visible at the moment it happens rather than as a stack overflow, and it is
+ * what lets an edit be absorbed: change a source, and the only answers recomputed are the ones that
+ * read something that changed.
  *
- * <p>One store is one compilation. It is not thread-safe and does not need to be: the work inside a
- * compile is a graph walk, not a set of independent jobs.
+ * <p>Recomputing is not the same as changing. An answer that comes out equal to the one it replaces
+ * leaves everything that read it alone — which is what keeps an edit local. Retyping a helper's body
+ * changes that module's classes; it does not change what the module declares, so nothing that
+ * imports it is looked at again.
+ *
+ * <p>One store is one workspace over time, not one compile. It is not thread-safe and does not need
+ * to be: the work inside a compile is a graph walk, not a set of independent jobs.
  */
 public final class Db {
 
-    private final Map<Key<?>, Answer<?>> answers = new HashMap<>();
-    /** What each answered key read while it was being answered. */
-    private final Map<Key<?>, Set<Key<?>>> reads = new HashMap<>();
+    /**
+     * What is known about one key.
+     *
+     * @param answer the answer as of {@code verifiedAt}
+     * @param verifiedAt the revision this answer was last known to be current at
+     * @param changedAt the revision the answer last came out different at
+     * @param reads what answering it read, in the order it read them
+     */
+    private record Memo(Answer<?> answer, long verifiedAt, long changedAt, Set<Key<?>> reads) {
+
+        Memo verifiedAt(long revision) {
+            return new Memo(answer, revision, changedAt, reads);
+        }
+    }
+
+    /** Bumped by every input that is given a value it did not already have. */
+    private long revision;
+
+    private final Map<Key<?>, Memo> memos = new HashMap<>();
     /** The keys being answered right now, outermost first — the chain a cycle is found on. */
     private final Set<Key<?>> inProgress = new LinkedHashSet<>();
     /** The reads of each in-progress key, innermost frame last. */
@@ -40,60 +62,104 @@ public final class Db {
      * that matters.
      */
     private final Set<Key<?>> throughCycle = new HashSet<>();
-    /** Every key that reported something, and what it reported, in the order the answers finished. */
-    private final Map<Key<?>, Answer<?>> told = new HashMap<>();
-    private final List<Key<?>> order = new ArrayList<>();
+    /** Every key that has ever reported something, in the order it first did — the order reports
+     * are read back in. */
+    private final List<Key<?>> spoke = new ArrayList<>();
+    private final Set<Key<?>> hasSpoken = new HashSet<>();
 
-    /** Gives an input its value. Returns this store, so a compilation can be set up in one
-     * expression. */
+    /**
+     * Gives an input its value. An input set to what it already held changes nothing, so a caller
+     * may hand over a whole workspace on every keystroke. Returns this store, so a compilation can
+     * be set up in one expression.
+     */
     public <T> Db set(Input<T> key, T value) {
-        answers.put(key, Answer.of(value));
+        Answer<T> now = Answer.of(value);
+        Memo known = memos.get(key);
+        if (known != null && known.answer().equals(now)) {
+            return this;
+        }
+        revision++;
+        memos.put(key, new Memo(now, revision, revision, Set.of()));
         return this;
     }
 
-    /** Answers {@code key}, computing it if this is the first time it has been asked. */
+    /** Answers {@code key}, computing it if nothing kept from before still holds. */
     @SuppressWarnings("unchecked")
     public <T> Answer<T> ask(Key<T> key) {
         recordRead(key);
-        Answer<?> known = answers.get(key);
-        if (known != null) {
-            return (Answer<T>) known;
+        Memo memo = memos.get(key);
+        if (memo != null && memo.verifiedAt() == revision) {
+            return (Answer<T>) memo.answer();
         }
         if (inProgress.contains(key)) {
             // Everything in flight has now seen an answer that depends on where it was entered.
             throughCycle.addAll(inProgress);
             return key.onCycle(List.copyOf(inProgress));
         }
+        if (memo != null && stillHolds(memo)) {
+            memos.put(key, memo.verifiedAt(revision));
+            return (Answer<T>) memo.answer();
+        }
         inProgress.add(key);
         frames.push(new LinkedHashSet<>());
         Answer<T> answer;
+        Set<Key<?>> read;
         try {
             answer = key.compute(this);
         } finally {
             // In the order they were read, so a caller walking the graph for reports meets them in
-            // the order the passes ran. An unordered copy here makes the first error a module
+            // the order the work happened. An unordered copy here makes the first error a module
             // reports depend on hash order.
-            reads.put(key, Collections.unmodifiableSet(frames.pop()));
+            read = Collections.unmodifiableSet(frames.pop());
             inProgress.remove(key);
         }
         if (!throughCycle.remove(key)) {
-            answers.put(key, answer);
+            long changedAt = memo != null && memo.answer().equals(answer)
+                    ? memo.changedAt() : revision;
+            memos.put(key, new Memo(answer, revision, changedAt, read));
         }
-        if (!answer.reports().isEmpty() && told.putIfAbsent(key, answer) == null) {
-            order.add(key);
+        if (!answer.reports().isEmpty() && hasSpoken.add(key)) {
+            spoke.add(key);
         }
         return answer;
     }
 
     /**
-     * Everything reported by every question this store has answered, in the order the answers were
-     * finished — which is the order the work happened, innermost first. A caller that stops at the
-     * first error stops at the same one a pipeline would have raised.
+     * Whether {@code memo}'s answer can be kept: everything it read still answers what it did when
+     * this answer was made. Asking each of them is what settles that, and each of those may settle
+     * the same way without running anything.
+     */
+    private boolean stillHolds(Memo memo) {
+        // Verification is not a read: a key being checked is not a dependency of whoever happened to
+        // ask at the moment it was checked.
+        frames.push(new LinkedHashSet<>());
+        try {
+            for (Key<?> read : memo.reads()) {
+                ask(read);
+                Memo dependency = memos.get(read);
+                if (dependency == null || dependency.changedAt() > memo.verifiedAt()) {
+                    return false;
+                }
+            }
+        } finally {
+            frames.pop();
+        }
+        return true;
+    }
+
+    /**
+     * Everything the answers this store now holds have to report, in the order the keys first
+     * reported. A key whose answer has since been recomputed contributes what it says now, so a
+     * problem that was fixed is not still listed.
      */
     public List<Found> allReports() {
         List<Found> found = new ArrayList<>();
-        for (Key<?> key : order) {
-            for (Report report : told.get(key).reports()) {
+        for (Key<?> key : spoke) {
+            Memo memo = memos.get(key);
+            if (memo == null) {
+                continue;
+            }
+            for (Report report : memo.answer().reports()) {
                 found.add(new Found(key.module(), key.sourceId(), report));
             }
         }
@@ -102,25 +168,23 @@ public final class Db {
 
     /** What {@code key} read while it was answered, empty if it has not been asked. */
     public Set<Key<?>> dependenciesOf(Key<?> key) {
-        return reads.getOrDefault(key, Set.of());
+        Memo memo = memos.get(key);
+        return memo == null ? Set.of() : memo.reads();
     }
 
     /** Whether {@code key}'s answer is being kept — it has been asked, and was not reached through
      * a cycle. */
     public boolean isComputed(Key<?> key) {
-        return answers.containsKey(key);
+        return memos.containsKey(key);
     }
 
-    /** A report and the module whose source it belongs to, which may be null. */
+    /** A report, the module it is about, and the source it names — either of which may be null. */
     public record Found(String module, String sourceId, Report report) {}
 
     /**
      * Everything reported while answering {@code root}, and by everything answering it needed.
      * Deepest first — a module's own errors come before those of a module that read it — so a
      * caller that stops at the first error stops at the same one the passes used to raise.
-     *
-     * <p>Each report is attributed to the module its key was about, so an error in an imported
-     * module lands on that module's source however far away it was asked for.
      */
     public List<Found> reportsUnder(Key<?> root) {
         List<Found> found = new ArrayList<>();
@@ -132,14 +196,14 @@ public final class Db {
         if (!seen.add(key)) {
             return;
         }
-        for (Key<?> read : reads.getOrDefault(key, Set.of())) {
-            gather(read, seen, found);
-        }
-        Answer<?> answer = answers.get(key);
-        if (answer == null) {
+        Memo memo = memos.get(key);
+        if (memo == null) {
             return;
         }
-        for (Report report : answer.reports()) {
+        for (Key<?> read : memo.reads()) {
+            gather(read, seen, found);
+        }
+        for (Report report : memo.answer().reports()) {
             found.add(new Found(key.module(), key.sourceId(), report));
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -109,6 +109,11 @@ public final class Db {
      */
     public void forget(String sourceId, String moduleName) {
         set(new Front.Text(sourceId), null);
+        // Dropping by module name is exact, not approximate. Every question about a module reads its
+        // declaring source through the workspace layout, and the layout names one source per module
+        // however many claim it — so while this source was the module, every answer about that module
+        // was an answer about this source. A source that claimed a name it did not get is passed a
+        // null module name and takes nothing else with it.
         memos.keySet().removeIf(key -> sourceId.equals(key.sourceId())
                 || (moduleName != null && moduleName.equals(key.module())));
         hasSpoken.removeIf(key -> !memos.containsKey(key));
@@ -136,10 +141,13 @@ public final class Db {
         frames.push(new LinkedHashSet<>());
         Answer<T> answer;
         Set<Key<?>> read;
-        // Every trace of answering this key is undone here, whether it answered or threw. A compile
-        // error is a value, so a throw is an internal fault — and a store that is kept across edits
-        // must come out of one as it went in, or the key it happened under would never be kept
-        // again.
+        // This key leaves nothing of itself behind, whether it answered or threw: not its frame, not
+        // its place in the chain, not a cycle mark. A compile error is a value, so a throw is an
+        // internal fault, and a store kept across edits would otherwise never keep this key again.
+        //
+        // What a dependency answered before the throw is kept, and should be: a query is a function
+        // of its inputs, so an answer that was reached is as good as any other. Only the key that
+        // failed is unfinished.
         boolean reachedThroughCycle = false;
         try {
             answer = key.compute(this);
@@ -188,16 +196,22 @@ public final class Db {
     /**
      * Everything this compilation now has to report, in the order the keys first reported it.
      *
-     * <p>Only questions this revision actually asked are read. A question that was asked and
+     * <p>Only questions asked since the last input changed are read. A question that was asked and
      * recomputed contributes what it says now, so a problem that was fixed is not still listed —
      * and a question that stopped being asked contributes nothing, because there is no longer
      * anything that wants to know. Deleting the last row of an {@code examples for} file is the
      * second case: nothing asks whether that file's rows hold any more, so nothing recomputes the
      * answer, and reading it would put a failure on a line that is not there.
      *
-     * <p>Being asked is what {@code verifiedAt} records. Answering a key sets it, and so does
-     * finding that a kept answer still holds, so every key reachable from what a caller asked for
-     * carries this revision and every key that is not reachable carries an older one.
+     * <p>Being asked is what {@code verifiedAt} records. Answering a key sets it, and so does finding
+     * that a kept answer still holds, so every key reached since the last input change carries this
+     * revision and every key that was not reached carries an older one.
+     *
+     * <p>"Since the last input change" is not "in the last round of asking", and the two come apart
+     * if a caller asks for less than it did before without changing anything: what the wider round
+     * reached still counts as reached. Every caller here asks for the whole compilation, so it does
+     * not arise — but a caller that asked only about the file in front of the author would need a
+     * generation of its own, separate from the input revision.
      */
     public List<Found> allReports() {
         List<Found> found = new ArrayList<>();
@@ -227,33 +241,6 @@ public final class Db {
 
     /** A report, the module it is about, and the source it names — either of which may be null. */
     public record Found(String module, String sourceId, Report report) {}
-
-    /**
-     * Everything reported while answering {@code root}, and by everything answering it needed.
-     * Deepest first — a module's own errors come before those of a module that read it — so a
-     * caller that stops at the first error stops at the same one the passes used to raise.
-     */
-    public List<Found> reportsUnder(Key<?> root) {
-        List<Found> found = new ArrayList<>();
-        gather(root, new HashSet<>(), found);
-        return found;
-    }
-
-    private void gather(Key<?> key, Set<Key<?>> seen, List<Found> found) {
-        if (!seen.add(key)) {
-            return;
-        }
-        Memo memo = memos.get(key);
-        if (memo == null) {
-            return;
-        }
-        for (Key<?> read : memo.reads()) {
-            gather(read, seen, found);
-        }
-        for (Report report : memo.answer().reports()) {
-            found.add(new Found(key.module(), key.sourceId(), report));
-        }
-    }
 
     private void recordRead(Key<?> key) {
         Set<Key<?>> frame = frames.peek();

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -1,0 +1,153 @@
+package souther.compiler.query;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The store a compilation's questions are asked of: it answers a {@link Key} by running it once,
+ * keeping the answer, and handing the same answer to everyone who asks again.
+ *
+ * <p>It also watches. While a key is being answered, every key it asks is recorded against it, so
+ * afterwards the graph knows what each answer was built from. That record is what an editor's
+ * recompile will read to find the answers an edit can have changed, and it is what makes a question
+ * that depends on itself visible at the moment it happens rather than as a stack overflow.
+ *
+ * <p>One store is one compilation. It is not thread-safe and does not need to be: the work inside a
+ * compile is a graph walk, not a set of independent jobs.
+ */
+public final class Db {
+
+    private final Map<Key<?>, Answer<?>> answers = new HashMap<>();
+    /** What each answered key read while it was being answered. */
+    private final Map<Key<?>, Set<Key<?>>> reads = new HashMap<>();
+    /** The keys being answered right now, outermost first — the chain a cycle is found on. */
+    private final Set<Key<?>> inProgress = new LinkedHashSet<>();
+    /** The reads of each in-progress key, innermost frame last. */
+    private final Deque<Set<Key<?>>> frames = new ArrayDeque<>();
+    /**
+     * Keys whose current answer was reached through a cycle. A cyclic answer depends on where the
+     * cycle was entered, so keeping it would make one caller's answer depend on whether another
+     * asked first; the whole chain in flight when the cycle was found is discarded instead. Cycles
+     * are the compiler reporting on a source that names itself, so recomputing them costs nothing
+     * that matters.
+     */
+    private final Set<Key<?>> throughCycle = new HashSet<>();
+    /** Every key that reported something, and what it reported, in the order the answers finished. */
+    private final Map<Key<?>, Answer<?>> told = new HashMap<>();
+    private final List<Key<?>> order = new ArrayList<>();
+
+    /** Gives an input its value. Returns this store, so a compilation can be set up in one
+     * expression. */
+    public <T> Db set(Input<T> key, T value) {
+        answers.put(key, Answer.of(value));
+        return this;
+    }
+
+    /** Answers {@code key}, computing it if this is the first time it has been asked. */
+    @SuppressWarnings("unchecked")
+    public <T> Answer<T> ask(Key<T> key) {
+        recordRead(key);
+        Answer<?> known = answers.get(key);
+        if (known != null) {
+            return (Answer<T>) known;
+        }
+        if (inProgress.contains(key)) {
+            // Everything in flight has now seen an answer that depends on where it was entered.
+            throughCycle.addAll(inProgress);
+            return key.onCycle(List.copyOf(inProgress));
+        }
+        inProgress.add(key);
+        frames.push(new LinkedHashSet<>());
+        Answer<T> answer;
+        try {
+            answer = key.compute(this);
+        } finally {
+            // In the order they were read, so a caller walking the graph for reports meets them in
+            // the order the passes ran. An unordered copy here makes the first error a module
+            // reports depend on hash order.
+            reads.put(key, Collections.unmodifiableSet(frames.pop()));
+            inProgress.remove(key);
+        }
+        if (!throughCycle.remove(key)) {
+            answers.put(key, answer);
+        }
+        if (!answer.reports().isEmpty() && told.putIfAbsent(key, answer) == null) {
+            order.add(key);
+        }
+        return answer;
+    }
+
+    /**
+     * Everything reported by every question this store has answered, in the order the answers were
+     * finished — which is the order the work happened, innermost first. A caller that stops at the
+     * first error stops at the same one a pipeline would have raised.
+     */
+    public List<Found> allReports() {
+        List<Found> found = new ArrayList<>();
+        for (Key<?> key : order) {
+            for (Report report : told.get(key).reports()) {
+                found.add(new Found(key.module(), key.sourceId(), report));
+            }
+        }
+        return found;
+    }
+
+    /** What {@code key} read while it was answered, empty if it has not been asked. */
+    public Set<Key<?>> dependenciesOf(Key<?> key) {
+        return reads.getOrDefault(key, Set.of());
+    }
+
+    /** Whether {@code key}'s answer is being kept — it has been asked, and was not reached through
+     * a cycle. */
+    public boolean isComputed(Key<?> key) {
+        return answers.containsKey(key);
+    }
+
+    /** A report and the module whose source it belongs to, which may be null. */
+    public record Found(String module, String sourceId, Report report) {}
+
+    /**
+     * Everything reported while answering {@code root}, and by everything answering it needed.
+     * Deepest first — a module's own errors come before those of a module that read it — so a
+     * caller that stops at the first error stops at the same one the passes used to raise.
+     *
+     * <p>Each report is attributed to the module its key was about, so an error in an imported
+     * module lands on that module's source however far away it was asked for.
+     */
+    public List<Found> reportsUnder(Key<?> root) {
+        List<Found> found = new ArrayList<>();
+        gather(root, new HashSet<>(), found);
+        return found;
+    }
+
+    private void gather(Key<?> key, Set<Key<?>> seen, List<Found> found) {
+        if (!seen.add(key)) {
+            return;
+        }
+        for (Key<?> read : reads.getOrDefault(key, Set.of())) {
+            gather(read, seen, found);
+        }
+        Answer<?> answer = answers.get(key);
+        if (answer == null) {
+            return;
+        }
+        for (Report report : answer.reports()) {
+            found.add(new Found(key.module(), key.sourceId(), report));
+        }
+    }
+
+    private void recordRead(Key<?> key) {
+        Set<Key<?>> frame = frames.peek();
+        if (frame != null) {
+            frame.add(key);
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -26,6 +26,18 @@ import java.util.Set;
  * changes that module's classes; it does not change what the module declares, so nothing that
  * imports it is looked at again.
  *
+ * <p>That rests on the answers being values, and two of them carry it. {@link Front.Layout} is what
+ * stops an edit to any source from reaching the whole workspace: every parse feeds it, and it comes
+ * out the same. {@link Names.Declarations} is what stops an edit at the module boundary: an importer
+ * builds against what a module declares, not against its bodies. Both are maps of records, and
+ * {@code IncrementalCompilationTest} pins both.
+ *
+ * <p>It does not hold everywhere. A module's classes are a {@code Map<String, byte[]>}, and arrays
+ * compare by identity, so regenerating them always counts as a change — and every module's examples
+ * read every module's classes. Comparing the bytes would not help: after a real edit they differ.
+ * What would is for an example to depend on the classes it reaches rather than on all of them,
+ * which is per-definition work and not here.
+ *
  * <p>One store is one workspace over time, not one compile. It is not thread-safe and does not need
  * to be: the work inside a compile is a graph walk, not a set of independent jobs.
  */
@@ -57,15 +69,19 @@ public final class Db {
     /**
      * Keys whose current answer was reached through a cycle. A cyclic answer depends on where the
      * cycle was entered, so keeping it would make one caller's answer depend on whether another
-     * asked first; the whole chain in flight when the cycle was found is discarded instead. Cycles
-     * are the compiler reporting on a source that names itself, so recomputing them costs nothing
-     * that matters.
+     * asked first; the whole chain in flight is discarded, not only the part inside the cycle,
+     * because an answer built from a cyclic one is as entry-dependent as the cyclic one.
+     *
+     * <p>That is more than the cycle, and it costs: while one exists, every key that reached it is
+     * recomputed on every ask. It is affordable because nothing in a compile is supposed to get
+     * here — modules that name each other are found by {@link Names.Cycles} and stopped before any
+     * question is asked that would answer itself.
      */
     private final Set<Key<?>> throughCycle = new HashSet<>();
     /** Every key that has ever reported something, in the order it first did — the order reports
      * are read back in. */
     private final List<Key<?>> spoke = new ArrayList<>();
-    private final Set<Key<?>> hasSpoken = new HashSet<>();
+    private final Set<Key<?>> hasSpoken = new LinkedHashSet<>();
 
     /**
      * Gives an input its value. An input set to what it already held changes nothing, so a caller
@@ -81,6 +97,22 @@ public final class Db {
         revision++;
         memos.put(key, new Memo(now, revision, revision, Set.of()));
         return this;
+    }
+
+    /**
+     * Drops everything kept about a source that is no longer part of this compilation — its text,
+     * and every answer that was about it or about the module it declared.
+     *
+     * <p>A store lives as long as the workspace does, so what it keeps about a file it will never be
+     * asked about again is held for nothing. Dropping an answer is always safe: the next question
+     * that wants it computes it.
+     */
+    public void forget(String sourceId, String moduleName) {
+        set(new Front.Text(sourceId), null);
+        memos.keySet().removeIf(key -> sourceId.equals(key.sourceId())
+                || (moduleName != null && moduleName.equals(key.module())));
+        hasSpoken.removeIf(key -> !memos.containsKey(key));
+        spoke.removeIf(key -> !memos.containsKey(key));
     }
 
     /** Answers {@code key}, computing it if nothing kept from before still holds. */
@@ -104,6 +136,11 @@ public final class Db {
         frames.push(new LinkedHashSet<>());
         Answer<T> answer;
         Set<Key<?>> read;
+        // Every trace of answering this key is undone here, whether it answered or threw. A compile
+        // error is a value, so a throw is an internal fault — and a store that is kept across edits
+        // must come out of one as it went in, or the key it happened under would never be kept
+        // again.
+        boolean reachedThroughCycle = false;
         try {
             answer = key.compute(this);
         } finally {
@@ -112,8 +149,9 @@ public final class Db {
             // reports depend on hash order.
             read = Collections.unmodifiableSet(frames.pop());
             inProgress.remove(key);
+            reachedThroughCycle = throughCycle.remove(key);
         }
-        if (!throughCycle.remove(key)) {
+        if (!reachedThroughCycle) {
             long changedAt = memo != null && memo.answer().equals(answer)
                     ? memo.changedAt() : revision;
             memos.put(key, new Memo(answer, revision, changedAt, read));
@@ -148,15 +186,24 @@ public final class Db {
     }
 
     /**
-     * Everything the answers this store now holds have to report, in the order the keys first
-     * reported. A key whose answer has since been recomputed contributes what it says now, so a
-     * problem that was fixed is not still listed.
+     * Everything this compilation now has to report, in the order the keys first reported it.
+     *
+     * <p>Only questions this revision actually asked are read. A question that was asked and
+     * recomputed contributes what it says now, so a problem that was fixed is not still listed —
+     * and a question that stopped being asked contributes nothing, because there is no longer
+     * anything that wants to know. Deleting the last row of an {@code examples for} file is the
+     * second case: nothing asks whether that file's rows hold any more, so nothing recomputes the
+     * answer, and reading it would put a failure on a line that is not there.
+     *
+     * <p>Being asked is what {@code verifiedAt} records. Answering a key sets it, and so does
+     * finding that a kept answer still holds, so every key reachable from what a caller asked for
+     * carries this revision and every key that is not reachable carries an older one.
      */
     public List<Found> allReports() {
         List<Found> found = new ArrayList<>();
         for (Key<?> key : spoke) {
             Memo memo = memos.get(key);
-            if (memo == null) {
+            if (memo == null || memo.verifiedAt() != revision) {
                 continue;
             }
             for (Report report : memo.answer().reports()) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -1,0 +1,494 @@
+package souther.compiler.query;
+
+import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.check.Exposing;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.meta.PublishedModule;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Getting from text to a set of named modules: the inputs, the parse of each source, which module
+ * each source declares, and the modules this compilation reaches that no source declares.
+ *
+ * <p>Everything here is about sources and names. Nothing yet knows what a name means — that starts
+ * at {@link Names}.
+ */
+public final class Front {
+
+    private Front() {}
+
+    /** The namespace the compiler ships. A user module may not take a reserved name, or it could
+     * grant itself the core's privileges. */
+    private static final String RESERVED = "souther";
+
+    /** Every source id this compilation was given, in the order they were given. The order is the
+     * index a diagnostic names when it says which file it came from. */
+    public record Ids() implements Input<List<String>> {}
+
+    /** The text of one source. */
+    public record Text(String id) implements Input<String> {}
+
+    /** The compiled modules of the projects this one depends on. */
+    public record Path() implements Input<ModulePath> {}
+
+    /**
+     * The name a source with no {@code module} header takes. Absent means a header is required,
+     * which is what linking a set of sources needs: a module reached by an import has to be named.
+     */
+    public record DefaultName() implements Input<String> {}
+
+    /**
+     * Modules the caller has already found unusable and did not hand over — a file an editor holds
+     * out of the compile because of its own syntax errors.
+     *
+     * <p>An importer of one is left alone rather than told the module is unknown: the error belongs
+     * to the file that will not parse, which reports it separately, and saying it again on the
+     * importer sends the author to a file that is fine.
+     */
+    public record Broken() implements Input<Set<String>> {}
+
+    /**
+     * Whether these sources are the compiler's own. The reserved namespace is what keeps a user
+     * module from granting itself the core's privileges; the core modules are in it by definition,
+     * so compiling them is the one case where the name is theirs to take.
+     */
+    public record Core() implements Input<Boolean> {}
+
+    /** One source, parsed, with the text of each declaration kept for publishing. */
+    public record Parsed(String id) implements Key<CstFrontend.Parsed> {
+        @Override
+        public Answer<CstFrontend.Parsed> compute(Db db) {
+            Answer<String> text = db.ask(new Text(id));
+            if (!text.present()) {
+                return Answer.absent(text.reports());
+            }
+            try {
+                return Answer.of(CstFrontend.parseWithSlices(
+                        text.value(), db.ask(new DefaultName()).value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /**
+     * Which source declares which module. An {@code examples for X} file declares no module of its
+     * own — it contributes rows to X — so it is listed apart, under the module it names.
+     *
+     * <p>A source that will not parse is in neither list. Its own error is reported where it is
+     * parsed, and here it is simply a module this compilation does not have: an importer of it gets
+     * the absence, not a second copy of the syntax error.
+     */
+    public record Layout() implements Key<Layout.Of> {
+
+        /**
+         * @param idOfModule the source each module was declared in
+         * @param exampleFilesOf the {@code examples for} sources contributing to each module
+         * @param exampleFileTargets the module each {@code examples for} source names, by source id
+         */
+        public record Of(Map<String, String> idOfModule,
+                         Map<String, List<String>> exampleFilesOf,
+                         Map<String, String> exampleFileTargets) {}
+
+        @Override
+        public Answer<Of> compute(Db db) {
+            List<String> ids = db.ask(new Ids()).value();
+            if (ids == null) {
+                return Answer.absent();
+            }
+            Map<String, String> idOfModule = new LinkedHashMap<>();
+            Map<String, List<String>> exampleFilesOf = new LinkedHashMap<>();
+            Map<String, String> exampleFileTargets = new LinkedHashMap<>();
+            List<Report> reports = new ArrayList<>();
+            for (String id : ids) {
+                Answer<CstFrontend.Parsed> parsed = db.ask(new Parsed(id));
+                if (!parsed.present()) {
+                    continue;   // reported where it was parsed
+                }
+                Ast.Module m = parsed.value().module();
+                if (m.exampleFileTarget() != null) {
+                    exampleFileTargets.put(id, m.exampleFileTarget());
+                    exampleFilesOf.computeIfAbsent(m.exampleFileTarget(), k -> new ArrayList<>()).add(id);
+                    continue;
+                }
+                idOfModule.putIfAbsent(m.name(), id);
+            }
+            return Answer.of(new Of(Ordered.map(idOfModule), Ordered.map(exampleFilesOf),
+                    Ordered.map(exampleFileTargets)), reports);
+        }
+    }
+
+    /**
+     * One module as its source declared it, with the standard-library {@code exposing} lines already
+     * rewritten and its name checked against the reserved namespace.
+     *
+     * <p>The rows of every {@code examples for} file naming it are appended here, so a module's
+     * examples are its examples wherever they were written. Which file a row came from is
+     * {@link Names.Examples}' business, not this one's.
+     */
+    public record Exposed(String name) implements Key<Ast.Module> {
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Layout.Of layout = db.ask(new Layout()).value();
+            if (layout == null) {
+                return Answer.absent();
+            }
+            String id = layout.idOfModule().get(name);
+            if (id == null) {
+                return Answer.absent();   // not declared by any source; the path may still have it
+            }
+            Answer<CstFrontend.Parsed> parsed = db.ask(new Parsed(id));
+            if (!parsed.present()) {
+                return Answer.absent(parsed.reports());
+            }
+            Ast.Module raw = parsed.value().module();
+            if (!Boolean.TRUE.equals(db.ask(new Core()).value())) {
+                Report reserved = reservedNamespace(raw.name(), raw.pos());
+                if (reserved != null) {
+                    return Answer.absent(reserved);
+                }
+            }
+            Ast.Module m = Exposing.rewrite(raw);
+            return Answer.of(withAttachedRows(db, m, layout.exampleFilesOf()
+                    .getOrDefault(name, List.of())));
+        }
+
+        /** The module with every attached file's examples and fakes appended. */
+        private Ast.Module withAttachedRows(Db db, Ast.Module m, List<String> files) {
+            if (files.isEmpty()) {
+                return m;
+            }
+            List<Ast.Example> examples = new ArrayList<>(m.examples());
+            List<Ast.Fake> fakes = new ArrayList<>(m.fakes());
+            for (String id : files) {
+                Answer<CstFrontend.Parsed> file = db.ask(new Parsed(id));
+                if (!file.present()) {
+                    continue;
+                }
+                examples.addAll(file.value().module().examples());
+                fakes.addAll(file.value().module().fakes());
+            }
+            return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), m.defs(),
+                    m.behaviors(), m.fns(), examples, fakes, m.exampleFileTarget(), m.pos());
+        }
+    }
+
+    /**
+     * The modules this compilation reaches that no source declares, read off the path. A module
+     * found there brings its own reaches with it, so a dependency of a dependency arrives too.
+     *
+     * <p>Which of its behaviors are injection targets comes with it: no {@code let} is published, so
+     * that cannot be read off a module here the way it is read off a source.
+     */
+    public record FromPath() implements Key<FromPath.Of> {
+
+        public record Of(Map<String, Ast.Module> modules, Map<String, Set<String>> injected) {}
+
+        @Override
+        public Answer<Of> compute(Db db) {
+            Layout.Of layout = db.ask(new Layout()).value();
+            ModulePath path = db.ask(new Path()).value();
+            if (layout == null || path == null) {
+                return Answer.of(new Of(Map.of(), Map.of()));
+            }
+            PublishedModule.Classes classes = path.declarations();
+            Map<String, Ast.Module> found = new LinkedHashMap<>();
+            Map<String, Set<String>> injected = new LinkedHashMap<>();
+            List<Report> reports = new ArrayList<>();
+            // What is waiting to be read, and — for one a module off the path needs — which module
+            // needs it, so an incomplete path is reported as that rather than as an import nobody
+            // wrote.
+            Deque<String> pending = new ArrayDeque<>();
+            Map<String, String> neededBy = new LinkedHashMap<>();
+            for (String declared : layout.idOfModule().keySet()) {
+                Ast.Module m = db.ask(new Exposed(declared)).value();
+                if (m != null) {
+                    pending.addAll(reaches(m));
+                }
+            }
+            Set<String> tried = new HashSet<>();
+            while (!pending.isEmpty()) {
+                String name = pending.poll();
+                if (layout.idOfModule().containsKey(name) || found.containsKey(name)
+                        || !tried.add(name)) {
+                    continue;
+                }
+                PublishedModule published = PublishedModule.read(name, classes);
+                if (published == null) {
+                    if (neededBy.containsKey(name) && !Prelude.isQualifier(name)) {
+                        reports.add(Report.of(Diagnostic.of(null, "check.module.pathincomplete")
+                                .title("check.module.title").args(name, neededBy.get(name))
+                                .hint("check.module.pathincomplete.hint", name).build()));
+                    }
+                    continue;   // written in a source being compiled: still that import's own error
+                }
+                Report reserved = reservedNamespace(published.module().name(),
+                        published.module().pos());
+                if (reserved != null) {
+                    reports.add(reserved);
+                    continue;
+                }
+                Ast.Module m = Exposing.rewrite(published.module());
+                found.put(name, m);
+                injected.put(name, published.injectedBehaviors());
+                for (String reach : reaches(m)) {
+                    neededBy.putIfAbsent(reach, name);
+                    pending.add(reach);
+                }
+            }
+            return Answer.of(new Of(Ordered.map(found), Ordered.map(injected)), reports);
+        }
+    }
+
+    /**
+     * A module of this compilation, wherever it came from: declared by a source, or read off the
+     * path. Absent when nothing here has it, which is what an import of an unknown module sees.
+     *
+     * <p>A source module reaches here with its qualified behavior references already bound to
+     * imports ({@link Names.Bound}); a path module has none to bind, because a behavior reference
+     * is not published.
+     */
+    public record Available(String name) implements Key<Ast.Module> {
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Ast.Module> bound = db.ask(new Names.Bound(name));
+            if (bound.present()) {
+                return bound;
+            }
+            FromPath.Of path = db.ask(new FromPath()).value();
+            Ast.Module fromPath = path == null ? null : path.modules().get(name);
+            return fromPath == null ? Answer.absent(bound.reports()) : Answer.of(fromPath);
+        }
+    }
+
+    /**
+     * The module a source declares, when it is the source that declares it. A second source naming
+     * the same module is the one reported: the first has a claim on the name, and the message
+     * belongs on the file the author would have to change.
+     */
+    public record Declares(String id) implements Key<String> {
+        @Override
+        public String sourceId() {
+            return id;
+        }
+
+        @Override
+        public Answer<String> compute(Db db) {
+            Answer<CstFrontend.Parsed> parsed = db.ask(new Parsed(id));
+            Layout.Of layout = db.ask(new Layout()).value();
+            if (!parsed.present() || layout == null
+                    || parsed.value().module().exampleFileTarget() != null) {
+                return Answer.absent();
+            }
+            Ast.Module m = parsed.value().module();
+            if (id.equals(layout.idOfModule().get(m.name()))) {
+                return Answer.of(m.name());
+            }
+            return Answer.absent(Report.raised(
+                    Diagnostic.of(null, "check.module.duplicate").title("check.module.title")
+                            .at(m.pos()).args(m.name()).build(),
+                    "duplicate module `" + m.name() + "`"));
+        }
+    }
+
+    /**
+     * Which source each of a module's example rows was written in, in the order the rows appear.
+     * A row that came from an {@code examples for} file is reported on that file, not on the module
+     * it contributes to.
+     */
+    public record ExampleOrigins(String name) implements Key<List<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<List<String>> compute(Db db) {
+            Layout.Of layout = db.ask(new Layout()).value();
+            if (layout == null) {
+                return Answer.of(List.of());
+            }
+            String own = layout.idOfModule().get(name);
+            List<String> origins = new ArrayList<>();
+            if (own != null) {
+                CstFrontend.Parsed parsed = db.ask(new Parsed(own)).value();
+                if (parsed != null) {
+                    for (int i = 0; i < parsed.module().examples().size(); i++) {
+                        origins.add(own);
+                    }
+                }
+            }
+            for (String id : layout.exampleFilesOf().getOrDefault(name, List.of())) {
+                CstFrontend.Parsed file = db.ask(new Parsed(id)).value();
+                if (file == null) {
+                    continue;
+                }
+                for (int i = 0; i < file.module().examples().size(); i++) {
+                    origins.add(id);
+                }
+            }
+            return Answer.of(List.copyOf(origins));
+        }
+    }
+
+    /**
+     * Whether an {@code examples for} file has a module to attach to. The rows contribute to a
+     * module this compilation does not have, so there is nothing to run them against.
+     */
+    public record AttachedTo(String id) implements Key<String> {
+        @Override
+        public String sourceId() {
+            return id;
+        }
+
+        @Override
+        public Answer<String> compute(Db db) {
+            Layout.Of layout = db.ask(new Layout()).value();
+            if (layout == null) {
+                return Answer.absent();
+            }
+            String target = layout.exampleFileTargets().get(id);
+            if (target == null) {
+                return Answer.absent();   // not an `examples for` file
+            }
+            if (layout.idOfModule().containsKey(target)) {
+                return Answer.of(target);
+            }
+            SourcePos pos = db.ask(new Parsed(id)).present()
+                    ? db.ask(new Parsed(id)).value().module().pos() : null;
+            return Answer.absent(Report.raised(
+                    Diagnostic.of("E1907", "check.example.notarget").title("check.example.title")
+                            .at(pos).args(target).build(),
+                    "an `examples for " + target + "` file names a module that is not being compiled"));
+        }
+    }
+
+    /**
+     * The source modules that also exist on the path. Which one an import means would be decided by
+     * nothing the author wrote, and the two would be different types under one name — the same
+     * reason two sources may not share a name.
+     */
+    public record Shadows() implements Key<Map<String, Report>> {
+        @Override
+        public Answer<Map<String, Report>> compute(Db db) {
+            Layout.Of layout = db.ask(new Layout()).value();
+            ModulePath path = db.ask(new Path()).value();
+            if (layout == null || path == null) {
+                return Answer.of(Map.of());
+            }
+            Map<String, Report> found = new LinkedHashMap<>();
+            for (String name : layout.idOfModule().keySet()) {
+                if (PublishedModule.read(name, path.declarations()) != null) {
+                    found.put(name, Report.raised(
+                            Diagnostic.of(null, "check.module.shadowspath").title("check.module.title")
+                                    .args(name).hint("check.module.shadowspath.hint", name).build(),
+                            "module `" + name + "` is compiled here and is also on the path"));
+                }
+            }
+            return Answer.of(Ordered.map(found));
+        }
+    }
+
+    /** Every module name this compilation knows — declared by a source or read off the path. */
+    public record ModuleNames() implements Key<Set<String>> {
+        @Override
+        public Answer<Set<String>> compute(Db db) {
+            Layout.Of layout = db.ask(new Layout()).value();
+            FromPath.Of path = db.ask(new FromPath()).value();
+            Set<String> names = new LinkedHashSet<>();
+            if (layout != null) {
+                names.addAll(layout.idOfModule().keySet());
+            }
+            if (path != null) {
+                names.addAll(path.modules().keySet());
+            }
+            return Answer.of(Ordered.set(names));
+        }
+    }
+
+    /** The names a source module declares — every module this compilation could compile. */
+    public record Declared() implements Key<List<String>> {
+        @Override
+        public Answer<List<String>> compute(Db db) {
+            Layout.Of layout = db.ask(new Layout()).value();
+            return layout == null ? Answer.of(List.of())
+                    : Answer.of(List.copyOf(layout.idOfModule().keySet()));
+        }
+    }
+
+    /**
+     * Every module name {@code m} names: the ones it imports, the qualifier of every type it writes
+     * with one, and the qualifier of every behavior it names that way. Neither kind of qualified
+     * reference needs an import line, so reading only the import lines would leave a module it
+     * reaches unread.
+     */
+    static Set<String> reaches(Ast.Module m) {
+        Set<String> names = new LinkedHashSet<>();
+        Map<String, String> aliases = new HashMap<>();
+        for (Ast.Import imp : m.imports()) {
+            names.add(imp.module());
+            if (imp.alias() != null) {
+                aliases.put(imp.alias(), imp.module());
+            }
+        }
+        List<String> written = new ArrayList<>();
+        for (Ast.TypeRef ref : Names.typeRefs(m)) {
+            written.add(ref.name());
+        }
+        for (Ast.BehaviorDef b : m.behaviors()) {
+            switch (b) {
+                case Ast.PipeBehavior pipe -> written.addAll(pipe.stages());
+                case Ast.SpecBehavior spec -> written.addAll(spec.requires());
+            }
+        }
+        for (String name : written) {
+            int dot = name.lastIndexOf('.');
+            if (dot > 0) {
+                String qualifier = name.substring(0, dot);
+                names.add(aliases.getOrDefault(qualifier, qualifier));
+            }
+        }
+        names.remove(m.name());
+        return names;
+    }
+
+    /** A module in the reserved namespace, or one named like a standard-library qualifier — or null
+     * when the name is the module's to take. */
+    static Report reservedNamespace(String name, SourcePos pos) {
+        if (name.equals(RESERVED) || name.startsWith(RESERVED + ".")) {
+            return Report.raised(
+                    Diagnostic.of(null, "check.module.reserved").title("check.module.title")
+                            .at(pos).args(name).build(),
+                    "module `" + name + "` is in the reserved `" + RESERVED + "` namespace: the"
+                            + " compiler ships souther.string / souther.list / souther.map /"
+                            + " souther.bool, and a user module cannot take a reserved name.");
+        }
+        // The short qualifiers are how the standard library is reached (`List.map`, `import
+        // String`); a user module by one of these names would shadow the library and could not be
+        // imported.
+        if (Prelude.isQualifier(name)) {
+            return Report.raised(
+                    Diagnostic.of(null, "check.module.qualifier").title("check.module.title")
+                            .at(pos).args(name).build(),
+                    "module `" + name + "` uses a name reserved for the standard-library qualifier `"
+                            + name + "` (as in `" + name + ".…` / `import " + name + " { … }`); pick"
+                            + " another module name.");
+        }
+        return null;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -72,10 +72,15 @@ public final class Front {
     /** One source, parsed, with the text of each declaration kept for publishing. */
     public record Parsed(String id) implements Key<CstFrontend.Parsed> {
         @Override
+        public String sourceId() {
+            return id;
+        }
+
+        @Override
         public Answer<CstFrontend.Parsed> compute(Db db) {
             Answer<String> text = db.ask(new Text(id));
             if (!text.present()) {
-                return Answer.absent(text.reports());
+                return Answer.absent();
             }
             try {
                 return Answer.of(CstFrontend.parseWithSlices(
@@ -114,7 +119,6 @@ public final class Front {
             Map<String, String> idOfModule = new LinkedHashMap<>();
             Map<String, List<String>> exampleFilesOf = new LinkedHashMap<>();
             Map<String, String> exampleFileTargets = new LinkedHashMap<>();
-            List<Report> reports = new ArrayList<>();
             for (String id : ids) {
                 Answer<CstFrontend.Parsed> parsed = db.ask(new Parsed(id));
                 if (!parsed.present()) {
@@ -129,7 +133,7 @@ public final class Front {
                 idOfModule.putIfAbsent(m.name(), id);
             }
             return Answer.of(new Of(Ordered.map(idOfModule), Ordered.map(exampleFilesOf),
-                    Ordered.map(exampleFileTargets)), reports);
+                    Ordered.map(exampleFileTargets)));
         }
     }
 
@@ -143,6 +147,11 @@ public final class Front {
      */
     public record Exposed(String name) implements Key<Ast.Module> {
         @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
         public Answer<Ast.Module> compute(Db db) {
             Layout.Of layout = db.ask(new Layout()).value();
             if (layout == null) {
@@ -154,7 +163,7 @@ public final class Front {
             }
             Answer<CstFrontend.Parsed> parsed = db.ask(new Parsed(id));
             if (!parsed.present()) {
-                return Answer.absent(parsed.reports());
+                return Answer.absent();
             }
             Ast.Module raw = parsed.value().module();
             if (!Boolean.TRUE.equals(db.ask(new Core()).value())) {
@@ -265,14 +274,41 @@ public final class Front {
      */
     public record Available(String name) implements Key<Ast.Module> {
         @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
         public Answer<Ast.Module> compute(Db db) {
             Answer<Ast.Module> bound = db.ask(new Names.Bound(name));
             if (bound.present()) {
-                return bound;
+                return Answer.of(bound.value());
             }
             FromPath.Of path = db.ask(new FromPath()).value();
             Ast.Module fromPath = path == null ? null : path.modules().get(name);
-            return fromPath == null ? Answer.absent(bound.reports()) : Answer.of(fromPath);
+            return fromPath == null ? Answer.absent() : Answer.of(fromPath);
+        }
+    }
+
+    /**
+     * The type names a module exposes.
+     *
+     * <p>Its own question, not a read of the module. Everything that resolves a name against another
+     * module asks this, and a module changes far more often than its {@code exposing} line does —
+     * reading the whole module here would mean a new behavior in one module rebuilding every module
+     * that imports a type from it.
+     */
+    public record Exposes(String name) implements Key<Set<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Set<String>> compute(Db db) {
+            Ast.Module m = db.ask(new Available(name)).value();
+            return Answer.of(m == null ? Set.of()
+                    : souther.compiler.check.Registry.baseNames(m.exposing()));
         }
     }
 
@@ -379,28 +415,30 @@ public final class Front {
     }
 
     /**
-     * The source modules that also exist on the path. Which one an import means would be decided by
+     * A source module that also exists on the path. Which one an import means would be decided by
      * nothing the author wrote, and the two would be different types under one name — the same
      * reason two sources may not share a name.
      */
-    public record Shadows() implements Key<Map<String, Report>> {
+    public record ShadowsPath(String name) implements Key<Boolean> {
         @Override
-        public Answer<Map<String, Report>> compute(Db db) {
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Boolean> compute(Db db) {
             Layout.Of layout = db.ask(new Layout()).value();
             ModulePath path = db.ask(new Path()).value();
-            if (layout == null || path == null) {
-                return Answer.of(Map.of());
+            if (layout == null || path == null || !layout.idOfModule().containsKey(name)) {
+                return Answer.of(Boolean.FALSE);
             }
-            Map<String, Report> found = new LinkedHashMap<>();
-            for (String name : layout.idOfModule().keySet()) {
-                if (PublishedModule.read(name, path.declarations()) != null) {
-                    found.put(name, Report.raised(
-                            Diagnostic.of(null, "check.module.shadowspath").title("check.module.title")
-                                    .args(name).hint("check.module.shadowspath.hint", name).build(),
-                            "module `" + name + "` is compiled here and is also on the path"));
-                }
+            if (PublishedModule.read(name, path.declarations()) == null) {
+                return Answer.of(Boolean.FALSE);
             }
-            return Answer.of(Ordered.map(found));
+            return Answer.absent(Report.raised(
+                    Diagnostic.of(null, "check.module.shadowspath").title("check.module.title")
+                            .args(name).hint("check.module.shadowspath.hint", name).build(),
+                    "module `" + name + "` is compiled here and is also on the path"));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -41,7 +41,12 @@ public final class Front {
     public record Ids() implements Input<List<String>> {}
 
     /** The text of one source. */
-    public record Text(String id) implements Input<String> {}
+    public record Text(String id) implements Input<String> {
+        @Override
+        public String sourceId() {
+            return id;
+        }
+    }
 
     /** The compiled modules of the projects this one depends on. */
     public record Path() implements Input<ModulePath> {}

--- a/souther-compiler/src/main/java/souther/compiler/query/Input.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Input.java
@@ -1,0 +1,19 @@
+package souther.compiler.query;
+
+/**
+ * A key whose answer is given rather than computed: the text of a source, the module path a compile
+ * resolves against. These are the leaves of the graph and the only part of a compilation that
+ * changes from outside — everything else is a function of them.
+ *
+ * <p>An input nobody gave a value for is absent, not an error. A compile is often asked about a
+ * file that is not there: an import naming a module the workspace does not contain, an
+ * {@code examples for} file whose target was never opened. The key that asked sees the absence and
+ * reports it where the author can act on it, which is not here.
+ */
+public interface Input<T> extends Key<T> {
+
+    @Override
+    default Answer<T> compute(Db db) {
+        return Answer.absent();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Key.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Key.java
@@ -47,8 +47,11 @@ public interface Key<T> {
 
     /**
      * The answer when this question is reached while it is already being answered — the key depends,
-     * through some chain, on itself. {@code cycle} is that chain, outermost first, ending at this
-     * key's other occurrence.
+     * through some chain, on itself.
+     *
+     * <p>{@code cycle} is every key being answered at that moment, outermost first. This key is in
+     * it, once, at the point the chain came back round to it; it is not repeated at the end. The
+     * keys before it are the ones that asked, which need not be part of the cycle at all.
      *
      * <p>A key kind that can be part of a cycle must say what a cycle means for it: modules that
      * import each other, helpers that call each other. Left unimplemented it is a programming error,

--- a/souther-compiler/src/main/java/souther/compiler/query/Key.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Key.java
@@ -1,0 +1,63 @@
+package souther.compiler.query;
+
+import java.util.List;
+
+/**
+ * One question about one thing, and the code that answers it.
+ *
+ * <p>A key is a value: two keys that ask the same question are equal, which is what lets the engine
+ * recognise the question it has already answered. Implementations are records, so that comes for
+ * free — and a key holds only what identifies the question, never a compilation, a registry or a
+ * position, because anything held here would be part of the question's identity.
+ *
+ * <p>The answer lives on the key rather than in a dispatch table somewhere, so one class is one
+ * question: what it is, what it reads, and what it does when it cannot answer are in one place. A
+ * key reaches everything else it needs by asking {@link Db}, which is what makes the read
+ * observable — nothing else in the compiler can see what a pass depended on.
+ */
+public interface Key<T> {
+
+    /**
+     * Answers this question, asking {@code db} for whatever else it needs. Every read must go
+     * through {@code db}: an answer computed from something reached another way is not recorded as
+     * a dependency, so nothing would know to recompute it.
+     */
+    Answer<T> compute(Db db);
+
+    /**
+     * The module this question is about, or null when it is about the compilation as a whole.
+     *
+     * <p>This is how a report finds its file. A key answered while some other module was being
+     * compiled still belongs to the module it names — an error in an imported module is that
+     * module's, published on that module's document, not on its importer's. Nothing else in the
+     * graph knows where an answer came from, so a key that is about one module says so.
+     */
+    default String module() {
+        return null;
+    }
+
+    /**
+     * The source this question is about, when it is about a source rather than a module — an
+     * {@code examples for} file declares no module of its own, so a problem with it has no module
+     * name to be found by. Null otherwise, and the module's own source is used instead.
+     */
+    default String sourceId() {
+        return null;
+    }
+
+    /**
+     * The answer when this question is reached while it is already being answered — the key depends,
+     * through some chain, on itself. {@code cycle} is that chain, outermost first, ending at this
+     * key's other occurrence.
+     *
+     * <p>A key kind that can be part of a cycle must say what a cycle means for it: modules that
+     * import each other, helpers that call each other. Left unimplemented it is a programming error,
+     * because the alternative is answering with something arbitrary and letting a later pass make
+     * sense of it.
+     */
+    default Answer<T> onCycle(List<Key<?>> cycle) {
+        throw new IllegalStateException(
+                "the query " + this + " depends on itself and says nothing about what that means: "
+                        + cycle);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -53,10 +53,10 @@ public final class Names {
 
             @Override
             public Set<String> exposedBy(String moduleName) {
-                Ast.Module m = db.ask(new Front.Available(moduleName)).value();
                 // `exposing` is written in the source and no pass rewrites it, so which stage this
                 // registry reads makes no difference to the answer.
-                return m == null ? Set.of() : Registry.baseNames(m.exposing());
+                Set<String> exposed = db.ask(new Front.Exposes(moduleName)).value();
+                return exposed == null ? Set.of() : exposed;
             }
 
             @Override
@@ -86,7 +86,7 @@ public final class Names {
         public Answer<Ast.Module> compute(Db db) {
             Answer<Ast.Module> exposed = db.ask(new Front.Exposed(name));
             if (!exposed.present()) {
-                return exposed;
+                return Answer.absent();
             }
             Set<String> modules = db.ask(new Front.ModuleNames()).value();
             Ast.Module m = exposed.value();
@@ -194,15 +194,44 @@ public final class Names {
 
         @Override
         public Answer<Map<String, Ast.Def>> compute(Db db) {
+            if (cyclic(db, name)) {
+                // What this module declares depends on the module it names, which depends on this
+                // one. Reported by InCycle; nothing below here can be answered, and going on would
+                // ask a question that is answering itself.
+                return Answer.absent();
+            }
             Answer<Ast.Module> m = db.ask(new Front.Available(name));
             if (!m.present()) {
-                return Answer.absent(m.reports());
+                return Answer.absent();
             }
             try {
                 return Answer.of(TypeChecker.ownDefs(m.value()));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
+        }
+    }
+
+    /**
+     * Whether a module takes part in an import cycle — absent, with the error, when it does.
+     *
+     * <p>{@link Cycles} finds them all in one walk; this is where one module's share of that is
+     * reported, so the error lands on the source that closes the cycle like any other.
+     */
+    public record InCycle(String name) implements Key<Boolean> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Boolean> compute(Db db) {
+            Cycles.Of cycles = db.ask(new Cycles()).value();
+            Report found = cycles == null ? null : cycles.reported().get(name);
+            if (found != null) {
+                return Answer.absent(found);
+            }
+            return cyclic(db, name) ? Answer.absent() : Answer.of(Boolean.FALSE);
         }
     }
 
@@ -249,7 +278,7 @@ public final class Names {
         public Answer<Of> compute(Db db) {
             Answer<Ast.Module> module = db.ask(new Front.Available(name));
             if (!module.present()) {
-                return Answer.absent(module.reports());
+                return Answer.absent();
             }
             Ast.Module m = module.value();
             Registry registry = registry(db, Stage.AVAILABLE);
@@ -319,7 +348,7 @@ public final class Names {
     static Answer<Symbols> symbols(Db db, String name, Stage stage) {
         Answer<Imports.Of> imports = db.ask(new Imports(name));
         if (!imports.present()) {
-            return Answer.absent(imports.reports());
+            return Answer.absent();
         }
         return Answer.of(Symbols.of(name, registry(db, stage), imports.value().scope(),
                 imports.value().aliases()));
@@ -353,14 +382,14 @@ public final class Names {
         public Answer<Resolve.Resolved> compute(Db db) {
             Answer<Ast.Module> available = db.ask(new Front.Available(name));
             if (!available.present()) {
-                return Answer.absent(available.reports());
+                return Answer.absent();
             }
             // Resolution reads other modules' declarations as they were written, not as they will
             // be resolved: a name written there is that module's to resolve, and asking for its
             // resolved form here would be this module waiting on its own.
             Answer<Symbols> scope = symbols(db, name, Stage.AVAILABLE);
             if (!scope.present()) {
-                return Answer.absent(scope.reports());
+                return Answer.absent();
             }
             try {
                 return Answer.of(Resolve.resolving(available.value(), scope.value()));
@@ -499,12 +528,21 @@ public final class Names {
      * followed through imports and through qualified type references alike: a qualified reference
      * needs no import line, so reading only the import lines would let a cycle through unseen.
      */
-    public record Cycles() implements Key<Map<String, Report>> {
+    public record Cycles() implements Key<Cycles.Of> {
+
+        /**
+         * @param reported the error for each module a cycle was closed at — one per cycle, on the
+         *                 source that wrote the reference that closes it
+         * @param members every module taking part in one, which is more: the error belongs to one
+         *                of them, but none of them can be compiled
+         */
+        public record Of(Map<String, Report> reported, Set<String> members) {}
+
         @Override
-        public Answer<Map<String, Report>> compute(Db db) {
+        public Answer<Of> compute(Db db) {
             List<String> declared = db.ask(new Front.Declared()).value();
             if (declared == null) {
-                return Answer.of(Map.of());
+                return Answer.of(new Of(Map.of(), Set.of()));
             }
             Set<String> modules = db.ask(new Front.ModuleNames()).value();
             Map<String, List<Dependency>> deps = new LinkedHashMap<>();
@@ -515,35 +553,45 @@ public final class Names {
                 }
             }
             Map<String, Report> found = new LinkedHashMap<>();
+            Set<String> members = new LinkedHashSet<>();
             Set<String> done = new LinkedHashSet<>();
-            Set<String> onStack = new LinkedHashSet<>();
+            List<String> stack = new ArrayList<>();
             for (String name : declared) {
-                visit(name, deps, done, onStack, found);
+                visit(name, deps, done, stack, found, members);
             }
-            return Answer.of(Ordered.map(found));
+            return Answer.of(new Of(Ordered.map(found), Ordered.set(members)));
         }
 
         private void visit(String name, Map<String, List<Dependency>> deps, Set<String> done,
-                           Set<String> onStack, Map<String, Report> found) {
+                           List<String> stack, Map<String, Report> found, Set<String> members) {
             if (done.contains(name) || !deps.containsKey(name)) {
                 return;
             }
-            onStack.add(name);
+            stack.add(name);
             for (Dependency dep : deps.get(name)) {
-                if (onStack.contains(dep.module())) {
-                    // the reference that closes the cycle is written here, so this is the file to
-                    // quote
+                int closes = stack.indexOf(dep.module());
+                if (closes >= 0) {
+                    // The reference that closes the cycle is written here, so this is the file to
+                    // quote. Everything from the module it names round to this one is in the cycle,
+                    // and none of them can be compiled — each needs an answer from the next.
                     found.putIfAbsent(name, Report.raised(
                             Diagnostic.literal(dep.pos(), "E1501",
                                     "Cyclic module dependency detected."),
                             "Cyclic module dependency detected."));
+                    members.addAll(stack.subList(closes, stack.size()));
                     continue;
                 }
-                visit(dep.module(), deps, done, onStack, found);
+                visit(dep.module(), deps, done, stack, found, members);
             }
-            onStack.remove(name);
+            stack.remove(stack.size() - 1);
             done.add(name);
         }
+    }
+
+    /** Whether {@code name} takes part in an import cycle, so nothing about it can be worked out. */
+    static boolean cyclic(Db db, String name) {
+        Cycles.Of cycles = db.ask(new Cycles()).value();
+        return cycles != null && cycles.members().contains(name);
     }
 
     /** One module reaching another, and where it does so. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -1,0 +1,562 @@
+package souther.compiler.query;
+
+import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Registry;
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeChecker;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Region;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.TypeName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What the names in a module mean: which module a qualifier names, which declarations an import
+ * brings in, and — once those are settled — the module with every written type name resolved to the
+ * declaration it denotes.
+ *
+ * <p>Each of these is asked once per module and answered once. That is the point of putting them
+ * here: {@link souther.compiler.check.Symbols} is built at several stages of a compile, and before
+ * this every stage revalidated the same imports and rebuilt the same scope, so a bad import was
+ * found two or three times and whichever came first decided what the author read.
+ */
+public final class Names {
+
+    private Names() {}
+
+    /** Which stage of a module's declarations a registry reads. The names a module declares are the
+     * same at every stage; what changes is what each declaration holds. */
+    public enum Stage { AVAILABLE, RESOLVED, DERIVED }
+
+    /** A registry over this compilation, reading each module's declarations at {@code stage}. */
+    public static Registry registry(Db db, Stage stage) {
+        return new Registry() {
+            @Override
+            public Map<String, Ast.Def> declaredIn(String moduleName) {
+                Answer<Map<String, Ast.Def>> defs = switch (stage) {
+                    case AVAILABLE -> db.ask(new Declarations(moduleName));
+                    case RESOLVED -> db.ask(new ResolvedDeclarations(moduleName));
+                    case DERIVED -> db.ask(new Shapes.DerivedDeclarations(moduleName));
+                };
+                return defs.present() ? defs.value() : Map.of();
+            }
+
+            @Override
+            public Set<String> exposedBy(String moduleName) {
+                Ast.Module m = db.ask(new Front.Available(moduleName)).value();
+                // `exposing` is written in the source and no pass rewrites it, so which stage this
+                // registry reads makes no difference to the answer.
+                return m == null ? Set.of() : Registry.baseNames(m.exposing());
+            }
+
+            @Override
+            public Set<String> moduleNames() {
+                Set<String> names = db.ask(new Front.ModuleNames()).value();
+                return names == null ? Set.of() : names;
+            }
+        };
+    }
+
+    /**
+     * A source module with every qualified behavior reference — a {@code >->} stage or a
+     * {@code requires} naming another module's behavior — rewritten to the bare name, and the module
+     * it came from recorded as an import.
+     *
+     * <p>A behavior's name is a member name in the generated class, so the bare form is what the
+     * rest of the compiler needs; the qualifier only says which module to take it from, which is
+     * exactly what an import says.
+     */
+    public record Bound(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Ast.Module> exposed = db.ask(new Front.Exposed(name));
+            if (!exposed.present()) {
+                return exposed;
+            }
+            Set<String> modules = db.ask(new Front.ModuleNames()).value();
+            Ast.Module m = exposed.value();
+            List<Report> reports = new ArrayList<>();
+            Map<String, String> qualifiers = new HashMap<>();
+            for (Ast.Import imp : m.imports()) {
+                if (imp.alias() != null) {
+                    qualifiers.put(imp.alias(), imp.module());
+                }
+            }
+            Map<String, Set<String>> taken = new LinkedHashMap<>();   // module → names it brings
+            for (Ast.Import imp : m.imports()) {
+                taken.computeIfAbsent(imp.module(), k -> new LinkedHashSet<>()).addAll(imp.names());
+            }
+            Map<String, Set<String>> added = new LinkedHashMap<>();
+            Map<String, SourcePos> at = new LinkedHashMap<>();
+            List<Ast.BehaviorDef> behaviors = new ArrayList<>();
+            boolean rewrote = false;
+            for (Ast.BehaviorDef b : m.behaviors()) {
+                switch (b) {
+                    case Ast.PipeBehavior pipe -> {
+                        List<String> stages = new ArrayList<>();
+                        for (String stage : pipe.stages()) {
+                            stages.add(bind(stage, qualifiers, modules, m, pipe.pos(), taken, added,
+                                    at, reports));
+                        }
+                        rewrote |= !stages.equals(pipe.stages());
+                        behaviors.add(new Ast.PipeBehavior(pipe.name(), stages, pipe.declaredOut(),
+                                pipe.pos()));
+                    }
+                    case Ast.SpecBehavior spec -> {
+                        List<String> requires = new ArrayList<>();
+                        for (String req : spec.requires()) {
+                            requires.add(bind(req, qualifiers, modules, m, spec.pos(), taken, added,
+                                    at, reports));
+                        }
+                        rewrote |= !requires.equals(spec.requires());
+                        behaviors.add(new Ast.SpecBehavior(spec.name(), spec.params(), spec.ret(),
+                                spec.constructs(), requires, spec.pos()));
+                    }
+                }
+            }
+            if (!reports.isEmpty()) {
+                return Answer.absent(reports);
+            }
+            if (!rewrote) {
+                return Answer.of(m);
+            }
+            List<Ast.Import> imports = new ArrayList<>(m.imports());
+            for (Map.Entry<String, Set<String>> e : added.entrySet()) {
+                imports.add(new Ast.Import(e.getKey(), null, List.copyOf(e.getValue()),
+                        at.get(e.getKey())));
+            }
+            return Answer.of(new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), imports,
+                    m.defs(), behaviors, m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(),
+                    m.pos()));
+        }
+
+        /** One written behavior name: the bare form it binds to, collecting the import it needs. */
+        private String bind(String written, Map<String, String> qualifiers, Set<String> modules,
+                            Ast.Module m, SourcePos pos, Map<String, Set<String>> taken,
+                            Map<String, Set<String>> added, Map<String, SourcePos> at,
+                            List<Report> reports) {
+            int dot = written.lastIndexOf('.');
+            if (dot < 0) {
+                return written;
+            }
+            String bare = written.substring(dot + 1);
+            // `X.decoder` / `X.encoder` name a codec, not a behavior of a module called X — a stage
+            // that writes one gets its own answer, which reading it as an import would hide, and
+            // would hide the more so where a module happens to be named like the type.
+            if (bare.equals("decoder") || bare.equals("encoder")) {
+                return written;
+            }
+            String qualifier = written.substring(0, dot);
+            if (Prelude.isQualifier(qualifier)) {
+                return written;   // a standard-library qualifier: a function, not a behavior
+            }
+            String target = qualifiers.getOrDefault(qualifier, qualifier);
+            if (target.equals(m.name())) {
+                return bare;      // this module, named through itself
+            }
+            if (!modules.contains(target)) {
+                reports.add(Report.raised(
+                        Diagnostic.of(null, "check.qualified.unknownmodule").title("check.module.title")
+                                .at(pos).args(qualifier, bare).build(),
+                        "no module named `" + qualifier + "`"));
+                return bare;
+            }
+            if (!taken.getOrDefault(target, Set.of()).contains(bare)) {
+                added.computeIfAbsent(target, k -> new LinkedHashSet<>()).add(bare);
+                at.putIfAbsent(target, pos);
+            }
+            return bare;
+        }
+    }
+
+    /** What a module declares, by the name written there — checked once, here, because the names
+     * are the same at every stage and every later registry reads them through this. */
+    public record Declarations(String name) implements Key<Map<String, Ast.Def>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Ast.Def>> compute(Db db) {
+            Answer<Ast.Module> m = db.ask(new Front.Available(name));
+            if (!m.present()) {
+                return Answer.absent(m.reports());
+            }
+            try {
+                return Answer.of(TypeChecker.ownDefs(m.value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /** The same declarations, with every written name in them resolved. */
+    public record ResolvedDeclarations(String name) implements Key<Map<String, Ast.Def>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Ast.Def>> compute(Db db) {
+            Answer<Ast.Module> m = db.ask(new Resolved(name));
+            return m.present() ? Answer.of(defsOf(m.value())) : Answer.absent();
+        }
+    }
+
+    /** A module's definitions by name, taking the names as already checked. */
+    static Map<String, Ast.Def> defsOf(Ast.Module m) {
+        Map<String, Ast.Def> defs = new LinkedHashMap<>();
+        for (Ast.Def def : m.defs()) {
+            defs.putIfAbsent(def.name(), def);
+        }
+        return Ordered.map(defs);
+    }
+
+    /**
+     * What each bare name means in a module: its own declarations plus the ones its imports bring
+     * in, and which module each {@code import ... as} alias names.
+     *
+     * <p>Every import is validated here and nowhere else — that it names a module this compilation
+     * has, that the module exposes what is asked for, that no two imports bring in the same name.
+     */
+    public record Imports(String name) implements Key<Imports.Of> {
+
+        public record Of(Map<String, TypeName> scope, Map<String, String> aliases) {}
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Of> compute(Db db) {
+            Answer<Ast.Module> module = db.ask(new Front.Available(name));
+            if (!module.present()) {
+                return Answer.absent(module.reports());
+            }
+            Ast.Module m = module.value();
+            Registry registry = registry(db, Stage.AVAILABLE);
+            Map<String, TypeName> scope = new HashMap<>();
+            for (String own : registry.declaredIn(name).keySet()) {
+                scope.put(own, new TypeName(name, own));
+            }
+            Set<String> ownNames = Ordered.set(scope.keySet());
+            // Which import brought each name in, so a second one naming it is reported against that
+            // import rather than against a local definition the module may not have.
+            Map<String, Ast.Import> from = new HashMap<>();
+            Map<String, String> aliases = new HashMap<>();
+            Set<String> broken = db.ask(new Front.Broken()).value();
+            for (Ast.Import imp : m.imports()) {
+                if (broken != null && broken.contains(imp.module())) {
+                    return Answer.absent();   // the file that will not parse reports its own error
+                }
+                Ast.Module src = db.ask(new Front.Available(imp.module())).value();
+                if (src == null) {
+                    return Answer.absent(unknownModule(imp));
+                }
+                if (!db.ask(new Declarations(imp.module())).present()) {
+                    // The module is there but says nothing usable. Whatever is wrong with it is
+                    // reported on its own source; repeating it here would send the author to a file
+                    // that is fine.
+                    return Answer.absent();
+                }
+                if (imp.alias() != null) {
+                    Report clash = aliasTaken(imp, aliases, registry.moduleNames());
+                    if (clash != null) {
+                        return Answer.absent(clash);
+                    }
+                    aliases.put(imp.alias(), imp.module());
+                }
+                Map<String, Ast.Def> srcDefs = registry.declaredIn(imp.module());
+                Set<String> exposed = registry.exposedBy(imp.module());
+                for (String imported : imp.names()) {
+                    if (!exposed.contains(imported)) {
+                        return Answer.absent(Report.raised(
+                                Diagnostic.of(null, "check.import.notexposed").title("check.module.title")
+                                        .at(imp.pos()).args(imported, imp.module()).build(),
+                                "`" + imported + "` is not exposed by `" + imp.module() + "`"));
+                    }
+                    if (!srcDefs.containsKey(imported)) {
+                        // a behavior import is resolved separately; it is not a data Def, so it does
+                        // not go into the symbols map.
+                        if (behaviorNames(src).contains(imported)) {
+                            continue;
+                        }
+                        return Answer.absent(Report.raised(
+                                Diagnostic.of(null, "check.import.notdefined").title("check.module.title")
+                                        .at(imp.pos()).args(imported, imp.module()).build(),
+                                "`" + imported + "` is not defined in `" + imp.module() + "`"));
+                    }
+                    if (scope.put(imported, new TypeName(imp.module(), imported)) != null) {
+                        return Answer.absent(importCollision(imported, imp,
+                                ownNames.contains(imported) ? null : from.get(imported)));
+                    }
+                    from.put(imported, imp);
+                }
+            }
+            return Answer.of(new Of(Ordered.map(scope), Ordered.map(aliases)));
+        }
+    }
+
+    /** What names mean in a module, over declarations at {@code stage}. */
+    static Answer<Symbols> symbols(Db db, String name, Stage stage) {
+        Answer<Imports.Of> imports = db.ask(new Imports(name));
+        if (!imports.present()) {
+            return Answer.absent(imports.reports());
+        }
+        return Answer.of(Symbols.of(name, registry(db, stage), imports.value().scope(),
+                imports.value().aliases()));
+    }
+
+    /** What names mean in a module before anything is derived from it — what {@link Resolved}
+     * resolves against. */
+    public record NameScope(String name) implements Key<Symbols> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Symbols> compute(Db db) {
+            return symbols(db, name, Stage.RESOLVED);
+        }
+    }
+
+    /**
+     * The module with every written type name resolved to the declaration it denotes. A name that
+     * denotes nothing is reported here, so nothing downstream ever reads an unresolved one.
+     */
+    public record Resolved(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Ast.Module> available = db.ask(new Front.Available(name));
+            if (!available.present()) {
+                return Answer.absent(available.reports());
+            }
+            // Resolution reads other modules' declarations as they were written, not as they will
+            // be resolved: a name written there is that module's to resolve, and asking for its
+            // resolved form here would be this module waiting on its own.
+            Answer<Symbols> scope = symbols(db, name, Stage.AVAILABLE);
+            if (!scope.present()) {
+                return Answer.absent(scope.reports());
+            }
+            try {
+                return Answer.of(Resolve.module(available.value(), scope.value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /**
+     * Which modules take part in an import cycle, and the error to report at each. A cycle is
+     * followed through imports and through qualified type references alike: a qualified reference
+     * needs no import line, so reading only the import lines would let a cycle through unseen.
+     */
+    public record Cycles() implements Key<Map<String, Report>> {
+        @Override
+        public Answer<Map<String, Report>> compute(Db db) {
+            List<String> declared = db.ask(new Front.Declared()).value();
+            if (declared == null) {
+                return Answer.of(Map.of());
+            }
+            Set<String> modules = db.ask(new Front.ModuleNames()).value();
+            Map<String, List<Dependency>> deps = new LinkedHashMap<>();
+            for (String name : declared) {
+                Ast.Module m = db.ask(new Front.Available(name)).value();
+                if (m != null) {
+                    deps.put(name, dependencies(m, modules));
+                }
+            }
+            Map<String, Report> found = new LinkedHashMap<>();
+            Set<String> done = new LinkedHashSet<>();
+            Set<String> onStack = new LinkedHashSet<>();
+            for (String name : declared) {
+                visit(name, deps, done, onStack, found);
+            }
+            return Answer.of(Ordered.map(found));
+        }
+
+        private void visit(String name, Map<String, List<Dependency>> deps, Set<String> done,
+                           Set<String> onStack, Map<String, Report> found) {
+            if (done.contains(name) || !deps.containsKey(name)) {
+                return;
+            }
+            onStack.add(name);
+            for (Dependency dep : deps.get(name)) {
+                if (onStack.contains(dep.module())) {
+                    // the reference that closes the cycle is written here, so this is the file to
+                    // quote
+                    found.putIfAbsent(name, Report.raised(
+                            Diagnostic.literal(dep.pos(), "E1501",
+                                    "Cyclic module dependency detected."),
+                            "Cyclic module dependency detected."));
+                    continue;
+                }
+                visit(dep.module(), deps, done, onStack, found);
+            }
+            onStack.remove(name);
+            done.add(name);
+        }
+    }
+
+    /** One module reaching another, and where it does so. */
+    private record Dependency(String module, SourcePos pos) {}
+
+    private static List<Dependency> dependencies(Ast.Module m, Set<String> modules) {
+        List<Dependency> deps = new ArrayList<>();
+        Map<String, String> qualifiers = new HashMap<>();
+        for (Ast.Import imp : m.imports()) {
+            deps.add(new Dependency(imp.module(), imp.pos()));
+            if (imp.alias() != null) {
+                qualifiers.put(imp.alias(), imp.module());
+            }
+        }
+        for (Ast.TypeRef ref : typeRefs(m)) {
+            int dot = ref.name().lastIndexOf('.');
+            if (dot < 0) {
+                continue;
+            }
+            String qualifier = ref.name().substring(0, dot);
+            String target = qualifiers.getOrDefault(qualifier, qualifier);
+            if (modules.contains(target) && !target.equals(m.name())) {
+                deps.add(new Dependency(target, ref.pos()));
+            }
+        }
+        return deps;
+    }
+
+    static Set<String> behaviorNames(Ast.Module m) {
+        Set<String> names = new LinkedHashSet<>();
+        for (Ast.BehaviorDef b : m.behaviors()) {
+            names.add(b.name());
+        }
+        return names;
+    }
+
+    static Report unknownModule(Ast.Import imp) {
+        return Report.raised(
+                Diagnostic.of(null, "check.import.unknownmodule").title("check.module.title")
+                        .at(imp.pos()).args(imp.module()).build(),
+                "unknown module `" + imp.module() + "`");
+    }
+
+    /**
+     * An alias must be a qualifier nothing else already is: another alias, a module in this
+     * compilation, or a standard-library qualifier. Left to win silently it would take over what
+     * {@code List.map} or {@code billing.Amount} means here.
+     */
+    private static Report aliasTaken(Ast.Import imp, Map<String, String> aliases,
+                                     Set<String> modules) {
+        String taken = aliases.containsKey(imp.alias()) ? aliases.get(imp.alias())
+                : modules.contains(imp.alias()) ? imp.alias()
+                : Prelude.isQualifier(imp.alias()) ? "souther" : null;
+        if (taken == null) {
+            return null;
+        }
+        return Report.raised(
+                Diagnostic.of(null, "check.import.aliastaken").title("check.module.title")
+                        .at(imp.pos()).args(imp.alias(), taken)
+                        .hint("check.import.aliastaken.hint").build(),
+                "the alias `" + imp.alias() + "` is already how `" + taken + "` is named here");
+    }
+
+    /**
+     * The name arrived twice. {@code earlier} is the import that already brought it in, or null when
+     * the module defines it itself. Either way the way out is inside the module: keep at most one of
+     * them bare and name the other through its module.
+     */
+    private static Report importCollision(String name, Ast.Import imp, Ast.Import earlier) {
+        if (earlier == null) {
+            return Report.raised(
+                    Diagnostic.of(null, "check.import.conflict").title("check.module.title")
+                            .at(imp.pos()).args(name).hint("check.import.conflict.hint").build(),
+                    "imported `" + name + "` conflicts with a local definition");
+        }
+        Diagnostic.Builder b = Diagnostic.of(null, "check.import.duplicate")
+                .title("check.module.title").at(imp.pos()).args(name, earlier.module(), imp.module())
+                .secondary(Region.point(earlier.pos()), "check.import.duplicate.first", name,
+                        earlier.module());
+        return Report.raised(
+                (earlier.module().equals(imp.module())
+                        ? b.hint("check.import.duplicate.same.hint")
+                        : b.hint("check.import.duplicate.hint", name, imp.module())).build(),
+                "`" + name + "` is imported from both `" + earlier.module() + "` and `"
+                        + imp.module() + "`; one name cannot stand for two types");
+    }
+
+    /** Every type written in {@code m}: its data's fields, and its behaviors' and fns' signatures. */
+    static List<Ast.TypeRef> typeRefs(Ast.Module m) {
+        List<Ast.TypeRef> refs = new ArrayList<>();
+        for (Ast.Def def : m.defs()) {
+            if (def instanceof Ast.Data d) {
+                for (Ast.Field f : d.fields()) {
+                    collectTypeRefs(f.type(), refs);
+                }
+            }
+        }
+        for (Ast.BehaviorDef b : m.behaviors()) {
+            if (b instanceof Ast.SpecBehavior spec) {
+                for (Ast.Param p : spec.params()) {
+                    collectRetType(p.type(), refs);
+                }
+                collectRetType(spec.ret(), refs);
+            } else if (b instanceof Ast.PipeBehavior pipe) {
+                collectRetType(pipe.declaredOut(), refs);
+            }
+        }
+        for (Ast.FnDef fn : m.fns()) {
+            for (Ast.FnParam p : fn.params()) {
+                if (p.type() instanceof Ast.RetType rt) {
+                    collectRetType(rt, refs);
+                } else if (p.type() instanceof Ast.FnType ft) {
+                    ft.params().forEach(pt -> collectRetType(pt, refs));
+                    collectRetType(ft.result(), refs);
+                }
+            }
+            collectRetType(fn.declaredReturn(), refs);
+        }
+        return refs;
+    }
+
+    private static void collectRetType(Ast.RetType ret, List<Ast.TypeRef> refs) {
+        if (ret != null) {
+            ret.cases().forEach(c -> collectTypeRefs(c, refs));
+        }
+    }
+
+    private static void collectTypeRefs(Ast.TypeRef ref, List<Ast.TypeRef> refs) {
+        if (ref == null) {
+            return;
+        }
+        if (ref.name() != null) {
+            refs.add(ref);
+        }
+        collectTypeRefs(ref.arg(), refs);
+        if (ref.tupleElems() != null) {
+            ref.tupleElems().forEach(e -> collectTypeRefs(e, refs));
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -343,14 +343,14 @@ public final class Names {
      * The module with every written type name resolved to the declaration it denotes. A name that
      * denotes nothing is reported here, so nothing downstream ever reads an unresolved one.
      */
-    public record Resolved(String name) implements Key<Ast.Module> {
+    public record Resolution(String name) implements Key<Resolve.Resolved> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Ast.Module> compute(Db db) {
+        public Answer<Resolve.Resolved> compute(Db db) {
             Answer<Ast.Module> available = db.ask(new Front.Available(name));
             if (!available.present()) {
                 return Answer.absent(available.reports());
@@ -363,10 +363,134 @@ public final class Names {
                 return Answer.absent(scope.reports());
             }
             try {
-                return Answer.of(Resolve.module(available.value(), scope.value()));
+                return Answer.of(Resolve.resolving(available.value(), scope.value()));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
+        }
+    }
+
+    /** The resolved module — {@link Resolution} without the record of how it got there. */
+    public record Resolved(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            return resolution.present() ? Answer.of(resolution.value().module()) : Answer.absent();
+        }
+    }
+
+    /**
+     * What the name written at {@code offset} in a module's source denotes, or absent when nothing
+     * there is a name of a declared type.
+     *
+     * <p>This is what an editor is asking when the cursor is on an identifier. It reads the answers
+     * the resolve pass already gave, so a qualified reference names the module it names and not
+     * whatever this module happens to declare by the same spelling.
+     */
+    public record DenotedAt(String name, SourcePos at) implements Key<Resolve.Denotation> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Resolve.Denotation> compute(Db db) {
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            if (!resolution.present()) {
+                return Answer.absent();
+            }
+            Resolve.Denotation innermost = null;
+            for (Resolve.Denotation d : resolution.value().denotations()) {
+                if (!spans(d.pos(), d.written(), at)) {
+                    continue;
+                }
+                // A container writes its element's name inside its own span, so the shortest match
+                // is the one the cursor is actually on.
+                if (innermost == null || d.written().length() < innermost.written().length()) {
+                    innermost = d;
+                }
+            }
+            return innermost == null ? Answer.absent() : Answer.of(innermost);
+        }
+    }
+
+    /**
+     * The type the cursor is on at {@code offset}: the one a name there denotes, or — when the
+     * cursor is on a declaration's own name — that declaration.
+     *
+     * <p>One question, so an editor's go-to-definition, find-references and rename all agree about
+     * what the cursor is on. They used to each decide for themselves, by spelling.
+     */
+    public record TypeAt(String name, SourcePos at) implements Key<TypeName> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<TypeName> compute(Db db) {
+            Answer<Map<String, Ast.Def>> defs = db.ask(new Declarations(name));
+            if (defs.present()) {
+                for (Ast.Def def : defs.value().values()) {
+                    if (spans(def.pos(), def.name(), at)) {
+                        return Answer.of(new TypeName(name, def.name()));
+                    }
+                }
+            }
+            Resolve.Denotation denoted = db.ask(new DenotedAt(name, at)).value();
+            return denoted == null ? Answer.absent() : Answer.of(denoted.denotes());
+        }
+    }
+
+    /** Every place a module names {@code denoted}, wherever it was declared. */
+    public record UsesOf(String name, TypeName denoted) implements Key<List<Resolve.Denotation>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<List<Resolve.Denotation>> compute(Db db) {
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            if (!resolution.present()) {
+                return Answer.of(List.of());
+            }
+            List<Resolve.Denotation> uses = new ArrayList<>();
+            for (Resolve.Denotation d : resolution.value().denotations()) {
+                if (denoted.equals(d.denotes())) {
+                    uses.add(d);
+                }
+            }
+            return Answer.of(List.copyOf(uses));
+        }
+    }
+
+    /** Whether the name {@code written} starting at {@code start} covers {@code at}. A name is one
+     * line's worth of text, so a position on another line is not on it. */
+    static boolean spans(SourcePos start, String written, SourcePos at) {
+        return start != null && at != null && start.line() == at.line()
+                && at.column() >= start.column()
+                && at.column() <= start.column() + written.length();
+    }
+    public record DeclaredAt(TypeName denoted) implements Key<SourcePos> {
+        @Override
+        public String module() {
+            return denoted.module();
+        }
+
+        @Override
+        public Answer<SourcePos> compute(Db db) {
+            Answer<Map<String, Ast.Def>> defs = db.ask(new Declarations(denoted.module()));
+            if (!defs.present()) {
+                return Answer.absent();
+            }
+            Ast.Def def = defs.value().get(denoted.name());
+            return def == null || def.pos() == null ? Answer.absent() : Answer.of(def.pos());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Ordered.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Ordered.java
@@ -1,0 +1,28 @@
+package souther.compiler.query;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Unmodifiable copies that keep the order they were built in.
+ *
+ * <p>{@code Map.copyOf} and {@code Set.copyOf} do not, and order is load-bearing here. The modules
+ * of a compilation are answered in the order their sources were given, and "the first error" means
+ * the first one found in that order — so a set of module names in hash order silently changes which
+ * file a batch compile sends the author to.
+ */
+final class Ordered {
+
+    private Ordered() {}
+
+    static <K, V> Map<K, V> map(Map<K, V> m) {
+        return Collections.unmodifiableMap(new LinkedHashMap<>(m));
+    }
+
+    static <T> Set<T> set(Set<T> s) {
+        return Collections.unmodifiableSet(new LinkedHashSet<>(s));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -57,28 +57,33 @@ public final class Output {
                 Map<String, byte[]> classes = new LinkedHashMap<>(Backend.generate(
                         lowering.value().lowered(), scope.value(), typePackages(prepared.value()),
                         imported.value(), injected.value(), checked.value()));
-                Report stamped = stamp(db, classes);
-                return stamped == null ? Answer.of(Ordered.map(classes)) : Answer.absent(stamped);
+                stamp(db, classes);
+                return Answer.of(Ordered.map(classes));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
         }
 
-        /** Puts this module's declarations on its classes, as written. Null when it worked. */
-        private Report stamp(Db db, Map<String, byte[]> classes) {
+        /**
+         * Puts this module's declarations on its classes, as its source wrote them.
+         *
+         * <p>Nothing here can fail in a way worth reporting. A module with no source of its own was
+         * read off the path, and its jar was stamped where it was built; and the declarations are
+         * only asked for once the module has checked, so they are there.
+         */
+        private void stamp(Db db, Map<String, byte[]> classes) {
             Front.Layout.Of layout = db.ask(new Front.Layout()).value();
             String id = layout == null ? null : layout.idOfModule().get(name);
             if (id == null) {
-                return null;   // read off the path: its jar was stamped where it was built
+                return;
             }
             CstFrontend.Parsed written = db.ask(new Front.Parsed(id)).value();
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
             Set<String> injected = db.ask(new Bodies.Injected(name)).value();
             if (written == null || !sigs.present() || injected == null) {
-                return null;
+                return;
             }
             ModuleMetadata.stamp(classes, written.module(), written.slices(), sigs.value(), injected);
-            return null;
         }
 
         /** Maps each imported type name to its declaring module, for cross-package references. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -1,0 +1,255 @@
+package souther.compiler.query;
+
+import souther.compiler.MemoryClassLoader;
+import souther.compiler.ast.Ast;
+import souther.compiler.check.DataChecker;
+import souther.compiler.check.Lower;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeChecker;
+import souther.compiler.codegen.Backend;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.meta.ModuleMetadata;
+import souther.compiler.meta.ModulePath;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The bytecode a module comes to, and the two things that can only be asked once it exists: whether
+ * its constant constructions satisfy their invariants, and whether its examples hold.
+ *
+ * <p>Both of those load classes, so both read {@link All} rather than one module's own — an example
+ * may reach across an import, and the class it reaches has to be there.
+ */
+public final class Output {
+
+    private Output() {}
+
+    /**
+     * One module's classes, with its declarations stamped on. The declarations go on before anything
+     * loads a class, so what a jar carries is the same bytes this compile checked.
+     */
+    public record Classes(String name) implements Key<Map<String, byte[]>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, byte[]>> compute(Db db) {
+            Answer<TypeChecker.Checked> checked = db.ask(new Bodies.Checked(name));
+            Answer<Lower.Lowered> lowering = db.ask(new Bodies.Lowering(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> imported = db.ask(new Bodies.Imported(name));
+            Answer<Set<String>> injected = db.ask(new Bodies.ImportedInjected(name));
+            Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
+            if (!checked.present() || !lowering.present() || !scope.present() || !imported.present()
+                    || !injected.present() || !prepared.present()) {
+                return Answer.absent();
+            }
+            try {
+                Map<String, byte[]> classes = new LinkedHashMap<>(Backend.generate(
+                        lowering.value().lowered(), scope.value(), typePackages(prepared.value()),
+                        imported.value(), injected.value(), checked.value()));
+                Report stamped = stamp(db, classes);
+                return stamped == null ? Answer.of(Ordered.map(classes)) : Answer.absent(stamped);
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+
+        /** Puts this module's declarations on its classes, as written. Null when it worked. */
+        private Report stamp(Db db, Map<String, byte[]> classes) {
+            Front.Layout.Of layout = db.ask(new Front.Layout()).value();
+            String id = layout == null ? null : layout.idOfModule().get(name);
+            if (id == null) {
+                return null;   // read off the path: its jar was stamped where it was built
+            }
+            CstFrontend.Parsed written = db.ask(new Front.Parsed(id)).value();
+            Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
+            Set<String> injected = db.ask(new Bodies.Injected(name)).value();
+            if (written == null || !sigs.present() || injected == null) {
+                return null;
+            }
+            ModuleMetadata.stamp(classes, written.module(), written.slices(), sigs.value(), injected);
+            return null;
+        }
+
+        /** Maps each imported type name to its declaring module, for cross-package references. */
+        private Map<String, String> typePackages(Ast.Module m) {
+            Map<String, String> packages = new LinkedHashMap<>();
+            for (Ast.Import imp : m.imports()) {
+                for (String imported : imp.names()) {
+                    packages.put(imported, imp.module());
+                }
+            }
+            return packages;
+        }
+    }
+
+    /**
+     * Every class this compilation generates. A module that did not check contributes none, which is
+     * what makes an example of a module that reaches it fail to load rather than run against
+     * something that was never checked.
+     */
+    public record All() implements Key<Map<String, byte[]>> {
+        @Override
+        public Answer<Map<String, byte[]>> compute(Db db) {
+            List<String> declared = db.ask(new Front.Declared()).value();
+            Map<String, byte[]> all = new LinkedHashMap<>();
+            if (declared == null) {
+                return Answer.of(Map.of());
+            }
+            for (String name : declared) {
+                Map<String, byte[]> classes = db.ask(new Classes(name)).value();
+                if (classes != null) {
+                    all.putAll(classes);
+                }
+            }
+            return Answer.of(Ordered.map(all));
+        }
+    }
+
+    /** The class loader an evaluation runs against: this compilation's classes over the ones the
+     * projects it depends on already built. */
+    static ClassLoader loader(Db db, Map<String, byte[]> classes) {
+        ModulePath path = db.ask(new Front.Path()).value();
+        ClassLoader parent = path == null ? Output.class.getClassLoader()
+                : path.loader(Output.class.getClassLoader());
+        return new MemoryClassLoader(classes, parent);
+    }
+
+    /**
+     * Whether each constant newtype construction in a module satisfies its invariant, by running the
+     * same bytecode a run-time construction would. A check that cannot be loaded or run here is left
+     * to the run-time check.
+     */
+    public record ConstConstructions(String name) implements Key<Boolean> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Boolean> compute(Db db) {
+            Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            if (!prepared.present() || !scope.present()) {
+                return Answer.absent();
+            }
+            List<DataChecker.ConstCheck> checks;
+            try {
+                checks = DataChecker.constNewtypeChecks(prepared.value(), scope.value());
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+            if (checks.isEmpty()) {
+                return Answer.of(Boolean.TRUE);
+            }
+            Map<String, byte[]> classes = db.ask(new All()).value();
+            if (classes == null) {
+                return Answer.absent();
+            }
+            ClassLoader loader = loader(db, classes);
+            List<Report> reports = new ArrayList<>();
+            for (DataChecker.ConstCheck check : checks) {
+                boolean holds;
+                try {
+                    Class<?> ctfe = Class.forName(
+                            check.type().module() + "." + check.type().name() + "$Ctfe", true, loader);
+                    holds = (boolean) ctfe.getMethod("check", paramClass(check.value()))
+                            .invoke(null, check.value());
+                } catch (ReflectiveOperationException | LinkageError _) {
+                    continue;   // cannot evaluate at compile time; the run-time check still applies
+                }
+                if (!holds) {
+                    String shown = check.typeName() + "("
+                            + (check.value() instanceof String s ? "\"" + s + "\"" : check.value()) + ")";
+                    reports.add(Report.raised(
+                            Diagnostic.of(null, "check.const.invariant").title("check.construct.title")
+                                    .at(check.pos()).args(shown).build(),
+                            "`" + shown + "` violates its invariant."));
+                }
+            }
+            return reports.isEmpty() ? Answer.of(Boolean.TRUE) : Answer.absent(reports);
+        }
+
+        private Class<?> paramClass(Object v) {
+            if (v instanceof Long) {
+                return long.class;
+            }
+            if (v instanceof Boolean) {
+                return boolean.class;
+            }
+            return v.getClass();   // String, BigDecimal
+        }
+    }
+
+    /**
+     * The examples of one module, evaluated. Every module's examples are evaluated before any
+     * failure stops a compile, so a change to a widely-imported data says how far it reaches in one
+     * compile rather than one module per round.
+     */
+    public record Examples(String name, String sourceId) implements Key<Boolean> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public String sourceId() {
+            return sourceId;
+        }
+
+        @Override
+        public Answer<Boolean> compute(Db db) {
+            Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
+            if (!prepared.present() || !scope.present() || !sigs.present()) {
+                return Answer.absent();
+            }
+            if (db.ask(new Bodies.Checked(name)).value() == null) {
+                return Answer.absent();   // a module that did not check has nothing to run
+            }
+            Map<String, byte[]> classes = db.ask(new All()).value();
+            if (classes == null) {
+                return Answer.absent();
+            }
+            Ast.Module rows = written(db, prepared.value());
+            if (rows.examples().isEmpty()) {
+                return Answer.of(Boolean.TRUE);
+            }
+            List<Report> reports = new ArrayList<>();
+            for (Diagnostic failure : souther.compiler.ExampleVerifier.check(rows, scope.value(),
+                    sigs.value(), classes, loader(db, Map.of()))) {
+                reports.add(Report.of(failure));
+            }
+            return reports.isEmpty() ? Answer.of(Boolean.TRUE) : Answer.absent(reports);
+        }
+
+        /** The module carrying only the rows written in {@code sourceId}. The fakes stay whole: a
+         * module's own fakes are what its attached files' rows run against, and the other way
+         * round. */
+        private Ast.Module written(Db db, Ast.Module m) {
+            List<String> origins = db.ask(new Front.ExampleOrigins(name)).value();
+            if (origins == null || origins.size() != m.examples().size()) {
+                return m;
+            }
+            List<Ast.Example> mine = new ArrayList<>();
+            for (int i = 0; i < origins.size(); i++) {
+                if (origins.get(i).equals(sourceId)) {
+                    mine.add(m.examples().get(i));
+                }
+            }
+            return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), m.defs(),
+                    m.behaviors(), m.fns(), mine, m.fakes(), m.exampleFileTarget(), m.pos());
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Report.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Report.java
@@ -1,0 +1,87 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.DiagnosticRenderer;
+import souther.compiler.diag.Severity;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * One thing a query found: the structured {@link Diagnostic} a renderer works from, and the
+ * one-line English text {@link CompileException#getMessage()} has always returned for it.
+ *
+ * <p>The second field is here because the first cannot reproduce it. A migrated throw site builds a
+ * catalog-keyed diagnostic and passes its English body separately to
+ * {@link CompileException#of(Diagnostic, String)}; that body never reaches the diagnostic, and it
+ * cannot be put there, because {@link DiagnosticRenderer} prefers a literal message over a catalog
+ * key — every migrated site would go back to rendering English instead of the reader's locale.
+ *
+ * <p>So a query wrapping a pass that still throws keeps both halves, and a caller that has to throw
+ * again — a batch compile stopping at the first error — raises the same exception the pass did. A
+ * report built any other way has no text of its own and renders one when asked.
+ *
+ * @param diagnostic what was found
+ * @param legacyMessage the text the pass raised it with, or null when it was not raised
+ */
+public record Report(Diagnostic diagnostic, String legacyMessage) {
+
+    public boolean isError() {
+        return diagnostic.severity() == Severity.ERROR;
+    }
+
+    /** A report with no raised text of its own. */
+    public static Report of(Diagnostic diagnostic) {
+        return new Report(diagnostic, null);
+    }
+
+    /**
+     * A report carrying the English body a pass would have raised it with — for a check moved off a
+     * throw and into a query, where the message a caller reads should not change because the check
+     * moved.
+     */
+    public static Report raised(Diagnostic diagnostic, String body) {
+        return new Report(diagnostic, CompileException.of(diagnostic, body).getMessage());
+    }
+
+    /** A thrown error as reports, one per diagnostic it carries. The exception's message belongs to
+     * its first diagnostic; the rest never had one of their own. */
+    public static List<Report> of(CompileException e) {
+        List<Diagnostic> diagnostics = e.diagnostics();
+        if (diagnostics.isEmpty()) {
+            return List.of(new Report(Diagnostic.literal(null, null, e.getMessage()), e.getMessage()));
+        }
+        List<Report> reports = new ArrayList<>();
+        reports.add(new Report(diagnostics.get(0), e.getMessage()));
+        for (int i = 1; i < diagnostics.size(); i++) {
+            reports.add(of(diagnostics.get(i)));
+        }
+        return List.copyOf(reports);
+    }
+
+    /** Every report of every answer, in order — for a key that passes on what it read. */
+    public static List<Report> ofAll(List<? extends Answer<?>> answers) {
+        List<Report> all = new ArrayList<>();
+        for (Answer<?> a : answers) {
+            all.addAll(a.reports());
+        }
+        return List.copyOf(all);
+    }
+
+    /** Only the errors among {@code reports} — what a caller that stops at the first one looks at,
+     * since a warning is not a reason to stop. */
+    public static List<Report> errorsIn(List<Report> reports) {
+        return reports.stream().filter(Report::isError).toList();
+    }
+
+    /** This report as an error to throw. One built from a raised exception throws that exception's
+     * message again; one built any other way renders its own, in English, because that message has
+     * always been English and a test that reads it should not move with the reader's locale. */
+    public CompileException asException() {
+        return legacyMessage == null
+                ? CompileException.of(diagnostic, DiagnosticRenderer.body(diagnostic, Locale.ENGLISH))
+                : new CompileException(diagnostic, legacyMessage);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -42,11 +42,11 @@ public final class Shapes {
         public Answer<Ast.Module> compute(Db db) {
             Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
             if (!resolved.present()) {
-                return Answer.absent(resolved.reports());
+                return Answer.absent();
             }
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
             if (!scope.present()) {
-                return Answer.absent(scope.reports());
+                return Answer.absent();
             }
             try {
                 Ast.Module derived = Deriver.derive(resolved.value(), scope.value());
@@ -86,11 +86,11 @@ public final class Shapes {
         public Answer<Ast.Module> compute(Db db) {
             Answer<Ast.Module> derived = db.ask(new Derived(name));
             if (!derived.present()) {
-                return Answer.absent(derived.reports());
+                return Answer.absent();
             }
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.DERIVED);
             if (!scope.present()) {
-                return Answer.absent(scope.reports());
+                return Answer.absent();
             }
             try {
                 return Answer.of(NewtypeDesugar.rewrite(derived.value(), scope.value()));
@@ -118,7 +118,7 @@ public final class Shapes {
         public Answer<Ast.Module> compute(Db db) {
             Answer<Ast.Module> desugared = db.ask(new Desugared(name));
             if (!desugared.present()) {
-                return Answer.absent(desugared.reports());
+                return Answer.absent();
             }
             Ast.Module m = desugared.value();
             try {

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -1,0 +1,153 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.HelperInliner;
+import souther.compiler.check.NewtypeDesugar;
+import souther.compiler.check.Symbols;
+import souther.compiler.derive.Deriver;
+import souther.compiler.diag.CompileException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What each declaration becomes before anything is checked against it: its codecs derived, the
+ * invariants of the types it spreads settled into it, and its newtype constructors turned into
+ * constructions.
+ *
+ * <p>These used to be three passes over a whole module in a fixed order, and getting that order
+ * wrong was its own class of defect. Here the order is not written anywhere: each answer names what
+ * it reads, and reading it is what makes it happen first.
+ */
+public final class Shapes {
+
+    private Shapes() {}
+
+    /**
+     * A module with its codecs derived and the invariants of every type it spreads settled into the
+     * spreading declaration.
+     *
+     * <p>The two go together because settling reads the spread source through the same symbols the
+     * derive produced: an invariant that arrives by spread is part of the declaration from here on,
+     * and a later pass that read the declaration before settling would read a type without it.
+     */
+    public record Derived(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            if (!resolved.present()) {
+                return Answer.absent(resolved.reports());
+            }
+            Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
+            if (!scope.present()) {
+                return Answer.absent(scope.reports());
+            }
+            try {
+                Ast.Module derived = Deriver.derive(resolved.value(), scope.value());
+                return Answer.of(HelperInliner.withSettledInvariants(derived, scope.value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /** A derived module's declarations by name — what every later stage resolves a type against. */
+    public record DerivedDeclarations(String name) implements Key<Map<String, Ast.Def>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Ast.Def>> compute(Db db) {
+            Answer<Ast.Module> m = db.ask(new Derived(name));
+            return m.present() ? Answer.of(Names.defsOf(m.value())) : Answer.absent();
+        }
+    }
+
+    /**
+     * A module with each newtype construction — {@code 金額(500)} — rewritten to a construction of
+     * that type. Only the module's fns change; what it declares is what {@link Derived} left, which
+     * is why every stage below reads its declarations from there and not from here.
+     */
+    public record Desugared(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Ast.Module> derived = db.ask(new Derived(name));
+            if (!derived.present()) {
+                return Answer.absent(derived.reports());
+            }
+            Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.DERIVED);
+            if (!scope.present()) {
+                return Answer.absent(scope.reports());
+            }
+            try {
+                return Answer.of(NewtypeDesugar.rewrite(derived.value(), scope.value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /**
+     * The module a check and a codegen actually run over: the desugared one, plus the recursive
+     * prelude helpers it reaches, as its own fns under their qualified names.
+     *
+     * <p>A recursive prelude helper cannot be inlined — it would expand forever — so it is emitted
+     * as one of the module's methods, the same as a module-own recursive helper. Only the reached
+     * ones are added; a module that never folds gets none.
+     */
+    public record Prepared(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Ast.Module> desugared = db.ask(new Desugared(name));
+            if (!desugared.present()) {
+                return Answer.absent(desugared.reports());
+            }
+            Ast.Module m = desugared.value();
+            try {
+                Map<String, Ast.FnDef> injected =
+                        HelperInliner.forModule(m).injectedRecursiveHelpers();
+                if (injected.isEmpty()) {
+                    return Answer.of(m);
+                }
+                List<Ast.FnDef> fns = new ArrayList<>(m.fns());
+                fns.addAll(injected.values());
+                return Answer.of(new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(),
+                        m.imports(), m.defs(), m.behaviors(), fns, m.examples(), m.fakes(),
+                        m.exampleFileTarget(), m.pos()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /** What names mean in a module once everything is derived — the scope a check runs in. */
+    public record Scope(String name) implements Key<Symbols> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Symbols> compute(Db db) {
+            return Names.symbols(db, name, Names.Stage.DERIVED);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleTest.java
@@ -4,6 +4,12 @@ import souther.compiler.diag.CompileException;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+import souther.compiler.query.Report;
+
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -263,27 +269,12 @@ class CompileExampleTest {
                   | (申請準備中 { 申請者 = 従業員ID("emp-1"), 予定費用 = 金額(200000) }, "2026-07-14") -> 提出済み
                   | (申請準備中 { 申請者 = 従業員ID("emp-1"), 予定費用 = 金額(300000) }, "2026-07-14") -> 提出済み
                 """;
-        souther.compiler.ast.Ast.Module module =
-                souther.compiler.frontend.CstFrontend.parse(model, "Main");
-        module = souther.compiler.check.Exposing.rewrite(module);
-        module = souther.compiler.check.Resolve.module(module,
-                souther.compiler.check.TypeChecker.symbols(module));
-        module = souther.compiler.derive.Deriver.derive(module);
-        module = souther.compiler.check.HelperInliner.withSettledInvariants(
-                module, souther.compiler.check.TypeChecker.symbols(module));
-        module = souther.compiler.check.NewtypeDesugar.rewrite(module,
-                souther.compiler.check.TypeChecker.symbols(module));
-        var symbols = souther.compiler.check.TypeChecker.symbols(module);
-        var lowering = souther.compiler.check.Lower.run(
-                module, symbols, java.util.Map.of(), java.util.Set.of());
-        module = lowering.settled();
-        var lowered = lowering.lowered();
-        var checked = souther.compiler.check.TypeChecker
-                .checkAndElaborate(module, symbols, java.util.Map.of(), java.util.Set.of(), lowered)
-                .checked();
-        var classes = souther.compiler.codegen.Backend.generate(lowered, checked);
-        var sigs = souther.compiler.check.PipelineSigs.signatures(module, symbols);
-        var fails = ExampleVerifier.check(module, symbols, sigs, classes);
+        // Every failing row is reported, not just the first: the query answers with all of them.
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        String moduleName = compilation.modules().get(0);
+        compilation.answerEverything();
+        List<Report> fails = compilation.db()
+                .ask(new Output.Examples(moduleName, compilation.sourceIds().get(0))).reports();
         assertEquals(2, fails.size());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
@@ -1,20 +1,12 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.query.Compilation;
 
-import souther.compiler.ast.Ast;
-import souther.compiler.check.Lower;
-import souther.compiler.check.Resolve;
-import souther.compiler.check.Symbols;
-import souther.compiler.check.TypeChecker;
-import souther.compiler.codegen.Backend;
-import souther.compiler.derive.Deriver;
-import souther.compiler.frontend.CstFrontend;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,15 +20,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 class CompileTypeVariableTest {
 
-    /** Compiles a core (reserved-namespace) module directly, bypassing the user-facing guard. */
+    /** Compiles a core (reserved-namespace) module, which the user-facing guard would reject. */
     private static Map<String, byte[]> compileCore(String src) {
-        Ast.Module m = Deriver.derive(Resolve.module(CstFrontend.parse(src)));
-        Symbols symbols = TypeChecker.symbols(m);
-        Lower.Lowered lowering = Lower.run(m, symbols, Map.of(), Set.of());
-        Ast.Module lowered = lowering.lowered();
-        TypeChecker.Checked checked =
-                TypeChecker.checkOrThrow(lowering.settled(), symbols, Map.of(), Set.of(), lowered);
-        return Backend.generate(lowered, checked);
+        Compilation compilation = Compilation.ofCoreSource(src);
+        compilation.answerEverything();
+        CompileException failed = compilation.firstError(compilation.db().allReports());
+        if (failed != null) {
+            throw failed;
+        }
+        return compilation.classes();
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/MultiFileDiagnosticOriginTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/MultiFileDiagnosticOriginTest.java
@@ -123,7 +123,7 @@ class MultiFileDiagnosticOriginTest {
     }
 
     @Test
-    void aFailingExampleInAMergedModuleNamesNoSource() {
+    void aFailingExampleNamesTheFileItWasWrittenIn() {
         String target = """
                 module t
                 data Out = { v: Int }
@@ -140,8 +140,8 @@ class MultiFileDiagnosticOriginTest {
         CompileException e = assertThrows(CompileException.class,
                 () -> Compiler.compileModules(List.of(target, examples)));
 
-        assertEquals(-1, e.sourceIndex(),
-                "the example was written in the other file, so neither file's line is quoted");
+        assertEquals(1, e.sourceIndex(),
+                "the row is written in the `examples for` file, so that is the file quoted");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/meta/ModulePathTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/meta/ModulePathTest.java
@@ -12,6 +12,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -78,5 +80,17 @@ class ModulePathTest {
             assertArrayEquals(CLASS, ModulePath.ofClassPath(List.of(jar)).bytes("shared.billing.Amount"));
         }
         Files.delete(jar);   // a handle left open would keep this from being replaceable on Windows
+    }
+
+    @Test
+    void twoPathsOverTheSameEntriesAreTheSamePath(@TempDir Path dir) throws IOException {
+        // A language server rebuilds its path on every request and keeps one compilation between
+        // edits. If a path were only ever equal to itself, that compilation would be thrown away and
+        // started again on every keystroke, and nothing would say so.
+        Path classes = classesDir(dir, CLASS);
+        assertEquals(ModulePath.ofClassPath(List.of(classes)),
+                ModulePath.ofClassPath(List.of(classes)));
+        assertNotEquals(ModulePath.ofClassPath(List.of(classes)),
+                ModulePath.ofClassPath(List.of()));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/CyclicModulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/CyclicModulesTest.java
@@ -1,0 +1,109 @@
+package souther.compiler.query;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Modules that name each other are rejected, and rejecting them is where it stops.
+ *
+ * <p>A cycle is the one thing that makes the questions below it unanswerable in the strict sense:
+ * what a module's behaviors are typed as depends on the module it names, which depends on this one.
+ * Reporting the cycle and then compiling anyway asks that question and gets no answer.
+ *
+ * <p>The editor path is what this is about. A batch compile stops at the first structural problem,
+ * so it never reached the rest; an editor reports everything and carries on, and had to be told
+ * where to stop.
+ */
+class CyclicModulesTest {
+
+    private static final String A = """
+            module m.a exposing ( A )
+            import m.b ( B )
+            data A = { b: B }
+            """;
+
+    private static final String B = """
+            module m.b exposing ( B )
+            import m.a ( A )
+            data B = String
+            """;
+
+    /** Two modules whose behaviors name each other, qualified — no import line written. */
+    private static final String X = """
+            module cyc.x exposing ( A, B, f, g : B )
+            data A = { n: Int }
+            data B = { n: Int }
+            behavior f : (a: A) -> B constructs B
+            let f (a) = B { n = a.n }
+            behavior g = cyc.y.h >-> f
+            """;
+
+    private static final String Y = """
+            module cyc.y exposing ( A, h, k : A )
+            data A = { n: Int }
+            behavior h : (a: A) -> A constructs A
+            let h (a) = A { n = a.n }
+            behavior k = cyc.x.f >-> h
+            """;
+
+    private static Map<String, String> documents(String first, String second) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("first.sou", first);
+        byId.put("second.sou", second);
+        return byId;
+    }
+
+    @Test
+    void anEditorIsToldAboutACycleThroughImports() {
+        Map<String, List<Diagnostic>> found =
+                Compiler.diagnoseModules(documents(A, B), Set.of());
+
+        assertTrue(found.values().stream().flatMap(List::stream)
+                        .anyMatch(d -> "E1501".equals(d.code())),
+                "the editor reports the cycle, as the batch compiler does");
+    }
+
+    @Test
+    void anEditorIsToldAboutACycleThroughQualifiedBehaviorReferences() {
+        // Neither module writes an import line; each names the other's behavior as a stage. That is
+        // the same cycle, and following only the import lines would not see it.
+        Map<String, List<Diagnostic>> found =
+                Compiler.diagnoseModules(documents(X, Y), Set.of());
+
+        assertTrue(found.values().stream().flatMap(List::stream)
+                        .anyMatch(d -> "E1501".equals(d.code())),
+                "a cycle written without an import line is still a cycle");
+    }
+
+    @Test
+    void nothingIsCompiledOutOfACycle() {
+        Compilation compilation = Compilation.ofDocuments(documents(X, Y), Set.of(),
+                souther.compiler.meta.ModulePath.EMPTY);
+        compilation.diagnostics();
+
+        assertEquals(Map.of(), compilation.classes(),
+                "a module whose signatures cannot be worked out emits nothing");
+        assertTrue(compilation.db().isComputed(new Output.All()),
+                "the cycle is stopped before anything asks a question that answers itself, so the"
+                        + " answers above it are kept rather than redone on every ask");
+    }
+
+    @Test
+    void aBatchCompileStopsAtTheCycle() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(A, B)));
+        assertEquals("E1501", e.diagnostic().code());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
@@ -188,6 +188,75 @@ class DbTest {
         assertThrows(IllegalStateException.class, () -> db.ask(new Loop()));
     }
 
+    /** Two files joined, so an edit to one can be watched for its effect on the other. */
+    record Length(String file) implements Key<Integer> {
+        @Override
+        public Answer<Integer> compute(Db db) {
+            ran("length:" + file);
+            Answer<String> text = db.ask(new Text(file));
+            return text.present() ? Answer.of(text.value().length()) : Answer.absent();
+        }
+    }
+
+    record Longest(String left, String right) implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            ran("longest");
+            int a = db.ask(new Length(left)).value();
+            int b = db.ask(new Length(right)).value();
+            return Answer.of(a >= b ? left : right);
+        }
+    }
+
+    @Test
+    void recomputesWhatAnEditCanHaveChanged() {
+        Db db = new Db().set(new Text("a.sou"), "one").set(new Text("b.sou"), "two");
+        assertEquals(3, db.ask(new Length("a.sou")).value());
+        db.set(new Text("a.sou"), "seven!");
+        assertEquals(6, db.ask(new Length("a.sou")).value());
+        assertEquals(2, runs("length:a.sou"));
+    }
+
+    @Test
+    void leavesAloneWhatTheEditCannotReach() {
+        Db db = new Db().set(new Text("a.sou"), "one").set(new Text("b.sou"), "two");
+        db.ask(new Length("b.sou"));
+        db.set(new Text("a.sou"), "changed");
+        db.ask(new Length("b.sou"));
+        assertEquals(1, runs("length:b.sou"));
+    }
+
+    @Test
+    void stopsWhereTheAnswerCameOutTheSame() {
+        Db db = new Db().set(new Text("a.sou"), "one").set(new Text("b.sou"), "xx");
+        assertEquals("a.sou", db.ask(new Longest("a.sou", "b.sou")).value());
+        // A different text of the same length: the length is recomputed and comes out equal, so
+        // nothing that read the length has anything to do.
+        db.set(new Text("a.sou"), "two");
+        assertEquals("a.sou", db.ask(new Longest("a.sou", "b.sou")).value());
+        assertEquals(2, runs("length:a.sou"));
+        assertEquals(1, runs("longest"));
+    }
+
+    @Test
+    void doesNothingWhenTheTextIsSetToWhatItAlreadyWas() {
+        Db db = new Db().set(new Text("a.sou"), "one");
+        db.ask(new Length("a.sou"));
+        db.set(new Text("a.sou"), "one");
+        db.ask(new Length("a.sou"));
+        assertEquals(1, runs("length:a.sou"));
+    }
+
+    @Test
+    void reportsWhatTheCurrentAnswersFoundRatherThanEveryAttempt() {
+        Db db = new Db().set(new Text("a.sou"), "one");
+        db.ask(new Complains("nope"));
+        assertEquals(1, db.allReports().size());
+        db.set(new Text("a.sou"), "two");
+        db.ask(new Complains("nope"));
+        assertEquals(1, db.allReports().size(), "the same complaint is not collected twice");
+    }
+
     @Test
     void reportsWhetherAKeyHasBeenComputed() {
         Db db = new Db().set(new Text("a.sou"), "x");

--- a/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
@@ -1,0 +1,198 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The query engine on its own: what it memoises, what it records, and what it does when a question
+ * turns out to depend on itself. Nothing here knows about Souther — the keys are toys, so what is
+ * being tested is the engine and not a pass that happens to run on it.
+ */
+class DbTest {
+
+    /** How often each key's {@code compute} ran. A key is a value, so it cannot hold the counter
+     * itself; the count lives here and the keys reach it as the enclosing class's state. */
+    private static final Map<String, Integer> RUNS = new HashMap<>();
+
+    private static void ran(String name) {
+        RUNS.merge(name, 1, Integer::sum);
+    }
+
+    private static int runs(String name) {
+        return RUNS.getOrDefault(name, 0);
+    }
+
+    @BeforeEach
+    void clearCounts() {
+        RUNS.clear();
+    }
+
+    /** The text of a file: given from outside, never computed. */
+    record Text(String file) implements Input<String> {}
+
+    /** That text in upper case — one computed key reading one input. */
+    record Shouted(String file) implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            ran("shouted:" + file);
+            Answer<String> text = db.ask(new Text(file));
+            if (!text.present()) {
+                return Answer.absent();
+            }
+            return Answer.of(text.value().toUpperCase());
+        }
+    }
+
+    /** Two shouted files joined, so a key with more than one dependency can be observed. */
+    record Both(String left, String right) implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            ran("both");
+            return Answer.of(db.ask(new Shouted(left)).value() + db.ask(new Shouted(right)).value());
+        }
+    }
+
+    /** A key that reports rather than answers. */
+    record Complains(String about) implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            ran("complains");
+            return Answer.absent(Report.of(Diagnostic.literal(null, "E9999", about)));
+        }
+    }
+
+    @Test
+    void answersAKey() {
+        Db db = new Db().set(new Text("a.sou"), "module a");
+        assertEquals("MODULE A", db.ask(new Shouted("a.sou")).value());
+    }
+
+    @Test
+    void computesEachKeyOnce() {
+        Db db = new Db().set(new Text("a.sou"), "module a");
+        db.ask(new Shouted("a.sou"));
+        db.ask(new Shouted("a.sou"));
+        assertEquals(1, runs("shouted:a.sou"));
+    }
+
+    @Test
+    void sharesOneComputationBetweenTwoAskers() {
+        Db db = new Db().set(new Text("a.sou"), "x").set(new Text("b.sou"), "y");
+        db.ask(new Both("a.sou", "b.sou"));
+        db.ask(new Shouted("a.sou"));
+        assertEquals(1, runs("shouted:a.sou"));
+    }
+
+    @Test
+    void recordsWhatAKeyRead() {
+        Db db = new Db().set(new Text("a.sou"), "x").set(new Text("b.sou"), "y");
+        db.ask(new Both("a.sou", "b.sou"));
+        assertEquals(Set.of(new Shouted("a.sou"), new Shouted("b.sou")),
+                db.dependenciesOf(new Both("a.sou", "b.sou")));
+        assertEquals(Set.of(new Text("a.sou")), db.dependenciesOf(new Shouted("a.sou")));
+    }
+
+    @Test
+    void reportsTravelWithTheAnswer() {
+        Db db = new Db();
+        Answer<String> answer = db.ask(new Complains("nope"));
+        assertNull(answer.value());
+        assertFalse(answer.present());
+        assertTrue(answer.hasError());
+        assertEquals(1, answer.reports().size());
+        assertEquals("nope", answer.reports().get(0).diagnostic().literalMessage());
+    }
+
+    @Test
+    void raisesTheMessageAPassRaisedItWith() {
+        Diagnostic d = Diagnostic.of("E1234", "check.module.duplicate").build();
+        CompileException raised = CompileException.of(d, "duplicate module `a`");
+        List<Report> reports = Report.of(raised);
+        assertEquals(raised.getMessage(), reports.get(0).asException().getMessage());
+    }
+
+    @Test
+    void memoisesAnAbsentAnswerToo() {
+        Db db = new Db();
+        db.ask(new Complains("nope"));
+        db.ask(new Complains("nope"));
+        assertEquals(1, runs("complains"));
+    }
+
+    @Test
+    void anInputWithNoValueIsAbsentRatherThanAnError() {
+        Db db = new Db();
+        assertFalse(db.ask(new Text("missing.sou")).present());
+        assertFalse(db.ask(new Shouted("missing.sou")).present());
+    }
+
+    /** A key that reads itself through another, with an answer for the case. */
+    record Ping(int depth) implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            ran("ping" + depth);
+            return Answer.of("ping" + depth + "-" + db.ask(new Ping(1 - depth)).value());
+        }
+
+        @Override
+        public Answer<String> onCycle(List<Key<?>> cycle) {
+            return Answer.of("cycle" + cycle.size());
+        }
+    }
+
+    /** A key that reads itself and has nothing to say about it. */
+    record Loop() implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            return db.ask(new Loop());
+        }
+    }
+
+    @Test
+    void aCycleGetsTheReenteredKeysOwnAnswer() {
+        Db db = new Db();
+        // Ping(0) reads Ping(1), which reads Ping(0) again: the second reading is the cycle, and
+        // both keys are on the stack when it is found.
+        assertEquals("ping0-ping1-cycle2", db.ask(new Ping(0)).value());
+    }
+
+    @Test
+    void memoisesNothingOnACycle() {
+        Db db = new Db();
+        db.ask(new Ping(0));
+        db.ask(new Ping(0));
+        // A cyclic answer depends on where the cycle was entered, so keeping it would make a later
+        // asker's answer depend on who asked first.
+        assertEquals(2, runs("ping0"));
+        assertFalse(db.isComputed(new Ping(0)));
+        assertFalse(db.isComputed(new Ping(1)));
+    }
+
+    @Test
+    void aCycleWithNoAnswerIsAProgrammingError() {
+        Db db = new Db();
+        assertThrows(IllegalStateException.class, () -> db.ask(new Loop()));
+    }
+
+    @Test
+    void reportsWhetherAKeyHasBeenComputed() {
+        Db db = new Db().set(new Text("a.sou"), "x");
+        assertFalse(db.isComputed(new Shouted("a.sou")));
+        db.ask(new Shouted("a.sou"));
+        assertTrue(db.isComputed(new Shouted("a.sou")));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
@@ -257,6 +257,51 @@ class DbTest {
         assertEquals(1, db.allReports().size(), "the same complaint is not collected twice");
     }
 
+    /** Whether {@link Fragile} still takes the path that cycles and then throws. */
+    private static boolean fragile = true;
+
+    /**
+     * A key that reaches a cycle and then fails outright — an internal fault, not a compile error,
+     * which is what a compile error is a value for. The store has to come out of it as it went in.
+     */
+    record Fragile(int depth) implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            ran("fragile" + depth);
+            if (depth == 0) {
+                if (!fragile) {
+                    return Answer.of("ok");
+                }
+                db.ask(new Fragile(1));
+                throw new IllegalStateException("boom");
+            }
+            db.ask(new Fragile(0));
+            return Answer.of("inner");
+        }
+
+        @Override
+        public Answer<String> onCycle(List<Key<?>> cycle) {
+            return Answer.of("cycle");
+        }
+    }
+
+    @Test
+    void aFailedAnswerLeavesNothingBehind() {
+        Db db = new Db();
+        assertThrows(IllegalStateException.class, () -> db.ask(new Fragile(0)));
+
+        // The store is used again — a language server keeps one across edits, so a fault in one
+        // request must not make every later answer to that question uncacheable.
+        fragile = false;
+        try {
+            assertEquals("ok", db.ask(new Fragile(0)).value());
+            db.ask(new Fragile(0));
+            assertEquals(2, runs("fragile0"), "the answer after the fault is kept like any other");
+        } finally {
+            fragile = true;
+        }
+    }
+
     @Test
     void reportsWhetherAKeyHasBeenComputed() {
         Db db = new Db().set(new Text("a.sou"), "x");

--- a/souther-compiler/src/test/java/souther/compiler/query/DuplicateModuleForgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/DuplicateModuleForgetTest.java
@@ -1,0 +1,56 @@
+package souther.compiler.query;
+
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Closing one of two sources that claim the same module name.
+ *
+ * <p>Forgetting a source drops the answers about the module it declared, and while two sources claim
+ * one name only one of them is the module — so those answers were all about the one being closed.
+ * The other source becomes the module and is answered afresh.
+ */
+class DuplicateModuleForgetTest {
+
+    private static final String FIRST = """
+            module shop.cart exposing ( Total )
+
+            data Total = Int
+            """;
+
+    private static final String SECOND = """
+            module shop.cart exposing ( Total, Extra )
+
+            data Total = String
+
+            data Extra = Int
+            """;
+
+    @Test
+    void theSurvivorBecomesTheModule() {
+        Map<String, String> both = new LinkedHashMap<>();
+        both.put("a.sou", FIRST);
+        both.put("b.sou", SECOND);
+        Compilation c = Compilation.ofDocuments(both, Set.of(), ModulePath.EMPTY);
+        Map<String, List<souther.compiler.diag.Diagnostic>> first = c.diagnostics();
+        assertEquals(1, first.get("b.sou").size(), "the second claim is the one reported");
+
+        Map<String, String> onlySecond = new LinkedHashMap<>();
+        onlySecond.put("b.sou", SECOND);
+        c.update(onlySecond, Set.of());
+
+        assertEquals(List.of(), c.diagnostics().get("b.sou"),
+                "b.sou is the module now, and there is nothing wrong with it");
+        assertTrue(c.classes().containsKey("shop.cart.Extra"),
+                "what is compiled is what b.sou declares, not what a.sou did");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -179,7 +179,9 @@ class IncrementalCompilationTest {
         assertFalse(c.db().isComputed(new Output.Classes("shop.customers")),
                 "nothing will ask about a module that is not there any more");
         assertFalse(c.db().isComputed(new Front.Parsed("customers.sou")),
-                "and its text is not held either");
+                "nor is its parse tree");
+        assertFalse(c.db().isComputed(new Front.Text("customers.sou")),
+                "nor its text");
         assertEquals(List.of("shop.prices", "shop.cart"), c.modules());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -5,9 +5,12 @@ import souther.compiler.meta.ModulePath;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -92,6 +95,33 @@ class IncrementalCompilationTest {
         assertSame(cart, c.db().ask(new Output.Classes("shop.cart")));
     }
 
+    /**
+     * The boundary the whole claim rests on. An importer builds against what a module declares, so
+     * changing a body it cannot see must not reach it — and that only works because a module's
+     * declarations compare by what they say.
+     */
+    @Test
+    void changingOnlyABodyDoesNotReachTheModulesThatImportIt() {
+        Compilation c = started();
+        Answer<?> cart = c.db().ask(new Output.Classes("shop.cart"));
+
+        c.update(workspace(PRICES + """
+
+                behavior twice : (n: Amount) -> Amount
+                    constructs Amount
+                let twice (n) = Amount(n.value * 2)
+                """, CART, CUSTOMERS), Set.of());
+        c.answerEverything();
+
+        assertNotSame(prices(c), null, "the edited module is still compiled");
+        assertSame(cart, c.db().ask(new Output.Classes("shop.cart")),
+                "shop.cart imports a type, and the type did not change");
+    }
+
+    private static Object prices(Compilation c) {
+        return c.db().ask(new Output.Classes("shop.prices")).value();
+    }
+
     @Test
     void changingWhatAModuleDeclaresReachesTheModulesThatImportIt() {
         Compilation c = started();
@@ -133,5 +163,23 @@ class IncrementalCompilationTest {
         c.answerEverything();
 
         assertTrue(c.db().allReports().isEmpty(), "the fixed error is not still listed");
+    }
+
+    @Test
+    void aClosedDocumentIsForgotten() {
+        Compilation c = started();
+        assertTrue(c.db().isComputed(new Output.Classes("shop.customers")));
+
+        Map<String, String> without = new LinkedHashMap<>();
+        without.put("prices.sou", PRICES);
+        without.put("cart.sou", CART);
+        c.update(without, Set.of());
+        c.answerEverything();
+
+        assertFalse(c.db().isComputed(new Output.Classes("shop.customers")),
+                "nothing will ask about a module that is not there any more");
+        assertFalse(c.db().isComputed(new Front.Parsed("customers.sou")),
+                "and its text is not held either");
+        assertEquals(List.of("shop.prices", "shop.cart"), c.modules());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -1,0 +1,137 @@
+package souther.compiler.query;
+
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What an edit costs. A compilation kept across edits recomputes what the edit reached and nothing
+ * else, which is issue #35 — not as a caching layer bolted on, but because an answer that comes out
+ * the same as the one it replaces leaves everything that read it alone.
+ *
+ * <p>"Not recomputed" is observed as the same answer object coming back: the store hands out what it
+ * kept, so a different instance means the work ran again.
+ */
+class IncrementalCompilationTest {
+
+    private static final String PRICES = """
+            module shop.prices exposing ( Amount )
+
+            data Amount = Int
+                invariant value >= 0
+            """;
+
+    /** Imports shop.prices, so an edit there can reach here. */
+    private static final String CART = """
+            module shop.cart exposing ( Total )
+
+            import shop.prices ( Amount )
+
+            data Total = { paid: Amount }
+            """;
+
+    /** Names nothing from the other two, so no edit there can reach here. */
+    private static final String CUSTOMERS = """
+            module shop.customers exposing ( Name )
+
+            data Name = String
+                invariant String.length(value) > 0
+            """;
+
+    private static Map<String, String> workspace(String prices, String cart, String customers) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("prices.sou", prices);
+        byId.put("cart.sou", cart);
+        byId.put("customers.sou", customers);
+        return byId;
+    }
+
+    private static Compilation started() {
+        Compilation c = Compilation.ofDocuments(workspace(PRICES, CART, CUSTOMERS), Set.of(),
+                ModulePath.EMPTY);
+        c.answerEverything();
+        assertTrue(c.db().allReports().isEmpty(), "the workspace compiles to begin with");
+        return c;
+    }
+
+    @Test
+    void anEditReachesTheModuleItWasMadeIn() {
+        Compilation c = started();
+        Answer<?> before = c.db().ask(new Output.Classes("shop.customers"));
+
+        c.update(workspace(PRICES, CART, CUSTOMERS + """
+                data Email = String
+                    invariant matches("[^@]+@[^@]+", value)
+                """), Set.of());
+        c.answerEverything();
+
+        assertNotSame(before, c.db().ask(new Output.Classes("shop.customers")));
+    }
+
+    @Test
+    void anEditDoesNotReachAModuleThatNamesNothingOfIt() {
+        Compilation c = started();
+        Answer<?> prices = c.db().ask(new Output.Classes("shop.prices"));
+        Answer<?> cart = c.db().ask(new Output.Classes("shop.cart"));
+
+        c.update(workspace(PRICES, CART, CUSTOMERS + """
+                data Email = String
+                    invariant matches("[^@]+@[^@]+", value)
+                """), Set.of());
+        c.answerEverything();
+
+        assertSame(prices, c.db().ask(new Output.Classes("shop.prices")));
+        assertSame(cart, c.db().ask(new Output.Classes("shop.cart")));
+    }
+
+    @Test
+    void changingWhatAModuleDeclaresReachesTheModulesThatImportIt() {
+        Compilation c = started();
+        Answer<?> cart = c.db().ask(new Output.Classes("shop.cart"));
+
+        c.update(workspace("""
+                module shop.prices exposing ( Amount )
+
+                data Amount = Int
+                    invariant value >= 1
+                """, CART, CUSTOMERS), Set.of());
+        c.answerEverything();
+
+        assertNotSame(cart, c.db().ask(new Output.Classes("shop.cart")),
+                "the imported type's invariant is part of what the importer builds against");
+    }
+
+    @Test
+    void settingASourceToWhatItAlreadySaidCostsNothing() {
+        Compilation c = started();
+        Answer<?> cart = c.db().ask(new Output.Classes("shop.cart"));
+
+        c.update(workspace(PRICES, CART, CUSTOMERS), Set.of());
+        c.answerEverything();
+
+        assertSame(cart, c.db().ask(new Output.Classes("shop.cart")));
+    }
+
+    @Test
+    void aProblemThatWasFixedStopsBeingReported() {
+        Compilation c = Compilation.ofDocuments(
+                workspace(PRICES, CART, "module shop.customers\ndata Name = Nope\n"), Set.of(),
+                ModulePath.EMPTY);
+        c.answerEverything();
+        assertTrue(c.db().allReports().stream().anyMatch(f -> f.report().isError()),
+                "an unknown type is an error to begin with");
+
+        c.update(workspace(PRICES, CART, CUSTOMERS), Set.of());
+        c.answerEverything();
+
+        assertTrue(c.db().allReports().isEmpty(), "the fixed error is not still listed");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/OneProblemOneDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneProblemOneDiagnosticTest.java
@@ -1,0 +1,62 @@
+package souther.compiler.query;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * One problem is one diagnostic, and it lands on the file that has it.
+ *
+ * <p>An answer is absent when something it read was absent, and several answers in a chain are
+ * absent for the one reason. Whichever of them found it is where it is reported; the ones above it
+ * say nothing, or the author is told the same thing once per question that could not be answered.
+ */
+class OneProblemOneDiagnosticTest {
+
+    private static Map<String, List<Diagnostic>> diagnose(String id, String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put(id, source);
+        return Compiler.diagnoseModules(byId, Set.of());
+    }
+
+    @Test
+    void anImportOfAModuleThatIsNotThereIsReportedOnce() {
+        List<Diagnostic> found = diagnose("a.sou", """
+                module m.a
+                import m.nope ( X )
+                data A = { x: X }
+                """).get("a.sou");
+
+        assertEquals(1, found.size(), "one unknown import, one diagnostic: " + found);
+        assertEquals("check.import.unknownmodule", found.get(0).messageKey());
+    }
+
+    @Test
+    void aModuleInTheReservedNamespaceIsReportedOnce() {
+        List<Diagnostic> found = diagnose("a.sou", """
+                module souther.evil
+                data A = Int
+                """).get("a.sou");
+
+        assertEquals(1, found.size(), "one reserved name, one diagnostic: " + found);
+    }
+
+    @Test
+    void aSourceThatWillNotParseSaysSo() {
+        List<Diagnostic> found = diagnose("bad.sou", """
+                module app.bad
+                data = = =
+                """).get("bad.sou");
+
+        assertEquals(1, found.size(),
+                "the parse error belongs to the source it was found in: " + found);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/StaleReportTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/StaleReportTest.java
@@ -1,0 +1,79 @@
+package souther.compiler.query;
+
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A problem that no longer exists is not still reported.
+ *
+ * <p>Recomputing an answer replaces what it said. A question that stops being asked at all is the
+ * other case: nothing recomputes it, so whatever it last said would sit there unless the reports
+ * are read from what the current answers are, rather than from every answer ever given.
+ *
+ * <p>An {@code examples for} file whose rows are all deleted is how that happens. The file is still
+ * open, so its document still takes diagnostics; it just contributes no rows, so the question "do
+ * this file's rows hold" is not asked any more.
+ */
+class StaleReportTest {
+
+    private static final String CART = """
+            module shop.cart exposing ( Total, double )
+
+            data Total = Int
+
+            behavior double : (n: Total) -> Total
+                constructs Total
+            let double (n) = Total(n.value * 2)
+            """;
+
+    private static final String FAILING_ROWS = """
+            examples for shop.cart
+            example double
+              | "wrong" : (Total(2)) -> Total(5)
+            """;
+
+    /** The same file with its rows gone: still an `examples for` file, contributing nothing. */
+    private static final String NO_ROWS = """
+            examples for shop.cart
+            """;
+
+    private static Map<String, String> workspace(String rows) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("cart.sou", CART);
+        byId.put("cart-examples.sou", rows);
+        return byId;
+    }
+
+    @Test
+    void anExampleFailureGoesAwayWhenItsRowIsDeleted() {
+        Compilation c = Compilation.ofDocuments(workspace(FAILING_ROWS), Set.of(), ModulePath.EMPTY);
+        Map<String, List<souther.compiler.diag.Diagnostic>> first = c.diagnostics();
+        assertEquals(1, first.get("cart-examples.sou").size(),
+                "the failing row is reported on the file it is written in");
+
+        c.update(workspace(NO_ROWS), Set.of());
+
+        assertEquals(List.of(), c.diagnostics().get("cart-examples.sou"),
+                "the row is gone, so its failure is gone");
+    }
+
+    @Test
+    void aWholeCompilationStaysCleanAfterTheProblemIsRemoved() {
+        Compilation c = Compilation.ofDocuments(workspace(FAILING_ROWS), Set.of(), ModulePath.EMPTY);
+        c.diagnostics();
+        c.update(workspace(NO_ROWS), Set.of());
+        c.diagnostics();
+
+        assertFalse(c.db().allReports().stream().anyMatch(f -> f.report().isError()),
+                "nothing is wrong with this workspace any more");
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -1,6 +1,7 @@
 package souther.lsp.analysis;
 
 import souther.compiler.Compiler;
+import souther.compiler.query.Compilation;
 import souther.compiler.ast.Ast;
 import souther.compiler.cst.CstError;
 import souther.compiler.cst.CstLexer;
@@ -43,6 +44,19 @@ import java.util.Set;
  * (the type checker does not recover yet, ADR-deferred).
  */
 public final class Analyzer {
+
+    /**
+     * The workspace's compile, kept between edits. An answer is recomputed only when something it
+     * read has changed, so a keystroke costs what it reached rather than a whole workspace — and a
+     * source that is edited back to what it said costs nothing at all.
+     *
+     * <p>Null until the first workspace-wide diagnose; a single-document analysis does not build
+     * one, because it is a compile of one file with nothing else in sight.
+     */
+    private Compilation workspaceCompile;
+    /** Which module path {@link #workspaceCompile} was built for. A different one is a different
+     * set of modules to resolve an import against, so the compile is started again. */
+    private souther.compiler.meta.ModulePath compiledAgainst;
 
     /** All diagnostics for a document: every syntax error, or — when there are none — the first
      * semantic error a compile turns up. */
@@ -140,7 +154,7 @@ public final class Analyzer {
 
         Map<String, List<Diagnostic>> byUri;
         try {
-            byUri = Compiler.diagnoseModules(compileSet, brokenModules, path);
+            byUri = compileOf(path, compileSet, brokenModules).diagnostics();
         } catch (RuntimeException | StackOverflowError e) {
             // Which file broke the walk is not known here, so every file that entered the compile is
             // marked. Silence would leave the whole workspace looking clean.
@@ -160,6 +174,18 @@ public final class Analyzer {
             }
         }
         return out;
+    }
+
+    /** The workspace's compile, brought up to date with what the documents now say. */
+    private Compilation compileOf(souther.compiler.meta.ModulePath path,
+                                  Map<String, String> sources, Set<String> broken) {
+        if (workspaceCompile == null || !path.equals(compiledAgainst)) {
+            workspaceCompile = Compilation.ofDocuments(sources, broken, path);
+            compiledAgainst = path;
+        } else {
+            workspaceCompile.update(sources, broken);
+        }
+        return workspaceCompile;
     }
 
     /**

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -1,7 +1,10 @@
 package souther.lsp.analysis;
 
 import souther.compiler.Compiler;
+import souther.compiler.check.Resolve;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.Names;
+import souther.compiler.types.TypeName;
 import souther.compiler.ast.Ast;
 import souther.compiler.cst.CstError;
 import souther.compiler.cst.CstLexer;
@@ -189,6 +192,59 @@ public final class Analyzer {
     }
 
     /**
+     * The same compile, for a request that arrives with a graph and no path — navigation. A file
+     * that will not parse is left out of it, as it is for diagnostics: it cannot join a module set.
+     * The path is whichever the last diagnose used, which is current, because a diagnose runs on
+     * every change.
+     */
+    private Compilation compileOf(ModuleGraph graph) {
+        Map<String, String> clean = new LinkedHashMap<>();
+        Set<String> broken = new HashSet<>();
+        for (String uri : graph.uris()) {
+            String text = graph.text(uri);
+            boolean readable;
+            try {
+                readable = CstParser.parse(text).errors().isEmpty();
+            } catch (RuntimeException | StackOverflowError e) {
+                readable = false;
+            }
+            if (readable) {
+                clean.put(uri, text);
+            } else {
+                String name = Compiler.moduleNameFromHeader(text);
+                if (name != null) {
+                    broken.add(name);
+                }
+            }
+        }
+        return compileOf(compiledAgainst == null ? souther.compiler.meta.ModulePath.EMPTY
+                : compiledAgainst, clean, broken);
+    }
+
+    /** What the cursor is on, as the compiler answers it: the type a name at {@code pos} denotes,
+     * or the declaration whose own name is there. Null when the compiler cannot say — a file that
+     * does not compile, or a name in the value namespace, which is still matched by spelling. */
+    private TypeName typeUnderCursor(Compilation compilation, String uri, ModuleGraph graph,
+                                     Position pos) {
+        String text = graph.text(uri);
+        String module = text == null ? null : Compiler.moduleNameFromHeader(text);
+        if (module == null) {
+            return null;
+        }
+        SourcePos at = new SourcePos(pos.line() + 1, pos.character() + 1);
+        return compilation.db().ask(new Names.TypeAt(module, at)).value();
+    }
+
+    /** The range of one written name, counting only its last segment: renaming a type rewrites the
+     * {@code Amount} of {@code up.Amount}, never the {@code up}. */
+    private Range writtenRange(Resolve.Denotation denotation) {
+        int line = denotation.pos().line() - 1;
+        int start = denotation.pos().column() - 1 + denotation.written().lastIndexOf('.') + 1;
+        return new Range(new Position(line, start),
+                new Position(line, denotation.pos().column() - 1 + denotation.written().length()));
+    }
+
+    /**
      * Quick-fix code actions overlapping {@code requested}: currently, replacing a misspelled name
      * with the compiler's did-you-mean suggestion. The suggestion lives on the structured compiler
      * diagnostic — which the published {@link LspDiagnostic} drops — so this recomputes the first
@@ -258,6 +314,10 @@ public final class Analyzer {
         if (text == null) {
             return Optional.empty();
         }
+        Optional<Location> answered = declarationOf(uri, pos, graph);
+        if (answered.isPresent()) {
+            return answered;
+        }
         LineIndex lines = new LineIndex(text);
         SyntaxNode root = CstParser.parse(text).root();
         SyntaxToken ident = identAt(root, lines.offsetOf(pos.line(), pos.character()));
@@ -298,6 +358,10 @@ public final class Analyzer {
         String text = graph.text(uri);
         if (text == null) {
             return List.of();
+        }
+        List<Location> answered = usesOf(uri, pos, graph, includeDeclaration);
+        if (answered != null) {
+            return answered;
         }
         SyntaxNode root = CstParser.parse(text).root();
         SyntaxToken ident = identAt(root, new LineIndex(text).offsetOf(pos.line(), pos.character()));
@@ -357,6 +421,62 @@ public final class Analyzer {
             }
         }
         return byUri;
+    }
+
+    /**
+     * Where the type under the cursor is declared, as the compiler answers it. Empty when it cannot
+     * say: the workspace does not compile, or the cursor is on a name in the value namespace, which
+     * is still matched by spelling below.
+     */
+    private Optional<Location> declarationOf(String uri, Position pos, ModuleGraph graph) {
+        Compilation compilation = compileOf(graph);
+        TypeName target = typeUnderCursor(compilation, uri, graph, pos);
+        if (target == null) {
+            return Optional.empty();
+        }
+        String targetUri = compilation.sourceIdOf(target.module());
+        String targetText = targetUri == null ? null : graph.text(targetUri);
+        if (targetText == null) {
+            return Optional.empty();
+        }
+        // Which module and which name is the compiler's answer — the part a spelling match gets
+        // wrong. Where in that file the name is written is the syntax tree's, which is what knows
+        // about characters; a module declares a name once, so there is nothing to choose between.
+        SyntaxNode def = declaringDef(CstParser.parse(targetText).root(), target.name());
+        SyntaxToken name = def == null ? null : nameToken(def);
+        return name == null ? Optional.empty()
+                : Optional.of(new Location(targetUri,
+                        tokenRange(new LineIndex(targetText), name)));
+    }
+
+    /**
+     * Every place the type under the cursor is named, as the compiler answers it, or null when it
+     * cannot say. A name resolves to one declaration wherever it is written, so a module that
+     * declares its own type of the same spelling is not swept up, and a qualified reference to
+     * another module's is.
+     */
+    private List<Location> usesOf(String uri, Position pos, ModuleGraph graph,
+                                  boolean includeDeclaration) {
+        Compilation compilation = compileOf(graph);
+        TypeName target = typeUnderCursor(compilation, uri, graph, pos);
+        if (target == null) {
+            return null;
+        }
+        List<Location> out = new ArrayList<>();
+        if (includeDeclaration) {
+            declarationOf(uri, pos, graph).ifPresent(out::add);
+        }
+        for (String module : compilation.modules()) {
+            String moduleUri = compilation.sourceIdOf(module);
+            if (moduleUri == null || graph.text(moduleUri) == null) {
+                continue;
+            }
+            for (Resolve.Denotation use
+                    : compilation.db().ask(new Names.UsesOf(module, target)).value()) {
+                out.add(new Location(moduleUri, writtenRange(use)));
+            }
+        }
+        return out;
     }
 
     /** Adds the {@code exposing ( name )} occurrence in the module that defines {@code name}, and each

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -408,7 +408,17 @@ public final class Analyzer {
         }
         // references() treats a name in an `exposing`/`import` list as a binding site, not a use, and
         // skips it. Rename must still update those, or the module stops exposing (and importers stop
-        // importing) the renamed symbol, breaking the build. Resolve the symbol again and add them.
+        // importing) the renamed symbol, breaking the build.
+        //
+        // Which module those belong to is the same question the references were found by, and it has
+        // to be answered the same way: renaming from a qualified use renames the module the
+        // reference names, and matching the spelling here would edit this module's own `exposing`
+        // instead — leaving both modules uncompilable.
+        TypeName target = typeUnderCursor(compileOf(graph), uri, graph, pos);
+        if (target != null) {
+            addExposingAndImportSites(target.name(), target.module(), graph, byUri);
+            return byUri;
+        }
         String text = graph.text(uri);
         SyntaxNode root = CstParser.parse(text).root();
         SyntaxToken ident = identAt(root, new LineIndex(text).offsetOf(pos.line(), pos.character()));

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesNamesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesNamesTest.java
@@ -68,6 +68,25 @@ class NavigationResolvesNamesTest {
         }
     }
 
+    /**
+     * Renaming from a qualified use renames the module the reference names. The binding sites go
+     * with it — {@code up} stops exposing the old name — and this module's own {@code exposing},
+     * which is about its own type of the same spelling, is left alone.
+     */
+    @Test
+    void renamingFromAQualifiedUseCarriesTheRightModulesExposing() {
+        Map<String, List<Range>> edits =
+                new Analyzer().renameEdits("file:///here.sou", THE_QUALIFIED_USE, graph());
+
+        assertEquals(2, edits.getOrDefault("file:///up.sou", List.of()).size(),
+                "up's declaration and up's `exposing` entry");
+        List<Range> here = edits.getOrDefault("file:///here.sou", List.of());
+        assertEquals(1, here.size(), "only the tail of `up.Amount`");
+        assertEquals(4, here.get(0).start().line());
+        assertEquals(21, here.get(0).start().character(),
+                "the `Amount` of `up.Amount`, not the `up`");
+    }
+
     @Test
     void aQualifiedReferenceGoesToTheModuleItNames() {
         Optional<Location> found =

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesNamesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesNamesTest.java
@@ -1,0 +1,80 @@
+package souther.lsp.analysis;
+
+import souther.lsp.protocol.Location;
+import souther.lsp.protocol.Position;
+import souther.lsp.protocol.Range;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Navigation answers what a name denotes, not what it is spelled.
+ *
+ * <p>Two modules may declare the same name, and a qualified reference reaches one of them without an
+ * import line. Matching the spelling cannot tell those apart: renaming one module's {@code Amount}
+ * would rewrite the tail of every {@code other.Amount} written anywhere, which changes what those
+ * references mean and stops the workspace compiling.
+ */
+class NavigationResolvesNamesTest {
+
+    private static final String UP = """
+            module up exposing ( Amount )
+
+            data Amount = Int
+            """;
+
+    /** Declares an Amount of its own and also names up's, qualified — no import line needed. */
+    private static final String HERE = """
+            module here exposing ( Amount, Box )
+
+            data Amount = String
+
+            data Box = { far: up.Amount, near: Amount }
+            """;
+
+    private static ModuleGraph graph() {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put("file:///up.sou", UP);
+        sources.put("file:///here.sou", HERE);
+        return ModuleGraph.of(sources);
+    }
+
+    /** Where `data Amount = String` names itself, in here.sou. */
+    private static final Position HERES_AMOUNT = new Position(2, 5);
+    /** Where `up.Amount` names up's, in here.sou. */
+    private static final Position THE_QUALIFIED_USE = new Position(4, 22);
+
+    @Test
+    void renamingOneModulesTypeLeavesTheOtherModulesAlone() {
+        Map<String, List<Range>> edits =
+                new Analyzer().renameEdits("file:///here.sou", HERES_AMOUNT, graph());
+
+        assertTrue(edits.getOrDefault("file:///up.sou", List.of()).isEmpty(),
+                "up declares an Amount of its own, which this rename is not about");
+        List<Range> here = edits.getOrDefault("file:///here.sou", List.of());
+        assertEquals(3, here.size(),
+                "the declaration, the `exposing` entry, and the one bare use — not the tail of"
+                        + " `up.Amount`");
+        for (Range r : here) {
+            assertTrue(r.start().line() != 4 || r.start().character() != 22,
+                    "the qualified reference names up's Amount and must be left alone");
+        }
+    }
+
+    @Test
+    void aQualifiedReferenceGoesToTheModuleItNames() {
+        Optional<Location> found =
+                new Analyzer().definition("file:///here.sou", THE_QUALIFIED_USE, graph());
+
+        assertTrue(found.isPresent(), "up.Amount denotes up's declaration");
+        assertEquals("file:///up.sou", found.get().uri(),
+                "a spelling match would have stopped at this module's own Amount");
+    }
+}


### PR DESCRIPTION
Issue #177 step 4, first part. The compiler stops being a pipeline and becomes a set of memoised
questions; the three sequences that used to run over the same stages become three short functions
that differ only in what they decide.

`Compiler.java` goes from 1379 lines to 293 and no longer names a single pass. The hand-rolled
pipelines are gone:

```
Deriver.derive / Lower.run / NewtypeDesugar.rewrite call sites:  7 -> 0
Resolve.module call sites:                                       5 -> 1   (the prelude bootstrap)
```

Measured migration cost: zero lines. souther-lang/examples builds unchanged.

## What is here

**A query engine** (`souther.compiler.query`). A key is one question and the code that answers it.
The store answers it once, keeps the answer, and records what answering it read.

**Nothing throws to report.** An answer is a value or nothing, plus what the attempt found. That is
what let `compiling`, `linking` and `diagnoseModules` collapse: the difference between them was
whether the first error was raised or collected, and that is now the caller's line of code rather
than its own copy of the compile.

**The order the passes ran in is not written anywhere.** Settling a helper's parameter type before
its call is expanded (#178), and inlining a spread's invariant before the importer reads it, were
kept by putting the passes in the right sequence. They are edges now, and reading an answer is what
makes it happen first.

**An edit is absorbed rather than recompiled.** Each answer knows the revision it was made at and
the revision it last came out different at, and an answer equal to the one it replaces leaves
everything that read it alone. Editing any source changes that source's parse, and the layout of the
workspace is built from every parse — but the layout comes out the same, so nothing below it is
looked at. This is #35, and there is no caching layer: the dependencies were already being recorded
to find a question that depends on itself. The language server keeps its compilation between
keystrokes.

## Two divergences found on the way

These are the pattern #177 is about — one question, several implementations — and both were live.

**Cycles were detected twice, by different rules.** The batch walk followed qualified type
references as well as imports; the editor's walk followed only imports. A cycle written without an
import line was invisible in an editor.

**A failing example merged in from an `examples for` file named no source at all**, because the
merge lost which file the row came from. Each row now carries its origin, so the file that has the
row is the file quoted. `MultiFileDiagnosticOriginTest` pinned the old limitation and now pins the
answer.

## Navigation

Go-to-definition, find-references and rename each decided what the cursor was on by matching the
identifier's text. Two modules may declare the same name, and a qualified reference reaches one of
them without an import line, so the text cannot tell them apart:

```souther
module up    exposing ( Amount )    data Amount = Int
module here  exposing ( Amount )    data Amount = String
                                    data Box = { far: up.Amount, near: Amount }
```

Renaming `here`'s `Amount` rewrote the tail of `up.Amount` — silently changing what that reference
means — and go-to-definition on `up.Amount` stopped at `here`'s. Both are covered by
`NavigationResolvesNamesTest`, which fails on develop.

The resolve pass has answered this since #180; it threw the answers away after rewriting the tree.
It keeps them now. Which module and which name is the compiler's answer; where in the file the name
is written stays the syntax tree's, which is what knows about characters.

A name in the value namespace — a behavior, a `let` — is still matched by spelling, because it is
not resolved yet. So is anything in a file that does not compile.

## Not here

Per-definition keys, and error recovery in the type checker. The second is what "the LSP's second
engine goes away" actually needs: without it an editor still cannot ask about half-typed source,
whatever the compiler is made of. Both are separate work.

#35 is finished by this. A develop-targeted PR does not close an issue automatically, so it needs
closing by hand after merge.

## Verification

```
mvn -o clean install -DskipTests && mvn -o test
  souther-syntax    37 tests
  souther-compiler  1222 tests
  souther-lsp       83 tests

mvn -o -f ../souther-examples/pom.xml clean test    BUILD SUCCESS, unchanged sources
```

Every commit compiles on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
