### PR TITLE
A projection the closure copied carries through the map

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -980,8 +980,13 @@ public final class InvariantChecker {
         if (built.shape() != Shape.MAPS || at == null || at >= stated.args().size()) {
             return null;
         }
-        Ast.Expr closure = inner.args().size() > 1 - built.from() ? inner.args().get(1 - built.from()) : null;
-        Ast.Expr traced = closure == null ? null : projectionThrough(stated.args().get(at), closure);
+        // Where the mapping's closure is written is already stated once, by the table that says which
+        // argument each combinator hands its elements to.
+        Combinator combo = COMBINATORS.get(inner.fn());
+        if (combo == null || combo.closureArg() >= inner.args().size()) {
+            return null;
+        }
+        Ast.Expr traced = projectionThrough(stated.args().get(at), inner.args().get(combo.closureArg()));
         return traced == null ? null : withArg(stated, at, traced);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -139,6 +139,11 @@ public final class InvariantChecker {
      * neither survives a mapping — what a mapped element is, is #226's question. */
     private record Carried(int container, Set<Shape> through) {}
 
+    /** Where a predicate reads the projection it is stated over. A mapping keeps a projection when
+     * the closure copies that field from the element unchanged, so the predicate holds of the mapped
+     * list exactly when it holds of what was mapped, over the field it came from. */
+    private static final Map<String, Integer> PROJECTION_OF = Map.of("List.allUniqueBy", 0);
+
     private static final Map<String, Carried> CARRIED = Map.of(
             "List.all", new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
             "List.allUniqueBy", new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
@@ -889,10 +894,14 @@ public final class InvariantChecker {
         // rule and the two meet in the key.
         Named named = resolve(call.args().get(carried.container()), binds, false);
         Ast.Expr container = named.term();
+        Ast.Call stated = call;
         while (container instanceof Ast.Call inner) {
             Built built = BUILT_FROM.get(inner.fn());
-            if (built == null || !carried.through().contains(built.shape())
-                    || built.from() >= inner.args().size()) {
+            if (built == null || built.from() >= inner.args().size()) {
+                break;
+            }
+            Ast.Call next = carries(stated, carried, inner, built);
+            if (next == null) {
                 break;
             }
             Ast.Expr source = inner.args().get(built.from());
@@ -900,15 +909,110 @@ public final class InvariantChecker {
             if (inside == null) {
                 break;
             }
-            String key = termKey(call, spliced(call.args().get(carried.container()), inside, binds),
+            String key = termKey(next, spliced(call.args().get(carried.container()), inside, binds),
                     Map.of(), 0);
             if (key == null) {
                 break;
             }
             keys.add(key);
+            stated = next;
             container = source;
         }
         return keys;
+    }
+
+    /**
+     * The predicate as it applies to what {@code inner} was built from, or {@code null} when it does
+     * not apply there. A construction the shape carries leaves the predicate as it was. A mapping
+     * carries nothing on its own, but a predicate stated over a projection carries when the closure
+     * copied that field across, over the field it came from.
+     */
+    private Ast.Call carries(Ast.Call stated, Carried carried, Ast.Call inner, Built built) {
+        if (carried.through().contains(built.shape())) {
+            return stated;
+        }
+        Integer at = PROJECTION_OF.get(stated.fn());
+        if (built.shape() != Shape.MAPS || at == null || at >= stated.args().size()) {
+            return null;
+        }
+        Ast.Expr closure = inner.args().size() > 1 - built.from() ? inner.args().get(1 - built.from()) : null;
+        Ast.Expr traced = closure == null ? null : projectionThrough(stated.args().get(at), closure);
+        return traced == null ? null : withArg(stated, at, traced);
+    }
+
+    /**
+     * The projection over an element that a projection over a mapped list reduces to, or
+     * {@code null}.
+     *
+     * <p>{@code .product} over {@code List.map(r -> Line { product = r.product, ... }, xs)} is
+     * {@code .product} over {@code xs}: the closure copied that field across, so two mapped elements
+     * differ there exactly when the two they came from did. Bounded deliberately — a field a closure
+     * computes from others is not this.
+     */
+    private Ast.Expr projectionThrough(Ast.Expr projection, Ast.Expr closure) {
+        if (!(projection instanceof Ast.Block proj) || proj.params().size() != 1
+                || !(closure instanceof Ast.Block step) || step.params().size() != 1) {
+            return null;
+        }
+        Map<String, Ast.Expr> bound = new HashMap<>();
+        String element = step.params().get(0);
+        List<String> read = chain(proj.body(), proj.params().get(0), new HashMap<>());
+        if (read == null) {
+            return null;
+        }
+        Ast.Expr made = through(step.body(), bound);
+        List<String> traced;
+        if (read.isEmpty()) {
+            traced = chain(made, element, bound);   // the closure hands the element straight back
+        } else {
+            if (!(made instanceof Ast.NewData nd) || !nd.spreads().isEmpty()) {
+                return null;
+            }
+            List<String> copied = null;
+            for (Ast.FieldInit fi : nd.inits()) {
+                if (fi.name().equals(read.get(0))) {
+                    copied = chain(fi.value(), element, bound);
+                }
+            }
+            if (copied == null) {
+                return null;
+            }
+            traced = new ArrayList<>(copied);
+            traced.addAll(read.subList(1, read.size()));
+        }
+        if (traced == null) {
+            return null;
+        }
+        Ast.Expr on = Ast.Var.local(element, step.pos());
+        for (String field : traced) {
+            on = new Ast.FieldAccess(on, field, step.pos());
+        }
+        return new Ast.Block(List.of(element), on, step.pos());
+    }
+
+    /** {@code e} with the bindings an expansion introduced read through — a helper spliced into a
+     * closure is {@code let $0_r = r in ...}, and what it builds is inside that. */
+    private static Ast.Expr through(Ast.Expr e, Map<String, Ast.Expr> bound) {
+        Ast.Expr cur = e;
+        while (cur instanceof Ast.LetIn li) {
+            bound.put(li.name(), li.value());
+            cur = li.body();
+        }
+        if (cur instanceof Ast.Var v && bound.containsKey(v.name())) {
+            return through(bound.get(v.name()), bound);
+        }
+        return cur;
+    }
+
+    /** The field chain {@code e} reads off {@code root}, or {@code null} if it reads anything else. */
+    private static List<String> chain(Ast.Expr e, String root, Map<String, Ast.Expr> bound) {
+        List<String> fields = new ArrayList<>();
+        Ast.Expr cur = through(e, bound);
+        while (cur instanceof Ast.FieldAccess fa) {
+            fields.add(0, fa.field());
+            cur = through(fa.target(), bound);
+        }
+        return cur instanceof Ast.Var v && v.name().equals(root) ? fields : null;
     }
 
     /** The clause's naming rule with one argument already named: what lets a key hold a term of the
@@ -992,6 +1096,22 @@ public final class InvariantChecker {
                 Map<String, String> inner = binding(bound, List.of(li.name()), depth);
                 String body = termKey(li.body(), site, inner, depth + 1);
                 yield value == null || body == null ? null : "let(" + value + ", " + body + ")";
+            }
+            // A construction is a pure function of its fields, and a closure that builds one is what a
+            // mapping usually is. Fields are keyed in name order, so two sites writing them in
+            // different orders write one term.
+            case Ast.NewData nd when nd.spreads().isEmpty() -> {
+                List<Ast.FieldInit> inits = new ArrayList<>(nd.inits());
+                inits.sort(java.util.Comparator.comparing(Ast.FieldInit::name));
+                StringBuilder sb = new StringBuilder(nd.typeName().denotes().toString()).append('{');
+                for (int i = 0; i < inits.size(); i++) {
+                    String v = termKey(inits.get(i).value(), site, bound, depth);
+                    if (v == null) {
+                        yield null;
+                    }
+                    sb.append(i == 0 ? "" : ", ").append(inits.get(i).name()).append('=').append(v);
+                }
+                yield sb.append('}').toString();
             }
             // Only the library's own functions: they are pure, so one written call is one value.
             case Ast.Call c when Prelude.hasQualified(c.fn()) ->

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1004,16 +1004,16 @@ public final class InvariantChecker {
                 || !(closure instanceof Ast.Block step) || step.params().size() != 1) {
             return null;
         }
-        Map<String, Ast.Expr> bound = new HashMap<>();
         String element = step.params().get(0);
-        List<String> read = chain(proj.body(), proj.params().get(0), new HashMap<>());
+        List<String> read = new Reads(proj.params().get(0)).chain(proj.body());
         if (read == null) {
             return null;
         }
-        Ast.Expr made = through(step.body(), bound);
+        Reads reads = new Reads(element);
+        Ast.Expr made = reads.produced(step.body());
         List<String> traced;
         if (read.isEmpty()) {
-            traced = chain(made, element, bound);   // the closure hands the element straight back
+            traced = reads.chain(made);   // the closure hands the element straight back
         } else {
             if (!(made instanceof Ast.NewData nd) || !nd.spreads().isEmpty()) {
                 return null;
@@ -1021,7 +1021,7 @@ public final class InvariantChecker {
             List<String> copied = null;
             for (Ast.FieldInit fi : nd.inits()) {
                 if (fi.name().equals(read.get(0))) {
-                    copied = chain(fi.value(), element, bound);
+                    copied = reads.chain(fi.value());
                 }
             }
             if (copied == null) {
@@ -1040,29 +1040,58 @@ public final class InvariantChecker {
         return new Ast.Block(List.of(element), on, step.pos());
     }
 
-    /** {@code e} with the bindings an expansion introduced read through — a helper spliced into a
-     * closure is {@code let $0_r = r in ...}, and what it builds is inside that. */
-    private static Ast.Expr through(Ast.Expr e, Map<String, Ast.Expr> bound) {
-        Ast.Expr cur = e;
-        while (cur instanceof Ast.LetIn li) {
-            bound.put(li.name(), li.value());
-            cur = li.body();
-        }
-        if (cur instanceof Ast.Var v && bound.containsKey(v.name())) {
-            return through(bound.get(v.name()), bound);
-        }
-        return cur;
-    }
+    /**
+     * What the names in a closure read off the element it is handed: a field chain, or nothing this
+     * trace can follow. A binding introduces what it reads <em>where it is written</em> — an expansion
+     * splices {@code let $0_r = r in ...} into a closure, and the closure may bind over its own
+     * parameter or over a name an earlier binding read — so what a name denotes is settled against the
+     * bindings before it and not reread later. Keeping the expression instead and substituting by
+     * spelling cannot say that: {@code let r = r} would stand for itself, which is the identity here
+     * and an endless walk there.
+     */
+    private static final class Reads {
 
-    /** The field chain {@code e} reads off {@code root}, or {@code null} if it reads anything else. */
-    private static List<String> chain(Ast.Expr e, String root, Map<String, Ast.Expr> bound) {
-        List<String> fields = new ArrayList<>();
-        Ast.Expr cur = through(e, bound);
-        while (cur instanceof Ast.FieldAccess fa) {
-            fields.add(0, fa.field());
-            cur = through(fa.target(), bound);
+        private final String element;
+        private final Map<String, List<String>> chains = new HashMap<>();
+
+        private Reads(String element) {
+            this.element = element;
         }
-        return cur instanceof Ast.Var v && v.name().equals(root) ? fields : null;
+
+        /** The expression the body produces, with what the bindings on the way there read taken in. */
+        Ast.Expr produced(Ast.Expr body) {
+            Ast.Expr cur = body;
+            while (cur instanceof Ast.LetIn li) {
+                List<String> read = chain(li.value());
+                chains.put(li.name(), read);
+                cur = li.body();
+            }
+            return cur;
+        }
+
+        /** The chain {@code e} reads off the element, or {@code null} if it reads anything else. */
+        List<String> chain(Ast.Expr e) {
+            return switch (e) {
+                case Ast.LetIn li -> {
+                    Reads inner = new Reads(element);
+                    inner.chains.putAll(chains);
+                    inner.chains.put(li.name(), chain(li.value()));
+                    yield inner.chain(li.body());
+                }
+                case Ast.FieldAccess fa -> {
+                    List<String> head = chain(fa.target());
+                    if (head == null) {
+                        yield null;
+                    }
+                    List<String> out = new ArrayList<>(head);
+                    out.add(fa.field());
+                    yield out;
+                }
+                case Ast.Var v when chains.containsKey(v.name()) -> chains.get(v.name());
+                case Ast.Var v -> v.name().equals(element) ? List.of() : null;
+                default -> null;
+            };
+        }
     }
 
     /** The clause's naming rule with one argument already named: what lets a key hold a term of the

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -902,6 +902,58 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aClosureBindingOverItsOwnParameterStillCopiesTheField() {
+        // `let r = r` is the identity, so the field is still copied from the element
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { sku: String }
+                data Line = { code: String }
+                data Lines = List<Line>
+                    invariant List.allUniqueBy(.code, value)
+                behavior build : (xs: List<Row>) -> Lines | Duplicate
+                    constructs Lines, Line, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(.sku, xs)
+                        else Duplicate
+                    Lines(List.map(r -> {
+                        let r = r
+                        Line { code = r.sku }
+                    }, xs))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "binding a name to itself is the identity, not a name standing for itself");
+    }
+
+    @Test
+    void aFieldReadBeforeTheNameWasReboundIsNotTheElements() {
+        // `a` reads the argument, and the later binding of that name does not reach back into it, so
+        // nothing says the built field came from the element
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { sku: String }
+                data Line = { code: String }
+                data Lines = List<Line>
+                    invariant List.allUniqueBy(.code, value)
+                behavior build : (xs: List<Row>, spare: Row) -> Lines | Duplicate
+                    constructs Lines, Line, Duplicate
+                let build (xs, spare) = {
+                    guard List.allUniqueBy(.sku, xs)
+                        else Duplicate
+                    Lines(List.map(r -> {
+                        let a = spare
+                        let spare = r
+                        Line { code = a.sku }
+                    }, xs))
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "the field was copied from the argument, not from the element");
+    }
+
+    @Test
     void aProjectionCarriesToTheFieldItWasCopiedFrom() {
         // the closure renames the field, so uniqueness of the result by `.code` is uniqueness of the
         // input by `.sku`

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -747,6 +747,144 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aProjectionTheClosureCopiesCarriesThroughTheMap() {
+        // the crm case: guard uniqueness of the input by `.product`, build from the mapped list. The
+        // closure copies `product` across, so two mapped rows differ there exactly when the two they
+        // came from did.
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { product: String, note: String }
+                data Line = { product: String, label: String }
+                data Lines = List<Line>
+                    invariant List.allUniqueBy(.product, value)
+                let toLine (r: Row): Line = Line { product = r.product, label = r.note }
+                behavior build : (xs: List<Row>) -> Lines | Duplicate
+                    constructs Lines, Line, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(.product, xs)
+                        else Duplicate
+                    Lines(List.map(r -> toLine(r), xs))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a copied field carries uniqueness through the map");
+    }
+
+    @Test
+    void aProjectionCarriesToTheFieldItWasCopiedFrom() {
+        // the closure renames the field, so uniqueness of the result by `.code` is uniqueness of the
+        // input by `.sku`
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { sku: String }
+                data Line = { code: String }
+                data Lines = List<Line>
+                    invariant List.allUniqueBy(.code, value)
+                behavior build : (xs: List<Row>) -> Lines | Duplicate
+                    constructs Lines, Line, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(.sku, xs)
+                        else Duplicate
+                    Lines(List.map(r -> Line { code = r.sku }, xs))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the projection carries to the field it was copied from");
+    }
+
+    @Test
+    void guardingTheWrongFieldDoesNotCarry() {
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { sku: String, name: String }
+                data Line = { code: String }
+                data Lines = List<Line>
+                    invariant List.allUniqueBy(.code, value)
+                behavior build : (xs: List<Row>) -> Lines | Duplicate
+                    constructs Lines, Line, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(.name, xs)
+                        else Duplicate
+                    Lines(List.map(r -> Line { code = r.sku }, xs))
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "uniqueness by one field says nothing about another");
+    }
+
+    @Test
+    void aComputedFieldDoesNotCarryAProjection() {
+        // `code` is built rather than copied, so two rows that differ can still land on one code
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { sku: String, name: String }
+                data Line = { code: String }
+                data Lines = List<Line>
+                    invariant List.allUniqueBy(.code, value)
+                behavior build : (xs: List<Row>) -> Lines | Duplicate
+                    constructs Lines, Line, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(.sku, xs)
+                        else Duplicate
+                    Lines(List.map(r -> Line { code = String.concat([r.sku, r.name]) }, xs))
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "a computed field is not a copied one");
+    }
+
+    @Test
+    void bothClausesOfAMappedConstructionDischargeTogether() {
+        // #222's target shape: a length clause and a uniqueness clause over the same mapped list,
+        // each discharged by its own guard
+        String m = """
+                module demo
+                data Duplicate
+                data NoLines
+                data Row = { product: String }
+                data Line = { product: String }
+                data Lines = List<Line>
+                    invariant List.length(value) >= 1 && List.allUniqueBy(.product, value)
+                behavior build : (xs: List<Row>) -> Lines | Duplicate | NoLines
+                    constructs Lines, Line, Duplicate, NoLines
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else NoLines
+                    guard List.allUniqueBy(.product, xs)
+                        else Duplicate
+                    Lines(List.map(r -> Line { product = r.product }, xs))
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "both clauses discharge");
+    }
+
+    @Test
+    void removingOneOfTheTwoGuardsIsReported() {
+        String m = """
+                module demo
+                data Duplicate
+                data Row = { product: String }
+                data Line = { product: String }
+                data Lines = List<Line>
+                    invariant List.length(value) >= 1 && List.allUniqueBy(.product, value)
+                behavior build : (xs: List<Row>) -> Lines | Duplicate
+                    constructs Lines, Line, Duplicate
+                let build (xs) = {
+                    guard List.allUniqueBy(.product, xs)
+                        else Duplicate
+                    Lines(List.map(r -> Line { product = r.product }, xs))
+                }
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "the length clause is no longer established");
+    }
+
+    @Test
     void aRequireGuardDischargesTheSubtraction() {
         // `guard 額 <= 残高` establishes the relation on the mainline, discharging `残高 - 額`
         String m = """

--- a/specification.adoc
+++ b/specification.adoc
@@ -1034,6 +1034,32 @@ let build (rows) = {
 
 An operation not in the table keeps nothing that can be relied on, and a clause over what it built is left to the run-time check.
 
+[#invariant-discharge-projection]
+===== A projection the closure copied
+
+A mapping keeps no property of its elements in general, but a clause stated over a *projection* is a clause about one field, and a closure that copies that field across keeps it. Two mapped elements differ at a copied field exactly when the two they came from did, so uniqueness by that field carries.
+
+[,text]
+----
+data QuoteLines = List<QuoteLine> invariant List.allUniqueBy(.product, value)
+
+let toLine (r: LineRequest): QuoteLine =
+    QuoteLine { product = r.product, quantity = Quantity(r.quantity), ... }
+
+behavior buildQuote : (lines: List<LineRequest>, ...) -> Quote | DuplicateProduct | NoLines
+let buildQuote (lines, ...) = {
+    guard List.length(lines) >= 1
+        else NoLines
+    guard List.allUniqueBy(.product, lines)
+        else DuplicateProduct
+    Quote { lines = QuoteLines(List.map(toLine, lines)), ... }   // both clauses discharged
+}
+----
+
+The field the closure copied need not be the one the clause names: when the closure writes `+code = r.sku+`, uniqueness of the result by `+.code+` is uniqueness of the input by `+.sku+`, and that is the guard to write.
+
+This is bounded to a field *copied*. A field the closure computes from others — `+code = String.concat([r.sku, r.name])+` — is not this: two rows that differ can land on one value, and nothing about the result follows.
+
 [#invariant-discharge-facts]
 ==== A clause that states no relation is settled, not derived
 


### PR DESCRIPTION
Closes #226 (a sub-issue of #222).

**Sits on #228, #229 and #231.** Its own commit is the last one.

## What carries

`List.map` keeps the count and nothing about the elements (#225). But a clause stated over a
*projection* is a clause about one field, and two mapped elements differ at a copied field exactly
when the two they came from did. So where the closure copies that field across, uniqueness by it
carries through the map.

The field need not keep its name. When the closure writes `code = r.sku`, uniqueness of the result by
`.code` is uniqueness of the input by `.sku` — and that is the guard to write, which the check now
says by discharging exactly that guard and no other.

The closure is read through the bindings an expansion introduced: a mapping is usually
`List.map(r -> toLine(r), xs)`, and under the analysis representation `toLine` is spliced in as
`let $0_r = r in QuoteLine { ... }`, so the record it builds is inside that.

Bounded to a field *copied*. `code = String.concat([r.sku, r.name])` is not this — two rows that
differ can land on one value.

## A construction is a term

Needed to get here, and worth stating on its own: `termKey` now renders an `Ast.NewData`. It is a
pure function of its fields, and a closure that builds one is what a mapping usually is. Fields are
keyed in name order so two sites writing them in different orders write one term. Without it a mapped
list could not be named at all, and the clause over it stayed *opaque* rather than discharged — which
is silent either way, and so exactly the kind of thing a test asserting "no warning" passes on for
the wrong reason. The tests here discriminate: `guardingTheWrongFieldDoesNotCarry` and
`aComputedFieldDoesNotCarryAProjection` differ from their passing counterparts only in the guard or
the closure, and are reported.

## #226's own target

Measured against souther-lang/examples rather than a fixture. With `buildQuote` as written, the
`QuoteLines` construction is silent; deleting `guard List.length(lines) >= 1 else NoLines` reports it
(E2011 at the construction). So both clauses of

```
data QuoteLines = List<QuoteLine>
    invariant List.length(value) >= 1 && List.allUniqueBy(.product, value)
```

are discharged by the two guards `buildQuote` writes, over a list it builds with
`List.map(r -> toLine(r), lines)` — the length by #225's rule, the uniqueness by this one. That is
finding F24 in the `crm` README answered.

## Verification

- `mvn -o clean test` green. Six tests added.
- souther-lang/examples reports the same ten warnings as #231 — again, the rule discharges rather
  than flags.
- Specification: `[#invariant-discharge-projection]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
