### PR TITLE
A fixture keeps the case it constructs

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -780,8 +780,16 @@ public final class ExampleVerifier {
         return constructedCase(e, new LinkedHashSet<>());
     }
 
-    /** As above; {@code followed} are the names already followed, so a value defined in terms of itself
-     * stops here and is reported as the cycle it is where the fixture is built. */
+    /**
+     * As above; {@code followed} are the names already followed, so a value defined in terms of itself
+     * stops here and is reported as the cycle it is where the fixture is built.
+     *
+     * <p>The binding a closed body carries is not read here, and does not need to be: a value is
+     * substituted where it is named, so the only name closing leaves standing in a fixture is the one a
+     * spread holds — a spread cannot hold an expression — and that name is read where the spread is
+     * copied. A closed body therefore ends in the construction, whether it was published itself or
+     * named by another value that was.
+     */
     private TypeName constructedCase(Ast.Expr e, Set<String> followed) {
         return switch (e) {
             case Ast.NewData nd -> nd.typeName().denotes();

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -26,6 +26,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -356,9 +357,10 @@ public final class ExampleVerifier {
                 return;
             }
         }
-        // validate the expected arm/value against the output cases before running
+        // validate the expected arm/value against the output cases before running. Which case the row
+        // asserts is read through what it names, so a row may name a value where it may name a case.
         String expectedArm = expectedArm(row.expected());
-        TypeName named = expectedArm == null ? null : symbols.resolveCase(expectedArm);
+        TypeName named = constructedCase(row.expected());
         // a name nothing here denotes is not an arm of the target either, and says so the same way
         if (expectedArm != null && !outCases.isEmpty()
                 && (named == null || !outCases.contains(named))) {
@@ -376,7 +378,7 @@ public final class ExampleVerifier {
         // against an empty expected value — a wrong answer for a row that was right.
         Object expectedValue;
         try {
-            expectedValue = row.expected() instanceof Ast.Var ? null
+            expectedValue = caseOnly(row.expected()) != null ? null
                     : builtExpected(row.expected(), sig.out());
         } catch (FixtureException fe) {
             out.add(Diagnostic.of("E1903", "check.example.expected").title("check.example.title")
@@ -505,11 +507,8 @@ public final class ExampleVerifier {
                     def[0] = value;
                 } else {
                     if (r.inputs().size() != paramTypes.size()) {
-                        out.add(Diagnostic.of("E1908", "check.fake.missing").title("check.example.title")
-                                .at(r.pos()).args(fk.target(), fk.target())
-                                .hint("check.fake.missing.hint", "a fake row has " + r.inputs().size()
-                                        + " input(s) but `" + fk.target() + "` takes " + paramTypes.size())
-                                .build());
+                        out.add(unbuildableFake(r.pos(), fk.target(), "a row has " + r.inputs().size()
+                                + " input(s) where the dependency takes " + paramTypes.size()));
                         return null;
                     }
                     Object[] key = new Object[paramTypes.size()];
@@ -520,10 +519,7 @@ public final class ExampleVerifier {
                 }
             }
         } catch (FixtureException fe) {
-            out.add(Diagnostic.of("E1908", "check.fake.missing").title("check.example.title")
-                    .at(fk.pos()).args(fk.target(), fk.target())
-                    .hint("check.fake.missing.hint", "a fake row could not be built: " + fe.getMessage())
-                    .build());
+            out.add(unbuildableFake(fk.pos(), fk.target(), fe.getMessage()));
             return null;
         }
         String depName = fk.target();
@@ -578,12 +574,20 @@ public final class ExampleVerifier {
             Class<?> fakeClass = loader.define(fakeName, () -> fakeSubclassBytes(fakeName, base, applyM));
             return fakeClass.getConstructor(java.util.function.Function.class).newInstance(body);
         } catch (ReflectiveOperationException e) {
-            out.add(Diagnostic.of("E1908", "check.fake.missing").title("check.example.title")
-                    .at(dep.pos()).args(dep.name(), dep.name())
-                    .hint("check.fake.missing.hint", "the fake's base subclass could not be built: " + e)
-                    .build());
+            out.add(unbuildableFake(dep.pos(), dep.name(),
+                    "its base subclass could not be built: " + e));
             return null;
         }
+    }
+
+    /**
+     * A fake that was supplied and could not be built. A dependency nothing stands in for is a different
+     * problem, and saying this as that named the dependency as its own requester and reported a fake as
+     * missing where one was written (issue #206).
+     */
+    private static Diagnostic unbuildableFake(SourcePos pos, String dependency, String reason) {
+        return Diagnostic.of("E1908", "check.fake.unbuildable").title("check.example.title")
+                .at(pos).args(dependency, reason).build();
     }
 
     private byte[] fakeSubclassBytes(String fakeName, Class<?> base, java.lang.reflect.Method apply) {
@@ -677,27 +681,42 @@ public final class ExampleVerifier {
 
     // --- comparison ---------------------------------------------------------------------------
 
-    /** Whether {@code result} matches the row's expected: a bare {@link Ast.Var} asserts only the
+    /** Whether {@code result} matches the row's expected: a name denoting a case asserts only the
      * arm (the concrete case class); anything else asserts the whole value, {@code expectedValue}
      * (built before the behavior ran), by structural equality. */
     private boolean matches(Ast.Expr expected, Object result, Object expectedValue) {
-        if (expected instanceof Ast.Var v) {
-            return NeutralForm.simpleName(result).equals(v.name());
+        String arm = caseOnly(expected);
+        if (arm != null) {
+            return NeutralForm.simpleName(result).equals(arm);
         }
         return expectedValue != null && expectedValue.equals(result);
     }
 
-    /** The expected value built the same way as an input, so structural equality compares like with
-     * like: a construction/newtype decodes through its type's decoder; a literal is its raw value.
-     * Throws {@link FixtureException} when the row's expectation cannot be built — the caller reports
-     * that as the fixture error it is, rather than comparing against nothing. */
-    private Object builtExpected(Ast.Expr expected, Type outType) {
-        if (expected instanceof Ast.NewData nd) {
-            return decode(Type.ref(nd.typeName().denotes()),
-                    raw(expected, Type.ref(nd.typeName().denotes())));
+    /**
+     * The case a row asserts and nothing more: a bare name denoting a case — a unit case, or a case
+     * written bare — where there is no value under it to compare. Null for anything else, including a
+     * name denoting a value, which stands for the value it was defined as.
+     *
+     * <p>The case's own name, not the spelling: what came out carries the name its type was declared
+     * under, so a row spelling that type qualified asserts the same case.
+     */
+    private String caseOnly(Ast.Expr expected) {
+        if (!(expected instanceof Ast.Var v)) {
+            return null;
         }
-        if (expected instanceof Ast.Call c && neutral.isNewtype(c.fn())) {
-            return decode(Type.ref(symbols.resolve(c.fn())), raw(expected));
+        TypeName type = symbols.resolveCase(v.name());
+        return type == null ? null : type.name();
+    }
+
+    /** The expected value built the same way as an input, so structural equality compares like with
+     * like: a fixture that names a case — written as a construction, or named through a value — decodes
+     * through that case's decoder; a literal is its raw value. Throws {@link FixtureException} when the
+     * row's expectation cannot be built — the caller reports that as the fixture error it is, rather
+     * than comparing against nothing. */
+    private Object builtExpected(Ast.Expr expected, Type outType) {
+        TypeName asserted = constructedCase(expected);
+        if (asserted != null) {
+            return decode(Type.ref(asserted), raw(expected, Type.ref(asserted)));
         }
         // A collection output has no case name to decode against, so the behavior's declared
         // output type is what says which of `List`/`Set`/`Map` the written list means and what
@@ -722,7 +741,8 @@ public final class ExampleVerifier {
         return t instanceof Type.ListOf || t instanceof Type.SetOf || t instanceof Type.MapOf;
     }
 
-    /** The arm name an expected asserts: a bare type name, or a construction's/newtype's type name. */
+    /** The arm an expected names, as it was written — what a row that names no case of the target is
+     * told it wrote. Which case it stands for is {@link #constructedCase}. */
     private String expectedArm(Ast.Expr expected) {
         if (expected instanceof Ast.Var v) {
             return v.name();
@@ -736,23 +756,60 @@ public final class ExampleVerifier {
         return null;   // a literal expected (a primitive output)
     }
 
-    /** The concrete type a fixture construction asserts — the case named by a record/newtype/unit
-     * expression — or {@code declared} for a literal. A sum-returning dependency's fake row names one
-     * case, so its output decodes against that case, not the declared sum (which has no decoder). */
+    /** The concrete type a fixture stands for — the case it constructs — or {@code declared} where
+     * nothing in it names one (a literal, a collection). A sum-returning dependency's fake row names one
+     * case, so its output decodes against that case, not the declared sum (which, written inline, has no
+     * decoder at all). */
     private Type fixtureType(Ast.Expr e, Type declared) {
-        String arm = expectedArm(e);
-        TypeName named = arm == null ? null : symbols.resolveCase(arm);
+        TypeName named = constructedCase(e);
         // a fixture naming nothing this target can produce is reported by the arm check; decoding it
         // against the declared type is what turns it into that diagnostic rather than a crash
         return named != null ? Type.ref(named) : declared;
     }
 
-    /** The written expectation, rendered as it was written: a bare arm stays the arm name, anything
-     * else is its neutral form under that arm ({@code Out { n = 7 }}). */
+    /**
+     * The case a fixture stands for: the one a construction names, and for a name, the one the value it
+     * denotes constructs.
+     *
+     * <p>Read through the value rather than off the spelling. A value's name is not a case name, and
+     * where the position is a union written inline there is no decoder to dispatch on a tag — so the
+     * value is the only thing that says which case it is, and reading the name found a type of that
+     * spelling or nothing (issue #206).
+     */
+    private TypeName constructedCase(Ast.Expr e) {
+        return constructedCase(e, new LinkedHashSet<>());
+    }
+
+    /** As above; {@code followed} are the names already followed, so a value defined in terms of itself
+     * stops here and is reported as the cycle it is where the fixture is built. */
+    private TypeName constructedCase(Ast.Expr e, Set<String> followed) {
+        return switch (e) {
+            case Ast.NewData nd -> nd.typeName().denotes();
+            case Ast.Call c when neutral.isNewtype(c.fn()) -> symbols.resolveCase(c.fn());
+            case Ast.LetIn let -> constructedCase(let.body(), followed);
+            case Ast.Var v -> namedCase(v.name(), followed);
+            case null, default -> null;
+        };
+    }
+
+    /** The case a bare name stands for: the type it denotes where it denotes one — a unit case, or a
+     * case written bare — and otherwise the case the value it names constructs. */
+    private TypeName namedCase(String name, Set<String> followed) {
+        TypeName type = symbols.resolveCase(name);
+        if (type != null) {
+            return type;
+        }
+        Ast.Expr body = followed.add(name) ? valueBody(name) : null;
+        return body == null ? null : constructedCase(body, followed);
+    }
+
+    /** The expectation, rendered as the value it stands for: a bare case stays the case name, anything
+     * else is its neutral form under the case it constructs ({@code Out { n = 7 }}) — which is what a
+     * row naming a value asserts, so that is what the failure shows. */
     private String describeExpected(Ast.Expr expected, Type outType) {
-        String arm = expectedArm(expected);
-        if (expected instanceof Ast.Var) {
-            return arm;   // a bare arm asserts only the case, so there is no value to show
+        String only = caseOnly(expected);
+        if (only != null) {
+            return only;   // a bare case asserts only that, so there is no value to show
         }
         if (isCollection(outType)) {
             Object built = builtExpectedOrNull(expected, outType);
@@ -761,8 +818,13 @@ public final class ExampleVerifier {
         // Render it through the same encoder the actual goes through, so the two sides are written
         // in one notation and can be read against each other; the fixture's own neutral form (which
         // still holds e.g. a LocalDate where the encoder writes its ISO text) is the fallback.
+        TypeName asserted = constructedCase(expected);
+        // The case it constructs, and nothing where it constructs none: a name standing for a literal
+        // has no case to write around the value, and writing the name there rendered `answer(42)`.
+        String arm = asserted != null ? asserted.name() : null;
         Object built = builtExpectedOrNull(expected, outType);
-        Object neutral = built == null || arm == null ? rawOrNull(expected) : encodedOrNull(built, arm);
+        Object neutral = built == null || asserted == null
+                ? rawOrNull(expected) : encodedOrNull(built, asserted);
         if (neutral == null) {
             neutral = rawOrNull(expected);
         }
@@ -833,9 +895,19 @@ public final class ExampleVerifier {
 
     /** {@code result} through its class's derived {@code encoder()}, or null when it has none. */
     private Object encodedOrNull(Object result, String name) {
+        TypeName type = symbols.resolve(name);
+        return encoded(result, type != null ? type.qualified() : module.name() + "." + name);
+    }
+
+    /** As above, for a type already resolved — a fixture says which case it constructs, and that answer
+     * names the class whether or not the reader spells the type the way its module does. */
+    private Object encodedOrNull(Object result, TypeName type) {
+        return encoded(result, type.qualified());
+    }
+
+    private Object encoded(Object result, String className) {
         try {
-            TypeName type = symbols.resolve(name);
-            Class<?> c = loader.loadClass(type != null ? type.qualified() : module.name() + "." + name);
+            Class<?> c = loader.loadClass(className);
             Object encoder = staticCodec(c, "encoder");
             return net.unit8.raoh.encode.Encoder.class.getMethod("encode", Object.class)
                     .invoke(encoder, result);
@@ -935,6 +1007,7 @@ public final class ExampleVerifier {
             case Ast.Call c -> collectionOrNewtype(c, expected);
             case Ast.Var v -> unitInput(v.name(), expected);
             case Ast.NewData nd -> record(nd);
+            case Ast.LetIn let -> bound(let, expected);
             case Ast.ListLit l -> {
                 Type element = NeutralForm.elementOf(expected);
                 List<Object> out = new ArrayList<>();
@@ -987,8 +1060,33 @@ public final class ExampleVerifier {
     }
 
     /**
-     * The body a value — a {@code let} with no parameter list — was defined as, or null where the
-     * name is not one of this module's values.
+     * A name bound while this fixture is being built, holding what it was bound to.
+     *
+     * <p>A spread holds a name rather than an expression, so a published body that spreads one of its
+     * module's values arrives with that value bound ahead of the construction — the shape a spread of a
+     * local already has. That binding is what the spread then names, so a fixture reads one the way it
+     * reads a value: the position says what type to read it as.
+     */
+    private final Map<String, Ast.Expr> bindings = new LinkedHashMap<>();
+
+    /** A {@code let} inside a fixture: its name stands for what it was bound to while the body is
+     * built, and a binding of the same spelling that was already in force is put back afterwards. */
+    private Object bound(Ast.LetIn let, Type expected) {
+        Ast.Expr shadowed = bindings.put(let.name(), let.value());
+        try {
+            return raw(let.body(), expected);
+        } finally {
+            if (shadowed == null) {
+                bindings.remove(let.name());
+            } else {
+                bindings.put(let.name(), shadowed);
+            }
+        }
+    }
+
+    /**
+     * What a name stands for: a binding in force, or the body a value — a {@code let} with no parameter
+     * list — was defined as. Null where the name is neither.
      *
      * <p>Whether a fixture may name it is not a property of this one body: a value stands for a
      * fixture when it is a literal, a construction, a spread, a {@code fromList} over one, or a name
@@ -996,6 +1094,10 @@ public final class ExampleVerifier {
      * values holds.
      */
     private Ast.Expr valueBody(String name) {
+        Ast.Expr binding = bindings.get(name);
+        if (binding != null) {
+            return binding;   // a binding in force is what the name means here
+        }
         for (Ast.FnDef fn : module.fns()) {
             if (fn.name().equals(name) && fn.params().isEmpty() && fn.body() != null) {
                 return fn.body();
@@ -1145,7 +1247,7 @@ public final class ExampleVerifier {
         Map<String, Ast.TypeRef> declared = neutral.fieldTypes(nd.typeName().denotes());
         Map<String, Object> map = new LinkedHashMap<>();
         // `...base` copies the fields of a value, and the fields written after it replace what it
-        // brought. Only a value can be spread here: a row has no bindings to read from.
+        // brought.
         for (Ast.ValueRef ref : nd.spreads()) {
             String spread = ref.bare();
             Ast.Expr value = valueBody(spread);
@@ -1159,7 +1261,15 @@ public final class ExampleVerifier {
                         + " spread");
             }
             for (Map.Entry<?, ?> f : fields.entrySet()) {
-                map.put(String.valueOf(f.getKey()), f.getValue());
+                String field = String.valueOf(f.getKey());
+                // A spread copies fields, and only the ones this construction has — which is what the
+                // language copies. The discriminator the spread source's own sum's decoder reads is not
+                // one of them: it says which case that value is, and this construction says which case
+                // it builds (below). Copying it left the source's case in place of it, and where the
+                // position is a union that is the case the behavior saw (issue #206).
+                if (declared.containsKey(field)) {
+                    map.put(field, f.getValue());
+                }
             }
         }
         for (Ast.FieldInit fi : nd.inits()) {

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -459,6 +459,7 @@ check.fake.missing=`{0}` depends on `{1}`, but no fake was supplied for it.
 check.fake.missing.through=`{0}` depends on `{1}` through {2}, but no fake was supplied for it.
 check.fake.missing.hint={0}
 check.fake.value=The fake value supplied for dependency `{0}` could not be built: {1}
+check.fake.unbuildable=The fake supplied for dependency `{0}` could not be built: {1}
 check.fake.miss=A fake had no output for an input: {0}
 
 # --- souther run (the command line drives one behavior; not compile errors) ---

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -458,6 +458,7 @@ check.fake.missing=`{0}` は `{1}` に依存しますが、その fake が与え
 check.fake.missing.through=`{0}` は {2} を通じて `{1}` に依存しますが、その fake が与えられていません。
 check.fake.missing.hint={0}
 check.fake.value=依存 `{0}` に与えた fake の値を構築できませんでした: {1}
+check.fake.unbuildable=依存 `{0}` に与えた fake を構築できませんでした: {1}
 check.fake.miss=fake が入力に対する出力を持っていません: {0}
 
 # --- souther run（コマンドラインが behavior を1つ駆動する。コンパイルエラーではない） ---

--- a/souther-compiler/src/test/java/souther/compiler/ExampleNamedValueFixtureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleNamedValueFixtureTest.java
@@ -1,0 +1,188 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The case a named fixture stands for is read through the value, not off the spelling of the name.
+ *
+ * <p>Where the position is a union written inline — a dependency returning {@code Account | NotFound} —
+ * there is no decoder to dispatch on a tag, so the case has to come from the value the fixture names.
+ * Reading it off the name found a type of that spelling or nothing, and a value's name is not a case
+ * name, so a {@code fake} row and a {@code with} value could only be written inline (issue #206). The
+ * expected side read a name as the case it asserts for the same reason.
+ */
+class ExampleNamedValueFixtureTest {
+
+    private static final String LOOKUP = """
+            module demo
+
+            data Account  = { id: String }
+            data NotFound
+            data Answer   = { label: String }
+
+            behavior lookUp : (key: String) -> Account | NotFound
+
+            behavior labelOf : (key: String) -> Answer
+                depends on lookUp
+                constructs Answer
+
+            let labelOf (key, lookUp) =
+                match lookUp(key) with
+                    | Account as a -> Answer { label = a.id }
+                    | NotFound     -> Answer { label = "none" }
+
+            let known = Account { id = "a-1" }
+            """;
+
+    @Test
+    void aFakeRowMayNameAValueWhereTheOutputIsAUnion() {
+        assertDoesNotThrow(() -> Compiler.compile(LOOKUP + """
+
+                fake lookUp
+                    | ("k") -> known
+                    | _     -> NotFound
+
+                example labelOf
+                    | "found"   : ("k") -> Answer { label = "a-1" }
+                    | "missing" : ("z") -> Answer { label = "none" }
+                """));
+    }
+
+    @Test
+    void aWithValueMayNameAValueWhereTheOutputIsAUnion() {
+        assertDoesNotThrow(() -> Compiler.compile(LOOKUP + """
+
+                example labelOf
+                    | "found" : ("k") with lookUp = known -> Answer { label = "a-1" }
+                """));
+    }
+
+    @Test
+    void anExpectedValueMayBeNamed() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data In  = { n: Int }
+                data Out = { label: String }
+
+                behavior run : (i: In) -> Out
+                    constructs Out
+
+                let run (i) = Out { label = "x" }
+
+                let expected = Out { label = "x" }
+
+                example run
+                    | "a named expectation" : (In { n = 1 }) -> expected
+                """));
+    }
+
+    @Test
+    void aNamedExpectationStillHasToHold() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data In  = { n: Int }
+                data Out = { label: String }
+
+                behavior run : (i: In) -> Out
+                    constructs Out
+
+                let run (i) = Out { label = "x" }
+
+                let expected = Out { label = "y" }
+
+                example run
+                    | "a named expectation" : (In { n = 1 }) -> expected
+                """));
+        assertEquals("E1905", e.diagnostic().code());
+        assertEquals("Out { label = \"y\" }", e.diagnostic().diff().expectedType(),
+                "the expectation is shown as the value it names stands for");
+    }
+
+    @Test
+    void aNamedExpectationMayStandForALiteral() {
+        // A value naming no case has no case to show around it, and the failure says the value.
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data In = { n: Int }
+
+                behavior run : (i: In) -> Int
+
+                let run (i) = 42
+
+                let answer = 42
+
+                example run
+                    | "a named literal" : (In { n = 1 }) -> answer
+                """));
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data In = { n: Int }
+
+                behavior run : (i: In) -> Int
+
+                let run (i) = 42
+
+                let answer = 7
+
+                example run
+                    | "a named literal" : (In { n = 1 }) -> answer
+                """));
+        assertEquals("7", e.diagnostic().diff().expectedType());
+    }
+
+    @Test
+    void aBareCaseNameStillAssertsOnlyTheCase() {
+        // A name that denotes a case asserts the case and nothing about the value under it — the rule a
+        // named value does not change.
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Approved = { by: String }
+                data Rejected = { why: String }
+                data Verdict  = Approved | Rejected
+
+                behavior judge : (n: Int) -> Verdict
+                    constructs Approved
+                    constructs Rejected
+
+                let judge (n) =
+                    if n >= 0 then Approved { by = "a" } else Rejected { why = "b" }
+
+                example judge
+                    | "positive" : (1)  -> Approved
+                    | "negative" : (-1) -> Rejected
+                """));
+    }
+
+    @Test
+    void aNameThatDenotesNothingIsStillReportedWhereItIsWritten() {
+        // Reading the expectation through the value it names does not move this report: nothing denotes
+        // the name, which resolution says where the row is written, before an example is evaluated.
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data In  = { n: Int }
+                data Out = { label: String }
+
+                behavior run : (i: In) -> Out
+                    constructs Out
+
+                let run (i) = Out { label = "x" }
+
+                example run
+                    | "nothing denotes this" : (In { n = 1 }) -> nowhere
+                """));
+        assertTrue(e.getMessage().contains("nowhere"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ExampleSpreadFixtureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleSpreadFixtureTest.java
@@ -1,0 +1,197 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A fixture built by a spread is a construction of the case it names. The spread copies the fields of
+ * the value it names, and the discriminator its sum's decoder reads is not one of them — so the case
+ * comes from the construction that writes it, wherever the fixture is written and however deep the
+ * chain of spreads goes.
+ *
+ * <p>It used to come from the spread source: the source's own neutral form carries its tag, copying
+ * every entry brought the tag along, and the enclosing construction's tag was then never written. Where
+ * the position is a union that decides which case the behavior sees, so a row ran against the wrong
+ * case — reporting a mismatch that named the right expectation and the wrong actual, or passing where
+ * both cases answer alike (issue #206).
+ */
+class ExampleSpreadFixtureTest {
+
+    private static final String DEALS = """
+            data Common = { id: String }
+            data Open   = { ...Common }
+            data Closed = { ...Common, closedOn: Date }
+            data Deal   = Open | Closed
+            data Answer = { label: String }
+
+            behavior labelOf : (deal: Deal) -> Answer
+                constructs Answer
+
+            let labelOf (deal) =
+                match deal with
+                    | Open   -> Answer { label = "open" }
+                    | Closed -> Answer { label = "closed" }
+            """;
+
+    @Test
+    void aValueBuiltByASpreadKeepsItsOwnCase() {
+        assertDoesNotThrow(() -> Compiler.compile("module demo\n" + DEALS + """
+
+                let openDeal     = Open { id = "d-1" }
+                let spreadClosed = Closed { ...openDeal, closedOn = Date("2026-07-30") }
+
+                example labelOf
+                    | "a flat fixture keeps its case"
+                        : (Closed { id = "d-1", closedOn = Date("2026-07-30") }) -> Answer { label = "closed" }
+                    | "a fixture built by a spread keeps its case"
+                        : (spreadClosed) -> Answer { label = "closed" }
+                    | "the row writing the case around it"
+                        : (Closed { ...spreadClosed }) -> Answer { label = "closed" }
+                """));
+    }
+
+    @Test
+    void aRowSpreadingAValueOfAnotherCaseKeepsTheCaseItWrites() {
+        assertDoesNotThrow(() -> Compiler.compile("module demo\n" + DEALS + """
+
+                let openDeal = Open { id = "d-1" }
+
+                example labelOf
+                    | "a row spreading a flat value into a union position"
+                        : (Closed { ...openDeal, closedOn = Date("2026-07-30") }) -> Answer { label = "closed" }
+                """));
+    }
+
+    @Test
+    void aChainOfSpreadsKeepsTheCaseTheOutermostConstructionWrites() {
+        assertDoesNotThrow(() -> Compiler.compile("module demo\n" + DEALS + """
+
+                let openDeal     = Open { id = "d-1" }
+                let spreadClosed = Closed { ...openDeal, closedOn = Date("2026-07-30") }
+                let reSpread     = Closed { ...spreadClosed }
+
+                example labelOf
+                    | "a spread of a spread" : (reSpread) -> Answer { label = "closed" }
+                """));
+    }
+
+    @Test
+    void anImportedValueBuiltByASpreadIsAFixture() {
+        // A published value arrives closed over its own module, which binds what its spread names ahead
+        // of the construction. A fixture reads that binding, so a value another module built by a
+        // spread can be named by a row here.
+        String deals = """
+                module deals exposing ( Common, Open, Closed, Deal, spreadClosed )
+
+                data Common = { id: String }
+                data Open   = { ...Common }
+                data Closed = { ...Common, closedOn: Date }
+                data Deal   = Open | Closed
+
+                let openDeal     = Open { id = "d-1" }
+                let spreadClosed = Closed { ...openDeal, closedOn = Date("2026-07-30") }
+                """;
+        String app = """
+                module app
+                import deals ( Deal, Open, Closed, spreadClosed )
+
+                data Answer = { label: String }
+
+                behavior labelOf : (deal: Deal) -> Answer
+                    constructs Answer
+
+                let labelOf (deal) =
+                    match deal with
+                        | Open   -> Answer { label = "open" }
+                        | Closed -> Answer { label = "closed" }
+
+                example labelOf
+                    | "an imported value built by a spread" : (spreadClosed) -> Answer { label = "closed" }
+                """;
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(deals, app)));
+    }
+
+    @Test
+    void aSpreadFixtureStillHasToHold() {
+        // The case a spread fixture keeps is not a way past the check: a row asserting the other case
+        // fails, and it is the row that is wrong rather than the fixture.
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compile("module demo\n" + DEALS + """
+
+                        let openDeal     = Open { id = "d-1" }
+                        let spreadClosed = Closed { ...openDeal, closedOn = Date("2026-07-30") }
+
+                        example labelOf
+                            | "wrong" : (spreadClosed) -> Answer { label = "open" }
+                        """));
+        assertEquals("E1905", e.diagnostic().code());
+    }
+
+    @Test
+    void aSpreadOfACaseOfAnotherSumIsStillTheCaseTheConstructionWrites() {
+        // The other face of the same thing: where the source's case is no case of the position's union,
+        // the tag it brought was not one the decoder accepts, so the row was refused rather than run
+        // against the wrong case. Each state of a pipeline is written as the one before it plus what
+        // that stage agreed, which is exactly this shape.
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Submitted = { id: String, submittedOn: Date }
+                data Withdrawn = { id: String }
+                data Request   = Submitted | Withdrawn
+
+                data Approved = { id: String, submittedOn: Date, approvedOn: Date }
+                data Refused  = { id: String, why: String }
+                data Decision = Approved | Refused
+
+                data Answer = { label: String }
+
+                behavior labelOf : (decision: Decision) -> Answer
+                    constructs Answer
+
+                let labelOf (decision) =
+                    match decision with
+                        | Approved -> Answer { label = "approved" }
+                        | Refused  -> Answer { label = "refused" }
+
+                let submitted = Submitted { id = "r-1", submittedOn = Date("2026-07-29") }
+
+                example labelOf
+                    | "the state after it is this state plus what the stage agreed"
+                        : (Approved { ...submitted, approvedOn = Date("2026-07-30") })
+                            -> Answer { label = "approved" }
+                """));
+    }
+
+    @Test
+    void aSpreadCopiesOnlyTheFieldsTheConstructionHas() {
+        // The language lets a spread bring a value with a field the construction does not declare, and
+        // drops it. A fixture is built the same way, so the row holds rather than handing the decoder a
+        // key nothing declared.
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Wide   = { id: String, extra: Int }
+                data Narrow = { id: String }
+                data Answer = { label: String }
+
+                let wide   = Wide { id = "x", extra = 1 }
+                let narrow = Narrow { ...wide }
+
+                behavior labelOf : (v: Narrow) -> Answer
+                    constructs Answer
+
+                let labelOf (v) = Answer { label = v.id }
+
+                example labelOf
+                    | "an extra field is not copied" : (narrow) -> Answer { label = "x" }
+                """));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ExampleSpreadFixtureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleSpreadFixtureTest.java
@@ -119,6 +119,57 @@ class ExampleSpreadFixtureTest {
     }
 
     @Test
+    void anImportedNameForAValueBuiltByASpreadKeepsItsCaseHoweverManyNamesItPassedThrough() {
+        // A value is substituted where it is named, so a name for a value built by a spread — and a name
+        // for that name — is closed to the same construction with the spread's own binding around it.
+        // Both the fixture and the case it stands for are read off that, so a chain of names across the
+        // import boundary says what one name says.
+        String deals = """
+                module deals exposing ( Common, Open, Closed, Deal, spreadClosed, named, namedTwice )
+
+                data Common = { id: String }
+                data Open   = { ...Common }
+                data Closed = { ...Common, closedOn: Date }
+                data Deal   = Open | Closed
+
+                let openDeal     = Open { id = "d-1" }
+                let spreadClosed = Closed { ...openDeal, closedOn = Date("2026-07-30") }
+                let named        = spreadClosed
+                let namedTwice   = named
+                """;
+        // The expected side is where the case a name stands for decides what is compared, rather than a
+        // decoder dispatching on a tag, so the chain is read there too.
+        String app = """
+                module app
+                import deals ( Deal, Open, Closed, spreadClosed, named, namedTwice )
+
+                data Answer = { label: String }
+
+                behavior labelOf : (deal: Deal) -> Answer
+                    constructs Answer
+
+                let labelOf (deal) =
+                    match deal with
+                        | Open   -> Answer { label = "open" }
+                        | Closed -> Answer { label = "closed" }
+
+                behavior pass : (deal: Closed) -> Closed
+
+                let pass (deal) = deal
+
+                example labelOf
+                    | "a name for a spread-built value" : (named)      -> Answer { label = "closed" }
+                    | "a name for that name"            : (namedTwice) -> Answer { label = "closed" }
+
+                example pass
+                    | "the value itself, expected"   : (spreadClosed) -> spreadClosed
+                    | "a name for it, expected"      : (spreadClosed) -> named
+                    | "a name for that name"         : (spreadClosed) -> namedTwice
+                """;
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(deals, app)));
+    }
+
+    @Test
     void aSpreadFixtureStillHasToHold() {
         // The case a spread fixture keeps is not a way past the check: a row asserting the other case
         // fails, and it is the row that is wrong rather than the fixture.

--- a/souther-compiler/src/test/java/souther/compiler/ExampleUnbuildableFixtureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleUnbuildableFixtureTest.java
@@ -89,6 +89,36 @@ class ExampleUnbuildableFixtureTest {
     }
 
     @Test
+    void aFakeRowThatCannotBeBuiltIsNotReportedAsAMissingFake() {
+        Diagnostic d = only(INJECTED + """
+                fake quote
+                  | (Amount(1)) -> Amount("x")
+
+                example bill
+                  | (Amount(1)) -> Receipt { total = Amount(1) }
+                """);
+
+        assertEquals("E1908", d.code());
+        assertEquals("check.fake.unbuildable", d.messageKey(),
+                "the module supplies a fake table; what failed is building one of its rows");
+    }
+
+    @Test
+    void aFakeRowOfTheWrongArityIsReportedAgainstTheDependencyItFakes() {
+        Diagnostic d = only(INJECTED + """
+                fake quote
+                  | (Amount(1), Amount(2)) -> Amount(3)
+
+                example bill
+                  | (Amount(1)) -> Receipt { total = Amount(3) }
+                """);
+
+        assertEquals("E1908", d.code());
+        assertEquals("check.fake.unbuildable", d.messageKey());
+        assertEquals("quote", d.args()[0], "the dependency the row fakes, named once");
+    }
+
+    @Test
     void aRowThatDoesNotHoldIsStillAMismatch() {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(BASE + """
                 example bill

--- a/specification.adoc
+++ b/specification.adoc
@@ -1932,7 +1932,7 @@ example 受注する
 
 An input and an expected value are fixtures: literals, newtype applications, record constructions, and helpers applied to those. A `+?+` field takes a value directly (wrapped in `+Some+`) or `+None+` for empty, the same way a `+let+` body writes an optional (<<optional>>); omitting the field reads as `+None+` too. A row's argument is decoded into the behavior's parameter type through that type's derived Decoder (<<decoder>>), so a fixture that breaks an invariant is rejected (<<e1903>>).
 
-A row may also *name a value* (<<fn-declaration>>) rather than write the whole input again, and may spread one to vary a field.
+A row may also *name a value* (<<fn-declaration>>) rather than write the whole input again, and may spread one to vary a field. A spread copies the fields of the value it names, and the case is the one the construction writing it names; a name on its own stands for the case the value it denotes constructs. So a fixture in a position typed by a sum says which case it is however it is written.
 
 [,text]
 ----
@@ -3084,7 +3084,7 @@ error E1908:
 hint: add `with 現在時刻 = ...` on the row, or a `fake 現在時刻` table
 ----
 
-Emitted when an example targets a behavior whose `+depends on+` dependency has neither a `+with+` on the row nor a `+fake+` declaration (<<example-fakes>>). A dependency that *is* faked but whose faked value cannot be built is reported under the same code and says that instead — the row supplies the fake, and what failed is the fixture.
+Emitted when an example targets a behavior whose `+depends on+` dependency has neither a `+with+` on the row nor a `+fake+` declaration (<<example-fakes>>). A dependency that *is* faked but whose fake cannot be built — a `+with+` value, or a row of its `+fake+` table — is reported under the same code and says that instead, naming the dependency once: the fake is supplied, and what failed is the fixture.
 
 [#e1909]
 === A fake has no output for an input


### PR DESCRIPTION
Closes the three faces of #206, and #211 with them — a name on the expected side is read the same way, so the same change answers both.

## What was wrong

Three faces, one root each.

**An input ran against the wrong case, silently.** `ExampleVerifier.record()` copied every entry of the spread source's neutral form into the enclosing construction. That form carries the source's own discriminator, and the tag written afterwards is a `putIfAbsent`, so the construction's own case never landed. Where the position is a union, the tag is what decides which case the behavior sees — so a row reported a mismatch naming the right expectation and the wrong actual, or passed where both cases answer alike. Where the source's case is no case of that union at all, the row was refused instead (`type: must be one of [...]`).

**An imported value built by a spread could not be named.** A spread holds a name rather than an expression, so closing a published body binds the value ahead of the construction. `raw()` had no case for that binding and said the fixture must be a literal or a construction.

**A `fake` row and a `with` value could not name a value.** `fixtureType` read the case off the spelling of the expression, and a value's name is not a case name. It does not show at an input, whose declared type is always a named sum with a decoder that dispatches on the tag; it shows where the type is a union written inline (`-> Account | NotFound`), which has no decoder, so the case has to come from the value. The expected side read a name as the case it asserts for the same reason.

## What changed

- A spread copies fields, and only the ones the construction has — which is what the language copies (`Narrow { ...wide }` drops a field `Narrow` does not declare). The discriminator is not a field.
- A fixture reads a binding the way it reads a value, so a closed published body that spreads one holds.
- `constructedCase` reads the case a fixture stands for, following a name to the value's body. `fixtureType`, the arm check (E1904), the built expectation and the rendering of a failure all read it.
- The expected side tells a name denoting a case from a name denoting a value: the first asserts the case and nothing under it, the second asserts the value (#211). A named expectation standing for a literal now renders as the literal rather than as `answer(42)`.

  #211 proposes reading a bare name as a value first and as a case name only when it is neither. The order is the other way round here — a case first — because the two answer the same thing: a spelling that is both a `data` and a `let` is already `check.dup.valuename`, so no name reaches both branches. Taking the case first leaves what a case name means untouched.
- `check.fake.unbuildable` replaces the three sites that reported an unbuildable fake as a missing one. `lookUp depends on lookUp` and "no fake was supplied" where one was written are both gone.
- Two sentences in the specification: what a spread copies and where the case comes from, and that E1908 covers a `with` value and a `fake` row alike. No ADR — the rules were already stated (§example-evaluable already says a value whose body is a spread is fixture-evaluable); the implementation did not hold them.

## Verification

13 new tests. Swapping `develop`'s `ExampleVerifier` back in fails 6 of the 7 spread tests, including the refusing face from the issue's second comment. The seventh documents the language rule the field filter mirrors, and passes either way. Full suite green (1507 + 95 + 37), `mvn clean install` clean.

## Not in this change

- souther-lang/examples `main` is already red against `develop` (`forecasting.sou:175`, E1401 — a helper calling a behavior), so the crm fixtures could not be measured end to end here. Unrelated to this change: `develop`'s compiler fails at the same position.
- A helper applied at the top of an expected result compares its neutral form against the live value, so a row that is right is reported as a mismatch (`-> taxed(Amount(100))` gives `expected 110 but was Amount(110)`). ADR-0077 says a row may apply a helper wherever a fixture value is written, so this is a gap of its own, one line from what this change touches. Filed as #214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
