### PR TITLE
A pure total stdlib size call is a term the invariant checker can name

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -206,7 +206,8 @@ final class InvariantChecker {
                             paths.put(fi.name(), p);
                         }
                     }
-                    check(type, new Bindings(forms::get, paths::get), d, nd.pos(), attempted);
+                    check(type, new Bindings(forms::get, paths::get,
+                            TypeOps.fieldTypes(type, symbols)), d, nd.pos(), attempted);
                 }
             }
             case Ast.Binary bin when isArith(bin.op()) -> {
@@ -215,8 +216,8 @@ final class InvariantChecker {
                     LinearForm value = affineOf(bin, types);
                     if (value != null) {
                         // an arithmetic result is a form, not a location, so it names no path
-                        check(type, new Bindings(name -> "value".equals(name) ? value : null, _ -> null),
-                                d, bin.pos(), attempted);
+                        check(type, new Bindings(name -> "value".equals(name) ? value : null, _ -> null,
+                                TypeOps.fieldTypes(type, symbols)), d, bin.pos(), attempted);
                     }
                 }
             }
@@ -227,7 +228,8 @@ final class InvariantChecker {
     /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
      * field is being given, and to that value's canonical path — so a size call over the field names
      * the same atom the body names when it calls the same function on the same container. */
-    private record Bindings(Function<String, LinearForm> form, Function<String, String> path) {}
+    private record Bindings(Function<String, LinearForm> form, Function<String, String> path,
+                            Map<String, Type> fields) {}
 
     /** Runs the discharge check for a construction of {@code type} whose field values resolve through
      * {@code binds}. A definite violation is an error; an unproven one a warning; a fully-discharged
@@ -358,7 +360,7 @@ final class InvariantChecker {
                     String p = resolvePath.apply(fieldName);
                     return p == null ? null : LinearForm.atom(p);
                 },
-                resolvePath);
+                resolvePath, fields);
         NumericDomain out = d;
         for (Ast.Expr inv : TypeOps.effectiveInvariants(data, symbols)) {
             List<Constraint> cs = invConstraints(inv, binds);
@@ -368,7 +370,11 @@ final class InvariantChecker {
                 }
             }
         }
-        if (!data.newtype()) {
+        if (data.newtype()) {
+            // A newtype's `.value` is the same location as the newtype, so what its base guarantees is
+            // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
+            out = seedAt(path, fields.get("value"), out, depth + 1);
+        } else {
             for (Map.Entry<String, Type> f : fields.entrySet()) {
                 out = seedAt(path + "." + f.getKey(), f.getValue(), out, depth + 1);
             }
@@ -425,7 +431,7 @@ final class InvariantChecker {
 
     /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}, and
      * a size call over one to that container's size atom. */
-    private static Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
+    private Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
         return n -> {
             String size = sizeAtom(n, arg -> invPath(arg, binds));
             if (size != null) {
@@ -437,15 +443,22 @@ final class InvariantChecker {
 
     /** The path an invariant expression names at the construction site: a bare field name through the
      * bindings, then plain field steps. */
-    private static String invPath(Ast.Expr e, Bindings binds) {
-        return switch (e) {
-            case Ast.Var v -> binds.path().apply(v.name());
-            case Ast.FieldAccess fa -> {
-                String base = invPath(fa.target(), binds);
-                yield base == null ? null : base + "." + fa.field();
-            }
-            default -> null;
-        };
+    private String invPath(Ast.Expr e, Bindings binds) {
+        // A clause is a path over the declaration's own fields, read by the very rule a body path is
+        // read by — so a newtype's `.value` is the same location on both sides — and then the field it
+        // is rooted at is replaced by what the construction is giving that field. One rule for what a
+        // location is, applied twice, rather than two rules that have to be kept agreeing.
+        String local = pathKey(e, binds.fields());
+        if (local == null) {
+            return null;
+        }
+        int dot = local.indexOf('.');
+        String root = dot < 0 ? local : local.substring(0, dot);
+        String given = binds.path().apply(root);
+        if (given == null) {
+            return null;
+        }
+        return dot < 0 ? given : given + local.substring(dot);
     }
 
     private static LinearForm negate(LinearForm f) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -68,6 +69,14 @@ final class InvariantChecker {
             Map.entry("Set.partition", new Combinator(0, 0, 1)),
             Map.entry("Option.map", new Combinator(0, 0, 1)));
 
+    /** The pure, total stdlib calls whose result is a number the domain can name: the size of a
+     * container or a string. Each becomes an atom keyed by the call written over its argument's path
+     * — {@code List.length(b.items)} — so an invariant clause and a guard naming the same container
+     * name the same atom, and the guard discharges the clause. The argument must be a nameable path:
+     * {@code List.length(List.map(f, xs))} is not this atom, and nothing relates the two. */
+    private static final Set<String> SIZE_CALLS =
+            Set.of("List.length", "String.length", "Set.size", "Map.size");
+
     private final Symbols symbols;
     private final List<CompileException> errors = new ArrayList<>();
     private final List<Diagnostic> warnings = new ArrayList<>();
@@ -109,11 +118,11 @@ final class InvariantChecker {
                 checkIfConstruction(ic.construct(), d, types, true);
                 Ast.forEachChild(ic.construct(), child -> walk(child, d, types));
                 Map<String, Type> t2 = new HashMap<>(types);
-                NumericDomain d2 = d;
+                NumericDomain d2 = rebind(d, ic.binder());
                 Type built = typeExpr(ic.construct(), types);
                 if (built != null) {
                     t2.put(ic.binder(), built);
-                    d2 = seedParam(ic.binder(), built, d);   // on this branch the invariant holds
+                    d2 = seedParam(ic.binder(), built, d2);   // on this branch the invariant holds
                 }
                 walk(ic.then(), d2, t2);
                 walk(ic.els(), d, types);
@@ -126,20 +135,27 @@ final class InvariantChecker {
                     t2.put(li.name(), vt);
                 }
                 LinearForm vf = affineOf(li.value(), types);
-                NumericDomain d2 = isNumeric(vt) && vf != null ? d.assign(li.name(), vf) : d;
+                NumericDomain d2 = rebind(d, li.name());
+                if (isNumeric(vt) && vf != null) {
+                    d2 = d2.assign(li.name(), vf);
+                }
                 walk(li.body(), d2, t2);
             }
             case Ast.Match m -> {
                 walk(m.scrutinee(), d, types);
                 for (Ast.Case c : m.cases()) {
                     Map<String, Type> t2 = new HashMap<>(types);
-                    if (c.binding() != null && c.caseTypes().size() == 1) {
-                        Type bound = MatchElaborator.caseBindType(c.caseTypes().get(0).denotes());
-                        if (bound != null) {
-                            t2.put(c.binding(), bound);
+                    NumericDomain d2 = d;
+                    if (c.binding() != null) {
+                        d2 = rebind(d, c.binding());
+                        if (c.caseTypes().size() == 1) {
+                            Type bound = MatchElaborator.caseBindType(c.caseTypes().get(0).denotes());
+                            if (bound != null) {
+                                t2.put(c.binding(), bound);
+                            }
                         }
                     }
-                    walk(c.body(), d, t2);
+                    walk(c.body(), d2, t2);
                 }
             }
             case Ast.Call call -> walkCall(call, d, types);
@@ -158,11 +174,11 @@ final class InvariantChecker {
                     && combo.listArg() < call.args().size()) {
                 Type elem = elementType(typeExpr(call.args().get(combo.listArg()), types));
                 Map<String, Type> t2 = new HashMap<>(types);
-                NumericDomain d2 = d;
+                String p = step.params().get(combo.elementParam());
+                NumericDomain d2 = rebind(d, p);
                 if (elem != null) {
-                    String p = step.params().get(combo.elementParam());
                     t2.put(p, elem);
-                    d2 = seedParam(p, elem, d);   // the element carries its type's invariant
+                    d2 = seedParam(p, elem, d2);   // the element carries its type's invariant
                 }
                 walk(step.body(), d2, t2);
             } else {
@@ -178,14 +194,19 @@ final class InvariantChecker {
         switch (e) {
             case Ast.NewData nd when nd.spreads().isEmpty() -> {
                 if (symbols.get(nd.typeName().denotes()) instanceof Ast.Data type) {
-                    Map<String, LinearForm> fields = new HashMap<>();
+                    Map<String, LinearForm> forms = new HashMap<>();
+                    Map<String, String> paths = new HashMap<>();
                     for (Ast.FieldInit fi : nd.inits()) {
                         LinearForm f = affineOf(fi.value(), types);
                         if (f != null) {
-                            fields.put(fi.name(), f);
+                            forms.put(fi.name(), f);
+                        }
+                        String p = pathKey(fi.value(), types);
+                        if (p != null) {
+                            paths.put(fi.name(), p);
                         }
                     }
-                    check(type, fields::get, d, nd.pos(), attempted);
+                    check(type, new Bindings(forms::get, paths::get), d, nd.pos(), attempted);
                 }
             }
             case Ast.Binary bin when isArith(bin.op()) -> {
@@ -193,7 +214,9 @@ final class InvariantChecker {
                         && symbols.get(r.name()) instanceof Ast.Data type && type.newtype()) {
                     LinearForm value = affineOf(bin, types);
                     if (value != null) {
-                        check(type, name -> "value".equals(name) ? value : null, d, bin.pos(), attempted);
+                        // an arithmetic result is a form, not a location, so it names no path
+                        check(type, new Bindings(name -> "value".equals(name) ? value : null, _ -> null),
+                                d, bin.pos(), attempted);
                     }
                 }
             }
@@ -201,11 +224,16 @@ final class InvariantChecker {
         }
     }
 
+    /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
+     * field is being given, and to that value's canonical path — so a size call over the field names
+     * the same atom the body names when it calls the same function on the same container. */
+    private record Bindings(Function<String, LinearForm> form, Function<String, String> path) {}
+
     /** Runs the discharge check for a construction of {@code type} whose field values resolve through
-     * {@code resolve}. A definite violation is an error; an unproven one a warning; a fully-discharged
+     * {@code binds}. A definite violation is an error; an unproven one a warning; a fully-discharged
      * or non-expressible invariant is silent. An {@code attempted} construction raises no warning:
      * what the warning reports is a possible abort, and an attempt takes its else branch instead. */
-    private void check(Ast.Data type, Function<String, LinearForm> resolve, NumericDomain d, SourcePos pos,
+    private void check(Ast.Data type, Bindings binds, NumericDomain d, SourcePos pos,
                        boolean attempted) {
         List<Ast.Expr> invs = TypeOps.effectiveInvariants(type, symbols);
         if (invs.isEmpty()) {
@@ -213,22 +241,23 @@ final class InvariantChecker {
         }
         List<Constraint> constraints = new ArrayList<>();
         for (Ast.Expr inv : invs) {
-            List<Constraint> cs = invConstraints(inv, resolve);
+            List<Constraint> cs = invConstraints(inv, binds);
             if (cs == null) {
                 return;   // some part is not expressible in the domain — leave the whole opaque
             }
             constraints.addAll(cs);
         }
+        NumericDomain dom = withSizeBounds(d, constraints);
         boolean possible = false;
         for (Constraint c : constraints) {
-            if (d.refutes(c.form(), c.rel())) {
+            if (dom.refutes(c.form(), c.rel())) {
                 errors.add(CompileException.of(
                         Diagnostic.of("E2010", "check.invariant.violation").title("check.invariant.title")
                                 .at(pos).args(type.name()).build(),
                         "constructing `" + type.name() + "` here violates its invariant on a reachable path"));
                 return;
             }
-            if (!d.entails(c.form(), c.rel())) {
+            if (!dom.entails(c.form(), c.rel())) {
                 possible = true;
             }
         }
@@ -244,12 +273,12 @@ final class InvariantChecker {
 
     private record Constraint(LinearForm form, Rel rel) {}
 
-    /** The constraints an invariant expression contributes under {@code resolve} (field/{@code value}
-     * name -> its affine form), or {@code null} if any part is not expressible. */
-    private List<Constraint> invConstraints(Ast.Expr inv, Function<String, LinearForm> resolve) {
+    /** The constraints an invariant expression contributes under {@code binds} (field/{@code value}
+     * name -> what it is being given), or {@code null} if any part is not expressible. */
+    private List<Constraint> invConstraints(Ast.Expr inv, Bindings binds) {
         if (inv instanceof Ast.Binary b && b.op() == Ast.BinOp.AND) {
-            List<Constraint> l = invConstraints(b.left(), resolve);
-            List<Constraint> r = invConstraints(b.right(), resolve);
+            List<Constraint> l = invConstraints(b.left(), binds);
+            List<Constraint> r = invConstraints(b.right(), binds);
             if (l == null || r == null) {
                 return null;
             }
@@ -260,12 +289,27 @@ final class InvariantChecker {
         if (inv instanceof Ast.Binary b) {
             Rel rel = relOf(b.op());
             if (rel != null) {
-                LinearForm la = affine(b.left(), resolveLeaf(resolve));
-                LinearForm ra = affine(b.right(), resolveLeaf(resolve));
+                LinearForm la = affine(b.left(), resolveLeaf(binds));
+                LinearForm ra = affine(b.right(), resolveLeaf(binds));
                 return la == null || ra == null ? null : List.of(new Constraint(la.minus(ra), rel));
             }
         }
         return null;
+    }
+
+    /** The domain told that every size atom the constraints name is non-negative. The atom enters the
+     * domain only through the clause naming it, so without this the fact a container's size is never
+     * negative is not available to discharge a clause that asks only for that. */
+    private static NumericDomain withSizeBounds(NumericDomain d, List<Constraint> constraints) {
+        NumericDomain out = d;
+        for (Constraint c : constraints) {
+            for (String atom : c.form().coefs().keySet()) {
+                if (isSizeAtom(atom)) {
+                    out = out.assume(LinearForm.atom(atom), Rel.GE);
+                }
+            }
+        }
+        return out;
     }
 
     /** Refines {@code d} by asserting {@code cond} (or its negation). Non-comparison conditions and
@@ -303,15 +347,21 @@ final class InvariantChecker {
             return d;
         }
         Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
-        Function<String, LinearForm> resolve = fieldName -> {
+        Function<String, String> resolvePath = fieldName -> {
             if (data.newtype() && fieldName.equals("value")) {
-                return LinearForm.atom(path);
+                return path;
             }
-            return fields.containsKey(fieldName) ? LinearForm.atom(path + "." + fieldName) : null;
+            return fields.containsKey(fieldName) ? path + "." + fieldName : null;
         };
+        Bindings binds = new Bindings(
+                fieldName -> {
+                    String p = resolvePath.apply(fieldName);
+                    return p == null ? null : LinearForm.atom(p);
+                },
+                resolvePath);
         NumericDomain out = d;
         for (Ast.Expr inv : TypeOps.effectiveInvariants(data, symbols)) {
-            List<Constraint> cs = invConstraints(inv, resolve);
+            List<Constraint> cs = invConstraints(inv, binds);
             if (cs != null) {
                 for (Constraint c : cs) {
                     out = out.assume(c.form(), c.rel());
@@ -373,9 +423,29 @@ final class InvariantChecker {
         });
     }
 
-    /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}. */
-    private static Function<Ast.Expr, LinearForm> resolveLeaf(Function<String, LinearForm> resolve) {
-        return n -> n instanceof Ast.Var v ? resolve.apply(v.name()) : null;
+    /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}, and
+     * a size call over one to that container's size atom. */
+    private static Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
+        return n -> {
+            String size = sizeAtom(n, arg -> invPath(arg, binds));
+            if (size != null) {
+                return LinearForm.atom(size);
+            }
+            return n instanceof Ast.Var v ? binds.form().apply(v.name()) : null;
+        };
+    }
+
+    /** The path an invariant expression names at the construction site: a bare field name through the
+     * bindings, then plain field steps. */
+    private static String invPath(Ast.Expr e, Bindings binds) {
+        return switch (e) {
+            case Ast.Var v -> binds.path().apply(v.name());
+            case Ast.FieldAccess fa -> {
+                String base = invPath(fa.target(), binds);
+                yield base == null ? null : base + "." + fa.field();
+            }
+            default -> null;
+        };
     }
 
     private static LinearForm negate(LinearForm f) {
@@ -389,24 +459,55 @@ final class InvariantChecker {
         return subtract ? a.minus(b) : a.plus(b);
     }
 
-    /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value), or
-     * {@code null} if {@code e} is not one. */
+    /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value) or of
+     * a size call over a nameable container, or {@code null} if {@code e} is neither. */
     private String atomOf(Ast.Expr e, Map<String, Type> types) {
+        String size = sizeAtom(e, arg -> pathKey(arg, types));
+        if (size != null) {
+            return size;
+        }
         return isNumeric(typeExpr(e, types)) ? pathKey(e, types) : null;
+    }
+
+    /** The atom key of {@code SIZE_CALL(container)} when {@code path} can name the container, else
+     * {@code null}. */
+    private static String sizeAtom(Ast.Expr e, Function<Ast.Expr, String> path) {
+        if (!(e instanceof Ast.Call call) || !SIZE_CALLS.contains(call.fn()) || call.args().size() != 1) {
+            return null;
+        }
+        String arg = path.apply(call.args().get(0));
+        return arg == null ? null : call.fn() + "(" + arg + ")";
+    }
+
+    private static boolean isSizeAtom(String atom) {
+        int open = atom.indexOf('(');
+        return open > 0 && atom.endsWith(")") && SIZE_CALLS.contains(atom.substring(0, open));
     }
 
     private String pathKey(Ast.Expr e, Map<String, Type> types) {
         return switch (e) {
             case Ast.Var v -> v.name();
             case Ast.FieldAccess fa -> {
-                if (fa.field().equals("value") && numericNewtype(typeExpr(fa.target(), types))) {
-                    yield pathKey(fa.target(), types);   // a newtype's .value is the same atom
+                Type owner = typeExpr(fa.target(), types);
+                if (fa.field().equals("value") && TypeOps.isSingleValueNewtype(owner, symbols)) {
+                    yield pathKey(fa.target(), types);   // a newtype's .value is the same location
                 }
                 String base = pathKey(fa.target(), types);
                 yield base == null ? null : base + "." + fa.field();
             }
             default -> null;
         };
+    }
+
+    /** The domain with every fact rooted at {@code name} dropped, because a binding of that name makes
+     * it denote something else. An atom is rooted at a name when it is the name, a field chain from
+     * it, or a size call over one. */
+    private static NumericDomain rebind(NumericDomain d, String name) {
+        return d.forgetIf(atom -> {
+            int open = atom.indexOf('(');
+            String path = isSizeAtom(atom) ? atom.substring(open + 1, atom.length() - 1) : atom;
+            return path.equals(name) || path.startsWith(name + ".");
+        });
     }
 
     // --- a minimal local typer (enough for atom/affine detection) ------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -247,15 +247,25 @@ final class NumericDomain {
     }
 
     private NumericDomain forget(String atom) {
+        return forgetIf(atom::equals);
+    }
+
+    /** The domain with every fact about a matching atom dropped. A binding that rebinds a name
+     * invalidates each atom rooted at it — the name now denotes something else — and the caller,
+     * which owns the atom-key syntax, decides which those are. */
+    NumericDomain forgetIf(java.util.function.Predicate<String> drop) {
+        if (bottom) {
+            return this;
+        }
         Map<String, BigDecimal> nlo = new HashMap<>(lo);
         Map<String, BigDecimal> nhi = new HashMap<>(hi);
-        nlo.remove(atom);
-        nhi.remove(atom);
+        nlo.keySet().removeIf(drop);
+        nhi.keySet().removeIf(drop);
         Map<String, Map<String, BigDecimal>> nd = new HashMap<>();
         diff.forEach((a, row) -> {
-            if (!a.equals(atom)) {
+            if (!drop.test(a)) {
                 Map<String, BigDecimal> nr = new HashMap<>(row);
-                nr.remove(atom);
+                nr.keySet().removeIf(drop);
                 if (!nr.isEmpty()) {
                     nd.put(a, nr);
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -1,8 +1,10 @@
 package souther.compiler.check;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -15,11 +17,11 @@ import java.util.Set;
  * <p>This is the decision procedure the invariant-discharge check runs on: {@link #assume} tightens
  * the domain along a {@code guard}/{@code if} guard or an input newtype's invariant, and
  * {@link #entails} / {@link #refutes} answer whether a construction's invariant is discharged or is
- * definitely violated on the current path. It is deliberately bounded to interval + difference-bound;
- * an invariant the checker cannot express here is left opaque (its runtime check stays), so the set of
- * facts it can prove is exactly the set of guards a user can write to discharge them (spec
- * §invariant-discharge). Instances are immutable — each operation returns a fresh domain, threaded
- * functionally like {@code TotalityChecker}'s scope map.
+ * definitely violated on the current path. What it derives is bounded to interval + difference-bound;
+ * a form of neither shape is kept as it was written, so a guard restating an invariant still
+ * discharges it even where nothing can be derived from the two together (spec §invariant-discharge).
+ * Instances are immutable — each operation returns a fresh domain, threaded functionally like
+ * {@code TotalityChecker}'s scope map.
  */
 final class NumericDomain {
 
@@ -64,21 +66,27 @@ final class NumericDomain {
         }
     }
 
+    /** A form asserted {@code f <= 0} (or {@code f < 0}) and kept as written, because its shape is
+     * neither an interval nor a difference. */
+    private record Asserted(LinearForm f, boolean strict) {}
+
     private final boolean bottom;                              // an infeasible path (guards contradict)
     private final Map<String, BigDecimal> lo;                  // atom -> lower bound (null key absent = -inf)
     private final Map<String, BigDecimal> hi;                  // atom -> upper bound (absent = +inf)
     private final Map<String, Map<String, BigDecimal>> diff;   // diff[a][b] = tightest known (a - b)
+    private final List<Asserted> kept;                         // forms outside both shapes, as written
 
     private NumericDomain(boolean bottom, Map<String, BigDecimal> lo, Map<String, BigDecimal> hi,
-                          Map<String, Map<String, BigDecimal>> diff) {
+                          Map<String, Map<String, BigDecimal>> diff, List<Asserted> kept) {
         this.bottom = bottom;
         this.lo = lo;
         this.hi = hi;
         this.diff = diff;
+        this.kept = kept;
     }
 
     static NumericDomain top() {
-        return new NumericDomain(false, Map.of(), Map.of(), Map.of());
+        return new NumericDomain(false, Map.of(), Map.of(), Map.of(), List.of());
     }
 
     boolean isBottom() {
@@ -87,8 +95,7 @@ final class NumericDomain {
 
     // --- assume: tighten along `f rel 0` -------------------------------------------------------
 
-    /** The domain refined by asserting {@code f rel 0}. Non-difference, non-interval forms are not
-     * representable and leave the domain unchanged (sound: it stays weaker, never wrongly tighter). */
+    /** The domain refined by asserting {@code f rel 0}. */
     NumericDomain assume(LinearForm f, Rel rel) {
         if (bottom) {
             return this;
@@ -100,10 +107,10 @@ final class NumericDomain {
         return addLe(negOf(rel) ? f.negate() : f, strictOf(rel));
     }
 
-    /** Assert {@code g <= 0} (or {@code g < 0} when strict), updating an interval or a difference. A
-     * form outside the interval/difference fragment is not representable and leaves the domain
-     * unchanged (sound). Strictness only sharpens the constant case; for an interval or difference a
-     * strict {@code < 0} is recorded as {@code <= 0} (weaker, so still sound). */
+    /** Assert {@code g <= 0} (or {@code g < 0} when strict), updating an interval or a difference, or
+     * keeping the form as written when it is neither. Strictness only sharpens the constant case; for
+     * an interval or difference a strict {@code < 0} is recorded as {@code <= 0} (weaker, so still
+     * sound). */
     private NumericDomain addLe(LinearForm g, boolean strict) {
         Map<String, BigDecimal> c = g.coefs();
         if (c.isEmpty()) {
@@ -128,7 +135,11 @@ final class NumericDomain {
         if (ab != null) {
             return withDiff(ab[0], ab[1], g.constant().negate());   // a - b <= -const
         }
-        return this;   // not representable — leave unchanged (sound)
+        // Neither shape holds it — a sum of two lengths, say. Keeping the form as written is what lets
+        // a guard restating an invariant discharge it, which is the promise the flagging rests on.
+        List<Asserted> next = new ArrayList<>(kept);
+        next.add(new Asserted(g, strict));
+        return new NumericDomain(false, lo, hi, diff, List.copyOf(next));
     }
 
     /** The two atoms of a unit difference {@code {a:+1, b:-1}} as {@code {a, b}}, or {@code null} if
@@ -204,6 +215,18 @@ final class NumericDomain {
                 }
             }
         }
+        // A form kept as written proves `g <= 0` when g is that form plus a constant no greater than
+        // zero: asserting `f <= 0` gives `f + c <= 0` for every `c <= 0`.
+        for (Asserted a : kept) {
+            LinearForm slack = g.minus(a.f());
+            if (!slack.coefs().isEmpty()) {
+                continue;
+            }
+            int s = slack.constant().signum();
+            if (s < 0 || (s == 0 && (!strict || a.strict()))) {
+                return true;
+            }
+        }
         return false;
     }
 
@@ -271,26 +294,28 @@ final class NumericDomain {
                 }
             }
         });
-        return new NumericDomain(false, nlo, nhi, nd);
+        List<Asserted> nk = new ArrayList<>(kept);
+        nk.removeIf(a -> a.f().coefs().keySet().stream().anyMatch(drop));
+        return new NumericDomain(false, nlo, nhi, nd, List.copyOf(nk));
     }
 
     // --- immutable updates ---------------------------------------------------------------------
 
     private NumericDomain bottom() {
-        return new NumericDomain(true, Map.of(), Map.of(), Map.of());
+        return new NumericDomain(true, Map.of(), Map.of(), Map.of(), List.of());
     }
 
     private NumericDomain withHi(String a, BigDecimal bound) {
         Map<String, BigDecimal> nhi = new HashMap<>(hi);
         nhi.merge(a, bound, NumericDomain::min);
-        NumericDomain d = new NumericDomain(false, lo, nhi, diff);
+        NumericDomain d = new NumericDomain(false, lo, nhi, diff, kept);
         return d.feasible(a) ? d : bottom();
     }
 
     private NumericDomain withLo(String a, BigDecimal bound) {
         Map<String, BigDecimal> nlo = new HashMap<>(lo);
         nlo.merge(a, bound, NumericDomain::max);
-        NumericDomain d = new NumericDomain(false, nlo, hi, diff);
+        NumericDomain d = new NumericDomain(false, nlo, hi, diff, kept);
         return d.feasible(a) ? d : bottom();
     }
 
@@ -298,7 +323,7 @@ final class NumericDomain {
         Map<String, Map<String, BigDecimal>> nd = new HashMap<>();
         diff.forEach((k, v) -> nd.put(k, new HashMap<>(v)));
         nd.computeIfAbsent(a, k -> new HashMap<>()).merge(b, bound, NumericDomain::min);
-        NumericDomain d = new NumericDomain(false, lo, hi, nd);
+        NumericDomain d = new NumericDomain(false, lo, hi, nd, kept);
         // Contradictory guards make the path infeasible: with a - b <= bound now recorded, if the
         // difference facts also prove b - a <= back and bound + back < 0, then 0 <= bound + back < 0.
         // Mark it bottom so entails discharges everything and refutes fires nothing — no false E2010

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -260,6 +260,46 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aGuardRestatingASumOfTwoLengthsDischarges() {
+        // the guard is the invariant written over the arguments. A sum of two atoms is outside the
+        // interval/difference shapes, so what discharges it is the form itself being assumed.
+        String m = """
+                module demo
+                data Empty
+                data Matches = { accounts: List<Int>, contacts: List<Int> }
+                    invariant List.length(accounts) + List.length(contacts) >= 1
+                behavior build : (xs: List<Int>, ys: List<Int>) -> Matches | Empty
+                    constructs Matches, Empty
+                let build (xs, ys) = {
+                    guard List.length(xs) + List.length(ys) >= 1
+                        else Empty
+                    Matches { accounts = xs, contacts = ys }
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a guard restating the invariant discharges it");
+    }
+
+    @Test
+    void aGuardWeakerThanTheInvariantDoesNotDischarge() {
+        String m = """
+                module demo
+                data Empty
+                data Matches = { accounts: List<Int>, contacts: List<Int> }
+                    invariant List.length(accounts) + List.length(contacts) >= 2
+                behavior build : (xs: List<Int>, ys: List<Int>) -> Matches | Empty
+                    constructs Matches, Empty
+                let build (xs, ys) = {
+                    guard List.length(xs) + List.length(ys) >= 1
+                        else Empty
+                    Matches { accounts = xs, contacts = ys }
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a guard that establishes less should not discharge");
+    }
+
+    @Test
     void aRebindingOfTheGuardedNameDropsTheFact() {
         // `xs` is rebound between the guard and the construction, so the guard's fact no longer holds
         // of what `Lines` is built from

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -107,6 +107,180 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void anUnguardedListLengthConstructionIsAPossibleViolationWarning() {
+        // `List.length(xs)` is a term the domain can name, so an invariant over it is expressible and
+        // the unguarded construction is flagged rather than left silent
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines constructs Lines
+                let build (xs) = Lines(xs)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "an unguarded length invariant should warn (E2011)");
+    }
+
+    @Test
+    void aGuardOnTheLengthDischargesTheConstruction() {
+        // the guard and the invariant name the same list, so they name the same atom
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines | NoItems constructs Lines, NoItems
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else NoItems
+                    Lines(xs)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the length invariant");
+    }
+
+    @Test
+    void aGuardOnAnotherListDoesNotDischarge() {
+        // the atom is keyed by the container the call names — guarding `ys` says nothing about `xs`
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>, ys: List<Int>) -> Lines | NoItems
+                    constructs Lines, NoItems
+                let build (xs, ys) = {
+                    guard List.length(ys) >= 1
+                        else NoItems
+                    Lines(xs)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a guard on another list should not discharge");
+    }
+
+    @Test
+    void aGuardOnAStringLengthDischargesTheConstruction() {
+        String m = """
+                module demo
+                data TooShort
+                data Name = String
+                    invariant String.length(value) >= 3
+                behavior build : (s: String) -> Name | TooShort constructs Name, TooShort
+                let build (s) = {
+                    guard String.length(s) >= 3
+                        else TooShort
+                    Name(s)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the string-length invariant");
+    }
+
+    @Test
+    void anUnguardedStringLengthConstructionIsAPossibleViolationWarning() {
+        String m = """
+                module demo
+                data Name = String
+                    invariant String.length(value) >= 3
+                behavior build : (s: String) -> Name constructs Name
+                let build (s) = Name(s)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "an unguarded string-length invariant should warn (E2011)");
+    }
+
+    @Test
+    void aGuardOnASetSizeDischargesTheConstruction() {
+        String m = """
+                module demo
+                data Empty
+                data Tags = Set<String>
+                    invariant Set.size(value) >= 1
+                behavior build : (s: Set<String>) -> Tags | Empty constructs Tags, Empty
+                let build (s) = {
+                    guard Set.size(s) >= 1
+                        else Empty
+                    Tags(s)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the set-size invariant");
+    }
+
+    @Test
+    void aGuardOnAMapSizeDischargesTheConstruction() {
+        String m = """
+                module demo
+                data Empty
+                data Index = Map<String, Int>
+                    invariant Map.size(value) >= 1
+                behavior build : (m: Map<String, Int>) -> Index | Empty constructs Index, Empty
+                let build (m) = {
+                    guard Map.size(m) >= 1
+                        else Empty
+                    Index(m)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the map-size invariant");
+    }
+
+    @Test
+    void anInputTypesLengthInvariantIsSeeded() {
+        // `l: Lines` was built through Lines' checked construction, so its length is known here
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                data Batch = List<Int>
+                    invariant List.length(value) >= 1
+                behavior rewrap : (l: Lines) -> Batch constructs Batch
+                let rewrap (l) = Batch(l.value)
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the input newtype's length invariant discharges the re-wrap");
+    }
+
+    @Test
+    void aLengthInvariantOverAMappedListStaysOpaque() {
+        // `List.length(List.map(f, xs))` is not the same atom as `List.length(xs)` at this increment,
+        // so the clause is not expressible here and the run-time check stands — no warning no guard
+        // written over the mapped list could silence
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines constructs Lines
+                let build (xs) = Lines(List.map(x -> x + 1, xs))
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "an unnameable container leaves the clause opaque");
+    }
+
+    @Test
+    void aRebindingOfTheGuardedNameDropsTheFact() {
+        // `xs` is rebound between the guard and the construction, so the guard's fact no longer holds
+        // of what `Lines` is built from
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines | NoItems constructs Lines, NoItems
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else NoItems
+                    let xs = List.filter(x -> x > 0, xs)
+                    Lines(xs)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a rebinding invalidates the guard's fact about that name");
+    }
+
+    @Test
     void aRequireGuardDischargesTheSubtraction() {
         // `guard 額 <= 残高` establishes the relation on the mainline, discharging `残高 - 額`
         String m = """

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -300,6 +300,99 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aNewtypeFieldsValueIsTheSameLocationOnBothSides() {
+        // `n` was built through `Name`'s checked construction, so its length is known here — and the
+        // clause names the very location the input's own invariant is about
+        String m = """
+                module demo
+                data Name = String
+                    invariant String.length(value) >= 3
+                data Person = { name: Name }
+                    invariant String.length(name.value) >= 3
+                behavior build : (n: Name) -> Person constructs Person
+                let build (n) = Person { name = n }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a newtype's `.value` is one location whichever side names it");
+    }
+
+    @Test
+    void aGuardOnANewtypeFieldsValueDischarges() {
+        String m = """
+                module demo
+                data TooShort
+                data Name = String
+                data Person = { name: Name }
+                    invariant String.length(name.value) >= 3
+                behavior build : (n: Name) -> Person | TooShort constructs Person, TooShort
+                let build (n) = {
+                    guard String.length(n.value) >= 3
+                        else TooShort
+                    Person { name = n }
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard sizes the same location the clause does");
+    }
+
+    @Test
+    void aGuardThroughTwoNewtypesDischarges() {
+        // the guard writes both `.value`s and the clause writes both, and each is the same location
+        String m = """
+                module demo
+                data TooShort
+                data Inner = String
+                data Outer = Inner
+                data Box = { held: Outer }
+                    invariant String.length(held.value.value) >= 3
+                behavior build : (o: Outer) -> Box | TooShort constructs Box, TooShort
+                let build (o) = {
+                    guard String.length(o.value.value) >= 3
+                        else TooShort
+                    Box { held = o }
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "each `.value` of a single-value newtype is the same location");
+    }
+
+    @Test
+    void aNewtypeOverANewtypeIsStillOneLocation() {
+        String m = """
+                module demo
+                data Inner = String
+                    invariant String.length(value) >= 3
+                data Outer = Inner
+                data Box = { held: Outer }
+                    invariant String.length(held.value.value) >= 3
+                behavior build : (o: Outer) -> Box constructs Box
+                let build (o) = Box { held = o }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "each `.value` of a single-value newtype is the same location");
+    }
+
+    @Test
+    void aGuardOnAnotherNewtypesValueDoesNotDischarge() {
+        String m = """
+                module demo
+                data TooShort
+                data Name = String
+                data Person = { name: Name }
+                    invariant String.length(name.value) >= 3
+                behavior build : (n: Name, other: Name) -> Person | TooShort
+                    constructs Person, TooShort
+                let build (n, other) = {
+                    guard String.length(other.value) >= 3
+                        else TooShort
+                    Person { name = n }
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "collapsing `.value` does not collapse two different newtypes into one");
+    }
+
+    @Test
     void aRebindingOfTheGuardedNameDropsTheFact() {
         // `xs` is rebound between the guard and the construction, so the guard's fact no longer holds
         // of what `Lines` is built from

--- a/specification.adoc
+++ b/specification.adoc
@@ -957,7 +957,7 @@ let withdraw (req) = {
 }
 ----
 
-The checked fragment is bounded: the decision procedure reasons over intervals and differences (`+value >= c+`, `+a <= b+`, and the like) with no external solver. The set of *flagged* constructions is tied to that fragment, so every flagged construction has a guard the procedure can verify — an invariant it cannot express (a non-linear or otherwise relational one) is left to the run-time check rather than reported as a possible violation no guard could silence.
+The checked fragment is bounded: the decision procedure derives over intervals and differences (`+value >= c+`, `+a <= b+`, and the like) with no external solver. A relation of neither shape — a sum of two lengths against a bound — is kept as it was written rather than derived from, so a guard *restating* an invariant discharges it even where the two together yield nothing. The set of *flagged* constructions is tied to that fragment, so every flagged construction has a guard the procedure can verify — an invariant it cannot express (a non-linear one, or one over a value it cannot name) is left to the run-time check rather than reported as a possible violation no guard could silence.
 
 An *attempted* construction (<<attempted-construction>>) is never possibly violated: a failing invariant takes its `+else+` branch, so there is no abort to warn about. It is what silences the warning for an invariant outside the fragment, where no guard could. A violation the procedure *decides* is still an error there, because with the outcome settled at compile time there was no branch. In the success branch the built value seeds the check with its own invariant, as an input of that type does.
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -961,6 +961,25 @@ The checked fragment is bounded: the decision procedure reasons over intervals a
 
 An *attempted* construction (<<attempted-construction>>) is never possibly violated: a failing invariant takes its `+else+` branch, so there is no abort to warn about. It is what silences the warning for an invariant outside the fragment, where no guard could. A violation the procedure *decides* is still an error there, because with the outcome settled at compile time there was no branch. In the success branch the built value seeds the check with its own invariant, as an input of that type does.
 
+[#invariant-discharge-terms]
+==== What the procedure can name
+
+A term it compares is the numeric content of a location — a parameter, a field chain, a newtype's wrapped value — or the size of a container or a string: `+List.length+`, `+String.length+`, `+Set.size+`, `+Map.size+` applied to such a location. A size is named by the location it is taken of, so a guard and an invariant clause mean the same term exactly when they take the size of the same one. The size of a container is never negative, and the procedure knows that much without being told.
+
+[,text]
+----
+data Lines = List<Int> invariant List.length(value) >= 1
+
+behavior build : (xs: List<Int>) -> Lines | NoItems
+let build (xs) = {
+    guard List.length(xs) >= 1
+        else NoItems
+    Lines(xs)                         // discharged: the guard sizes the same list
+}
+----
+
+A size taken of anything else — `+List.length(List.map(f, xs))+` — is not a term, and a clause needing it is left to the run-time check.
+
 [#invariant-reify]
 ==== Reifying a cross-behavior relation
 


### PR DESCRIPTION
Closes #223 (a sub-issue of #222).

## The hole

The invariant-discharge check reasons over atoms keyed by a string, and nothing ever turned a stdlib
call into one. So a property of a collection or a string was not merely unproven but unrepresented:
a construction that must abort was accepted in silence, and a guard stating exactly the invariant
discharged nothing. Measured on `develop`, the three rows of #222's table:

| invariant | body | before | after |
| --- | --- | --- | --- |
| `data Money = Int invariant value >= 0` | `Money(n)`, no guard | E2011 | E2011 |
| `data Name = String invariant String.length(value) >= 3` | `Name(s)`, no guard | *nothing* | E2011 |
| `data Lines = List<Int> invariant List.length(value) >= 1` | `Lines(xs)`, no guard | *nothing* | E2011 |

## What is a term now

`List.length`, `String.length`, `Set.size` and `Map.size` applied to a nameable location — a
parameter, a field chain, a newtype's wrapped value — become an atom keyed by the call written over
that location's path (`List.length(b.items)`). A guard and an invariant clause mean the same term
exactly when they size the same location. The size of a container is never negative, and the
procedure is told that much about every size atom a clause names.

Resolving the invariant's leaf names needed more than it had: the construction site handed over an
affine form per field, which cannot say *what* `value` is, only what it computes to. It now hands
over the value's canonical path as well, which is what lets `List.length(value)` at the clause and
`List.length(xs)` in the guard land on one key.

No preservation rules: `List.length(List.map(f, xs))` names no location, so a clause needing it
stays outside the fragment and its run-time check stands. That is #225.

## A rebinding drops the facts about the name

Found while adding the above, and a hole of its own. A `let`, a match binding, a combinator's
closure parameter and an attempt's binder can each shadow an outer name, and the facts held under
that name were about what it used to denote. Only an exact numeric assignment forgot anything;
`p.a` survived a rebinding of `p`. `NumericDomain.forgetIf` now drops every atom rooted at a name
the binding takes over.

## A guard restating an invariant now discharges it whatever its shape

Turning the flagging on exposed this. The domain derives over intervals and differences, and a
relation of neither shape was dropped on assertion — so `crm`'s `PossibleDuplicate`, whose
invariant is `List.length(accounts) + List.length(contacts) >= 1` and which is guarded by exactly
that, was reported anyway. Nothing the author could write would silence it, which is the one thing
the flagging rule promises. A form the two shapes do not hold is now kept as it was written, and
proves what it states plus any constant no greater than zero.

## Verification

- `mvn -o clean test` green; 12 tests added to `CompileInvariantDischargeTest`.
- Every module of souther-lang/examples compiled before and after. `develop` reports three warnings
  (`Quantity`, `UnitPrice`, `DiscountRate` in `crm`); this branch reports those three plus one:
  `Label` in `issuetracker`, built inside a `Set.map` over a set a `Set.filter` has just made
  non-empty of empties. That is honest — the check does not know `Set.filter` preserves an element
  property, which is #225 — and today it is silenced by attempting the construction rather than by
  a guard, since a `Set.map` closure has nowhere to put an `else`.
- Comparisons were run through `souther compile`, not the Maven build: the annotation-processor
  path reports no warnings at all.
- Specification: `[#invariant-discharge-terms]` states what the procedure can name, and the
  bounded-fragment paragraph now says a restated relation is kept as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
