### PR TITLE
A definition is its own question in the body layer

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -10,6 +10,7 @@ import souther.compiler.diag.SourcePos;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -50,25 +51,47 @@ public final class HelperInliner {
      * auto-imported prelude helpers (spec §reserved-namespace) join the inlining map so a bare
      * {@code not(x)} expands at any call site; a module-own helper of the same name shadows one. */
     public static HelperInliner forModule(Ast.Module module) {
-        Set<String> behaviorNames = new HashSet<>();
-        for (Ast.BehaviorDef b : module.behaviors()) {
-            behaviorNames.add(b.name());
-        }
-        Map<String, Ast.FnDef> own = new HashMap<>();
-        for (Ast.FnDef fn : module.fns()) {
-            if (!behaviorNames.contains(fn.name())) {
-                own.put(fn.name(), fn);
-            }
-        }
+        HelperInliner inliner = forHelpers(helpersOf(module));
+        inliner.computeReferencedPreludeRecursive(module);
+        return inliner;
+    }
+
+    /**
+     * The inlining an expansion needs, over the helpers alone.
+     *
+     * <p>Which helper a call expands to, and which calls are left standing because the helper recurses,
+     * follow from the helpers and nothing else — so a body is expanded without reading the bodies
+     * beside it. What does read the whole module is {@link #injectedRecursiveHelpers}: which prelude
+     * recursive helpers a module emits as its own methods is a fact about the module, not about any
+     * one call, and {@link #forModule} is what answers it. A module that has already taken those on as
+     * its own fns has them here like any other helper, so both say the same thing about it.
+     */
+    public static HelperInliner forHelpers(Map<String, Ast.FnDef> own) {
         // prelude helpers are keyed by their qualified name (`List.map`); a module's own helpers by
         // their bare name (`対象明細`). A qualified call resolves to the prelude, a bare call to the
         // module's own — the standard library has no bare names (spec §stdlib).
         Map<String, Ast.FnDef> helpers = new HashMap<>(Prelude.helpers());
         helpers.putAll(own);
-        HelperInliner inliner = new HelperInliner(helpers, own);
+        // In the order they are written, so a module with two helpers to complain about complains
+        // about the earlier one first.
+        HelperInliner inliner = new HelperInliner(helpers, new LinkedHashMap<>(own));
         inliner.classifyRecursion();
-        inliner.computeReferencedPreludeRecursive(module);
         return inliner;
+    }
+
+    /** A module's helpers: the fns that implement no behavior, keyed by name. */
+    public static Map<String, Ast.FnDef> helpersOf(Ast.Module module) {
+        Set<String> behaviorNames = new HashSet<>();
+        for (Ast.BehaviorDef b : module.behaviors()) {
+            behaviorNames.add(b.name());
+        }
+        Map<String, Ast.FnDef> own = new LinkedHashMap<>();
+        for (Ast.FnDef fn : module.fns()) {
+            if (!behaviorNames.contains(fn.name())) {
+                own.put(fn.name(), fn);
+            }
+        }
+        return own;
     }
 
     /** Prelude recursive helpers this module reaches, by qualified name (`List.foldFrom`). A prelude

--- a/souther-compiler/src/main/java/souther/compiler/check/InjectionSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InjectionSigs.java
@@ -16,7 +16,7 @@ import java.util.Set;
  * 14.3). A call to any of them is typed from its declaration, so both the settling of helper
  * parameter types (before the module is lowered) and the type check itself read the same map.
  */
-final class InjectionSigs {
+public final class InjectionSigs {
 
     private InjectionSigs() {}
 
@@ -26,8 +26,8 @@ final class InjectionSigs {
      * of the same name as an imported one wins; the imported signature only fills a name this module
      * does not declare.
      */
-    static Map<String, ReqSig> of(Ast.Module module, Symbols symbols,
-                                  Map<String, Sig> importedSigs, Set<String> importedInjected) {
+    public static Map<String, ReqSig> of(Ast.Module module, Symbols symbols,
+                                         Map<String, Sig> importedSigs, Set<String> importedInjected) {
         Set<String> implemented = new HashSet<>();
         for (Ast.FnDef fn : module.fns()) {
             implemented.add(fn.name());

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -1,14 +1,11 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
-import souther.compiler.diag.CompileException;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * The Lower stage (ADR-0021): rewrites the surface AST toward the form the backend emits, so the
@@ -38,49 +35,35 @@ public final class Lower {
     public record Lowered(Ast.Module settled, Ast.Module lowered) {}
 
     /**
-     * Settles the helper parameter types the author left unwritten, then returns {@code module} with
-     * each behavior-implementing fn body inlined and every list comprehension (in a body or a data
-     * invariant) desugared to an {@code if}.
+     * {@code module} with every helper parameter the author left unwritten carrying the type its body
+     * gives it.
      *
-     * <p>Settling comes first because inlining is what carries a parameter's type onto the binding a
-     * call becomes (issue #178): a type settled after this stage would never reach the expansion.
+     * <p>Settling comes before the expansion because inlining is what carries a parameter's type onto
+     * the binding a call becomes (issue #178): a type settled afterwards would never reach it.
      */
-    public static Lowered run(Ast.Module module, Symbols symbols,
-                              Map<String, Sig> importedSigs, Set<String> importedInjected) {
-        Map<String, ReqSig> reqSigs;
-        try {
-            reqSigs = InjectionSigs.of(module, symbols, importedSigs, importedInjected);
-        } catch (CompileException _) {
-            // a signature that does not build is reported by the check that follows; settling reads
-            // what it can and leaves the rest for the annotation rule.
-            reqSigs = Map.of();
-        }
-        Ast.Module settled = HelperParams.settle(module, symbols, reqSigs);
-        return new Lowered(settled, lower(settled));
+    public static Ast.Module settle(Ast.Module module, Symbols symbols,
+                                    Map<String, ReqSig> reqSigs) {
+        return HelperParams.settle(module, symbols, reqSigs);
     }
 
-    private static Ast.Module lower(Ast.Module module) {
-        HelperInliner inliner = HelperInliner.forModule(module);
-        Set<String> behaviorNames = new HashSet<>();
-        for (Ast.BehaviorDef b : module.behaviors()) {
-            behaviorNames.add(b.name());
-        }
-        Set<String> recursive = inliner.recursiveHelpers();
-        List<Ast.FnDef> fns = new ArrayList<>();
-        for (Ast.FnDef fn : module.fns()) {
-            // A behavior body and a recursive helper both survive to the backend with their body
-            // inlined (non-recursive calls expanded, recursive calls left standing, spec 13.1). A
-            // non-recursive helper is fully inlined at its call sites and never emitted — drop it.
-            if (behaviorNames.contains(fn.name()) || recursive.contains(fn.name())) {
-                // a recursive helper expands its own body with its parameters hidden from helper
-                // resolution (foldFrom's `step` is a parameter, not a same-named user helper).
-                Ast.Expr expanded = recursive.contains(fn.name())
-                        ? inliner.inlineRecursiveBody(fn)
-                        : inliner.inline(fn.body());
-                fns.add(new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
-                        desugar(expanded), fn.partial(), fn.pos()));
-            }
-        }
+    /**
+     * One fn as the backend emits it: its helper calls expanded and its comprehensions desugared.
+     *
+     * <p>A behavior body and a recursive helper both survive to the backend this way — non-recursive
+     * calls expanded, recursive calls left standing (spec 13.1). A recursive helper expands its own
+     * body with its parameters hidden from helper resolution ({@code foldFrom}'s {@code step} is a
+     * parameter, not a same-named user helper), which is what {@code recursive} says. A helper that is
+     * neither is fully inlined at its call sites and never emitted, so nothing asks for it here.
+     */
+    public static Ast.FnDef body(Ast.FnDef fn, HelperInliner inliner, boolean recursive) {
+        Ast.Expr expanded = recursive ? inliner.inlineRecursiveBody(fn) : inliner.inline(fn.body());
+        return new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
+                desugar(expanded), fn.partial(), fn.pos());
+    }
+
+    /** {@code module} with {@code fns} as its fns and every data invariant desugared — the tree the
+     * backend emits from. */
+    public static Ast.Module lowered(Ast.Module module, List<Ast.FnDef> fns) {
         List<Ast.Def> defs = new ArrayList<>();
         for (Ast.Def def : module.defs()) {
             if (def instanceof Ast.Data d && d.invariant().isPresent()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -29,15 +29,16 @@ public final class TypeChecker {
 
     /**
      * What a successful check produced for the backend (issue #81): the Core of every body it typed,
-     * carrying the type decided for each node, plus the warnings the check raised. The backend emits
-     * from these rather than translating the AST and inferring the same types a second time.
+     * carrying the type decided for each node. The backend emits from these rather than translating
+     * the AST and inferring the same types a second time.
+     *
+     * <p>What the check found is not in here. A warning belongs to the question that raised it, which
+     * is one body, and a caller that wants them reads them from there.
      */
-    public record Checked(Map<String, Core> behaviorBodies, Map<String, Core> recursiveHelpers,
-                          List<Diagnostic> warnings) {}
+    public record Checked(Map<String, Core> behaviorBodies, Map<String, Core> recursiveHelpers) {}
 
     /** The bodies elaborated so far, filled as the check walks them. */
     static final class Elaborated {
-        final Map<String, Core> behaviors = new LinkedHashMap<>();
         final Map<String, Core> helpers = new LinkedHashMap<>();
     }
 
@@ -54,45 +55,38 @@ public final class TypeChecker {
      * @param errors what the check found wrong
      * @param abandoned the units it could not read at all, each resting on a name that denotes
      *                  nothing — reported already, and each a reason the module cannot be emitted
+     * @param stopped whether the check stopped rather than finished. A structural check builds what a
+     *                later phase reads — the {@code fns} map, the {@code exposed} set — so when one
+     *                fails there is nothing left to check the rest against, and a body checked all
+     *                the same reports being unable to see what was already reported missing.
+     * @param recursiveHelpers the recursive helper bodies it elaborated, which the backend emits as
+     *                         methods
      */
     public record Reported(List<CompileException> errors, List<Unanswerable> abandoned,
-                           Checked checked) {}
+                           boolean stopped, Map<String, Core> recursiveHelpers) {}
 
-    public static Reported checkReporting(Ast.Module module, Symbols symbols,
-                                          Map<String, Sig> importedSigs, Set<String> importedInjected,
-                                          Ast.Module lowered) {
-        List<Diagnostic> warnings = new ArrayList<>();
+    /**
+     * Everything the check has to say about a module that is not one behavior's body: its
+     * declarations, its helpers, its {@code exposing} line, its compositions. A behavior's body is
+     * asked for on its own ({@link #checkBehavior}), so what one of them says is not in here.
+     *
+     * <p>{@code reqSigs} and {@code recursiveHelperFns} are handed over rather than worked out here,
+     * because the body check reads the same two and they must be the same two.
+     */
+    public static Reported checkModule(Ast.Module module, Symbols symbols,
+                                       Map<String, Sig> importedSigs, Set<String> importedInjected,
+                                       Ast.Module lowered, Map<String, ReqSig> reqSigs,
+                                       Map<String, Type> recursiveHelperFns) {
         Elaborated elaborated = new Elaborated();
         List<Unanswerable> abandoned = new ArrayList<>();
-        List<CompileException> errors =
-                checkCollecting(module, symbols, importedSigs, importedInjected, lowered, warnings,
-                        elaborated, abandoned);
-        return new Reported(errors, List.copyOf(abandoned),
-                new Checked(elaborated.behaviors, elaborated.helpers, warnings));
-    }
-
-    /** Every error found in {@code module}, recovering past each so the whole module is checked; the
-     * originating exceptions in the order they were found (so the first is the one the old fail-fast
-     * check would have thrown), deduped. */
-    static List<CompileException> checkCollecting(Ast.Module module, Symbols symbols,
-                                                          Map<String, Sig> importedSigs,
-                                                          Set<String> importedInjected, Ast.Module lowered,
-                                                          List<Diagnostic> warnings, Elaborated elaborated) {
-        return checkCollecting(module, symbols, importedSigs, importedInjected, lowered, warnings,
-                elaborated, new ArrayList<>());
-    }
-
-    static List<CompileException> checkCollecting(Ast.Module module, Symbols symbols,
-                                                          Map<String, Sig> importedSigs,
-                                                          Set<String> importedInjected, Ast.Module lowered,
-                                                          List<Diagnostic> warnings, Elaborated elaborated,
-                                                          List<Unanswerable> abandoned) {
         List<CompileException> errors = new ArrayList<>();
+        boolean stopped = false;
         try {
-            checkRecovering(module, symbols, importedSigs, importedInjected, lowered, errors, warnings,
-                    elaborated, abandoned);
+            checkRecovering(module, symbols, importedSigs, importedInjected, lowered, errors,
+                    elaborated, abandoned, reqSigs, recursiveHelperFns);
         } catch (Unanswerable e) {
             abandoned.add(e);
+            stopped = true;
         } catch (CompileException e) {
             // A structural / prerequisite check (a duplicate name, an `exposing` violation, a module
             // cycle) is fail-fast: it can leave later phases without the state they read, so its first
@@ -101,8 +95,38 @@ public final class TypeChecker {
             // An unresolvable type no longer gets here: it denotes the error type, which absorbs, so
             // the module is checked past it and never reaches codegen.
             errors.add(e);
+            stopped = true;
         }
-        return deduped(errors);
+        return new Reported(deduped(errors), List.copyOf(abandoned), stopped, elaborated.helpers);
+    }
+
+    /**
+     * One behavior's body against the behavior it implements (spec 13.1), as the Core the backend
+     * emits. Its own question: what it reads is the behavior, its {@code let}, and what the module
+     * around it means — never another body.
+     */
+    public static Core checkBehavior(Ast.SpecBehavior spec, Ast.FnDef fn, Ast.Expr loweredBody,
+                                     Symbols symbols, Set<String> allBehaviors,
+                                     Map<String, ReqSig> reqSigs, HelperInliner inliner,
+                                     Map<String, Type> recursiveHelperFns,
+                                     Map<String, Map<TypeName, String>> recHelperConstructs,
+                                     List<Diagnostic> warnings) {
+        return SpecChecker.checkSpecFn(spec, fn, loweredBody, symbols, allBehaviors, reqSigs,
+                inliner, recursiveHelperFns, recHelperConstructs, warnings);
+    }
+
+    /** The signatures of a module's recursive helpers — what a self- or mutual call is typed
+     * against, and what a body that calls one reads. */
+    public static Map<String, Type> recursiveHelperSigs(HelperInliner inliner, Symbols symbols) {
+        return HelperTyping.recursiveHelperSigs(inliner, symbols);
+    }
+
+    /** What each recursive helper constructs, transitively. A recursive helper is not inlined, so its
+     * constructions are attributed to the behavior that calls it (spec 12.5). */
+    public static Map<String, Map<TypeName, String>> recursiveHelperConstructs(
+            Set<String> names, Map<String, Ast.Expr> loweredBodies, HelperInliner inliner,
+            Symbols symbols) {
+        return HelperTyping.recursiveHelperConstructs(names, loweredBodies, inliner, symbols);
     }
 
     /** Runs one independent unit's check, recording its first error instead of throwing so the next
@@ -156,14 +180,15 @@ public final class TypeChecker {
     static void checkRecovering(Ast.Module module, Symbols symbols,
                                         Map<String, Sig> importedSigs, Set<String> importedInjected,
                                         Ast.Module lowered,
-                                        List<CompileException> errors, List<Diagnostic> warnings,
-                                        Elaborated elaborated, List<Unanswerable> abandoned) {
+                                        List<CompileException> errors,
+                                        Elaborated elaborated, List<Unanswerable> abandoned,
+                                        Map<String, ReqSig> reqSigs,
+                                        Map<String, Type> recursiveHelperFns) {
         Map<String, Ast.Expr> loweredBodies = new HashMap<>();
         for (Ast.FnDef fn : lowered.fns()) {
             loweredBodies.put(fn.name(), fn.body());
         }
         HelperInliner inliner = HelperInliner.forModule(module);
-        Map<String, Type> recursiveHelperFns = HelperTyping.recursiveHelperSigs(inliner, symbols);
         // An invariant runs on every construction and must terminate (spec §invariant-expressions).
         // A total recursive helper does terminate, so it is admissible — including the stdlib fold
         // (`List.foldFrom`) that backs the list quantifiers `List.all`/`any`/`member`/`distinct`,
@@ -273,8 +298,8 @@ public final class TypeChecker {
         // and binds it, whether it named it as a `>->` stage or as a `requires` dependency. Its
         // signature comes from the module that declared it; a local behavior of the same name wins.
         // The same map is built before the module is lowered, where a helper's parameter type is
-        // settled from a call to an injected behavior (issue #178), so it is built in one place.
-        Map<String, ReqSig> reqSigs = InjectionSigs.of(module, symbols, importedSigs, importedInjected);
+        // settled from a call to an injected behavior (issue #178), and read again by every body
+        // check. It arrives here rather than being built again because it is one question.
         for (Ast.BehaviorDef b : module.behaviors()) {
             if (b instanceof Ast.SpecBehavior spec && !fns.containsKey(spec.name())) {
                 // `requires` names what an implementation calls (12.6), and an injection target has
@@ -308,25 +333,11 @@ public final class TypeChecker {
         // Recursion is total by default (spec §fn-declaration): a non-`partial` recursive helper must
         // be structurally recursive, so its examples terminate at compile time.
         collect(errors, abandoned, () -> TotalityChecker.check(inliner));
-        // What each recursive helper constructs, transitively — a recursive helper is not inlined, so
-        // its constructions are attributed to the behavior that calls it (spec 12.5).
-        Map<String, Map<TypeName, String>> recHelperConstructs =
-                HelperTyping.recursiveHelperConstructs(recursiveHelperFns.keySet(), loweredBodies, inliner, symbols);
-        for (Ast.BehaviorDef b : module.behaviors()) {
-            if (b instanceof Ast.SpecBehavior spec) {
-                Ast.FnDef fn = fns.get(spec.name());
-                if (fn != null) {
-                    collect(errors, abandoned, () -> elaborated.behaviors.put(fn.name(),
-                            SpecChecker.checkSpecFn(spec, fn, loweredBodies.get(spec.name()), symbols,
-                            allBehaviors, reqSigs, inliner, recursiveHelperFns, recHelperConstructs,
-                            warnings)));
-                }
-            }
-        }
         // A fn matching a pipeline is rejected (a pipeline is already its own implementation, so it
         // cannot also have a fn body — spec 13.1). A fn matching a SpecBehavior is that behavior's
-        // implementation (checked above); any other fn is a helper (checked by checkHelpers). These
-        // terminal validations build no state, so each is recovered independently.
+        // implementation, which is checked as its own question; any other fn is a helper (checked by
+        // checkHelpers). These terminal validations build no state, so each is recovered
+        // independently.
         collect(errors, abandoned, () -> {
             for (Ast.FnDef fn : module.fns()) {
                 if (!specNames.contains(fn.name()) && allBehaviors.contains(fn.name())) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -4,7 +4,6 @@ import souther.compiler.ast.Ast;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
-import souther.compiler.diag.Region;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
@@ -150,23 +149,17 @@ public final class TypeChecker {
         }
     }
 
-    /** Collected errors as a stable set in first-seen order: one per (code, message, region), so the
-     * same underlying error reported by two phases is shown once. */
+    /** Collected errors as a stable set in first-seen order: one per problem, so the same underlying
+     * error found by two phases is shown once. What makes two of them one problem is the diagnostic's
+     * own {@link Diagnostic#identity()} — the same comparison a caller collecting from several
+     * questions makes. */
     static List<CompileException> deduped(List<CompileException> errors) {
-        Map<String, CompileException> unique = new LinkedHashMap<>();
+        Map<Object, CompileException> unique = new LinkedHashMap<>();
         for (CompileException e : errors) {
-            unique.putIfAbsent(dedupKey(e.diagnostic()), e);
+            Diagnostic d = e.diagnostic();
+            unique.putIfAbsent(d == null ? "null" : d.identity(), e);
         }
         return new ArrayList<>(unique.values());
-    }
-
-    static String dedupKey(Diagnostic d) {
-        if (d == null) {
-            return "null";
-        }
-        Region r = d.region();
-        String at = r == null ? "" : r.start() + ":" + r.end();
-        return d.code() + "|" + d.messageKey() + "|" + d.literalMessage() + "|" + at;
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -1,8 +1,11 @@
 package souther.compiler.query;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.check.HelperInliner;
+import souther.compiler.check.InjectionSigs;
 import souther.compiler.check.Lower;
 import souther.compiler.check.PipelineSigs;
+import souther.compiler.check.ReqSig;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeChecker;
@@ -180,17 +183,23 @@ public final class Bodies {
     }
 
     /**
-     * A module with every helper call expanded into the body that called it, and with the parameter
-     * types those expansions settled written back into the declarations.
+     * The signatures of the behaviors a module injects — its own targets and the imported ones it
+     * names (spec 13.2, 14.3). What a call to one of them is typed against, both where a helper's
+     * parameter types are settled and in the check itself.
+     *
+     * <p>A signature that does not build is not reported here: the check reports it where it reports
+     * it today, and settling reads what it can and leaves the rest to the annotation rule. Answering
+     * with nothing at all would make every helper in the module undetermined on top of the real
+     * error.
      */
-    public record Lowering(String name) implements Key<Lower.Lowered> {
+    public record ReqSigs(String name) implements Key<Map<String, ReqSig>> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Lower.Lowered> compute(Db db) {
+        public Answer<Map<String, ReqSig>> compute(Db db) {
             Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
             Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
             Answer<Map<String, Sig>> imported = db.ask(new Imported(name));
@@ -200,11 +209,168 @@ public final class Bodies {
                 return Answer.absent();
             }
             try {
-                return Answer.of(Lower.run(prepared.value(), scope.value(), imported.value(),
+                return Answer.of(InjectionSigs.of(prepared.value(), scope.value(), imported.value(),
                         injected.value()));
+            } catch (CompileException _) {
+                return Answer.of(Map.of());
+            }
+        }
+    }
+
+    /** A module with every helper parameter the author left unwritten carrying the type its body
+     * gives it — the surface tree the check reads its declarations from. */
+    public record Settled(String name) implements Key<Ast.Module> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Ast.Module> compute(Db db) {
+            Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, ReqSig>> reqSigs = db.ask(new ReqSigs(name));
+            if (!prepared.present() || !scope.present() || !reqSigs.present()) {
+                return Answer.absent();
+            }
+            try {
+                return Answer.of(Lower.settle(prepared.value(), scope.value(), reqSigs.value()));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
+        }
+    }
+
+    /**
+     * The module's helpers, settled — what every body in it expands its calls against.
+     *
+     * <p>Its own question, and a map of definitions rather than an inliner, because that is what makes
+     * it an answer two bodies can share: a helper says what it says whatever the behavior beside it
+     * was edited to, so a body that reads this is left alone. An inliner cannot do that job — nothing
+     * says when two of them are the same, so every reader of one would run again whatever changed.
+     */
+    public record Helpers(String name) implements Key<Map<String, Ast.FnDef>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Ast.FnDef>> compute(Db db) {
+            Answer<Ast.Module> settled = db.ask(new Settled(name));
+            return settled.present()
+                    ? Answer.of(HelperInliner.helpersOf(settled.value())) : Answer.absent();
+        }
+    }
+
+    /** The helpers a module emits as methods rather than expanding: the ones that recurse (spec
+     * 13.1), including the prelude ones it has taken on as its own. */
+    public record RecursiveHelpers(String name) implements Key<Set<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Set<String>> compute(Db db) {
+            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(name));
+            if (!helpers.present()) {
+                return Answer.absent();
+            }
+            return Answer.of(HelperInliner.forHelpers(helpers.value()).recursiveHelpers());
+        }
+    }
+
+    /** One settled fn, so what a body is expanded from is the fn itself and not the module it sits
+     * in. */
+    public record SettledFn(String module, String fn) implements Key<Ast.FnDef> {
+
+        @Override
+        public Answer<Ast.FnDef> compute(Db db) {
+            Answer<Ast.Module> settled = db.ask(new Settled(module));
+            if (!settled.present()) {
+                return Answer.absent();
+            }
+            for (Ast.FnDef candidate : settled.value().fns()) {
+                if (candidate.name().equals(fn)) {
+                    return Answer.of(candidate);
+                }
+            }
+            return Answer.absent();
+        }
+    }
+
+    /**
+     * One body as the backend emits it: its helper calls expanded and its comprehensions desugared.
+     *
+     * <p>What it reads is the fn itself and the helpers around it, so editing another body in the same
+     * module does not expand this one again.
+     */
+    public record LoweredBody(String module, String fn) implements Key<Ast.FnDef> {
+
+        @Override
+        public Answer<Ast.FnDef> compute(Db db) {
+            Answer<Ast.FnDef> def = db.ask(new SettledFn(module, fn));
+            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(module));
+            Answer<Set<String>> recursive = db.ask(new RecursiveHelpers(module));
+            if (!def.present() || !helpers.present() || !recursive.present()) {
+                return Answer.absent();
+            }
+            try {
+                return Answer.of(Lower.body(def.value(), HelperInliner.forHelpers(helpers.value()),
+                        recursive.value().contains(fn)));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /**
+     * A module with every helper call expanded into the body that called it, and with the parameter
+     * types those expansions settled written back into the declarations.
+     *
+     * <p>The bodies are asked for one at a time; what is left here is which fns survive to the
+     * backend — a behavior's implementation and a recursive helper — which is a fact about the module
+     * rather than about any one of them.
+     */
+    public record Lowering(String name) implements Key<Lower.Lowered> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Lower.Lowered> compute(Db db) {
+            Answer<Ast.Module> settled = db.ask(new Settled(name));
+            Answer<Set<String>> recursive = db.ask(new RecursiveHelpers(name));
+            if (!settled.present() || !recursive.present()) {
+                return Answer.absent();
+            }
+            Set<String> behaviors = Names.behaviorNames(settled.value());
+            Set<String> taken = new LinkedHashSet<>();
+            List<Ast.FnDef> fns = new ArrayList<>();
+            for (Ast.FnDef fn : settled.value().fns()) {
+                // A non-recursive helper is fully inlined at its call sites and never emitted — it has
+                // no body of its own down here, so nothing asks for one.
+                if (!behaviors.contains(fn.name()) && !recursive.value().contains(fn.name())) {
+                    continue;
+                }
+                // A name is one question, so a name written twice is asked once and answered by the
+                // first. The check reports the duplicate and this module is not emitted; what it must
+                // not do is carry the same body twice.
+                if (!taken.add(fn.name())) {
+                    continue;
+                }
+                Answer<Ast.FnDef> body = db.ask(new LoweredBody(name, fn.name()));
+                if (!body.present()) {
+                    // Why is the body's to say, and it said it. A module with a body that does not
+                    // expand has none to emit.
+                    return Answer.absent();
+                }
+                fns.add(body.value());
+            }
+            return Answer.of(new Lower.Lowered(settled.value(),
+                    Lower.lowered(settled.value(), fns)));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -10,8 +10,12 @@ import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.Unanswerable;
+import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -374,13 +378,210 @@ public final class Bodies {
         }
     }
 
+    /** The signatures of a module's recursive helpers — what a self- or mutual call is typed
+     * against, and what every body that calls one reads. */
+    public record RecursiveHelperSigs(String name) implements Key<Map<String, Type>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Type>> compute(Db db) {
+            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            if (!helpers.present() || !scope.present()) {
+                return Answer.absent();
+            }
+            try {
+                return Answer.of(TypeChecker.recursiveHelperSigs(
+                        HelperInliner.forHelpers(helpers.value()), scope.value()));
+            } catch (CompileException e) {
+                // A recursive helper that does not say what it returns costs the signatures of all of
+                // them, and there is no module to check without them.
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /** What each recursive helper constructs, transitively. A recursive helper is not inlined, so its
+     * constructions are attributed to the behavior that calls it (spec 12.5). */
+    public record RecursiveHelperConstructs(String name)
+            implements Key<Map<String, Map<TypeName, String>>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Map<TypeName, String>>> compute(Db db) {
+            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(name));
+            Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            if (!helpers.present() || !sigs.present() || !scope.present()) {
+                return Answer.absent();
+            }
+            Map<String, Ast.Expr> bodies = new LinkedHashMap<>();
+            for (String helper : sigs.value().keySet()) {
+                Answer<Ast.FnDef> body = db.ask(new LoweredBody(name, helper));
+                if (!body.present()) {
+                    return Answer.absent();
+                }
+                bodies.put(helper, body.value().body());
+            }
+            try {
+                return Answer.of(TypeChecker.recursiveHelperConstructs(sigs.value().keySet(), bodies,
+                        HelperInliner.forHelpers(helpers.value()), scope.value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /** The names of the behaviors a module declares — what a body reads to tell a call to one of them
+     * from a call to anything else. */
+    public record BehaviorNames(String name) implements Key<Set<String>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Set<String>> compute(Db db) {
+            Answer<Ast.Module> settled = db.ask(new Settled(name));
+            return settled.present()
+                    ? Answer.of(Names.behaviorNames(settled.value())) : Answer.absent();
+        }
+    }
+
+    /** One behavior's declaration, so what a body is checked against is the behavior it implements
+     * and not the module it sits in. */
+    public record Spec(String module, String behavior) implements Key<Ast.SpecBehavior> {
+
+        @Override
+        public Answer<Ast.SpecBehavior> compute(Db db) {
+            Answer<Ast.Module> settled = db.ask(new Settled(module));
+            if (!settled.present()) {
+                return Answer.absent();
+            }
+            for (Ast.BehaviorDef b : settled.value().behaviors()) {
+                if (b instanceof Ast.SpecBehavior spec && spec.name().equals(behavior)) {
+                    return Answer.of(spec);
+                }
+            }
+            return Answer.absent();
+        }
+    }
+
+    /**
+     * One behavior's body checked against the behavior it implements, as the Core the backend emits.
+     *
+     * <p>What it reads is the behavior, its {@code let}, and what the module around it means. Not
+     * another body — so a mistake in one behavior is that behavior's, and editing one leaves the rest
+     * of the file alone.
+     */
+    public record CheckedBehavior(String module, String behavior) implements Key<Core> {
+
+        @Override
+        public Answer<Core> compute(Db db) {
+            Answer<Ast.SpecBehavior> spec = db.ask(new Spec(module, behavior));
+            Answer<Ast.FnDef> fn = db.ask(new SettledFn(module, behavior));
+            Answer<Ast.FnDef> body = db.ask(new LoweredBody(module, behavior));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(module));
+            Answer<Set<String>> behaviors = db.ask(new BehaviorNames(module));
+            Answer<Map<String, ReqSig>> reqSigs = db.ask(new ReqSigs(module));
+            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(module));
+            Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(module));
+            Answer<Map<String, Map<TypeName, String>>> constructs =
+                    db.ask(new RecursiveHelperConstructs(module));
+            if (!spec.present() || !fn.present() || !body.present() || !scope.present()
+                    || !behaviors.present() || !reqSigs.present() || !helpers.present()
+                    || !sigs.present() || !constructs.present()) {
+                return Answer.absent();
+            }
+            List<Diagnostic> warnings = new ArrayList<>();
+            try {
+                Core core = TypeChecker.checkBehavior(spec.value(), fn.value(), body.value().body(),
+                        scope.value(), behaviors.value(), reqSigs.value(),
+                        HelperInliner.forHelpers(helpers.value()), sigs.value(), constructs.value(),
+                        warnings);
+                List<Report> reports = new ArrayList<>();
+                for (Diagnostic warning : warnings) {
+                    reports.add(Report.of(warning));
+                }
+                return Answer.of(core, reports);
+            } catch (Unanswerable _) {
+                // The name it rested on was reported where it was written. This body has no meaning
+                // to emit, which the absence says, and nothing further to add.
+                return Answer.absent();
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /**
+     * What a module's own check found: its declarations, its helpers, its {@code exposing} line, its
+     * compositions — everything that is not one behavior's body.
+     *
+     * <p>It answers whatever it found, because what it found is the answer. Whether there is a module
+     * to emit is {@link Checked}'s to say, from this and every body together.
+     */
+    public record ModuleCheck(String name) implements Key<ModuleCheck.Of> {
+
+        /**
+         * @param recursiveHelpers the bodies it elaborated, which the backend emits as methods
+         * @param sound whether it found nothing wrong. An abandoned unit is wrong and says nothing
+         *              of its own, so this is not the same as having reported nothing
+         * @param stopped whether it stopped rather than finished, leaving the bodies nothing to be
+         *                checked against
+         */
+        public record Of(Map<String, Core> recursiveHelpers, boolean sound, boolean stopped) {}
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Of> compute(Db db) {
+            Answer<Lower.Lowered> lowering = db.ask(new Lowering(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> imported = db.ask(new Imported(name));
+            Answer<Set<String>> injected = db.ask(new ImportedInjected(name));
+            Answer<Map<String, ReqSig>> reqSigs = db.ask(new ReqSigs(name));
+            Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(name));
+            if (!lowering.present() || !scope.present() || !imported.present()
+                    || !injected.present() || !reqSigs.present() || !sigs.present()) {
+                return Answer.absent();
+            }
+            TypeChecker.Reported reported;
+            try {
+                reported = TypeChecker.checkModule(lowering.value().settled(), scope.value(),
+                        imported.value(), injected.value(), lowering.value().lowered(),
+                        reqSigs.value(), sigs.value());
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+            List<Report> reports = new ArrayList<>();
+            for (CompileException e : reported.errors()) {
+                reports.addAll(Report.of(e));
+            }
+            boolean sound = reported.errors().isEmpty() && reported.abandoned().isEmpty();
+            return Answer.of(
+                    new Of(reported.recursiveHelpers(), sound, reported.stopped()),
+                    reports);
+        }
+    }
+
     /**
      * The result of type-checking a module. Absent when anything in it is wrong: a module that does
      * not check must not reach codegen, and an importer of it is skipped rather than compiled
      * against a broken module.
      *
-     * <p>Warnings ride on a present answer, which is how an invariant-discharge warning reaches the
-     * author of a module that compiled.
+     * <p>What each body came to is asked for one body at a time, and each of those reports what it
+     * found. What is left here is the decision they and the module's own check come to together:
+     * whether there is a module to emit.
      */
     public record Checked(String name) implements Key<TypeChecker.Checked> {
         @Override
@@ -390,12 +591,12 @@ public final class Bodies {
 
         @Override
         public Answer<TypeChecker.Checked> compute(Db db) {
-            Answer<Lower.Lowered> lowering = db.ask(new Lowering(name));
-            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
-            Answer<Map<String, Sig>> imported = db.ask(new Imported(name));
-            Answer<Set<String>> injected = db.ask(new ImportedInjected(name));
-            if (!lowering.present() || !scope.present() || !imported.present()
-                    || !injected.present()) {
+            Answer<Ast.Module> settled = db.ask(new Settled(name));
+            // Asked before any body, so a module told about its own mistakes is told about them
+            // first: an author reads the file from the top, and the check of a body it declares
+            // cannot come before the declaration it rests on.
+            Answer<ModuleCheck.Of> module = db.ask(new ModuleCheck(name));
+            if (!settled.present() || !module.present()) {
                 return Answer.absent();
             }
             // Whether anything about this module's names came out wrong decides whether it can be
@@ -403,19 +604,30 @@ public final class Bodies {
             // type absorbs so that the check can carry on, and stopping here would mean a mistake in
             // one declaration silencing every other definition in the file.
             boolean named = Boolean.TRUE.equals(db.ask(new Names.Sound(name)).value());
-            TypeChecker.Reported reported;
-            try {
-                reported = TypeChecker.checkReporting(lowering.value().settled(), scope.value(),
-                        imported.value(), injected.value(), lowering.value().lowered());
-            } catch (CompileException e) {
-                return Answer.absent(e);
+            Set<String> implemented = new LinkedHashSet<>();
+            for (Ast.FnDef fn : settled.value().fns()) {
+                implemented.add(fn.name());
             }
-            List<Report> reports = new ArrayList<>();
-            for (CompileException e : reported.errors()) {
-                reports.addAll(Report.of(e));
-            }
-            for (Diagnostic warning : reported.checked().warnings()) {
-                reports.add(Report.of(warning));
+            Map<String, Core> bodies = new LinkedHashMap<>();
+            boolean bodiesCheck = true;
+            // A module whose own check stopped built nothing for a body to be checked against, so
+            // asking would report not being able to see what has already been reported missing.
+            if (!module.value().stopped()) {
+                // In the order they are declared, so what the backend emits does not move with what
+                // the check happened to ask for first.
+                for (Ast.BehaviorDef b : settled.value().behaviors()) {
+                    // An injection target has no body here — something else supplies it (spec 13.2)
+                    // — so there is nothing to check and nothing missing when there is none.
+                    if (!(b instanceof Ast.SpecBehavior spec) || !implemented.contains(spec.name())) {
+                        continue;
+                    }
+                    Answer<Core> core = db.ask(new CheckedBehavior(name, spec.name()));
+                    if (core.present()) {
+                        bodies.put(spec.name(), core.value());
+                    } else {
+                        bodiesCheck = false;
+                    }
+                }
             }
             // A unit the check could not read at all leaves the module without a meaning to emit,
             // and says nothing of its own: the name it rested on was reported where it was written.
@@ -425,10 +637,12 @@ public final class Bodies {
             // reported here at all — an import of a module that is here and unusable leaves a hole,
             // and what is wrong was reported on that module.
             boolean sound = named
-                    && !TypeOps.holdsAnErroneousType(lowering.value().settled())
-                    && reported.errors().isEmpty()
-                    && reported.abandoned().isEmpty();
-            return sound ? Answer.of(reported.checked(), reports) : Answer.absent(reports);
+                    && bodiesCheck
+                    && module.value().sound()
+                    && !TypeOps.holdsAnErroneousType(settled.value());
+            return sound
+                    ? Answer.of(new TypeChecker.Checked(bodies, module.value().recursiveHelpers()))
+                    : Answer.absent();
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -285,8 +285,15 @@ public final class Bodies {
         }
     }
 
-    /** One settled fn, so what a body is expanded from is the fn itself and not the module it sits
-     * in. */
+    /**
+     * One settled fn, so what a body is expanded from is the fn itself and not the module it sits in.
+     *
+     * <p>A projection, not a settling of its own: the module is settled together — one helper's
+     * settled type can settle the next one's — and this reads one fn out of the result. The
+     * difference matters because it is what a reader depends on that decides how far an edit
+     * travels, not what the work was. Settling per definition, if it is ever worth it, goes behind
+     * this without any reader noticing.
+     */
     public record SettledFn(String module, String fn) implements Key<Ast.FnDef> {
 
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -1,11 +1,14 @@
 package souther.compiler.query;
 
 import java.util.ArrayDeque;
+import souther.compiler.diag.Diagnostic;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -214,7 +217,7 @@ public final class Db {
      * generation of its own, separate from the input revision.
      */
     public List<Found> allReports() {
-        Map<String, Found> found = new java.util.LinkedHashMap<>();
+        Map<Told, Found> found = new LinkedHashMap<>();
         for (Key<?> key : spoke) {
             Memo memo = memos.get(key);
             if (memo == null || memo.verifiedAt() != revision) {
@@ -225,13 +228,15 @@ public final class Db {
                 // legitimately: a helper is checked on its own and again in each body it is expanded
                 // into, and both are looking at the same line. The first to say it is the one that
                 // says it, so the order is the order the work happened in.
-                found.putIfAbsent(
-                        key.module() + " " + key.sourceId() + " " + report.problem(),
+                found.putIfAbsent(new Told(key.module(), key.sourceId(), report.problem()),
                         new Found(key.module(), key.sourceId(), report));
             }
         }
         return new ArrayList<>(found.values());
     }
+
+    /** One thing the author is told, wherever it was found: a problem, on a file. */
+    private record Told(String module, String sourceId, Diagnostic.Identity problem) {}
 
     /** What {@code key} read while it was answered, empty if it has not been asked. */
     public Set<Key<?>> dependenciesOf(Key<?> key) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -214,17 +214,23 @@ public final class Db {
      * generation of its own, separate from the input revision.
      */
     public List<Found> allReports() {
-        List<Found> found = new ArrayList<>();
+        Map<String, Found> found = new java.util.LinkedHashMap<>();
         for (Key<?> key : spoke) {
             Memo memo = memos.get(key);
             if (memo == null || memo.verifiedAt() != revision) {
                 continue;
             }
             for (Report report : memo.answer().reports()) {
-                found.add(new Found(key.module(), key.sourceId(), report));
+                // One problem is one diagnostic, whichever questions found it. Two of them can, and
+                // legitimately: a helper is checked on its own and again in each body it is expanded
+                // into, and both are looking at the same line. The first to say it is the one that
+                // says it, so the order is the order the work happened in.
+                found.putIfAbsent(
+                        key.module() + " " + key.sourceId() + " " + report.problem(),
+                        new Found(key.module(), key.sourceId(), report));
             }
         }
-        return found;
+        return new ArrayList<>(found.values());
     }
 
     /** What {@code key} read while it was answered, empty if it has not been asked. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Report.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Report.java
@@ -77,17 +77,20 @@ public record Report(Diagnostic diagnostic, String legacyMessage) {
     }
 
     /**
-     * What makes this the same problem as another: what is wrong, said the same way, in the same
-     * place.
+     * What makes this the same problem as another: everything the diagnostic says, said the same way,
+     * in the same place — {@link Diagnostic#identity()}, arguments included.
      *
      * <p>Two questions can find one problem. A helper is checked on its own and again wherever it is
      * expanded, and both are looking at the same line of the same helper — so the author is told
      * twice about one mistake unless the two are recognised as one. Neither is wrong to have found
      * it, and neither can see the other, so it is the reading of them that settles it.
+     *
+     * <p>The whole diagnostic, because a narrower comparison merges what it leaves out. Two checks of
+     * one expression against different expectations say the same thing at the same place with
+     * different arguments, and those are two problems.
      */
-    public String problem() {
-        return diagnostic.code() + "|" + diagnostic.messageKey() + "|" + diagnostic.literalMessage()
-                + "|" + diagnostic.severity() + "|" + diagnostic.region();
+    public Diagnostic.Identity problem() {
+        return diagnostic.identity();
     }
 
     /** This report as an error to throw. One built from a raised exception throws that exception's

--- a/souther-compiler/src/main/java/souther/compiler/query/Report.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Report.java
@@ -76,6 +76,20 @@ public record Report(Diagnostic diagnostic, String legacyMessage) {
         return reports.stream().filter(Report::isError).toList();
     }
 
+    /**
+     * What makes this the same problem as another: what is wrong, said the same way, in the same
+     * place.
+     *
+     * <p>Two questions can find one problem. A helper is checked on its own and again wherever it is
+     * expanded, and both are looking at the same line of the same helper — so the author is told
+     * twice about one mistake unless the two are recognised as one. Neither is wrong to have found
+     * it, and neither can see the other, so it is the reading of them that settles it.
+     */
+    public String problem() {
+        return diagnostic.code() + "|" + diagnostic.messageKey() + "|" + diagnostic.literalMessage()
+                + "|" + diagnostic.severity() + "|" + diagnostic.region();
+    }
+
     /** This report as an error to throw. One built from a raised exception throws that exception's
      * message again; one built any other way renders its own, in English, because that message has
      * always been English and a test that reads it should not move with the reader's locale. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileBrokenInputIsDiagnosedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileBrokenInputIsDiagnosedTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 /**
  * A program the compiler rejects must be rejected with a diagnostic. Anything else — an
  * IndexOutOfBounds, a ClassCast, a StackOverflow — is not a {@code CompileException}, so it escapes
- * the recovery boundary in {@code TypeChecker.checkCollecting} and reaches the author as a stack
+ * the recovery boundary in {@code TypeChecker.checkModule} and reaches the author as a stack
  * trace; in the language server, where a non-diagnostic failure is swallowed so the server survives,
  * it reaches them as no marker at all.
  *

--- a/souther-compiler/src/test/java/souther/compiler/query/ASignatureThatDoesNotBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ASignatureThatDoesNotBuildTest.java
@@ -1,0 +1,59 @@
+package souther.compiler.query;
+
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * What happens to the rest of a module when the signatures of the behaviors it injects cannot be
+ * built.
+ *
+ * <p>{@link Bodies.ReqSigs} answers with nothing injected rather than with nothing at all, because a
+ * helper's parameter types are settled from those signatures and stopping there would leave every
+ * helper in the module undetermined on top of the real error. That is a recovery, and a recovery has
+ * to say how far it goes: the mistake is reported where it is, once; no body reports being unable to
+ * see what is already known missing; and nothing is emitted.
+ */
+class ASignatureThatDoesNotBuildTest {
+
+    /** `fetch` is an injection target — no `let` — and its output names a primitive beside a data,
+     * which is not a union a behavior can have. `use` requires it and calls it. */
+    private static final String SOURCE = """
+            module m.a exposing ( A )
+
+            data A = Int
+
+            behavior fetch : (a: A) -> Int | A
+
+            behavior use : (a: A) -> A
+                requires fetch
+            let use (a, fetch) = fetch(a)
+            """;
+
+    private static Compilation compiled() {
+        Compilation c = Compilation.ofDocuments(Map.of("a.sou", SOURCE), Set.of(), ModulePath.EMPTY);
+        c.answerEverything();
+        return c;
+    }
+
+    @Test
+    void theSignatureIsReportedAndNothingElseIs() {
+        List<Db.Found> found = compiled().db().allReports();
+
+        assertEquals(1, found.size(), "one signature that does not build, one diagnostic: " + found);
+        assertEquals("check.union.members", found.get(0).report().diagnostic().messageKey());
+    }
+
+    @Test
+    void theModuleIsNotEmitted() {
+        assertNull(compiled().db().ask(new Output.Classes("m.a")).value(),
+                "a module whose injected signatures did not build has no meaning to emit");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -196,19 +196,28 @@ class IncrementalCompilationTest {
         return c;
     }
 
+    /** The same workspace with {@code thrice}'s body changed — an edit inside one definition, made
+     * at the end of the file so nothing before it moves. */
+    private static Map<String, String> thriceTimes(String factor) {
+        return Map.of("orders.sou", ORDERS.replace("n.value * 3)", "n.value * " + factor + ")"));
+    }
+
     /**
      * A body is expanded from itself and the helpers around it, so what another body in the same
      * module says is none of its business. Expanding a module's bodies as one tree made every
      * behavior depend on every other one, so editing any body in a file re-expanded all of them.
      */
     @Test
-    void editingOneBodyDoesNotExpandTheBodiesBesideIt() {
+    void editingOneBodyExpandsThatBodyAndNotTheOnesBesideIt() {
         Compilation c = orders(ORDERS);
         Answer<?> twice = c.db().ask(new Bodies.LoweredBody("shop.orders", "twice"));
+        Answer<?> thrice = c.db().ask(new Bodies.LoweredBody("shop.orders", "thrice"));
 
-        c.update(Map.of("orders.sou", ORDERS.replace("n.value * 3", "n.value * 30")), Set.of());
+        c.update(thriceTimes("30"), Set.of());
         c.answerEverything();
 
+        assertNotSame(thrice, c.db().ask(new Bodies.LoweredBody("shop.orders", "thrice")),
+                "the edit is `thrice`'s, so it is expanded again");
         assertSame(twice, c.db().ask(new Bodies.LoweredBody("shop.orders", "twice")),
                 "`twice` says what it said, and `thrice` is not part of it");
     }
@@ -218,15 +227,36 @@ class IncrementalCompilationTest {
      * so a mistake made in another body — or its being edited at all — is none of its business.
      */
     @Test
-    void editingOneBodyDoesNotCheckTheBodiesBesideIt() {
+    void editingOneBodyChecksThatBodyAndNotTheOnesBesideIt() {
         Compilation c = orders(ORDERS);
         Answer<?> twice = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "twice"));
+        Answer<?> thrice = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "thrice"));
 
-        c.update(Map.of("orders.sou", ORDERS.replace("n.value * 3", "n.value * 30")), Set.of());
+        c.update(thriceTimes("30"), Set.of());
         c.answerEverything();
 
+        assertNotSame(thrice, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "thrice")),
+                "the edit is `thrice`'s, so it is checked again");
         assertSame(twice, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "twice")),
                 "`twice` is checked against `behavior twice`, which says what it said");
+    }
+
+    /**
+     * A helper is expanded into the bodies that call it, so editing one reaches them. It reaches the
+     * ones that do not call it as well: a body reads the module's helpers, not the helpers it calls,
+     * and narrowing that is per-helper work rather than per-body work.
+     */
+    @Test
+    void editingAHelperReachesTheBodiesItIsExpandedInto() {
+        Compilation c = orders(ORDERS);
+        Answer<?> twice = c.db().ask(new Bodies.LoweredBody("shop.orders", "twice"));
+
+        c.update(Map.of("orders.sou", ORDERS.replace("let doubled (n) = n * 2",
+                "let doubled (n) = n * 2 + 0")), Set.of());
+        c.answerEverything();
+
+        assertNotSame(twice, c.db().ask(new Bodies.LoweredBody("shop.orders", "twice")),
+                "`twice` calls `doubled`, and `doubled` is part of what `twice` becomes");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -213,6 +213,22 @@ class IncrementalCompilationTest {
                 "`twice` says what it said, and `thrice` is not part of it");
     }
 
+    /**
+     * And a body is checked against the behavior it implements and what the module around it means,
+     * so a mistake made in another body — or its being edited at all — is none of its business.
+     */
+    @Test
+    void editingOneBodyDoesNotCheckTheBodiesBesideIt() {
+        Compilation c = orders(ORDERS);
+        Answer<?> twice = c.db().ask(new Bodies.CheckedBehavior("shop.orders", "twice"));
+
+        c.update(Map.of("orders.sou", ORDERS.replace("n.value * 3", "n.value * 30")), Set.of());
+        c.answerEverything();
+
+        assertSame(twice, c.db().ask(new Bodies.CheckedBehavior("shop.orders", "twice")),
+                "`twice` is checked against `behavior twice`, which says what it said");
+    }
+
     @Test
     void changingWhatAModuleDeclaresReachesTheModulesThatImportIt() {
         Compilation c = started();

--- a/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/IncrementalCompilationTest.java
@@ -170,6 +170,49 @@ class IncrementalCompilationTest {
         return c.db().ask(new Output.Classes("shop.prices")).value();
     }
 
+    /** Two behaviors and a helper both of them call, in one module. */
+    private static final String ORDERS = """
+            module shop.orders exposing ( Amount )
+
+            data Amount = Int
+                invariant value >= 0
+
+            let doubled (n) = n * 2
+
+            behavior twice : (n: Amount) -> Amount
+                constructs Amount
+            let twice (n) = Amount(doubled(n.value))
+
+            behavior thrice : (n: Amount) -> Amount
+                constructs Amount
+            let thrice (n) = Amount(n.value * 3)
+            """;
+
+    private static Compilation orders(String source) {
+        Compilation c = Compilation.ofDocuments(Map.of("orders.sou", source), Set.of(),
+                ModulePath.EMPTY);
+        c.answerEverything();
+        assertTrue(c.db().allReports().isEmpty(), "the module compiles to begin with");
+        return c;
+    }
+
+    /**
+     * A body is expanded from itself and the helpers around it, so what another body in the same
+     * module says is none of its business. Expanding a module's bodies as one tree made every
+     * behavior depend on every other one, so editing any body in a file re-expanded all of them.
+     */
+    @Test
+    void editingOneBodyDoesNotExpandTheBodiesBesideIt() {
+        Compilation c = orders(ORDERS);
+        Answer<?> twice = c.db().ask(new Bodies.LoweredBody("shop.orders", "twice"));
+
+        c.update(Map.of("orders.sou", ORDERS.replace("n.value * 3", "n.value * 30")), Set.of());
+        c.answerEverything();
+
+        assertSame(twice, c.db().ask(new Bodies.LoweredBody("shop.orders", "twice")),
+                "`twice` says what it said, and `thrice` is not part of it");
+    }
+
     @Test
     void changingWhatAModuleDeclaresReachesTheModulesThatImportIt() {
         Compilation c = started();

--- a/souther-compiler/src/test/java/souther/compiler/query/OneProblemOneDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneProblemOneDiagnosticTest.java
@@ -50,6 +50,30 @@ class OneProblemOneDiagnosticTest {
         assertEquals(1, found.size(), "one reserved name, one diagnostic: " + found);
     }
 
+    /**
+     * A helper is checked on its own and again wherever it is expanded, so a mistake in one is found
+     * twice, at the same place, by two questions that cannot see each other. The author has one
+     * mistake and is told once.
+     */
+    @Test
+    void aMistakeInAHelperThatIsExpandedIntoABodyIsReportedOnce() {
+        List<Diagnostic> found = diagnose("""
+                module m.a
+
+                data A = Int
+                    invariant value >= 0
+
+                let doubled (n: Int) : Int = n * "two"
+
+                behavior twice : (a: A) -> A
+                    constructs A
+                let twice (a) = A(doubled(a.value))
+                """).get("a.sou");
+
+        assertEquals(1, found.size(),
+                "one mistake in `doubled`, one diagnostic: " + found);
+    }
+
     private static Map<String, List<Diagnostic>> diagnoseAs(String id, String source) {
         Map<String, String> byId = new LinkedHashMap<>();
         byId.put(id, source);

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -36,6 +36,33 @@ public record Diagnostic(Severity severity,
         return region == null ? null : region.start();
     }
 
+    /**
+     * What makes two diagnostics one problem: everything this one says, compared by what it says.
+     *
+     * <p>Written out rather than left to the record because {@code args} is an array, and a record
+     * compares an array component by identity — so two diagnostics built the same way from the same
+     * values are never equal. The arguments are the difference between "expected A, found B" and
+     * "expected C, found B", which is two problems and not one, so they are in here.
+     */
+    public record Identity(Severity severity, String code, String titleKey, Region region,
+                           List<LabeledRegion.Of> secondary, String messageKey, List<Object> args,
+                           String literalMessage, TypeComparison diff, List<Note.Of> notes,
+                           String suggestion) {}
+
+    public Identity identity() {
+        List<LabeledRegion.Of> labels = new ArrayList<>();
+        for (LabeledRegion label : secondary == null ? List.<LabeledRegion>of() : secondary) {
+            labels.add(label.identity());
+        }
+        List<Note.Of> hints = new ArrayList<>();
+        for (Note note : notes == null ? List.<Note>of() : notes) {
+            hints.add(note.identity());
+        }
+        return new Identity(severity, code, titleKey, region, labels, messageKey,
+                args == null ? List.of() : java.util.Arrays.asList(args), literalMessage, diff,
+                hints, suggestion);
+    }
+
     /** A pre-formatted English message wrapped verbatim — the compatibility path for a site that
      * has not yet been moved onto a catalog key. {@code pos} may be null for a position-less error. */
     public static Diagnostic literal(SourcePos pos, String code, String message) {

--- a/souther-syntax/src/main/java/souther/compiler/diag/LabeledRegion.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/LabeledRegion.java
@@ -7,4 +7,13 @@ package souther.compiler.diag;
  * locale); {@code labelArgs} fill its placeholders.
  */
 public record LabeledRegion(Region region, String labelKey, Object[] labelArgs) {
+
+    /** What makes two labels the same label. A record compares an array component by identity, and
+     * {@code labelArgs} is one. */
+    public record Of(Region region, String labelKey, java.util.List<Object> labelArgs) {}
+
+    public Of identity() {
+        return new Of(region, labelKey,
+                labelArgs == null ? java.util.List.of() : java.util.Arrays.asList(labelArgs));
+    }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Note.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Note.java
@@ -5,4 +5,12 @@ package souther.compiler.diag;
  * against the selected locale; {@code args} fill its placeholders.
  */
 public record Note(String messageKey, Object[] args) {
+
+    /** What makes two notes the same note. A record compares an array component by identity, and
+     * {@code args} is one, so a caller asking whether two notes say the same thing compares these. */
+    public record Of(String messageKey, java.util.List<Object> args) {}
+
+    public Of identity() {
+        return new Of(messageKey, args == null ? java.util.List.of() : java.util.Arrays.asList(args));
+    }
 }


### PR DESCRIPTION
Step 4 of #177, continued: the last of the per-definition keys. Declarations became their own
question in #185; bodies are the other half.

## What it was

Lowering read a module and expanded its bodies as one pass over one tree, and the type check read a
module and answered for all of it. So every body in a file depended on every other one: editing a
behavior's body re-expanded and re-checked all of them, and an editor asking what one definition
means had to have the whole module checked to find out.

## What it is

A body is its own question, at both stages.

- `Bodies.LoweredBody(module, fn)` — one body expanded and desugared. What it reads is the fn it is
  and the helpers of the module.
- `Bodies.CheckedBehavior(module, behavior)` — one body checked against the behavior it implements,
  as the Core the backend emits.

The shared context each of them reads is a value, not an object: `Helpers`, `RecursiveHelpers`,
`ReqSigs`, `RecursiveHelperSigs`, `RecursiveHelperConstructs`, `BehaviorNames`. That is what makes
them shareable — a `HelperInliner` has no equality, so a key answering with one would make every
reader run again whatever changed. `HelperInliner.forHelpers` builds one from the helpers alone.

What is left at the module is its own check — declarations, helpers, `exposing`, compositions —
and the decision it and the bodies come to together: whether there is a module to emit.

`IncrementalCompilationTest` pins both: editing one behavior's body leaves the expansion and the
check of the one beside it as the same answer.

## What changed for an author

- The module's own check is asked before any body, so a module told about its own mistakes is told
  about them first. Two reports move: a `let` that implements a composition, and a composition's
  stages and declared output, now come before a body error rather than after.
- A module whose own check stopped is not asked about its bodies. A structural check builds what a
  later phase reads, so a body checked without it reports being unable to see what has already been
  reported missing.
- One problem is one diagnostic, whichever questions found it. A helper is checked on its own and
  again in each body it is expanded into, and both look at the same line; the check used to drop the
  second because both were inside one answer. Now they are two answers, so the reading of them is
  what recognises them as one.
- A module with two helpers to complain about complains about the earlier one first: the helpers are
  read in the order they are written rather than in hash order.

## Left

Error recovery in the checker was done in #183; per-definition keys are this. Step 4 has nothing
further outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
