### PR TITLE
A guard settles a clause that states no relation

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -206,7 +206,8 @@ final class InvariantChecker {
                             paths.put(fi.name(), p);
                         }
                     }
-                    check(type, new Bindings(forms::get, paths::get), d, nd.pos(), attempted);
+                    check(type, new Bindings(forms::get, paths::get,
+                            TypeOps.fieldTypes(type, symbols)), d, nd.pos(), attempted);
                 }
             }
             case Ast.Binary bin when isArith(bin.op()) -> {
@@ -215,8 +216,8 @@ final class InvariantChecker {
                     LinearForm value = affineOf(bin, types);
                     if (value != null) {
                         // an arithmetic result is a form, not a location, so it names no path
-                        check(type, new Bindings(name -> "value".equals(name) ? value : null, _ -> null),
-                                d, bin.pos(), attempted);
+                        check(type, new Bindings(name -> "value".equals(name) ? value : null, _ -> null,
+                                TypeOps.fieldTypes(type, symbols)), d, bin.pos(), attempted);
                     }
                 }
             }
@@ -227,7 +228,8 @@ final class InvariantChecker {
     /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
      * field is being given, and to that value's canonical path — so a size call over the field names
      * the same atom the body names when it calls the same function on the same container. */
-    private record Bindings(Function<String, LinearForm> form, Function<String, String> path) {}
+    private record Bindings(Function<String, LinearForm> form, Function<String, String> path,
+                            Map<String, Type> fields) {}
 
     /** Runs the discharge check for a construction of {@code type} whose field values resolve through
      * {@code binds}. A definite violation is an error; an unproven one a warning; a fully-discharged
@@ -358,7 +360,7 @@ final class InvariantChecker {
                     String p = resolvePath.apply(fieldName);
                     return p == null ? null : LinearForm.atom(p);
                 },
-                resolvePath);
+                resolvePath, fields);
         NumericDomain out = d;
         for (Ast.Expr inv : TypeOps.effectiveInvariants(data, symbols)) {
             List<Constraint> cs = invConstraints(inv, binds);
@@ -368,7 +370,11 @@ final class InvariantChecker {
                 }
             }
         }
-        if (!data.newtype()) {
+        if (data.newtype()) {
+            // A newtype's `.value` is the same location as the newtype, so what its base guarantees is
+            // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
+            out = seedAt(path, fields.get("value"), out, depth + 1);
+        } else {
             for (Map.Entry<String, Type> f : fields.entrySet()) {
                 out = seedAt(path + "." + f.getKey(), f.getValue(), out, depth + 1);
             }
@@ -425,7 +431,7 @@ final class InvariantChecker {
 
     /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}, and
      * a size call over one to that container's size atom. */
-    private static Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
+    private Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
         return n -> {
             String size = sizeAtom(n, arg -> invPath(arg, binds));
             if (size != null) {
@@ -437,15 +443,22 @@ final class InvariantChecker {
 
     /** The path an invariant expression names at the construction site: a bare field name through the
      * bindings, then plain field steps. */
-    private static String invPath(Ast.Expr e, Bindings binds) {
-        return switch (e) {
-            case Ast.Var v -> binds.path().apply(v.name());
-            case Ast.FieldAccess fa -> {
-                String base = invPath(fa.target(), binds);
-                yield base == null ? null : base + "." + fa.field();
-            }
-            default -> null;
-        };
+    private String invPath(Ast.Expr e, Bindings binds) {
+        // A clause is a path over the declaration's own fields, read by the very rule a body path is
+        // read by — so a newtype's `.value` is the same location on both sides — and then the field it
+        // is rooted at is replaced by what the construction is giving that field. One rule for what a
+        // location is, applied twice, rather than two rules that have to be kept agreeing.
+        String local = pathKey(e, binds.fields());
+        if (local == null) {
+            return null;
+        }
+        int dot = local.indexOf('.');
+        String root = dot < 0 ? local : local.substring(0, dot);
+        String given = binds.path().apply(root);
+        if (given == null) {
+            return null;
+        }
+        return dot < 0 ? given : given + local.substring(dot);
     }
 
     private static LinearForm negate(LinearForm f) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.NumericDomain.LinearForm;
 import souther.compiler.check.NumericDomain.Rel;
@@ -17,15 +18,16 @@ import java.util.Set;
 import java.util.function.Function;
 
 /**
- * The intraprocedural invariant-discharge check (spec §invariant-discharge). It walks a behavior's body threading a
- * {@link NumericDomain} — seeded from the input newtypes' invariants and refined along each
- * {@code guard}/{@code if} guard (a {@code guard} is already an {@code if} here) — and, at every
- * construction whose invariant is expressible in the domain, asks whether the guards
- * <em>discharge</em> it. A construction the domain proves must violate its invariant on a reachable
- * path is a compile error (the path-sensitive generalization of the constant check {@code 金額(-5)});
- * one it cannot prove is a warning (a possible abort — guard it, or reify the relation into a type
- * invariant). An invariant it cannot express is left opaque (no diagnostic; the run-time check stays),
- * so every flagged construction has a guard the domain can verify.
+ * The intraprocedural invariant-discharge check (spec §invariant-discharge). It walks a behavior's
+ * body threading what the guards have settled — a {@link NumericDomain} of relations and a
+ * {@link PredicateFacts} of everything that states no relation — seeded from the input types'
+ * invariants and refined along each {@code guard}/{@code if} guard (a {@code guard} is already an
+ * {@code if} here). At every construction whose invariant it can carry, it asks whether the guards
+ * <em>discharge</em> it. A construction proven to violate its invariant on a reachable path is a
+ * compile error (the path-sensitive generalization of the constant check {@code 金額(-5)}); one it
+ * cannot prove is a warning (a possible abort — guard it, or reify the relation into a type
+ * invariant). An invariant naming something it cannot name is left opaque (no diagnostic; the
+ * run-time check stays), so every flagged construction has a guard that discharges it.
  *
  * <p>The walk mirrors {@link TotalityChecker}: a {@code switch} over {@code Ast.Expr} threading an
  * immutable environment. It is fail-open — any internal error is swallowed so an analysis bug can
@@ -85,15 +87,36 @@ final class InvariantChecker {
         this.symbols = symbols;
     }
 
+    /** What the guards have settled on the current path: numeric relations, and predicates known to
+     * hold or to fail. Threaded functionally through the walk, as the domain alone once was. */
+    private record Known(NumericDomain numbers, PredicateFacts facts) {
+
+        static Known top() {
+            return new Known(NumericDomain.top(), PredicateFacts.none());
+        }
+
+        Known with(NumericDomain n) {
+            return new Known(n, facts);
+        }
+
+        Known with(PredicateFacts f) {
+            return new Known(numbers, f);
+        }
+
+        Known forgetIf(java.util.function.Predicate<String> drop) {
+            return new Known(numbers.forgetIf(drop), facts.forgetIf(drop));
+        }
+    }
+
     /** Analyzes one behavior body against its input types. Never throws. */
     static Findings analyze(Ast.Expr body, Map<String, Type> params, Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols);
         try {
-            NumericDomain d = NumericDomain.top();
+            Known k = Known.top();
             for (Map.Entry<String, Type> p : params.entrySet()) {
-                d = c.seedParam(p.getKey(), p.getValue(), d);
+                k = c.seedParam(p.getKey(), p.getValue(), k);
             }
-            c.walk(body, d, new HashMap<>(params));
+            c.walk(body, k, new HashMap<>(params));
         } catch (RuntimeException _) {
             // fail-open: the run-time invariant check remains the backstop
         }
@@ -102,52 +125,52 @@ final class InvariantChecker {
 
     // --- the walk ------------------------------------------------------------------------------
 
-    private void walk(Ast.Expr e, NumericDomain d, Map<String, Type> types) {
-        checkIfConstruction(e, d, types, false);
+    private void walk(Ast.Expr e, Known k, Map<String, Type> types) {
+        checkIfConstruction(e, k, types, false);
         switch (e) {
             case Ast.If iff -> {
-                walk(iff.cond(), d, types);
-                walk(iff.then(), assumeCond(iff.cond(), d, types, true), types);
-                walk(iff.els(), assumeCond(iff.cond(), d, types, false), types);
+                walk(iff.cond(), k, types);
+                walk(iff.then(), assumeCond(iff.cond(), k, types, true), types);
+                walk(iff.els(), assumeCond(iff.cond(), k, types, false), types);
             }
             case Ast.IfConstructed ic -> {
                 // The attempt's own construction cannot abort — a failing invariant is the else
                 // branch — so it is checked for a decided violation and never warned about as a
                 // possible one. Its field values are walked on their own so a construction nested
                 // inside an argument is still an ordinary, aborting one.
-                checkIfConstruction(ic.construct(), d, types, true);
-                Ast.forEachChild(ic.construct(), child -> walk(child, d, types));
+                checkIfConstruction(ic.construct(), k, types, true);
+                Ast.forEachChild(ic.construct(), child -> walk(child, k, types));
                 Map<String, Type> t2 = new HashMap<>(types);
-                NumericDomain d2 = rebind(d, ic.binder());
+                Known k2 = rebind(k, ic.binder());
                 Type built = typeExpr(ic.construct(), types);
                 if (built != null) {
                     t2.put(ic.binder(), built);
-                    d2 = seedParam(ic.binder(), built, d2);   // on this branch the invariant holds
+                    k2 = seedParam(ic.binder(), built, k2);   // on this branch the invariant holds
                 }
-                walk(ic.then(), d2, t2);
-                walk(ic.els(), d, types);
+                walk(ic.then(), k2, t2);
+                walk(ic.els(), k, types);
             }
             case Ast.LetIn li -> {
-                walk(li.value(), d, types);
+                walk(li.value(), k, types);
                 Map<String, Type> t2 = new HashMap<>(types);
                 Type vt = typeExpr(li.value(), types);
                 if (vt != null) {
                     t2.put(li.name(), vt);
                 }
                 LinearForm vf = affineOf(li.value(), types);
-                NumericDomain d2 = rebind(d, li.name());
+                Known k2 = rebind(k, li.name());
                 if (isNumeric(vt) && vf != null) {
-                    d2 = d2.assign(li.name(), vf);
+                    k2 = k2.with(k2.numbers().assign(li.name(), vf));
                 }
-                walk(li.body(), d2, t2);
+                walk(li.body(), k2, t2);
             }
             case Ast.Match m -> {
-                walk(m.scrutinee(), d, types);
+                walk(m.scrutinee(), k, types);
                 for (Ast.Case c : m.cases()) {
                     Map<String, Type> t2 = new HashMap<>(types);
-                    NumericDomain d2 = d;
+                    Known k2 = k;
                     if (c.binding() != null) {
-                        d2 = rebind(d, c.binding());
+                        k2 = rebind(k, c.binding());
                         if (c.caseTypes().size() == 1) {
                             Type bound = MatchElaborator.caseBindType(c.caseTypes().get(0).denotes());
                             if (bound != null) {
@@ -155,17 +178,17 @@ final class InvariantChecker {
                             }
                         }
                     }
-                    walk(c.body(), d2, t2);
+                    walk(c.body(), k2, t2);
                 }
             }
-            case Ast.Call call -> walkCall(call, d, types);
-            default -> Ast.forEachChild(e, child -> walk(child, d, types));
+            case Ast.Call call -> walkCall(call, k, types);
+            default -> Ast.forEachChild(e, child -> walk(child, k, types));
         }
     }
 
     /** Walks a call, binding a combinator closure's element parameter to the list's element type (and
      * seeding its invariant) so a construction inside the closure is analyzed rather than left opaque. */
-    private void walkCall(Ast.Call call, NumericDomain d, Map<String, Type> types) {
+    private void walkCall(Ast.Call call, Known k, Map<String, Type> types) {
         Combinator combo = COMBINATORS.get(call.fn());
         for (int i = 0; i < call.args().size(); i++) {
             Ast.Expr arg = call.args().get(i);
@@ -175,21 +198,21 @@ final class InvariantChecker {
                 Type elem = elementType(typeExpr(call.args().get(combo.listArg()), types));
                 Map<String, Type> t2 = new HashMap<>(types);
                 String p = step.params().get(combo.elementParam());
-                NumericDomain d2 = rebind(d, p);
+                Known k2 = rebind(k, p);
                 if (elem != null) {
                     t2.put(p, elem);
-                    d2 = seedParam(p, elem, d2);   // the element carries its type's invariant
+                    k2 = seedParam(p, elem, k2);   // the element carries its type's invariant
                 }
-                walk(step.body(), d2, t2);
+                walk(step.body(), k2, t2);
             } else {
-                walk(arg, d, types);
+                walk(arg, k, types);
             }
         }
     }
 
     // --- construction detection & discharge check ----------------------------------------------
 
-    private void checkIfConstruction(Ast.Expr e, NumericDomain d, Map<String, Type> types,
+    private void checkIfConstruction(Ast.Expr e, Known k, Map<String, Type> types,
                                      boolean attempted) {
         switch (e) {
             case Ast.NewData nd when nd.spreads().isEmpty() -> {
@@ -206,7 +229,7 @@ final class InvariantChecker {
                             paths.put(fi.name(), p);
                         }
                     }
-                    check(type, new Bindings(forms::get, paths::get), d, nd.pos(), attempted);
+                    check(type, new Bindings(forms::get, paths::get), k, nd.pos(), attempted);
                 }
             }
             case Ast.Binary bin when isArith(bin.op()) -> {
@@ -216,7 +239,7 @@ final class InvariantChecker {
                     if (value != null) {
                         // an arithmetic result is a form, not a location, so it names no path
                         check(type, new Bindings(name -> "value".equals(name) ? value : null, _ -> null),
-                                d, bin.pos(), attempted);
+                                k, bin.pos(), attempted);
                     }
                 }
             }
@@ -233,31 +256,36 @@ final class InvariantChecker {
      * {@code binds}. A definite violation is an error; an unproven one a warning; a fully-discharged
      * or non-expressible invariant is silent. An {@code attempted} construction raises no warning:
      * what the warning reports is a possible abort, and an attempt takes its else branch instead. */
-    private void check(Ast.Data type, Bindings binds, NumericDomain d, SourcePos pos,
-                       boolean attempted) {
+    private void check(Ast.Data type, Bindings binds, Known k, SourcePos pos, boolean attempted) {
         List<Ast.Expr> invs = TypeOps.effectiveInvariants(type, symbols);
         if (invs.isEmpty()) {
             return;
         }
-        List<Constraint> constraints = new ArrayList<>();
+        Obligations owed = Obligations.none();
         for (Ast.Expr inv : invs) {
-            List<Constraint> cs = invConstraints(inv, binds);
-            if (cs == null) {
-                return;   // some part is not expressible in the domain — leave the whole opaque
+            Obligations o = obligations(inv, binds);
+            if (o == null) {
+                return;   // some part is not expressible — leave the whole invariant opaque
             }
-            constraints.addAll(cs);
+            owed = owed.and(o);
         }
-        NumericDomain dom = withSizeBounds(d, constraints);
+        NumericDomain dom = withSizeBounds(k.numbers(), owed.numeric());
         boolean possible = false;
-        for (Constraint c : constraints) {
+        for (Constraint c : owed.numeric()) {
             if (dom.refutes(c.form(), c.rel())) {
-                errors.add(CompileException.of(
-                        Diagnostic.of("E2010", "check.invariant.violation").title("check.invariant.title")
-                                .at(pos).args(type.name()).build(),
-                        "constructing `" + type.name() + "` here violates its invariant on a reachable path"));
+                reportViolation(type, pos);
                 return;
             }
             if (!dom.entails(c.form(), c.rel())) {
+                possible = true;
+            }
+        }
+        for (Fact f : owed.predicates()) {
+            if (k.facts().refutes(f.key(), f.positive())) {
+                reportViolation(type, pos);
+                return;
+            }
+            if (!k.facts().entails(f.key(), f.positive())) {
                 possible = true;
             }
         }
@@ -269,32 +297,76 @@ final class InvariantChecker {
         }
     }
 
+    private void reportViolation(Ast.Data type, SourcePos pos) {
+        errors.add(CompileException.of(
+                Diagnostic.of("E2010", "check.invariant.violation").title("check.invariant.title")
+                        .at(pos).args(type.name()).build(),
+                "constructing `" + type.name() + "` here violates its invariant on a reachable path"));
+    }
+
     // --- invariant / condition -> constraints --------------------------------------------------
 
     private record Constraint(LinearForm form, Rel rel) {}
 
-    /** The constraints an invariant expression contributes under {@code binds} (field/{@code value}
-     * name -> what it is being given), or {@code null} if any part is not expressible. */
-    private List<Constraint> invConstraints(Ast.Expr inv, Bindings binds) {
-        if (inv instanceof Ast.Binary b && b.op() == Ast.BinOp.AND) {
-            List<Constraint> l = invConstraints(b.left(), binds);
-            List<Constraint> r = invConstraints(b.right(), binds);
-            if (l == null || r == null) {
-                return null;
-            }
-            List<Constraint> both = new ArrayList<>(l);
-            both.addAll(r);
-            return both;
+    /** A predicate stated of a term, by the term's canonical key. {@code positive} is false for a
+     * clause written under {@code Bool.not}. */
+    private record Fact(String key, boolean positive) {}
+
+    /** What a construction owes: numeric relations the domain must prove, and predicates the guards
+     * must have settled. */
+    private record Obligations(List<Constraint> numeric, List<Fact> predicates) {
+
+        private static final Obligations NONE = new Obligations(List.of(), List.of());
+
+        static Obligations none() {
+            return NONE;
         }
-        if (inv instanceof Ast.Binary b) {
-            Rel rel = relOf(b.op());
-            if (rel != null) {
-                LinearForm la = affine(b.left(), resolveLeaf(binds));
-                LinearForm ra = affine(b.right(), resolveLeaf(binds));
-                return la == null || ra == null ? null : List.of(new Constraint(la.minus(ra), rel));
+
+        static Obligations of(Constraint c) {
+            return new Obligations(List.of(c), List.of());
+        }
+
+        static Obligations of(Fact f) {
+            return new Obligations(List.of(), List.of(f));
+        }
+
+        Obligations and(Obligations o) {
+            List<Constraint> n = new ArrayList<>(numeric);
+            n.addAll(o.numeric);
+            List<Fact> p = new ArrayList<>(predicates);
+            p.addAll(o.predicates);
+            return new Obligations(n, p);
+        }
+    }
+
+    /** What an invariant expression owes under {@code binds} (field/{@code value} name -> what it is
+     * being given), or {@code null} if it names nothing this check can carry. A comparison the domain
+     * can express is owed to the domain; anything else is owed as a fact, which a guard stating the
+     * same thing of the same term settles. */
+    private Obligations obligations(Ast.Expr inv, Bindings binds) {
+        return obligations(inv, binds, true);
+    }
+
+    private Obligations obligations(Ast.Expr inv, Bindings binds, boolean positive) {
+        if (inv instanceof Ast.Binary b && b.op() == Ast.BinOp.AND && positive) {
+            Obligations l = obligations(b.left(), binds, true);
+            Obligations r = obligations(b.right(), binds, true);
+            return l == null || r == null ? null : l.and(r);
+        }
+        if (inv instanceof Ast.Binary b && relOf(b.op()) != null) {
+            Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
+            LinearForm la = eff == null ? null : affine(b.left(), resolveLeaf(binds));
+            LinearForm ra = eff == null ? null : affine(b.right(), resolveLeaf(binds));
+            if (la != null && ra != null) {
+                return Obligations.of(new Constraint(la.minus(ra), eff));
             }
         }
-        return null;
+        Ast.Expr under = negated(inv);
+        if (under != null) {
+            return obligations(under, binds, !positive);
+        }
+        String key = termKey(inv, e -> invPath(e, binds), Map.of(), 0);
+        return key == null ? null : Obligations.of(new Fact(key, positive));
     }
 
     /** The domain told that every size atom the constraints name is non-negative. The atom enters the
@@ -312,39 +384,61 @@ final class InvariantChecker {
         return out;
     }
 
-    /** Refines {@code d} by asserting {@code cond} (or its negation). Non-comparison conditions and
-     * non-affine operands leave the domain unchanged (sound). */
-    private NumericDomain assumeCond(Ast.Expr cond, NumericDomain d, Map<String, Type> types, boolean positive) {
-        if (cond instanceof Ast.Binary b && b.op() == Ast.BinOp.AND && positive) {
-            return assumeCond(b.right(), assumeCond(b.left(), d, types, true), types, true);
+    /** Refines {@code k} by asserting {@code cond} (or its negation): a comparison tightens the
+     * numeric domain, a stdlib predicate settles a fact. A condition of neither shape, and an operand
+     * outside the affine fragment, leave {@code k} unchanged (sound). */
+    private Known assumeCond(Ast.Expr cond, Known k, Map<String, Type> types, boolean positive) {
+        // `&&` asserted true gives both sides; `||` asserted false gives both sides negated.
+        if (cond instanceof Ast.Binary b
+                && (b.op() == Ast.BinOp.AND && positive || b.op() == Ast.BinOp.OR && !positive)) {
+            return assumeCond(b.right(), assumeCond(b.left(), k, types, positive), types, positive);
         }
         if (cond instanceof Ast.Binary b) {
             Rel rel = relOf(b.op());
-            if (rel != null) {
+            Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
+            if (eff != null) {
                 LinearForm la = affineOf(b.left(), types);
                 LinearForm ra = affineOf(b.right(), types);
-                Rel eff = positive ? rel : negateRel(rel);
-                if (la != null && ra != null && eff != null) {
-                    return d.assume(la.minus(ra), eff);
+                if (la != null && ra != null) {
+                    return k.with(k.numbers().assume(la.minus(ra), eff));
                 }
             }
         }
-        return d;
+        Ast.Expr under = negated(cond);
+        if (under != null) {
+            return assumeCond(under, k, types, !positive);
+        }
+        String key = termKey(cond, e -> pathKey(e, types), Map.of(), 0);
+        return key == null ? k : k.with(k.facts().assume(key, positive));
+    }
+
+    /** What a negation is applied to, or {@code null} if {@code e} is not one. {@code Bool.not} is an
+     * ordinary helper, so by here it is the body it expands to — {@code if b then false else true},
+     * over a binding holding the argument. */
+    private static Ast.Expr negated(Ast.Expr e) {
+        if (e instanceof Ast.LetIn li) {
+            Ast.Expr inner = negated(li.body());
+            return inner instanceof Ast.Var v && v.name().equals(li.name()) ? li.value() : null;
+        }
+        return e instanceof Ast.If iff
+                && iff.then() instanceof Ast.BoolLit t && !t.value()
+                && iff.els() instanceof Ast.BoolLit f && f.value()
+                ? iff.cond() : null;
     }
 
     // --- seeding -------------------------------------------------------------------------------
 
-    /** Seeds the domain with what a parameter's type guarantees: a numeric newtype's own invariant on
-     * its value, or a product data's invariant over its fields (and one level of numeric-newtype
-     * fields), each substituted onto the parameter's atom(s). Sound by closed construction — an input
-     * of type T was built through T's checked constructor. */
-    private NumericDomain seedParam(String name, Type t, NumericDomain d) {
-        return seedAt(name, t, d, 0);
+    /** Seeds the check with what a parameter's type guarantees: a numeric newtype's own invariant on
+     * its value, a predicate its invariant states of it, or a product data's invariant over its fields
+     * (and one level of fields), each substituted onto the parameter's own term. Sound by closed
+     * construction — an input of type T was built through T's checked constructor. */
+    private Known seedParam(String name, Type t, Known k) {
+        return seedAt(name, t, k, 0);
     }
 
-    private NumericDomain seedAt(String path, Type t, NumericDomain d, int depth) {
+    private Known seedAt(String path, Type t, Known k, int depth) {
         if (depth > 2 || !(t instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)) {
-            return d;
+            return k;
         }
         Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
         Function<String, String> resolvePath = fieldName -> {
@@ -359,12 +453,20 @@ final class InvariantChecker {
                     return p == null ? null : LinearForm.atom(p);
                 },
                 resolvePath);
-        NumericDomain out = d;
+        Known out = k;
+        // Each conjunct on its own: an input's invariant is a set of things that hold, and one the
+        // check cannot express does not cost it the others.
         for (Ast.Expr inv : TypeOps.effectiveInvariants(data, symbols)) {
-            List<Constraint> cs = invConstraints(inv, binds);
-            if (cs != null) {
-                for (Constraint c : cs) {
-                    out = out.assume(c.form(), c.rel());
+            for (Ast.Expr conjunct : conjuncts(inv)) {
+                Obligations o = obligations(conjunct, binds);
+                if (o == null) {
+                    continue;
+                }
+                for (Constraint c : o.numeric()) {
+                    out = out.with(out.numbers().assume(c.form(), c.rel()));
+                }
+                for (Fact f : o.predicates()) {
+                    out = out.with(out.facts().assume(f.key(), f.positive()));
                 }
             }
         }
@@ -479,6 +581,109 @@ final class InvariantChecker {
         return arg == null ? null : call.fn() + "(" + arg + ")";
     }
 
+    /** The conjuncts of an invariant expression, flattened. */
+    private static List<Ast.Expr> conjuncts(Ast.Expr e) {
+        if (e instanceof Ast.Binary b && b.op() == Ast.BinOp.AND) {
+            List<Ast.Expr> out = new ArrayList<>(conjuncts(b.left()));
+            out.addAll(conjuncts(b.right()));
+            return out;
+        }
+        return List.of(e);
+    }
+
+    /**
+     * The canonical key of an expression as a term, or {@code null} when nothing here can be named.
+     * Two expressions with one key compute one value, which is the whole of what the fact set knows:
+     * a guard and an invariant clause state the same predicate exactly when their calls key alike.
+     *
+     * <p>A location is asked of {@code site} — the body's path rule, or the invariant's rule for what
+     * a field is being given — so the two sides meet on the construction's own names. A closure
+     * parameter is keyed by where it is bound rather than by its spelling, so {@code r -> r.a} and
+     * {@code row -> row.a} are one term while a free name inside the closure is still resolved
+     * through {@code site} and so is part of the term. Anything outside this grammar keys as
+     * {@code null}, and the clause reading it is left opaque.
+     */
+    private String termKey(Ast.Expr e, Function<Ast.Expr, String> site, Map<String, String> bound,
+                           int depth) {
+        String root = rootName(e);
+        if (root != null) {
+            String at = bound.get(root);
+            return at != null ? chainOn(at, e) : site.apply(e);
+        }
+        return switch (e) {
+            case Ast.IntLit i -> Long.toString(i.value());
+            case Ast.DecimalLit d -> d.value().toPlainString() + "m";
+            case Ast.StringLit s -> "\"" + s.value() + "\"";
+            case Ast.BoolLit b -> Boolean.toString(b.value());
+            case Ast.Neg n -> wrap("-", termKey(n.operand(), site, bound, depth));
+            case Ast.Binary b -> {
+                String l = termKey(b.left(), site, bound, depth);
+                String r = termKey(b.right(), site, bound, depth);
+                yield l == null || r == null ? null : "(" + l + " " + b.op() + " " + r + ")";
+            }
+            case Ast.ListLit l -> elementsKey("[", l.elements(), site, bound, depth, "]");
+            case Ast.Tuple t -> elementsKey("(", t.elements(), site, bound, depth, ")");
+            case Ast.TupleGet g -> wrap("." + g.index(), termKey(g.tuple(), site, bound, depth));
+            case Ast.If iff -> elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
+                    site, bound, depth, ")");
+            case Ast.Block b -> {
+                Map<String, String> inner = binding(bound, b.params(), depth);
+                yield wrap("\\" + b.params().size(), termKey(b.body(), site, inner, depth + 1));
+            }
+            case Ast.LetIn li -> {
+                String value = termKey(li.value(), site, bound, depth);
+                Map<String, String> inner = binding(bound, List.of(li.name()), depth);
+                String body = termKey(li.body(), site, inner, depth + 1);
+                yield value == null || body == null ? null : "let(" + value + ", " + body + ")";
+            }
+            // Only the library's own functions: they are pure, so one written call is one value.
+            case Ast.Call c when Prelude.hasQualified(c.fn()) ->
+                    elementsKey(c.fn() + "(", c.args(), site, bound, depth, ")");
+            default -> null;
+        };
+    }
+
+    /** {@code bound} with each of {@code names} keyed by where it is bound rather than by its
+     * spelling, so two expressions that differ only in what they called a binding are one term. */
+    private static Map<String, String> binding(Map<String, String> bound, List<String> names, int depth) {
+        Map<String, String> inner = new HashMap<>(bound);
+        for (int i = 0; i < names.size(); i++) {
+            inner.put(names.get(i), "#" + depth + "." + i);
+        }
+        return inner;
+    }
+
+    private String elementsKey(String open, List<Ast.Expr> parts, Function<Ast.Expr, String> site,
+                               Map<String, String> bound, int depth, String close) {
+        StringBuilder sb = new StringBuilder(open);
+        for (int i = 0; i < parts.size(); i++) {
+            String part = termKey(parts.get(i), site, bound, depth);
+            if (part == null) {
+                return null;
+            }
+            sb.append(i == 0 ? "" : ", ").append(part);
+        }
+        return sb.append(close).toString();
+    }
+
+    private static String wrap(String prefix, String inner) {
+        return inner == null ? null : prefix + "(" + inner + ")";
+    }
+
+    /** The name at the head of a {@code x}/{@code x.a.b} chain, or {@code null} if {@code e} is not one. */
+    private static String rootName(Ast.Expr e) {
+        return switch (e) {
+            case Ast.Var v -> v.name();
+            case Ast.FieldAccess fa -> rootName(fa.target());
+            default -> null;
+        };
+    }
+
+    /** The field chain of {@code e} rebuilt on {@code head}. */
+    private static String chainOn(String head, Ast.Expr e) {
+        return e instanceof Ast.FieldAccess fa ? chainOn(head, fa.target()) + "." + fa.field() : head;
+    }
+
     private static boolean isSizeAtom(String atom) {
         int open = atom.indexOf('(');
         return open > 0 && atom.endsWith(")") && SIZE_CALLS.contains(atom.substring(0, open));
@@ -499,15 +704,25 @@ final class InvariantChecker {
         };
     }
 
-    /** The domain with every fact rooted at {@code name} dropped, because a binding of that name makes
-     * it denote something else. An atom is rooted at a name when it is the name, a field chain from
-     * it, or a size call over one. */
-    private static NumericDomain rebind(NumericDomain d, String name) {
-        return d.forgetIf(atom -> {
-            int open = atom.indexOf('(');
-            String path = isSizeAtom(atom) ? atom.substring(open + 1, atom.length() - 1) : atom;
-            return path.equals(name) || path.startsWith(name + ".");
-        });
+    /** What is known after a binding takes over {@code name}: everything that mentioned it is dropped,
+     * because the name now denotes something else. The test is on the key's text and errs towards
+     * dropping — a term that merely reads like it mentions the name loses a fact it could have kept,
+     * which costs precision and never soundness. */
+    private static Known rebind(Known k, String name) {
+        return k.forgetIf(key -> mentions(key, name));
+    }
+
+    /** Whether {@code key} contains {@code name} as a whole identifier. */
+    private static boolean mentions(String key, String name) {
+        for (int i = key.indexOf(name); i >= 0; i = key.indexOf(name, i + 1)) {
+            int end = i + name.length();
+            boolean left = i == 0 || !Character.isUnicodeIdentifierPart(key.charAt(i - 1));
+            boolean right = end == key.length() || !Character.isUnicodeIdentifierPart(key.charAt(end));
+            if (left && right) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // --- a minimal local typer (enough for atom/affine detection) ------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -68,6 +69,14 @@ final class InvariantChecker {
             Map.entry("Set.partition", new Combinator(0, 0, 1)),
             Map.entry("Option.map", new Combinator(0, 0, 1)));
 
+    /** The pure, total stdlib calls whose result is a number the domain can name: the size of a
+     * container or a string. Each becomes an atom keyed by the call written over its argument's path
+     * — {@code List.length(b.items)} — so an invariant clause and a guard naming the same container
+     * name the same atom, and the guard discharges the clause. The argument must be a nameable path:
+     * {@code List.length(List.map(f, xs))} is not this atom, and nothing relates the two. */
+    private static final Set<String> SIZE_CALLS =
+            Set.of("List.length", "String.length", "Set.size", "Map.size");
+
     private final Symbols symbols;
     private final List<CompileException> errors = new ArrayList<>();
     private final List<Diagnostic> warnings = new ArrayList<>();
@@ -109,11 +118,11 @@ final class InvariantChecker {
                 checkIfConstruction(ic.construct(), d, types, true);
                 Ast.forEachChild(ic.construct(), child -> walk(child, d, types));
                 Map<String, Type> t2 = new HashMap<>(types);
-                NumericDomain d2 = d;
+                NumericDomain d2 = rebind(d, ic.binder());
                 Type built = typeExpr(ic.construct(), types);
                 if (built != null) {
                     t2.put(ic.binder(), built);
-                    d2 = seedParam(ic.binder(), built, d);   // on this branch the invariant holds
+                    d2 = seedParam(ic.binder(), built, d2);   // on this branch the invariant holds
                 }
                 walk(ic.then(), d2, t2);
                 walk(ic.els(), d, types);
@@ -126,20 +135,27 @@ final class InvariantChecker {
                     t2.put(li.name(), vt);
                 }
                 LinearForm vf = affineOf(li.value(), types);
-                NumericDomain d2 = isNumeric(vt) && vf != null ? d.assign(li.name(), vf) : d;
+                NumericDomain d2 = rebind(d, li.name());
+                if (isNumeric(vt) && vf != null) {
+                    d2 = d2.assign(li.name(), vf);
+                }
                 walk(li.body(), d2, t2);
             }
             case Ast.Match m -> {
                 walk(m.scrutinee(), d, types);
                 for (Ast.Case c : m.cases()) {
                     Map<String, Type> t2 = new HashMap<>(types);
-                    if (c.binding() != null && c.caseTypes().size() == 1) {
-                        Type bound = MatchElaborator.caseBindType(c.caseTypes().get(0).denotes());
-                        if (bound != null) {
-                            t2.put(c.binding(), bound);
+                    NumericDomain d2 = d;
+                    if (c.binding() != null) {
+                        d2 = rebind(d, c.binding());
+                        if (c.caseTypes().size() == 1) {
+                            Type bound = MatchElaborator.caseBindType(c.caseTypes().get(0).denotes());
+                            if (bound != null) {
+                                t2.put(c.binding(), bound);
+                            }
                         }
                     }
-                    walk(c.body(), d, t2);
+                    walk(c.body(), d2, t2);
                 }
             }
             case Ast.Call call -> walkCall(call, d, types);
@@ -158,11 +174,11 @@ final class InvariantChecker {
                     && combo.listArg() < call.args().size()) {
                 Type elem = elementType(typeExpr(call.args().get(combo.listArg()), types));
                 Map<String, Type> t2 = new HashMap<>(types);
-                NumericDomain d2 = d;
+                String p = step.params().get(combo.elementParam());
+                NumericDomain d2 = rebind(d, p);
                 if (elem != null) {
-                    String p = step.params().get(combo.elementParam());
                     t2.put(p, elem);
-                    d2 = seedParam(p, elem, d);   // the element carries its type's invariant
+                    d2 = seedParam(p, elem, d2);   // the element carries its type's invariant
                 }
                 walk(step.body(), d2, t2);
             } else {
@@ -178,14 +194,19 @@ final class InvariantChecker {
         switch (e) {
             case Ast.NewData nd when nd.spreads().isEmpty() -> {
                 if (symbols.get(nd.typeName().denotes()) instanceof Ast.Data type) {
-                    Map<String, LinearForm> fields = new HashMap<>();
+                    Map<String, LinearForm> forms = new HashMap<>();
+                    Map<String, String> paths = new HashMap<>();
                     for (Ast.FieldInit fi : nd.inits()) {
                         LinearForm f = affineOf(fi.value(), types);
                         if (f != null) {
-                            fields.put(fi.name(), f);
+                            forms.put(fi.name(), f);
+                        }
+                        String p = pathKey(fi.value(), types);
+                        if (p != null) {
+                            paths.put(fi.name(), p);
                         }
                     }
-                    check(type, fields::get, d, nd.pos(), attempted);
+                    check(type, new Bindings(forms::get, paths::get), d, nd.pos(), attempted);
                 }
             }
             case Ast.Binary bin when isArith(bin.op()) -> {
@@ -193,7 +214,9 @@ final class InvariantChecker {
                         && symbols.get(r.name()) instanceof Ast.Data type && type.newtype()) {
                     LinearForm value = affineOf(bin, types);
                     if (value != null) {
-                        check(type, name -> "value".equals(name) ? value : null, d, bin.pos(), attempted);
+                        // an arithmetic result is a form, not a location, so it names no path
+                        check(type, new Bindings(name -> "value".equals(name) ? value : null, _ -> null),
+                                d, bin.pos(), attempted);
                     }
                 }
             }
@@ -201,11 +224,16 @@ final class InvariantChecker {
         }
     }
 
+    /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
+     * field is being given, and to that value's canonical path — so a size call over the field names
+     * the same atom the body names when it calls the same function on the same container. */
+    private record Bindings(Function<String, LinearForm> form, Function<String, String> path) {}
+
     /** Runs the discharge check for a construction of {@code type} whose field values resolve through
-     * {@code resolve}. A definite violation is an error; an unproven one a warning; a fully-discharged
+     * {@code binds}. A definite violation is an error; an unproven one a warning; a fully-discharged
      * or non-expressible invariant is silent. An {@code attempted} construction raises no warning:
      * what the warning reports is a possible abort, and an attempt takes its else branch instead. */
-    private void check(Ast.Data type, Function<String, LinearForm> resolve, NumericDomain d, SourcePos pos,
+    private void check(Ast.Data type, Bindings binds, NumericDomain d, SourcePos pos,
                        boolean attempted) {
         List<Ast.Expr> invs = TypeOps.effectiveInvariants(type, symbols);
         if (invs.isEmpty()) {
@@ -213,22 +241,23 @@ final class InvariantChecker {
         }
         List<Constraint> constraints = new ArrayList<>();
         for (Ast.Expr inv : invs) {
-            List<Constraint> cs = invConstraints(inv, resolve);
+            List<Constraint> cs = invConstraints(inv, binds);
             if (cs == null) {
                 return;   // some part is not expressible in the domain — leave the whole opaque
             }
             constraints.addAll(cs);
         }
+        NumericDomain dom = withSizeBounds(d, constraints);
         boolean possible = false;
         for (Constraint c : constraints) {
-            if (d.refutes(c.form(), c.rel())) {
+            if (dom.refutes(c.form(), c.rel())) {
                 errors.add(CompileException.of(
                         Diagnostic.of("E2010", "check.invariant.violation").title("check.invariant.title")
                                 .at(pos).args(type.name()).build(),
                         "constructing `" + type.name() + "` here violates its invariant on a reachable path"));
                 return;
             }
-            if (!d.entails(c.form(), c.rel())) {
+            if (!dom.entails(c.form(), c.rel())) {
                 possible = true;
             }
         }
@@ -244,12 +273,12 @@ final class InvariantChecker {
 
     private record Constraint(LinearForm form, Rel rel) {}
 
-    /** The constraints an invariant expression contributes under {@code resolve} (field/{@code value}
-     * name -> its affine form), or {@code null} if any part is not expressible. */
-    private List<Constraint> invConstraints(Ast.Expr inv, Function<String, LinearForm> resolve) {
+    /** The constraints an invariant expression contributes under {@code binds} (field/{@code value}
+     * name -> what it is being given), or {@code null} if any part is not expressible. */
+    private List<Constraint> invConstraints(Ast.Expr inv, Bindings binds) {
         if (inv instanceof Ast.Binary b && b.op() == Ast.BinOp.AND) {
-            List<Constraint> l = invConstraints(b.left(), resolve);
-            List<Constraint> r = invConstraints(b.right(), resolve);
+            List<Constraint> l = invConstraints(b.left(), binds);
+            List<Constraint> r = invConstraints(b.right(), binds);
             if (l == null || r == null) {
                 return null;
             }
@@ -260,12 +289,27 @@ final class InvariantChecker {
         if (inv instanceof Ast.Binary b) {
             Rel rel = relOf(b.op());
             if (rel != null) {
-                LinearForm la = affine(b.left(), resolveLeaf(resolve));
-                LinearForm ra = affine(b.right(), resolveLeaf(resolve));
+                LinearForm la = affine(b.left(), resolveLeaf(binds));
+                LinearForm ra = affine(b.right(), resolveLeaf(binds));
                 return la == null || ra == null ? null : List.of(new Constraint(la.minus(ra), rel));
             }
         }
         return null;
+    }
+
+    /** The domain told that every size atom the constraints name is non-negative. The atom enters the
+     * domain only through the clause naming it, so without this the fact a container's size is never
+     * negative is not available to discharge a clause that asks only for that. */
+    private static NumericDomain withSizeBounds(NumericDomain d, List<Constraint> constraints) {
+        NumericDomain out = d;
+        for (Constraint c : constraints) {
+            for (String atom : c.form().coefs().keySet()) {
+                if (isSizeAtom(atom)) {
+                    out = out.assume(LinearForm.atom(atom), Rel.GE);
+                }
+            }
+        }
+        return out;
     }
 
     /** Refines {@code d} by asserting {@code cond} (or its negation). Non-comparison conditions and
@@ -303,15 +347,21 @@ final class InvariantChecker {
             return d;
         }
         Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
-        Function<String, LinearForm> resolve = fieldName -> {
+        Function<String, String> resolvePath = fieldName -> {
             if (data.newtype() && fieldName.equals("value")) {
-                return LinearForm.atom(path);
+                return path;
             }
-            return fields.containsKey(fieldName) ? LinearForm.atom(path + "." + fieldName) : null;
+            return fields.containsKey(fieldName) ? path + "." + fieldName : null;
         };
+        Bindings binds = new Bindings(
+                fieldName -> {
+                    String p = resolvePath.apply(fieldName);
+                    return p == null ? null : LinearForm.atom(p);
+                },
+                resolvePath);
         NumericDomain out = d;
         for (Ast.Expr inv : TypeOps.effectiveInvariants(data, symbols)) {
-            List<Constraint> cs = invConstraints(inv, resolve);
+            List<Constraint> cs = invConstraints(inv, binds);
             if (cs != null) {
                 for (Constraint c : cs) {
                     out = out.assume(c.form(), c.rel());
@@ -373,9 +423,29 @@ final class InvariantChecker {
         });
     }
 
-    /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}. */
-    private static Function<Ast.Expr, LinearForm> resolveLeaf(Function<String, LinearForm> resolve) {
-        return n -> n instanceof Ast.Var v ? resolve.apply(v.name()) : null;
+    /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}, and
+     * a size call over one to that container's size atom. */
+    private static Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
+        return n -> {
+            String size = sizeAtom(n, arg -> invPath(arg, binds));
+            if (size != null) {
+                return LinearForm.atom(size);
+            }
+            return n instanceof Ast.Var v ? binds.form().apply(v.name()) : null;
+        };
+    }
+
+    /** The path an invariant expression names at the construction site: a bare field name through the
+     * bindings, then plain field steps. */
+    private static String invPath(Ast.Expr e, Bindings binds) {
+        return switch (e) {
+            case Ast.Var v -> binds.path().apply(v.name());
+            case Ast.FieldAccess fa -> {
+                String base = invPath(fa.target(), binds);
+                yield base == null ? null : base + "." + fa.field();
+            }
+            default -> null;
+        };
     }
 
     private static LinearForm negate(LinearForm f) {
@@ -389,24 +459,55 @@ final class InvariantChecker {
         return subtract ? a.minus(b) : a.plus(b);
     }
 
-    /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value), or
-     * {@code null} if {@code e} is not one. */
+    /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value) or of
+     * a size call over a nameable container, or {@code null} if {@code e} is neither. */
     private String atomOf(Ast.Expr e, Map<String, Type> types) {
+        String size = sizeAtom(e, arg -> pathKey(arg, types));
+        if (size != null) {
+            return size;
+        }
         return isNumeric(typeExpr(e, types)) ? pathKey(e, types) : null;
+    }
+
+    /** The atom key of {@code SIZE_CALL(container)} when {@code path} can name the container, else
+     * {@code null}. */
+    private static String sizeAtom(Ast.Expr e, Function<Ast.Expr, String> path) {
+        if (!(e instanceof Ast.Call call) || !SIZE_CALLS.contains(call.fn()) || call.args().size() != 1) {
+            return null;
+        }
+        String arg = path.apply(call.args().get(0));
+        return arg == null ? null : call.fn() + "(" + arg + ")";
+    }
+
+    private static boolean isSizeAtom(String atom) {
+        int open = atom.indexOf('(');
+        return open > 0 && atom.endsWith(")") && SIZE_CALLS.contains(atom.substring(0, open));
     }
 
     private String pathKey(Ast.Expr e, Map<String, Type> types) {
         return switch (e) {
             case Ast.Var v -> v.name();
             case Ast.FieldAccess fa -> {
-                if (fa.field().equals("value") && numericNewtype(typeExpr(fa.target(), types))) {
-                    yield pathKey(fa.target(), types);   // a newtype's .value is the same atom
+                Type owner = typeExpr(fa.target(), types);
+                if (fa.field().equals("value") && TypeOps.isSingleValueNewtype(owner, symbols)) {
+                    yield pathKey(fa.target(), types);   // a newtype's .value is the same location
                 }
                 String base = pathKey(fa.target(), types);
                 yield base == null ? null : base + "." + fa.field();
             }
             default -> null;
         };
+    }
+
+    /** The domain with every fact rooted at {@code name} dropped, because a binding of that name makes
+     * it denote something else. An atom is rooted at a name when it is the name, a field chain from
+     * it, or a size call over one. */
+    private static NumericDomain rebind(NumericDomain d, String name) {
+        return d.forgetIf(atom -> {
+            int open = atom.indexOf('(');
+            String path = isSizeAtom(atom) ? atom.substring(open + 1, atom.length() - 1) : atom;
+            return path.equals(name) || path.startsWith(name + ".");
+        });
     }
 
     // --- a minimal local typer (enough for atom/affine detection) ------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -626,7 +626,7 @@ final class InvariantChecker {
         return switch (e) {
             case Ast.IntLit i -> Long.toString(i.value());
             case Ast.DecimalLit d -> d.value().toPlainString() + "m";
-            case Ast.StringLit s -> "\"" + s.value() + "\"";
+            case Ast.StringLit s -> quoted(s.value());
             case Ast.BoolLit b -> Boolean.toString(b.value());
             case Ast.Neg n -> wrap("-", termKey(n.operand(), site, bound, depth));
             case Ast.Binary b -> {
@@ -677,6 +677,12 @@ final class InvariantChecker {
             sb.append(i == 0 ? "" : ", ").append(part);
         }
         return sb.append(close).toString();
+    }
+
+    /** A string value written into a key with the punctuation the key itself uses escaped, so a value
+     * holding a quote or a comma cannot be read back as a different expression. */
+    private static String quoted(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
     }
 
     private static String wrap(String prefix, String inner) {

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -247,15 +247,25 @@ final class NumericDomain {
     }
 
     private NumericDomain forget(String atom) {
+        return forgetIf(atom::equals);
+    }
+
+    /** The domain with every fact about a matching atom dropped. A binding that rebinds a name
+     * invalidates each atom rooted at it — the name now denotes something else — and the caller,
+     * which owns the atom-key syntax, decides which those are. */
+    NumericDomain forgetIf(java.util.function.Predicate<String> drop) {
+        if (bottom) {
+            return this;
+        }
         Map<String, BigDecimal> nlo = new HashMap<>(lo);
         Map<String, BigDecimal> nhi = new HashMap<>(hi);
-        nlo.remove(atom);
-        nhi.remove(atom);
+        nlo.keySet().removeIf(drop);
+        nhi.keySet().removeIf(drop);
         Map<String, Map<String, BigDecimal>> nd = new HashMap<>();
         diff.forEach((a, row) -> {
-            if (!a.equals(atom)) {
+            if (!drop.test(a)) {
                 Map<String, BigDecimal> nr = new HashMap<>(row);
-                nr.remove(atom);
+                nr.keySet().removeIf(drop);
                 if (!nr.isEmpty()) {
                     nd.put(a, nr);
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -1,8 +1,10 @@
 package souther.compiler.check;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -15,11 +17,11 @@ import java.util.Set;
  * <p>This is the decision procedure the invariant-discharge check runs on: {@link #assume} tightens
  * the domain along a {@code guard}/{@code if} guard or an input newtype's invariant, and
  * {@link #entails} / {@link #refutes} answer whether a construction's invariant is discharged or is
- * definitely violated on the current path. It is deliberately bounded to interval + difference-bound;
- * an invariant the checker cannot express here is left opaque (its runtime check stays), so the set of
- * facts it can prove is exactly the set of guards a user can write to discharge them (spec
- * §invariant-discharge). Instances are immutable — each operation returns a fresh domain, threaded
- * functionally like {@code TotalityChecker}'s scope map.
+ * definitely violated on the current path. What it derives is bounded to interval + difference-bound;
+ * a form of neither shape is kept as it was written, so a guard restating an invariant still
+ * discharges it even where nothing can be derived from the two together (spec §invariant-discharge).
+ * Instances are immutable — each operation returns a fresh domain, threaded functionally like
+ * {@code TotalityChecker}'s scope map.
  */
 final class NumericDomain {
 
@@ -64,21 +66,27 @@ final class NumericDomain {
         }
     }
 
+    /** A form asserted {@code f <= 0} (or {@code f < 0}) and kept as written, because its shape is
+     * neither an interval nor a difference. */
+    private record Asserted(LinearForm f, boolean strict) {}
+
     private final boolean bottom;                              // an infeasible path (guards contradict)
     private final Map<String, BigDecimal> lo;                  // atom -> lower bound (null key absent = -inf)
     private final Map<String, BigDecimal> hi;                  // atom -> upper bound (absent = +inf)
     private final Map<String, Map<String, BigDecimal>> diff;   // diff[a][b] = tightest known (a - b)
+    private final List<Asserted> kept;                         // forms outside both shapes, as written
 
     private NumericDomain(boolean bottom, Map<String, BigDecimal> lo, Map<String, BigDecimal> hi,
-                          Map<String, Map<String, BigDecimal>> diff) {
+                          Map<String, Map<String, BigDecimal>> diff, List<Asserted> kept) {
         this.bottom = bottom;
         this.lo = lo;
         this.hi = hi;
         this.diff = diff;
+        this.kept = kept;
     }
 
     static NumericDomain top() {
-        return new NumericDomain(false, Map.of(), Map.of(), Map.of());
+        return new NumericDomain(false, Map.of(), Map.of(), Map.of(), List.of());
     }
 
     boolean isBottom() {
@@ -87,8 +95,7 @@ final class NumericDomain {
 
     // --- assume: tighten along `f rel 0` -------------------------------------------------------
 
-    /** The domain refined by asserting {@code f rel 0}. Non-difference, non-interval forms are not
-     * representable and leave the domain unchanged (sound: it stays weaker, never wrongly tighter). */
+    /** The domain refined by asserting {@code f rel 0}. */
     NumericDomain assume(LinearForm f, Rel rel) {
         if (bottom) {
             return this;
@@ -100,10 +107,10 @@ final class NumericDomain {
         return addLe(negOf(rel) ? f.negate() : f, strictOf(rel));
     }
 
-    /** Assert {@code g <= 0} (or {@code g < 0} when strict), updating an interval or a difference. A
-     * form outside the interval/difference fragment is not representable and leaves the domain
-     * unchanged (sound). Strictness only sharpens the constant case; for an interval or difference a
-     * strict {@code < 0} is recorded as {@code <= 0} (weaker, so still sound). */
+    /** Assert {@code g <= 0} (or {@code g < 0} when strict), updating an interval or a difference, or
+     * keeping the form as written when it is neither. Strictness only sharpens the constant case; for
+     * an interval or difference a strict {@code < 0} is recorded as {@code <= 0} (weaker, so still
+     * sound). */
     private NumericDomain addLe(LinearForm g, boolean strict) {
         Map<String, BigDecimal> c = g.coefs();
         if (c.isEmpty()) {
@@ -128,7 +135,11 @@ final class NumericDomain {
         if (ab != null) {
             return withDiff(ab[0], ab[1], g.constant().negate());   // a - b <= -const
         }
-        return this;   // not representable — leave unchanged (sound)
+        // Neither shape holds it — a sum of two lengths, say. Keeping the form as written is what lets
+        // a guard restating an invariant discharge it, which is the promise the flagging rests on.
+        List<Asserted> next = new ArrayList<>(kept);
+        next.add(new Asserted(g, strict));
+        return new NumericDomain(false, lo, hi, diff, List.copyOf(next));
     }
 
     /** The two atoms of a unit difference {@code {a:+1, b:-1}} as {@code {a, b}}, or {@code null} if
@@ -204,6 +215,18 @@ final class NumericDomain {
                 }
             }
         }
+        // A form kept as written proves `g <= 0` when g is that form plus a constant no greater than
+        // zero: asserting `f <= 0` gives `f + c <= 0` for every `c <= 0`.
+        for (Asserted a : kept) {
+            LinearForm slack = g.minus(a.f());
+            if (!slack.coefs().isEmpty()) {
+                continue;
+            }
+            int s = slack.constant().signum();
+            if (s < 0 || (s == 0 && (!strict || a.strict()))) {
+                return true;
+            }
+        }
         return false;
     }
 
@@ -271,26 +294,28 @@ final class NumericDomain {
                 }
             }
         });
-        return new NumericDomain(false, nlo, nhi, nd);
+        List<Asserted> nk = new ArrayList<>(kept);
+        nk.removeIf(a -> a.f().coefs().keySet().stream().anyMatch(drop));
+        return new NumericDomain(false, nlo, nhi, nd, List.copyOf(nk));
     }
 
     // --- immutable updates ---------------------------------------------------------------------
 
     private NumericDomain bottom() {
-        return new NumericDomain(true, Map.of(), Map.of(), Map.of());
+        return new NumericDomain(true, Map.of(), Map.of(), Map.of(), List.of());
     }
 
     private NumericDomain withHi(String a, BigDecimal bound) {
         Map<String, BigDecimal> nhi = new HashMap<>(hi);
         nhi.merge(a, bound, NumericDomain::min);
-        NumericDomain d = new NumericDomain(false, lo, nhi, diff);
+        NumericDomain d = new NumericDomain(false, lo, nhi, diff, kept);
         return d.feasible(a) ? d : bottom();
     }
 
     private NumericDomain withLo(String a, BigDecimal bound) {
         Map<String, BigDecimal> nlo = new HashMap<>(lo);
         nlo.merge(a, bound, NumericDomain::max);
-        NumericDomain d = new NumericDomain(false, nlo, hi, diff);
+        NumericDomain d = new NumericDomain(false, nlo, hi, diff, kept);
         return d.feasible(a) ? d : bottom();
     }
 
@@ -298,7 +323,7 @@ final class NumericDomain {
         Map<String, Map<String, BigDecimal>> nd = new HashMap<>();
         diff.forEach((k, v) -> nd.put(k, new HashMap<>(v)));
         nd.computeIfAbsent(a, k -> new HashMap<>()).merge(b, bound, NumericDomain::min);
-        NumericDomain d = new NumericDomain(false, lo, hi, nd);
+        NumericDomain d = new NumericDomain(false, lo, hi, nd, kept);
         // Contradictory guards make the path infeasible: with a - b <= bound now recorded, if the
         // difference facts also prove b - a <= back and bound + back < 0, then 0 <= bound + back < 0.
         // Mark it bottom so entails discharges everything and refutes fires nothing — no false E2010

--- a/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
@@ -1,0 +1,73 @@
+package souther.compiler.check;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * The predicates the guards have settled on the current path, each keyed by a canonical rendering of
+ * the call that states it (see {@link InvariantChecker}). A predicate that is not a comparison —
+ * {@code List.allUniqueBy}, {@code List.member}, {@code String.matches} — holds no numeric relation
+ * and so has nowhere to live in {@link NumericDomain}; this is where it lives instead.
+ *
+ * <p>Nothing here reasons: two predicates relate only by being the same key. What that buys is the
+ * guarantee the discharge check needs — a construction whose invariant states a predicate is
+ * discharged by a guard stating the same predicate of the same term, and reported when there is
+ * none. Immutable, threaded functionally alongside the numeric domain.
+ */
+final class PredicateFacts {
+
+    private static final PredicateFacts NONE = new PredicateFacts(false, Set.of(), Set.of());
+    private static final PredicateFacts BOTTOM = new PredicateFacts(true, Set.of(), Set.of());
+
+    private final boolean bottom;    // contradictory guards — this path is not taken
+    private final Set<String> holds;
+    private final Set<String> fails;
+
+    private PredicateFacts(boolean bottom, Set<String> holds, Set<String> fails) {
+        this.bottom = bottom;
+        this.holds = holds;
+        this.fails = fails;
+    }
+
+    static PredicateFacts none() {
+        return NONE;
+    }
+
+    /** The facts with {@code key} settled. Settling it both ways makes the path infeasible. */
+    PredicateFacts assume(String key, boolean positive) {
+        if (bottom) {
+            return this;
+        }
+        if ((positive ? fails : holds).contains(key)) {
+            return BOTTOM;
+        }
+        Set<String> next = new HashSet<>(positive ? holds : fails);
+        next.add(key);
+        return positive
+                ? new PredicateFacts(false, Set.copyOf(next), fails)
+                : new PredicateFacts(false, holds, Set.copyOf(next));
+    }
+
+    /** Whether the guards prove {@code key} (or its negation, when {@code positive} is false). */
+    boolean entails(String key, boolean positive) {
+        return bottom || (positive ? holds : fails).contains(key);
+    }
+
+    /** Whether the guards prove the opposite of what {@code positive} asks of {@code key}. */
+    boolean refutes(String key, boolean positive) {
+        return !bottom && (positive ? fails : holds).contains(key);
+    }
+
+    /** The facts with every matching key dropped — what a binding that rebinds a name leaves behind. */
+    PredicateFacts forgetIf(Predicate<String> drop) {
+        if (bottom || (holds.stream().noneMatch(drop) && fails.stream().noneMatch(drop))) {
+            return this;
+        }
+        Set<String> h = new HashSet<>(holds);
+        Set<String> f = new HashSet<>(fails);
+        h.removeIf(drop);
+        f.removeIf(drop);
+        return new PredicateFacts(false, Set.copyOf(h), Set.copyOf(f));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -260,6 +260,46 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aGuardRestatingASumOfTwoLengthsDischarges() {
+        // the guard is the invariant written over the arguments. A sum of two atoms is outside the
+        // interval/difference shapes, so what discharges it is the form itself being assumed.
+        String m = """
+                module demo
+                data Empty
+                data Matches = { accounts: List<Int>, contacts: List<Int> }
+                    invariant List.length(accounts) + List.length(contacts) >= 1
+                behavior build : (xs: List<Int>, ys: List<Int>) -> Matches | Empty
+                    constructs Matches, Empty
+                let build (xs, ys) = {
+                    guard List.length(xs) + List.length(ys) >= 1
+                        else Empty
+                    Matches { accounts = xs, contacts = ys }
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a guard restating the invariant discharges it");
+    }
+
+    @Test
+    void aGuardWeakerThanTheInvariantDoesNotDischarge() {
+        String m = """
+                module demo
+                data Empty
+                data Matches = { accounts: List<Int>, contacts: List<Int> }
+                    invariant List.length(accounts) + List.length(contacts) >= 2
+                behavior build : (xs: List<Int>, ys: List<Int>) -> Matches | Empty
+                    constructs Matches, Empty
+                let build (xs, ys) = {
+                    guard List.length(xs) + List.length(ys) >= 1
+                        else Empty
+                    Matches { accounts = xs, contacts = ys }
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a guard that establishes less should not discharge");
+    }
+
+    @Test
     void aRebindingOfTheGuardedNameDropsTheFact() {
         // `xs` is rebound between the guard and the construction, so the guard's fact no longer holds
         // of what `Lines` is built from

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -107,6 +107,180 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void anUnguardedListLengthConstructionIsAPossibleViolationWarning() {
+        // `List.length(xs)` is a term the domain can name, so an invariant over it is expressible and
+        // the unguarded construction is flagged rather than left silent
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines constructs Lines
+                let build (xs) = Lines(xs)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "an unguarded length invariant should warn (E2011)");
+    }
+
+    @Test
+    void aGuardOnTheLengthDischargesTheConstruction() {
+        // the guard and the invariant name the same list, so they name the same atom
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines | NoItems constructs Lines, NoItems
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else NoItems
+                    Lines(xs)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the length invariant");
+    }
+
+    @Test
+    void aGuardOnAnotherListDoesNotDischarge() {
+        // the atom is keyed by the container the call names — guarding `ys` says nothing about `xs`
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>, ys: List<Int>) -> Lines | NoItems
+                    constructs Lines, NoItems
+                let build (xs, ys) = {
+                    guard List.length(ys) >= 1
+                        else NoItems
+                    Lines(xs)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a guard on another list should not discharge");
+    }
+
+    @Test
+    void aGuardOnAStringLengthDischargesTheConstruction() {
+        String m = """
+                module demo
+                data TooShort
+                data Name = String
+                    invariant String.length(value) >= 3
+                behavior build : (s: String) -> Name | TooShort constructs Name, TooShort
+                let build (s) = {
+                    guard String.length(s) >= 3
+                        else TooShort
+                    Name(s)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the string-length invariant");
+    }
+
+    @Test
+    void anUnguardedStringLengthConstructionIsAPossibleViolationWarning() {
+        String m = """
+                module demo
+                data Name = String
+                    invariant String.length(value) >= 3
+                behavior build : (s: String) -> Name constructs Name
+                let build (s) = Name(s)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "an unguarded string-length invariant should warn (E2011)");
+    }
+
+    @Test
+    void aGuardOnASetSizeDischargesTheConstruction() {
+        String m = """
+                module demo
+                data Empty
+                data Tags = Set<String>
+                    invariant Set.size(value) >= 1
+                behavior build : (s: Set<String>) -> Tags | Empty constructs Tags, Empty
+                let build (s) = {
+                    guard Set.size(s) >= 1
+                        else Empty
+                    Tags(s)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the set-size invariant");
+    }
+
+    @Test
+    void aGuardOnAMapSizeDischargesTheConstruction() {
+        String m = """
+                module demo
+                data Empty
+                data Index = Map<String, Int>
+                    invariant Map.size(value) >= 1
+                behavior build : (m: Map<String, Int>) -> Index | Empty constructs Index, Empty
+                let build (m) = {
+                    guard Map.size(m) >= 1
+                        else Empty
+                    Index(m)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the map-size invariant");
+    }
+
+    @Test
+    void anInputTypesLengthInvariantIsSeeded() {
+        // `l: Lines` was built through Lines' checked construction, so its length is known here
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                data Batch = List<Int>
+                    invariant List.length(value) >= 1
+                behavior rewrap : (l: Lines) -> Batch constructs Batch
+                let rewrap (l) = Batch(l.value)
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the input newtype's length invariant discharges the re-wrap");
+    }
+
+    @Test
+    void aLengthInvariantOverAMappedListStaysOpaque() {
+        // `List.length(List.map(f, xs))` is not the same atom as `List.length(xs)` at this increment,
+        // so the clause is not expressible here and the run-time check stands — no warning no guard
+        // written over the mapped list could silence
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines constructs Lines
+                let build (xs) = Lines(List.map(x -> x + 1, xs))
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "an unnameable container leaves the clause opaque");
+    }
+
+    @Test
+    void aRebindingOfTheGuardedNameDropsTheFact() {
+        // `xs` is rebound between the guard and the construction, so the guard's fact no longer holds
+        // of what `Lines` is built from
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines | NoItems constructs Lines, NoItems
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else NoItems
+                    let xs = List.filter(x -> x > 0, xs)
+                    Lines(xs)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a rebinding invalidates the guard's fact about that name");
+    }
+
+    @Test
     void aRequireGuardDischargesTheSubtraction() {
         // `guard 額 <= 残高` establishes the relation on the mainline, discharging `残高 - 額`
         String m = """

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -300,6 +300,99 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aNewtypeFieldsValueIsTheSameLocationOnBothSides() {
+        // `n` was built through `Name`'s checked construction, so its length is known here — and the
+        // clause names the very location the input's own invariant is about
+        String m = """
+                module demo
+                data Name = String
+                    invariant String.length(value) >= 3
+                data Person = { name: Name }
+                    invariant String.length(name.value) >= 3
+                behavior build : (n: Name) -> Person constructs Person
+                let build (n) = Person { name = n }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a newtype's `.value` is one location whichever side names it");
+    }
+
+    @Test
+    void aGuardOnANewtypeFieldsValueDischarges() {
+        String m = """
+                module demo
+                data TooShort
+                data Name = String
+                data Person = { name: Name }
+                    invariant String.length(name.value) >= 3
+                behavior build : (n: Name) -> Person | TooShort constructs Person, TooShort
+                let build (n) = {
+                    guard String.length(n.value) >= 3
+                        else TooShort
+                    Person { name = n }
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard sizes the same location the clause does");
+    }
+
+    @Test
+    void aGuardThroughTwoNewtypesDischarges() {
+        // the guard writes both `.value`s and the clause writes both, and each is the same location
+        String m = """
+                module demo
+                data TooShort
+                data Inner = String
+                data Outer = Inner
+                data Box = { held: Outer }
+                    invariant String.length(held.value.value) >= 3
+                behavior build : (o: Outer) -> Box | TooShort constructs Box, TooShort
+                let build (o) = {
+                    guard String.length(o.value.value) >= 3
+                        else TooShort
+                    Box { held = o }
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "each `.value` of a single-value newtype is the same location");
+    }
+
+    @Test
+    void aNewtypeOverANewtypeIsStillOneLocation() {
+        String m = """
+                module demo
+                data Inner = String
+                    invariant String.length(value) >= 3
+                data Outer = Inner
+                data Box = { held: Outer }
+                    invariant String.length(held.value.value) >= 3
+                behavior build : (o: Outer) -> Box constructs Box
+                let build (o) = Box { held = o }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "each `.value` of a single-value newtype is the same location");
+    }
+
+    @Test
+    void aGuardOnAnotherNewtypesValueDoesNotDischarge() {
+        String m = """
+                module demo
+                data TooShort
+                data Name = String
+                data Person = { name: Name }
+                    invariant String.length(name.value) >= 3
+                behavior build : (n: Name, other: Name) -> Person | TooShort
+                    constructs Person, TooShort
+                let build (n, other) = {
+                    guard String.length(other.value) >= 3
+                        else TooShort
+                    Person { name = n }
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "collapsing `.value` does not collapse two different newtypes into one");
+    }
+
+    @Test
     void aRebindingOfTheGuardedNameDropsTheFact() {
         // `xs` is rebound between the guard and the construction, so the guard's fact no longer holds
         // of what `Lines` is built from

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -523,6 +523,43 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aLiteralHoldingTheKeysOwnPunctuationIsAnotherTerm() {
+        // one element whose value is `a", "b` is not the two elements `a` and `b`
+        String m = """
+                module demo
+                data Unknown
+                data Known = String
+                    invariant List.member(value, ["a\\", \\"b"])
+                behavior build : (s: String) -> Known | Unknown constructs Known, Unknown
+                let build (s) = {
+                    guard List.member(s, ["a", "b"])
+                        else Unknown
+                    Known(s)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "another list is another fact however its elements are spelled");
+    }
+
+    @Test
+    void aNewlineAndTheTwoCharactersSpellingItAreDifferentTerms() {
+        String m = """
+                module demo
+                data Unknown
+                data Known = String
+                    invariant List.member(value, ["a\\nb"])
+                behavior build : (s: String) -> Known | Unknown constructs Known, Unknown
+                let build (s) = {
+                    guard List.member(s, ["a\\\\nb"])
+                        else Unknown
+                    Known(s)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a newline is not the backslash and the n that spell it");
+    }
+
+    @Test
     void aGuardOnAPatternMatchDischargesTheConstruction() {
         String m = """
                 module demo

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -321,6 +321,242 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aGuardOnAUniquenessPredicateDischargesTheConstruction() {
+        // the guard and the clause project the same way over the same list, so they are one fact
+        String m = """
+                module demo
+                data Duplicate
+                data Lines = List<Int>
+                    invariant List.allUniqueBy(x -> x, value)
+                behavior build : (xs: List<Int>) -> Lines | Duplicate constructs Lines, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(x -> x, xs)
+                        else Duplicate
+                    Lines(xs)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the guard discharges the uniqueness invariant");
+    }
+
+    @Test
+    void anUnguardedUniquenessConstructionIsAPossibleViolationWarning() {
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.allUniqueBy(x -> x, value)
+                behavior build : (xs: List<Int>) -> Lines constructs Lines
+                let build (xs) = Lines(xs)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "an unguarded uniqueness invariant should warn (E2011)");
+    }
+
+    @Test
+    void aGuardWritingAnotherProjectionDoesNotDischarge() {
+        // uniqueness by `.a` says nothing about uniqueness by `.b`
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { a: Int, b: Int }
+                data Rows = List<Row>
+                    invariant List.allUniqueBy(r -> r.b, value)
+                behavior build : (xs: List<Row>) -> Rows | Duplicate constructs Rows, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(r -> r.a, xs)
+                        else Duplicate
+                    Rows(xs)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a guard on another projection should not discharge");
+    }
+
+    @Test
+    void aClosureIsTheSameTermWhateverItsParameterIsCalled() {
+        // the parameter's spelling is not part of what the closure computes
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { a: Int, b: Int }
+                data Rows = List<Row>
+                    invariant List.allUniqueBy(r -> r.a, value)
+                behavior build : (xs: List<Row>) -> Rows | Duplicate constructs Rows, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(row -> row.a, xs)
+                        else Duplicate
+                    Rows(xs)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "renaming the closure parameter does not change the term");
+    }
+
+    @Test
+    void theProjectionShorthandIsTheSameTermAsTheClosure() {
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { a: Int, b: Int }
+                data Rows = List<Row>
+                    invariant List.allUniqueBy(.a, value)
+                behavior build : (xs: List<Row>) -> Rows | Duplicate constructs Rows, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(r -> r.a, xs)
+                        else Duplicate
+                    Rows(xs)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "`.a` and `r -> r.a` are one term");
+    }
+
+    @Test
+    void aGuardOnMembershipDischargesTheConstruction() {
+        String m = """
+                module demo
+                data Unknown
+                data Known = String
+                    invariant List.member(value, ["a", "b"])
+                behavior build : (s: String) -> Known | Unknown constructs Known, Unknown
+                let build (s) = {
+                    guard List.member(s, ["a", "b"])
+                        else Unknown
+                    Known(s)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the membership guard discharges the construction");
+    }
+
+    @Test
+    void aGuardOnAPatternMatchDischargesTheConstruction() {
+        String m = """
+                module demo
+                data Malformed
+                data Code = String
+                    invariant String.matches("[A-Z]{2}-[0-9]{4}", value)
+                behavior build : (s: String) -> Code | Malformed constructs Code, Malformed
+                let build (s) = {
+                    guard String.matches("[A-Z]{2}-[0-9]{4}", s)
+                        else Malformed
+                    Code(s)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the pattern guard discharges the construction");
+    }
+
+    @Test
+    void aDifferentPatternDoesNotDischarge() {
+        String m = """
+                module demo
+                data Malformed
+                data Code = String
+                    invariant String.matches("[A-Z]{2}-[0-9]{4}", value)
+                behavior build : (s: String) -> Code | Malformed constructs Code, Malformed
+                let build (s) = {
+                    guard String.matches("[A-Z]{3}-[0-9]{4}", s)
+                        else Malformed
+                    Code(s)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "another pattern is another fact");
+    }
+
+    @Test
+    void aPredicateTheGuardsSettleFalseIsADefiniteViolation() {
+        // on the else branch the predicate is known not to hold, so the construction must abort
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.allUniqueBy(x -> x, value)
+                behavior build : (xs: List<Int>) -> Lines constructs Lines
+                let build (xs) =
+                    if List.allUniqueBy(x -> x, xs) then Lines(xs) else Lines(xs)
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(m));
+        assertEquals("E2010", e.diagnostic().code(),
+                "a predicate settled false is a definite violation: " + e.getMessage());
+    }
+
+    @Test
+    void aNegatedGuardSettlesThePredicateOnTheMainline() {
+        // `Bool.not(p)` on the guard leaves `p` false where the construction stands
+        String m = """
+                module demo
+                data Ok
+                data Lines = List<Int>
+                    invariant List.allUniqueBy(x -> x, value)
+                behavior build : (xs: List<Int>) -> Lines | Ok constructs Lines, Ok
+                let build (xs) = {
+                    guard Bool.not(List.allUniqueBy(x -> x, xs))
+                        else Ok
+                    Lines(xs)
+                }
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(m));
+        assertEquals("E2010", e.diagnostic().code(),
+                "the negated guard settles the predicate false: " + e.getMessage());
+    }
+
+    @Test
+    void anInputTypesPredicateInvariantIsSeeded() {
+        String m = """
+                module demo
+                data Row = { a: Int }
+                data Rows = List<Row>
+                    invariant List.allUniqueBy(r -> r.a, value)
+                data Batch = List<Row>
+                    invariant List.allUniqueBy(r -> r.a, value)
+                behavior rewrap : (rs: Rows) -> Batch constructs Batch
+                let rewrap (rs) = Batch(rs.value)
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the input newtype's uniqueness invariant discharges the re-wrap");
+    }
+
+    @Test
+    void aFreeNameInsideTheClosureIsPartOfTheTerm() {
+        // the clause's `floor` is the field being given, so the guard has to bound by the same value
+        String m = """
+                module demo
+                data TooSmall
+                data Bounded = { items: List<Int>, floor: Int }
+                    invariant List.all(x -> x >= floor, items)
+                behavior build : (xs: List<Int>, lo: Int, hi: Int) -> Bounded | TooSmall
+                    constructs Bounded, TooSmall
+                let build (xs, lo, hi) = {
+                    guard List.all(x -> x >= hi, xs)
+                        else TooSmall
+                    Bounded { items = xs, floor = lo }
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a guard bounding by another value should not discharge");
+    }
+
+    @Test
+    void aRebindingDropsThePredicateFact() {
+        String m = """
+                module demo
+                data Duplicate
+                data Lines = List<Int>
+                    invariant List.allUniqueBy(x -> x, value)
+                behavior build : (xs: List<Int>) -> Lines | Duplicate constructs Lines, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(x -> x, xs)
+                        else Duplicate
+                    let xs = xs ++ [1]
+                    Lines(xs)
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a rebinding invalidates the guard's fact about that name");
+    }
+
+    @Test
     void aRequireGuardDischargesTheSubtraction() {
         // `guard 額 <= 残高` establishes the relation on the mainline, discharging `残高 - 額`
         String m = """

--- a/specification.adoc
+++ b/specification.adoc
@@ -957,7 +957,7 @@ let withdraw (req) = {
 }
 ----
 
-The checked fragment is bounded: the decision procedure reasons over intervals and differences (`+value >= c+`, `+a <= b+`, and the like) with no external solver. The set of *flagged* constructions is tied to that fragment, so every flagged construction has a guard the procedure can verify — an invariant it cannot express (a non-linear or otherwise relational one) is left to the run-time check rather than reported as a possible violation no guard could silence.
+The checked fragment is bounded: the decision procedure derives over intervals and differences (`+value >= c+`, `+a <= b+`, and the like) with no external solver. A relation of neither shape — a sum of two lengths against a bound — is kept as it was written rather than derived from, so a guard *restating* an invariant discharges it even where the two together yield nothing. The set of *flagged* constructions is tied to that fragment, so every flagged construction has a guard the procedure can verify — an invariant it cannot express (a non-linear one, or one over a value it cannot name) is left to the run-time check rather than reported as a possible violation no guard could silence.
 
 An *attempted* construction (<<attempted-construction>>) is never possibly violated: a failing invariant takes its `+else+` branch, so there is no abort to warn about. It is what silences the warning for an invariant outside the fragment, where no guard could. A violation the procedure *decides* is still an error there, because with the outcome settled at compile time there was no branch. In the success branch the built value seeds the check with its own invariant, as an input of that type does.
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -980,6 +980,27 @@ let build (xs) = {
 
 A size taken of anything else — `+List.length(List.map(f, xs))+` — is not a term, and a clause needing it is left to the run-time check.
 
+[#invariant-discharge-facts]
+==== A clause that states no relation is settled, not derived
+
+Not every invariant is a comparison. `+List.allUniqueBy(.product, value)+`, `+List.member(value, codes)+` and `+String.matches("[A-Z]{2}-[0-9]{4}", value)+` state something about a value that no arithmetic relates to anything else. Such a clause is *settled* by a guard rather than derived: a `+guard+` states its condition where it does not depart and denies it where it does, and a construction under a guard stating the clause is discharged, one under a guard denying it a violation.
+
+[,text]
+----
+data Lines = List<Line> invariant List.allUniqueBy(.product, value)
+
+behavior build : (rows: List<Line>) -> Lines | DuplicateProduct
+let build (rows) = {
+    guard List.allUniqueBy(.product, rows)
+        else DuplicateProduct
+    Lines(rows)                       // discharged: the guard states the clause
+}
+----
+
+Two clauses are one thing exactly when they are the same expression over the same terms. Nothing relates two different ones — uniqueness by `+.product+` says nothing about uniqueness by `+.sku+`, and one pattern says nothing about another. What a binding is *called* is not part of the expression, so `+r -> r.product+`, `+row -> row.product+` and `+.product+` state one thing; a name the closure reads from outside it is part of the expression, so bounding by one field is not bounding by another.
+
+This is what a clause outside the derived fragment falls back to, whatever its shape. A comparison over a value the procedure cannot name is settled the same way, which is why `+guard+`-ing it verbatim discharges the construction.
+
 [#invariant-reify]
 ==== Reifying a cross-behavior relation
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -961,6 +961,25 @@ The checked fragment is bounded: the decision procedure reasons over intervals a
 
 An *attempted* construction (<<attempted-construction>>) is never possibly violated: a failing invariant takes its `+else+` branch, so there is no abort to warn about. It is what silences the warning for an invariant outside the fragment, where no guard could. A violation the procedure *decides* is still an error there, because with the outcome settled at compile time there was no branch. In the success branch the built value seeds the check with its own invariant, as an input of that type does.
 
+[#invariant-discharge-terms]
+==== What the procedure can name
+
+A term it compares is the numeric content of a location — a parameter, a field chain, a newtype's wrapped value — or the size of a container or a string: `+List.length+`, `+String.length+`, `+Set.size+`, `+Map.size+` applied to such a location. A size is named by the location it is taken of, so a guard and an invariant clause mean the same term exactly when they take the size of the same one. The size of a container is never negative, and the procedure knows that much without being told.
+
+[,text]
+----
+data Lines = List<Int> invariant List.length(value) >= 1
+
+behavior build : (xs: List<Int>) -> Lines | NoItems
+let build (xs) = {
+    guard List.length(xs) >= 1
+        else NoItems
+    Lines(xs)                         // discharged: the guard sizes the same list
+}
+----
+
+A size taken of anything else — `+List.length(List.map(f, xs))+` — is not a term, and a clause needing it is left to the run-time check.
+
 [#invariant-reify]
 ==== Reifying a cross-behavior relation
 


### PR DESCRIPTION
Closes #224 (a sub-issue of #222).

**Sits on #228.** Its two commits are the first two here; review this PR's own commit, or merge #228
first and the diff resolves. Merging #228 with `--delete-branch` is safe — this PR targets `develop`,
not that branch.

## The issue's premise does not hold

#224 asks for a fact domain over a named set of pure total stdlib predicates: `List.allUniqueBy`,
`List.all`, `List.member`, `Set.member`. Every one of those is a *prelude helper*, and a helper is
expanded before this check reads either a behavior body or a data's invariant
(`HelperInliner.withInlinedInvariants`). Matching them by name finds none of them —
`List.allUniqueBy(x -> x, value)` is by then
`List.length(List.distinct(List.map(...))) == List.length(...)`. Only the intrinsics
(`String.matches`, `Set.contains`, `Map.containsKey`) survive as calls.

## What is here instead

Not a table of predicate names, a rule about shape: **a comparison the domain can derive over is
owed to the domain; anything else is settled by key.** An expression is canonicalized to a term, and
a clause and a guard mean one thing exactly when they canonicalize alike. Both sides are expanded by
the same pass, so the same source is the same key — which is what makes `List.allUniqueBy` work
without naming it anywhere.

- `PredicateFacts` (new): the keys the guards have settled true and false, with a bottom for a path
  whose guards contradict. Nothing reasons — uniqueness by `.product` says nothing about uniqueness
  by `.sku`.
- `termKey`: the canonical form. A binding is keyed by where it is bound rather than by its
  spelling, so `r -> r.a`, `row -> row.a` and `.a` are one term; a name a closure reads from outside
  it resolves through the construction's own bindings and stays part of the term. Outside the
  grammar it keys as `null` and the clause is left opaque.
- `Bool.not` is a helper as well, so it is read as the `if b then false else true` it becomes.
- Seeding takes an input invariant conjunct by conjunct, so a clause the check cannot carry no
  longer costs it the others.

## Effect on souther-lang/examples

Measured in-tree (the annotation-processor path reports no warnings, and the CLI's shaded jar needs
a `clean` to be current — the numbers in #228's first draft were read off a stale one and have been
corrected there).

| | warnings |
| --- | --- |
| `develop` | 3 — `Quantity`, `UnitPrice`, `DiscountRate` in `crm` |
| #228 | 4 — plus `Label` in `issuetracker` |
| this | 10 — plus `Amount` ×3 and `Prospecting` in `crm`, `Amount` and `Refund` in `ordering` |

Each of the six is a construction the check cannot prove safe:

- `crm` `Prospecting` — `invariant Date.daysBetween(openedOn, closeDate) >= 0`, and `openFromLead`
  really does abort when the close date precedes the conversion. A guard silences it.
- `ordering` `billing.settle` — `Amount(diff)` on the branch where `Decimal.compare(...) > 0`, which
  the check does not connect to `diff >= 0`.
- `crm` `forecasting` ×3 and `issuetracker` `Label` — inside a `Map.map` / `Set.map` closure, where
  no `else` can go, so only an attempt silences them. #225 is what discharges these.

Catching up the examples is worth its own PR.

## Verification

- `mvn -o clean test` green; 12 tests added to `CompileInvariantDischargeTest`, covering discharge,
  a different projection, a renamed closure parameter, `.a` against `r -> r.a`, membership, a
  pattern, a settled-false violation, a negated guard, seeding from an input type, a free name
  inside the closure, and a rebinding.
- Specification: `[#invariant-discharge-facts]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
