### PR TITLE
A registered combinator rule is one that can fire

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -113,6 +113,12 @@ public final class Prelude {
      *  xs, 0)} (the walk from the head). */
     private static final Set<String> SUGARED = Set.of("List.fold");
 
+    /** Whether {@code qualifiedName} is one of those — a name no tree holds after the rewrite, so a
+     *  rule keyed by it can never be looked up (see {@code InvariantChecker}'s combinator table). */
+    public static boolean sugared(String qualifiedName) {
+        return SUGARED.contains(qualifiedName);
+    }
+
     /** Whether {@code qualifiedName} (e.g. {@code "List.map"}) is a standard-library function —
      *  a prelude helper, a prelude intrinsic, a checker built-in, or a sugar for one. */
     public static boolean hasQualified(String qualifiedName) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -52,11 +52,16 @@ public final class InvariantChecker {
     /** A stdlib combinator whose closure (argument {@code closureArg}) is handed each element of its
      * container argument ({@code listArg}) as closure parameter {@code elementParam} — mirrors
      * {@link TotalityChecker}'s table, so a construction inside a {@code List.map}/{@code fold} closure
-     * is analyzed with the element bound to the container's element type ({@link #elementType}). */
+     * is analyzed with the element bound to the container's element type ({@link #elementType}).
+     *
+     * <p>A rule is keyed by the name a call still has when this tree is read, which is not every name
+     * an author can write: {@code List.fold} is rewritten to {@code List.foldFrom} before any of this,
+     * so a rule under that name could not be looked up. {@code InvariantCombinatorRulesTest} holds the
+     * table to both halves of that — every name survives the rewrite, and every name has a program
+     * that fires it. */
     private record Combinator(int closureArg, int elementParam, int listArg) {}
 
     private static final Map<String, Combinator> COMBINATORS = Map.ofEntries(
-            Map.entry("List.fold", new Combinator(0, 1, 2)),
             Map.entry("List.foldFrom", new Combinator(0, 1, 2)),
             Map.entry("List.foldr", new Combinator(0, 1, 2)),
             Map.entry("List.map", new Combinator(0, 0, 1)),
@@ -82,6 +87,11 @@ public final class InvariantChecker {
             Map.entry("Set.filter", new Combinator(0, 0, 1)),
             Map.entry("Set.partition", new Combinator(0, 0, 1)),
             Map.entry("Option.map", new Combinator(0, 0, 1)));
+
+    /** The operations the table has a rule for, for the test that holds it to being reachable. */
+    static Set<String> combinatorNames() {
+        return COMBINATORS.keySet();
+    }
 
     /** The pure, total stdlib calls whose result is a number the domain can name: the size of a
      * container or a string. Each becomes an atom keyed by the call written over its argument's path

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -51,8 +51,9 @@ public final class InvariantChecker {
 
     /** A stdlib combinator whose closure (argument {@code closureArg}) is handed each element of its
      * container argument ({@code listArg}) as closure parameter {@code elementParam} — mirrors
-     * {@link TotalityChecker}'s table, so a construction inside a {@code List.map}/{@code fold} closure
-     * is analyzed with the element bound to the container's element type ({@link #elementType}).
+     * {@link TotalityChecker}'s table, so a construction inside a {@code List.map} or
+     * {@code List.foldFrom} closure is analyzed with the element bound to the container's element type
+     * ({@link #elementType}).
      *
      * <p>A rule is keyed by the name a call still has when this tree is read, which is not every name
      * an author can write: {@code List.fold} is rewritten to {@code List.foldFrom} before any of this,

--- a/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
@@ -1,0 +1,257 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.Prelude;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The invariant check binds a combinator's closure parameter to the container's element type, from a
+ * table keyed by the operation's name. A rule in that table can be plainly correct and never run —
+ * that is what happened when the check was handed a tree where the operations had already become the
+ * folds they are — so the table is held to being reachable here rather than measured later.
+ *
+ * <p>Two halves. A name must survive to where the check reads it: {@code List.fold} does not, being
+ * rewritten to {@code List.foldFrom} first, so no rule may be keyed by it. And each name must have a
+ * program that fires its rule — a construction inside the closure that discharges only because the
+ * element carries its type's invariant, so removing the rule leaves the element unnamed and the
+ * construction reported.
+ */
+class InvariantCombinatorRulesTest {
+
+    /** A program whose closure builds a value that discharges only if {@code fn}'s rule bound the
+     * element. The construction is bound by a {@code let} so the closure still answers what the
+     * operation asks of it, whatever that is. */
+    private record Fires(String fn, String body) {}
+
+    private static final String PREAMBLE = """
+            module demo
+            data Money = Decimal
+                invariant value >= 0m
+            data Positive = Decimal
+                invariant value >= 0m
+            """;
+
+    private static final List<Fires> FIRES = List.of(
+            new Fires("List.foldFrom", """
+                    behavior f : (xs: List<Money>) -> Int constructs Positive
+                    let f (xs) = List.foldFrom((acc, x) -> {
+                        let p = Positive(x.value)
+                        acc
+                    }, 0, xs, 0)
+                    """),
+            new Fires("List.foldr", """
+                    behavior f : (xs: List<Money>) -> Int constructs Positive
+                    let f (xs) = List.foldr((acc, x) -> {
+                        let p = Positive(x.value)
+                        acc
+                    }, 0, xs)
+                    """),
+            new Fires("List.map", """
+                    behavior f : (xs: List<Money>) -> List<Int> constructs Positive
+                    let f (xs) = List.map(x -> {
+                        let p = Positive(x.value)
+                        0
+                    }, xs)
+                    """),
+            new Fires("List.filter", """
+                    behavior f : (xs: List<Money>) -> List<Money> constructs Positive
+                    let f (xs) = List.filter(x -> {
+                        let p = Positive(x.value)
+                        true
+                    }, xs)
+                    """),
+            new Fires("List.all", """
+                    behavior f : (xs: List<Money>) -> Bool constructs Positive
+                    let f (xs) = List.all(x -> {
+                        let p = Positive(x.value)
+                        true
+                    }, xs)
+                    """),
+            new Fires("List.any", """
+                    behavior f : (xs: List<Money>) -> Bool constructs Positive
+                    let f (xs) = List.any(x -> {
+                        let p = Positive(x.value)
+                        true
+                    }, xs)
+                    """),
+            new Fires("List.find", """
+                    behavior f : (xs: List<Money>) -> Money constructs Positive, Money
+                    let f (xs) = Option.withDefault(Money(0m), List.find(x -> {
+                        let p = Positive(x.value)
+                        true
+                    }, xs))
+                    """),
+            new Fires("List.partition", """
+                    behavior f : (xs: List<Money>) -> Int constructs Positive
+                    let f (xs) = {
+                        let (yes, no) = List.partition(x -> {
+                            let p = Positive(x.value)
+                            true
+                        }, xs)
+                        List.length(yes)
+                    }
+                    """),
+            new Fires("List.concatMap", """
+                    behavior f : (xs: List<Money>) -> List<Int> constructs Positive
+                    let f (xs) = List.concatMap(x -> {
+                        let p = Positive(x.value)
+                        [0]
+                    }, xs)
+                    """),
+            new Fires("List.filterMap", """
+                    behavior f : (xs: List<Money>) -> List<Int> constructs Positive
+                    let f (xs) = List.filterMap(x -> {
+                        let p = Positive(x.value)
+                        List.get(0, [0])
+                    }, xs)
+                    """),
+            new Fires("List.sortBy", """
+                    behavior f : (xs: List<Money>) -> List<Money> constructs Positive
+                    let f (xs) = List.sortBy(x -> {
+                        let p = Positive(x.value)
+                        x.value
+                    }, xs)
+                    """),
+            new Fires("List.groupBy", """
+                    behavior f : (xs: List<Money>) -> Int constructs Positive
+                    let f (xs) = Map.size(List.groupBy(x -> {
+                        let p = Positive(x.value)
+                        x.value
+                    }, xs))
+                    """),
+            new Fires("List.indexBy", """
+                    behavior f : (xs: List<Money>) -> Int constructs Positive
+                    let f (xs) = Map.size(List.indexBy(x -> {
+                        let p = Positive(x.value)
+                        x.value
+                    }, xs))
+                    """),
+            new Fires("List.allUniqueBy", """
+                    behavior f : (xs: List<Money>) -> Bool constructs Positive
+                    let f (xs) = List.allUniqueBy(x -> {
+                        let p = Positive(x.value)
+                        x.value
+                    }, xs)
+                    """),
+            new Fires("List.indexedMap", """
+                    behavior f : (xs: List<Money>) -> List<Int> constructs Positive
+                    let f (xs) = List.indexedMap((i, x) -> {
+                        let p = Positive(x.value)
+                        i
+                    }, xs)
+                    """),
+            new Fires("Map.fold", """
+                    behavior f : (m: Map<String, Money>) -> Int constructs Positive
+                    let f (m) = Map.fold((acc, k, v) -> {
+                        let p = Positive(v.value)
+                        acc
+                    }, 0, m)
+                    """),
+            new Fires("Map.map", """
+                    behavior f : (m: Map<String, Money>) -> Int constructs Positive
+                    let f (m) = Map.size(Map.map((k, v) -> {
+                        let p = Positive(v.value)
+                        0
+                    }, m))
+                    """),
+            new Fires("Map.filter", """
+                    behavior f : (m: Map<String, Money>) -> Int constructs Positive
+                    let f (m) = Map.size(Map.filter((k, v) -> {
+                        let p = Positive(v.value)
+                        true
+                    }, m))
+                    """),
+            new Fires("Map.update", """
+                    behavior f : (m: Map<String, Money>) -> Int constructs Positive
+                    let f (m) = Map.size(Map.update("a", v -> {
+                        let p = Positive(v.value)
+                        v
+                    }, m))
+                    """),
+            new Fires("Map.upsert", """
+                    behavior f : (m: Map<String, Money>, d: Money) -> Int constructs Positive
+                    let f (m, d) = Map.size(Map.upsert("a", d, v -> {
+                        let p = Positive(v.value)
+                        v
+                    }, m))
+                    """),
+            new Fires("Set.fold", """
+                    behavior f : (s: Set<Money>) -> Int constructs Positive
+                    let f (s) = Set.fold((acc, x) -> {
+                        let p = Positive(x.value)
+                        acc
+                    }, 0, s)
+                    """),
+            new Fires("Set.map", """
+                    behavior f : (s: Set<Money>) -> Int constructs Positive
+                    let f (s) = Set.size(Set.map(x -> {
+                        let p = Positive(x.value)
+                        x.value
+                    }, s))
+                    """),
+            new Fires("Set.filter", """
+                    behavior f : (s: Set<Money>) -> Int constructs Positive
+                    let f (s) = Set.size(Set.filter(x -> {
+                        let p = Positive(x.value)
+                        true
+                    }, s))
+                    """),
+            new Fires("Set.partition", """
+                    behavior f : (s: Set<Money>) -> Int constructs Positive
+                    let f (s) = {
+                        let (yes, no) = Set.partition(x -> {
+                            let p = Positive(x.value)
+                            true
+                        }, s)
+                        Set.size(yes)
+                    }
+                    """),
+            new Fires("Option.map", """
+                    data Box = { one: Money? }
+                    behavior f : (b: Box) -> Int constructs Positive
+                    let f (b) = Option.withDefault(0, Option.map(x -> {
+                        let p = Positive(x.value)
+                        0
+                    }, b.one))
+                    """));
+
+    @Test
+    void everyRuleIsKeyedByANameTheAnalysisStillSees() {
+        for (String fn : InvariantChecker.combinatorNames()) {
+            assertTrue(Prelude.hasQualified(fn), fn + " is not a standard-library operation");
+            assertFalse(Prelude.sugared(fn),
+                    fn + " is rewritten to another call before this tree is read, so its rule cannot"
+                            + " fire — key the rule by what the rewrite leaves");
+        }
+    }
+
+    @Test
+    void everyRuleHasAProgramThatFiresIt() {
+        Set<String> covered = FIRES.stream().map(Fires::fn).collect(Collectors.toCollection(TreeSet::new));
+        assertEquals(new TreeSet<>(InvariantChecker.combinatorNames()), covered,
+                "a rule is registered with no program that fires it, or the other way round");
+    }
+
+    @Test
+    void theElementCarriesItsInvariantIntoEveryCombinatorsClosure() {
+        for (Fires f : FIRES) {
+            Compiler.Compiled c = Compiler.compileWithWarnings(PREAMBLE + f.body());
+            long warnings = c.warnings().stream()
+                    .filter(d -> d.severity() == Severity.WARNING).count();
+            assertEquals(0, warnings,
+                    f.fn() + ": the construction in the closure should discharge from the element's"
+                            + " own invariant, and does not — the rule did not bind the element");
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
@@ -244,7 +244,7 @@ class InvariantCombinatorRulesTest {
     }
 
     @Test
-    void theElementCarriesItsInvariantIntoEveryCombinatorsClosure() {
+    void theElementCarriesItsInvariantIntoEachClosure() {
         for (Fires f : FIRES) {
             Compiler.Compiled c = Compiler.compileWithWarnings(PREAMBLE + f.body());
             long warnings = c.warnings().stream()

--- a/specification.adoc
+++ b/specification.adoc
@@ -989,6 +989,8 @@ The check reads a behavior's body and the invariants around it at the level the 
 
 An invariant that arrives from another module arrives expanded (<<published-modules>>), so a clause of an imported type is read as the computation it became rather than as the operations it was written as. Such a clause is outside the statically dischargeable fragment even where the same clause written here would be inside it.
 
+An operation the rules name is named as the call that survives to here, which is not every spelling an author can write: `+List.fold+` is the walk `+List.foldFrom+` from the head (<<stdlib-list>>) and is rewritten to it before any of this, so it is the second name the rules are written against. A rule under a name nothing here holds could not be reached, which is why the compiler's own tests hold each rule to a program that fires it.
+
 [#invariant-discharge-preservation]
 ==== What an operation keeps of what it was built from
 


### PR DESCRIPTION
Closes #230.

## What was open

#231 gave the invariant-discharge check its own representation, and the rules keyed by an operation's name became reachable again: measured over souther-lang/examples, **22 of 26 fire**, against three when #230 was written. Over the compiler test suite as well, **25 of 26**.

The twenty-sixth cannot fire at all. `List.fold` is sugar (`Prelude.SUGARED`) — `List.fold(step, seed, xs)` is rewritten to `List.foldFrom(step, seed, xs, 0)` before any inlining — so no call by that name reaches the table. Removing the entry leaves the whole suite green, which is the evidence, and it is removed.

## What holds the table now

`InvariantCombinatorRulesTest` asks two things of every entry.

- **The name survives to where the check reads it**: a standard-library operation, and not sugar for another call. Putting the `List.fold` entry back fails this with the reason, rather than passing and never running.
- **The name has a program that fires it**: a construction inside that operation's closure which discharges only because the element carries its type's invariant. One program per operation, twenty-five of them, and the registered names must be exactly the covered ones — so a rule added with no program fails, which is the case #230 says was previously found by measuring.

Each program was checked to depend on its own rule: pulling one entry out of the table and running the class, for all twenty-five, fails that operation's assertion (`the rule did not bind the element`) as well as the coverage one. `Option.map` needed its optional to come from a field, since the element type is read off the container's type and an intrinsic's result is not in the map the walk carries.

## Verification

- `mvn -o clean test` green (1621 + 98).
- souther-lang/examples: ten warnings, the same ten at the same positions as before.
- `specification.adoc` §invariant-discharge-representation now says the rules are written against the name the rewrite leaves.