### PR TITLE
The fixtures a row names live where the rows are

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -1300,7 +1300,11 @@ public final class ExampleVerifier {
         // `...base` copies the fields of a value, and the fields written after it replace what it
         // brought.
         for (Ast.ValueRef ref : nd.spreads()) {
-            String spread = ref.bare();
+            // The name as this row spells it, which is what the values a fixture may name are keyed by:
+            // a definition of this module by its own name, one another module published by that module's
+            // name and its own. `bare()` is the name it was *declared* under, which is not that key for
+            // an imported value — so a row could name one but not spread it (issue #212).
+            String spread = ref.written();
             Ast.Expr value = valueBody(spread);
             if (value == null) {
                 throw new FixtureException("`" + spread

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -100,29 +100,52 @@ public final class AstBuilder {
                 examples, fakes, null, pos);
     }
 
-    /** An {@code examples for <module>} file: an example-only contribution to its target module. Any
-     * non-example declaration in it is E1906. The returned {@link Ast.Module} carries only examples
-     * and its {@code exampleFileTarget}; the compiler merges it into the target. */
+    /**
+     * An {@code examples for <module>} file: what its target module's rows are written in. It holds the
+     * rows, the fakes they run against, and the values those rows name; anything else in it is E1906. The
+     * returned {@link Ast.Module} carries those and its {@code exampleFileTarget}; the compiler merges it
+     * into the target.
+     *
+     * <p>A value is a {@code let} with no parameter list, and it is here because a row that names one had
+     * nowhere in this file to declare it — so the fixture went back to the model file, which is the file
+     * the rows exercise rather than the one they are written in (issue #210). A {@code let} with
+     * parameters is a helper, which is a method the target module emits, and a companion file does not
+     * add to what the model compiles to.
+     */
     private Ast.Module exampleFileModule(SyntaxNode file, SyntaxNode header) {
         String target = qualifiedNameText(header.child(SyntaxKind.QUALIFIED_NAME).orElseThrow());
         moduleName = target;
         SourcePos pos = pos(header);
         List<Ast.Example> examples = new ArrayList<>();
         List<Ast.Fake> fakes = new ArrayList<>();
+        List<Ast.FnDef> values = new ArrayList<>();
         for (SyntaxNode n : file.childNodes()) {
             switch (n.kind()) {
                 case EXAMPLE_DEF -> examples.add(example(n));
                 case FAKE_DEF -> fakes.add(fake(n));
                 case EXAMPLES_FILE_HEADER -> { /* the header itself */ }
-                case IMPORT_DECL, DATA_DEF, BEHAVIOR_DEF, FN_DEF -> throw CompileException.of(
-                        Diagnostic.of("E1906", "check.example.file.only").title("check.example.title")
-                                .at(pos(n)).build(),
-                        "an `examples for` file may contain only examples");
+                case FN_DEF -> {
+                    Ast.FnDef fn = fnDef(n);
+                    if (!fn.params().isEmpty()) {
+                        throw onlyExamples(n);
+                    }
+                    values.add(fn);
+                }
+                case IMPORT_DECL, DATA_DEF, BEHAVIOR_DEF -> throw onlyExamples(n);
                 default -> { /* ERROR nodes already reported */ }
             }
         }
         return new Ast.Module(target, List.of(), new HashMap<>(), List.of(), List.of(), List.of(),
-                List.of(), examples, fakes, target, pos);
+                values, examples, fakes, target, pos);
+    }
+
+    private CompileException onlyExamples(SyntaxNode n) {
+        return CompileException.of(
+                Diagnostic.of("E1906", "check.example.file.only").title("check.example.title")
+                        .at(pos(n)).build(),
+                "an `examples for` file holds examples, the fakes they run against and the values they"
+                        + " name; a data, a behavior, an import and a `let` with parameters belong in the"
+                        + " module itself");
     }
 
     /** {@code example <target> | rows...}. The contextual {@code example} lexes as an identifier, so

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -182,13 +182,25 @@ public final class Front {
                     .getOrDefault(name, List.of())));
         }
 
-        /** The module with every attached file's examples and fakes appended. */
+        /**
+         * The module with every attached file's examples, fakes and values appended.
+         *
+         * <p>The values join the module the rows join, as the fakes do: a module's own values are what its
+         * attached files' rows name, and the other way round. Nothing outside can reach them either way —
+         * an attached file is not a module and is not imported, and the values it declares are in no
+         * {@code exposing}.
+         */
         private Ast.Module withAttachedRows(Db db, Ast.Module m, List<String> files) {
             if (files.isEmpty()) {
                 return m;
             }
             List<Ast.Example> examples = new ArrayList<>(m.examples());
             List<Ast.Fake> fakes = new ArrayList<>(m.fakes());
+            List<Ast.FnDef> fns = new ArrayList<>(m.fns());
+            Set<String> taken = new LinkedHashSet<>();
+            for (Ast.FnDef fn : m.fns()) {
+                taken.add(fn.name());
+            }
             for (String id : files) {
                 Answer<CstFrontend.Parsed> file = db.ask(new Parsed(id));
                 if (!file.present()) {
@@ -196,9 +208,17 @@ public final class Front {
                 }
                 examples.addAll(file.value().module().examples());
                 fakes.addAll(file.value().module().fakes());
+                for (Ast.FnDef value : file.value().module().fns()) {
+                    // A name already declared is not merged, so the module has no duplicate to report
+                    // against a position in a file it cannot quote — the attached file's own key reports
+                    // it, where the position and the file agree (see Output.Examples).
+                    if (taken.add(value.name())) {
+                        fns.add(value);
+                    }
+                }
             }
             return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), m.defs(),
-                    m.behaviors(), m.fns(), examples, fakes, m.exampleFileTarget(), m.pos());
+                    m.behaviors(), fns, examples, fakes, m.exampleFileTarget(), m.pos());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -18,6 +18,7 @@ import souther.compiler.meta.ModulePath;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -243,7 +244,10 @@ public final class Output {
             if (requirements == null) {
                 return Answer.absent();
             }
-            List<Report> reports = new ArrayList<>();
+            List<Report> reports = new ArrayList<>(alreadyDeclared(db));
+            if (!reports.isEmpty()) {
+                return Answer.absent(reports);   // a row naming one would read the other declaration
+            }
             Map<String, Ast.FnDef> values = db.ask(new Bodies.Helpers(name)).value();
             for (Diagnostic failure : souther.compiler.ExampleVerifier.check(rows, scope.value(),
                     sigs.value(), classes, requirements, loader(db, Map.of()),
@@ -251,6 +255,54 @@ public final class Output {
                 reports.add(Report.of(failure));
             }
             return reports.isEmpty() ? Answer.of(Boolean.TRUE) : Answer.absent(reports);
+        }
+
+        /**
+         * A value this source declares under a name something already declares — the module itself, or an
+         * attached file ahead of this one. The rows would read that other declaration, so the one written
+         * here would say nothing.
+         *
+         * <p>Reported from this key rather than from the module's own duplicate check because a position
+         * is a line and a column: the module's key can only be quoted against the module's file, and the
+         * position is in this one.
+         */
+        private List<Report> alreadyDeclared(Db db) {
+            Front.Layout.Of layout = db.ask(new Front.Layout()).value();
+            if (layout == null || sourceId == null || sourceId.equals(layout.idOfModule().get(name))) {
+                return List.of();   // the module's own source declares what it declares
+            }
+            Set<String> taken = new LinkedHashSet<>(declaredIn(db, layout.idOfModule().get(name)));
+            List<Report> reports = new ArrayList<>();
+            for (String id : layout.exampleFilesOf().getOrDefault(name, List.of())) {
+                CstFrontend.Parsed parsed = db.ask(new Front.Parsed(id)).value();
+                if (parsed == null) {
+                    continue;
+                }
+                for (Ast.FnDef value : parsed.module().fns()) {
+                    boolean fresh = taken.add(value.name());
+                    if (!fresh && id.equals(sourceId)) {
+                        reports.add(Report.of(Diagnostic.of("E1906", "check.example.file.declared")
+                                .title("check.example.title").at(value.pos(), value.name().length())
+                                .args(value.name(), name).build()));
+                    }
+                }
+                if (id.equals(sourceId)) {
+                    break;   // the files after this one are their own key's to report
+                }
+            }
+            return reports;
+        }
+
+        /** The names the values of one source declare, or none where nothing parsed it. */
+        private Set<String> declaredIn(Db db, String id) {
+            Set<String> names = new LinkedHashSet<>();
+            CstFrontend.Parsed parsed = id == null ? null : db.ask(new Front.Parsed(id)).value();
+            if (parsed != null) {
+                for (Ast.FnDef fn : parsed.module().fns()) {
+                    names.add(fn.name());
+                }
+            }
+            return names;
         }
 
         /** The module carrying only the rows written in {@code sourceId}. The fakes stay whole: a

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -438,7 +438,8 @@ check.example.arm=`{0}` is not one of the result cases of `{1}`.
 check.example.arm.hint=Expected one of: {0}
 check.example.mismatch=This example does not hold.
 check.example.mismatch.hint={0}
-check.example.file.only=An `examples for` file may contain only examples, not data, behavior, let, or import.
+check.example.file.only=An `examples for` file holds examples, the fakes they run against and the values they name. A data, a behavior, an import, and a `let` with parameters belong in the module itself.
+check.example.file.declared=`{0}` is already declared by `{1}`, so the rows here would read that one. Rename this value, or drop it and name the one the module declares.
 check.example.notarget=`examples for {0}` names a module that is not being compiled.
 check.example.nonterminating=This example did not terminate ({0}) — a `partial` recursion it reaches may not stop. Make it structural, or reduce it.
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -437,7 +437,8 @@ check.example.arm=`{0}` は `{1}` の結果ケースではありません。
 check.example.arm.hint=次のいずれかを期待します: {0}
 check.example.mismatch=この example は成り立ちません。
 check.example.mismatch.hint={0}
-check.example.file.only=`examples for` ファイルには example だけを書けます（data・behavior・let・import は書けません）。
+check.example.file.only=`examples for` ファイルに書けるのは example と、それが使う fake と、その行が名指す値だけです。data・behavior・import・引数を持つ `let` はモジュール本体に書いてください。
+check.example.file.declared=`{0}` は `{1}` が既に宣言しているので、ここの行はそちらを読みます。この値を改名するか、これを消してモジュールの宣言を名指してください。
 check.example.notarget=`examples for {0}` はコンパイル対象にないモジュールを指しています。
 check.example.nonterminating=この example は停止しませんでした（{0}）。到達する `partial` な再帰が停止しない可能性があります。構造的にするか、規模を小さくしてください。
 

--- a/souther-compiler/src/test/java/souther/compiler/ExampleFileValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleFileValuesTest.java
@@ -1,0 +1,144 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * An {@code examples for} file declares the values its own rows name.
+ *
+ * <p>The file exists so that rows which would make the model source long can live beside it, and a row may
+ * name a value rather than restate everything inside it. Those two did not meet: the file could hold only
+ * examples, so a fixture a row named had to be declared in the model file — the file the rows exercise
+ * rather than the one they are written in, which is the opposite of what the companion is for (issue #210).
+ *
+ * <p>A value is a {@code let} with no parameter list. A {@code let} with parameters is a helper, which is a
+ * method the target module emits, and a companion file does not add to what the model compiles to.
+ */
+class ExampleFileValuesTest {
+
+    private static final String MODEL = """
+            module f25
+
+            data In  = { n: Int }
+            data Out = { m: Int }
+
+            behavior run : (i: In) -> Out
+                constructs Out
+
+            let run (i) = Out { m = i.n }
+            """;
+
+    @Test
+    void aRowNamesAValueItsOwnFileDeclares() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(MODEL, """
+                examples for f25
+
+                let base = In { n = 1 }
+
+                example run
+                    | "a fixture beside the rows that name it" : (base) -> Out { m = 1 }
+                """)));
+    }
+
+    @Test
+    void aRowVariesAFieldOfAValueItsOwnFileDeclares() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(MODEL, """
+                examples for f25
+
+                let base = In { n = 1 }
+
+                example run
+                    | "unchanged" : (base) -> Out { m = 1 }
+                    | "one field varied" : (In { ...base, n = 7 }) -> Out { m = 7 }
+                """)));
+    }
+
+    @Test
+    void aRowInTheModelFileNamesOneToo() {
+        // The values join the module the rows join, as the fakes do.
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(MODEL + """
+
+                example run
+                    | "the model's own row" : (base) -> Out { m = 1 }
+                """, """
+                examples for f25
+
+                let base = In { n = 1 }
+                """)));
+    }
+
+    @Test
+    void aRowThatDoesNotHoldStillFails() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(MODEL, """
+                        examples for f25
+
+                        let base = In { n = 1 }
+
+                        example run
+                            | "wrong" : (base) -> Out { m = 2 }
+                        """)));
+        assertEquals("E1905", e.diagnostic().code());
+    }
+
+    @Test
+    void aHelperIsStillNotSomethingAnExamplesFileHolds() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(MODEL, """
+                        examples for f25
+
+                        let twice (n: Int): Int = n * 2
+
+                        example run
+                            | "x" : (In { n = 1 }) -> Out { m = 1 }
+                        """)));
+        assertEquals("E1906", e.diagnostic().code());
+        assertEquals("check.example.file.only", e.diagnostic().messageKey());
+    }
+
+    @Test
+    void aDataIsStillNotSomethingAnExamplesFileHolds() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(MODEL, """
+                        examples for f25
+
+                        data Extra = { x: Int }
+
+                        example run
+                            | "x" : (In { n = 1 }) -> Out { m = 1 }
+                        """)));
+        assertEquals("E1906", e.diagnostic().code());
+        assertEquals("check.example.file.only", e.diagnostic().messageKey());
+    }
+
+    @Test
+    void aNameTheModuleAlreadyDeclaresIsReportedOnTheFileThatWroteIt() {
+        // A position is a line and a column, so a diagnostic quoted against the wrong file quotes an
+        // unrelated line. The module's own duplicate check can only be quoted against the module's file,
+        // and this declaration is in the attached one — so the attached file's own key reports it.
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(MODEL + """
+
+                        let base = In { n = 5 }
+                        """, """
+                        examples for f25
+
+                        let base = In { n = 1 }
+
+                        example run
+                            | "which base?" : (base) -> Out { m = 1 }
+                        """)));
+
+        assertEquals("E1906", e.diagnostic().code());
+        assertEquals("check.example.file.declared", e.diagnostic().messageKey());
+        assertEquals(1, e.sourceIndex(), "the declaration is in the attached file");
+        assertEquals(3, e.diagnostic().pos().line(), "and at its own line");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ExampleImportedSpreadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleImportedSpreadTest.java
@@ -1,0 +1,151 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A row spreads a value another module published, the same way it spreads one of its own.
+ *
+ * <p>A published value crosses closed, so spreading it is reading fields off a value already resolved —
+ * which is what the language already allows in a body. Only the fixture reader refused it, and for a
+ * reason that had nothing to do with the module boundary: it looked the value up by the name it was
+ * *declared* under, while the values a fixture may name are keyed by how the row spells them, an imported
+ * one under its module's name. So a row could name a published value but not vary a field of it
+ * (issue #212).
+ */
+class ExampleImportedSpreadTest {
+
+    private static final String UP = """
+            module up exposing ( Deal, Wide, Small, Big, standard )
+
+            data Deal  = { n: Int, amount: Int }
+            data Small = { amount: Int }
+            data Big   = { amount: Int }
+            data Wide  = Small | Big
+
+            let standard = Deal { n = 1, amount = 100 }
+            """;
+
+    @Test
+    void aRowVariesAFieldOfAPublishedValue() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(UP, """
+                module down
+                import up ( Deal, standard )
+
+                data Out = { m: Int }
+
+                behavior run : (d: Deal) -> Out
+                    constructs Out
+
+                let run (d) = Out { m = d.amount }
+
+                example run
+                    | "named unchanged" : (standard) -> Out { m = 100 }
+                    | "one field varied" : (Deal { ...standard, amount = 200 }) -> Out { m = 200 }
+                """)));
+    }
+
+    @Test
+    void anImportedValueIsSpreadInEveryPositionAFixtureIsWritten() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(UP, """
+                module down
+                import up ( Deal, standard )
+
+                data Out = { m: Int }
+
+                behavior rateOf : (d: Deal) -> Deal
+
+                behavior run : (d: Deal) -> Out
+                    depends on rateOf
+                    constructs Out
+
+                let run (d, rateOf) = Out { m = rateOf(d).amount }
+
+                behavior echo : (d: Deal) -> Deal
+                let echo (d) = d
+
+                fake rateOf
+                    | _ -> Deal { ...standard, amount = 300 }
+
+                example run
+                    | "a fake row spreads it" : (Deal { ...standard }) -> Out { m = 300 }
+
+                example echo
+                    | "the expected side spreads it"
+                        : (Deal { ...standard, amount = 400 }) -> Deal { ...standard, amount = 400 }
+                """)));
+    }
+
+    @Test
+    void aSpreadOfAPublishedValueKeepsTheCaseTheConstructionWrites() {
+        // With issue #206: the case comes from the construction, and the fields from the value — across
+        // the module boundary as within one.
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(UP, """
+                module down
+                import up ( Wide, Small, Big, standard )
+
+                data Answer = { label: String }
+
+                behavior labelOf : (w: Wide) -> Answer
+                    constructs Answer
+
+                let labelOf (w) =
+                    match w with
+                        | Small -> Answer { label = "small" }
+                        | Big   -> Answer { label = "big" }
+
+                example labelOf
+                    | "a published value spread into a union position"
+                        : (Big { ...standard }) -> Answer { label = "big" }
+                """)));
+    }
+
+    @Test
+    void aSpreadOfAPublishedValueStillHasToHold() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(UP, """
+                        module down
+                        import up ( Deal, standard )
+
+                        data Out = { m: Int }
+
+                        behavior run : (d: Deal) -> Out
+                            constructs Out
+
+                        let run (d) = Out { m = d.amount }
+
+                        example run
+                            | "wrong" : (Deal { ...standard, amount = 200 }) -> Out { m = 100 }
+                        """)));
+        assertEquals("E1905", e.diagnostic().code());
+    }
+
+    @Test
+    void aNameNoValueDenotesIsStillNotSomethingToSpread() {
+        // The lookup key changed; what a fixture may spread did not.
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module solo
+
+                data Deal = { n: Int, amount: Int }
+                data Out  = { m: Int }
+
+                behavior run : (d: Deal) -> Out
+                    constructs Out
+
+                let run (d) = Out { m = d.amount }
+
+                let notAValue (n: Int): Int = n
+
+                example run
+                    | "a helper is not a value" : (Deal { ...notAValue, amount = 1 }) -> Out { m = 1 }
+                """));
+        assertEquals("E1903", e.diagnostic().code());
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -1998,7 +1998,7 @@ A composition's dependencies are its stages' (<<composition-with-requirements>>)
 [#example-placement]
 === Inline or an attached file
 
-The base form is written inline, in the same source as the behavior. To keep fixtures out of the model source, examples may instead be written in an attached file that begins with `+examples for <module>+` and contains only `+example+` declarations. The compiler merges an attached file into its target module; it is not a module of its own and needs no `+import+` (it sees the target module's names directly). An attached file that names a module not being compiled is <<e1907>>; one that contains anything other than an `+example+` is <<e1906>>.
+The base form is written inline, in the same source as the behavior. To keep fixtures out of the model source, examples may instead be written in an attached file that begins with `+examples for <module>+`. It holds the rows, the `+fake+` tables they run against, and the values they name; a data, a behavior, an `+import+` and a `+let+` with parameters belong in the module itself, and writing one there is <<e1906>>. The compiler merges an attached file into its target module; it is not a module of its own and needs no `+import+` (it sees the target module's names directly). Its values join the module the rows join, so a name the module already declares is <<e1906>> too — the rows would read that declaration and the one written here would say nothing. An attached file that names a module not being compiled is <<e1907>>.
 
 [#control-flow]
 == Control structures
@@ -3058,10 +3058,10 @@ Emitted when a row's evaluated result does not match the expected arm or value. 
 [,text]
 ----
 error E1906:
-An `examples for` file may contain only examples, not data, behavior, let, or import.
+An `examples for` file holds examples, the fakes they run against and the values they name. A data, a behavior, an import, and a `let` with parameters belong in the module itself.
 ----
 
-Emitted when a file that begins with `+examples for+` contains anything other than `+example+` declarations (<<example-placement>>).
+Emitted when a file that begins with `+examples for+` holds something other than an example, a `+fake+` table, or a value its rows name — and when a value it declares carries a name the target module already declares (<<example-placement>>). The second is reported on the attached file, where the declaration is written.
 
 [#e1907]
 === Examples file names an absent module

--- a/specification.adoc
+++ b/specification.adoc
@@ -1932,7 +1932,7 @@ example 受注する
 
 An input and an expected value are fixtures: literals, newtype applications, record constructions, and helpers applied to those. A `+?+` field takes a value directly (wrapped in `+Some+`) or `+None+` for empty, the same way a `+let+` body writes an optional (<<optional>>); omitting the field reads as `+None+` too. A row's argument is decoded into the behavior's parameter type through that type's derived Decoder (<<decoder>>), so a fixture that breaks an invariant is rejected (<<e1903>>).
 
-A row may also *name a value* (<<fn-declaration>>) rather than write the whole input again, and may spread one to vary a field. A spread copies the fields of the value it names, and the case is the one the construction writing it names; a name on its own stands for the case the value it denotes constructs. So a fixture in a position typed by a sum says which case it is however it is written.
+A row may also *name a value* (<<fn-declaration>>) rather than write the whole input again, and may spread one to vary a field. A spread copies the fields of the value it names — one another module published as readily as one of this module's own, since a published value crosses closed — and the case is the one the construction writing it names; a name on its own stands for the case the value it denotes constructs. So a fixture in a position typed by a sum says which case it is however it is written.
 
 [,text]
 ----


### PR DESCRIPTION
Closes #212 and #210. Two fixes, one commit each; both are restrictions with no reason behind them rather than decisions to revisit.

## #212 — a row spreads a value another module published

Naming a published value worked, varying one field of it did not, and the reason had nothing to do with the module boundary. Measured before changing anything:

```
DEBUG spread written=up.standard bare=standard denotes=up.standard found=false keys=[up.standard]
```

The values a fixture may name are keyed by **how the row spells them** — a definition of this module by its own name, one another module published by that module's name and its own. The spread looked its value up by `bare()`, the name it was *declared* under, so every imported value missed. Naming works because that path uses the written spelling, which the qualification pass rewrote.

Two things make this a defect rather than a rule: the language already accepts the same spread in a body (`let varied = Deal { ...standard, amount = n }` compiles), and a published value crosses closed, so spreading it reads fields off a value already resolved.

Covered in every position a fixture is written — an input, an expected result, a `fake` row output — and together with #206, where the case comes from the construction and the fields from the value across the boundary as within one module. 4 of the 5 tests fail on `develop`; the fifth is the control that a name no value denotes is still not something to spread.

## #210 — an examples file declares the values its own rows name

The file may now hold a `let` with no parameter list. A `let` with parameters is a helper, which is a method the target module emits, and a companion file does not add to what the model compiles to. The values join the module the rows join, as the fakes already do, so a row in either file names them.

A name the module already declares is refused: the rows would read that declaration and the one written here would say nothing.

**Where that refusal is reported is the part worth reviewing.** The module's own duplicate check produced this, against the model file:

```
-- DUPLICATE DEFINITION ------------------------f25.sou:3:1
3| data Out = { m: Int }
   ^
`let base` is already defined.
```

A position is a line and a column, so a diagnostic carried by a module-keyed query is quoted against the module's file — and the declaration is in the attached one, so it quoted an unrelated line. The merge therefore does not introduce the duplicate, and the attached file's own key (`Output.Examples(module, sourceId)`, which already exists so that a row's failure is reported on the file that wrote it) reports it, where the position and the file agree. The test asserts the source index and the line, not just the code.

5 of the 7 tests fail on `develop`; the two that pass are the controls that a data and a helper are still refused.

## Verification

Full suite green (1530 + 95 + 37), `mvn clean install` clean. Both new test classes were run against `develop` in a worktree to confirm they fail there for the reasons above.

Specification: what an attached file holds and that a value's name may not shadow the module's (E1906 covers both), and that a spread copies the fields of a published value as readily as a local one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
