### PR TITLE
Attempt the case that carries every reason

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
@@ -387,4 +387,53 @@ class CompileAttemptedConstructionTest {
                 Codecs.encode(loader, "demo.Out", Codecs.apply(impl, 200000L)),
                 "a depth this far past the stack only returns if the tail call became a jump");
     }
+
+    /**
+     * A behavior that reports every reason a request was refused, not the first one it meets, builds
+     * the reasons as a list and departs by the case that carries them. What is attempted there is a
+     * record literal rather than a newtype's {@code T(v)}: "at least one reason" is the departure
+     * case's own invariant, so the list needs no named type of its own and no guard restates the
+     * emptiness test beside the construction (issue #165).
+     */
+    @Test
+    void aDepartureCarryingEveryReasonIsAttemptedAsARecordLiteral() throws Exception {
+        String src = """
+                module demo exposing (
+                    convert, Converted, Blocked,
+                    BlockReason, BudgetNotConfirmed, CloseDateInPast
+                )
+
+                data BudgetNotConfirmed
+                data CloseDateInPast
+                data BlockReason = BudgetNotConfirmed | CloseDateInPast
+
+                data Blocked = { reasons: List<BlockReason> }
+                    invariant List.length(reasons) >= 1
+
+                data Converted = { id: Int }
+
+                let blockingReasons (n: Int): List<BlockReason> =
+                       (if n >= 10 then [] else [ BudgetNotConfirmed ])
+                    ++ (if n >= 20 then [] else [ CloseDateInPast ])
+
+                behavior convert : (n: Int) -> Converted | Blocked
+                    constructs Converted, Blocked, BudgetNotConfirmed, CloseDateInPast
+
+                let convert (n) =
+                    if Blocked { reasons = blockingReasons(n) } as blocked
+                    then blocked
+                    else Converted { id = n }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object impl = loader.loadClass("demo.Convert" + "$Impl").getConstructor().newInstance();
+
+        assertEquals("demo.Converted", Codecs.apply(impl, 25L).getClass().getName(),
+                "no reason applies, so the invariant fails and the attempt takes its else branch");
+        assertEquals(Map.of("reasons", List.of("CloseDateInPast")),
+                Codecs.encode(loader, "demo.Blocked", Codecs.apply(impl, 15L)),
+                "one reason applies");
+        assertEquals(Map.of("reasons", List.of("BudgetNotConfirmed", "CloseDateInPast")),
+                Codecs.encode(loader, "demo.Blocked", Codecs.apply(impl, 5L)),
+                "both apply, and both are reported — the departure carries every reason, not the first");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -121,6 +121,10 @@ class FormatterTest {
                 }
                 let accept (raw: String): List<Code> =
                     if Code(raw) as c then [ c ] else []
+                data Blocked = { reasons: List<Code> }
+                    invariant List.length(reasons) >= 1
+                let report (cs: List<Code>): List<Blocked> =
+                    if Blocked { reasons = cs } as b then [ b ] else []
                 """;
         assertEquals(code(src), code(Formatter.format(src)),
                 "the `as` binder was lost:\n" + Formatter.format(src));

--- a/specification.adoc
+++ b/specification.adoc
@@ -2043,6 +2043,21 @@ the branch. The invariant is run — the type's own and every invariant a `+...+
 (<<invariant-mvp>>, <<field-spread>>). Holding, the value is built and `+<名前>+` names it in the
 success branch; failing, the `+else+` value is taken and no value is built. The invariant runs once.
 
+A construction is either spelling — a newtype's `+T(v)+` or a record literal `+T { ... }+`
+(<<record-literal>>). A behavior that reports every business failure rather than the first one it meets
+builds the reasons as a list and attempts the case that carries them, so "at least one reason" is that
+case's own invariant rather than a guard written beside it.
+
+[,text]
+----
+data 変換不可 = { 理由: List<変換不可理由> }
+    invariant List.length(理由) >= 1
+
+if 変換不可 { 理由 = 阻害理由(見込客, 依頼) } as 不可
+    then 不可
+    else 変換済み { ... }
+----
+
 The name is in scope in the success branch only. *Nothing carries the failure.* There is no value for
 it — no `+Option+`, no `+Result+`, no reason — and the name a business failure gets is the one written
 in `+else+`, which MAY be a value naming nothing (`+else []+`).


### PR DESCRIPTION
Issue #165 asked for a `require all` collecting several guards into one departure case carrying a list of reasons. This says no to that form and shows what the attempted construction of #162 already answers.

## Why `require all` does not collect them

Two of `crm`'s four reason sources — duplicate accounts and duplicate contacts — produce one reason per matching record, so how many there are is not known until they are gathered. A fixed sequence of guards leaves the `++` in place, and the model would carry two ways to accumulate instead of one.

What the guards were actually paying for is elsewhere, and both parts go:

- a named list type (`BlockReasons`) whose only job was to hold the non-empty invariant, and
- a `List.isEmpty` test restating that invariant beside the construction.

`ConversionBlocked` carries `List<BlockReason>` and declares `invariant List.length(reasons) >= 1` itself. `convertLead` attempts that construction, so the rule is checked once, where it is declared.

## What is here

- The spec says a construction is either spelling — a newtype's `T(v)` or a record literal `T { ... }`. The section's examples were all newtypes, so the product form was left to be inferred from the sentence about spread invariants.
- A test pinning the shape end to end: no reason, one reason, and both reasons reported together.
- The formatter test grows the record-literal form, for the same reason it holds the newtype one — a dropped `as` turns a departure into a plain condition.

Cross-module merging of two modules' reasons is unchanged and is not what a new guard form would reach: a sum cannot name an imported case, which is ADR-0057's translation rule, recorded as F1 in the examples README.

The model rewrite is souther-lang/examples#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)