### PR TITLE
A clause says how it can be discharged

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ClauseDischarge.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ClauseDischarge.java
@@ -1,0 +1,59 @@
+package souther.compiler.check;
+
+import souther.compiler.diag.SourcePos;
+
+import java.util.Optional;
+
+/**
+ * How one clause of an invariant can be discharged at compile time (spec
+ * §invariant-discharge-capability).
+ *
+ * <p>Once some clauses are statically dischargeable and others are not, the same {@code invariant}
+ * keyword means two different things to a reader: one shape reports an unguarded construction and the
+ * other stays silent. Left implicit, an author believes a static guarantee exists where it does not.
+ * This is the answer, per clause, so the classification is a property of the language and not of
+ * whatever the checker happens to manage.
+ *
+ * <p>It is the clause's own capability, read with the construction assumed to name what it is given.
+ * A construction that names nothing the check can name discharges nothing whatever its clauses say —
+ * that is a fact about the construction, and belongs where the construction is.
+ */
+public record ClauseDischarge(SourcePos clause, Kind kind, Optional<String> reason) {
+
+    /** What can discharge a clause. The first two are the statically dischargeable ones, and they are
+     * separate because they admit different guards: a relation the domain reasons over is discharged
+     * by any guard that <em>implies</em> it, while a term it can only compare for identity is
+     * discharged by a guard stating the same thing and by nothing weaker. */
+    public enum Kind {
+
+        /** A relation the numeric domain reasons over: bounds, differences, sums of them. */
+        DERIVABLE,
+
+        /** A term the check can name but not reason about, discharged by a guard establishing the
+         * same canonical property. */
+        EXACT_MATCH,
+
+        /** Not representable as a static obligation. No guard discharges it; the run-time check on
+         * construction is the whole of its enforcement. */
+        RUNTIME_ONLY
+    }
+
+    public static ClauseDischarge derivable(SourcePos clause) {
+        return new ClauseDischarge(clause, Kind.DERIVABLE, Optional.empty());
+    }
+
+    public static ClauseDischarge exactMatch(SourcePos clause) {
+        return new ClauseDischarge(clause, Kind.EXACT_MATCH, Optional.empty());
+    }
+
+    /** {@code reason} names what in the clause the check cannot read — there is more than one way to
+     * be outside the fragment, and which one it is decides what the author can do about it. */
+    public static ClauseDischarge runtimeOnly(SourcePos clause, String reason) {
+        return new ClauseDischarge(clause, Kind.RUNTIME_ONLY, Optional.of(reason));
+    }
+
+    /** Whether a construction of this type can be judged safe from this clause at all. */
+    public boolean statically() {
+        return kind != Kind.RUNTIME_ONLY;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -577,6 +577,17 @@ public final class HelperInliner {
                 defs, m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
     }
 
+    /** The conjuncts of an invariant expression, flattened, in the order they are written — what a
+     * reader sees as separate clauses. */
+    public static List<Ast.Expr> conjunctsOf(Ast.Expr e) {
+        if (e instanceof Ast.Binary b && b.op() == Ast.BinOp.AND) {
+            List<Ast.Expr> out = new ArrayList<>(conjunctsOf(b.left()));
+            out.addAll(conjunctsOf(b.right()));
+            return out;
+        }
+        return List.of(e);
+    }
+
     /** Looks up a helper by name across the prelude and the module's own helpers, or null if the
      * name is not a helper (a builtin, injected behavior, or unknown). Used to type-check a function
      * passed to a helper's function parameter against the declared type, at the call site. */

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -200,6 +200,92 @@ public final class InvariantChecker {
         }
     }
 
+    /**
+     * How a clause of {@code data}'s invariant can be discharged, read on its own — the construction
+     * is assumed to name what it is given, so what is left is the clause's own shape. {@code at} is
+     * where the clause is written, which is the pre-expansion position; {@code clause} is that clause
+     * in the representation the check reads.
+     */
+    public static ClauseDischarge capabilityOf(Ast.Expr clause, SourcePos at, Ast.Data data,
+                                               Symbols symbols) {
+        InvariantChecker c = new InvariantChecker(symbols, Map.of());
+        Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
+        Bindings binds = Bindings.ofPaths(
+                name -> fields.containsKey(name) ? LinearForm.atom(name) : null,
+                name -> fields.containsKey(name) ? name : null);
+        List<Clause> owed;
+        try {
+            owed = c.obligations(clause, binds);
+        } catch (RuntimeException _) {
+            owed = null;   // fail-open, as the walk is
+        }
+        if (owed == null || owed.isEmpty()) {
+            return ClauseDischarge.runtimeOnly(at, c.whyUnreadable(clause, binds));
+        }
+        for (Clause owe : owed) {
+            if (owe.numeric() != null) {
+                return ClauseDischarge.derivable(at);
+            }
+        }
+        return ClauseDischarge.exactMatch(at);
+    }
+
+    /** What in {@code clause} the check cannot read, said so an author can act on it. */
+    private String whyUnreadable(Ast.Expr clause, Bindings binds) {
+        Ast.Expr blocked = unreadable(clause);
+        if (blocked instanceof Ast.Call call) {
+            return "it calls `" + call.fn() + "`, which the check reads as a value and not as a term";
+        }
+        if (blocked != null) {
+            return "it is not one of the shapes the check reads";
+        }
+        String name = unnamed(clause, binds, Set.of());
+        if (name != null) {
+            return "it reads `" + name + "`, and a clause is read through the fields the construction"
+                    + " fills";
+        }
+        return "it names a term the check cannot name";
+    }
+
+    /** A name the clause reads that is neither a field of the declaration nor bound inside the clause,
+     * or {@code null} if it reads none. */
+    private String unnamed(Ast.Expr e, Bindings binds, Set<String> bound) {
+        if (e instanceof Ast.Var v) {
+            return bound.contains(v.name()) || binds.path().apply(v.name()) != null ? null : v.name();
+        }
+        Set<String> inner = bound;
+        if (e instanceof Ast.Block b && !b.params().isEmpty()) {
+            inner = new java.util.HashSet<>(bound);
+            inner.addAll(b.params());
+        } else if (e instanceof Ast.LetIn li) {
+            inner = new java.util.HashSet<>(bound);
+            inner.add(li.name());
+        }
+        Set<String> scope = inner;
+        String[] found = {null};
+        Ast.forEachChild(e, child -> {
+            if (found[0] == null) {
+                found[0] = unnamed(child, binds, scope);
+            }
+        });
+        return found[0];
+    }
+
+    /** The innermost part of {@code e} the term grammar cannot read, or {@code null} if it reads all
+     * of it. Every location is granted, so what is left is the shape. */
+    private Ast.Expr unreadable(Ast.Expr e) {
+        Ast.Expr[] found = {null};
+        Ast.forEachChild(e, child -> {
+            if (found[0] == null) {
+                found[0] = unreadable(child);
+            }
+        });
+        if (found[0] != null) {
+            return found[0];
+        }
+        return termKey(e, x -> rootName(x) != null ? "?" : null, Map.of(), 0) == null ? e : null;
+    }
+
     /** Analyzes one behavior body against its input types. Never throws. A {@code null} source is a
      * body the analysis representation could not be built for, and is not analyzed at all. */
     static Findings analyze(Source source, Map<String, Type> params, Symbols symbols) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -484,10 +484,12 @@ public final class InvariantChecker {
         List<Clause> owed = new ArrayList<>();
         for (Ast.Expr inv : invs) {
             List<Clause> o = obligations(inv, binds);
-            if (o == null) {
-                return;   // some part is not expressible — leave the whole invariant opaque
+            if (o != null) {
+                owed.addAll(o);
             }
-            owed.addAll(o);
+        }
+        if (owed.isEmpty()) {
+            return;   // nothing here is expressible — the run-time check stands for all of it
         }
         NumericDomain dom = k.numbers();
         for (Clause c : owed) {
@@ -578,13 +580,15 @@ public final class InvariantChecker {
     private List<Clause> obligations(Ast.Expr rawInv, Bindings binds, boolean positive) {
         Ast.Expr inv = asSizeComparison(rawInv);
         if (inv instanceof Ast.Binary b && b.op() == Ast.BinOp.AND && positive) {
+            // Each conjunct on its own: an invariant is a set of things that hold, and one the check
+            // cannot read leaves its own run-time check standing without costing the others theirs.
             List<Clause> l = obligations(b.left(), binds, true);
             List<Clause> r = obligations(b.right(), binds, true);
-            if (l == null || r == null) {
+            if (l == null && r == null) {
                 return null;
             }
-            List<Clause> both = new ArrayList<>(l);
-            both.addAll(r);
+            List<Clause> both = new ArrayList<>(l == null ? List.of() : l);
+            both.addAll(r == null ? List.of() : r);
             return both;
         }
         Ast.Expr under = negated(inv);
@@ -726,27 +730,23 @@ public final class InvariantChecker {
                 },
                 resolvePath, fields);
         Known out = k;
-        // Each conjunct on its own: an input's invariant is a set of things that hold, and one the
-        // check cannot express does not cost it the others.
         for (Ast.Expr inv : invariantsOf(ref.name(), data)) {
-            for (Ast.Expr conjunct : conjuncts(inv)) {
-                List<Clause> o = obligations(conjunct, binds);
-                if (o == null) {
-                    continue;
+            List<Clause> o = obligations(inv, binds);
+            if (o == null) {
+                continue;
+            }
+            for (Clause c : o) {
+                for (Constraint known : c.known()) {
+                    out = out.with(out.numbers().assume(known.form(), known.rel()));
                 }
-                for (Clause c : o) {
-                    for (Constraint known : c.known()) {
-                        out = out.with(out.numbers().assume(known.form(), known.rel()));
-                    }
-                    if (c.numeric() != null) {
-                        out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
-                    }
-                    if (c.fact() != null) {
-                        // What an input's type guarantees is guaranteed of the term as written; a
-                        // container built from it is another term, and reads the rules where it is
-                        // constructed rather than here.
-                        out = out.with(out.facts().assume(c.fact().keys().get(0), c.fact().positive()));
-                    }
+                if (c.numeric() != null) {
+                    out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
+                }
+                if (c.fact() != null) {
+                    // What an input's type guarantees is guaranteed of the term as written; a
+                    // container built from it is another term, and reads the rules where it is
+                    // constructed rather than here.
+                    out = out.with(out.facts().assume(c.fact().keys().get(0), c.fact().positive()));
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -212,7 +212,7 @@ public final class InvariantChecker {
         Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
         Bindings binds = Bindings.ofPaths(
                 name -> fields.containsKey(name) ? LinearForm.atom(name) : null,
-                name -> fields.containsKey(name) ? name : null);
+                name -> fields.containsKey(name) ? name : null, fields);
         List<Clause> owed;
         try {
             owed = c.obligations(clause, binds);

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -1,15 +1,20 @@
 package souther.compiler.query;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.HelperInliner;
+import souther.compiler.check.InliningPolicy;
+import souther.compiler.check.InvariantChecker;
 import souther.compiler.check.NewtypeDesugar;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.check.Symbols;
 import souther.compiler.derive.Deriver;
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -225,6 +230,69 @@ public final class Shapes {
      * an imported clause fall outside the statically dischargeable fragment: the analysis reads what
      * it is given, and there the operations have already become the folds they are.
      */
+    /**
+     * How each clause of each invariant this module declares can be discharged at compile time (spec
+     * §invariant-discharge-capability), in the order the clauses are written.
+     *
+     * <p>Only this module's own declarations. The classification is the clause's, and a clause is
+     * written where its type is declared; a reader in another module asks that module.
+     */
+    public record InvariantCapabilities(String name)
+            implements Key<Map<TypeName, List<ClauseDischarge>>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<TypeName, List<ClauseDischarge>>> compute(Db db) {
+            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
+            if (!resolved.present() || !scope.present()) {
+                return Answer.absent();
+            }
+            try {
+                Map<TypeName, List<ClauseDischarge>> out = new LinkedHashMap<>();
+                for (Ast.Def def : resolved.value().defs()) {
+                    if (!(def instanceof Ast.Data data) || data.invariant().isEmpty()) {
+                        continue;
+                    }
+                    // The clause is classified in the representation the check reads, and reported at
+                    // the position it is written — an expansion carries positions of its own, and the
+                    // author is looking at the source.
+                    HelperInliner inliner = HelperInliner.forHelpers(
+                            HelperInliner.helpersOf(resolved.value()), InliningPolicy.DISCHARGE);
+                    List<ClauseDischarge> clauses = new ArrayList<>();
+                    for (Ast.Expr written : HelperInliner.conjunctsOf(data.invariant().get())) {
+                        clauses.add(InvariantChecker.capabilityOf(inliner.inline(written),
+                                leftmost(written), data, scope.value()));
+                    }
+                    out.put(new TypeName(name, data.name()), List.copyOf(clauses));
+                }
+                return Answer.of(Map.copyOf(out));
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
+        }
+    }
+
+    /** Where a clause begins: the earliest position anything in it carries. A node's own position is
+     * where its operator is written, and a reader points at the clause. */
+    private static SourcePos leftmost(Ast.Expr e) {
+        SourcePos[] found = {e.pos()};
+        Ast.forEachChild(e, child -> {
+            SourcePos inner = leftmost(child);
+            if (inner != null && (found[0] == null || earlier(inner, found[0]))) {
+                found[0] = inner;
+            }
+        });
+        return found[0];
+    }
+
+    private static boolean earlier(SourcePos a, SourcePos b) {
+        return a.line() != b.line() ? a.line() < b.line() : a.column() < b.column();
+    }
+
     public record InvariantsForDischarge(String name) implements Key<Map<TypeName, Ast.Expr>> {
         @Override
         public String module() {

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -222,15 +222,6 @@ public final class Shapes {
     }
 
     /**
-     * The invariants this module declares, in the representation the invariant-discharge analysis
-     * reads ({@link souther.compiler.check.InliningPolicy#DISCHARGE}) — beside the settled form that
-     * every other stage sees on the declaration itself.
-     *
-     * <p>Only this module's own. What another module publishes arrives settled, which is what makes
-     * an imported clause fall outside the statically dischargeable fragment: the analysis reads what
-     * it is given, and there the operations have already become the folds they are.
-     */
-    /**
      * How each clause of each invariant this module declares can be discharged at compile time (spec
      * §invariant-discharge-capability), in the order the clauses are written.
      *
@@ -293,6 +284,15 @@ public final class Shapes {
         return a.line() != b.line() ? a.line() < b.line() : a.column() < b.column();
     }
 
+    /**
+     * The invariants this module declares, in the representation the invariant-discharge analysis
+     * reads ({@link souther.compiler.check.InliningPolicy#DISCHARGE}) — beside the settled form that
+     * every other stage sees on the declaration itself.
+     *
+     * <p>Only this module's own. What another module publishes arrives settled, which is what makes
+     * an imported clause fall outside the statically dischargeable fragment: the analysis reads what
+     * it is given, and there the operations have already become the folds they are.
+     */
     public record InvariantsForDischarge(String name) implements Key<Map<TypeName, Ast.Expr>> {
         @Override
         public String module() {

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -1162,4 +1162,39 @@ class CompileInvariantDischargeTest {
         assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
                 "which side of an equality a term is written on is not part of what it says");
     }
+
+    @Test
+    void aClauseTheCheckCannotReadLeavesTheOthersReported() {
+        // the second clause is a shape the check does not read (a comprehension), and the first is a
+        // length it derives over — writing them together does not cost the first its guard
+        String m = """
+                module demo
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                           && List.length([1 | List.length(value) >= 1]) >= 1
+                behavior build : (xs: List<Int>) -> Lines constructs Lines
+                let build (xs) = Lines(xs)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "the derivable clause is still unproven, and guarding it is still open to the author");
+    }
+
+    @Test
+    void aClauseTheCheckCannotReadIsNotItselfReported() {
+        String m = """
+                module demo
+                data Ok
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                           && List.length([1 | List.length(value) >= 1]) >= 1
+                behavior build : (xs: List<Int>) -> Lines | Ok constructs Lines, Ok
+                let build (xs) = {
+                    guard List.length(xs) >= 1
+                        else Ok
+                    Lines(xs)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "what is reported is a clause a guard could discharge, and the comprehension is not one");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/InvariantCapabilitiesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/InvariantCapabilitiesTest.java
@@ -1,0 +1,117 @@
+package souther.compiler.query;
+
+import souther.compiler.check.ClauseDischarge;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What the compiler says about each clause of an invariant: whether a construction of that type can
+ * be judged safe from it, and by what kind of guard (spec §invariant-discharge-capability).
+ *
+ * <p>Once some clauses are statically dischargeable and others are not, the same {@code invariant}
+ * keyword means two things to a reader, and nothing in the source distinguishes them. These pin the
+ * answer, so the classification is the language's rather than whatever the checker manages today.
+ */
+class InvariantCapabilitiesTest {
+
+    private static List<ClauseDischarge> of(String source, String type) {
+        Compilation c = Compilation.ofDocuments(Map.of("a.sou", source), Set.of(), ModulePath.EMPTY);
+        Map<TypeName, List<ClauseDischarge>> caps =
+                c.db().ask(new Shapes.InvariantCapabilities("m.a")).value();
+        return caps == null ? List.of() : caps.getOrDefault(new TypeName("m.a", type), List.of());
+    }
+
+    @Test
+    void aRelationTheDomainReasonsOverIsDerivable() {
+        List<ClauseDischarge> clauses = of("""
+                module m.a
+                data Money = Int
+                    invariant value >= 0
+                """, "Money");
+        assertEquals(1, clauses.size());
+        assertEquals(ClauseDischarge.Kind.DERIVABLE, clauses.get(0).kind());
+    }
+
+    @Test
+    void aLengthIsDerivableToo() {
+        List<ClauseDischarge> clauses = of("""
+                module m.a
+                data Lines = List<Int>
+                    invariant List.length(value) >= 1
+                """, "Lines");
+        assertEquals(ClauseDischarge.Kind.DERIVABLE, clauses.get(0).kind());
+    }
+
+    @Test
+    void aPredicateTakesAnExactMatch() {
+        List<ClauseDischarge> clauses = of("""
+                module m.a
+                data Code = String
+                    invariant String.matches("[A-Z]{2}", value)
+                """, "Code");
+        assertEquals(ClauseDischarge.Kind.EXACT_MATCH, clauses.get(0).kind());
+    }
+
+    @Test
+    void aShapeTheCheckDoesNotReadIsRuntimeOnly() {
+        List<ClauseDischarge> clauses = of("""
+                module m.a
+                data Kind = String
+                    invariant match value with
+                        | _ -> true
+                """, "Kind");
+        assertEquals(ClauseDischarge.Kind.RUNTIME_ONLY, clauses.get(0).kind());
+        assertTrue(clauses.get(0).reason().isPresent(), "there is more than one way to be outside");
+    }
+
+    @Test
+    void eachClauseOfAConjunctionIsAnsweredOnItsOwn() {
+        // the two clauses of #222's target: a length the domain reasons over, and a uniqueness it can
+        // only compare for identity
+        List<ClauseDischarge> clauses = of("""
+                module m.a
+                data Row = { product: String }
+                data Lines = List<Row>
+                    invariant List.length(value) >= 1 && List.allUniqueBy(.product, value)
+                """, "Lines");
+        assertEquals(2, clauses.size(), "one answer per clause");
+        assertEquals(ClauseDischarge.Kind.DERIVABLE, clauses.get(0).kind());
+        assertEquals(ClauseDischarge.Kind.EXACT_MATCH, clauses.get(1).kind());
+    }
+
+    @Test
+    void aClauseIsAnsweredAtItsOwnPosition() {
+        List<ClauseDischarge> clauses = of("""
+                module m.a
+                data Row = { product: String }
+                data Lines = List<Row>
+                    invariant List.length(value) >= 1 && List.allUniqueBy(.product, value)
+                """, "Lines");
+        assertEquals(4, clauses.get(0).clause().line(), "both clauses are on the invariant's line");
+        assertEquals(4, clauses.get(1).clause().line());
+        assertTrue(clauses.get(0).clause().column() < clauses.get(1).clause().column(),
+                "in the order they are written, so a position picks one out");
+    }
+
+    @Test
+    void aClauseThroughAHelperIsAnsweredAsWhatTheHelperSays() {
+        // the helper is expanded before the clause is read, so `twice(value) >= 0` is arithmetic
+        List<ClauseDischarge> clauses = of("""
+                module m.a
+                let twice (n: Int): Int = n * 2
+                data Even = Int
+                    invariant twice(value) >= 0
+                """, "Even");
+        assertEquals(ClauseDischarge.Kind.DERIVABLE, clauses.get(0).kind());
+        assertEquals(4, clauses.get(0).clause().line(), "reported where it is written, not where it expands");
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -213,7 +213,8 @@ public final class LspServer {
         if (text == null) {
             return null;
         }
-        Hover h = analyzer.hover(text, p.position()).orElse(null);
+        ModuleGraph graph = workspace.snapshot(documents.openDocuments());
+        Hover h = analyzer.hover(p.uri(), text, p.position(), graph).orElse(null);
         if (h == null) {
             return null;
         }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -4,6 +4,8 @@ import souther.compiler.Compiler;
 import souther.compiler.check.Resolve;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
+import souther.compiler.query.Shapes;
+import souther.compiler.check.ClauseDischarge;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
 import souther.compiler.ast.Ast;
@@ -866,6 +868,92 @@ public final class Analyzer {
         }
         SyntaxToken name = nameToken(def);
         return name == null ? Optional.empty() : Optional.of(tokenRange(lines, name));
+    }
+
+    /**
+     * Hover: on a clause of an invariant, how that clause can be discharged at compile time; anywhere
+     * else, the signature line of the definition the identifier under the cursor names.
+     *
+     * <p>The clause answer is the compiler's, because the classification is a fact about the language
+     * and not something a reader of the syntax can work out. The rest stays syntactic: a hover that
+     * only shows what is written does not need a compile, and this one asks for one only where it has
+     * something semantic to say.
+     */
+    public Optional<Hover> hover(String uri, String text, Position pos, ModuleGraph graph) {
+        Optional<Hover> clause = invariantClauseHover(uri, text, pos, graph);
+        return clause.isPresent() ? clause : hover(text, pos);
+    }
+
+    /** The discharge classification of the invariant clause the cursor is in, or empty when it is not
+     * in one. */
+    private Optional<Hover> invariantClauseHover(String uri, String text, Position pos,
+                                                 ModuleGraph graph) {
+        LineIndex lines = new LineIndex(text);
+        SyntaxNode root = CstParser.parse(text).root();
+        int offset = lines.offsetOf(pos.line(), pos.character());
+        SyntaxNode clause = enclosing(root, offset, SyntaxKind.INVARIANT_CLAUSE);
+        if (clause == null) {
+            return Optional.empty();
+        }
+        SyntaxNode data = enclosing(root, offset, SyntaxKind.DATA_DEF);
+        SyntaxToken name = data == null ? null : nameToken(data);
+        String module = Compiler.moduleNameFromHeader(text);
+        if (name == null || module == null) {
+            return Optional.empty();
+        }
+        Compilation compilation = compileOf(graph);
+        Map<TypeName, List<ClauseDischarge>> byType =
+                compilation.db().ask(new Shapes.InvariantCapabilities(module)).value();
+        List<ClauseDischarge> clauses = byType == null
+                ? null : byType.get(new TypeName(module, name.text()));
+        if (clauses == null || clauses.isEmpty()) {
+            return Optional.empty();
+        }
+        // The clauses are in the order they are written, so the one the cursor is in is the last that
+        // starts at or before it.
+        ClauseDischarge found = null;
+        for (ClauseDischarge c : clauses) {
+            if (lines.offsetOf(c.clause().line() - 1, c.clause().column() - 1) <= offset) {
+                found = c;
+            }
+        }
+        if (found == null) {
+            return Optional.empty();
+        }
+        return Optional.of(new Hover(dischargeContents(found), nodeRange(lines, clause)));
+    }
+
+    /** What a clause's classification says, in the terms an author acts on. */
+    private String dischargeContents(ClauseDischarge clause) {
+        String head = switch (clause.kind()) {
+            case DERIVABLE -> """
+                    **Static discharge: derivable**
+
+                    The checker can prove this clause from numeric relations when the constructed                     value is nameable, so any guard that implies it discharges the construction.""";
+            case EXACT_MATCH -> """
+                    **Static discharge: exact match**
+
+                    The checker can discharge this clause only from a guard establishing the same                     canonical property. Nothing weaker discharges it.""";
+            case RUNTIME_ONLY -> """
+                    **Static discharge: runtime only**
+
+                    This clause cannot be represented by the static checker and is enforced only at                     construction time. No guard discharges it.""";
+        };
+        return clause.reason().map(why -> head + "\n\n" + why + ".").orElse(head);
+    }
+
+    /** The innermost node of {@code kind} whose span contains {@code offset}, or null. */
+    private SyntaxNode enclosing(SyntaxNode node, int offset, SyntaxKind kind) {
+        SyntaxNode found = node.kind() == kind ? node : null;
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxNode child && offset >= child.start() && offset <= child.end()) {
+                SyntaxNode inner = enclosing(child, offset, kind);
+                if (inner != null) {
+                    found = inner;
+                }
+            }
+        }
+        return found;
     }
 
     /** Hover: shows the signature line of the definition the identifier under the cursor names. */

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -926,18 +926,15 @@ public final class Analyzer {
     /** What a clause's classification says, in the terms an author acts on. */
     private String dischargeContents(ClauseDischarge clause) {
         String head = switch (clause.kind()) {
-            case DERIVABLE -> """
-                    **Static discharge: derivable**
-
-                    The checker can prove this clause from numeric relations when the constructed                     value is nameable, so any guard that implies it discharges the construction.""";
-            case EXACT_MATCH -> """
-                    **Static discharge: exact match**
-
-                    The checker can discharge this clause only from a guard establishing the same                     canonical property. Nothing weaker discharges it.""";
-            case RUNTIME_ONLY -> """
-                    **Static discharge: runtime only**
-
-                    This clause cannot be represented by the static checker and is enforced only at                     construction time. No guard discharges it.""";
+            case DERIVABLE -> "**Static discharge: derivable**\n\n"
+                    + "The checker can prove this clause from numeric relations when the constructed "
+                    + "value is nameable, so any guard that implies it discharges the construction.";
+            case EXACT_MATCH -> "**Static discharge: exact match**\n\n"
+                    + "The checker can discharge this clause only from a guard establishing the same "
+                    + "canonical property. Nothing weaker discharges it.";
+            case RUNTIME_ONLY -> "**Static discharge: runtime only**\n\n"
+                    + "This clause cannot be represented by the static checker and is enforced only "
+                    + "at construction time. No guard discharges it.";
         };
         return clause.reason().map(why -> head + "\n\n" + why + ".").orElse(head);
     }
@@ -946,7 +943,7 @@ public final class Analyzer {
     private SyntaxNode enclosing(SyntaxNode node, int offset, SyntaxKind kind) {
         SyntaxNode found = node.kind() == kind ? node : null;
         for (SyntaxElement e : node.children()) {
-            if (e instanceof SyntaxNode child && offset >= child.start() && offset <= child.end()) {
+            if (e instanceof SyntaxNode child && offset >= child.start() && offset < child.end()) {
                 SyntaxNode inner = enclosing(child, offset, kind);
                 if (inner != null) {
                     found = inner;

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -185,6 +185,45 @@ class AnalyzerTest {
         assertTrue(hover.get().contents().contains("id: String"), hover.get().contents());
     }
 
+    /** `data`, `invariant` on the next line, one clause per line so a position picks one out. */
+    private static final String CLAUSES_SRC = """
+            module demo
+            data Money = Int
+                invariant value >= 0
+            data Code = String
+                invariant String.matches("[A-Z]{2}", value)
+            data Sum = Int
+                invariant Int.sum([value]) >= 0
+            """;
+
+    private Optional<Hover> clauseHover(int line, int character) {
+        ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///demo.sou", CLAUSES_SRC));
+        return analyzer.hover("file:///demo.sou", CLAUSES_SRC, new Position(line, character), graph);
+    }
+
+    @Test
+    void hoverOnANumericClauseSaysItIsDerivable() {
+        // `value >= 0` — a relation the domain reasons over, so any guard implying it discharges
+        Optional<Hover> hover = clauseHover(2, 18);
+        assertTrue(hover.isPresent());
+        assertTrue(hover.get().contents().contains("derivable"), hover.get().contents());
+    }
+
+    @Test
+    void hoverOnAPatternClauseSaysItTakesAnExactMatch() {
+        // `String.matches(...)` — nameable but not a relation, so only the same guard discharges it
+        Optional<Hover> hover = clauseHover(4, 20);
+        assertTrue(hover.isPresent());
+        assertTrue(hover.get().contents().contains("exact match"), hover.get().contents());
+    }
+
+    @Test
+    void hoverOutsideAnInvariantStillShowsTheSignature() {
+        Optional<Hover> hover = clauseHover(1, 5);   // over `Money`
+        assertTrue(hover.isPresent());
+        assertTrue(hover.get().contents().contains("data Money"), hover.get().contents());
+    }
+
     @Test
     void diagnosticsAcrossModulesLandOnTheOwningFile() {
         String a = "module a exposing ( N )\ndata N = { v: Int }\n";

--- a/specification.adoc
+++ b/specification.adoc
@@ -942,7 +942,7 @@ The check is intraprocedural. Within a behavior's `+let+` body it seeds what the
 * *Discharged* — the guards prove the invariant. No diagnostic; the construction cannot abort here (overflow aside).
 * *Definitely violated* — the guards prove the invariant false on a reachable path. A compile error — the path-sensitive generalization of the constant check `+Money(-5)+` (<<newtype>>).
 * *Possibly violated* — expressible but not proven. A warning: a possible abort. Guard it with `+guard+`, reify the relation into a type invariant (below), or attempt the construction (<<attempted-construction>>), which cannot abort.
-* *Not expressible* — an invariant outside the checked fragment. No diagnostic; the run-time check stands.
+* *Not expressible* — a clause outside the checked fragment. No diagnostic for it; the run-time check stands. The other clauses of the same invariant are answered on their own, so writing one the check cannot read beside one it can does not cost the second its report (<<invariant-discharge-capability>>).
 
 Guards that cannot all hold describe a path the behavior does not take, and a construction standing on one is neither of the middle two: nothing is built there, so nothing is reported. That the guards contradict is itself derived over the same fragment — `+a <= b+` with `+b <= 0+` bounds `+a+` above without a word about `+a+` — so a path is dead whenever the relations say so, whatever order they were written in.
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -1081,6 +1081,24 @@ Two clauses are one thing exactly when they are the same expression over the sam
 
 This is what a clause outside the derived fragment falls back to, whatever its shape. A comparison over a value the procedure cannot name is settled the same way, which is why `+guard+`-ing it verbatim discharges the construction.
 
+[#invariant-discharge-capability]
+==== A clause says how it can be discharged
+
+Some clauses are statically dischargeable and others are not, and the same `+invariant+` keyword is written for both. Left implicit, an author believes there is a static guarantee where there is none. So the compiler answers, per clause, how that clause can be discharged. It is a query rather than a diagnostic — a correct program would carry one on every declaration, which is noise — and the LSP surfaces it on the clause.
+
+[cols="1,3"]
+|===
+| | what discharges it
+
+| *derivable* | a relation the procedure reasons over. Any guard that *implies* it discharges the construction: `+guard amount >= 10+` discharges `+invariant value >= 0+`.
+| *exact match* | a term the procedure can name but not reason about. Only a guard establishing *the same* property discharges it, and nothing weaker: `+invariant List.allUniqueBy(.product, value)+` takes `+guard List.allUniqueBy(.product, lines)+`.
+| *runtime only* | not representable as a static obligation. No guard discharges it, and the run-time check on construction is the whole of its enforcement.
+|===
+
+The first two are the *statically dischargeable* ones, and they are separate because they admit different guards — which is what an author needs to know before writing one. The third carries a reason, because there is more than one way to be outside the fragment and which one it is decides what can be done about it.
+
+The classification is the clause's own, read with the construction assumed to name what it is given. A construction that names nothing the procedure can name discharges nothing whatever its clauses say (<<invariant-discharge-terms>>); that is a fact about the construction and not about the clause.
+
 [#invariant-reify]
 ==== Reifying a cross-behavior relation
 


### PR DESCRIPTION
Closes #227 (a sub-issue of #222).

**Sits on #228, #229, #231 and #232.** Its own commit is the last one.

## Three answers, and why not the issue's three

#227 asks for *statically dischargeable / run-time only / unsupported*. `unsupported` is dropped: an
invariant is always checked on construction, so there is no state in which a clause is neither
statically dischargeable nor enforced at run time. The concept had nothing to carry, and keeping it
would have blurred the line with `runtime only`. If a state ever exists that needs it — an invariant
the backend cannot emit, a feature gate — it can be added then.

What is here instead splits the statically dischargeable side, because the two halves admit different
guards and that is what an author needs to know *before* writing one:

| | what discharges it |
| --- | --- |
| **derivable** | a relation the domain reasons over. Any guard that *implies* it: `guard amount >= 10` discharges `invariant value >= 0`. |
| **exact match** | a term the check can name but not reason about. Only a guard establishing the same property, and nothing weaker. |
| **runtime only** | not representable as a static obligation. No guard discharges it. |

Calling the first two one thing would hide the difference that decides how the code gets written.
`runtime only` carries a reason, since there is more than one way to be outside the fragment:

- `it is not one of the shapes the check reads` — a `match` in a clause
- `it calls \`X\`, which the check reads as a value and not as a term`
- `it reads \`HalfUp\`, and a clause is read through the fields the construction fills`

## Scope of the answer

The classification is the clause's own, read with the construction assumed to name what it is given —
each field standing for a distinct location. Whether a *particular* construction names its value is a
separate fact, about that construction, and belongs where it is written. The hover wording says so
rather than promising more than it has.

## Surface

Hover, not inlay hints. `Analyzer.hover` asks the compiler only where it has something semantic to
say — a clause of an invariant is answered by `Shapes.InvariantCapabilities`, and everything else
stays the syntactic hover it was, so a hover over ordinary code still needs no compile.

A clause is reported at its **leftmost** position rather than at its own node's. A node carries the
position of its operator, so `value >= 0` reported at `>=` left a cursor on `value` finding no clause
— which is where a reader points.

## Verification

- `mvn -o clean test` green. Seven tests in a new `InvariantCapabilitiesTest`, covering each of the
  three kinds, a conjunction answered clause by clause, the positions being ordered so a cursor
  picks one out, and a clause written through a helper being answered as the arithmetic it is and
  reported where it is *written* rather than where it expands. Three in `AnalyzerTest` for the hover,
  including that a hover outside an invariant is unchanged.
- Specification: `[#invariant-discharge-capability]`.

With this, #222's five sub-issues are all answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
