### PR TITLE
Resolve the value namespace once, into the tree

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -274,10 +274,10 @@ public final class ExampleVerifier {
     /** Builds a {@code Behavior} proxy for each of {@code spec}'s requires, in declared order; null
      * (with a diagnostic reported) when one is missing or invalid. */
     private Object[] resolveFakes(Ast.SpecBehavior spec, Ast.ExampleRow row, List<Diagnostic> out) {
-        List<String> reqs = spec.requires();
+        List<Ast.ValueRef> reqs = spec.requires();
         Object[] proxies = new Object[reqs.size()];
         for (int i = 0; i < reqs.size(); i++) {
-            Object p = resolveFake(spec.name(), reqs.get(i), row, out);
+            Object p = resolveFake(spec.name(), reqs.get(i).bare(), row, out);
             if (p == null) {
                 return null;
             }

--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -89,13 +89,6 @@ public final class Prelude {
      *  checker built-ins (which are not in the prelude sources) are listed here explicitly. */
     private static final Map<String, String> BARE_TO_QUALIFIED = new LinkedHashMap<>();
 
-    /** Names that are sugar for another standard-library call, recognised as library functions but
-     *  rewritten before inlining: {@code List.fold(step, seed, xs)} is {@code List.foldFrom(step, seed,
-     *  xs, 0)} (the walk from the head). */
-    private static final Set<String> SUGARED = Set.of("List.fold");
-
-    // Everything the load below reads must be in place before it runs: it resolves the prelude
-    // sources, and resolving a call asks whether the name it applies is a library function.
     static {
         load();
     }
@@ -114,6 +107,11 @@ public final class Prelude {
     public static Set<String> qualifiers() {
         return QUALIFIERS;
     }
+
+    /** Names that are sugar for another standard-library call, recognised as library functions but
+     *  rewritten before inlining: {@code List.fold(step, seed, xs)} is {@code List.foldFrom(step, seed,
+     *  xs, 0)} (the walk from the head). */
+    private static final Set<String> SUGARED = Set.of("List.fold");
 
     /** Whether {@code qualifiedName} (e.g. {@code "List.map"}) is a standard-library function —
      *  a prelude helper, a prelude intrinsic, a checker built-in, or a sugar for one. */

--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -89,6 +89,13 @@ public final class Prelude {
      *  checker built-ins (which are not in the prelude sources) are listed here explicitly. */
     private static final Map<String, String> BARE_TO_QUALIFIED = new LinkedHashMap<>();
 
+    /** Names that are sugar for another standard-library call, recognised as library functions but
+     *  rewritten before inlining: {@code List.fold(step, seed, xs)} is {@code List.foldFrom(step, seed,
+     *  xs, 0)} (the walk from the head). */
+    private static final Set<String> SUGARED = Set.of("List.fold");
+
+    // Everything the load below reads must be in place before it runs: it resolves the prelude
+    // sources, and resolving a call asks whether the name it applies is a library function.
     static {
         load();
     }
@@ -107,11 +114,6 @@ public final class Prelude {
     public static Set<String> qualifiers() {
         return QUALIFIERS;
     }
-
-    /** Names that are sugar for another standard-library call, recognised as library functions but
-     *  rewritten before inlining: {@code List.fold(step, seed, xs)} is {@code List.foldFrom(step, seed,
-     *  xs, 0)} (the walk from the head). */
-    private static final Set<String> SUGARED = Set.of("List.fold");
 
     /** Whether {@code qualifiedName} (e.g. {@code "List.map"}) is a standard-library function —
      *  a prelude helper, a prelude intrinsic, a checker built-in, or a sugar for one. */

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -178,10 +178,19 @@ public final class Runner {
 
     // --- behavior selection ---------------------------------------------------------------------
 
+    /** The names a behavior requires, as a message lists them. */
+    private static String requiredNames(Ast.SpecBehavior spec) {
+        List<String> names = new java.util.ArrayList<>();
+        for (Ast.ValueRef req : spec.requires()) {
+            names.add(req.bare());
+        }
+        return String.join(", ", names);
+    }
+
     private static Ast.BehaviorDef resolveBehavior(Ast.Module module, String requested) {
         java.util.Set<String> implemented = module.fns().stream()
                 .map(Ast.FnDef::name).collect(Collectors.toSet());
-        Map<String, List<String>> pipeStages = PipelineSigs.pipelineStages(module);
+        Map<String, List<Ast.ValueRef>> pipeStages = PipelineSigs.pipelineStages(module);
         Map<String, Ast.BehaviorDef> runnable = new java.util.LinkedHashMap<>();
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (b instanceof Ast.SpecBehavior spec
@@ -223,14 +232,15 @@ public final class Runner {
      * dependencies would make that constructor take those behaviors, which {@code run} cannot supply.
      */
     private static Blocker pipelineBlocker(Ast.Module module, Ast.PipeBehavior pipe,
-            java.util.Set<String> implemented, Map<String, List<String>> pipeStages) {
+            java.util.Set<String> implemented, Map<String, List<Ast.ValueRef>> pipeStages) {
         Map<String, Ast.SpecBehavior> specs = new java.util.HashMap<>();
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (b instanceof Ast.SpecBehavior spec) {
                 specs.put(spec.name(), spec);
             }
         }
-        for (String stage : PipelineSigs.flattenStages(pipe.stages(), pipeStages, pipe.pos())) {
+        for (Ast.ValueRef named : PipelineSigs.flattenStages(pipe.stages(), pipeStages, pipe.pos())) {
+            String stage = named.bare();
             if (!implemented.contains(stage)) {
                 return new Blocker("run.pipeline.noimpl",
                         "`" + pipe.name() + "` is a pipeline whose stage `" + stage
@@ -239,7 +249,7 @@ public final class Runner {
             }
             Ast.SpecBehavior spec = specs.get(stage);
             if (spec != null && !spec.requires().isEmpty()) {
-                String requires = String.join(", ", spec.requires());
+                String requires = requiredNames(spec);
                 return new Blocker("run.pipeline.requires",
                         "`" + pipe.name() + "` is a pipeline whose stage `" + stage
                                 + "` requires injected dependencies (" + requires
@@ -255,7 +265,7 @@ public final class Runner {
         String available = runnable.isEmpty() ? "none" : String.join(", ", runnable);
         java.util.Set<String> implemented = module.fns().stream()
                 .map(Ast.FnDef::name).collect(Collectors.toSet());
-        Map<String, List<String>> pipeStages = PipelineSigs.pipelineStages(module);
+        Map<String, List<Ast.ValueRef>> pipeStages = PipelineSigs.pipelineStages(module);
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (!b.name().equals(name)) {
                 continue;
@@ -278,7 +288,7 @@ public final class Runner {
                                     + "Runnable: " + available + ".", name, available);
                 }
                 if (!spec.requires().isEmpty()) {
-                    String requires = String.join(", ", spec.requires());
+                    String requires = requiredNames(spec);
                     return fail("run.behavior.requires",
                             "`" + name + "` requires injected dependencies (" + requires
                                     + "), which `run` cannot supply. Runnable: " + available + ".",

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -3,6 +3,7 @@ package souther.compiler.ast;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -49,6 +50,53 @@ public interface Ast {
         /** The same name, resolved to what it denotes. */
         public Name denoting(TypeName resolved) {
             return new Name(written, resolved, pos);
+        }
+
+        @Override
+        public String toString() {
+            return written;
+        }
+    }
+
+    /**
+     * A name in the value namespace, in both forms it has: {@code written} as the source spelled it —
+     * bare {@code price}, qualified {@code billing.price}, or through an import alias — and
+     * {@code denotes} as it resolves. What {@link Name} is for a type.
+     *
+     * <p>A check reads {@link #denotes()}. A name that denotes nothing was reported where it was
+     * written and carries {@link ValueName.Unresolved}, so a reader downstream never has a spelling
+     * to match and never repeats the report.
+     */
+    record ValueRef(String written, ValueName denotes, SourcePos pos) implements Ast {
+
+        /** A name as the parser read it, before resolution has said what it denotes. */
+        public static ValueRef written(String written, SourcePos pos) {
+            return new ValueRef(written, null, pos);
+        }
+
+        /** The same name, resolved to what it denotes. */
+        public ValueRef denoting(ValueName resolved) {
+            return new ValueRef(written, resolved, pos);
+        }
+
+        /**
+         * The bare name this reaches its declaration by, whatever the source spelled.
+         *
+         * <p>Every name here has been through resolution by the time anything reads it, including
+         * one that denotes nothing — that is an answer too. A name with no answer at all means a
+         * tree reached a reader without being resolved, which would put this back to matching
+         * spellings, so it says so rather than falling back to the spelling.
+         */
+        public String bare() {
+            if (denotes == null) {
+                throw new IllegalStateException("`" + written + "` was never resolved");
+            }
+            return denotes.name();
+        }
+
+        /** Whether this name denotes nothing — reported where it was written. */
+        public boolean unresolved() {
+            return denotes instanceof ValueName.Unresolved;
         }
 
         @Override
@@ -142,7 +190,7 @@ public interface Ast {
                         List<Param> params,
                         RetType ret,
                         List<Name> constructs,
-                        List<String> requires,
+                        List<ValueRef> requires,
                         SourcePos pos) implements BehaviorDef {}
 
     /** A behavior parameter. Its type may be an anonymous union of cases (spec 12.2). */
@@ -153,7 +201,7 @@ public interface Ast {
      * is the optional trailing output declaration (14.5): null when absent (output is inferred), else
      * the declared cases, which must match the inferred output exactly (E1604).
      */
-    record PipeBehavior(String name, List<String> stages, RetType declaredOut, SourcePos pos)
+    record PipeBehavior(String name, List<ValueRef> stages, RetType declaredOut, SourcePos pos)
             implements BehaviorDef {}
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -603,11 +603,41 @@ public interface Ast {
 
     record BoolLit(boolean value, SourcePos pos) implements Expr {}
 
-    record Var(String name, SourcePos pos) implements Expr {}
+    /**
+     * A name used as a value. {@code denotes} is what it names, answered once during resolution; a
+     * reader asks it rather than deciding for itself whether the spelling is a local, a unit data or
+     * something the language provides.
+     */
+    record Var(String name, ValueName denotes, SourcePos pos) implements Expr {
+
+        /** A name as the parser read it, before resolution has said what it denotes. */
+        public Var(String name, SourcePos pos) {
+            this(name, null, pos);
+        }
+
+        public Var denoting(ValueName resolved) {
+            return new Var(name, resolved, pos);
+        }
+    }
 
     record FieldAccess(Expr target, String field, SourcePos pos) implements Expr {}
 
-    record Call(String fn, List<Expr> args, SourcePos pos) implements Expr {}
+    /**
+     * A call. {@code denotes} is what {@code fn} names — a helper, a library function, an injected
+     * behavior, a function-typed parameter, or the type a newtype construction wraps — answered once
+     * during resolution.
+     */
+    record Call(String fn, ValueName denotes, List<Expr> args, SourcePos pos) implements Expr {
+
+        /** A call as the parser read it, before resolution has said what {@code fn} denotes. */
+        public Call(String fn, List<Expr> args, SourcePos pos) {
+            this(fn, null, args, pos);
+        }
+
+        public Call denoting(ValueName resolved) {
+            return new Call(fn, resolved, args, pos);
+        }
+    }
 
     record Binary(BinOp op, Expr left, Expr right, SourcePos pos) implements Expr {}
 
@@ -630,7 +660,7 @@ public interface Ast {
             case Neg n -> new Neg(f.apply(n.operand()), n.pos());
             case FieldAccess fa -> new FieldAccess(f.apply(fa.target()), fa.field(), fa.pos());
             case Binary b -> new Binary(b.op(), f.apply(b.left()), f.apply(b.right()), b.pos());
-            case Call c -> new Call(c.fn(), mapExprs(c.args(), f), c.pos());
+            case Call c -> new Call(c.fn(), c.denotes(), mapExprs(c.args(), f), c.pos());
             case If iff -> new If(f.apply(iff.cond()), f.apply(iff.then()), f.apply(iff.els()), iff.pos());
             case LetIn li -> new LetIn(li.name(), f.apply(li.value()), li.declaredType(), li.annotated(),
                     li.opens(), f.apply(li.body()), li.pos());

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -615,6 +615,18 @@ public interface Ast {
             this(name, null, pos);
         }
 
+        /**
+         * A read of something bound in the body, as a pass that put the binding there writes it.
+         *
+         * <p>A pass that runs after resolution says what it means rather than leaving a spelling for
+         * a reader to work out. The binder it gives is where this pass put the name, which is
+         * identity within the tree it built and nothing beyond it — an editor reads the resolved
+         * tree, where a binder is where the author wrote it.
+         */
+        public static Var local(String name, SourcePos pos) {
+            return new Var(name, new ValueName.Local(name, pos), pos);
+        }
+
         public Var denoting(ValueName resolved) {
             return new Var(name, resolved, pos);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -9,6 +9,7 @@ import souther.compiler.diag.Localizable;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 import java.util.Set;
 
 import java.util.ArrayList;
@@ -109,11 +110,24 @@ public final class CallElaborator {
         }
     }
 
+    /**
+     * The type of a call, by what the name it applies denotes.
+     *
+     * <p>Which of these a name is was answered when the module's names were resolved, so the order
+     * the cases are written in here decides nothing. Before that this was a sequence of attempts —
+     * the library, then a function-typed binding, then an injected behavior — and a name that could
+     * be read two ways was whichever came first.
+     */
     static Type typeOfCall(CallArgs ca, Ast.Call call, Map<String, Type> env, CheckContext ctx, Type expected) {
         List<Ast.Expr> args = call.args();
+        if (call.denotes() == null) {
+            throw new IllegalStateException(
+                    "`" + call.fn() + "` reached the check unresolved, at " + call.pos());
+        }
+        boolean library = call.denotes() instanceof ValueName.Stdlib;
         // A shipped intrinsic behaves like a built-in: check the call against its declared signature
         // (from the prelude) and yield its result type; the backend emits the primitive for its key.
-        Prelude.IntrinsicSig intrinsic = Prelude.intrinsics().get(call.fn());
+        Prelude.IntrinsicSig intrinsic = library ? Prelude.intrinsics().get(call.fn()) : null;
         if (intrinsic != null) {
             if (args.size() != intrinsic.params().size()) {
                 throw CompileException.of(
@@ -148,7 +162,7 @@ public final class CallElaborator {
             }
             return result;
         }
-        return switch (call.fn()) {
+        return switch (library ? call.fn() : "") {
             case "String.length" -> {
                 arity(call, 1);
                 ca.require(0, Type.STRING, "argument of String.length");
@@ -399,9 +413,9 @@ public final class CallElaborator {
                     }
                     yield TypeOps.substitute(fn.result(), bind);
                 }
-                // a qualified name that matched no stdlib builtin/intrinsic above is a wrong stdlib
+                // a library qualifier that matched no builtin or intrinsic above is a wrong stdlib
                 // call (spec §stdlib) — report it as such, not as a missing behavior.
-                if (call.fn().indexOf('.') >= 0) {
+                if (library || call.fn().indexOf('.') >= 0) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.stdlib.notfunction").title("check.unknown.title")
                                     .at(call.pos(), call.fn().length()).args(call.fn()).build(),

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -124,6 +124,10 @@ public final class CallElaborator {
             throw new IllegalStateException(
                     "`" + call.fn() + "` reached the check unresolved, at " + call.pos());
         }
+        if (call.denotes() instanceof ValueName.Unresolved) {
+            // reported where the name was written; this definition has no meaning to work out
+            throw new Unanswerable(call.pos());
+        }
         boolean library = call.denotes() instanceof ValueName.Stdlib;
         // A shipped intrinsic behaves like a built-in: check the call against its declared signature
         // (from the prelude) and yield its result type; the backend emits the primitive for its key.

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -716,14 +716,6 @@ public final class Elaborator {
     }
 
     /**
-     * Rejects {@code Some} / {@code None} written where no {@code ?} field is being given a value
-     * (E1303). Giving a field its value is the one place an optional is made — the wrap is implicit
-     * and {@code None} is the empty one (spec 7.3) — and everywhere else an optional is read and
-     * passed on. Neither an unknown-name report nor an arbitrary-call report says that, and the
-     * latter sent the reader off to write a Java binding, which makes no optional either (issue
-     * #166). Patterns do not come through here: {@code | Some v} is matched, not evaluated.
-     */
-    /**
      * A name written where a value goes that is not one: an unknown name, a type that is not a unit
      * data, a function named without being applied, or one of Option's cases outside the one place
      * an optional is made.
@@ -744,6 +736,14 @@ public final class Elaborator {
                 "unknown identifier `" + v.name() + "`" + Suggest.hint(v.name(), env.keySet()));
     }
 
+    /**
+     * Rejects {@code Some} / {@code None} written where no {@code ?} field is being given a value
+     * (E1303). Giving a field its value is the one place an optional is made — the wrap is implicit
+     * and {@code None} is the empty one (spec 7.3) — and everywhere else an optional is read and
+     * passed on. Neither an unknown-name report nor an arbitrary-call report says that, and the
+     * latter sent the reader off to write a Java binding, which makes no optional either (issue
+     * #166). Patterns do not come through here: {@code | Some v} is matched, not evaluated.
+     */
     static void optionCaseWritten(String name, SourcePos pos) {
         boolean some = name.equals("Some");
         if (!some && !name.equals("None")) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -8,6 +8,7 @@ import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -154,35 +155,26 @@ public final class Elaborator {
                             .at(block.pos()).build(),
                     "a block is not a value: it may be passed as an argument or bound to a `let` and "
                             + "applied, but it cannot be returned or stored in a data (spec 12.5)");
-            case Ast.Var v -> {
-                Type t = env.get(v.name());
-                if (t != null) {
-                    yield new Core.Var(v.name(), t, v.pos());
-                }
-                // a bare name that isn't a local is a unit-data value (spec 8.4)
-                if (ctx.symbols().declaration(v.name()) instanceof Ast.UnitData) {
-                    yield new Core.Var(v.name(), Type.ref(ctx.symbols().resolve(v.name())), v.pos());
-                }
-                if (v.name().equals("null")) {
-                    throw new CompileException(v.pos(), "E1301",
-                            "`null` is not part of the language. Use an optional field with `?`.");
-                }
+            // What the name is was answered when the module's names were resolved; what is left here
+            // is its type. A binding is looked up, a unit data is its own value (spec 8.4), and
+            // anything else is not a value — reported below under the name that was written.
+            case Ast.Var v -> switch (v.denotes()) {
+                case null -> throw new IllegalStateException(
+                        "`" + v.name() + "` reached the check unresolved, at " + v.pos());
+                // A binding with no type here is not a naming question: an inference probe types a
+                // body before the binding it asks about has one, and reads the report to find out.
+                case ValueName.Local _ when env.get(v.name()) != null ->
+                        new Core.Var(v.name(), env.get(v.name()), v.pos());
+                case ValueName.OfType named
+                        when ctx.symbols().get(named.type()) instanceof Ast.UnitData ->
+                        new Core.Var(v.name(), Type.ref(named.type()), v.pos());
                 // `None` where a `?` field is being given a value: the empty optional (spec 7.3).
                 // Only the field's own type puts it here — nothing else expects an optional, because
                 // nothing else can say `T?` (ADR-0011) — so this stays a construction rule.
-                if (v.name().equals("None") && expected instanceof Type.OptionOf) {
-                    yield new Core.OptionNone(expected, v.pos());
-                }
-                optionCaseWritten(v.name(), v.pos());
-                throw CompileException.of(
-                        Diagnostic.of(null, "check.unknown.name.msg")
-                                .title("check.unknown.title")
-                                .at(v.pos(), v.name().length())
-                                .args(v.name())
-                                .suggestion(Suggest.candidate(v.name(), env.keySet()))
-                                .build(),
-                        "unknown identifier `" + v.name() + "`" + Suggest.hint(v.name(), env.keySet()));
-            }
+                case ValueName.Builtin b when b.name().equals("None")
+                        && expected instanceof Type.OptionOf -> new Core.OptionNone(expected, v.pos());
+                default -> throw notAValue(v, env);
+            };
             case Ast.FieldAccess fa -> elaborateFieldAccess(fa, env, ctx);
             case Ast.Call call -> CallElaborator.elaborateCall(call, env, ctx, expected);
             case Ast.Binary bin -> BinaryElaborator.elaborateBinary(bin, env, ctx);
@@ -731,6 +723,27 @@ public final class Elaborator {
      * latter sent the reader off to write a Java binding, which makes no optional either (issue
      * #166). Patterns do not come through here: {@code | Some v} is matched, not evaluated.
      */
+    /**
+     * A name written where a value goes that is not one: an unknown name, a type that is not a unit
+     * data, a function named without being applied, or one of Option's cases outside the one place
+     * an optional is made.
+     */
+    private static CompileException notAValue(Ast.Var v, Map<String, Type> env) {
+        if (v.name().equals("null")) {
+            return new CompileException(v.pos(), "E1301",
+                    "`null` is not part of the language. Use an optional field with `?`.");
+        }
+        optionCaseWritten(v.name(), v.pos());
+        return CompileException.of(
+                Diagnostic.of(null, "check.unknown.name.msg")
+                        .title("check.unknown.title")
+                        .at(v.pos(), v.name().length())
+                        .args(v.name())
+                        .suggestion(Suggest.candidate(v.name(), env.keySet()))
+                        .build(),
+                "unknown identifier `" + v.name() + "`" + Suggest.hint(v.name(), env.keySet()));
+    }
+
     static void optionCaseWritten(String name, SourcePos pos) {
         boolean some = name.equals("Some");
         if (!some && !name.equals("None")) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -728,10 +728,10 @@ public final class Elaborator {
      * data, a function named without being applied, or one of Option's cases outside the one place
      * an optional is made.
      */
-    private static CompileException notAValue(Ast.Var v, Map<String, Type> env) {
-        if (v.name().equals("null")) {
-            return new CompileException(v.pos(), "E1301",
-                    "`null` is not part of the language. Use an optional field with `?`.");
+    private static RuntimeException notAValue(Ast.Var v, Map<String, Type> env) {
+        if (v.denotes() instanceof ValueName.Unresolved) {
+            // reported where the name was written; this definition has no meaning to work out
+            return new Unanswerable(v.pos());
         }
         optionCaseWritten(v.name(), v.pos());
         return CompileException.of(

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
+import souther.compiler.types.ValueName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
@@ -212,7 +213,8 @@ public final class HelperInliner {
         }
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.add(new Ast.IntLit(0, call.pos()));
-        return new Ast.Call("List.foldFrom", args, call.pos());
+        return new Ast.Call("List.foldFrom", new ValueName.Stdlib("List.foldFrom"), args,
+                call.pos());
     }
 
     /** Inlines a recursive helper's own body, expanding the non-recursive helper calls it makes while
@@ -254,7 +256,7 @@ public final class HelperInliner {
             return body;
         }
         String bound = "$r" + k;
-        return Ast.LetIn.annotated(bound, body, declared, new Ast.Var(bound, pos), pos);
+        return Ast.LetIn.annotated(bound, body, declared, Ast.Var.local(bound, pos), pos);
     }
 
     /** Whether a written type has a collection anywhere inside it — the types whose element/value type
@@ -382,7 +384,7 @@ public final class HelperInliner {
                 if (helper == null || recursive.contains(call.fn())) {
                     // builtin, injected behavior, or a recursive helper — a recursive helper is
                     // lowered to a method, so its call stays a Call (spec 13.1); only its args inline.
-                    yield new Ast.Call(call.fn(), args, call.pos());
+                    yield new Ast.Call(call.fn(), call.denotes(), args, call.pos());
                 }
                 if (args.size() != helper.params().size()) {
                     LambdaOrigin origin = lambdaOrigins.get(helper.name());
@@ -580,12 +582,13 @@ public final class HelperInliner {
         for (int i = 0; i < helper.params().size(); i++) {
             String p = "$b" + k + "_" + i;
             params.add(p);
-            callArgs.add(new Ast.Var(p, v.pos()));
+            callArgs.add(Ast.Var.local(p, v.pos()));
         }
-        Ast.Block block = new Ast.Block(params, new Ast.Call(v.name(), callArgs, v.pos()), v.pos());
+        Ast.Block block = new Ast.Block(params,
+                new Ast.Call(v.name(), v.denotes(), callArgs, v.pos()), v.pos());
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.set(idx, block);
-        return new Ast.Call(call.fn(), args, call.pos());
+        return new Ast.Call(call.fn(), call.denotes(), args, call.pos());
     }
 
     /**
@@ -606,12 +609,18 @@ public final class HelperInliner {
      */
     private Ast.Expr rename(Ast.Expr e, Map<String, String> subst, Set<String> fnParams, SourcePos at) {
         return switch (e) {
-            case Ast.Var v -> subst.containsKey(v.name()) ? new Ast.Var(subst.get(v.name()), at(at, v.pos())) : e;
+            case Ast.Var v -> subst.containsKey(v.name())
+                    ? Ast.Var.local(subst.get(v.name()), at(at, v.pos())) : e;
             case Ast.FieldAccess fa -> new Ast.FieldAccess(rename(fa.target(), subst, fnParams, at), fa.field(), at(at, fa.pos()));
             case Ast.Call call -> {
-                String callee = fnParams.contains(call.fn()) && subst.containsKey(call.fn())
-                        ? subst.get(call.fn()) : call.fn();
-                yield new Ast.Call(callee, renameList(call.args(), subst, fnParams, at), at(at, call.pos()));
+                boolean renamed = fnParams.contains(call.fn()) && subst.containsKey(call.fn());
+                String callee = renamed ? subst.get(call.fn()) : call.fn();
+                // a renamed callee is the function argument this parameter was bound to, under the
+                // name this expansion gave it; anything else keeps what the call already denoted
+                ValueName denotes = renamed
+                        ? new ValueName.Local(callee, at(at, call.pos())) : call.denotes();
+                yield new Ast.Call(callee, denotes, renameList(call.args(), subst, fnParams, at),
+                        at(at, call.pos()));
             }
             case Ast.Binary bin -> new Ast.Binary(bin.op(), rename(bin.left(), subst, fnParams, at), rename(bin.right(), subst, fnParams, at), at(at, bin.pos()));
             case Ast.Neg neg -> new Ast.Neg(rename(neg.operand(), subst, fnParams, at), at(at, neg.pos()));

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,7 +36,11 @@ public final class NewtypeDesugar {
         return switch (e) {
             case Ast.Call call -> {
                 List<Ast.Expr> args = mapExprs(call.args(), symbols);
-                TypeName built = symbols.resolve(call.fn());
+                // Whether this name is a type or something else was answered when the module's names
+                // were resolved. Asking the type namespace again here would read a binding of the
+                // same spelling as the type it shadows, and rewrite an application of it into a
+                // construction — both of which compile, so the meaning would change in silence.
+                TypeName built = call.denotes() instanceof ValueName.OfType named ? named.type() : null;
                 if (built != null && symbols.get(built) instanceof Ast.Data nt && nt.newtype()) {
                     if (args.size() != 1) {
                         throw CompileException.of(
@@ -50,7 +55,7 @@ public final class NewtypeDesugar {
                             List.of(new Ast.FieldInit("value", args.get(0), call.pos())),
                             List.of(), call.pos());
                 }
-                yield new Ast.Call(call.fn(), args, call.pos());
+                yield new Ast.Call(call.fn(), call.denotes(), args, call.pos());
             }
             case Ast.NewData nd -> {
                 List<Ast.FieldInit> inits = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PipelineSigs.java
@@ -54,18 +54,25 @@ public final class PipelineSigs {
                 sigs.put(spec.name(), new Sig(ins, TypeOps.successType(spec.ret(), symbols)));
             }
         }
-        Map<String, List<String>> pipeStages = pipelineStages(module);
+        Map<String, List<Ast.ValueRef>> pipeStages = pipelineStages(module);
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (b instanceof Ast.PipeBehavior pipe) {
-                sigs.put(pipe.name(), pipeSig(pipe, sigs, symbols, pipeStages));
+                try {
+                    sigs.put(pipe.name(), pipeSig(pipe, sigs, symbols, pipeStages));
+                } catch (Unanswerable _) {
+                    // A stage that names nothing was reported where it was written, and this
+                    // composition has no signature to work out. It is one behavior: the others keep
+                    // theirs, and the module is checked past it. Nothing will be emitted — the name
+                    // that denotes nothing is what `Names.Sound` answers for.
+                }
             }
         }
         return sigs;
     }
 
     /** Maps each pipeline behavior's name to its declared stages (for flattening, spec 14.2). */
-    public static Map<String, List<String>> pipelineStages(Ast.Module module) {
-        Map<String, List<String>> stages = new HashMap<>();
+    public static Map<String, List<Ast.ValueRef>> pipelineStages(Ast.Module module) {
+        Map<String, List<Ast.ValueRef>> stages = new HashMap<>();
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (b instanceof Ast.PipeBehavior pipe) {
                 stages.put(pipe.name(), pipe.stages());
@@ -81,60 +88,60 @@ public final class PipelineSigs {
      * finish}, exactly as the flat form would, so a retired case stays retired across a named
      * intermediate. A pipeline viewed on its own still has the merged output its own stages produce.
      */
-    public static List<String> flattenStages(List<String> stages, Map<String, List<String>> pipeStages,
-                                             SourcePos pos) {
-        List<String> out = new ArrayList<>();
+    public static List<Ast.ValueRef> flattenStages(List<Ast.ValueRef> stages,
+                                                   Map<String, List<Ast.ValueRef>> pipeStages,
+                                                   SourcePos pos) {
+        List<Ast.ValueRef> out = new ArrayList<>();
         flattenInto(stages, pipeStages, out, new LinkedHashSet<>(), pos);
         return out;
     }
 
-    private static void flattenInto(List<String> stages, Map<String, List<String>> pipeStages,
-                                    List<String> out, Set<String> inProgress, SourcePos pos) {
-        for (String s : stages) {
-            List<String> sub = pipeStages.get(s);
+    private static void flattenInto(List<Ast.ValueRef> stages,
+                                    Map<String, List<Ast.ValueRef>> pipeStages,
+                                    List<Ast.ValueRef> out, Set<String> inProgress, SourcePos pos) {
+        for (Ast.ValueRef s : stages) {
+            List<Ast.ValueRef> sub = pipeStages.get(s.bare());
             if (sub == null) {
                 out.add(s);
                 continue;
             }
-            if (!inProgress.add(s)) {
+            if (!inProgress.add(s.bare())) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.pipe.selfcompose").title("check.pipe.title")
-                                .at(pos).args(s).build(),
-                        "pipeline `" + s + "` composes with itself (a cycle)");
+                                .at(pos).args(s.written()).build(),
+                        "pipeline `" + s.written() + "` composes with itself (a cycle)");
             }
             flattenInto(sub, pipeStages, out, inProgress, pos);
-            inProgress.remove(s);
+            inProgress.remove(s.bare());
         }
     }
 
-    /** The signature of a pipeline stage. Only behaviors compose with {@code >->}; decode/encode
-     * are boundary edges, not stages (spec 14.1). */
-    public static Sig stageSig(String stage, Map<String, Sig> sigs, Symbols symbols,
+    /**
+     * The signature of a pipeline stage.
+     *
+     * <p>Which behavior a stage names was answered when the module's names were resolved, so there
+     * is no spelling to test here. A stage that names nothing was reported there, and this
+     * composition has no meaning to work out: the behavior it belongs to is abandoned, and the
+     * definitions around it are checked as they would be without it.
+     */
+    public static Sig stageSig(Ast.ValueRef stage, Map<String, Sig> sigs, Symbols symbols,
                                SourcePos pos) {
-        if (stage.endsWith(".decoder") || stage.endsWith(".encoder")) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.pipe.boundary").title("check.pipe.title").at(pos).build(),
-                    "decode/encode are boundary edges, not pipeline stages; `>->` composes behaviors"
-                            + " only (spec 14.1)");
+        if (stage.unresolved()) {
+            throw new Unanswerable(stage.pos());
         }
-        Sig s = sigs.get(stage);
+        Sig s = sigs.get(stage.bare());
         if (s == null) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.unknown.behavior.msg")
-                            .title("check.unknown.title")
-                            .at(pos, stage.length())
-                            .args(stage)
-                            .suggestion(Suggest.candidate(stage, sigs.keySet()))
-                            .build(),
-                    "unknown behavior `" + stage + "` in pipeline" + Suggest.hint(stage, sigs.keySet()));
+            // The behavior is declared by a module this compilation could not work out — reported
+            // on that module, whose author is the one who can act on it.
+            throw new Unanswerable(stage.pos());
         }
         return s;
     }
 
     private static Sig pipeSig(Ast.PipeBehavior pipe, Map<String, Sig> sigs, Symbols symbols,
-                               Map<String, List<String>> pipeStages) {
+                               Map<String, List<Ast.ValueRef>> pipeStages) {
         // flatten nested pipeline stages so `>->` is associative (spec 14.2)
-        List<String> stages = flattenStages(pipe.stages(), pipeStages, pipe.pos());
+        List<Ast.ValueRef> stages = flattenStages(pipe.stages(), pipeStages, pipe.pos());
         Sig first = stageSig(stages.get(0), sigs, symbols, pipe.pos());
         Type mainline = first.out();
         Set<TypeName> retired = new LinkedHashSet<>();
@@ -147,7 +154,8 @@ public final class PipelineSigs {
             if (g.ins().size() != 1) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.pipe.multiinput").title("check.pipe.title")
-                                .at(pipe.pos()).args(stages.get(i), g.ins().size(), pipe.name()).build(),
+                                .at(pipe.pos()).args(stages.get(i).written(), g.ins().size(),
+                                        pipe.name()).build(),
                         "`" + stages.get(i) + "` takes " + g.ins().size() + " inputs, so it cannot follow"
                                 + " `>->` in `" + pipe.name() + "`. Every stage after the first takes one"
                                 + " input: call it inline or open the branches with `match` instead"

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -41,6 +41,8 @@ public final class Resolve {
     private final Values values;
     /** Every name this pass answered, in the order it met them. */
     private final List<Denotation> denotations = new ArrayList<>();
+    /** The same, for the names used as values. */
+    private final List<ValueUse> values0 = new ArrayList<>();
     /** Every name it could not answer, as the error it would once have thrown. */
     private final List<CompileException> unresolved = new ArrayList<>();
 
@@ -89,6 +91,13 @@ public final class Resolve {
     public record Denotation(String written, TypeName denotes, SourcePos pos) {}
 
     /**
+     * One written name in the value namespace and what it turned out to denote, where it was
+     * written. What {@link Denotation} is for a type, and collected for the same reason: an editor
+     * asking what is under the cursor is asking about the answer this traversal already gave.
+     */
+    public record ValueUse(String written, ValueName denotes, SourcePos pos) {}
+
+    /**
      * A resolved module, every name the pass answered in it, and the names it could not answer.
      *
      * <p>A name that denotes nothing does not end the pass. It denotes {@link TypeName#unresolved},
@@ -96,7 +105,7 @@ public final class Resolve {
      * resolved as if the mistake were not there — so an author is told about every unknown name at
      * once instead of one per compile, and an editor can still say what the names around it mean.
      */
-    public record Resolved(Ast.Module module, List<Denotation> denotations,
+    public record Resolved(Ast.Module module, List<Denotation> denotations, List<ValueUse> values,
                            List<CompileException> unresolved) {}
 
     /** {@code m} with every name it writes resolved against its own definitions — a module compiled
@@ -172,7 +181,7 @@ public final class Resolve {
         return new Resolved(
                 new Ast.Module(m.name(), m.exposing(), exposedOutputs, m.imports(), defs,
                         behaviors, fns, examples, fakes, m.exampleFileTarget(), m.pos()),
-                List.copyOf(r.denotations), List.copyOf(r.unresolved));
+                List.copyOf(r.denotations), List.copyOf(r.values0), List.copyOf(r.unresolved));
     }
 
     private Ast.FnDef fn(Ast.FnDef f) {
@@ -447,8 +456,10 @@ public final class Resolve {
      */
     private Ast.Expr expr(Ast.Expr e, Bindings bound) {
         return switch (e) {
-            case Ast.Var v -> v.denoting(valueName(v.name(), v.pos(), bound));
-            case Ast.Call call -> new Ast.Call(call.fn(), calledName(call, bound),
+            case Ast.Var v -> v.denoting(answered(v.name(), v.pos(),
+                    valueName(v.name(), v.pos(), bound)));
+            case Ast.Call call -> new Ast.Call(call.fn(),
+                    answered(call.fn(), call.pos(), calledName(call, bound)),
                     exprs(call.args(), bound), call.pos());
             case Ast.NewData nd -> {
                 List<Ast.FieldInit> inits = new ArrayList<>();
@@ -552,6 +563,14 @@ public final class Resolve {
             return new ValueName.OfType(written, type);   // a newtype applied to what it wraps
         }
         return nothing(written, call.pos(), notCallable(written, call.pos(), bound));
+    }
+
+    /** Records what a name used as a value was answered with, and hands it back. */
+    private ValueName answered(String written, SourcePos pos, ValueName denotes) {
+        if (pos != null) {
+            values0.add(new ValueUse(written, denotes, pos));
+        }
+        return denotes;
     }
 
     /** Records that a name in a body denotes nothing, and gives it the name that says so. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -503,7 +503,12 @@ public final class Resolve {
         if (binder != null) {
             return new ValueName.Local(written, binder);   // a function-typed parameter, applied
         }
-        if (Prelude.hasQualified(written)) {
+        // A library qualifier makes this a library reference — `Date(...)`, whose namespace is the
+        // whole name, included. Whether the library has a function of that name is the check's to
+        // say: asking here would tie the answer to how much of the library has been loaded, and the
+        // library resolves its own sources while it loads.
+        int dot = written.lastIndexOf('.');
+        if (Prelude.isQualifier(dot < 0 ? written : written.substring(0, dot))) {
             return new ValueName.Stdlib(written);
         }
         if (values.helpers().contains(written)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -6,11 +6,16 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
+import souther.compiler.Prelude;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Says once, for a whole module, what every written type name denotes.
@@ -33,13 +38,39 @@ import java.util.Map;
 public final class Resolve {
 
     private final Symbols symbols;
+    private final Values values;
     /** Every name this pass answered, in the order it met them. */
     private final List<Denotation> denotations = new ArrayList<>();
     /** Every name it could not answer, as the error it would once have thrown. */
     private final List<CompileException> unresolved = new ArrayList<>();
 
-    private Resolve(Symbols symbols) {
+    private Resolve(Symbols symbols, Values values) {
         this.symbols = symbols;
+        this.values = values;
+    }
+
+    /**
+     * What a module can name in the value namespace without a binding: its own helpers, and the
+     * behaviors it can reach.
+     *
+     * <p>The behaviors come from outside — an import brings one in — so they are given rather than
+     * read off the module. A module resolved on its own reaches only what it declares.
+     */
+    public record Values(String module, Set<String> helpers,
+                         Map<String, ValueName.Behavior> behaviors) {
+
+        /** What a module reaches when nothing else is in sight. */
+        public static Values of(Ast.Module m) {
+            Set<String> helpers = new LinkedHashSet<>();
+            for (Ast.FnDef fn : m.fns()) {
+                helpers.add(fn.name());
+            }
+            Map<String, ValueName.Behavior> behaviors = new LinkedHashMap<>();
+            for (Ast.BehaviorDef b : m.behaviors()) {
+                behaviors.put(b.name(), new ValueName.Behavior(m.name(), b.name()));
+            }
+            return new Values(m.name(), helpers, behaviors);
+        }
     }
 
     /**
@@ -88,7 +119,13 @@ public final class Resolve {
 
     /** As {@link #module(Ast.Module, Symbols)}, keeping what each name was answered with. */
     public static Resolved resolving(Ast.Module m, Symbols symbols) {
-        Resolve r = new Resolve(symbols);
+        return resolving(m, symbols, Values.of(m));
+    }
+
+    /** As {@link #resolving(Ast.Module, Symbols)}, with what the module reaches in the value
+     * namespace given rather than read off the module itself. */
+    public static Resolved resolving(Ast.Module m, Symbols symbols, Values values) {
+        Resolve r = new Resolve(symbols, values);
         List<Ast.Def> defs = new ArrayList<>();
         for (Ast.Def def : m.defs()) {
             defs.add(r.def(def));
@@ -140,11 +177,13 @@ public final class Resolve {
 
     private Ast.FnDef fn(Ast.FnDef f) {
         List<Ast.FnParam> params = new ArrayList<>();
+        Bindings bound = Bindings.NONE;
         for (Ast.FnParam p : f.params()) {
             params.add(new Ast.FnParam(p.name(), paramType(p.type()), p.typeFromPattern(), p.pos()));
+            bound = bound.and(p.name(), p.pos());
         }
         return new Ast.FnDef(f.name(), params, retType(f.declaredReturn()), f.intrinsicKey(),
-                f.body() == null ? null : expr(f.body()), f.partial(), f.pos());
+                f.body() == null ? null : expr(f.body(), bound), f.partial(), f.pos());
     }
 
     // --- written types ---
@@ -221,8 +260,10 @@ public final class Resolve {
     private Ast.Def def(Ast.Def def) {
         return switch (def) {
             case Ast.UnitData u -> u;
+            // an invariant reads the fields of the data it belongs to, which are what bind its
+            // names — `value > 0` is about this declaration's `value`, whatever else is in scope
             case Ast.Data d -> new Ast.Data(d.name(), d.newtype(), names(d.includes()), fields(d.fields()),
-                    d.invariant().map(this::expr), d.decoder().map(this::decoder),
+                    d.invariant().map(inv -> expr(inv, boundFields(d))), d.decoder().map(this::decoder),
                     d.encoder().map(this::encoder), d.pos());
             case Ast.SumData s -> new Ast.SumData(s.name(), sumCases(s), s.decoder().map(this::discriminate),
                     s.encoder().map(this::sumEncoder), s.pos());
@@ -250,6 +291,15 @@ public final class Resolve {
         return out;
     }
 
+    /** The fields of a declaration, as the names its own invariant reads. */
+    private Bindings boundFields(Ast.Data d) {
+        Bindings bound = Bindings.NONE;
+        for (Ast.Field f : d.fields()) {
+            bound = bound.and(f.name(), f.pos());
+        }
+        return bound;
+    }
+
     private Ast.Discriminate discriminate(Ast.Discriminate d) {
         List<Ast.Variant> variants = new ArrayList<>();
         for (Ast.Variant v : d.variants()) {
@@ -268,28 +318,36 @@ public final class Resolve {
 
     // --- decoders ---
 
+    /** A decoder reads the value it is decoding under the name it gives it, and an object decoder
+     * reads what each of its binds took out of the object. Those are what bind its names. */
     private Ast.DecoderDef decoder(Ast.DecoderDef d) {
         return switch (d) {
-            case Ast.PrimDecoder p -> new Ast.PrimDecoder(p.from(), p.inputName(), stmts(p.stmts()),
-                    construct(p.result()), p.pos());
+            case Ast.PrimDecoder p -> {
+                Bindings bound = Bindings.NONE.and(p.inputName(), p.pos());
+                List<Ast.DecStmt> stmts = new ArrayList<>();
+                for (Ast.DecStmt s : p.stmts()) {
+                    if (s instanceof Ast.Let let) {
+                        stmts.add(new Ast.Let(let.name(), expr(let.value(), bound), let.pos()));
+                        bound = bound.and(let.name(), let.pos());
+                    } else {
+                        stmts.add(s);
+                    }
+                }
+                yield new Ast.PrimDecoder(p.from(), p.inputName(), stmts,
+                        construct(p.result(), bound), p.pos());
+            }
             case Ast.ObjectDecoder o -> {
                 List<Ast.Bind> binds = new ArrayList<>();
+                Bindings bound = Bindings.NONE;
                 for (Ast.Bind b : o.binds()) {
                     binds.add(new Ast.Bind(b.name(), b.key(), decRef(b.ref()), b.pos()));
+                    bound = bound.and(b.name(), b.pos());
                 }
-                yield new Ast.ObjectDecoder(binds, construct(o.result()), o.pos());
+                yield new Ast.ObjectDecoder(binds, construct(o.result(), bound), o.pos());
             }
             case Ast.NewtypeDecoder n -> new Ast.NewtypeDecoder(decRef(n.inner()), n.inputName(),
-                    construct(n.result()), n.pos());
+                    construct(n.result(), Bindings.NONE.and(n.inputName(), n.pos())), n.pos());
         };
-    }
-
-    private List<Ast.DecStmt> stmts(List<Ast.DecStmt> stmts) {
-        List<Ast.DecStmt> out = new ArrayList<>();
-        for (Ast.DecStmt s : stmts) {
-            out.add(s instanceof Ast.Let let ? new Ast.Let(let.name(), expr(let.value()), let.pos()) : s);
-        }
-        return out;
     }
 
     private Ast.DecRef decRef(Ast.DecRef ref) {
@@ -303,38 +361,43 @@ public final class Resolve {
         };
     }
 
-    private Ast.Construct construct(Ast.Construct c) {
+    private Ast.Construct construct(Ast.Construct c, Bindings bound) {
         List<Ast.FieldInit> inits = new ArrayList<>();
         for (Ast.FieldInit i : c.inits()) {
-            inits.add(new Ast.FieldInit(i.name(), expr(i.value()), i.pos()));
+            inits.add(new Ast.FieldInit(i.name(), expr(i.value(), bound), i.pos()));
         }
         return new Ast.Construct(type(c.typeName()), inits, c.spreads(), c.pos());
     }
 
     // --- encoders ---
 
+    /** An encoder reads the value it is encoding under the name it gives it. */
     private Ast.EncoderDef encoder(Ast.EncoderDef e) {
-        return new Ast.EncoderDef(e.selfName(), rawExpr(e.result()), e.pos());
+        return new Ast.EncoderDef(e.selfName(),
+                rawExpr(e.result(), Bindings.NONE.and(e.selfName(), e.pos())), e.pos());
     }
 
-    private Ast.RawExpr rawExpr(Ast.RawExpr r) {
+    private Ast.RawExpr rawExpr(Ast.RawExpr r, Bindings bound) {
         return switch (r) {
-            case Ast.TextRaw t -> new Ast.TextRaw(expr(t.arg()), t.pos());
-            case Ast.IntRaw i -> new Ast.IntRaw(expr(i.arg()), i.pos());
-            case Ast.BoolRaw b -> new Ast.BoolRaw(expr(b.arg()), b.pos());
-            case Ast.DecimalRaw d -> new Ast.DecimalRaw(expr(d.arg()), d.pos());
-            case Ast.IsoTextRaw i -> new Ast.IsoTextRaw(expr(i.arg()), i.pos());
-            case Ast.EncodeRaw en -> new Ast.EncodeRaw(type(en.typeName()), expr(en.arg()), en.pos());
-            case Ast.ListEnc l -> new Ast.ListEnc(expr(l.source()), encElem(l.elem()), l.pos());
-            case Ast.SetEnc s -> new Ast.SetEnc(expr(s.source()), encElem(s.elem()), s.pos());
-            case Ast.MapEnc m -> new Ast.MapEnc(expr(m.source()), encElem(m.elem()), encElem(m.key()),
-                    m.pos());
-            case Ast.OptionRaw o -> new Ast.OptionRaw(expr(o.access()), rawExpr(o.inner()), o.elemVar(),
-                    o.pos());
+            case Ast.TextRaw t -> new Ast.TextRaw(expr(t.arg(), bound), t.pos());
+            case Ast.IntRaw i -> new Ast.IntRaw(expr(i.arg(), bound), i.pos());
+            case Ast.BoolRaw b -> new Ast.BoolRaw(expr(b.arg(), bound), b.pos());
+            case Ast.DecimalRaw d -> new Ast.DecimalRaw(expr(d.arg(), bound), d.pos());
+            case Ast.IsoTextRaw i -> new Ast.IsoTextRaw(expr(i.arg(), bound), i.pos());
+            case Ast.EncodeRaw en ->
+                    new Ast.EncodeRaw(type(en.typeName()), expr(en.arg(), bound), en.pos());
+            case Ast.ListEnc l -> new Ast.ListEnc(expr(l.source(), bound), encElem(l.elem()), l.pos());
+            case Ast.SetEnc s -> new Ast.SetEnc(expr(s.source(), bound), encElem(s.elem()), s.pos());
+            case Ast.MapEnc m -> new Ast.MapEnc(expr(m.source(), bound), encElem(m.elem()),
+                    encElem(m.key()), m.pos());
+            // the inner expression reads the element the option holds, under the name given here
+            case Ast.OptionRaw o -> new Ast.OptionRaw(expr(o.access(), bound),
+                    rawExpr(o.inner(), bound.and(o.elemVar(), o.pos())), o.elemVar(), o.pos());
             case Ast.ObjectRaw o -> {
                 List<Ast.RawEntry> entries = new ArrayList<>();
                 for (Ast.RawEntry entry : o.entries()) {
-                    entries.add(new Ast.RawEntry(entry.key(), rawExpr(entry.value()), entry.pos()));
+                    entries.add(new Ast.RawEntry(entry.key(), rawExpr(entry.value(), bound),
+                            entry.pos()));
                 }
                 yield new Ast.ObjectRaw(entries, o.pos());
             }
@@ -353,37 +416,135 @@ public final class Resolve {
 
     // --- expressions ---
 
-    /** Rewrites the names {@code e} itself writes; the recursion into its children is
-     * {@link Ast#mapChildren}, so a new expression kind is carried without being named here. */
     private Ast.Expr expr(Ast.Expr e) {
-        Ast.Expr mapped = Ast.mapChildren(e, this::expr);
-        return switch (mapped) {
-            case Ast.NewData nd ->
-                    new Ast.NewData(type(nd.typeName()), nd.inits(), nd.spreads(), nd.pos());
+        return expr(e, Bindings.NONE);
+    }
+
+    /**
+     * Rewrites the names {@code e} itself writes, against the bindings in force where it is written.
+     *
+     * <p>A node that binds a name is written out here, because what its parts are resolved against
+     * differs: a {@code let}'s value is outside its own binding and its body is inside. Everything
+     * else recurses through {@link Ast#mapChildren}, so a new expression kind is carried without
+     * being named here.
+     */
+    private Ast.Expr expr(Ast.Expr e, Bindings bound) {
+        return switch (e) {
+            case Ast.Var v -> v.denoting(valueName(v.name(), v.pos(), bound));
+            case Ast.Call call -> new Ast.Call(call.fn(), calledName(call, bound),
+                    exprs(call.args(), bound), call.pos());
+            case Ast.NewData nd -> {
+                List<Ast.FieldInit> inits = new ArrayList<>();
+                for (Ast.FieldInit i : nd.inits()) {
+                    inits.add(new Ast.FieldInit(i.name(), expr(i.value(), bound), i.pos()));
+                }
+                yield new Ast.NewData(type(nd.typeName()), inits, nd.spreads(), nd.pos());
+            }
             // a binding's pattern may write Option's `Some`, which the binding check then rejects
             // for what it is — a name that opens nothing — rather than as a name nothing declares
-            case Ast.LetIn li -> new Ast.LetIn(li.name(), li.value(), paramType(li.declaredType()),
-                    li.annotated(),
+            case Ast.LetIn li -> new Ast.LetIn(li.name(), expr(li.value(), bound),
+                    paramType(li.declaredType()), li.annotated(),
                     li.opens() == null ? null : caseName(li.opens()),
-                    li.body(), li.pos());
+                    expr(li.body(), bound.and(li.name(), li.pos())), li.pos());
+            case Ast.Block b -> new Ast.Block(b.params(),
+                    expr(b.body(), bound.andAll(b.params(), b.pos())), b.pos());
             case Ast.Match m -> {
                 List<Ast.Case> cases = new ArrayList<>();
                 for (Ast.Case c : m.cases()) {
-                    cases.add(new Ast.Case(caseNames(c.caseTypes()), c.binding(), c.body(),
+                    Bindings inArm = c.binding() == null ? bound : bound.and(c.binding(), c.pos());
+                    cases.add(new Ast.Case(caseNames(c.caseTypes()), c.binding(),
+                            expr(c.body(), inArm),
                             c.unwrapAsserts() == null ? null : names(c.unwrapAsserts()), c.pos()));
                 }
-                yield new Ast.Match(m.scrutinee(), cases, m.pos());
+                yield new Ast.Match(expr(m.scrutinee(), bound), cases, m.pos());
             }
-            default -> mapped;
+            default -> Ast.mapChildren(e, x -> expr(x, bound));
         };
     }
 
     private List<Ast.Expr> exprs(List<Ast.Expr> es) {
+        return exprs(es, Bindings.NONE);
+    }
+
+    private List<Ast.Expr> exprs(List<Ast.Expr> es, Bindings bound) {
         List<Ast.Expr> out = new ArrayList<>();
         for (Ast.Expr e : es) {
-            out.add(expr(e));
+            out.add(expr(e, bound));
         }
         return out;
+    }
+
+    // --- names in a body ---
+
+    /**
+     * What a name used as a value denotes. A binding in force wins over everything else — a body may
+     * bind a name a module declares, and the binding is what the name means there.
+     */
+    private ValueName valueName(String written, SourcePos pos, Bindings bound) {
+        SourcePos binder = bound.binderOf(written);
+        if (binder != null) {
+            return new ValueName.Local(written, binder);
+        }
+        if (Elaborator.ROUNDING_MODES.contains(written) || written.equals("None")
+                || written.equals("Some")) {
+            return new ValueName.Builtin(written);
+        }
+        TypeName type = symbols.resolve(written);
+        if (type != null && !type.isUnresolved()) {
+            return new ValueName.OfType(written, type);
+        }
+        return new ValueName.Unresolved(written);
+    }
+
+    /** What the name a call applies denotes. */
+    private ValueName calledName(Ast.Call call, Bindings bound) {
+        String written = call.fn();
+        SourcePos binder = bound.binderOf(written);
+        if (binder != null) {
+            return new ValueName.Local(written, binder);   // a function-typed parameter, applied
+        }
+        if (Prelude.hasQualified(written)) {
+            return new ValueName.Stdlib(written);
+        }
+        if (values.helpers().contains(written)) {
+            return new ValueName.Helper(values.module(), written);
+        }
+        ValueName.Behavior behavior = values.behaviors().get(written);
+        if (behavior != null) {
+            return behavior;
+        }
+        TypeName type = symbols.resolve(written);
+        if (type != null && !type.isUnresolved()) {
+            return new ValueName.OfType(written, type);   // a newtype applied to what it wraps
+        }
+        return new ValueName.Unresolved(written);
+    }
+
+    /**
+     * The names bound at a point in a body, each with where it was bound. Persistent: extending it
+     * leaves the outer scope as it was, which is what an inner binding shadowing an outer one is.
+     */
+    record Bindings(Map<String, SourcePos> byName) {
+
+        static final Bindings NONE = new Bindings(Map.of());
+
+        Bindings and(String name, SourcePos binder) {
+            Map<String, SourcePos> next = new HashMap<>(byName);
+            next.put(name, binder);
+            return new Bindings(Map.copyOf(next));
+        }
+
+        Bindings andAll(List<String> names, SourcePos binder) {
+            Map<String, SourcePos> next = new HashMap<>(byName);
+            for (String name : names) {
+                next.put(name, binder);
+            }
+            return new Bindings(Map.copyOf(next));
+        }
+
+        SourcePos binderOf(String name) {
+            return byName.get(name);
+        }
     }
 
     // --- names ---

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -291,11 +291,28 @@ public final class Resolve {
         return out;
     }
 
-    /** The fields of a declaration, as the names its own invariant reads. */
+    /**
+     * The fields of a declaration, as the names its own invariant reads — the ones written here and
+     * the ones a spread brings in, which are as much this declaration's fields as the written ones
+     * (and are what a spread-in invariant was written against).
+     */
     private Bindings boundFields(Ast.Data d) {
-        Bindings bound = Bindings.NONE;
+        return boundFields(d, Bindings.NONE, new LinkedHashSet<>());
+    }
+
+    private Bindings boundFields(Ast.Data d, Bindings bound, Set<TypeName> spread) {
         for (Ast.Field f : d.fields()) {
             bound = bound.and(f.name(), f.pos());
+        }
+        for (Ast.Name include : d.includes()) {
+            TypeName source = include.denotes() != null
+                    ? include.denotes() : symbols.resolve(include.written());
+            // a spread of a spread reaches the fields underneath; a spread that names nothing, or
+            // names its way back round, is reported where the declaration is checked
+            if (source != null && spread.add(source)
+                    && symbols.get(source) instanceof Ast.Data src) {
+                bound = boundFields(src, bound, spread);
+            }
         }
         return bound;
     }
@@ -493,7 +510,16 @@ public final class Resolve {
         if (type != null && !type.isUnresolved()) {
             return new ValueName.OfType(written, type);
         }
-        return new ValueName.Unresolved(written);
+        // a helper or a behavior named without being applied — handed to a combinator by name,
+        // which the inliner expands into a block that applies it
+        if (values.helpers().contains(written)) {
+            return new ValueName.Helper(values.module(), written);
+        }
+        ValueName.Behavior behavior = values.behaviors().get(written);
+        if (behavior != null) {
+            return behavior;
+        }
+        return nothing(written, pos, unknownIdentifier(written, pos, bound));
     }
 
     /** What the name a call applies denotes. */
@@ -502,6 +528,9 @@ public final class Resolve {
         SourcePos binder = bound.binderOf(written);
         if (binder != null) {
             return new ValueName.Local(written, binder);   // a function-typed parameter, applied
+        }
+        if (written.equals("Some") || written.equals("None")) {
+            return new ValueName.Builtin(written);   // Option's cases, which are not calls (E1303)
         }
         // A library qualifier makes this a library reference — `Date(...)`, whose namespace is the
         // whole name, included. Whether the library has a function of that name is the check's to
@@ -522,7 +551,57 @@ public final class Resolve {
         if (type != null && !type.isUnresolved()) {
             return new ValueName.OfType(written, type);   // a newtype applied to what it wraps
         }
+        return nothing(written, call.pos(), notCallable(written, call.pos(), bound));
+    }
+
+    /** Records that a name in a body denotes nothing, and gives it the name that says so. */
+    private ValueName nothing(String written, SourcePos pos, CompileException why) {
+        unresolved.add(why);
         return new ValueName.Unresolved(written);
+    }
+
+    /** The names a body could have written where it wrote one nothing answers to. */
+    private List<String> reachable(Bindings bound) {
+        List<String> names = new ArrayList<>(bound.byName().keySet());
+        names.addAll(values.helpers());
+        names.addAll(values.behaviors().keySet());
+        return names;
+    }
+
+    private CompileException unknownIdentifier(String written, SourcePos pos, Bindings bound) {
+        if (written.equals("null")) {
+            return new CompileException(pos, "E1301",
+                    "`null` is not part of the language. Use an optional field with `?`.");
+        }
+        List<String> candidates = reachable(bound);
+        return CompileException.of(
+                Diagnostic.of(null, "check.unknown.name.msg").title("check.unknown.title")
+                        .at(pos, written.length()).args(written)
+                        .suggestion(Suggest.candidate(written, candidates)).build(),
+                "unknown identifier `" + written + "`" + Suggest.hint(written, candidates));
+    }
+
+    /**
+     * A name applied to arguments that names nothing that can be applied. A standard-library
+     * function written bare is told apart: it exists, and is reached qualified (spec §stdlib).
+     */
+    private CompileException notCallable(String written, SourcePos pos, Bindings bound) {
+        String qualified = Prelude.qualifiedFor(written);
+        if (qualified != null) {
+            return CompileException.of(
+                    Diagnostic.of(null, "check.stdlib.qualified.msg").title("check.unknown.title")
+                            .at(pos, written.length()).args(written, qualified).build(),
+                    "`" + written + "` is a standard-library function and must be called qualified,"
+                            + " as `" + qualified + "` (spec §stdlib).");
+        }
+        List<String> candidates = reachable(bound);
+        return CompileException.of(
+                Diagnostic.of("E1401", "e1401.msg").at(pos, written.length()).args(written)
+                        .suggestion(Suggest.candidate(written, candidates))
+                        .hint("e1401.hint").build(),
+                "`" + written + "` is not a behavior or builtin" + Suggest.hint(written, candidates)
+                        + ". Calling arbitrary JVM methods is not allowed; declare a behavior"
+                        + " without a `let` and implement it from Java.");
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -565,10 +565,21 @@ public final class Resolve {
         return nothing(written, call.pos(), notCallable(written, call.pos(), bound));
     }
 
-    /** Records what a name used as a value was answered with, and hands it back. */
+    /**
+     * Records what a name used as a value was answered with, and hands it back.
+     *
+     * <p>A name that denotes a type — a unit data written as a value, a newtype applied to what it
+     * wraps — is a use of that type as much as one written in a field's type is, and is recorded as
+     * one too. Otherwise renaming the type would rewrite every other mention of it and leave these,
+     * which is a rename that stops the workspace compiling.
+     */
     private ValueName answered(String written, SourcePos pos, ValueName denotes) {
-        if (pos != null) {
-            values0.add(new ValueUse(written, denotes, pos));
+        if (pos == null) {
+            return denotes;
+        }
+        values0.add(new ValueUse(written, denotes, pos));
+        if (denotes instanceof ValueName.OfType named) {
+            denotations.add(new Denotation(written, named.type(), pos));
         }
         return denotes;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -45,9 +45,12 @@ public final class SpecChecker {
                     continue;
                 }
                 String req = required.bare();
+                // at the name, as the clause that names nothing is: one clause, one place to look,
+                // whichever of the two is wrong with it
                 throw CompileException.of(
                         Diagnostic.of("E1607", "e1607.implemented").title("e1607.title")
-                                .at(spec.pos()).args(spec.name(), req)
+                                .at(required.pos(), required.written().length())
+                                .args(spec.name(), req)
                                 .hint("e1607.implemented.hint").build(),
                         "`behavior " + spec.name() + "` declares `requires " + req + "`, but `"
                                 + req + "` has an implementation of its own, so it is not an"

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -145,6 +145,14 @@ public final class SpecChecker {
                             + "`, so its return type comes from the behavior — do not declare one"
                             + " (spec 13.1)");
         }
+        for (Ast.ValueRef required : spec.requires()) {
+            // A `requires` naming nothing was reported where it is written. What this fn's trailing
+            // parameters should be called comes from those names, so there is nothing to hold them
+            // against — saying they are named wrongly would name the spelling that denotes nothing.
+            if (required.unresolved()) {
+                throw new Unanswerable(required.pos());
+            }
+        }
         int nBusiness = spec.params().size();
         int nReq = spec.requires().size();
         if (fn.params().size() != nBusiness + nReq) {

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -7,6 +7,7 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -29,37 +30,28 @@ public final class SpecChecker {
      * imports. Reported where the clause is written, so a behavior that has an implementation and one
      * that was never declared are told apart — the body check sees only a call it cannot type and
      * reports both as an arbitrary JVM call (E1401, issue #96).
+     *
+     * <p>That the name is a behavior at all was settled when the module's names were resolved, and a
+     * clause that names none was reported there. What is left here is the behavior that exists and
+     * implements itself.
      */
-    static void checkRequiresAreInjectionTargets(Ast.Module module, Map<String, ReqSig> reqSigs,
-                                                 Set<String> importedBehaviors) {
-        Set<String> behaviorNames = new HashSet<>();
-        for (Ast.BehaviorDef b : module.behaviors()) {
-            behaviorNames.add(b.name());
-        }
+    static void checkRequiresAreInjectionTargets(Ast.Module module, Map<String, ReqSig> reqSigs) {
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (!(b instanceof Ast.SpecBehavior spec)) {
                 continue;
             }
-            for (String req : spec.requires()) {
-                if (reqSigs.containsKey(req)) {
+            for (Ast.ValueRef required : spec.requires()) {
+                if (required.unresolved() || reqSigs.containsKey(required.bare())) {
                     continue;
                 }
-                if (behaviorNames.contains(req) || importedBehaviors.contains(req)) {
-                    throw CompileException.of(
-                            Diagnostic.of("E1607", "e1607.implemented").title("e1607.title")
-                                    .at(spec.pos()).args(spec.name(), req)
-                                    .hint("e1607.implemented.hint").build(),
-                            "`behavior " + spec.name() + "` declares `requires " + req + "`, but `"
-                                    + req + "` has an implementation of its own, so it is not an"
-                                    + " injection target — compose it with `>->` instead (spec 13.2)");
-                }
+                String req = required.bare();
                 throw CompileException.of(
-                        Diagnostic.of("E1607", "e1607.unknown").title("e1607.title")
+                        Diagnostic.of("E1607", "e1607.implemented").title("e1607.title")
                                 .at(spec.pos()).args(spec.name(), req)
-                                .suggestion(Suggest.candidate(req, reqSigs.keySet()))
-                                .hint("e1607.unknown.hint").build(),
-                        "`behavior " + spec.name() + "` declares `requires " + req + "`, which is not a"
-                                + " behavior in scope" + Suggest.hint(req, reqSigs.keySet()));
+                                .hint("e1607.implemented.hint").build(),
+                        "`behavior " + spec.name() + "` declares `requires " + req + "`, but `"
+                                + req + "` has an implementation of its own, so it is not an"
+                                + " injection target — compose it with `>->` instead (spec 13.2)");
             }
         }
     }
@@ -97,7 +89,14 @@ public final class SpecChecker {
             if (!(b instanceof Ast.PipeBehavior pipe) || !exposed.contains(pipe.name())) {
                 continue;
             }
-            Set<TypeName> inferred = TypeOps.leafCases(sigs.get(pipe.name()).out(), symbols);
+            Sig sig = sigs.get(pipe.name());
+            if (sig == null) {
+                // A composition with no signature is one that rests on a stage naming nothing,
+                // reported where that stage was written. There is no output to hold a declaration
+                // against, and the other compositions still have theirs.
+                continue;
+            }
+            Set<TypeName> inferred = TypeOps.leafCases(sig.out(), symbols);
             Ast.RetType declared = module.exposedOutputs().get(pipe.name());
             if (declared == null) {
                 throw CompileException.of(
@@ -169,7 +168,7 @@ public final class SpecChecker {
         }
         for (int i = 0; i < nReq; i++) {
             String got = fn.params().get(nBusiness + i).name();
-            String want = spec.requires().get(i);
+            String want = spec.requires().get(i).bare();
             if (!got.equals(want)) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.impl.reqorder").title("check.impl.title")
@@ -256,8 +255,12 @@ public final class SpecChecker {
         // The requires clause must match what the fn actually calls (spec 12.6): missing -> E1602,
         // extra -> E1603.
         List<String> actual = requiredCalls(body, reqSigs.keySet());
+        List<String> declared = new ArrayList<>();
+        for (Ast.ValueRef required : spec.requires()) {
+            declared.add(required.bare());
+        }
         for (String call : actual) {
-            if (!spec.requires().contains(call)) {
+            if (!declared.contains(call)) {
                 throw CompileException.of(
                         Diagnostic.of("E1602", "e1602.msg").at(spec.pos())
                                 .args(fn.name(), call, spec.name()).hint("e1602.hint").build(),
@@ -265,7 +268,7 @@ public final class SpecChecker {
                                 + " `behavior " + spec.name() + "` does not declare `requires " + call + "`.");
             }
         }
-        for (String req : spec.requires()) {
+        for (String req : declared) {
             if (!actual.contains(req)) {
                 throw CompileException.of(
                         Diagnostic.of("E1603", "e1603.msg").at(spec.pos())
@@ -423,16 +426,17 @@ public final class SpecChecker {
                 arity.put(spec.name(), spec.params().size());
             }
         }
-        Map<String, List<String>> pipeStages = PipelineSigs.pipelineStages(module);
+        Map<String, List<Ast.ValueRef>> pipeStages = PipelineSigs.pipelineStages(module);
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (!(b instanceof Ast.PipeBehavior pipe)) {
                 continue;
             }
             // check the flattened stages: a named intermediate splices in its own first stage, which
             // then sits after `>->` and so must be single-input too (spec 14.1, 14.2)
-            List<String> stages = PipelineSigs.flattenStages(pipe.stages(), pipeStages, pipe.pos());
+            List<Ast.ValueRef> stages = PipelineSigs.flattenStages(pipe.stages(), pipeStages,
+                    pipe.pos());
             for (int i = 1; i < stages.size(); i++) {
-                String stage = stages.get(i);
+                String stage = stages.get(i).bare();
                 Integer n = arity.get(stage);
                 if (n != null && n != 1) {
                     throw CompileException.of(

--- a/souther-compiler/src/main/java/souther/compiler/check/Suggest.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Suggest.java
@@ -8,20 +8,20 @@ import java.util.Collection;
  * closeness bound is Levenshtein distance ≤ 2 and strictly less than the name's length, so a short
  * name does not match every candidate.
  */
-final class Suggest {
+public final class Suggest {
 
     private Suggest() {
     }
 
     /** {@code " (did you mean `X`?)"} for the closest candidate within bound, or {@code ""}. */
-    static String hint(String name, Collection<String> candidates) {
+    public static String hint(String name, Collection<String> candidates) {
         String best = candidate(name, candidates);
         return best == null ? "" : " (did you mean `" + best + "`?)";
     }
 
     /** The closest in-scope candidate to {@code name} within the closeness bound, or {@code null}.
      * The structured form of {@link #hint}, for a diagnostic's {@code suggestion} field. */
-    static String candidate(String name, Collection<String> candidates) {
+    public static String candidate(String name, Collection<String> candidates) {
         String best = null;
         int bestDistance = Integer.MAX_VALUE;
         for (String candidate : candidates) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -220,7 +220,11 @@ public final class TypeChecker {
                     outputCases.add(t.name());
                 }
                 DataChecker.rejectDuplicateNames(outputCases, "the behavior output", spec.pos());
-                DataChecker.rejectDuplicateNames(spec.requires(), "`requires`", spec.pos());
+                List<String> required = new ArrayList<>();
+                for (Ast.ValueRef req : spec.requires()) {
+                    required.add(req.bare());
+                }
+                DataChecker.rejectDuplicateNames(required, "`requires`", spec.pos());
                 DataChecker.rejectDuplicateTypes(spec.constructs(), "`constructs`", spec.pos());
             }
         }
@@ -290,7 +294,7 @@ public final class TypeChecker {
         }
         // Fail-fast with the reqSigs it reads: a `requires` that named something else leaves the call
         // untypeable, and the body check would report it as a call to an unknown name (E1401).
-        SpecChecker.checkRequiresAreInjectionTargets(module, reqSigs, importedSigs.keySet());
+        SpecChecker.checkRequiresAreInjectionTargets(module, reqSigs);
         // A binding whose value is a lambda takes no annotation (spec 16.1). Read on the surface bodies:
         // lowering has already expanded such a binding away at each of its applications.
         for (Ast.FnDef fn : module.fns()) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -264,7 +264,7 @@ public final class Backend {
         b.ctx.setRequiredSignatures(requiredParam, requiredSuccess);
         Map<String, Sig> sigs = PipelineSigs.signatures(module, b.symbols, importedSigs);
         Map<String, List<String>> behaviorDeps = requirementSets(module, requiredNames);
-        Map<String, List<String>> pipeStages = PipelineSigs.pipelineStages(module);
+        Map<String, List<Ast.ValueRef>> pipeStages = PipelineSigs.pipelineStages(module);
         for (Ast.BehaviorDef bd : module.behaviors()) {
             switch (bd) {
                 case Ast.SpecBehavior spec -> {
@@ -280,14 +280,14 @@ public final class Backend {
                         }
                         out.put(module.name() + "." + behaviorClass(spec.name()),
                                 b.generateBehaviorInterface(spec.name(), pts, b.successType(spec.ret()),
-                                        spec.requires()));
+                                        requiredBy(spec)));
                     }
                     // else: injection target — its abstract base was generated above (spec 13.3)
                 }
                 case Ast.PipeBehavior pipe -> {
                     out.put(module.name() + "." + CodegenContext.behaviorImplClass(pipe.name()),
                             b.generatePipe(pipe, requiredNames, sigs, behaviorDeps, pipeStages));
-                    Sig sig = PipelineSigs.stageSig(pipe.name(), sigs, symbols, pipe.pos());
+                    Sig sig = sigs.get(pipe.name());   // its own signature, worked out above
                     out.put(module.name() + "." + behaviorClass(pipe.name()),
                             b.generateBehaviorInterface(pipe.name(), sig.ins(), sig.out(),
                                     behaviorDeps.getOrDefault(pipe.name(), List.of())));
@@ -716,7 +716,7 @@ public final class Backend {
         int n = spec.params().size();
         // declared requires, validated to equal what the fn calls (E1602/E1603); the same order is
         // used by pipeline callers (requirementSets), so the injected fields line up.
-        List<String> injected = spec.requires();
+        List<String> injected = requiredBy(spec);
         ClassDesc[] applyParams = new ClassDesc[n];
         for (int i = 0; i < n; i++) {
             applyParams[i] = CD_Object;
@@ -796,10 +796,10 @@ public final class Backend {
         switch (bd) {
             // an injection target short-circuits above, so a SpecBehavior here is fn-implemented:
             // its dependencies are its declared requires, in that order (spec 12.6, 13.6)
-            case Ast.SpecBehavior spec -> deps.addAll(spec.requires());
+            case Ast.SpecBehavior spec -> deps.addAll(requiredBy(spec));
             case Ast.PipeBehavior pipe -> {
-                for (String stage : pipe.stages()) {
-                    deps.addAll(resolveDeps(stage, byName, requiredNames, memo, inProgress));
+                for (Ast.ValueRef stage : pipe.stages()) {
+                    deps.addAll(resolveDeps(stage.bare(), byName, requiredNames, memo, inProgress));
                 }
             }
         }
@@ -809,14 +809,23 @@ public final class Backend {
         return out;
     }
 
+    /** The behaviors a spec declares it requires, by the name each is reached by. */
+    private static List<String> requiredBy(Ast.SpecBehavior spec) {
+        List<String> names = new ArrayList<>();
+        for (Ast.ValueRef req : spec.requires()) {
+            names.add(req.bare());
+        }
+        return names;
+    }
+
     private byte[] generatePipe(Ast.PipeBehavior pipe, Set<String> requiredNames,
                                 Map<String, Sig> sigs, Map<String, List<String>> behaviorDeps,
-                                Map<String, List<String>> pipeStages) {
+                                Map<String, List<Ast.ValueRef>> pipeStages) {
         ClassDesc cdP = cdBehaviorImpl(pipe.name());   // the $Impl behind the public interface
         // Flatten nested pipeline stages so the routing is over leaf behaviors (spec 14.2): a named
         // intermediate `half = split >-> work` inlines to `split, work`, which keeps a retired case
         // retired across the composition, making `>->` associative.
-        List<String> flat = PipelineSigs.flattenStages(pipe.stages(), pipeStages, pipe.pos());
+        List<Ast.ValueRef> flat = PipelineSigs.flattenStages(pipe.stages(), pipeStages, pipe.pos());
         // the pipeline's injected fields are the union of its stages' requirements (spec 14.3)
         List<String> reqStages = behaviorDeps.getOrDefault(pipe.name(), List.of());
         // the pipeline takes whatever its first stage takes (spec 14.1)
@@ -833,14 +842,14 @@ public final class Backend {
 
             cb.withMethodBody("apply", mtdApply, ClassFile.ACC_PUBLIC, code -> {
                 // slot 1 always holds the running value (an output case, as an Object).
-                List<String> stages = flat;
+                List<Ast.ValueRef> stages = flat;
                 // stage 0 consumes the pipeline's arguments unconditionally
-                applyFirstStage(code, cdP, stages.get(0), arity, requiredNames, behaviorDeps);
+                applyFirstStage(code, cdP, stages.get(0).bare(), arity, requiredNames, behaviorDeps);
                 Type mainline = PipelineSigs.stageSig(stages.get(0), sigs, symbols, pipe.pos()).out();
                 Label end = code.newLabel();
                 for (int i = 1; i < stages.size(); i++) {
-                    String stage = stages.get(i);
-                    Sig g = PipelineSigs.stageSig(stage, sigs, symbols, pipe.pos());
+                    String stage = stages.get(i).bare();
+                    Sig g = PipelineSigs.stageSig(stages.get(i), sigs, symbols, pipe.pos());
                     if (TypeOps.isDataLike(mainline)) {
                         // Apply g only when the running value is one of the main-line cases it
                         // accepts. Anything else has left the main line: jump to the end rather
@@ -867,7 +876,7 @@ public final class Backend {
                 code.areturn();
             });
             if (arity != 1) {
-                Sig sig = PipelineSigs.stageSig(pipe.name(), sigs, symbols, pipe.pos());
+                Sig sig = sigs.get(pipe.name());   // its own signature, worked out above
                 emitTypedApplyBridge(cb, cdP, typedApplyDesc(pipe.name(), sig.ins(), sig.out()));
             }
         });

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -287,7 +287,7 @@ public final class Backend {
                 case Ast.PipeBehavior pipe -> {
                     out.put(module.name() + "." + CodegenContext.behaviorImplClass(pipe.name()),
                             b.generatePipe(pipe, requiredNames, sigs, behaviorDeps, pipeStages));
-                    Sig sig = sigs.get(pipe.name());   // its own signature, worked out above
+                    Sig sig = declaredSig(pipe, sigs);
                     out.put(module.name() + "." + behaviorClass(pipe.name()),
                             b.generateBehaviorInterface(pipe.name(), sig.ins(), sig.out(),
                                     behaviorDeps.getOrDefault(pipe.name(), List.of())));
@@ -809,6 +809,22 @@ public final class Backend {
         return out;
     }
 
+    /**
+     * A composition's own signature, worked out when the module's signatures were.
+     *
+     * <p>A composition resting on a stage that names nothing has none — it was abandoned there. A
+     * module holding one is not emitted, so reaching this with no signature means the gate that
+     * decides let something through that has no meaning, and there is nothing to emit for it.
+     */
+    private static Sig declaredSig(Ast.PipeBehavior pipe, Map<String, Sig> sigs) {
+        Sig sig = sigs.get(pipe.name());
+        if (sig == null) {
+            throw new IllegalStateException("`" + pipe.name() + "` reached codegen with no signature,"
+                    + " at " + pipe.pos());
+        }
+        return sig;
+    }
+
     /** The behaviors a spec declares it requires, by the name each is reached by. */
     private static List<String> requiredBy(Ast.SpecBehavior spec) {
         List<String> names = new ArrayList<>();
@@ -876,7 +892,7 @@ public final class Backend {
                 code.areturn();
             });
             if (arity != 1) {
-                Sig sig = sigs.get(pipe.name());   // its own signature, worked out above
+                Sig sig = declaredSig(pipe, sigs);
                 emitTypedApplyBridge(cb, cdP, typedApplyDesc(pipe.name(), sig.ins(), sig.out()));
             }
         });

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -82,7 +82,7 @@ public final class Deriver {
         if (single != null) {
             Ast.RawKind kind = rawKind(single.getValue());
             Ast.Construct result = new Ast.Construct(self,
-                    List.of(new Ast.FieldInit(single.getKey(), new Ast.Var("__in", pos), pos)),
+                    List.of(new Ast.FieldInit(single.getKey(), Ast.Var.local("__in", pos), pos)),
                     List.of(), pos);
             return new Ast.PrimDecoder(kind, "__in", List.of(), result, pos);
         }
@@ -90,7 +90,7 @@ public final class Deriver {
         if (d.newtype() && !isCase) {
             Map.Entry<String, Type> only = fields.entrySet().iterator().next();
             Ast.Construct result = new Ast.Construct(self,
-                    List.of(new Ast.FieldInit(only.getKey(), new Ast.Var("__in", pos), pos)),
+                    List.of(new Ast.FieldInit(only.getKey(), Ast.Var.local("__in", pos), pos)),
                     List.of(), pos);
             return new Ast.NewtypeDecoder(
                     decRef(only.getValue(), d, only.getKey(), fieldPos(d, only.getKey())),
@@ -101,7 +101,7 @@ public final class Deriver {
         for (Map.Entry<String, Type> f : fields.entrySet()) {
             binds.add(new Ast.Bind(f.getKey(), f.getKey(),
                     decRef(f.getValue(), d, f.getKey(), fieldPos(d, f.getKey())), pos));
-            inits.add(new Ast.FieldInit(f.getKey(), new Ast.Var(f.getKey(), pos), pos));
+            inits.add(new Ast.FieldInit(f.getKey(), Ast.Var.local(f.getKey(), pos), pos));
         }
         return new Ast.ObjectDecoder(binds, new Ast.Construct(self, inits, List.of(), pos), pos);
     }
@@ -173,7 +173,7 @@ public final class Deriver {
         SourcePos pos = d.pos();
         Map.Entry<String, Type> single = bareField(d, fields, isCase);
         if (single != null) {
-            Ast.Expr access = new Ast.FieldAccess(new Ast.Var("self", pos), single.getKey(), pos);
+            Ast.Expr access = new Ast.FieldAccess(Ast.Var.local("self", pos), single.getKey(), pos);
             return new Ast.EncoderDef("self", primRaw(single.getValue(), access, pos), pos);
         }
         // a newtype over a non-primitive Y encodes self.value as Y writes itself — Y's
@@ -181,7 +181,7 @@ public final class Deriver {
         // so this is the same choice a field of type Y makes.
         if (d.newtype() && !isCase) {
             Map.Entry<String, Type> only = fields.entrySet().iterator().next();
-            Ast.Expr access = new Ast.FieldAccess(new Ast.Var("self", pos), only.getKey(), pos);
+            Ast.Expr access = new Ast.FieldAccess(Ast.Var.local("self", pos), only.getKey(), pos);
             return new Ast.EncoderDef("self",
                     rawForAccess(only.getValue(), access, d, only.getKey(), pos), pos);
         }
@@ -215,7 +215,7 @@ public final class Deriver {
     }
 
     private static Ast.RawExpr rawFor(Type t, String field, Ast.Data d, SourcePos pos) {
-        return rawForAccess(t, new Ast.FieldAccess(new Ast.Var("self", pos), field, pos),
+        return rawForAccess(t, new Ast.FieldAccess(Ast.Var.local("self", pos), field, pos),
                 d, field, pos);
     }
 
@@ -235,7 +235,7 @@ public final class Deriver {
         }
         if (t instanceof Type.OptionOf oo) {
             String elemVar = "$opt";
-            Ast.RawExpr inner = rawForAccess(oo.element(), new Ast.Var(elemVar, pos), d, field, pos);
+            Ast.RawExpr inner = rawForAccess(oo.element(), Ast.Var.local(elemVar, pos), d, field, pos);
             return new Ast.OptionRaw(access, inner, elemVar, pos);
         }
         if (t instanceof Type.MapOf mo) {

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -310,7 +310,7 @@ public final class AstBuilder {
             });
             Ast.RetType ret = retType(s.child(SyntaxKind.RET_TYPE).orElseThrow());
             List<Ast.Name> constructs = new ArrayList<>();
-            List<String> requires = new ArrayList<>();
+            List<Ast.ValueRef> requires = new ArrayList<>();
             for (SyntaxNode clause : s.childNodes()) {
                 // either clause may name through a module, so the idents of one name are joined and
                 // a comma starts the next
@@ -318,14 +318,14 @@ public final class AstBuilder {
                     constructs.addAll(dottedNames(clause));
                 } else if (clause.kind() == SyntaxKind.REQUIRES_CLAUSE) {
                     for (Ast.Name required : dottedNames(clause)) {
-                        requires.add(required.written());
+                        requires.add(Ast.ValueRef.written(required.written(), required.pos()));
                     }
                 }
             }
             return new Ast.SpecBehavior(name, params, ret, constructs, requires, pos);
         }
         SyntaxNode pipe = n.child(SyntaxKind.PIPE_BEHAVIOR).orElseThrow();
-        List<String> stages = new ArrayList<>();
+        List<Ast.ValueRef> stages = new ArrayList<>();
         for (SyntaxNode st : childNodes(pipe, SyntaxKind.STAGE)) {
             StringBuilder sb = new StringBuilder();
             for (SyntaxToken t : identTokens(st)) {
@@ -334,7 +334,7 @@ public final class AstBuilder {
                 }
                 sb.append(t.text());
             }
-            stages.add(sb.toString());
+            stages.add(Ast.ValueRef.written(sb.toString(), pos(st)));
         }
         Ast.RetType declaredOut = pipe.child(SyntaxKind.RET_TYPE).map(this::retType).orElse(null);
         return new Ast.PipeBehavior(name, stages, declaredOut, pos);

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -270,15 +270,31 @@ public final class Compilation {
         return published;
     }
 
-    /** The first error among {@code found}, as the exception the pass raised, tagged with the source
-     * it belongs to — or null when nothing there is an error. */
+    /**
+     * The first error among {@code found}, as the exception the pass raised, tagged with the source
+     * it belongs to — or null when nothing there is an error.
+     *
+     * <p>First means first in the order the sources were given, not first worked out. A question is
+     * answered when something asks it, and what asks first is an implementation detail: resolving one
+     * module's names reaches another module's, so moving a report earlier in the compiler would
+     * otherwise change which file a batch compile sends the author to. A report about no source in
+     * particular comes before all of them.
+     */
     public CompileException firstError(List<Db.Found> found) {
+        Db.Found first = null;
+        int at = Integer.MAX_VALUE;
         for (Db.Found f : found) {
-            if (f.report().isError()) {
-                return f.report().asException().inSource(indexOf(f));
+            if (!f.report().isError()) {
+                continue;
+            }
+            int index = indexOf(f);
+            int order = index < 0 ? -1 : index;
+            if (order < at) {
+                first = f;
+                at = order;
             }
         }
-        return null;
+        return first == null ? null : first.report().asException().inSource(indexOf(first));
     }
 
     /** Which source a report belongs to: the one it named, or the one that declares the module it

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -318,6 +318,32 @@ public final class Front {
     }
 
     /**
+     * The behavior names a module declares.
+     *
+     * <p>Read where a {@code >->} stage or a {@code requires} is resolved, which is why it asks
+     * {@link Exposed} rather than {@link Available}: binding a module's own stages is what
+     * {@link Available} does, and a module whose stage names another module's behavior would
+     * otherwise be waiting on itself. Nothing between the two changes which behaviors a module
+     * declares.
+     */
+    public record Behaviors(String name) implements Key<Set<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Set<String>> compute(Db db) {
+            Ast.Module m = db.ask(new Exposed(name)).value();
+            if (m == null) {
+                FromPath.Of path = db.ask(new FromPath()).value();
+                m = path == null ? null : path.modules().get(name);
+            }
+            return m == null ? Answer.absent() : Answer.of(Names.behaviorNames(m));
+        }
+    }
+
+    /**
      * The module a source declares, when it is the source that declares it. A second source naming
      * the same module is the one reported: the first has a claim on the name, and the message
      * belongs on the file the author would have to change.
@@ -494,9 +520,12 @@ public final class Front {
             written.add(ref.name());
         }
         for (Ast.BehaviorDef b : m.behaviors()) {
-            switch (b) {
-                case Ast.PipeBehavior pipe -> written.addAll(pipe.stages());
-                case Ast.SpecBehavior spec -> written.addAll(spec.requires());
+            List<Ast.ValueRef> named = switch (b) {
+                case Ast.PipeBehavior pipe -> pipe.stages();
+                case Ast.SpecBehavior spec -> spec.requires();
+            };
+            for (Ast.ValueRef ref : named) {
+                written.add(ref.written());
             }
         }
         for (String name : written) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -4,6 +4,7 @@ import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Registry;
 import souther.compiler.check.Resolve;
+import souther.compiler.check.Suggest;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.diag.CompileException;
@@ -11,6 +12,7 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -68,13 +70,20 @@ public final class Names {
     }
 
     /**
-     * A source module with every qualified behavior reference — a {@code >->} stage or a
-     * {@code requires} naming another module's behavior — rewritten to the bare name, and the module
-     * it came from recorded as an import.
+     * A source module with every name in the value namespace — a {@code >->} stage, a
+     * {@code requires} — resolved to the behavior it denotes, and the module a qualified one came
+     * from recorded as an import.
      *
      * <p>A behavior's name is a member name in the generated class, so the bare form is what the
-     * rest of the compiler needs; the qualifier only says which module to take it from, which is
-     * exactly what an import says.
+     * rest of the compiler reaches it by; the qualifier only says which module to take it from, which
+     * is exactly what an import says. Both are in the answer: the resolved name says what the stage
+     * means, and the synthesized import is how the borrowed signature and the injected field are
+     * found.
+     *
+     * <p>A name that denotes no behavior is reported here, once, and denotes nothing from here on.
+     * The answer is still present — a stage nobody declares is one definition's mistake, and the
+     * definitions around it are checked as they would be without it. What must not happen, emitting
+     * a module with a hole in it, is stopped by {@link Sound}.
      */
     public record Bound(String name) implements Key<Ast.Module> {
         @Override
@@ -88,99 +97,204 @@ public final class Names {
             if (!exposed.present()) {
                 return Answer.absent();
             }
-            Set<String> modules = db.ask(new Front.ModuleNames()).value();
             Ast.Module m = exposed.value();
-            List<Report> reports = new ArrayList<>();
-            Map<String, String> qualifiers = new HashMap<>();
-            for (Ast.Import imp : m.imports()) {
-                if (imp.alias() != null) {
-                    qualifiers.put(imp.alias(), imp.module());
-                }
-            }
-            Map<String, Set<String>> taken = new LinkedHashMap<>();   // module → names it brings
-            for (Ast.Import imp : m.imports()) {
-                taken.computeIfAbsent(imp.module(), k -> new LinkedHashSet<>()).addAll(imp.names());
-            }
-            Map<String, Set<String>> added = new LinkedHashMap<>();
-            Map<String, SourcePos> at = new LinkedHashMap<>();
+            Binding binding = new Binding(db, m);
             List<Ast.BehaviorDef> behaviors = new ArrayList<>();
-            boolean rewrote = false;
             for (Ast.BehaviorDef b : m.behaviors()) {
                 switch (b) {
                     case Ast.PipeBehavior pipe -> {
-                        List<String> stages = new ArrayList<>();
-                        for (String stage : pipe.stages()) {
-                            stages.add(bind(stage, qualifiers, modules, m, pipe.pos(), taken, added,
-                                    at, reports));
+                        List<Ast.ValueRef> stages = new ArrayList<>();
+                        for (Ast.ValueRef stage : pipe.stages()) {
+                            stages.add(binding.stage(stage));
                         }
-                        rewrote |= !stages.equals(pipe.stages());
                         behaviors.add(new Ast.PipeBehavior(pipe.name(), stages, pipe.declaredOut(),
                                 pipe.pos()));
                     }
                     case Ast.SpecBehavior spec -> {
-                        List<String> requires = new ArrayList<>();
-                        for (String req : spec.requires()) {
-                            requires.add(bind(req, qualifiers, modules, m, spec.pos(), taken, added,
-                                    at, reports));
+                        List<Ast.ValueRef> requires = new ArrayList<>();
+                        for (Ast.ValueRef req : spec.requires()) {
+                            requires.add(binding.required(req, spec.name()));
                         }
-                        rewrote |= !requires.equals(spec.requires());
                         behaviors.add(new Ast.SpecBehavior(spec.name(), spec.params(), spec.ret(),
                                 spec.constructs(), requires, spec.pos()));
                     }
                 }
             }
-            if (!reports.isEmpty()) {
-                return Answer.absent(reports);
+            Ast.Module bound = new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(),
+                    binding.imports(), m.defs(), behaviors, m.fns(), m.examples(), m.fakes(),
+                    m.exampleFileTarget(), m.pos());
+            return Answer.of(bound, binding.reports());
+        }
+    }
+
+    /**
+     * Resolving one module's behavior names: which behavior each stage and each {@code requires}
+     * denotes, and which imports naming them through a module asks for.
+     */
+    private static final class Binding {
+
+        private final Db db;
+        private final Ast.Module m;
+        private final Map<String, String> qualifiers = new HashMap<>();
+        private final Map<String, Set<String>> taken = new LinkedHashMap<>();  // module → its names
+        private final Map<String, Set<String>> added = new LinkedHashMap<>();
+        private final Map<String, SourcePos> at = new LinkedHashMap<>();
+        private final List<Report> reports = new ArrayList<>();
+
+        Binding(Db db, Ast.Module m) {
+            this.db = db;
+            this.m = m;
+            for (Ast.Import imp : m.imports()) {
+                if (imp.alias() != null) {
+                    qualifiers.put(imp.alias(), imp.module());
+                }
+                taken.computeIfAbsent(imp.module(), k -> new LinkedHashSet<>()).addAll(imp.names());
             }
-            if (!rewrote) {
-                return Answer.of(m);
+        }
+
+        List<Report> reports() {
+            return reports;
+        }
+
+        /** The module's imports, plus one for each module a qualified reference named. */
+        List<Ast.Import> imports() {
+            if (added.isEmpty()) {
+                return m.imports();
             }
             List<Ast.Import> imports = new ArrayList<>(m.imports());
             for (Map.Entry<String, Set<String>> e : added.entrySet()) {
                 imports.add(new Ast.Import(e.getKey(), null, List.copyOf(e.getValue()),
                         at.get(e.getKey())));
             }
-            return Answer.of(new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), imports,
-                    m.defs(), behaviors, m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(),
-                    m.pos()));
+            return imports;
         }
 
-        /** One written behavior name: the bare form it binds to, collecting the import it needs. */
-        private String bind(String written, Map<String, String> qualifiers, Set<String> modules,
-                            Ast.Module m, SourcePos pos, Map<String, Set<String>> taken,
-                            Map<String, Set<String>> added, Map<String, SourcePos> at,
-                            List<Report> reports) {
+        /**
+         * A {@code >->} stage. {@code X.decoder} / {@code X.encoder} name a codec, which is a
+         * boundary edge rather than a behavior (spec 14.1) — said here, where the question is what
+         * the name denotes, so nothing further down has a spelling to test for it.
+         */
+        Ast.ValueRef stage(Ast.ValueRef ref) {
+            String written = ref.written();
+            int dot = written.lastIndexOf('.');
+            // Only a qualified one: `decoder` on its own is an ordinary name, and a module may
+            // declare a behavior by it.
+            String last = dot < 0 ? "" : written.substring(dot + 1);
+            if (last.equals("decoder") || last.equals("encoder")) {
+                return nothing(ref, Report.raised(
+                        Diagnostic.of(null, "check.pipe.boundary").title("check.pipe.title")
+                                .at(ref.pos()).build(),
+                        "decode/encode are boundary edges, not pipeline stages; `>->` composes"
+                                + " behaviors only (spec 14.1)"));
+            }
+            return behavior(ref, this::unknownBehavior);
+        }
+
+        /**
+         * A name a {@code requires} clause writes. It must name an injection target, and whether the
+         * behavior it names is one is the check's to say (E1607); that nothing declares the name at
+         * all is settled here, in the same message, because it is the same question — what does this
+         * name denote — asked of a clause rather than of a stage.
+         */
+        Ast.ValueRef required(Ast.ValueRef ref, String by) {
+            return behavior(ref, (name, candidates) -> Report.raised(
+                    Diagnostic.of("E1607", "e1607.unknown").title("e1607.title")
+                            .at(name.pos(), name.written().length()).args(by, name.written())
+                            .suggestion(Suggest.candidate(name.written(), candidates))
+                            .hint("e1607.unknown.hint").build(),
+                    "`behavior " + by + "` declares `requires " + name.written() + "`, which is not a"
+                            + " behavior in scope" + Suggest.hint(name.written(), candidates)));
+        }
+
+        /** A name that must denote a behavior, with what to say when none does. */
+        private Ast.ValueRef behavior(Ast.ValueRef ref, Unknown unknown) {
+            String written = ref.written();
             int dot = written.lastIndexOf('.');
             if (dot < 0) {
-                return written;
+                return bare(ref, written, unknown);
             }
             String bare = written.substring(dot + 1);
-            // `X.decoder` / `X.encoder` name a codec, not a behavior of a module called X — a stage
-            // that writes one gets its own answer, which reading it as an import would hide, and
-            // would hide the more so where a module happens to be named like the type.
-            if (bare.equals("decoder") || bare.equals("encoder")) {
-                return written;
-            }
             String qualifier = written.substring(0, dot);
             if (Prelude.isQualifier(qualifier)) {
-                return written;   // a standard-library qualifier: a function, not a behavior
+                // a standard-library qualifier names a function, and a function is not a behavior
+                return nothing(ref, unknown.report(ref, Set.of()));
             }
             String target = qualifiers.getOrDefault(qualifier, qualifier);
             if (target.equals(m.name())) {
-                return bare;      // this module, named through itself
+                return bare(ref, bare, unknown);   // this module, named through itself
             }
-            if (!modules.contains(target)) {
-                reports.add(Report.raised(
+            if (!db.ask(new Front.ModuleNames()).value().contains(target)) {
+                return nothing(ref, Report.raised(
                         Diagnostic.of(null, "check.qualified.unknownmodule").title("check.module.title")
-                                .at(pos).args(qualifier, bare).build(),
+                                .at(ref.pos()).args(qualifier, bare).build(),
                         "no module named `" + qualifier + "`"));
-                return bare;
+            }
+            Answer<Set<String>> declared = db.ask(new Front.Behaviors(target));
+            if (!declared.present()) {
+                // The module is one this compilation has and could not read. What is wrong with it
+                // is reported on its own source; saying anything here sends the author to a file
+                // that is fine.
+                return ref.denoting(new ValueName.Unresolved(written));
+            }
+            if (!declared.value().contains(bare)) {
+                return nothing(ref, unknown.report(ref, declared.value()));
             }
             if (!taken.getOrDefault(target, Set.of()).contains(bare)) {
                 added.computeIfAbsent(target, k -> new LinkedHashSet<>()).add(bare);
-                at.putIfAbsent(target, pos);
+                at.putIfAbsent(target, ref.pos());
             }
-            return bare;
+            return ref.denoting(new ValueName.Behavior(target, bare));
+        }
+
+        /** A bare name: this module's own behavior, or one an import brought in. */
+        private Ast.ValueRef bare(Ast.ValueRef ref, String written, Unknown unknown) {
+            if (behaviorNames(m).contains(written)) {
+                return ref.denoting(new ValueName.Behavior(m.name(), written));
+            }
+            Set<String> reachable = new LinkedHashSet<>(behaviorNames(m));
+            boolean unreadable = false;
+            for (Ast.Import imp : m.imports()) {
+                Answer<Set<String>> declared = db.ask(new Front.Behaviors(imp.module()));
+                if (!declared.present()) {
+                    unreadable = true;
+                    continue;
+                }
+                for (String name : imp.names()) {
+                    if (declared.value().contains(name)) {
+                        if (name.equals(written)) {
+                            return ref.denoting(new ValueName.Behavior(imp.module(), written));
+                        }
+                        reachable.add(name);
+                    }
+                }
+            }
+            if (unreadable) {
+                // An import that could not be followed may have been where this name came from.
+                // Whatever is wrong with that module is reported there.
+                return ref.denoting(new ValueName.Unresolved(written));
+            }
+            return nothing(ref, unknown.report(ref, reachable));
+        }
+
+        /** What to say about a name no behavior answers to, given the names that were reachable. */
+        private interface Unknown {
+            Report report(Ast.ValueRef ref, Set<String> candidates);
+        }
+
+        private Report unknownBehavior(Ast.ValueRef ref, Set<String> candidates) {
+            String written = ref.written();
+            return Report.raised(
+                    Diagnostic.of(null, "check.unknown.behavior.msg").title("check.unknown.title")
+                            .at(ref.pos(), written.length()).args(written)
+                            .suggestion(Suggest.candidate(written, candidates)).build(),
+                    "unknown behavior `" + written + "` in pipeline"
+                            + Suggest.hint(written, candidates));
+        }
+
+        /** Records why a name denotes nothing, and gives it the name that says so. */
+        private Ast.ValueRef nothing(Ast.ValueRef ref, Report report) {
+            reports.add(report);
+            return ref.denoting(new ValueName.Unresolved(ref.written()));
         }
     }
 
@@ -474,6 +588,7 @@ public final class Names {
                     db.ask(new Front.Exposed(name)),
                     db.ask(new Front.ShadowsPath(name)),
                     db.ask(new InCycle(name)),
+                    db.ask(new Bound(name)),
                     db.ask(new Declarations(name)),
                     db.ask(new Imports(name)),
                     db.ask(new Resolution(name)));

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -632,6 +632,13 @@ public final class Names {
                     return Answer.of(Boolean.FALSE);
                 }
             }
+            // Whether anything was reported here is not the whole question. A name that denotes
+            // nothing because the module it would have come from cannot be read is reported on that
+            // module, and leaves a hole here that nothing said anything about — so the names are
+            // asked as well as the reports.
+            if (Boolean.TRUE.equals(db.ask(new Nameless(name)).value())) {
+                return Answer.of(Boolean.FALSE);
+            }
             Ast.Module m = db.ask(new Front.Available(name)).value();
             if (m != null) {
                 for (Ast.Import imp : m.imports()) {
@@ -645,6 +652,41 @@ public final class Names {
                 }
             }
             return Answer.of(Boolean.TRUE);
+        }
+    }
+
+    /**
+     * Whether a module writes a name in the value namespace that denotes nothing.
+     *
+     * <p>Asked because a report is not the only way a hole gets there. A stage naming a module this
+     * compilation has and cannot read is reported on that module — the author of this one has
+     * nothing to fix — and this module is left with a composition that has no meaning, which nothing
+     * here said. Emitting it would emit a call to a behavior that does not exist.
+     */
+    public record Nameless(String name) implements Key<Boolean> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Boolean> compute(Db db) {
+            Ast.Module m = db.ask(new Bound(name)).value();
+            if (m == null) {
+                return Answer.of(Boolean.FALSE);   // there is no module here to have a hole in
+            }
+            for (Ast.BehaviorDef b : m.behaviors()) {
+                List<Ast.ValueRef> named = switch (b) {
+                    case Ast.PipeBehavior pipe -> pipe.stages();
+                    case Ast.SpecBehavior spec -> spec.requires();
+                };
+                for (Ast.ValueRef ref : named) {
+                    if (ref.unresolved()) {
+                        return Answer.of(Boolean.TRUE);
+                    }
+                }
+            }
+            return Answer.of(Boolean.FALSE);
         }
     }
 
@@ -785,30 +827,6 @@ public final class Names {
                 }
             }
             return Answer.absent();
-        }
-    }
-
-    /** Every place a module names {@code denoted} as a value. */
-    public record ValueUsesOf(String name, ValueName denoted)
-            implements Key<List<Resolve.ValueUse>> {
-        @Override
-        public String module() {
-            return name;
-        }
-
-        @Override
-        public Answer<List<Resolve.ValueUse>> compute(Db db) {
-            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
-            if (!resolution.present()) {
-                return Answer.of(List.of());
-            }
-            List<Resolve.ValueUse> uses = new ArrayList<>();
-            for (Resolve.ValueUse use : resolution.value().values()) {
-                if (denoted.equals(use.denotes())) {
-                    uses.add(use);
-                }
-            }
-            return Answer.of(List.copyOf(uses));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -128,6 +128,52 @@ public final class Names {
     }
 
     /**
+     * The behaviors a module can name without a qualifier: its own, and the ones its imports bring
+     * in, each under the bare name it is reached by.
+     *
+     * <p>{@code whole} is false when an import could not be followed, so a name that is not here may
+     * still have come from somewhere — the difference between "nothing declares this" and "this
+     * compilation cannot say".
+     */
+    public record BehaviorsInScope(String name) implements Key<BehaviorsInScope.Of> {
+
+        public record Of(Map<String, ValueName.Behavior> byName, boolean whole) {}
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Of> compute(Db db) {
+            Ast.Module m = db.ask(new Front.Exposed(name)).value();
+            if (m == null) {
+                return Answer.absent();
+            }
+            Map<String, ValueName.Behavior> byName = new LinkedHashMap<>();
+            for (String own : behaviorNames(m)) {
+                byName.put(own, new ValueName.Behavior(name, own));
+            }
+            boolean whole = true;
+            for (Ast.Import imp : m.imports()) {
+                Answer<Set<String>> declared = db.ask(new Front.Behaviors(imp.module()));
+                if (!declared.present()) {
+                    whole = false;
+                    continue;
+                }
+                for (String imported : imp.names()) {
+                    if (declared.value().contains(imported)) {
+                        // a name this module declares itself is the one it means
+                        byName.putIfAbsent(imported,
+                                new ValueName.Behavior(imp.module(), imported));
+                    }
+                }
+            }
+            return Answer.of(new Of(Ordered.map(byName), whole));
+        }
+    }
+
+    /**
      * Resolving one module's behavior names: which behavior each stage and each {@code requires}
      * denotes, and which imports naming them through a module asks for.
      */
@@ -248,32 +294,20 @@ public final class Names {
 
         /** A bare name: this module's own behavior, or one an import brought in. */
         private Ast.ValueRef bare(Ast.ValueRef ref, String written, Unknown unknown) {
-            if (behaviorNames(m).contains(written)) {
-                return ref.denoting(new ValueName.Behavior(m.name(), written));
+            BehaviorsInScope.Of scope = db.ask(new BehaviorsInScope(m.name())).value();
+            if (scope == null) {
+                return ref.denoting(new ValueName.Unresolved(written));
             }
-            Set<String> reachable = new LinkedHashSet<>(behaviorNames(m));
-            boolean unreadable = false;
-            for (Ast.Import imp : m.imports()) {
-                Answer<Set<String>> declared = db.ask(new Front.Behaviors(imp.module()));
-                if (!declared.present()) {
-                    unreadable = true;
-                    continue;
-                }
-                for (String name : imp.names()) {
-                    if (declared.value().contains(name)) {
-                        if (name.equals(written)) {
-                            return ref.denoting(new ValueName.Behavior(imp.module(), written));
-                        }
-                        reachable.add(name);
-                    }
-                }
+            ValueName.Behavior named = scope.byName().get(written);
+            if (named != null) {
+                return ref.denoting(named);
             }
-            if (unreadable) {
+            if (!scope.whole()) {
                 // An import that could not be followed may have been where this name came from.
                 // Whatever is wrong with that module is reported there.
                 return ref.denoting(new ValueName.Unresolved(written));
             }
-            return nothing(ref, unknown.report(ref, reachable));
+            return nothing(ref, unknown.report(ref, scope.byName().keySet()));
         }
 
         /** What to say about a name no behavior answers to, given the names that were reachable. */
@@ -547,7 +581,8 @@ public final class Names {
             }
             Resolve.Resolved resolution;
             try {
-                resolution = Resolve.resolving(available.value(), scope.value());
+                resolution = Resolve.resolving(available.value(), scope.value(),
+                        reachableValues(db, available.value()));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -611,6 +646,18 @@ public final class Names {
             }
             return Answer.of(Boolean.TRUE);
         }
+    }
+
+    /** What a module's bodies can name without a binding: its own helpers, and every behavior it can
+     * reach — its own and the ones its imports bring in. */
+    private static Resolve.Values reachableValues(Db db, Ast.Module m) {
+        Set<String> helpers = new LinkedHashSet<>();
+        for (Ast.FnDef fn : m.fns()) {
+            helpers.add(fn.name());
+        }
+        BehaviorsInScope.Of behaviors = db.ask(new BehaviorsInScope(m.name())).value();
+        return new Resolve.Values(m.name(), helpers,
+                behaviors == null ? Map.of() : behaviors.byName());
     }
 
     /** The resolved module — {@link Resolution} without the record of how it got there. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -760,6 +760,100 @@ public final class Names {
         }
     }
 
+    /**
+     * What the name used as a value at {@code at} denotes, or absent when nothing there is one.
+     *
+     * <p>What {@link DenotedAt} answers for a type. An editor asking about a name in a body reads
+     * the answer resolution already gave, so a binding is the binding it is and not whatever else
+     * in the module happens to be spelled the same.
+     */
+    public record ValueDenotedAt(String name, SourcePos at) implements Key<Resolve.ValueUse> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Resolve.ValueUse> compute(Db db) {
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            if (!resolution.present()) {
+                return Answer.absent();
+            }
+            for (Resolve.ValueUse use : resolution.value().values()) {
+                if (spans(use.pos(), use.written(), at)) {
+                    return Answer.of(use);
+                }
+            }
+            return Answer.absent();
+        }
+    }
+
+    /** Every place a module names {@code denoted} as a value. */
+    public record ValueUsesOf(String name, ValueName denoted)
+            implements Key<List<Resolve.ValueUse>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<List<Resolve.ValueUse>> compute(Db db) {
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            if (!resolution.present()) {
+                return Answer.of(List.of());
+            }
+            List<Resolve.ValueUse> uses = new ArrayList<>();
+            for (Resolve.ValueUse use : resolution.value().values()) {
+                if (denoted.equals(use.denotes())) {
+                    uses.add(use);
+                }
+            }
+            return Answer.of(List.copyOf(uses));
+        }
+    }
+
+    /**
+     * Where what {@code denoted} names is written: the {@code let} or {@code behavior} that declares
+     * it, or the binding that introduced a local.
+     */
+    public record ValueDeclaredAt(ValueName denoted) implements Key<SourcePos> {
+        @Override
+        public String module() {
+            return switch (denoted) {
+                case ValueName.Helper h -> h.module();
+                case ValueName.Behavior b -> b.module();
+                case ValueName.Local _, ValueName.Stdlib _, ValueName.OfType _,
+                        ValueName.Builtin _, ValueName.Unresolved _ -> null;
+            };
+        }
+
+        @Override
+        public Answer<SourcePos> compute(Db db) {
+            if (denoted instanceof ValueName.Local local) {
+                return local.binder() == null ? Answer.absent() : Answer.of(local.binder());
+            }
+            String in = module();
+            if (in == null) {
+                return Answer.absent();   // the library and the language declare their own names
+            }
+            Ast.Module m = db.ask(new Front.Available(in)).value();
+            if (m == null) {
+                return Answer.absent();
+            }
+            for (Ast.BehaviorDef b : m.behaviors()) {
+                if (b.name().equals(denoted.name())) {
+                    return Answer.of(b.pos());
+                }
+            }
+            for (Ast.FnDef fn : m.fns()) {
+                if (fn.name().equals(denoted.name())) {
+                    return Answer.of(fn.pos());
+                }
+            }
+            return Answer.absent();
+        }
+    }
+
     /** Whether the name {@code written} starting at {@code start} covers {@code at}. A name is one
      * line's worth of text, so a position on another line is not on it. */
     static boolean spans(SourcePos start, String written, SourcePos at) {

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -1,21 +1,86 @@
 package souther.compiler.types;
 
+import souther.compiler.diag.SourcePos;
+
 /**
  * What a name written in the value namespace denotes — the answer {@link TypeName} gives for the
  * type namespace.
  *
- * <p>A behavior is named from a {@code >->} stage and from a {@code requires} clause, bare or
- * qualified, and whether two spellings mean one behavior was a question each consumer used to answer
- * for itself. Resolution answers it once, in {@link souther.compiler.query.Names.Bound}, and every
- * name-bearing position carries the answer from there on.
+ * <p>A behavior is named from a {@code >->} stage and from a {@code requires} clause; a body names a
+ * local, a helper, a library function, an injected behavior, a type used as a value. Whether two
+ * spellings mean one thing was a question each consumer used to answer for itself, in the order that
+ * consumer happened to try. Resolution answers it once — a behavior name where the module's names are
+ * bound, a name in a body where its bindings are known — and every name-bearing position carries the
+ * answer from there on.
  *
  * <p>The interface is sealed and the switches over it carry no {@code default}, so a case added here
  * is a compile error at every place that reads one rather than something silently taken for another.
  */
 public sealed interface ValueName {
 
-    /** The bare name, which is what a behavior is reached by wherever it was declared. */
+    /** The bare name, which is what a definition is reached by wherever it was declared. */
     String name();
+
+    /**
+     * A name bound inside a body: a parameter, a {@code let}, a {@code match} arm's binding, or a
+     * block's parameter. {@code binder} is where the binding that introduced it is written, which is
+     * what tells two bindings of one spelling apart.
+     */
+    record Local(String name, SourcePos binder) implements ValueName {
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    /** A module's own {@code let} — a helper, which is expanded into the body that called it. */
+    record Helper(String module, String name) implements ValueName {
+
+        @Override
+        public String toString() {
+            return module + "." + name;
+        }
+    }
+
+    /**
+     * A standard-library function, under the qualified name the library is keyed by
+     * ({@code List.map}, {@code String.trim}). A prelude helper, a prelude intrinsic and a checker
+     * built-in are one thing to a name: what is on the other side of the name is the library's own
+     * business.
+     */
+    record Stdlib(String qualified) implements ValueName {
+
+        @Override
+        public String name() {
+            return qualified;
+        }
+
+        @Override
+        public String toString() {
+            return qualified;
+        }
+    }
+
+    /** A type written where a value goes: a unit data as a value, or a newtype applied to the value
+     * it wraps. Which of the two is decided by what the type is, not by how the name was written. */
+    record OfType(String name, TypeName type) implements ValueName {
+
+        @Override
+        public String toString() {
+            return type.toString();
+        }
+    }
+
+    /** A name the language itself gives a meaning: {@code None}, and the rounding modes a
+     * {@code divide} takes. Declared by no module and bound by no body. */
+    record Builtin(String name) implements ValueName {
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
 
     /** A behavior, and the module that declares it. */
     record Behavior(String module, String name) implements ValueName {

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -1,0 +1,55 @@
+package souther.compiler.types;
+
+/**
+ * What a name written in the value namespace denotes — the answer {@link TypeName} gives for the
+ * type namespace.
+ *
+ * <p>A behavior is named from a {@code >->} stage and from a {@code requires} clause, bare or
+ * qualified, and whether two spellings mean one behavior was a question each consumer used to answer
+ * for itself. Resolution answers it once, in {@link souther.compiler.query.Names.Bound}, and every
+ * name-bearing position carries the answer from there on.
+ *
+ * <p>The interface is sealed and the switches over it carry no {@code default}, so a case added here
+ * is a compile error at every place that reads one rather than something silently taken for another.
+ */
+public sealed interface ValueName {
+
+    /** The bare name, which is what a behavior is reached by wherever it was declared. */
+    String name();
+
+    /** A behavior, and the module that declares it. */
+    record Behavior(String module, String name) implements ValueName {
+
+        public Behavior {
+            if (module == null || name == null) {
+                throw new IllegalArgumentException("module and name are required: " + module + "."
+                        + name);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return module + "." + name;
+        }
+    }
+
+    /**
+     * A name nothing denotes, keeping the spelling that was written.
+     *
+     * <p>Why it denotes nothing was reported where it was written, so a reader that meets one says
+     * nothing further: the definition resting on it is abandoned, and the definitions around it are
+     * checked as they would be without it. This is what {@link TypeName#unresolved} is for a type.
+     */
+    record Unresolved(String written) implements ValueName {
+
+        @Override
+        public String name() {
+            return written;
+        }
+
+        @Override
+        public String toString() {
+            return written;
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileMultiInvariantTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileMultiInvariantTest.java
@@ -54,4 +54,26 @@ class CompileMultiInvariantTest {
                 new BytesClassLoader(Compiler.compile(MODULE), CompileMultiInvariantTest.class.getClassLoader());
         assertThrows(ConstraintViolation.class, () -> make(150L, loader));
     }
+
+    /**
+     * An invariant reads the fields a spread brought in as its own, including through a spread of a
+     * spread. They are named where the invariant is written, so name resolution has to reach them
+     * the same way the check does.
+     */
+    @Test
+    void anInvariantReadsTheFieldsASpreadBringsIn() {
+        String src = """
+                module demo
+
+                data Common = { createdOn: Int }
+                data Worked = { ...Common, touches: Int }
+                data Lead = { ...Worked, score: Int }
+                    invariant touches >= 1 && createdOn >= 0 && score >= 0
+
+                behavior make : (n: Int) -> Lead constructs Lead
+                let make (n) = Lead { createdOn = n, touches = 1, score = n }
+                """;
+
+        assertEquals(true, Compiler.compile(src).containsKey("demo.Lead"));
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileNewtypeConstructTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNewtypeConstructTest.java
@@ -270,4 +270,25 @@ class CompileNewtypeConstructTest {
         Object addNeg = Codecs.decoded(loader, "demo.Cmd", Map.of("type", "Add", "n", -5L));
         assertThrows(ConstraintViolation.class, () -> apply(loader, "Run", addNeg));
     }
+
+    /**
+     * A binding of the same spelling is what the name means where it is bound, so applying it is a
+     * call and not a construction. The desugar used to ask the type namespace on its own and rewrote
+     * this to `Amount { value = n }` — a silent change of meaning, since both forms compile.
+     */
+    @Test
+    void aParameterNamedLikeANewtypeIsAppliedRatherThanConstructed() throws Exception {
+        String src = """
+                module demo
+                data Amount = Int
+
+                let call (Amount: (Int) -> Int, n: Int): Int = Amount(n)
+
+                behavior g : (n: Int) -> Int
+                let g (n) = call(x -> x * 2, n)
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+
+        assertEquals(6L, apply(loader, "G", 3L));
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileRequiresClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRequiresClauseTest.java
@@ -126,4 +126,36 @@ class CompileRequiresClauseTest {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
         assertEquals("E1401", e.code(), e.getMessage());
     }
+
+    /**
+     * Both ways a `requires` can be wrong are reported at the name it writes: one clause, one place
+     * to look. The unknown one is answered where the module's names are resolved and the implemented
+     * one where the injection targets are known, so the two would otherwise drift apart.
+     */
+    @Test
+    void bothKindsOfBadRequiresArePointedAtTheName() {
+        String implemented = """
+                module demo
+                data A = { x: Int }
+                data R = { z: Int }
+
+                behavior one : (a: A) -> R constructs R
+                let one (a) = R { z = a.x }
+
+                behavior use : (a: A) -> R
+                    requires one
+                let use (a, one) = one(a)
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(implemented));
+        assertEquals("E1607", e.code(), e.getMessage());
+        assertTrue(e.getMessage().startsWith("9:14 "),
+                "at the `one` of `requires one`: " + e.getMessage());
+
+        String unknown = implemented.replace("requires one", "requires nosuch")
+                .replace("let use (a, one) = one(a)", "let use (a, nosuch) = nosuch(a)");
+        CompileException absent = assertThrows(CompileException.class, () -> Compiler.compile(unknown));
+        assertEquals("E1607", absent.code(), absent.getMessage());
+        assertTrue(absent.getMessage().startsWith("9:14 "),
+                "and at the `nosuch` of `requires nosuch`: " + absent.getMessage());
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -247,4 +247,37 @@ class ResolvedValueNamesTest {
             assertTrue(denotes(e) != null, "unanswered name in " + e);
         }
     }
+
+    /**
+     * A name in a body that denotes a type is recorded as a use of that type, so everything that
+     * asks where a type is named finds it — a rename that missed one would leave a body naming a
+     * type that no longer exists.
+     */
+    @Test
+    void aTypeNamedInABodyIsAUseOfThatType() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", """
+                module m.a exposing ( Amount, Approved, f )
+
+                data Amount = Int
+                data Approved
+
+                behavior f : (n: Int) -> Amount | Approved
+                    constructs Amount, Approved
+                let f (n) = if n > 0 then Amount(n) else Approved
+                """);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+
+        List<souther.compiler.check.Resolve.Denotation> amount = c.db()
+                .ask(new Names.UsesOf("m.a", new souther.compiler.types.TypeName("m.a", "Amount")))
+                .value();
+        List<souther.compiler.check.Resolve.Denotation> approved = c.db()
+                .ask(new Names.UsesOf("m.a", new souther.compiler.types.TypeName("m.a", "Approved")))
+                .value();
+
+        assertTrue(amount.stream().anyMatch(d -> d.pos().line() == 8),
+                "the construction `Amount(n)` in the body: " + amount);
+        assertTrue(approved.stream().anyMatch(d -> d.pos().line() == 8),
+                "the unit value `Approved` in the body: " + approved);
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -1,0 +1,250 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a name in a body denotes is answered once, where the module's names are resolved, and the
+ * answer is in the tree.
+ *
+ * <p>Before this, each reader worked it out in the order it happened to try: the checker asked its
+ * type environment, then the unit data declarations, then the library, then the injected behaviors;
+ * the newtype desugar asked only the type namespace, so a binding of the same spelling was invisible
+ * to it. These pin the one answer, so a reader that disagrees with it is a reader that is wrong.
+ */
+class ResolvedValueNamesTest {
+
+    private static Ast.Module resolve(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", source);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        return c.db().ask(new Names.Resolved("m.a")).value();
+    }
+
+    /** Every name used as a value in the module's bodies, in the order it is written. */
+    private static List<Ast.Expr> named(Ast.Module m) {
+        List<Ast.Expr> out = new ArrayList<>();
+        for (Ast.FnDef fn : m.fns()) {
+            if (fn.body() != null) {
+                collect(fn.body(), out);
+            }
+        }
+        return out;
+    }
+
+    private static void collect(Ast.Expr e, List<Ast.Expr> out) {
+        if (e instanceof Ast.Var || e instanceof Ast.Call) {
+            out.add(e);
+        }
+        Ast.mapChildren(e, child -> {
+            collect(child, out);
+            return child;
+        });
+    }
+
+    private static ValueName denotes(Ast.Expr e) {
+        return e instanceof Ast.Var v ? v.denotes() : ((Ast.Call) e).denotes();
+    }
+
+    /** The one named {@code written}, which each of these writes once. */
+    private static ValueName denotationOf(String source, String written) {
+        for (Ast.Expr e : named(resolve(source))) {
+            String spelled = e instanceof Ast.Var v ? v.name() : ((Ast.Call) e).fn();
+            if (spelled.equals(written)) {
+                return denotes(e);
+            }
+        }
+        throw new AssertionError("nothing named `" + written + "` in the resolved module");
+    }
+
+    @Test
+    void aParameterIsLocalToTheBindingThatIntroducedIt() {
+        Ast.Module m = resolve("""
+                module m.a exposing ( f )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+                """);
+
+        ValueName denoted = denotationOf("""
+                module m.a exposing ( f )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+                """, "n");
+        ValueName.Local local = assertInstanceOf(ValueName.Local.class, denoted);
+        assertEquals("n", local.name());
+        assertEquals(m.fns().get(0).params().get(0).pos(), local.binder(),
+                "the binder is the parameter it was bound by");
+    }
+
+    /** A body may bind a name the module declares, and inside the binding that is what it means. */
+    @Test
+    void aBindingWinsOverTheDeclarationOfTheSameSpelling() {
+        String source = """
+                module m.a exposing ( Amount, f )
+
+                data Amount = Int
+
+                behavior f : (n: Int) -> Int
+                let f (n) = {
+                    let Amount = n
+                    Amount
+                }
+                """;
+
+        assertInstanceOf(ValueName.Local.class, denotationOf(source, "Amount"));
+    }
+
+    /** Two bindings of one spelling are two names, told apart by where each was bound. */
+    @Test
+    void twoBindingsOfOneSpellingAreTwoNames() {
+        String source = """
+                module m.a exposing ( f, g )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+
+                behavior g : (n: Int) -> Int
+                let g (n) = n
+                """;
+        List<ValueName> locals = new ArrayList<>();
+        for (Ast.Expr e : named(resolve(source))) {
+            locals.add(denotes(e));
+        }
+
+        assertEquals(2, locals.size(), locals.toString());
+        assertNotEquals(locals.get(0), locals.get(1),
+                "one spelling, two bindings, two names: " + locals);
+    }
+
+    @Test
+    void aLibraryCallDenotesTheLibraryFunction() {
+        String source = """
+                module m.a exposing ( f )
+
+                behavior f : (xs: List<Int>) -> Int
+                let f (xs) = List.length(xs)
+                """;
+
+        assertEquals(new ValueName.Stdlib("List.length"), denotationOf(source, "List.length"));
+    }
+
+    @Test
+    void aCallOfTheModulesOwnLetDenotesThatHelper() {
+        String source = """
+                module m.a exposing ( f )
+
+                let double (n: Int): Int = n * 2
+
+                behavior f : (n: Int) -> Int
+                let f (n) = double(n)
+                """;
+
+        assertEquals(new ValueName.Helper("m.a", "double"), denotationOf(source, "double"));
+    }
+
+    @Test
+    void aCallOfAnInjectedBehaviorDenotesThatBehavior() {
+        String source = """
+                module m.a exposing ( f )
+
+                behavior rate : (n: Int) -> Int
+
+                behavior f : (n: Int) -> Int
+                    requires rate
+                let f (n, rate) = rate(n)
+                """;
+
+        // the trailing `requires` parameter binds the name in the body (spec 12.6)
+        assertInstanceOf(ValueName.Local.class, denotationOf(source, "rate"));
+    }
+
+    @Test
+    void aUnitDataUsedAsAValueDenotesThatType() {
+        String source = """
+                module m.a exposing ( Approved, f )
+
+                data Approved
+
+                behavior f : (n: Int) -> Approved
+                    constructs Approved
+                let f (n) = Approved
+                """;
+
+        ValueName.OfType denoted = assertInstanceOf(ValueName.OfType.class,
+                denotationOf(source, "Approved"));
+        assertEquals("m.a", denoted.type().module());
+        assertEquals("Approved", denoted.type().name());
+    }
+
+    /** {@code Amount(500)} names a type, not a function; that it is a construction is settled here
+     * and not by a later pass asking the type namespace again. */
+    @Test
+    void aNewtypeAppliedToAValueDenotesTheTypeItConstructs() {
+        String source = """
+                module m.a exposing ( Amount, f )
+
+                data Amount = Int
+
+                behavior f : (n: Int) -> Amount
+                    constructs Amount
+                let f (n) = Amount(n)
+                """;
+
+        ValueName.OfType denoted = assertInstanceOf(ValueName.OfType.class,
+                denotationOf(source, "Amount"));
+        assertEquals("Amount", denoted.type().name());
+    }
+
+    @Test
+    void aNameNothingAnswersToDenotesNothing() {
+        String source = """
+                module m.a exposing ( f )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = nosuch
+                """;
+
+        assertInstanceOf(ValueName.Unresolved.class, denotationOf(source, "nosuch"));
+    }
+
+    /** Every name in every body is answered — nothing is left as a spelling for a later reader to
+     * work out for itself. */
+    @Test
+    void everyNameInABodyIsAnswered() {
+        Ast.Module m = resolve("""
+                module m.a exposing ( Amount, Approved, f )
+
+                data Amount = Int
+                data Approved
+
+                let double (n: Int): Int = n * 2
+
+                behavior f : (xs: List<Int>) -> Amount | Approved
+                    constructs Amount, Approved
+                let f (xs) = {
+                    let total = List.length(xs)
+                    if total > 0 then Amount(double(total)) else Approved
+                }
+                """);
+
+        for (Ast.Expr e : named(m)) {
+            assertTrue(denotes(e) != null, "unanswered name in " + e);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/UnresolvedNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/UnresolvedNamesTest.java
@@ -125,6 +125,92 @@ class UnresolvedNamesTest {
     }
 
     /**
+     * The same, for a name in the value namespace. A stage that names no behavior is one definition's
+     * mistake, and the definitions around it are checked as they would be without it.
+     */
+    @Test
+    void anUnknownBehaviorInAPipelineStillLetsTheOtherDefinitionsBeChecked() {
+        List<Diagnostic> found = diagnose("""
+                module m.a exposing ( f, p, g )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+
+                behavior p = f >-> nosuch
+
+                behavior g : (n: Int) -> Int
+                let g (n) = "not an Int"
+                """);
+
+        assertEquals(2, found.size(),
+                "the unknown behavior, and g's own mistake: " + found);
+        assertTrue(found.stream().anyMatch(d -> "check.unknown.behavior.msg".equals(d.messageKey())),
+                "the stage that names no behavior: " + found);
+        assertTrue(found.stream().anyMatch(d -> d.diff() != null),
+                "and the type mismatch in the definition that has one: " + found);
+    }
+
+    /** A stage that names nothing is pointed at where it is written, not at the whole behavior. */
+    @Test
+    void anUnknownStageIsReportedAtTheStage() {
+        List<Diagnostic> found = diagnose("""
+                module m.a exposing ( f, p )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+
+                behavior p = f >-> nosuch
+                """);
+
+        assertEquals(1, found.size(), found.toString());
+        assertEquals(6, found.get(0).region().start().line(), found.toString());
+        assertEquals(20, found.get(0).region().start().column(),
+                "the stage, not the behavior it is in: " + found);
+    }
+
+    /** A composition resting on a stage that names nothing has no meaning to emit, and neither has
+     * the module it is in. */
+    @Test
+    void aModuleWithAStageThatNamesNothingEmitsNothing() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", """
+                module m.a exposing ( f, p )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+
+                behavior p = f >-> nosuch
+                """);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(),
+                souther.compiler.meta.ModulePath.EMPTY);
+        c.diagnostics();
+
+        assertEquals(Map.of(), c.classes(),
+                "there is no bytecode for a composition nobody could resolve");
+    }
+
+    /** The same, where the stage names a module this compilation does not have. */
+    @Test
+    void aStageInAModuleNobodyHasStillLetsTheOtherDefinitionsBeChecked() {
+        List<Diagnostic> found = diagnose("""
+                module m.a exposing ( f, p, g )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+
+                behavior p = nosuch.h >-> f
+
+                behavior g : (n: Int) -> Int
+                let g (n) = "not an Int"
+                """);
+
+        assertEquals(2, found.size(),
+                "the stage nobody declares, and g's own mistake: " + found);
+        assertTrue(found.stream().anyMatch(d -> d.diff() != null),
+                "and the type mismatch in the definition that has one: " + found);
+    }
+
+    /**
      * The same as {@link #abandoningOneDefinitionStillChecksTheOthers}, with the unknown name in a
      * declaration rather than in a body. Where the name is written must not decide whether the rest
      * of the module is checked.

--- a/souther-compiler/src/test/java/souther/compiler/query/UnresolvedNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/UnresolvedNamesTest.java
@@ -150,6 +150,47 @@ class UnresolvedNamesTest {
                 "and the type mismatch in the definition that has one: " + found);
     }
 
+    /** Every unknown name in a body at once, as for a type — not the first one a check happened to
+     * reach. */
+    @Test
+    void everyUnknownNameInABodyIsReportedAtOnce() {
+        List<Diagnostic> found = diagnose("""
+                module m.a exposing ( f, g )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = nowhere
+
+                behavior g : (n: Int) -> Int
+                let g (n) = elsewhere
+                """);
+
+        assertEquals(2, found.size(), "both, not the first: " + found);
+        assertTrue(found.stream().allMatch(d -> "check.unknown.name.msg".equals(d.messageKey())),
+                found.toString());
+    }
+
+    /** A definition resting on a name in the value namespace that denotes nothing says nothing
+     * further, and the definitions around it are checked as they would be without it. */
+    @Test
+    void abandoningADefinitionOverAnUnknownValueNameStillChecksTheOthers() {
+        List<Diagnostic> found = diagnose("""
+                module m.a exposing ( f, g )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = nowhere
+
+                behavior g : (n: Int) -> Int
+                let g (n) = "not an Int"
+                """);
+
+        assertEquals(2, found.size(),
+                "the unknown name, and g's own mistake — nothing about what f does: " + found);
+        assertTrue(found.stream().anyMatch(d -> "check.unknown.name.msg".equals(d.messageKey())),
+                "the name that denotes nothing: " + found);
+        assertTrue(found.stream().anyMatch(d -> d.diff() != null),
+                "and the type mismatch in the definition that has one: " + found);
+    }
+
     /** A stage that names nothing is pointed at where it is written, not at the whole behavior. */
     @Test
     void anUnknownStageIsReportedAtTheStage() {

--- a/souther-compiler/src/test/java/souther/compiler/query/UnresolvedNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/UnresolvedNamesTest.java
@@ -274,4 +274,63 @@ class UnresolvedNamesTest {
         assertTrue(found.stream().anyMatch(d -> d.diff() != null),
                 "and the type mismatch in the definition that has one: " + found);
     }
+
+    /**
+     * A stage naming a module this compilation has and cannot read leaves a hole nothing here
+     * reported: what is wrong is that module's, and its author is the one who can act on it. The
+     * module holding the hole must still not be emitted — its composition calls a behavior that will
+     * not exist — and the compiler must say so rather than fail on the way to saying it.
+     */
+    @Test
+    void aStageInAModuleThatCannotBeReadIsNotEmittedAndSaysNothingHere() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("x.sou", """
+                module souther.x exposing ( ship )
+
+                behavior ship : (n: Int) -> Int
+                let ship (n) = n
+                """);
+        byId.put("a.sou", """
+                module m.a exposing ( f, p )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+
+                behavior p = f >-> souther.x.ship
+                """);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(),
+                souther.compiler.meta.ModulePath.EMPTY);
+
+        assertEquals(List.of(), c.diagnostics().get("a.sou"),
+                "the reserved module name is x's mistake, not this one's");
+        assertTrue(c.diagnostics().get("x.sou").stream()
+                        .anyMatch(d -> "check.module.reserved".equals(d.messageKey())),
+                "and it is reported there: " + c.diagnostics().get("x.sou"));
+        assertEquals(Map.of(), c.classes(),
+                "a composition whose stage nobody can name is not emitted");
+    }
+
+    /** One mistake in a `requires`, one diagnostic: the fn's trailing parameters are named by the
+     * clause, so a clause that names nothing leaves nothing to hold them against. */
+    @Test
+    void aRequiresNamingNothingIsReportedOnceNotTwice() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("b.sou", """
+                module m.b exposing ( ship )
+
+                behavior ship : (n: Int) -> Int
+                """);
+        byId.put("a.sou", """
+                module m.a exposing ( f )
+
+                behavior f : (n: Int) -> Int
+                    requires m.b.charge
+                let f (n, charge) = charge(n)
+                """);
+        List<Diagnostic> found = Compiler.diagnoseModules(byId, Set.of()).get("a.sou");
+
+        assertEquals(1, found.size(),
+                "the clause that names nothing, and nothing about the parameters it names: " + found);
+        assertEquals("E1607", found.get(0).code(), found.toString());
+    }
 }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -5,6 +5,7 @@ import souther.compiler.check.Resolve;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 import souther.compiler.ast.Ast;
 import souther.compiler.cst.CstError;
 import souther.compiler.cst.CstLexer;
@@ -318,6 +319,10 @@ public final class Analyzer {
         if (answered.isPresent()) {
             return answered;
         }
+        Optional<Location> value = valueDeclarationOf(uri, pos, graph);
+        if (value.isPresent()) {
+            return value;
+        }
         LineIndex lines = new LineIndex(text);
         SyntaxNode root = CstParser.parse(text).root();
         SyntaxToken ident = identAt(root, lines.offsetOf(pos.line(), pos.character()));
@@ -431,6 +436,78 @@ public final class Analyzer {
             }
         }
         return byUri;
+    }
+
+    /** What the cursor is on in the value namespace, as the compiler answers it, or null when
+     * nothing there is a name used as a value. */
+    private ValueName valueUnderCursor(Compilation compilation, String uri, ModuleGraph graph,
+                                       Position pos) {
+        String text = graph.text(uri);
+        String module = text == null ? null : Compiler.moduleNameFromHeader(text);
+        if (module == null) {
+            return null;
+        }
+        SourcePos at = new SourcePos(pos.line() + 1, pos.character() + 1);
+        Resolve.ValueUse use = compilation.db().ask(new Names.ValueDenotedAt(module, at)).value();
+        return use == null ? null : use.denotes();
+    }
+
+    /**
+     * Where what the cursor names as a value is written, as the compiler answers it: the binding
+     * that introduced a local, or the {@code let} or {@code behavior} that declares it.
+     *
+     * <p>A local was out of reach while this was matched by spelling — one spelling may be bound in
+     * several bodies, and nothing said which binding a use belonged to. Resolution says.
+     */
+    private Optional<Location> valueDeclarationOf(String uri, Position pos, ModuleGraph graph) {
+        Compilation compilation = compileOf(graph);
+        ValueName target = valueUnderCursor(compilation, uri, graph, pos);
+        if (target == null) {
+            return Optional.empty();
+        }
+        SourcePos at = compilation.db().ask(new Names.ValueDeclaredAt(target)).value();
+        if (at == null) {
+            return Optional.empty();
+        }
+        String targetUri = switch (target) {
+            case ValueName.Local _ -> uri;   // bound in the body the cursor is in
+            case ValueName.Helper h -> compilation.sourceIdOf(h.module());
+            case ValueName.Behavior b -> compilation.sourceIdOf(b.module());
+            case ValueName.Stdlib _, ValueName.OfType _, ValueName.Builtin _,
+                    ValueName.Unresolved _ -> null;
+        };
+        String targetText = targetUri == null ? null : graph.text(targetUri);
+        if (targetText == null) {
+            return Optional.empty();
+        }
+        // Which name, and where it was written, is the compiler's; which characters spell it there
+        // is the syntax tree's — the declaration's position is its first keyword, and a binding's is
+        // the form that binds it.
+        LineIndex lines = new LineIndex(targetText);
+        SyntaxToken name = identFrom(CstParser.parse(targetText).root(),
+                lines.offsetOf(at.line() - 1, at.column() - 1), target.name());
+        return name == null ? Optional.empty()
+                : Optional.of(new Location(targetUri, tokenRange(lines, name)));
+    }
+
+    /** The first identifier spelled {@code name} at or after {@code offset} — the name token of the
+     * form that starts there. */
+    private SyntaxToken identFrom(SyntaxNode node, int offset, String name) {
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxNode child) {
+                if (child.end() <= offset) {
+                    continue;
+                }
+                SyntaxToken found = identFrom(child, offset, name);
+                if (found != null) {
+                    return found;
+                }
+            } else if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT
+                    && t.start() >= offset && t.text().equals(name)) {
+                return t;
+            }
+        }
+        return null;
     }
 
     /**

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesValuesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesValuesTest.java
@@ -2,10 +2,12 @@ package souther.lsp.analysis;
 
 import souther.lsp.protocol.Location;
 import souther.lsp.protocol.Position;
+import souther.lsp.protocol.Range;
 
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -63,5 +65,66 @@ class NavigationResolvesValuesTest {
         assertTrue(found.isPresent(), "the helper is declared in this file");
         assertEquals(2, found.get().range().start().line(),
                 "the `let double` declaration: " + found.get());
+    }
+
+    private static final String UP = """
+            module up exposing ( Amount )
+
+            data Amount = Int
+            """;
+
+    /** Declares an Amount of its own, and builds up's through an alias. */
+    private static final String HERE = """
+            module here exposing ( Amount, f )
+
+            import up as B
+
+            data Amount = String
+
+            behavior f : (n: Int) -> B.Amount
+                constructs B.Amount
+            let f (n) = B.Amount(n)
+            """;
+
+    private static ModuleGraph twoModules() {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put("file:///up.sou", UP);
+        sources.put("file:///here.sou", HERE);
+        return ModuleGraph.of(sources);
+    }
+
+    /** The `Amount` of `B.Amount(n)`, in here.sou. */
+    private static final Position THE_QUALIFIED_CONSTRUCTION = new Position(8, 16);
+
+    /**
+     * A newtype applied to the value it wraps names a type, and the name is answered like any other
+     * mention of it. Matching the spelling sent this to whatever the file declared by that name —
+     * here, a different type in this very module.
+     */
+    @Test
+    void aQualifiedConstructionGoesToTheTypeItNames() {
+        Optional<Location> found = new Analyzer()
+                .definition("file:///here.sou", THE_QUALIFIED_CONSTRUCTION, twoModules());
+
+        assertTrue(found.isPresent(), found.toString());
+        assertEquals("file:///up.sou", found.get().uri(),
+                "`B.Amount` names up's Amount, not the one this module declares: " + found.get());
+    }
+
+    /**
+     * And renaming that type rewrites the construction with everything else. Leaving it behind is a
+     * rename that stops the workspace compiling, which is worse than one that does nothing.
+     */
+    @Test
+    void renamingATypeRewritesTheConstructionsOfItInBodies() {
+        Map<String, List<Range>> edits =
+                new Analyzer().renameEdits("file:///up.sou", new Position(2, 5), twoModules());
+
+        List<Range> here = edits.getOrDefault("file:///here.sou", List.of());
+        assertTrue(here.stream().anyMatch(r -> r.start().line() == 8 && r.start().character() == 14),
+                "the `Amount` of `B.Amount(n)` on the last line: " + here);
+        assertEquals(3, here.size(),
+                "the output, the `constructs`, and the construction — not this module's own Amount: "
+                        + here);
     }
 }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesValuesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesValuesTest.java
@@ -1,0 +1,67 @@
+package souther.lsp.analysis;
+
+import souther.lsp.protocol.Location;
+import souther.lsp.protocol.Position;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Navigation on a name used as a value answers what it denotes.
+ *
+ * <p>A spelling cannot say which binding a use belongs to — one spelling may be bound in several
+ * bodies, and a body may bind a name the module also declares — so a local was out of reach and a
+ * helper was found by matching text. Resolution answers both, and navigation reads the answer.
+ */
+class NavigationResolvesValuesTest {
+
+    private static final String SOURCE = """
+            module demo exposing ( f )
+
+            let double (n: Int): Int = n * 2
+
+            behavior f : (double: Int) -> Int
+            let f (double) = double + 1
+
+            behavior g : (n: Int) -> Int
+            let g (n) = double(n)
+            """;
+
+    private static ModuleGraph graph() {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put("file:///demo.sou", SOURCE);
+        return ModuleGraph.of(sources);
+    }
+
+    /** The `double` of `double + 1`, which is f's parameter. */
+    private static final Position THE_PARAMETER_USE = new Position(5, 17);
+    /** The `double` of `double(n)`, which is the module's helper. */
+    private static final Position THE_HELPER_CALL = new Position(8, 12);
+
+    @Test
+    void aUseOfAParameterGoesToTheParameter() {
+        Optional<Location> found = new Analyzer()
+                .definition("file:///demo.sou", THE_PARAMETER_USE, graph());
+
+        assertTrue(found.isPresent(), "a binding is where its name was bound");
+        assertEquals(5, found.get().range().start().line(),
+                "f's parameter, on f's own line: " + found.get());
+    }
+
+    /** The same spelling, one line apart, naming the module's helper rather than the parameter. */
+    @Test
+    void aCallOfTheHelperGoesToTheHelper() {
+        Optional<Location> found = new Analyzer()
+                .definition("file:///demo.sou", THE_HELPER_CALL, graph());
+
+        assertTrue(found.isPresent(), "the helper is declared in this file");
+        assertEquals(2, found.get().range().start().line(),
+                "the `let double` declaration: " + found.get());
+    }
+}


### PR DESCRIPTION
Step 4 of #177, first half: names in the value namespace are resolved once, where the module's names
are worked out, and every reader asks the answer instead of deciding for itself.

The type namespace has worked this way since #180. The value namespace did not, and the difference
showed:

- A `>->` stage and a `requires` carried a spelling, matched against a map of signatures. One name
  nothing answered to took away every behavior's signature at once, so a single misspelled stage hid
  every other mistake in the file — the same failure the error type retired for types (#183).
- A name in a body was worked out by trying: the type environment, then the unit data declarations,
  then the library, then the injected behaviors, each reader in its own order. The newtype desugar
  asked only the type namespace, so `Amount(n)` under a binding of that spelling was rewritten into a
  construction of the type. Both forms compile, so the meaning changed in silence. There is a test.
- An unknown name was reported by whichever check reached it first, so the same missing name read as
  an unknown identifier in one place and as an arbitrary JVM call in another.
- Go-to-definition matched the spelling against the file's top-level definitions, so a parameter
  named like a helper sent the author to the helper, and a local was out of reach.

## What is in the tree now

`ValueName` is sealed over what a name in the value namespace can denote: the binding that
introduced it and where, a library function, the module's own helper, a behavior and its module, the
type a unit value or a newtype construction names, or nothing. `Ast.ValueRef` carries it for a stage
and a `requires`; `Ast.Var` and `Ast.Call` carry it for a body. A pass that synthesizes a name says
what it means rather than leaving a spelling behind, and the checker says so outright — a name that
reaches it unresolved is an impossibility, not something to work out.

A name that denotes nothing is reported where it is written, once, and the checks stop at it. So a
module says what every unknown name in it is at once, and a definition resting on one is abandoned
without a second report about what it does; the definitions beside it are checked as they would be
without it.

## Two things worth knowing

**The order a batch compile raises errors in is now the order the sources were given.** It followed
the order the questions happened to be answered in, so moving a report earlier in the compiler
changed which file the author was sent to — the coupling `CompileModuleErrorOrderTest` exists to
catch.

**A library reference is one because its qualifier is a library namespace**, not because a table had
an entry. Asking the table ties the answer to how much of the library has loaded, and the library
resolves its own sources while it loads.

## Verification

Whole reactor green. `souther-examples` builds unchanged — migration cost 0 lines, as for steps 1, 2
and 3. One gap was found only there: an invariant reads the fields a spread brought in as its own,
through a spread of a spread, and resolution has to reach them the same way the check does
(`crm.sou` writes one). Pinned by a test here too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
