### PR TITLE
Ask for one declaration, not for everything declared beside it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Registry.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Registry.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.types.TypeName;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -18,8 +19,21 @@ import java.util.Set;
  */
 public interface Registry {
 
+    /**
+     * One declaration, or null when no module of this compilation declares it.
+     *
+     * <p>The question nearly everything asks, and the reason it is not {@link #declaredIn}: reading
+     * a whole module's declarations to reach one of them makes the reader depend on all of them, so
+     * declaring something new — which nobody can even see yet — reaches every module that imported
+     * anything from there.
+     */
+    Ast.Def declaration(TypeName name);
+
     /** Every definition of one module, keyed by the name written there. Empty when this compilation
-     * has no such module. */
+     * has no such module.
+     *
+     * <p>For the questions that really are about a whole module — which sum a case belongs to, what
+     * a "did you mean" may offer. A reader after one declaration asks {@link #declaration}. */
     Map<String, Ast.Def> declaredIn(String moduleName);
 
     /** The base type names {@code moduleName} exposes, with any {@code .decoder} / {@code .encoder}
@@ -40,6 +54,11 @@ public interface Registry {
         return new Registry() {
             private final Map<String, Map<String, Ast.Def>> defs = new HashMap<>();
             private final Map<String, Set<String>> exposed = new HashMap<>();
+
+            @Override
+            public Ast.Def declaration(TypeName name) {
+                return declaredIn(name.module()).get(name.name());
+            }
 
             @Override
             public Map<String, Ast.Def> declaredIn(String moduleName) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -88,7 +88,7 @@ public final class Symbols {
 
     /** The definition of {@code name}, or null when no module declares it. */
     public Ast.Def get(TypeName name) {
-        return declaredIn(name.module()).get(name.name());
+        return registry.declaration(name);
     }
 
     public boolean contains(TypeName name) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -44,6 +44,16 @@ public final class Names {
     public static Registry registry(Db db, Stage stage) {
         return new Registry() {
             @Override
+            public Ast.Def declaration(TypeName named) {
+                Answer<Ast.Def> def = switch (stage) {
+                    case AVAILABLE -> db.ask(new Declaration(named));
+                    case RESOLVED -> db.ask(new ResolvedDeclaration(named));
+                    case DERIVED -> db.ask(new Shapes.DerivedDef(named));
+                };
+                return def.present() ? def.value() : null;
+            }
+
+            @Override
             public Map<String, Ast.Def> declaredIn(String moduleName) {
                 Answer<Map<String, Ast.Def>> defs = switch (stage) {
                     case AVAILABLE -> db.ask(new Declarations(moduleName));
@@ -387,6 +397,49 @@ public final class Names {
         }
     }
 
+    /**
+     * One declaration, as the module wrote it.
+     *
+     * <p>Its own question, so that reading it is a dependency on it and not on everything declared
+     * beside it. Whether the work behind it is done for one declaration or for the module is not
+     * this key's business: what a reader depends on is the answer, and this answer says what one
+     * declaration says.
+     */
+    public record Declaration(TypeName named) implements Key<Ast.Def> {
+        @Override
+        public String module() {
+            return named.module();
+        }
+
+        @Override
+        public Answer<Ast.Def> compute(Db db) {
+            Answer<Map<String, Ast.Def>> defs = db.ask(new Declarations(named.module()));
+            if (!defs.present()) {
+                return Answer.absent();
+            }
+            Ast.Def def = defs.value().get(named.name());
+            return def == null ? Answer.absent() : Answer.of(def);
+        }
+    }
+
+    /** The same, with every written name in it resolved. */
+    public record ResolvedDeclaration(TypeName named) implements Key<Ast.Def> {
+        @Override
+        public String module() {
+            return named.module();
+        }
+
+        @Override
+        public Answer<Ast.Def> compute(Db db) {
+            Answer<Map<String, Ast.Def>> defs = db.ask(new ResolvedDeclarations(named.module()));
+            if (!defs.present()) {
+                return Answer.absent();
+            }
+            Ast.Def def = defs.value().get(named.name());
+            return def == null ? Answer.absent() : Answer.of(def);
+        }
+    }
+
     /** The same declarations, with every written name in them resolved. */
     public record ResolvedDeclarations(String name) implements Key<Map<String, Ast.Def>> {
         @Override
@@ -475,7 +528,6 @@ public final class Names {
                     }
                     aliases.put(imp.alias(), imp.module());
                 }
-                Map<String, Ast.Def> srcDefs = registry.declaredIn(imp.module());
                 Set<String> exposed = registry.exposedBy(imp.module());
                 for (String imported : imp.names()) {
                     if (!exposed.contains(imported)) {
@@ -486,7 +538,9 @@ public final class Names {
                         nameless(scope, List.of(imported));
                         continue;
                     }
-                    if (!srcDefs.containsKey(imported)) {
+                    // asked one name at a time: what else that module declares is not what this
+                    // import is about, and reading it would make this module depend on it
+                    if (registry.declaration(new TypeName(imp.module(), imported)) == null) {
                         // a behavior import is resolved separately; it is not a data Def, so it does
                         // not go into the symbols map.
                         if (behaviorNames(src).contains(imported)) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -7,6 +7,7 @@ import souther.compiler.check.TypeChecker;
 import souther.compiler.check.Symbols;
 import souther.compiler.derive.Deriver;
 import souther.compiler.diag.CompileException;
+import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -76,6 +77,31 @@ public final class Shapes {
             return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
                     List.copyOf(kept), m.behaviors(), m.fns(), m.examples(), m.fakes(),
                     m.exampleFileTarget(), m.pos());
+        }
+    }
+
+    /**
+     * One declaration with its codecs derived and its spreads settled — what every later stage
+     * resolves a type to.
+     *
+     * <p>Its own question, so a reader depends on the declaration it named and not on everything
+     * declared beside it. A module still derives its declarations together; that is how the answer
+     * is worked out, not what the answer is about, and moving that apart changes nothing here.
+     */
+    public record DerivedDef(TypeName named) implements Key<Ast.Def> {
+        @Override
+        public String module() {
+            return named.module();
+        }
+
+        @Override
+        public Answer<Ast.Def> compute(Db db) {
+            Answer<Map<String, Ast.Def>> defs = db.ask(new DerivedDeclarations(named.module()));
+            if (!defs.present()) {
+                return Answer.absent();
+            }
+            Ast.Def def = defs.value().get(named.name());
+            return def == null ? Answer.absent() : Answer.of(def);
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -65,6 +65,54 @@ class IncrementalCompilationTest {
         return c;
     }
 
+    /**
+     * An importer names some of what a module declares, so a declaration it does not name is none of
+     * its business. Reading a module's declarations as one map made every importer depend on all of
+     * them, so declaring something new — which no importer can even see yet — reached every module
+     * that imported anything from there.
+     */
+    @Test
+    void declaringSomethingNewDoesNotReachAnImporterThatDoesNotNameIt() {
+        Compilation c = started();
+        Answer<?> cart = c.db().ask(new Output.Classes("shop.cart"));
+
+        c.update(workspace(PRICES + """
+
+                data Discount = Int
+                """, CART, CUSTOMERS), Set.of());
+        c.answerEverything();
+
+        assertSame(cart, c.db().ask(new Output.Classes("shop.cart")),
+                "shop.cart names `Amount`, and `Amount` says what it said");
+    }
+
+    /**
+     * And an edit to a declaration an importer does not name leaves it alone as well — the importer
+     * reads the one it named, so what the one beside it says is none of its business.
+     */
+    @Test
+    void editingADeclarationAnImporterDoesNotNameDoesNotReachIt() {
+        Compilation c = started();
+        Answer<?> cart = c.db().ask(new Output.Classes("shop.cart"));
+
+        c.update(workspace(PRICES + """
+
+                data Discount = { off: Int }
+                """, CART, CUSTOMERS), Set.of());
+        c.answerEverything();
+        Answer<?> once = c.db().ask(new Output.Classes("shop.cart"));
+        assertSame(cart, once, "declaring `Discount` is not shop.cart's business");
+
+        c.update(workspace(PRICES + """
+
+                data Discount = { off: Int, until: Date }
+                """, CART, CUSTOMERS), Set.of());
+        c.answerEverything();
+
+        assertSame(once, c.db().ask(new Output.Classes("shop.cart")),
+                "and neither is changing what `Discount` says");
+    }
+
     @Test
     void anEditReachesTheModuleItWasMadeIn() {
         Compilation c = started();


### PR DESCRIPTION
Step 4 of #177, continued. Reading a declaration meant reading the map of every declaration its
module has, so every reader of one depended on all of them.

Measured, before: adding `data Discount = Int` to `shop.prices` re-emitted **every class of
`shop.cart`**, which imports only `Amount` and cannot even see `Discount` yet. Editing `Discount`
afterwards did it again.

After: neither reaches `shop.cart`. Two tests in `IncrementalCompilationTest` hold it.

## What changed

`Registry.declaration(TypeName)` is the question now — one declaration, at whichever stage the
reader wants one (as written, resolved, derived) — and `Symbols.get` and import validation ask it.
The per-name keys behind it project out of the module-wide answers, which is deliberate: what a
reader depends on is the answer, and that answer says what one declaration says. A module still
derives its declarations together; that is how the answer is worked out, not what it is about, and
moving that apart later changes nothing on the reader side.

## What this does not do, and what it would take

Within one module, this is not yet observable, and the reason is worth writing down: an answer that
is recomputed and comes out equal stops its *readers* from running, but is itself a fresh answer. So
a per-definition projection pays off one level below itself — across a module boundary here, because
the reader on the other side is a whole module's classes.

Making it observable inside a module needs the checking layer split per definition, which needs two
things first:

- `Shapes.Prepared` and `Bodies.Lowering` projected per definition, so a behavior reads its own body
  rather than the module's.
- The context a body check shares — the helper inliner, the recursive-helper signatures, the
  injection signatures — answered as **values** rather than as objects. A key whose answer is a
  freshly built object is never equal to the last one, so every reader of it runs again whatever
  changed.

Codegen is a separate question and this PR does not touch it: `Backend.generate` is built on
module-wide shared state, and the emit gate is per module by design (#183), so a module's classes
being emitted together is not in tension with anything. Whether to split it should follow a
measurement, not this reasoning.

## Verification

Whole reactor green. `souther-examples` builds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
