### PR TITLE
A helper answers an expected result with the value

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -359,17 +359,18 @@ public final class ExampleVerifier {
         }
         // validate the expected arm/value against the output cases before running. Which case the row
         // asserts is read through what it names, so a row may name a value where it may name a case.
-        String expectedArm = expectedArm(row.expected());
+        // Only where that answers is there an arm to hold against the target's: a helper answers with a
+        // case nothing here can read off the text, and reporting that as an arm the target cannot produce
+        // refused a row whose expectation was right (issue #214).
         TypeName named = constructedCase(row.expected());
-        // a name nothing here denotes is not an arm of the target either, and says so the same way
-        if (expectedArm != null && !outCases.isEmpty()
-                && (named == null || !outCases.contains(named))) {
+        if (named != null && !outCases.isEmpty() && !outCases.contains(named)) {
+            String expectedArm = expectedArm(row.expected());
             List<String> names = new ArrayList<>();
             for (TypeName c : outCases) {
                 names.add(c.name());
             }
             out.add(Diagnostic.of("E1904", "check.example.arm").title("check.example.title")
-                    .at(row.pos()).args(expectedArm, target.name())
+                    .at(row.pos()).args(expectedArm != null ? expectedArm : named.name(), target.name())
                     .hint("check.example.arm.hint", String.join(", ", names)).build());
             return;
         }
@@ -718,6 +719,10 @@ public final class ExampleVerifier {
         if (asserted != null) {
             return decode(Type.ref(asserted), raw(expected, Type.ref(asserted)));
         }
+        Object answer = helperAnswer(expected, new LinkedHashSet<>());
+        if (answer != null) {
+            return answer;
+        }
         // A collection output has no case name to decode against, so the behavior's declared
         // output type is what says which of `List`/`Set`/`Map` the written list means and what
         // its elements are — the same decision a collection argument's declared type makes.
@@ -725,6 +730,30 @@ public final class ExampleVerifier {
             return decode(outType, raw(expected, outType));
         }
         return raw(expected);   // a literal expected value
+    }
+
+    /**
+     * The value a helper answered with, where a helper answered the whole expectation — written as the
+     * application, or named through the values that stand for it. Null where none did.
+     *
+     * <p>The value itself, not that value read back into the neutral form a fixture is written in. The
+     * neutral form is for what encloses a fixture, and nothing encloses this one: reading it back only to
+     * decode it again asks a decoder to recover what the helper already built, and which case the answer
+     * is — the thing a written construction says and an application does not — is in the value rather
+     * than in the text. So a newtype, a record and a case of a union answered by a helper were all
+     * compared against their own neutral form, and a row that was right was reported as a mismatch
+     * (issue #214).
+     */
+    private Object helperAnswer(Ast.Expr e, Set<String> followed) {
+        return switch (e) {
+            case Ast.Call c when appliedHelper(c) instanceof Ast.FnDef helper -> answered(c, helper);
+            case Ast.LetIn let -> helperAnswer(let.body(), followed);
+            case Ast.Var v when symbols.resolveCase(v.name()) == null -> {
+                Ast.Expr body = followed.add(v.name()) ? valueBody(v.name()) : null;
+                yield body == null ? null : helperAnswer(body, followed);
+            }
+            case null, default -> null;
+        };
     }
 
     /** As above, for the rendering of a failure, where a value that cannot be built is shown as
@@ -819,27 +848,22 @@ public final class ExampleVerifier {
         if (only != null) {
             return only;   // a bare case asserts only that, so there is no value to show
         }
-        if (isCollection(outType)) {
-            Object built = builtExpectedOrNull(expected, outType);
+        TypeName asserted = constructedCase(expected);
+        Object built = builtExpectedOrNull(expected, outType);
+        if (asserted == null) {
+            // Nothing here names a case: a literal, a collection, or a value a helper answered with.
+            // What was built is a value, so it is shown the way the result is — which is what puts the
+            // two sides of a mismatch in one notation.
             return built == null ? showValue(rawOrNull(expected)) : showAny(built);
         }
         // Render it through the same encoder the actual goes through, so the two sides are written
         // in one notation and can be read against each other; the fixture's own neutral form (which
         // still holds e.g. a LocalDate where the encoder writes its ISO text) is the fallback.
-        TypeName asserted = constructedCase(expected);
-        // The case it constructs, and nothing where it constructs none: a name standing for a literal
-        // has no case to write around the value, and writing the name there rendered `answer(42)`.
-        String arm = asserted != null ? asserted.name() : null;
-        Object built = builtExpectedOrNull(expected, outType);
-        Object neutral = built == null || asserted == null
-                ? rawOrNull(expected) : encodedOrNull(built, asserted);
+        Object neutral = built == null ? rawOrNull(expected) : encodedOrNull(built, asserted);
         if (neutral == null) {
             neutral = rawOrNull(expected);
         }
-        if (neutral == null) {
-            return arm != null ? arm : "?";
-        }
-        return arm != null ? show(arm, neutral) : showValue(neutral);
+        return neutral == null ? asserted.name() : show(asserted.name(), neutral);
     }
 
     /** What actually came out, in the same notation: the case name plus the value the derived encoder
@@ -1147,10 +1171,22 @@ public final class ExampleVerifier {
             }
             return raw(c.args().get(0), expected);
         }
-        if (!neutral.isNewtype(c.fn()) && helperDef(c.fn()) instanceof Ast.FnDef helper) {
+        if (appliedHelper(c) instanceof Ast.FnDef helper) {
             return applied(c, helper, expected);
         }
         return newtypeInner(c);
+    }
+
+    /** The helper an application applies, or null where the call is not one: a {@code fromList} is the
+     * fixture's own notation for a collection and a newtype application is a construction, so neither is
+     * a helper however it is spelled. Asked wherever an application has to be told from a construction,
+     * so the two readers of a call cannot come to different answers. */
+    private Ast.FnDef appliedHelper(Ast.Call c) {
+        if (c.fn().equals("Set.fromList") || c.fn().equals("Map.fromList")
+                || neutral.isNewtype(c.fn())) {
+            return null;
+        }
+        return helperDef(c.fn());
     }
 
     /**
@@ -1181,12 +1217,19 @@ public final class ExampleVerifier {
     }
 
     /**
-     * A helper applied in a fixture (ADR-0077): its arguments are built as fixtures against its
-     * parameter types, it is run as the method its module emits, and the value it returns is
-     * re-materialised into the neutral form a fixture is written in — so what encloses the call goes on
-     * being built the one way, whether the call stands at the top of a position or inside a record.
+     * A helper applied inside a fixture: it is run, and the value it returns is re-materialised into the
+     * neutral form a fixture is written in — so what encloses the call goes on being built the one way,
+     * a field of a record and an element of a list alike. An application that encloses nothing is
+     * {@link #helperAnswer}: there the value itself is what the row asserts.
      */
     private Object applied(Ast.Call c, Ast.FnDef helper, Type expected) {
+        return neutral.of(answered(c, helper), expected, c.fn());
+    }
+
+    /** The value a helper answers with, run as the method its module emits. Its arguments are fixtures
+     * built against its parameter types, so an argument breaking one of those types' invariants is
+     * reported as the fixture it is. */
+    private Object answered(Ast.Call c, Ast.FnDef helper) {
         if (c.args().size() != helper.params().size()) {
             throw new FixtureException("`" + c.fn() + "` takes " + helper.params().size()
                     + " argument(s) but is called with " + c.args().size());
@@ -1201,7 +1244,7 @@ public final class ExampleVerifier {
             Type paramType = TypeOps.resolveParamType(p.type(), symbols);
             args[i] = decode(paramType, raw(c.args().get(i), paramType));
         }
-        return neutral.of(helpers.invoke(c.fn(), args), expected, c.fn());
+        return helpers.invoke(c.fn(), args);
     }
 
     private Object newtypeInner(Ast.Call c) {

--- a/souther-compiler/src/test/java/souther/compiler/ExampleHelperAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleHelperAnswerTest.java
@@ -1,0 +1,230 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A row whose whole expectation is a helper's answer asserts the value that helper answered with.
+ *
+ * <p>A fixture is built in the neutral form a decoder reads, because what encloses it is built the one
+ * way. Nothing encloses the expectation, and a helper has already built its value — so reading it back
+ * into the neutral form left the comparison holding a form against a value. It showed wherever the output
+ * type has a case: a newtype was compared against its inner value, a record against its field map, a case
+ * of a union against its field map and tag. A collection and a primitive held, because there the declared
+ * output type is enough to read the form back with (issue #214).
+ */
+class ExampleHelperAnswerTest {
+
+    private static final String RECORD = """
+            module demo
+
+            data In  = { n: Int }
+            data Out = { m: Int }
+
+            behavior run : (i: In) -> Out
+                constructs Out
+
+            let run (i) = doubled(i.n)
+
+            let doubled (n: Int) = Out { m = n * 2 }
+            """;
+
+    private static Diagnostic only(String model) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(model));
+        assertEquals(1, e.diagnostics().size(), "one row, one diagnostic: " + e.getMessage());
+        return e.diagnostics().get(0);
+    }
+
+    @Test
+    void aRecordAHelperAnsweredWith() {
+        assertDoesNotThrow(() -> Compiler.compile(RECORD + """
+
+                example run
+                    | "the rule the row is about" : (In { n = 5 }) -> doubled(5)
+                """));
+    }
+
+    @Test
+    void aNewtypeAHelperAnsweredWith() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Amount = Int
+                data In     = { n: Int }
+
+                behavior run : (i: In) -> Amount
+
+                let run (i) = taxed(i.n)
+
+                let taxed (n: Int) = Amount(n * 110 / 100)
+
+                example run
+                    | "a newtype" : (In { n = 100 }) -> taxed(100)
+                """));
+    }
+
+    @Test
+    void aCaseOfAUnionAHelperAnsweredWith() {
+        // The case is in the value the helper answered with; nothing in the text says it.
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Yes     = { m: Int }
+                data No      = { why: String }
+                data Verdict = Yes | No
+                data In      = { n: Int }
+
+                behavior run : (i: In) -> Verdict
+                    constructs Yes
+
+                let run (i) = judged(i.n)
+
+                let judged (n: Int) = Yes { m = n * 2 }
+
+                example run
+                    | "a case of a union" : (In { n = 5 }) -> judged(5)
+                """));
+    }
+
+    @Test
+    void aDateAHelperAnsweredWith() {
+        // A `Date`'s neutral form is the parsed temporal while its encoder writes ISO text, so the two
+        // sides of this row were built and shown in different notations.
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Out = { on: Date }
+                data In  = { n: Int }
+
+                behavior run : (i: In) -> Out
+                    constructs Out
+
+                let run (i) = dated(i.n)
+
+                let dated (n: Int) = Out { on = Date("2026-07-30") }
+
+                example run
+                    | "a date-bearing record" : (In { n = 5 }) -> dated(5)
+                """));
+    }
+
+    @Test
+    void aNameForAHelpersAnswer() {
+        // The name stands for the answer, so the row asserts what the helper answered with. This was
+        // refused as an arm the target cannot produce, because a helper's case is not in the text.
+        assertDoesNotThrow(() -> Compiler.compile(RECORD + """
+
+                let expected = doubled(5)
+
+                example run
+                    | "a name for the answer" : (In { n = 5 }) -> expected
+                """));
+    }
+
+    @Test
+    void aCollectionAHelperAnsweredWith() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data In  = { n: Int }
+                data Out = { m: Int }
+
+                behavior lines : (i: In) -> List<Out>
+                    constructs Out
+
+                let lines (i) = listed(i.n)
+
+                let listed (n: Int) = [ Out { m = n }, Out { m = n } ]
+
+                example lines
+                    | "a list of records" : (In { n = 5 }) -> listed(5)
+                """));
+    }
+
+    @Test
+    void aHelpersAnswerStillHasToHold() {
+        Diagnostic d = only(RECORD + """
+
+                example run
+                    | "the wrong answer" : (In { n = 5 }) -> doubled(6)
+                """);
+
+        assertEquals("E1905", d.code());
+        assertEquals("Out { m = 12 }", d.diff().expectedType(),
+                "the expectation is the value the helper answered with");
+        assertEquals("Out { m = 10 }", d.diff().actualType(),
+                "and both sides are shown in one notation");
+    }
+
+    @Test
+    void aNamedHelperAnswerStillHasToHold() {
+        Diagnostic d = only(RECORD + """
+
+                let expected = doubled(6)
+
+                example run
+                    | "the wrong answer, named" : (In { n = 5 }) -> expected
+                """);
+
+        assertEquals("E1905", d.code());
+        assertEquals("Out { m = 12 }", d.diff().expectedType());
+    }
+
+    @Test
+    void aHelperAnsweringACaseTheTargetCannotProduceIsAMismatch() {
+        // Which case a helper answers with is not known before it runs, so this is not an arm error: the
+        // row is compared, and it does not hold.
+        Diagnostic d = only("""
+                module demo
+
+                data Yes     = { m: Int }
+                data No      = { why: String }
+                data Verdict = Yes | No
+                data Other   = { m: Int }
+                data In      = { n: Int }
+
+                behavior run : (i: In) -> Verdict
+                    constructs Yes
+
+                let run (i) = judged(i.n)
+
+                let judged (n: Int) = Yes { m = n * 2 }
+
+                let elsewhere (n: Int) = Other { m = n * 2 }
+
+                example run
+                    | "a case the target cannot produce" : (In { n = 5 }) -> elsewhere(5)
+                """);
+
+        assertEquals("E1905", d.code());
+    }
+
+    @Test
+    void aHelperInsideTheExpectationIsUnchanged() {
+        // The neutral form is for what encloses a fixture, and a record encloses this one.
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Amount = Int
+                data In     = { n: Int }
+                data Out    = { total: Amount }
+
+                behavior run : (i: In) -> Out
+                    constructs Out
+                    constructs Amount
+
+                let run (i) = Out { total = taxed(i.n) }
+
+                let taxed (n: Int) = Amount(n * 110 / 100)
+
+                example run
+                    | "a helper inside a record" : (In { n = 100 }) -> Out { total = taxed(100) }
+                """));
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -1945,7 +1945,7 @@ example 変換する
 
 What a row may name is a property of the value graph, not of one definition's text: a value is *fixture-evaluable* when its body is a literal, a construction, a spread, `+Set.fromList+` / `+Map.fromList+` over one, a helper applied to those, or a reference to another fixture-evaluable value. So a chain of values holds even though each link names the next. A value that reaches itself has no fixture to be, and is reported as the cycle it is.
 
-A row may also *apply a helper* — the rule the row is about — wherever a fixture value is written: an input, an expected result, a `+with+` value, a `+fake+` table's inputs and outputs, a record field, a list element, a map key or value, and an argument of another helper application. The helper is *run*, as the module that compiled it runs it, and the value it returns is read back into the form a fixture is written in, so what encloses the application is built the one way. Its arguments are fixtures like any others, so a fixture that breaks the argument type's invariant is <<e1903>>.
+A row may also *apply a helper* — the rule the row is about — wherever a fixture value is written: an input, an expected result, a `+with+` value, a `+fake+` table's inputs and outputs, a record field, a list element, a map key or value, and an argument of another helper application. The helper is *run*, as the module that compiled it runs it, and the value it returns is read back into the form a fixture is written in, so what encloses the application is built the one way. Where nothing encloses it — the application is the whole of an expected result, or the whole of a value the row names — the row asserts the value the helper answered with, and which case that is comes from the value rather than from the text. Its arguments are fixtures like any others, so a fixture that breaks the argument type's invariant is <<e1903>>.
 
 [,text]
 ----
@@ -3037,7 +3037,7 @@ error E1904:
 hint: expected one of: 提出済み, 却下
 ----
 
-Emitted when a row's expected arm is not one of the target behavior's output cases (<<example-expected>>).
+Emitted when a row's expected arm is not one of the target behavior's output cases (<<example-expected>>). An expectation whose case is not written — a helper's answer — has no arm to hold against them and is compared as the value it is; a row expecting the wrong case is then <<e1905>>.
 
 [#e1905]
 === Example does not hold


### PR DESCRIPTION
Closes #214.

## Where it failed, measured

The reported repro is one cell of a table. I ran the rest before touching anything — a row whose whole expectation is `made(5)`, against each kind of output:

| output | before |
| --- | --- |
| `Int` | holds |
| `List<Int>`, `Set<Int>`, `Map<String, Int>`, `List<Out>` | holds |
| newtype `Amount` | `expected 110 but was Amount(110)` |
| record `Out` | `expected [ ("m", 10) ] but was Out { m = 10 }` |
| case of a union `Verdict` | `expected [ ("m", 10), ("type", "Yes") ] but was Yes { m = 10 }` |
| record holding a `Date` | `expected [ ("on", Date("2026-07-30")) ] but was Out { on = "2026-07-30" }` |
| a name for the answer (`let expected = made(5)`) | E1904 — `expected` is not a result case of `run` |

It fails exactly where the output type has a case, and holds where the declared output type is enough to read the neutral form back with. That is the whole shape of it: the collection branch of `builtExpected` decodes, and the branch after it — reached by everything else — returns the neutral form as though what was left could only be a literal.

The last row is the same root wearing a second face. A name for the answer is refused rather than compared, because the arm check asks which case the row asserts and a helper's answer does not say.

## What changed

An application that encloses nothing answers with the value itself. The neutral form exists so that what encloses a fixture is built the one way — a field of a record, an element of a list — and nothing encloses a row's whole expectation. Reading the value back only to decode it again asks a decoder to recover what the helper already built, and it cannot recover the one thing the text does not hold: which case the answer is. The value has it.

- `helperAnswer` finds an application that answers the whole expectation, written or reached through the names that stand for it, and hands back what the helper returned. `answered` is the run without the read-back; `applied` is `answered` plus the read-back, which is still what every enclosed application does.
- The arm check reports only where the case is written. A helper's answer has no arm, so E1904 belongs to a written case and E1905 to an answered one — a row expecting the wrong case is still caught, as a mismatch.
- A failure shows what was built rather than the form it was built in, which is the notation the actual is already shown in. This is what fixes the `Date` row: the neutral form of a date is the parsed temporal while the encoder writes ISO text, so the two sides were being written in different notations.
- The predicate that tells an application from a construction (`Set.fromList`/`Map.fromList`/a newtype are not applications) is asked in one place now, so the two readers of a call cannot come to different answers.

## Verification

10 tests over the table above, both directions: each kind holds, and a wrong answer is still a mismatch that names `Out { m = 12 }` against `Out { m = 10 }`. Against `develop` 7 of the 10 fail; the 3 that pass are the ones stating what already held (a collection, an enclosed application, and that a helper answering a case the target cannot produce is a mismatch rather than an arm error).

Full suite green (1518 + 95 + 37), `mvn clean install` clean. The three E1904 tests in `CompileExampleTest` still hold — each writes a name that resolves as a type, so the case is known and the check still fires.

Two sentences in the specification: what a row asserts when nothing encloses the application, and which of E1904/E1905 answers a case that is not written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
