### PR TITLE
An operation says what it keeps of the container it was built from

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
+import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
@@ -90,9 +91,22 @@ public final class HelperInliner {
      * its own fns has them here like any other helper, so both say the same thing about it.
      */
     public static HelperInliner forHelpers(Map<String, Ast.FnDef> own) {
+        return forHelpers(own, InliningPolicy.FULL);
+    }
+
+    /**
+     * The same, resolving only what {@code policy} says to resolve.
+     *
+     * <p>{@link InliningPolicy#DISCHARGE} leaves the standard library out of the table, so a call to
+     * one of its operations is not a helper call here and survives as written. Nothing else changes:
+     * a module's own helper is expanded, and a recursive call is left standing, by the same rules.
+     */
+    public static HelperInliner forHelpers(Map<String, Ast.FnDef> own, InliningPolicy policy) {
         // In the order they are written, so a module with two helpers to complain about complains
         // about the earlier one first.
-        HelperInliner inliner = new HelperInliner(withPrelude(own), new LinkedHashMap<>(own));
+        Map<String, Ast.FnDef> table = policy == InliningPolicy.FULL
+                ? withPrelude(own) : new LinkedHashMap<>(own);
+        HelperInliner inliner = new HelperInliner(table, new LinkedHashMap<>(own));
         inliner.classifyRecursion();
         inliner.rejectValueCycles();
         return inliner;
@@ -525,6 +539,29 @@ public final class HelperInliner {
      * (e.g. {@code invariant 正の数(value)}) expands to its body before the invariant is type-checked
      * or emitted — the same lowering a behavior body gets (spec 12.5, §invariant-expressions).
      */
+    /**
+     * Each declaration's invariant in the representation the invariant-discharge analysis reads: the
+     * module's own helpers expanded, the language's own operations left standing
+     * ({@link InliningPolicy#DISCHARGE}). Keyed by the declaration's name in {@code m}.
+     *
+     * <p>This is the same settling {@link #withSettledInvariants} does, stopped one step earlier. The
+     * settled form is what travels to an importer and what the backend emits; an importer therefore
+     * reads an imported invariant in the settled form and finds nothing here for it, which is where
+     * an imported clause falls outside the statically dischargeable fragment (spec
+     * §invariant-discharge).
+     */
+    public static Map<TypeName, Ast.Expr> invariantsForDischarge(Ast.Module m, Symbols symbols) {
+        Ast.Module settled = HelperParams.settle(m, symbols, Map.of());
+        HelperInliner inliner = forHelpers(helpersOf(settled), InliningPolicy.DISCHARGE);
+        Map<TypeName, Ast.Expr> out = new LinkedHashMap<>();
+        for (Ast.Def def : settled.defs()) {
+            if (def instanceof Ast.Data d && d.invariant().isPresent()) {
+                out.put(new TypeName(m.name(), d.name()), inliner.inline(d.invariant().get()));
+            }
+        }
+        return out;
+    }
+
     Ast.Module withInlinedInvariants(Ast.Module m) {
         List<Ast.Def> defs = new ArrayList<>();
         for (Ast.Def def : m.defs()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InliningPolicy.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InliningPolicy.java
@@ -1,0 +1,27 @@
+package souther.compiler.check;
+
+/**
+ * Which abstractions an expansion resolves, and so what an expanded tree is a representation
+ * <em>of</em>.
+ *
+ * <p>Expansion is not one thing done once. The backend needs every call it cannot emit to be gone,
+ * and reads a tree of algorithms. A static analysis needs the operations it has rules about to still
+ * be operations, and reads a tree of meanings. Asking for one and getting the other is what made the
+ * invariant-discharge check's combinator rules unreachable: it was written against
+ * {@code List.map(f, xs)} and handed the fold that is.
+ *
+ * <p>The line is not "the standard library is special". It is whether the language defines what an
+ * operation does to the properties the analysis tracks. A standard-library operation has such a
+ * definition and every module already has it, so it survives as a call. A module's own helper has
+ * none — nothing could be derived from leaving it standing — and it does not travel to an importer
+ * either, so it is expanded.
+ */
+public enum InliningPolicy {
+
+    /** Expand everything expandable: what the backend emits from. */
+    FULL,
+
+    /** Expand a module's own helpers; leave the language's own operations standing. What the
+     * invariant-discharge analysis reads (spec §invariant-discharge). */
+    DISCHARGE
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -509,8 +509,10 @@ public final class InvariantChecker {
                 numeric = new Constraint(la.minus(ra), eff);
             }
         }
-        List<String> keys = factKeys(inv, binds);
-        Fact fact = keys.isEmpty() ? null : new Fact(positive ? keys : firstOnly(keys), positive);
+        Polar polar = polar(inv, positive);
+        List<String> keys = factKeys(polar.expr(), binds);
+        boolean stated = polar.positive();
+        Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);
         if (numeric == null && fact == null) {
             return null;
         }
@@ -555,8 +557,36 @@ public final class InvariantChecker {
         }
         // Both routes, always: which one carries a clause is decided where the clause is read, and a
         // guard does not know which that will be.
-        String key = bodyKey(cond, types);
-        return key == null ? out : out.with(out.facts().assume(key, positive));
+        Polar polar = polar(cond, positive);
+        String key = bodyKey(polar.expr(), types);
+        return key == null ? out : out.with(out.facts().assume(key, polar.positive()));
+    }
+
+    /** A predicate as one of {@code ==}/{@code <} states it, and whether it is being stated or denied. */
+    private record Polar(Ast.Expr expr, boolean positive) {}
+
+    /**
+     * {@code e}, asserted with polarity {@code positive}, as the comparison of {@code ==} or {@code <}
+     * that says the same thing: {@code a /= b} is {@code a == b} denied, {@code a >= b} is
+     * {@code a < b} denied, and {@code a > b} is {@code b < a}. A fact is settled by key equality, so
+     * without this the six ways to compare two terms are six facts, and a guard written one way would
+     * leave a clause written the other unsettled.
+     */
+    private static Polar polar(Ast.Expr e, boolean positive) {
+        if (!(e instanceof Ast.Binary b) || relOf(b.op()) == null) {
+            return new Polar(e, positive);
+        }
+        return switch (b.op()) {
+            case NE -> new Polar(comparison(Ast.BinOp.EQ, b.left(), b.right(), b), !positive);
+            case GE -> new Polar(comparison(Ast.BinOp.LT, b.left(), b.right(), b), !positive);
+            case GT -> new Polar(comparison(Ast.BinOp.LT, b.right(), b.left(), b), positive);
+            case LE -> new Polar(comparison(Ast.BinOp.LT, b.right(), b.left(), b), !positive);
+            default -> new Polar(e, positive);
+        };
+    }
+
+    private static Ast.Binary comparison(Ast.BinOp op, Ast.Expr left, Ast.Expr right, Ast.Binary of) {
+        return new Ast.Binary(op, left, right, of.pos());
     }
 
     /** What a negation is applied to, or {@code null} if {@code e} is not one. {@code Bool.not} is an
@@ -991,7 +1021,7 @@ public final class InvariantChecker {
             case Ast.Binary b -> {
                 String l = termKey(b.left(), site, bound, depth);
                 String r = termKey(b.right(), site, bound, depth);
-                yield l == null || r == null ? null : "(" + l + " " + b.op() + " " + r + ")";
+                yield l == null || r == null ? null : binaryKey(b.op(), l, r);
             }
             case Ast.ListLit l -> elementsKey("[", l.elements(), site, bound, depth, "]");
             case Ast.Tuple t -> elementsKey("(", t.elements(), site, bound, depth, ")");
@@ -1036,6 +1066,29 @@ public final class InvariantChecker {
             sb.append(i == 0 ? "" : ", ").append(part);
         }
         return sb.append(close).toString();
+    }
+
+    /**
+     * A binary as a key. The six comparisons are two: {@code ==} over the pair in a settled order,
+     * since which side is written first is not part of what it says, and {@code <}, with the other
+     * three written as one of those denied. Two clauses comparing the same two terms are then one term
+     * however the author reached for it — which matters wherever the comparison is not the whole
+     * condition, since only there can the denial not be carried by the polarity instead.
+     */
+    private static String binaryKey(Ast.BinOp op, String l, String r) {
+        return switch (op) {
+            case EQ -> l.compareTo(r) <= 0 ? cmp("EQ", l, r) : cmp("EQ", r, l);
+            case NE -> "!" + binaryKey(Ast.BinOp.EQ, l, r);
+            case LT -> cmp("LT", l, r);
+            case GT -> cmp("LT", r, l);
+            case GE -> "!" + cmp("LT", l, r);
+            case LE -> "!" + cmp("LT", r, l);
+            default -> cmp(op.toString(), l, r);
+        };
+    }
+
+    private static String cmp(String op, String l, String r) {
+        return "(" + l + " " + op + " " + r + ")";
     }
 
     /** A string value written into a key with the punctuation the key itself uses escaped, so a value

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -8,6 +8,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -33,9 +34,20 @@ import java.util.function.Function;
  * immutable environment. It is fail-open — any internal error is swallowed so an analysis bug can
  * never reject a valid program.
  */
-final class InvariantChecker {
+public final class InvariantChecker {
 
     record Findings(List<CompileException> errors, List<Diagnostic> warnings) {}
+
+    /**
+     * What this check reads: one behavior's body and the invariants of the types around it, both in
+     * the representation the rules are written at ({@link InliningPolicy#DISCHARGE}) rather than the
+     * one the backend emits from.
+     *
+     * <p>{@code invariants} holds the declarations of the module being checked. A type another module
+     * declares is absent, and its clause is read off the declaration in the settled form — where the
+     * operations have already become the folds they are, so it falls outside the fragment.
+     */
+    public record Source(Ast.Expr body, Map<TypeName, Ast.Expr> invariants) {}
 
     /** A stdlib combinator whose closure (argument {@code closureArg}) is handed each element of its
      * container argument ({@code listArg}) as closure parameter {@code elementParam} — mirrors
@@ -79,12 +91,31 @@ final class InvariantChecker {
     private static final Set<String> SIZE_CALLS =
             Set.of("List.length", "String.length", "Set.size", "Map.size");
 
+    /** Emptiness, by the size call it means. This is not a rule about what an operation does to a
+     * property (spec §invariant-discharge-preservation) but about what a predicate <em>says</em>:
+     * {@code List.isEmpty(xs)} and {@code List.length(xs) == 0} are one statement, so a guard writing
+     * either discharges a clause writing the other. Without it the two would be unrelated, which is
+     * an accident of which one the author reached for. */
+    private static final Map<String, String> EMPTINESS = Map.of(
+            "List.isEmpty", "List.length",
+            "Set.isEmpty", "Set.size",
+            "Map.isEmpty", "Map.size",
+            "String.isEmpty", "String.length");
+
     private final Symbols symbols;
+    private final Map<TypeName, Ast.Expr> dischargeInvariants;
     private final List<CompileException> errors = new ArrayList<>();
     private final List<Diagnostic> warnings = new ArrayList<>();
 
-    private InvariantChecker(Symbols symbols) {
+    private InvariantChecker(Symbols symbols, Map<TypeName, Ast.Expr> dischargeInvariants) {
         this.symbols = symbols;
+        this.dischargeInvariants = dischargeInvariants;
+    }
+
+    /** Every invariant that applies to {@code named}, each in the analysis representation where this
+     * module declares it. */
+    private List<Ast.Expr> invariantsOf(TypeName named, Ast.Data data) {
+        return TypeOps.effectiveInvariants(named, data, symbols, dischargeInvariants::get);
     }
 
     /** What the guards have settled on the current path: numeric relations, and predicates known to
@@ -108,15 +139,19 @@ final class InvariantChecker {
         }
     }
 
-    /** Analyzes one behavior body against its input types. Never throws. */
-    static Findings analyze(Ast.Expr body, Map<String, Type> params, Symbols symbols) {
-        InvariantChecker c = new InvariantChecker(symbols);
+    /** Analyzes one behavior body against its input types. Never throws. A {@code null} source is a
+     * body the analysis representation could not be built for, and is not analyzed at all. */
+    static Findings analyze(Source source, Map<String, Type> params, Symbols symbols) {
+        InvariantChecker c = new InvariantChecker(symbols, source == null ? Map.of() : source.invariants());
+        if (source == null) {
+            return new Findings(c.errors, c.warnings);
+        }
         try {
             Known k = Known.top();
             for (Map.Entry<String, Type> p : params.entrySet()) {
                 k = c.seedParam(p.getKey(), p.getValue(), k);
             }
-            c.walk(body, k, new HashMap<>(params));
+            c.walk(source.body(), k, new HashMap<>(params));
         } catch (RuntimeException _) {
             // fail-open: the run-time invariant check remains the backstop
         }
@@ -229,7 +264,8 @@ final class InvariantChecker {
                             paths.put(fi.name(), p);
                         }
                     }
-                    check(type, new Bindings(forms::get, paths::get), k, nd.pos(), attempted);
+                    check(nd.typeName().denotes(), type, new Bindings(forms::get, paths::get), k,
+                            nd.pos(), attempted);
                 }
             }
             case Ast.Binary bin when isArith(bin.op()) -> {
@@ -238,7 +274,8 @@ final class InvariantChecker {
                     LinearForm value = affineOf(bin, types);
                     if (value != null) {
                         // an arithmetic result is a form, not a location, so it names no path
-                        check(type, new Bindings(name -> "value".equals(name) ? value : null, _ -> null),
+                        check(r.name(), type,
+                                new Bindings(name -> "value".equals(name) ? value : null, _ -> null),
                                 k, bin.pos(), attempted);
                     }
                 }
@@ -256,38 +293,31 @@ final class InvariantChecker {
      * {@code binds}. A definite violation is an error; an unproven one a warning; a fully-discharged
      * or non-expressible invariant is silent. An {@code attempted} construction raises no warning:
      * what the warning reports is a possible abort, and an attempt takes its else branch instead. */
-    private void check(Ast.Data type, Bindings binds, Known k, SourcePos pos, boolean attempted) {
-        List<Ast.Expr> invs = TypeOps.effectiveInvariants(type, symbols);
+    private void check(TypeName named, Ast.Data type, Bindings binds, Known k, SourcePos pos,
+                       boolean attempted) {
+        List<Ast.Expr> invs = invariantsOf(named, type);
         if (invs.isEmpty()) {
             return;
         }
-        Obligations owed = Obligations.none();
+        List<Clause> owed = new ArrayList<>();
         for (Ast.Expr inv : invs) {
-            Obligations o = obligations(inv, binds);
+            List<Clause> o = obligations(inv, binds);
             if (o == null) {
                 return;   // some part is not expressible — leave the whole invariant opaque
             }
-            owed = owed.and(o);
+            owed.addAll(o);
         }
-        NumericDomain dom = withSizeBounds(k.numbers(), owed.numeric());
+        NumericDomain dom = withSizeBounds(k.numbers(), owed);
         boolean possible = false;
-        for (Constraint c : owed.numeric()) {
-            if (dom.refutes(c.form(), c.rel())) {
+        for (Clause c : owed) {
+            if (c.dischargedBy(dom, k.facts())) {
+                continue;
+            }
+            if (c.refutedBy(dom, k.facts())) {
                 reportViolation(type, pos);
                 return;
             }
-            if (!dom.entails(c.form(), c.rel())) {
-                possible = true;
-            }
-        }
-        for (Fact f : owed.predicates()) {
-            if (k.facts().refutes(f.key(), f.positive())) {
-                reportViolation(type, pos);
-                return;
-            }
-            if (!k.facts().entails(f.key(), f.positive())) {
-                possible = true;
-            }
+            possible = true;
         }
         if (possible && !attempted) {
             warnings.add(
@@ -312,30 +342,22 @@ final class InvariantChecker {
      * clause written under {@code Bool.not}. */
     private record Fact(String key, boolean positive) {}
 
-    /** What a construction owes: numeric relations the domain must prove, and predicates the guards
-     * must have settled. */
-    private record Obligations(List<Constraint> numeric, List<Fact> predicates) {
+    /**
+     * One clause of an invariant, and the two ways it can come out: a relation for the domain to
+     * prove, and the key a guard restating it settles. Either may be absent, and where both are
+     * present either one discharging the clause is enough — a guard is written one way and a clause
+     * another, and which of the two routes carries it is not the author's concern.
+     */
+    private record Clause(Constraint numeric, Fact fact) {
 
-        private static final Obligations NONE = new Obligations(List.of(), List.of());
-
-        static Obligations none() {
-            return NONE;
+        boolean dischargedBy(NumericDomain d, PredicateFacts facts) {
+            return numeric != null && d.entails(numeric.form(), numeric.rel())
+                    || fact != null && facts.entails(fact.key(), fact.positive());
         }
 
-        static Obligations of(Constraint c) {
-            return new Obligations(List.of(c), List.of());
-        }
-
-        static Obligations of(Fact f) {
-            return new Obligations(List.of(), List.of(f));
-        }
-
-        Obligations and(Obligations o) {
-            List<Constraint> n = new ArrayList<>(numeric);
-            n.addAll(o.numeric);
-            List<Fact> p = new ArrayList<>(predicates);
-            p.addAll(o.predicates);
-            return new Obligations(n, p);
+        boolean refutedBy(NumericDomain d, PredicateFacts facts) {
+            return numeric != null && d.refutes(numeric.form(), numeric.rel())
+                    || fact != null && facts.refutes(fact.key(), fact.positive());
         }
     }
 
@@ -343,39 +365,50 @@ final class InvariantChecker {
      * being given), or {@code null} if it names nothing this check can carry. A comparison the domain
      * can express is owed to the domain; anything else is owed as a fact, which a guard stating the
      * same thing of the same term settles. */
-    private Obligations obligations(Ast.Expr inv, Bindings binds) {
+    private List<Clause> obligations(Ast.Expr inv, Bindings binds) {
         return obligations(inv, binds, true);
     }
 
-    private Obligations obligations(Ast.Expr inv, Bindings binds, boolean positive) {
+    private List<Clause> obligations(Ast.Expr rawInv, Bindings binds, boolean positive) {
+        Ast.Expr inv = asSizeComparison(rawInv);
         if (inv instanceof Ast.Binary b && b.op() == Ast.BinOp.AND && positive) {
-            Obligations l = obligations(b.left(), binds, true);
-            Obligations r = obligations(b.right(), binds, true);
-            return l == null || r == null ? null : l.and(r);
-        }
-        if (inv instanceof Ast.Binary b && relOf(b.op()) != null) {
-            Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
-            LinearForm la = eff == null ? null : affine(b.left(), resolveLeaf(binds));
-            LinearForm ra = eff == null ? null : affine(b.right(), resolveLeaf(binds));
-            if (la != null && ra != null) {
-                return Obligations.of(new Constraint(la.minus(ra), eff));
+            List<Clause> l = obligations(b.left(), binds, true);
+            List<Clause> r = obligations(b.right(), binds, true);
+            if (l == null || r == null) {
+                return null;
             }
+            List<Clause> both = new ArrayList<>(l);
+            both.addAll(r);
+            return both;
         }
         Ast.Expr under = negated(inv);
         if (under != null) {
             return obligations(under, binds, !positive);
         }
+        Constraint numeric = null;
+        if (inv instanceof Ast.Binary b && relOf(b.op()) != null) {
+            Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
+            LinearForm la = eff == null ? null : affine(b.left(), resolveLeaf(binds));
+            LinearForm ra = eff == null ? null : affine(b.right(), resolveLeaf(binds));
+            if (la != null && ra != null) {
+                numeric = new Constraint(la.minus(ra), eff);
+            }
+        }
         String key = termKey(inv, e -> invPath(e, binds), Map.of(), 0);
-        return key == null ? null : Obligations.of(new Fact(key, positive));
+        Fact fact = key == null ? null : new Fact(key, positive);
+        return numeric == null && fact == null ? null : List.of(new Clause(numeric, fact));
     }
 
     /** The domain told that every size atom the constraints name is non-negative. The atom enters the
      * domain only through the clause naming it, so without this the fact a container's size is never
      * negative is not available to discharge a clause that asks only for that. */
-    private static NumericDomain withSizeBounds(NumericDomain d, List<Constraint> constraints) {
+    private static NumericDomain withSizeBounds(NumericDomain d, List<Clause> clauses) {
         NumericDomain out = d;
-        for (Constraint c : constraints) {
-            for (String atom : c.form().coefs().keySet()) {
+        for (Clause clause : clauses) {
+            if (clause.numeric() == null) {
+                continue;
+            }
+            for (String atom : clause.numeric().form().coefs().keySet()) {
                 if (isSizeAtom(atom)) {
                     out = out.assume(LinearForm.atom(atom), Rel.GE);
                 }
@@ -387,35 +420,41 @@ final class InvariantChecker {
     /** Refines {@code k} by asserting {@code cond} (or its negation): a comparison tightens the
      * numeric domain, a stdlib predicate settles a fact. A condition of neither shape, and an operand
      * outside the affine fragment, leave {@code k} unchanged (sound). */
-    private Known assumeCond(Ast.Expr cond, Known k, Map<String, Type> types, boolean positive) {
+    private Known assumeCond(Ast.Expr rawCond, Known k, Map<String, Type> types, boolean positive) {
+        Ast.Expr cond = asSizeComparison(rawCond);
         // `&&` asserted true gives both sides; `||` asserted false gives both sides negated.
         if (cond instanceof Ast.Binary b
                 && (b.op() == Ast.BinOp.AND && positive || b.op() == Ast.BinOp.OR && !positive)) {
             return assumeCond(b.right(), assumeCond(b.left(), k, types, positive), types, positive);
         }
-        if (cond instanceof Ast.Binary b) {
-            Rel rel = relOf(b.op());
-            Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
-            if (eff != null) {
-                LinearForm la = affineOf(b.left(), types);
-                LinearForm ra = affineOf(b.right(), types);
-                if (la != null && ra != null) {
-                    return k.with(k.numbers().assume(la.minus(ra), eff));
-                }
-            }
-        }
         Ast.Expr under = negated(cond);
         if (under != null) {
             return assumeCond(under, k, types, !positive);
         }
+        Known out = k;
+        if (cond instanceof Ast.Binary b) {
+            Rel rel = relOf(b.op());
+            Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
+            LinearForm la = eff == null ? null : affineOf(b.left(), types);
+            LinearForm ra = eff == null ? null : affineOf(b.right(), types);
+            if (la != null && ra != null) {
+                out = out.with(out.numbers().assume(la.minus(ra), eff));
+            }
+        }
+        // Both routes, always: which one carries a clause is decided where the clause is read, and a
+        // guard does not know which that will be.
         String key = termKey(cond, e -> pathKey(e, types), Map.of(), 0);
-        return key == null ? k : k.with(k.facts().assume(key, positive));
+        return key == null ? out : out.with(out.facts().assume(key, positive));
     }
 
     /** What a negation is applied to, or {@code null} if {@code e} is not one. {@code Bool.not} is an
-     * ordinary helper, so by here it is the body it expands to — {@code if b then false else true},
-     * over a binding holding the argument. */
+     * ordinary helper: the analysis representation keeps it as a call, and a clause read off an
+     * imported declaration is the body it expands to — {@code if b then false else true} over a
+     * binding holding the argument. Both are read. */
     private static Ast.Expr negated(Ast.Expr e) {
+        if (e instanceof Ast.Call call && call.fn().equals("Bool.not") && call.args().size() == 1) {
+            return call.args().get(0);
+        }
         if (e instanceof Ast.LetIn li) {
             Ast.Expr inner = negated(li.body());
             return inner instanceof Ast.Var v && v.name().equals(li.name()) ? li.value() : null;
@@ -456,17 +495,19 @@ final class InvariantChecker {
         Known out = k;
         // Each conjunct on its own: an input's invariant is a set of things that hold, and one the
         // check cannot express does not cost it the others.
-        for (Ast.Expr inv : TypeOps.effectiveInvariants(data, symbols)) {
+        for (Ast.Expr inv : invariantsOf(ref.name(), data)) {
             for (Ast.Expr conjunct : conjuncts(inv)) {
-                Obligations o = obligations(conjunct, binds);
+                List<Clause> o = obligations(conjunct, binds);
                 if (o == null) {
                     continue;
                 }
-                for (Constraint c : o.numeric()) {
-                    out = out.with(out.numbers().assume(c.form(), c.rel()));
-                }
-                for (Fact f : o.predicates()) {
-                    out = out.with(out.facts().assume(f.key(), f.positive()));
+                for (Clause c : o) {
+                    if (c.numeric() != null) {
+                        out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
+                    }
+                    if (c.fact() != null) {
+                        out = out.with(out.facts().assume(c.fact().key(), c.fact().positive()));
+                    }
                 }
             }
         }
@@ -579,6 +620,17 @@ final class InvariantChecker {
         }
         String arg = path.apply(call.args().get(0));
         return arg == null ? null : call.fn() + "(" + arg + ")";
+    }
+
+    /** An emptiness check as the comparison it means, or {@code e} unchanged. */
+    private static Ast.Expr asSizeComparison(Ast.Expr e) {
+        if (e instanceof Ast.Call call && call.args().size() == 1
+                && EMPTINESS.containsKey(call.fn())) {
+            Ast.Call size = new Ast.Call(EMPTINESS.get(call.fn()), call.denotes(), call.args(),
+                    call.pos());
+            return new Ast.Binary(Ast.BinOp.EQ, size, new Ast.IntLit(0, call.pos()), call.pos());
+        }
+        return e;
     }
 
     /** The conjuncts of an invariant expression, flattened. */
@@ -802,6 +854,7 @@ final class InvariantChecker {
             case LE -> Rel.LE;
             case LT -> Rel.LT;
             case EQ -> Rel.EQ;
+            case NE -> Rel.NE;
             default -> null;
         };
     }
@@ -812,7 +865,8 @@ final class InvariantChecker {
             case GT -> Rel.LE;
             case LE -> Rel.GT;
             case LT -> Rel.GE;
-            case EQ -> null;
+            case EQ -> Rel.NE;
+            case NE -> Rel.EQ;
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -91,6 +91,62 @@ public final class InvariantChecker {
     private static final Set<String> SIZE_CALLS =
             Set.of("List.length", "String.length", "Set.size", "Map.size");
 
+    /**
+     * What a construction of a container keeps of the container it was built from. This is the table
+     * that decides how much of a model the language tracks rather than leaves to a run-time check
+     * (spec §invariant-discharge-preservation), and it is stated per operation because that is the
+     * level an author writes at.
+     *
+     * <ul>
+     * <li>{@code PERMUTES} — the same elements in another order. Everything survives.
+     * <li>{@code SUBSET} — some of the same elements. Nothing new is there, so a property of every
+     *     element survives and the size can only fall.
+     * <li>{@code MAPS} — one new element for each. As many as before, and nothing is known of what
+     *     they are.
+     * <li>{@code COLLAPSES} — at most one new element for each. Neither the elements nor the count.
+     * </ul>
+     */
+    private enum Shape {
+        PERMUTES, SUBSET, MAPS, COLLAPSES;
+
+        /** Whether the result has exactly as many as the container it was built from. */
+        boolean keepsSize() {
+            return this == PERMUTES || this == MAPS;
+        }
+    }
+
+    /** Which argument a container was built from, and what the building keeps of it. */
+    private record Built(int from, Shape shape) {}
+
+    private static final Map<String, Built> BUILT_FROM = Map.ofEntries(
+            Map.entry("List.reverse", new Built(0, Shape.PERMUTES)),
+            Map.entry("List.sort", new Built(0, Shape.PERMUTES)),
+            Map.entry("List.sortBy", new Built(1, Shape.PERMUTES)),
+            Map.entry("List.map", new Built(1, Shape.MAPS)),
+            Map.entry("List.indexedMap", new Built(1, Shape.MAPS)),
+            Map.entry("Map.map", new Built(1, Shape.MAPS)),
+            Map.entry("List.filter", new Built(1, Shape.SUBSET)),
+            Map.entry("List.distinct", new Built(0, Shape.SUBSET)),
+            Map.entry("List.take", new Built(1, Shape.SUBSET)),
+            Map.entry("List.drop", new Built(1, Shape.SUBSET)),
+            Map.entry("Set.filter", new Built(1, Shape.SUBSET)),
+            Map.entry("Map.filter", new Built(1, Shape.SUBSET)),
+            Map.entry("List.filterMap", new Built(1, Shape.COLLAPSES)),
+            Map.entry("Set.map", new Built(1, Shape.COLLAPSES)));
+
+    /** Where a predicate reads its container, and which shapes of construction carry it there.
+     * {@code List.all} holds of any sublist of a list it holds of; {@code List.member} does not, and
+     * neither survives a mapping — what a mapped element is, is #226's question. */
+    private record Carried(int container, Set<Shape> through) {}
+
+    private static final Map<String, Carried> CARRIED = Map.of(
+            "List.all", new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            "List.allUniqueBy", new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            "List.any", new Carried(1, Set.of(Shape.PERMUTES)),
+            "List.member", new Carried(1, Set.of(Shape.PERMUTES)),
+            "Set.contains", new Carried(1, Set.of(Shape.PERMUTES)),
+            "Map.containsKey", new Carried(1, Set.of(Shape.PERMUTES)));
+
     /** Emptiness, by the size call it means. This is not a rule about what an operation does to a
      * property (spec §invariant-discharge-preservation) but about what a predicate <em>says</em>:
      * {@code List.isEmpty(xs)} and {@code List.length(xs) == 0} are one statement, so a guard writing
@@ -254,17 +310,21 @@ public final class InvariantChecker {
                 if (symbols.get(nd.typeName().denotes()) instanceof Ast.Data type) {
                     Map<String, LinearForm> forms = new HashMap<>();
                     Map<String, String> paths = new HashMap<>();
+                    Map<String, Ast.Expr> given = new HashMap<>();
+                    Function<Ast.Expr, String> bodyKey = value -> siteKey(value, types);
                     for (Ast.FieldInit fi : nd.inits()) {
                         LinearForm f = affineOf(fi.value(), types);
                         if (f != null) {
                             forms.put(fi.name(), f);
                         }
-                        String p = pathKey(fi.value(), types);
+                        String p = bodyKey.apply(fi.value());
                         if (p != null) {
                             paths.put(fi.name(), p);
                         }
+                        given.put(fi.name(), fi.value());
                     }
-                    check(nd.typeName().denotes(), type, new Bindings(forms::get, paths::get), k,
+                    check(nd.typeName().denotes(), type,
+                            new Bindings(forms::get, paths::get, given::get, bodyKey), k,
                             nd.pos(), attempted);
                 }
             }
@@ -275,7 +335,7 @@ public final class InvariantChecker {
                     if (value != null) {
                         // an arithmetic result is a form, not a location, so it names no path
                         check(r.name(), type,
-                                new Bindings(name -> "value".equals(name) ? value : null, _ -> null),
+                                Bindings.ofPaths(name -> "value".equals(name) ? value : null, _ -> null),
                                 k, bin.pos(), attempted);
                     }
                 }
@@ -287,7 +347,34 @@ public final class InvariantChecker {
     /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
      * field is being given, and to that value's canonical path — so a size call over the field names
      * the same atom the body names when it calls the same function on the same container. */
-    private record Bindings(Function<String, LinearForm> form, Function<String, String> path) {}
+    private record Bindings(Function<String, LinearForm> form, Function<String, String> path,
+                            Function<String, Ast.Expr> given, Function<Ast.Expr, String> bodyKey) {
+
+        /** A clause naming only fields, with nothing of the site to look through — what seeding has. */
+        static Bindings ofPaths(Function<String, LinearForm> form, Function<String, String> path) {
+            return new Bindings(form, path, _ -> null, _ -> null);
+        }
+
+        /** Nothing to substitute: what the body's own expressions are read with. */
+        static Bindings ofBody(Function<Ast.Expr, String> bodyKey) {
+            return new Bindings(_ -> null, _ -> null, _ -> null, bodyKey);
+        }
+    }
+
+    /** How a clause's own expression is named: through the fields the construction is filling, and
+     * through nothing else. A body expression reaches the same space of keys only by being
+     * substituted for a field, which is what {@link #resolve} does. */
+    private Function<Ast.Expr, String> siteOf(Bindings binds) {
+        return e -> termKey(e, x -> invPath(x, binds), Map.of(), 0);
+    }
+
+    /** The expression a clause's leaf stands for at the construction site, or {@code null} when the
+     * clause names something the site does not hand over. A rule about how a container was built has
+     * to read the construction's own expression: the clause writes {@code value}, and what
+     * {@code value} is being given is where the operations are. */
+    private static Ast.Expr atSite(Ast.Expr e, Bindings binds) {
+        return e instanceof Ast.Var v ? binds.given().apply(v.name()) : null;
+    }
 
     /** Runs the discharge check for a construction of {@code type} whose field values resolve through
      * {@code binds}. A definite violation is an error; an unproven one a warning; a fully-discharged
@@ -307,7 +394,12 @@ public final class InvariantChecker {
             }
             owed.addAll(o);
         }
-        NumericDomain dom = withSizeBounds(k.numbers(), owed);
+        NumericDomain dom = k.numbers();
+        for (Clause c : owed) {
+            for (Constraint known : c.known()) {
+                dom = dom.assume(known.form(), known.rel());
+            }
+        }
         boolean possible = false;
         for (Clause c : owed) {
             if (c.dischargedBy(dom, k.facts())) {
@@ -338,9 +430,28 @@ public final class InvariantChecker {
 
     private record Constraint(LinearForm form, Rel rel) {}
 
-    /** A predicate stated of a term, by the term's canonical key. {@code positive} is false for a
-     * clause written under {@code Bool.not}. */
-    private record Fact(String key, boolean positive) {}
+    /**
+     * A predicate stated of a term. {@code keys} is the term as written first, then each container it
+     * was built from by a construction that carries the predicate — any one of them settled is this
+     * clause established. Refuting reads only the first: denying a predicate of a list says nothing
+     * about a list built from it. {@code positive} is false for a clause written under a negation,
+     * and such a clause carries nowhere, since the implication runs the other way.
+     */
+    private record Fact(List<String> keys, boolean positive) {
+
+        boolean entailedBy(PredicateFacts facts) {
+            for (String key : keys) {
+                if (facts.entails(key, positive)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        boolean refutedBy(PredicateFacts facts) {
+            return facts.refutes(keys.get(0), positive);
+        }
+    }
 
     /**
      * One clause of an invariant, and the two ways it can come out: a relation for the domain to
@@ -348,16 +459,16 @@ public final class InvariantChecker {
      * present either one discharging the clause is enough — a guard is written one way and a clause
      * another, and which of the two routes carries it is not the author's concern.
      */
-    private record Clause(Constraint numeric, Fact fact) {
+    private record Clause(Constraint numeric, Fact fact, List<Constraint> known) {
 
         boolean dischargedBy(NumericDomain d, PredicateFacts facts) {
             return numeric != null && d.entails(numeric.form(), numeric.rel())
-                    || fact != null && facts.entails(fact.key(), fact.positive());
+                    || fact != null && fact.entailedBy(facts);
         }
 
         boolean refutedBy(NumericDomain d, PredicateFacts facts) {
             return numeric != null && d.refutes(numeric.form(), numeric.rel())
-                    || fact != null && facts.refutes(fact.key(), fact.positive());
+                    || fact != null && fact.refutedBy(facts);
         }
     }
 
@@ -394,27 +505,18 @@ public final class InvariantChecker {
                 numeric = new Constraint(la.minus(ra), eff);
             }
         }
-        String key = termKey(inv, e -> invPath(e, binds), Map.of(), 0);
-        Fact fact = key == null ? null : new Fact(key, positive);
-        return numeric == null && fact == null ? null : List.of(new Clause(numeric, fact));
+        List<String> keys = factKeys(inv, binds);
+        Fact fact = keys.isEmpty() ? null : new Fact(positive ? keys : firstOnly(keys), positive);
+        if (numeric == null && fact == null) {
+            return null;
+        }
+        List<Constraint> known = new ArrayList<>();
+        sizeFacts(inv, binds, known);
+        return List.of(new Clause(numeric, fact, known));
     }
 
-    /** The domain told that every size atom the constraints name is non-negative. The atom enters the
-     * domain only through the clause naming it, so without this the fact a container's size is never
-     * negative is not available to discharge a clause that asks only for that. */
-    private static NumericDomain withSizeBounds(NumericDomain d, List<Clause> clauses) {
-        NumericDomain out = d;
-        for (Clause clause : clauses) {
-            if (clause.numeric() == null) {
-                continue;
-            }
-            for (String atom : clause.numeric().form().coefs().keySet()) {
-                if (isSizeAtom(atom)) {
-                    out = out.assume(LinearForm.atom(atom), Rel.GE);
-                }
-            }
-        }
-        return out;
+    private static List<String> firstOnly(List<String> keys) {
+        return keys.isEmpty() ? keys : List.of(keys.get(0));
     }
 
     /** Refines {@code k} by asserting {@code cond} (or its negation): a comparison tightens the
@@ -432,6 +534,12 @@ public final class InvariantChecker {
             return assumeCond(under, k, types, !positive);
         }
         Known out = k;
+        // What holds of the sizes the condition names, whichever way the condition itself is read.
+        List<Constraint> known = new ArrayList<>();
+        sizeFacts(cond, types, known);
+        for (Constraint c : known) {
+            out = out.with(out.numbers().assume(c.form(), c.rel()));
+        }
         if (cond instanceof Ast.Binary b) {
             Rel rel = relOf(b.op());
             Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
@@ -443,7 +551,7 @@ public final class InvariantChecker {
         }
         // Both routes, always: which one carries a clause is decided where the clause is read, and a
         // guard does not know which that will be.
-        String key = termKey(cond, e -> pathKey(e, types), Map.of(), 0);
+        String key = bodyKey(cond, types);
         return key == null ? out : out.with(out.facts().assume(key, positive));
     }
 
@@ -486,7 +594,7 @@ public final class InvariantChecker {
             }
             return fields.containsKey(fieldName) ? path + "." + fieldName : null;
         };
-        Bindings binds = new Bindings(
+        Bindings binds = Bindings.ofPaths(
                 fieldName -> {
                     String p = resolvePath.apply(fieldName);
                     return p == null ? null : LinearForm.atom(p);
@@ -502,11 +610,17 @@ public final class InvariantChecker {
                     continue;
                 }
                 for (Clause c : o) {
+                    for (Constraint known : c.known()) {
+                        out = out.with(out.numbers().assume(known.form(), known.rel()));
+                    }
                     if (c.numeric() != null) {
                         out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
                     }
                     if (c.fact() != null) {
-                        out = out.with(out.facts().assume(c.fact().key(), c.fact().positive()));
+                        // What an input's type guarantees is guaranteed of the term as written; a
+                        // container built from it is another term, and reads the rules where it is
+                        // constructed rather than here.
+                        out = out.with(out.facts().assume(c.fact().keys().get(0), c.fact().positive()));
                     }
                 }
             }
@@ -536,6 +650,16 @@ public final class InvariantChecker {
             // (a divide truncates for Int, and a variable factor is non-linear), so leave those opaque.
             case Ast.Binary b when b.op() == Ast.BinOp.MUL ->
                     scale(affine(b.left(), leaf), affine(b.right(), leaf));
+            // A binding an expansion introduced ({@code let $0_n = n.value in $0_n * 2}) is what an
+            // arithmetic helper becomes, so reading through it is reading the arithmetic the author
+            // wrote. An inner binding of the same name makes its own rule first, which is what
+            // shadowing is.
+            case Ast.LetIn li -> {
+                LinearForm bound = affine(li.value(), leaf);
+                yield bound == null ? leaf.apply(e) : affine(li.body(),
+                        n -> n instanceof Ast.Var v && v.name().equals(li.name())
+                                ? bound : leaf.apply(n));
+            }
             default -> leaf.apply(e);
         };
     }
@@ -568,14 +692,40 @@ public final class InvariantChecker {
 
     /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}, and
      * a size call over one to that container's size atom. */
-    private static Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
+    private Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
         return n -> {
-            String size = sizeAtom(n, arg -> invPath(arg, binds));
+            String size = clauseSizeAtom(n, binds);
             if (size != null) {
                 return LinearForm.atom(size);
             }
             return n instanceof Ast.Var v ? binds.form().apply(v.name()) : null;
         };
+    }
+
+    /** A container a clause names, as the term it stands for, and the rule that names that term. */
+    private record Named(Ast.Expr term, Function<Ast.Expr, String> key) {}
+
+    /** What a clause's container argument really is: the construction's own expression where the
+     * clause names a field, the clause's own expression otherwise. {@code peel} takes the
+     * size-keeping operations off — a size reads how many, and how the elements are made has no
+     * bearing on that. */
+    private Named resolve(Ast.Expr arg, Bindings binds, boolean peel) {
+        Ast.Expr here = peel ? sizeSource(arg) : arg;
+        Ast.Expr given = atSite(here, binds);
+        if (given == null) {
+            return new Named(here, siteOf(binds));
+        }
+        return new Named(peel ? sizeSource(given) : given, binds.bodyKey());
+    }
+
+    /** The atom a size call in a clause names, or {@code null}. */
+    private String clauseSizeAtom(Ast.Expr e, Bindings binds) {
+        if (!(e instanceof Ast.Call call) || !SIZE_CALLS.contains(call.fn()) || call.args().size() != 1) {
+            return null;
+        }
+        Named named = resolve(call.args().get(0), binds, true);
+        String key = named.key().apply(named.term());
+        return key == null ? null : call.fn() + "(" + key + ")";
     }
 
     /** The path an invariant expression names at the construction site: a bare field name through the
@@ -605,21 +755,172 @@ public final class InvariantChecker {
     /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value) or of
      * a size call over a nameable container, or {@code null} if {@code e} is neither. */
     private String atomOf(Ast.Expr e, Map<String, Type> types) {
-        String size = sizeAtom(e, arg -> pathKey(arg, types));
+        String size = sizeAtom(e, arg -> bodyKey(arg, types));
         if (size != null) {
             return size;
         }
         return isNumeric(typeExpr(e, types)) ? pathKey(e, types) : null;
     }
 
-    /** The atom key of {@code SIZE_CALL(container)} when {@code path} can name the container, else
+    /** A body expression's canonical key: a location names itself, and everything else is read
+     * structurally. */
+    private String bodyKey(Ast.Expr e, Map<String, Type> types) {
+        return termKey(e, x -> pathKey(x, types), Map.of(), 0);
+    }
+
+    /**
+     * How a value a construction is being given is named where a clause reads it: a location names
+     * itself, and a container built from one by an operation the table covers names that
+     * construction. Anything else names nothing.
+     *
+     * <p>The restriction is what ties the flagging to the rules. A value the check has no rule about
+     * — a string joined from parts, a number a helper returned — can be rendered, but nothing follows
+     * from rendering it, and reporting its construction would be reporting a possible violation the
+     * author has no reasonable guard for.
+     */
+    private String siteKey(Ast.Expr e, Map<String, Type> types) {
+        String path = pathKey(e, types);
+        if (path != null) {
+            return path;
+        }
+        if (e instanceof Ast.Call call) {
+            Built built = BUILT_FROM.get(call.fn());
+            if (built != null && built.from() < call.args().size()
+                    && siteKey(call.args().get(built.from()), types) != null) {
+                return bodyKey(e, types);
+            }
+        }
+        return null;
+    }
+
+    /** The atom key of {@code SIZE_CALL(container)} when {@code key} can name the container, else
      * {@code null}. */
-    private static String sizeAtom(Ast.Expr e, Function<Ast.Expr, String> path) {
+    private static String sizeAtom(Ast.Expr e, Function<Ast.Expr, String> key) {
         if (!(e instanceof Ast.Call call) || !SIZE_CALLS.contains(call.fn()) || call.args().size() != 1) {
             return null;
         }
-        String arg = path.apply(call.args().get(0));
+        String arg = key.apply(sizeSource(call.args().get(0)));
         return arg == null ? null : call.fn() + "(" + arg + ")";
+    }
+
+    /** The container a size is really the size of: an operation that keeps the size of what it was
+     * built from is peeled away, so {@code List.length(List.map(f, xs))} is the atom
+     * {@code List.length(xs)}. How the elements are made has no bearing on how many there are, which
+     * is why the closure does not enter the key. */
+    private static Ast.Expr sizeSource(Ast.Expr e) {
+        if (e instanceof Ast.Call call) {
+            Built built = BUILT_FROM.get(call.fn());
+            if (built != null && built.shape().keepsSize() && built.from() < call.args().size()) {
+                return sizeSource(call.args().get(built.from()));
+            }
+        }
+        return e;
+    }
+
+    /** What is known of the size of every container a clause names: never negative, and no greater
+     * than the size of what it was built from wherever the building can only drop elements. */
+    private void sizeFacts(Ast.Expr e, Bindings binds, List<Constraint> out) {
+        if (!(e instanceof Ast.Call call)) {
+            Ast.forEachChild(e, child -> sizeFacts(child, binds, out));
+            return;
+        }
+        if (SIZE_CALLS.contains(call.fn()) && call.args().size() == 1) {
+            Named named = resolve(call.args().get(0), binds, true);
+            String atom = clauseSizeAtom(e, binds);
+            if (atom != null) {
+                out.add(new Constraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
+                bounds(call.fn(), named.term(), named.key(), out);
+            }
+        }
+        for (Ast.Expr arg : call.args()) {
+            sizeFacts(arg, binds, out);
+        }
+    }
+
+    /** The same, over a body expression, where a term is only ever itself. */
+    private void sizeFacts(Ast.Expr e, Map<String, Type> types, List<Constraint> out) {
+        sizeFacts(e, Bindings.ofBody(x -> bodyKey(x, types)), out);
+    }
+
+    /** {@code size(c) <= size(what c was built from)}, down the chain, wherever the building can only
+     * drop elements. */
+    private void bounds(String sizeCall, Ast.Expr container, Function<Ast.Expr, String> key,
+                        List<Constraint> out) {
+        if (!(container instanceof Ast.Call call)) {
+            return;
+        }
+        Built built = BUILT_FROM.get(call.fn());
+        if (built == null || built.shape().keepsSize() || built.from() >= call.args().size()) {
+            return;
+        }
+        Ast.Expr source = sizeSource(call.args().get(built.from()));
+        String here = key.apply(container);
+        String there = key.apply(source);
+        if (here == null || there == null) {
+            return;
+        }
+        out.add(new Constraint(
+                LinearForm.atom(sizeCall + "(" + here + ")")
+                        .minus(LinearForm.atom(sizeCall + "(" + there + ")")),
+                Rel.LE));
+        bounds(sizeCall, source, key, out);
+    }
+
+    /** The keys a guard could have settled to establish this clause: the predicate as written, and
+     * the same predicate of each container the written one was built from by a construction that
+     * carries it. Stating {@code List.all(p, xs)} is stating it of every sublist of {@code xs}. */
+    private List<String> factKeys(Ast.Expr inv, Bindings binds) {
+        String written = siteOf(binds).apply(inv);
+        if (written == null) {
+            return List.of();
+        }
+        List<String> keys = new ArrayList<>();
+        keys.add(written);
+        if (!(inv instanceof Ast.Call call)) {
+            return keys;
+        }
+        Carried carried = CARRIED.get(call.fn());
+        if (carried == null || carried.container() >= call.args().size()) {
+            return keys;
+        }
+        // The predicate over each container the one it names was built from — read at the site, so
+        // the operations the construction wrote are the ones peeled off. The peeled container is a
+        // term of the body, and the rest of the call is the clause's, so each is named by its own
+        // rule and the two meet in the key.
+        Named named = resolve(call.args().get(carried.container()), binds, false);
+        Ast.Expr container = named.term();
+        while (container instanceof Ast.Call inner) {
+            Built built = BUILT_FROM.get(inner.fn());
+            if (built == null || !carried.through().contains(built.shape())
+                    || built.from() >= inner.args().size()) {
+                break;
+            }
+            Ast.Expr source = inner.args().get(built.from());
+            String inside = named.key().apply(source);
+            if (inside == null) {
+                break;
+            }
+            String key = termKey(call, spliced(call.args().get(carried.container()), inside, binds),
+                    Map.of(), 0);
+            if (key == null) {
+                break;
+            }
+            keys.add(key);
+            container = source;
+        }
+        return keys;
+    }
+
+    /** The clause's naming rule with one argument already named: what lets a key hold a term of the
+     * clause and a term of the body at once. */
+    private Function<Ast.Expr, String> spliced(Ast.Expr at, String named, Bindings binds) {
+        return e -> e == at ? named : invPath(e, binds);
+    }
+
+    private static Ast.Call withArg(Ast.Call call, int at, Ast.Expr arg) {
+        List<Ast.Expr> args = new ArrayList<>(call.args());
+        args.set(at, arg);
+        return new Ast.Call(call.fn(), call.denotes(), args, call.pos());
     }
 
     /** An emptiness check as the comparison it means, or {@code e} unchanged. */
@@ -661,6 +962,10 @@ public final class InvariantChecker {
         if (root != null) {
             String at = bound.get(root);
             return at != null ? chainOn(at, e) : site.apply(e);
+        }
+        String named = site.apply(e);
+        if (named != null) {
+            return named;   // a subterm the site has already named — see spliced
         }
         return switch (e) {
             case Ast.IntLit i -> Long.toString(i.value());
@@ -790,6 +1095,16 @@ public final class InvariantChecker {
                         ? TypeOps.fieldTypes(d, symbols).get(fa.field()) : null;
             }
             case Ast.NewData nd -> Type.ref(nd.typeName().denotes());
+            case Ast.LetIn li -> {
+                Map<String, Type> inner = new HashMap<>(types);
+                Type bound = typeExpr(li.value(), types);
+                if (bound == null) {
+                    inner.remove(li.name());
+                } else {
+                    inner.put(li.name(), bound);
+                }
+                yield typeExpr(li.body(), inner);
+            }
             case Ast.Neg n -> typeExpr(n.operand(), types);
             case Ast.Binary b when isArith(b.op()) -> arithType(b, types);
             default -> null;

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -26,7 +26,7 @@ import java.util.Set;
 final class NumericDomain {
 
     /** A comparison of a {@link LinearForm} against zero. */
-    enum Rel { GE, GT, LE, LT, EQ }
+    enum Rel { GE, GT, LE, LT, EQ, NE }
 
     /** An affine form {@code const + Σ coef·atom} over the domain's atoms. */
     record LinearForm(BigDecimal constant, Map<String, BigDecimal> coefs) {
@@ -97,7 +97,9 @@ final class NumericDomain {
 
     /** The domain refined by asserting {@code f rel 0}. */
     NumericDomain assume(LinearForm f, Rel rel) {
-        if (bottom) {
+        if (bottom || rel == Rel.NE) {
+            // `f != 0` is a disjunction, and the domain holds conjunctions of bounds. Nothing to
+            // record; what settles such a guard is the fact keyed on the comparison itself.
             return this;
         }
         if (rel == Rel.EQ) {
@@ -182,6 +184,9 @@ final class NumericDomain {
         if (rel == Rel.EQ) {
             return proveLe(f, false) && proveLe(f.negate(), false);
         }
+        if (rel == Rel.NE) {
+            return proveLe(f, true) || proveLe(f.negate(), true);   // f < 0, or f > 0
+        }
         return proveLe(negOf(rel) ? f.negate() : f, strictOf(rel));
     }
 
@@ -191,6 +196,9 @@ final class NumericDomain {
     boolean refutes(LinearForm f, Rel rel) {
         if (bottom || rel == Rel.EQ) {
             return false;   // an unreachable path violates nothing; equality is never refuted here
+        }
+        if (rel == Rel.NE) {
+            return entails(f, Rel.EQ);   // proving it equal is proving it not unequal
         }
         return proveLe(negOf(rel) ? f : f.negate(), !strictOf(rel));
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -75,6 +75,7 @@ final class NumericDomain {
     private final Map<String, BigDecimal> hi;                  // atom -> upper bound (absent = +inf)
     private final Map<String, Map<String, BigDecimal>> diff;   // diff[a][b] = tightest known (a - b)
     private final List<Asserted> kept;                         // forms outside both shapes, as written
+    private Map<String, Map<String, BigDecimal>> closed;       // diff closed transitively, on first ask
 
     private NumericDomain(boolean bottom, Map<String, BigDecimal> lo, Map<String, BigDecimal> hi,
                           Map<String, Map<String, BigDecimal>> diff, List<Asserted> kept) {
@@ -354,14 +355,14 @@ final class NumericDomain {
         Map<String, BigDecimal> nhi = new HashMap<>(hi);
         nhi.merge(a, bound, NumericDomain::min);
         NumericDomain d = new NumericDomain(false, lo, nhi, diff, kept);
-        return d.feasible(a) ? d : bottom();
+        return d.feasible() ? d : bottom();
     }
 
     private NumericDomain withLo(String a, BigDecimal bound) {
         Map<String, BigDecimal> nlo = new HashMap<>(lo);
         nlo.merge(a, bound, NumericDomain::max);
         NumericDomain d = new NumericDomain(false, nlo, hi, diff, kept);
-        return d.feasible(a) ? d : bottom();
+        return d.feasible() ? d : bottom();
     }
 
     private NumericDomain withDiff(String a, String b, BigDecimal bound) {
@@ -369,55 +370,90 @@ final class NumericDomain {
         diff.forEach((k, v) -> nd.put(k, new HashMap<>(v)));
         nd.computeIfAbsent(a, k -> new HashMap<>()).merge(b, bound, NumericDomain::min);
         NumericDomain d = new NumericDomain(false, lo, hi, nd, kept);
-        // Contradictory guards make the path infeasible: with a - b <= bound now recorded, if the
-        // difference facts also prove b - a <= back and bound + back < 0, then 0 <= bound + back < 0.
-        // Mark it bottom so entails discharges everything and refutes fires nothing — no false E2010
-        // on a dead path.
-        BigDecimal back = d.closedDiff(b, a);
-        if (back != null && bound.add(back).signum() < 0) {
-            return bottom();
+        return d.feasible() ? d : bottom();
+    }
+
+    /**
+     * Whether the bounds and the differences can hold at once. Guards that contradict make the path
+     * infeasible, and the domain must say so: {@link #entails} then discharges everything and
+     * {@link #refutes} fires nothing, so nothing is reported at a construction that is not reached.
+     *
+     * <p>A bound is an edge to or from zero, so the two ways a contradiction shows up are one thing
+     * seen twice: a difference cycle whose sum is negative, and a lower bound above an upper one once
+     * the differences between them are closed. Deriving a bound through a difference is what made the
+     * second reachable — {@code a <= b} and {@code b <= 0} bound {@code a} without recording anything
+     * about {@code a} — so both are asked here rather than at the atom the assertion happened to name.
+     */
+    private boolean feasible() {
+        for (Map.Entry<String, Map<String, BigDecimal>> row : closed().entrySet()) {
+            BigDecimal cycle = row.getValue().get(row.getKey());
+            if (cycle != null && cycle.signum() < 0) {
+                return false;
+            }
         }
-        return d;
+        for (String a : lo.keySet()) {
+            BigDecimal l = bestLo(a);
+            BigDecimal h = bestHi(a);
+            if (l != null && h != null && l.compareTo(h) > 0) {
+                return false;
+            }
+        }
+        return true;
     }
 
-    private boolean feasible(String a) {
-        BigDecimal l = lo.get(a);
-        BigDecimal h = hi.get(a);
-        return l == null || h == null || l.compareTo(h) <= 0;
-    }
-
-    /** The tightest proven upper bound on {@code a - b}, closing difference facts transitively over a
-     * bounded number of hops, or {@code null} if none is known. */
+    /** The tightest proven upper bound on {@code a - b}, or {@code null} if none is known. */
     private BigDecimal closedDiff(String a, String b) {
         if (a.equals(b)) {
             return BigDecimal.ZERO;
         }
-        // Bellman-Ford style relaxation of `a - x <= c` edges to reach `a - b`.
-        Map<String, BigDecimal> best = new HashMap<>();
-        best.put(a, BigDecimal.ZERO);
+        Map<String, BigDecimal> row = closed().get(a);
+        return row == null ? null : row.get(b);
+    }
+
+    /** The difference facts closed transitively — {@code a - b <= c} with {@code b - d <= e} gives
+     * {@code a - d <= c + e} — computed once for the domain and read by every query it answers, since
+     * a bound on one atom is derived through the differences to every other. */
+    private Map<String, Map<String, BigDecimal>> closed() {
+        if (closed == null) {
+            closed = close(diff);
+        }
+        return closed;
+    }
+
+    private static Map<String, Map<String, BigDecimal>> close(Map<String, Map<String, BigDecimal>> diff) {
         Set<String> atoms = new HashSet<>(diff.keySet());
         diff.values().forEach(r -> atoms.addAll(r.keySet()));
-        for (int i = 0; i < atoms.size() + 1; i++) {
-            boolean changed = false;
-            for (Map.Entry<String, Map<String, BigDecimal>> row : diff.entrySet()) {
-                BigDecimal du = best.get(row.getKey());
-                if (du == null) {
+        Map<String, Map<String, BigDecimal>> d = new HashMap<>();
+        diff.forEach((a, row) -> d.put(a, new HashMap<>(row)));
+        for (String through : atoms) {
+            Map<String, BigDecimal> from = d.get(through);
+            if (from == null) {
+                continue;
+            }
+            List<Map.Entry<String, BigDecimal>> hops = List.copyOf(from.entrySet());
+            for (String a : atoms) {
+                if (a.equals(through)) {
+                    continue;   // a hop from an atom to itself only repeats a cycle already recorded
+                }
+                BigDecimal toThrough = edge(d, a, through);
+                if (toThrough == null) {
                     continue;
                 }
-                for (Map.Entry<String, BigDecimal> edge : row.getValue().entrySet()) {
-                    BigDecimal cand = du.add(edge.getValue());
-                    BigDecimal cur = best.get(edge.getKey());
-                    if (cur == null || cand.compareTo(cur) < 0) {
-                        best.put(edge.getKey(), cand);
-                        changed = true;
+                for (Map.Entry<String, BigDecimal> hop : hops) {
+                    BigDecimal candidate = toThrough.add(hop.getValue());
+                    BigDecimal known = edge(d, a, hop.getKey());
+                    if (known == null || candidate.compareTo(known) < 0) {
+                        d.computeIfAbsent(a, k -> new HashMap<>()).put(hop.getKey(), candidate);
                     }
                 }
             }
-            if (!changed) {
-                break;
-            }
         }
-        return best.get(b);
+        return d;
+    }
+
+    private static BigDecimal edge(Map<String, Map<String, BigDecimal>> d, String a, String b) {
+        Map<String, BigDecimal> row = d.get(a);
+        return row == null ? null : row.get(b);
     }
 
     private static BigDecimal min(BigDecimal x, BigDecimal y) {

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -243,13 +243,50 @@ final class NumericDomain {
         BigDecimal acc = f.constant();
         for (Map.Entry<String, BigDecimal> e : f.coefs().entrySet()) {
             BigDecimal k = e.getValue();
-            BigDecimal b = k.signum() > 0 ? hi.get(e.getKey()) : lo.get(e.getKey());
+            BigDecimal b = k.signum() > 0 ? bestHi(e.getKey()) : bestLo(e.getKey());
             if (b == null) {
                 return null;   // unbounded in the contributing direction
             }
             acc = acc.add(k.multiply(b));
         }
         return acc;
+    }
+
+    /** The tightest upper bound on an atom: its own, or one reached through a difference —
+     * {@code a - b <= d} and {@code b <= c} give {@code a <= c + d}, which is what relates the size of
+     * a filtered list to a bound on the list it came from. */
+    private BigDecimal bestHi(String a) {
+        BigDecimal best = hi.get(a);
+        for (Map.Entry<String, BigDecimal> b : hi.entrySet()) {
+            if (b.getKey().equals(a)) {
+                continue;
+            }
+            BigDecimal d = closedDiff(a, b.getKey());
+            if (d == null) {
+                continue;
+            }
+            BigDecimal through = b.getValue().add(d);
+            best = best == null ? through : min(best, through);
+        }
+        return best;
+    }
+
+    /** The tightest lower bound on an atom, the same way: {@code b - a <= d} and {@code b >= c} give
+     * {@code a >= c - d}. */
+    private BigDecimal bestLo(String a) {
+        BigDecimal best = lo.get(a);
+        for (Map.Entry<String, BigDecimal> b : lo.entrySet()) {
+            if (b.getKey().equals(a)) {
+                continue;
+            }
+            BigDecimal d = closedDiff(b.getKey(), a);
+            if (d == null) {
+                continue;
+            }
+            BigDecimal through = b.getValue().subtract(d);
+            best = best == null ? through : max(best, through);
+        }
+        return best;
     }
 
     // --- assignment ----------------------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -227,6 +227,7 @@ public final class SpecChecker {
      * do not bind values — they resolve as inline calls to those behaviors.
      */
     static Core checkSpecFn(Ast.SpecBehavior spec, Ast.FnDef fn, Ast.Expr inlinedBody,
+                                    InvariantChecker.Source discharge,
                                     Symbols symbols, Map<String, ReqSig> calleeSigs,
                                     Map<String, ReqSig> reqSigs, HelperInliner inliner,
                                     Map<String, Type> recursiveHelperFns,
@@ -388,7 +389,7 @@ public final class SpecChecker {
         // A guard-discharged one is silent; an unproven one is a warning (a possible abort); one the
         // guards prove must fail on a reachable path is an error (the path-sensitive generalization of
         // the constant `金額(-5)` check).
-        InvariantChecker.Findings inv = InvariantChecker.analyze(body, env, symbols);
+        InvariantChecker.Findings inv = InvariantChecker.analyze(discharge, env, symbols);
         warnings.addAll(inv.warnings());
         if (!inv.errors().isEmpty()) {
             throw inv.errors().get(0);

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -114,12 +114,13 @@ public final class TypeChecker {
      * around it means — never another body.
      */
     public static Core checkBehavior(Ast.SpecBehavior spec, Ast.FnDef fn, Ast.Expr loweredBody,
+                                     InvariantChecker.Source discharge,
                                      Symbols symbols, Map<String, ReqSig> calleeSigs,
                                      Map<String, ReqSig> reqSigs, HelperInliner inliner,
                                      Map<String, Type> recursiveHelperFns,
                                      Map<String, DataChecker.Constructs> recHelperConstructs,
                                      List<Diagnostic> warnings) {
-        return SpecChecker.checkSpecFn(spec, fn, loweredBody, symbols, calleeSigs, reqSigs,
+        return SpecChecker.checkSpecFn(spec, fn, loweredBody, discharge, symbols, calleeSigs, reqSigs,
                 inliner, recursiveHelperFns, recHelperConstructs, warnings);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 /**
  * The type-level questions the checker asks, independent of any expression being checked: resolving
@@ -655,14 +656,32 @@ public final class TypeOps {
 
     /** All invariants that apply to a data: included data's invariants first, then its own. */
     public static List<Ast.Expr> effectiveInvariants(Ast.Data data, Symbols symbols) {
+        return effectiveInvariants(null, data, symbols, _ -> null);
+    }
+
+    /**
+     * The same, reading each declaration's invariant through {@code form} rather than off the
+     * declaration.
+     *
+     * <p>An analysis that reads a representation other than the settled one asks for it by the
+     * declaration's name, and gets the settled one wherever {@code form} has nothing to say — which
+     * is every declaration another module made, since what travels is the settled form.
+     */
+    public static List<Ast.Expr> effectiveInvariants(TypeName named, Ast.Data data, Symbols symbols,
+                                                     Function<TypeName, Ast.Expr> form) {
         List<Ast.Expr> invs = new ArrayList<>();
         for (Ast.Name inc : data.includes()) {
             Ast.Data id = spreadTarget(inc, symbols);
             if (id != null) {
-                invs.addAll(effectiveInvariants(id, symbols));
+                invs.addAll(effectiveInvariants(inc.denotes(), id, symbols, form));
             }
         }
-        data.invariant().ifPresent(invs::add);
+        Ast.Expr own = named == null ? null : form.apply(named);
+        if (own != null) {
+            invs.add(own);
+        } else {
+            data.invariant().ifPresent(invs::add);
+        }
         return invs;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -5,6 +5,8 @@ import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.check.InjectionSigs;
+import souther.compiler.check.InliningPolicy;
+import souther.compiler.check.InvariantChecker;
 import souther.compiler.check.Lower;
 import souther.compiler.check.PipelineSigs;
 import souther.compiler.check.ReqSig;
@@ -729,6 +731,35 @@ public final class Bodies {
     }
 
     /**
+     * One body as the invariant-discharge analysis reads it: the module's own helpers expanded, the
+     * language's own operations left standing ({@link InliningPolicy#DISCHARGE}).
+     *
+     * <p>Not the tree the backend emits. That one has been expanded until nothing it cannot emit is
+     * left, and reading it is reading algorithms — a {@code List.map} is a fold there, and a rule
+     * about what {@code List.map} does to a length has nothing to match. This is the same body at the
+     * level the rules are written at.
+     */
+    public record BodyForInvariantDischarge(String module, String fn) implements Key<Ast.FnDef> {
+
+        @Override
+        public Answer<Ast.FnDef> compute(Db db) {
+            Answer<Ast.FnDef> def = db.ask(new SettledFn(module, fn));
+            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(module));
+            Answer<Set<String>> recursive = db.ask(new RecursiveHelpers(module));
+            if (!def.present() || !helpers.present() || !recursive.present()) {
+                return Answer.absent();
+            }
+            try {
+                return Answer.of(Lower.body(def.value(),
+                        HelperInliner.forHelpers(helpers.value(), InliningPolicy.DISCHARGE),
+                        recursive.value().contains(fn)));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /**
      * A module with every helper call expanded into the body that called it, and with the parameter
      * types those expansions settled written back into the declarations.
      *
@@ -896,15 +927,25 @@ public final class Bodies {
             Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(module));
             Answer<Map<String, DataChecker.Constructs>> constructs =
                     db.ask(new RecursiveHelperConstructs(module));
+            Answer<Ast.FnDef> discharge = db.ask(new BodyForInvariantDischarge(module, behavior));
+            Answer<Map<TypeName, Ast.Expr>> dischargeInvariants =
+                    db.ask(new Shapes.InvariantsForDischarge(module));
             if (!spec.present() || !fn.present() || !body.present() || !scope.present()
                     || !calleeSigs.present() || !reqSigs.present() || !helpers.present()
                     || !sigs.present() || !constructs.present()) {
                 return Answer.absent();
             }
+            // The invariant-discharge analysis reads its own representation of the body and of the
+            // invariants (spec §invariant-discharge). Where it is not available the check is skipped
+            // rather than run against the emitted tree, whose operations are no longer operations.
+            InvariantChecker.Source dischargeSource = discharge.present()
+                    ? new InvariantChecker.Source(discharge.value().body(),
+                            dischargeInvariants.present() ? dischargeInvariants.value() : Map.of())
+                    : null;
             List<Diagnostic> warnings = new ArrayList<>();
             try {
                 Core core = TypeChecker.checkBehavior(spec.value(), fn.value(), body.value().body(),
-                        scope.value(), calleeSigs.value(), reqSigs.value(),
+                        dischargeSource, scope.value(), calleeSigs.value(), reqSigs.value(),
                         HelperInliner.forHelpers(helpers.value()), sigs.value(), constructs.value(),
                         warnings);
                 List<Report> reports = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -215,4 +215,34 @@ public final class Shapes {
             return Names.symbols(db, name, Names.Stage.DERIVED);
         }
     }
+
+    /**
+     * The invariants this module declares, in the representation the invariant-discharge analysis
+     * reads ({@link souther.compiler.check.InliningPolicy#DISCHARGE}) — beside the settled form that
+     * every other stage sees on the declaration itself.
+     *
+     * <p>Only this module's own. What another module publishes arrives settled, which is what makes
+     * an imported clause fall outside the statically dischargeable fragment: the analysis reads what
+     * it is given, and there the operations have already become the folds they are.
+     */
+    public record InvariantsForDischarge(String name) implements Key<Map<TypeName, Ast.Expr>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<TypeName, Ast.Expr>> compute(Db db) {
+            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
+            if (!resolved.present() || !scope.present()) {
+                return Answer.absent();
+            }
+            try {
+                return Answer.of(HelperInliner.invariantsForDischarge(resolved.value(), scope.value()));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantBehaviorTest.java
@@ -65,6 +65,11 @@ class CompileInvariantBehaviorTest {
      * result expression was railway-bound, so the else branch emitted a bare constructor call.
      * {@code guard} now desugars to {@code if} (spec 16.4) and both branches are tail, so the
      * construction goes through {@code __construct} wherever it sits — and aborts on violation.
+     *
+     * <p>The guard reads the digit count rather than the number, so what the else branch knows says
+     * nothing about {@code cost}. Guarding on the number itself makes the violation decided at
+     * compile time (E2010, spec §invariant-discharge), and there is then no run-time abort left to
+     * pin.
      */
     @Test
     void invariantIsCheckedForAConstructionInsideAGuardElse() throws Exception {
@@ -78,7 +83,8 @@ class CompileInvariantBehaviorTest {
                     constructs Kept, Adjusted
 
                 let adjust (d) = {
-                    guard d.value /= 999 else Adjusted { cost = d.value - 2000 }
+                    guard String.length(String.fromInt(d.value)) /= 3
+                        else Adjusted { cost = d.value - 2000 }
                     Kept { v = d.value }
                 }
                 """;

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -284,10 +284,8 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
-    void aLengthInvariantOverAMappedListStaysOpaque() {
-        // `List.length(List.map(f, xs))` is not the same atom as `List.length(xs)` at this increment,
-        // so the clause is not expressible here and the run-time check stands — no warning no guard
-        // written over the mapped list could silence
+    void anUnguardedConstructionFromAMappedListIsReported() {
+        // the length of the mapped list is the length of `xs`, and nothing here says what that is
         String m = """
                 module demo
                 data Lines = List<Int>
@@ -295,8 +293,8 @@ class CompileInvariantDischargeTest {
                 behavior build : (xs: List<Int>) -> Lines constructs Lines
                 let build (xs) = Lines(List.map(x -> x + 1, xs))
                 """;
-        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
-                "an unnameable container leaves the clause opaque");
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "the length of the mapped list is the length of what was mapped");
     }
 
     @Test
@@ -594,6 +592,158 @@ class CompileInvariantDischargeTest {
                 """;
         assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
                 "a rebinding invalidates the guard's fact about that name");
+    }
+
+    @Test
+    void aMappingKeepsTheLengthOfWhatItMapped() {
+        // the crm case: guard the input's length, build from the mapped list. How the elements are
+        // made has no bearing on how many there are.
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines | NoItems constructs Lines, NoItems
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else NoItems
+                    Lines(List.map(x -> x + 1, xs))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a mapping keeps the length");
+    }
+
+    @Test
+    void aReorderingKeepsTheLength() {
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines | NoItems constructs Lines, NoItems
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else NoItems
+                    Lines(List.reverse(List.sort(xs)))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "reversing and sorting keep the length");
+    }
+
+    @Test
+    void aSelectionOnlyBoundsTheLength() {
+        // filtering can drop everything, so guarding the input says nothing about the result
+        String m = """
+                module demo
+                data NoItems
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                behavior build : (xs: List<Int>) -> Lines | NoItems constructs Lines, NoItems
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else NoItems
+                    Lines(List.filter(x -> x > 0, xs))
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a selection does not keep the length");
+    }
+
+    @Test
+    void aSelectionBoundsTheLengthFromAbove() {
+        // the other direction is known: no more came out than went in, so a cap on the input caps
+        // the result
+        String m = """
+                module demo
+                data TooMany
+                data Lines = List<Int>
+                    invariant List.length(value) <= 10
+                behavior build : (xs: List<Int>) -> Lines | TooMany constructs Lines, TooMany
+                let build (xs) = {
+                    guard List.length(xs) <= 10
+                        else TooMany
+                    Lines(List.filter(x -> x > 0, xs))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "no more came out of the filter than went in");
+    }
+
+    @Test
+    void aReorderingCarriesUniqueness() {
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { a: Int }
+                data Rows = List<Row>
+                    invariant List.allUniqueBy(r -> r.a, value)
+                behavior build : (xs: List<Row>) -> Rows | Duplicate constructs Rows, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(r -> r.a, xs)
+                        else Duplicate
+                    Rows(List.sortBy(r -> r.a, xs))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "sorting keeps the elements, so it keeps their distinctness");
+    }
+
+    @Test
+    void aSelectionCarriesAPropertyOfEveryElement() {
+        String m = """
+                module demo
+                data OutOfRange
+                data Row = { a: Int }
+                data Rows = List<Row>
+                    invariant List.all(r -> r.a >= 1, value)
+                behavior build : (xs: List<Row>) -> Rows | OutOfRange constructs Rows, OutOfRange
+                let build (xs) = {
+                    guard List.all(r -> r.a >= 1, xs)
+                        else OutOfRange
+                    Rows(List.filter(r -> r.a > 5, xs))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "nothing new is in a sublist, so what held of every element still holds");
+    }
+
+    @Test
+    void aSelectionDoesNotCarryMembership() {
+        String m = """
+                module demo
+                data Missing
+                data Rows = List<Int>
+                    invariant List.member(1, value)
+                behavior build : (xs: List<Int>) -> Rows | Missing constructs Rows, Missing
+                let build (xs) = {
+                    guard List.member(1, xs)
+                        else Missing
+                    Rows(List.filter(x -> x > 5, xs))
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a filter may drop the very element that was there");
+    }
+
+    @Test
+    void aMappingDoesNotCarryUniqueness() {
+        // distinct elements can map to one — that a projection survives a map is #226's question
+        String m = """
+                module demo
+                data Duplicate
+                data Rows = List<Int>
+                    invariant List.allUniqueBy(x -> x, value)
+                behavior build : (xs: List<Int>) -> Rows | Duplicate constructs Rows, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(x -> x, xs)
+                        else Duplicate
+                    Rows(List.map(x -> x * 0, xs))
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a mapping says nothing about what the elements became");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -90,6 +90,46 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void emptinessAndItsSizeComparisonAreOneStatement() {
+        // `Set.isEmpty(s)` and `Set.size(s) == 0` say one thing, so which the author reached for does
+        // not decide whether the construction discharges
+        String m = """
+                module demo
+                data Empty
+                data Tags = Set<String>
+                    invariant Bool.not(Set.isEmpty(value))
+                behavior build : (s: Set<String>) -> Tags | Empty constructs Tags, Empty
+                let build (s) = {
+                    guard Set.size(s) >= 1
+                        else Empty
+                    Tags(s)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the size guard discharges the emptiness invariant");
+    }
+
+    @Test
+    void theElementAMapHandsItsClosureCarriesItsOwnInvariant() {
+        // The combinator rule for `List.map` binds the closure's parameter to the list's element type
+        // and seeds that type's invariant, so `x >= 0` is known here and the re-wrap discharges. This
+        // only happens if the analysis reads a representation where `List.map` is still `List.map`:
+        // against the tree the backend emits it is a fold, and the rule has nothing to match.
+        String m = """
+                module demo
+                data Money = Decimal
+                    invariant value >= 0m
+                data Positive = Decimal
+                    invariant value >= 0m
+                data Bag = { items: List<Money> }
+                behavior copy : (b: Bag) -> List<Positive> constructs Positive
+                let copy (b) = List.map(x -> Positive(x.value), b.items)
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the element's own invariant discharges the re-wrap");
+    }
+
+    @Test
     void aConstructionInsideAMapClosureIsAnalyzed() {
         // the closure element x: Money carries x >= 0; `x - Money(1m)` can go negative, so it is a
         // possible violation. Without binding the combinator's element parameter the construction

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -895,4 +895,81 @@ class CompileInvariantDischargeTest {
         assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
                 "the guard discharges the subtraction");
     }
+
+    @Test
+    void guardsThatCannotAllHoldLeaveNothingToReport() {
+        // `a <= b`, `b <= 0` and `a >= 1` cannot hold together, so the construction is not reached and
+        // says nothing about the invariant — the bound on `a` is only derivable through the difference
+        String m = """
+                module demo
+                data Ok
+                data AtLeastTwo = Int
+                    invariant value >= 2
+                behavior build : (a: Int, b: Int) -> AtLeastTwo | Ok constructs AtLeastTwo, Ok
+                let build (a, b) = {
+                    guard a <= b
+                        else Ok
+                    guard b <= 0
+                        else Ok
+                    guard a >= 1
+                        else Ok
+                    AtLeastTwo(a)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "an unreachable construction is neither violated nor possibly violated");
+    }
+
+    @Test
+    void theOrderTheContradictingGuardsAreWrittenDoesNotMatter() {
+        String m = """
+                module demo
+                data Ok
+                data AtLeastTwo = Int
+                    invariant value >= 2
+                behavior build : (a: Int, b: Int) -> AtLeastTwo | Ok constructs AtLeastTwo, Ok
+                let build (a, b) = {
+                    guard a >= 1
+                        else Ok
+                    guard b <= 0
+                        else Ok
+                    guard a <= b
+                        else Ok
+                    AtLeastTwo(a)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the difference asserted last closes the same contradiction");
+    }
+
+    @Test
+    void aComparisonAndItsDenialAreOneFact() {
+        // the else branch of `a == b` is where `a /= b` holds
+        String m = """
+                module demo
+                data Ok
+                data Pair = { left: Int, right: Int }
+                    invariant left /= right
+                behavior build : (a: Int, b: Int) -> Pair | Ok constructs Pair, Ok
+                let build (a, b) =
+                    if a == b then Ok else Pair { left = a, right = b }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "denying the equality states the inequality");
+    }
+
+    @Test
+    void anEqualityIsOneFactWhicheverSideIsWrittenFirst() {
+        String m = """
+                module demo
+                data Ok
+                data Pair = { left: Int, right: Int }
+                    invariant right /= left
+                behavior build : (a: Int, b: Int) -> Pair | Ok constructs Pair, Ok
+                let build (a, b) =
+                    if a == b then Ok else Pair { left = a, right = b }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "which side of an equality a term is written on is not part of what it says");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/BodyForInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/BodyForInvariantDischargeTest.java
@@ -1,0 +1,78 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The invariant-discharge analysis reads its own representation of a body, and what makes it its own
+ * is which abstractions are still there.
+ *
+ * <p>The tree the backend emits has been expanded until nothing it cannot emit is left, so a
+ * {@code List.map} in it is the fold that {@code List.map} is. A rule about what {@code List.map}
+ * does to a length has nothing to match there, which is how the analysis came to hold a table of
+ * combinator rules that could not fire. These pin the two apart.
+ */
+class BodyForInvariantDischargeTest {
+
+    private static final String SOURCE = """
+            module m.a
+            data Money = Decimal
+                invariant value >= 0m
+            data Bag = { items: List<Money> }
+            let doubled (x: Money): Money = x + x
+            behavior shift : (b: Bag) -> List<Money>
+            let shift (b) = List.map(x -> doubled(x), b.items)
+            """;
+
+    private static Ast.Expr body(Key<Ast.FnDef> key) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", SOURCE);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        return c.db().ask(key).value().body();
+    }
+
+    private static List<String> calls(Ast.Expr e) {
+        List<String> out = new ArrayList<>();
+        collect(e, out);
+        return out;
+    }
+
+    private static void collect(Ast.Expr e, List<String> out) {
+        if (e instanceof Ast.Call call) {
+            out.add(call.fn());
+        }
+        Ast.forEachChild(e, child -> collect(child, out));
+    }
+
+    @Test
+    void theAnalysisBodyKeepsTheOperationsTheLanguageDefines() {
+        List<String> fns = calls(body(new Bodies.BodyForInvariantDischarge("m.a", "shift")));
+        assertTrue(fns.contains("List.map"),
+                "a standard-library operation is what the rules are written about: " + fns);
+    }
+
+    @Test
+    void theAnalysisBodyExpandsTheModulesOwnHelpers() {
+        List<String> fns = calls(body(new Bodies.BodyForInvariantDischarge("m.a", "shift")));
+        assertFalse(fns.contains("doubled"),
+                "a helper of this module carries no such rule, and does not travel: " + fns);
+    }
+
+    @Test
+    void theEmittedBodyHasExpandedTheOperationAway() {
+        List<String> fns = calls(body(new Bodies.LoweredBody("m.a", "shift")));
+        assertFalse(fns.contains("List.map"),
+                "the backend emits folds, not operations: " + fns);
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -978,7 +978,61 @@ let build (xs) = {
 }
 ----
 
-A size taken of anything else — `+List.length(List.map(f, xs))+` — is not a term, and a clause needing it is left to the run-time check.
+A size taken of a container built by an operation is read through that operation, by the rules in <<invariant-discharge-preservation>>. A size taken of anything else — of what a `+let+` returned, of a string joined from parts — is not a term, and a clause needing it is left to the run-time check.
+
+[#invariant-discharge-representation]
+==== What the check reads
+
+The check reads a behavior's body and the invariants around it at the level the rules above are written at: the standard library's operations are operations, and a module's own `+let+`s are expanded into the body that called them (spec 12.5). The two go together. The language defines what `+List.map+` does to a length, and every module has that definition, so a call to it says something on its own. A `+let+` carries no such definition and does not travel to an importing module either, so what it says is its body.
+
+An invariant that arrives from another module arrives expanded (<<published-modules>>), so a clause of an imported type is read as the computation it became rather than as the operations it was written as. Such a clause is outside the statically dischargeable fragment even where the same clause written here would be inside it.
+
+[#invariant-discharge-preservation]
+==== What an operation keeps of what it was built from
+
+An invariant is stated of a value, and a value is often built from another by a standard-library operation. Whether the clause carries across that operation is a property of the operation, and is stated here rather than left to the checker: an author predicts which constructions are judged safe by reading this table.
+
+Four shapes cover the operations.
+
+[cols="1,3"]
+|===
+| shape | what the result is
+
+| *permutes* | the same elements in another order — `+List.reverse+`, `+List.sort+`, `+List.sortBy+`
+| *subset* | some of the same elements — `+List.filter+`, `+List.distinct+`, `+List.take+`, `+List.drop+`, `+Set.filter+`, `+Map.filter+`
+| *maps* | one new element for each — `+List.map+`, `+List.indexedMap+`, `+Map.map+`
+| *collapses* | at most one new element for each — `+List.filterMap+`, `+Set.map+`
+|===
+
+What each keeps:
+
+[cols="1,1,1,1"]
+|===
+| shape | size | a property of every element | a particular element
+
+| *permutes* | the same | kept | kept
+| *subset* | no greater | kept | not kept
+| *maps* | the same | not kept | not kept
+| *collapses* | no greater | not kept | not kept
+|===
+
+So `+List.length(List.map(f, xs))+` *is* `+List.length(xs)+` — how the elements are made has no bearing on how many there are — and a guard on the length of `+xs+` discharges a construction from the mapped list. `+List.length(List.filter(p, xs))+` is its own term, no greater than `+List.length(xs)+`: an upper bound on the input bounds the result, and a lower bound on the input says nothing.
+
+[,text]
+----
+data Lines = List<Line> invariant List.length(value) >= 1
+
+behavior build : (rows: List<Row>) -> Lines | NoRows
+let build (rows) = {
+    guard List.length(rows) >= 1
+        else NoRows
+    Lines(List.map(toLine, rows))     // discharged: a mapping keeps the length
+}
+----
+
+"A property of every element" is a clause like `+List.all(p, value)+` or `+List.allUniqueBy(f, value)+`: nothing new is in a sublist, so what held of every element still holds. "A particular element" is `+List.member(x, value)+` or `+Set.contains(x, value)+`, which a selection may drop.
+
+An operation not in the table keeps nothing that can be relied on, and a clause over what it built is left to the run-time check.
 
 [#invariant-discharge-facts]
 ==== A clause that states no relation is settled, not derived

--- a/specification.adoc
+++ b/specification.adoc
@@ -944,6 +944,8 @@ The check is intraprocedural. Within a behavior's `+let+` body it seeds what the
 * *Possibly violated* — expressible but not proven. A warning: a possible abort. Guard it with `+guard+`, reify the relation into a type invariant (below), or attempt the construction (<<attempted-construction>>), which cannot abort.
 * *Not expressible* — an invariant outside the checked fragment. No diagnostic; the run-time check stands.
 
+Guards that cannot all hold describe a path the behavior does not take, and a construction standing on one is neither of the middle two: nothing is built there, so nothing is reported. That the guards contradict is itself derived over the same fragment — `+a <= b+` with `+b <= 0+` bounds `+a+` above without a word about `+a+` — so a path is dead whenever the relations say so, whatever order they were written in.
+
 [,text]
 ----
 data Money = Decimal invariant value >= 0m
@@ -1051,7 +1053,7 @@ let build (rows) = {
 }
 ----
 
-Two clauses are one thing exactly when they are the same expression over the same terms. Nothing relates two different ones — uniqueness by `+.product+` says nothing about uniqueness by `+.sku+`, and one pattern says nothing about another. What a binding is *called* is not part of the expression, so `+r -> r.product+`, `+row -> row.product+` and `+.product+` state one thing; a name the closure reads from outside it is part of the expression, so bounding by one field is not bounding by another.
+Two clauses are one thing exactly when they are the same expression over the same terms. Nothing relates two different ones — uniqueness by `+.product+` says nothing about uniqueness by `+.sku+`, and one pattern says nothing about another. What a binding is *called* is not part of the expression, so `+r -> r.product+`, `+row -> row.product+` and `+.product+` state one thing; a name the closure reads from outside it is part of the expression, so bounding by one field is not bounding by another. Which of the six comparisons an author reached for is not part of it either: `+a /= b+` is `+a == b+` denied, `+a >= b+` is `+a < b+` denied, and which side of an equality a term is written on says nothing — so a `+guard+` on `+a == b+` discharges a clause reading `+b /= a+` where it departs.
 
 This is what a clause outside the derived fragment falls back to, whatever its shape. A comparison over a value the procedure cannot name is settled the same way, which is why `+guard+`-ing it verbatim discharges the construction.
 


### PR DESCRIPTION
Closes #225 (a sub-issue of #222).

**Sits on #228 and #229.** Its own commits are the last two.

## The check was reading the wrong tree

#225 asks for a table of which stdlib operation preserves which property. Written against the tree
this check was reading, not one row of it could fire: a prelude helper is expanded before the check
sees either a body or an invariant, so `List.map(f, xs)` arrives as the fold that `List.map` is.
Measured across every module of souther-lang/examples, three of the twenty-five combinator rules the
checker already held could ever match. That is #230, filed separately.

So the first commit changes what the analysis reads, and the second writes the table.

## The representation

`InliningPolicy` names the difference between the tree the backend emits and the tree this analysis
reads. The line is not that the standard library is special: it is whether the language *defines*
what an operation does to the properties being tracked. A standard-library operation has such a
definition and every module already has it, so it survives as a call. A module's own helper has
none, and does not travel to an importer either, so it is expanded exactly as before.

`Bodies.BodyForInvariantDischarge` and `Shapes.InvariantsForDischarge` supply it. A type another
module declares arrives settled, so an imported clause is read as the computation it became and
falls outside the statically dischargeable fragment — stated in the specification rather than left
as a surprise, and relevant to #227.

Two capabilities are carried across the change rather than lost to it:

- `List.isEmpty` was read as `List.length(xs) == 0` only because it was expanded. It is now read
  that way because the two say one thing — a rule about what a predicate *means*, kept separate from
  the preservation table.
- A clause now carries both routes to its discharge, a relation for the domain and a key a guard
  restating it settles, and either is enough. Which route carries a clause is decided where the
  clause is read, and a guard cannot know which that will be.

## The table

| shape | operations | size | property of every element | a particular element |
| --- | --- | --- | --- | --- |
| permutes | `reverse`, `sort`, `sortBy` | same | kept | kept |
| subset | `filter`, `distinct`, `take`, `drop`, `Set.filter`, `Map.filter` | no greater | kept | not kept |
| maps | `map`, `indexedMap`, `Map.map` | same | not kept | not kept |
| collapses | `filterMap`, `Set.map` | no greater | not kept | not kept |

`List.length(List.map(f, xs))` *is* `List.length(xs)` — how the elements are made has no bearing on
how many there are — so guarding the input's length discharges a construction from the mapped list,
which is the shape `buildQuote` writes. `List.length(List.filter(p, xs))` is its own term, no
greater than `List.length(xs)`.

Two gaps in the domain stood in the way and are fixed: a difference and an interval did not compose,
so `size(filter) <= size(xs)` with `size(xs) <= 10` proved nothing; and the affine walk stopped at a
binding, so the arithmetic a helper expands into (`let $0_n = n.value in $0_n * 2`) was opaque where
`n.value * 2` was not.

## What is deliberately not here

Uniqueness through a mapping. `List.map` keeps the count and nothing about the elements; that
`List.allUniqueBy(.product, ...)` survives when the closure copies `.product` unchanged is #226.

## Verification

- `mvn -o clean test` green; 1590 tests. Eleven added to `CompileInvariantDischargeTest` and three
  to a new `BodyForInvariantDischargeTest` that pins the two representations apart.
- souther-lang/examples reports **exactly** the ten warnings #229 leaves it with — the rules
  discharge, they do not flag. Naming what a construction is given is gated on the table, so a value
  the check has no rule about (a string joined from parts, a number a helper returned) stays
  unnameable and its construction stays silent, rather than being reported with no guard worth
  suggesting.
- Two existing tests changed with the representation, both because the check now proves more:
  `invariantIsCheckedForAConstructionInsideAGuardElse` guarded on the number it then subtracted
  from, which is now a decided violation rather than a run-time abort, so it guards on the digit
  count instead; and the #223 test asserting a mapped list stays opaque now asserts it is reported,
  which is the point of this change.
- Specification: `[#invariant-discharge-representation]` and `[#invariant-discharge-preservation]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
