### PR TITLE
An invariant names what is in scope where it is written

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -102,10 +102,23 @@ public final class HelperInliner {
      * a module's own helper is expanded, and a recursive call is left standing, by the same rules.
      */
     public static HelperInliner forHelpers(Map<String, Ast.FnDef> own, InliningPolicy policy) {
+        return forHelpers(own, Map.of(), policy);
+    }
+
+    /**
+     * The same, with the definitions other modules publish to this one joining the table.
+     *
+     * <p>They are in the table and not in {@code own}, as they are for {@link #forModule}: an imported
+     * definition is one this module expands and not one it declares.
+     */
+    public static HelperInliner forHelpers(Map<String, Ast.FnDef> own,
+                                           Map<String, Ast.FnDef> imported, InliningPolicy policy) {
         // In the order they are written, so a module with two helpers to complain about complains
         // about the earlier one first.
+        Map<String, Ast.FnDef> joined = new LinkedHashMap<>(imported);
+        joined.putAll(own);
         Map<String, Ast.FnDef> table = policy == InliningPolicy.FULL
-                ? withPrelude(own) : new LinkedHashMap<>(own);
+                ? withPrelude(joined) : joined;
         HelperInliner inliner = new HelperInliner(table, new LinkedHashMap<>(own));
         inliner.classifyRecursion();
         inliner.rejectValueCycles();
@@ -374,14 +387,7 @@ public final class HelperInliner {
                     : new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
                             qualifyForeign(fn.body(), m.name()), fn.partial(), fn.pos()));
         }
-        List<Ast.Def> defs = new ArrayList<>();
-        for (Ast.Def def : m.defs()) {
-            defs.add(def instanceof Ast.Data d && !d.invariants().isEmpty()
-                    ? new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(),
-                            Ast.mapClauses(d.invariants(), inv -> qualifyForeign(inv, m.name())),
-                            d.decoder(), d.encoder(), d.pos())
-                    : def);
-        }
+        List<Ast.Def> defs = qualifiedInvariants(m);
         List<Ast.Example> examples = new ArrayList<>();
         for (Ast.Example ex : m.examples()) {
             List<Ast.ExampleRow> rows = new ArrayList<>();
@@ -417,6 +423,31 @@ public final class HelperInliner {
         }
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
                 m.behaviors(), fns, examples, fakes, m.exampleFileTarget(), m.pos());
+    }
+
+    /** {@code m} with the foreign names in its invariants written qualified, and nothing else
+     * changed. An invariant is read before the bodies are — settled here, classified for discharge
+     * there — so this is the part of {@link #qualifyImports} that has to be available on its own. */
+    public static Ast.Module withQualifiedInvariants(Ast.Module m) {
+        List<Ast.Def> defs = qualifiedInvariants(m);
+        return defs.equals(m.defs()) ? m
+                : new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
+                        m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(),
+                        m.pos());
+    }
+
+    /** {@code m}'s declarations with every name in an invariant that denotes another module's
+     * definition written qualified. */
+    private static List<Ast.Def> qualifiedInvariants(Ast.Module m) {
+        List<Ast.Def> defs = new ArrayList<>();
+        for (Ast.Def def : m.defs()) {
+            defs.add(def instanceof Ast.Data d && !d.invariants().isEmpty()
+                    ? new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(),
+                            Ast.mapClauses(d.invariants(), inv -> qualifyForeign(inv, m.name())),
+                            d.decoder(), d.encoder(), d.pos())
+                    : def);
+        }
+        return defs;
     }
 
     /** {@code e} with every name denoting a helper of a module other than {@code self} written
@@ -530,10 +561,18 @@ public final class HelperInliner {
      *
      * <p>An invariant is pure and cannot call an injected behavior (spec §invariant-expressions), so
      * nothing here needs the injected signatures to settle the helpers an invariant reaches.
+     *
+     * <p>{@code published} is what the modules this one imports offer it. An invariant names what is
+     * in scope where it is written, and an imported definition is in scope there as it is in a body; it
+     * is substituted here for the reason a body's is, so what the invariant carries afterwards names
+     * nothing of the module that declared it. The names are written qualified first, because that is
+     * the spelling the table is keyed by — {@link #qualifyImports} does it again for the bodies below,
+     * and says the same thing both times.
      */
-    public static Ast.Module withSettledInvariants(Ast.Module m, Symbols symbols) {
-        Ast.Module settled = HelperParams.settle(m, symbols, Map.of());
-        return forModule(settled).withInlinedInvariants(settled);
+    public static Ast.Module withSettledInvariants(Ast.Module m, Symbols symbols,
+                                                   Map<String, Ast.FnDef> published) {
+        Ast.Module settled = withQualifiedInvariants(HelperParams.settle(m, symbols, Map.of()));
+        return forModule(settled, published).withInlinedInvariants(settled);
     }
 
     /**
@@ -543,19 +582,21 @@ public final class HelperInliner {
      */
     /**
      * Each declaration's invariant in the representation the invariant-discharge analysis reads: the
-     * module's own helpers expanded, the language's own operations left standing
+     * helpers it can name expanded, the language's own operations left standing
      * ({@link InliningPolicy#DISCHARGE}). Keyed by the declaration's name in {@code m}.
      *
-     * <p>This is the same settling {@link #withSettledInvariants} does, stopped one step earlier. The
-     * settled form is what travels to an importer and what the backend emits; an importer therefore
-     * reads an imported invariant in the settled form and finds nothing here for it, which is where
-     * an imported clause falls outside the statically dischargeable fragment (spec
+     * <p>This is the same settling {@link #withSettledInvariants} does, stopped one step earlier, and
+     * it reads the same table: what the clause names is substituted whether this module declared it or
+     * imported it. The settled form is what travels to an importer and what the backend emits; an
+     * importer therefore reads an imported invariant in the settled form and finds nothing here for
+     * it, which is where an imported clause falls outside the statically dischargeable fragment (spec
      * §invariant-discharge).
      */
     public static Map<TypeName, List<Ast.InvariantClause>> invariantsForDischarge(
-            Ast.Module m, Symbols symbols) {
-        Ast.Module settled = HelperParams.settle(m, symbols, Map.of());
-        HelperInliner inliner = forHelpers(helpersOf(settled), InliningPolicy.DISCHARGE);
+            Ast.Module m, Symbols symbols, Map<String, Ast.FnDef> published) {
+        Ast.Module settled = withQualifiedInvariants(HelperParams.settle(m, symbols, Map.of()));
+        HelperInliner inliner =
+                forHelpers(helpersOf(settled), published, InliningPolicy.DISCHARGE);
         Map<TypeName, List<Ast.InvariantClause>> out = new LinkedHashMap<>();
         for (Ast.Def def : settled.defs()) {
             if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -503,8 +503,10 @@ public final class Bodies {
      * the reader never imported arrives because the body it was published inside calls it. The reader
      * emits them as its own methods (see {@link Shapes.Prepared}).
      *
-     * <p>Read from the imports of the desugared module rather than the settled one, so that settling
-     * can read this: what a module imports is written down and is not something settling decides.
+     * <p>Read from the imports of the resolved module, which is the earliest answer carrying them.
+     * What a module imports is written down and is not something desugaring or settling decides, so
+     * reading it there is what leaves every later stage free to read this — {@link Shapes.Derived}
+     * among them, which settles the invariants and would ask through itself for any answer below it.
      */
     public record ImportedDefinitions(String name) implements Key<Map<String, Ast.FnDef>> {
         @Override
@@ -520,12 +522,12 @@ public final class Bodies {
             if (Names.cyclic(db, name)) {
                 return Answer.absent();
             }
-            Answer<Ast.Module> desugared = db.ask(new Shapes.Desugared(name));
-            if (!desugared.present()) {
+            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            if (!resolved.present()) {
                 return Answer.absent();
             }
             Map<String, Ast.FnDef> out = new LinkedHashMap<>();
-            for (Ast.Import imp : desugared.value().imports()) {
+            for (Ast.Import imp : resolved.value().imports()) {
                 Answer<Ast.Module> from = db.ask(new Settled(imp.module()));
                 // Closed against everything the declaring module can name, not only what it declares:
                 // a published body may call a helper that module imported in turn, and a chain of

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -39,6 +39,11 @@ public final class Shapes {
      * <p>The two go together because settling reads the spread source through the same symbols the
      * derive produced: an invariant that arrives by spread is part of the declaration from here on,
      * and a later pass that read the declaration before settling would read a type without it.
+     *
+     * <p>Settling substitutes what the modules this one imports publish to it, as lowering a body
+     * does. The dependency runs the other way from the rest of this file — a shape reaching into
+     * bodies — and it is the imported module's bodies it reaches, never this one's: what a module
+     * imports is read off its resolved form, so nothing here is asked through itself.
      */
     public record Derived(String name) implements Key<Ast.Module> {
         @Override
@@ -56,10 +61,16 @@ public final class Shapes {
             if (!scope.present()) {
                 return Answer.absent();
             }
+            Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
+            // A module whose imports form a cycle takes nothing from them. The cycle is reported where
+            // it is found; an invariant naming an imported definition is left unsettled and reported
+            // as the unknown name it then is, which is the same answer every other stage gives there.
+            Map<String, Ast.FnDef> published = imported.present() ? imported.value() : Map.of();
             try {
                 Ast.Module declared = onlyWhatItDeclares(resolved.value());
                 Ast.Module derived = Deriver.derive(declared, scope.value());
-                return Answer.of(HelperInliner.withSettledInvariants(derived, scope.value()));
+                return Answer.of(
+                        HelperInliner.withSettledInvariants(derived, scope.value(), published));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -242,9 +253,15 @@ public final class Shapes {
             if (!resolved.present() || !scope.present()) {
                 return Answer.absent();
             }
+            Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
+            Map<String, Ast.FnDef> published = imported.present() ? imported.value() : Map.of();
+            // What the clause says is what the check reads, so an imported bound is substituted here
+            // as it is where the invariant is settled. A clause left naming it would be classified as
+            // a rule this analysis cannot read, and a construction the bound rejects would compile.
+            Ast.Module declaring = HelperInliner.withQualifiedInvariants(resolved.value());
             try {
                 Map<TypeName, List<ClauseDischarge>> out = new LinkedHashMap<>();
-                for (Ast.Def def : resolved.value().defs()) {
+                for (Ast.Def def : declaring.defs()) {
                     if (!(def instanceof Ast.Data data) || data.invariants().isEmpty()) {
                         continue;
                     }
@@ -252,7 +269,7 @@ public final class Shapes {
                     // the position it is written — an expansion carries positions of its own, and the
                     // author is looking at the source.
                     HelperInliner inliner = HelperInliner.forHelpers(
-                            HelperInliner.helpersOf(resolved.value()), InliningPolicy.DISCHARGE);
+                            HelperInliner.helpersOf(declaring), published, InliningPolicy.DISCHARGE);
                     List<ClauseDischarge> clauses = new ArrayList<>();
                     // A declared clause is one rule to depart by and may still be several conjuncts to
                     // discharge, so `a && b` under one name is classified twice under that name: what
@@ -294,9 +311,11 @@ public final class Shapes {
      * reads ({@link souther.compiler.check.InliningPolicy#DISCHARGE}) — beside the settled form that
      * every other stage sees on the declaration itself.
      *
-     * <p>Only this module's own. What another module publishes arrives settled, which is what makes
-     * an imported clause fall outside the statically dischargeable fragment: the analysis reads what
-     * it is given, and there the operations have already become the folds they are.
+     * <p>Only the clauses this module declares. What another module publishes arrives settled, which
+     * is what makes an imported clause fall outside the statically dischargeable fragment: the
+     * analysis reads what it is given, and there the operations have already become the folds they
+     * are. A clause declared here that names an imported definition is this module's clause and stays
+     * inside the fragment — the definition is substituted, as it is everywhere the invariant is read.
      */
     public record InvariantsForDischarge(String name)
             implements Key<Map<TypeName, List<Ast.InvariantClause>>> {
@@ -312,8 +331,11 @@ public final class Shapes {
             if (!resolved.present() || !scope.present()) {
                 return Answer.absent();
             }
+            Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
+            Map<String, Ast.FnDef> published = imported.present() ? imported.value() : Map.of();
             try {
-                return Answer.of(HelperInliner.invariantsForDischarge(resolved.value(), scope.value()));
+                return Answer.of(HelperInliner.invariantsForDischarge(
+                        resolved.value(), scope.value(), published));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantImportedDefinitionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantImportedDefinitionTest.java
@@ -1,0 +1,161 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An invariant names what is in scope where it is written, and a definition another module publishes
+ * is in scope there like any other name. A limit several modules' types are written against is
+ * written once, in the module that owns it.
+ *
+ * <p>What an invariant may name is what travels with it: a published value is substituted where it is
+ * named and a published helper expanded where it is called, both closed by the module that declares
+ * them, so the settled invariant names nothing of that module. A module reading the type from a jar
+ * reads the invariant as written and resolves the name against the declaring module, which is why
+ * that module is on its class path.
+ */
+class CompileInvariantImportedDefinitionTest {
+
+    private static final String LIMITS = """
+            module limits exposing ( maxLen, fits )
+
+            let maxLen = 3
+
+            let fits (s: String) : Bool = String.length(s) <= maxLen
+            """;
+
+    @Test
+    void anInvariantNamesAnImportedValue() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(LIMITS, """
+                module ids exposing ( V )
+
+                import limits ( maxLen )
+
+                data V = String
+                    invariant String.length(value) <= maxLen
+                """)));
+    }
+
+    @Test
+    void anInvariantCallsAnImportedHelper() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(LIMITS, """
+                module ids exposing ( V )
+
+                import limits ( fits )
+
+                data V = String
+                    invariant fits(value)
+                """)));
+    }
+
+    /** The substituted value is what the rule is checked against: a construction the limit rejects
+     * is rejected, and the limit is the declaring module's. */
+    @Test
+    void theImportedValueIsWhatTheRuleIsCheckedAgainst() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compileModules(List.of(LIMITS, """
+                module ids exposing ( V )
+
+                import limits ( maxLen )
+
+                data V = String
+                    invariant String.length(value) <= maxLen
+                """)), getClass().getClassLoader());
+
+        assertEquals("abc", Codecs.encode(loader, "ids.V", Codecs.decoded(loader, "ids.V", "abc")));
+        assertEquals("Err", Codecs.decode(loader, "ids.V", "abcd").getClass().getSimpleName());
+    }
+
+    /** A published helper means what it meant where it was written, in an invariant as in a body:
+     * {@code fits} rests on the limit its own module wrote, not on the one the reader spells the same
+     * way. */
+    @Test
+    void anImportedHelperKeepsItsOwnDependenciesWhenTheReaderSharesTheirNames() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compileModules(List.of(LIMITS, """
+                module ids exposing ( V )
+
+                import limits ( fits )
+
+                let maxLen = 99
+
+                data V = String
+                    invariant fits(value)
+                """)), getClass().getClassLoader());
+
+        assertEquals("Err", Codecs.decode(loader, "ids.V", "abcd").getClass().getSimpleName());
+    }
+
+    /** An unexposed value has no name here, in an invariant as anywhere else. */
+    @Test
+    void anUnpublishedValueCannotBeNamedInAnInvariant() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of("""
+                        module limits exposing ( fits )
+
+                        let maxLen = 3
+
+                        let fits (s: String) : Bool = String.length(s) <= maxLen
+                        """, """
+                        module ids exposing ( V )
+
+                        import limits ( maxLen )
+
+                        data V = String
+                            invariant String.length(value) <= maxLen
+                        """)));
+
+        assertTrue(e.getMessage().contains("maxLen"), e.getMessage());
+    }
+
+    /**
+     * The discharge analysis reads the clause with the imported bound substituted, so a construction
+     * the bound rejects is proven to violate rather than left as a rule the check cannot read.
+     */
+    @Test
+    void anImportedBoundIsReadByTheDischargeAnalysis() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of("""
+                        module limits exposing ( floor )
+
+                        let floor = 0m
+                        """, """
+                        module money exposing ( Money, calc )
+
+                        import limits ( floor )
+
+                        data Money = Decimal
+                            invariant value >= floor
+
+                        behavior calc : (m: Money) -> Money constructs Money
+                        let calc (m) = Money(0m) - Money(1m)
+                        """)));
+
+        assertEquals("E2010", e.diagnostic().code(), e.getMessage());
+    }
+
+    /** The invariant travels as written, so the module it names is one the reading project needs on
+     * its class path — and reading it there is what makes the name resolve. */
+    @Test
+    void anImportedValueInAnInvariantCrossesAProjectBoundary() throws Exception {
+        Map<String, byte[]> upstream = Compiler.compile(LIMITS);
+        ModulePath path = upstream::get;
+
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
+                module app.ids exposing ( V )
+
+                import limits ( maxLen )
+
+                data V = String
+                    invariant String.length(value) <= maxLen
+                """), path));
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -918,6 +918,27 @@ data カゴ = { items: List<明細> } invariant List.all(x -> 正の数(x.数量
 
 What may be called is a `+let+`, not a behavior (<<fn>>). An invariant is part of what a type is: it travels to an importing module as the source it was written as, together with the helper `+let+`s it names (<<published-modules>>). It names only what travels with it, so a behavior MUST NOT be called from an invariant whatever its requirement set — including one that depends on nothing and is callable from a `+let+` body (<<calling-a-behavior>>). To name a business rule, use a `+let+`.
 
+A value or a helper another module publishes travels with it, so an invariant MAY name one, as a `+let+` body may (<<exposed-values>>). A limit or a format several modules' types are written against is therefore written once, in the module that owns it.
+
+[,text]
+----
+module limits exposing ( 最大文字数 )
+
+let 最大文字数 = 20
+----
+
+[,text]
+----
+module 会員 exposing ( 会員名 )
+
+import limits ( 最大文字数 )
+
+data 会員名 = String
+    invariant String.length(value) <= 最大文字数
+----
+
+The value is substituted and the helper expanded where they are named, closed by the module that declares them (<<exposed-values>>), so what the rule says does not change with where it is read. A project importing `+会員名+` from a jar reads the invariant as it was written and resolves `+最大文字数+` against `+limits+`, which is why that module is on its class path (<<published-modules>>).
+
 A `+let+` may be called from an invariant when it satisfies all of the following, all statically decidable.
 
 * the requirement set is empty (the corresponding behavior writes no `+depends on+`; <<depends-on>>)
@@ -1003,9 +1024,9 @@ A size taken of a container built by an operation is read through that operation
 [#invariant-discharge-representation]
 ==== What the check reads
 
-The check reads a behavior's body and the invariants around it at the level the rules above are written at: the standard library's operations are operations, and a module's own `+let+`s are expanded into the body that called them (spec 12.5). The two go together. The language defines what `+List.map+` does to a length, and every module has that definition, so a call to it says something on its own. A `+let+` carries no such definition and does not travel to an importing module either, so what it says is its body.
+The check reads a behavior's body and the invariants around it at the level the rules above are written at: the standard library's operations are operations, and the `+let+`s a body or an invariant names are expanded into it (spec 12.5). The two go together. The language defines what `+List.map+` does to a length, and every module has that definition, so a call to it says something on its own. A `+let+` carries no such definition, so what it says is its body — the one another module published as readily as the one written here.
 
-An invariant that arrives from another module arrives expanded (<<published-modules>>), so a clause of an imported type is read as the computation it became rather than as the operations it was written as. Such a clause is outside the statically dischargeable fragment even where the same clause written here would be inside it.
+An invariant that arrives from another module arrives expanded (<<published-modules>>), so a clause of an imported type is read as the computation it became rather than as the operations it was written as. Such a clause is outside the statically dischargeable fragment even where the same clause written here would be inside it. A clause written here is inside it whatever it names: an imported value or helper is substituted before the check reads the clause (<<invariant-expressions>>), so the rule the check reads is the rule the author wrote.
 
 An operation the rules name is named as the call that survives to here, which is not every spelling an author can write: `+List.fold+` is the walk `+List.foldFrom+` from the head (<<stdlib-list>>) and is rewritten to it before any of this, so it is the second name the rules are written against. A rule under a name nothing here holds could not be reached, which is why the compiler's own tests hold each rule to a program that fires it.
 


### PR DESCRIPTION
A behavior body reads a definition another module publishes; an invariant did not. The name resolved — the import was read — and the substitution then found nothing to substitute, because the table it was given was empty where the body's carries `Bodies.ImportedDefinitions`.

```souther
module limits exposing ( maxLen )
let maxLen = 3
```

```souther
module ids exposing ( V )
import limits ( maxLen )

data V = String
    invariant String.length(value) <= maxLen    // unknown identifier `limits.maxLen`
```

The gap was wider than the issue reports: an imported helper failed too (`limits.fits` is not a standard-library function), while an imported *type* in an invariant already worked. The boundary was "types cross into an invariant, values and helpers do not", which is not a rule that can be written down.

## Why this is a wiring and not a decision

An invariant may name only what travels with it. A published value is substituted where it is named and a published helper expanded where it is called, both closed by the module that declares them, so what the settled invariant carries names nothing of that module — which is what travelling means. `specification.adoc` already states the class-path consequence: a module on the class path needs another when what it declares names it, "in a field's type, a spread, an invariant, a helper an invariant calls, or an exposed composition's output". No ADR is raised.

The publishing side already worked. A module carries its invariants as written, and the import line survives `withNeededImports` because the name is written in the published text, so a project importing the type resolves the name against the declaring module on its class path.

## The query edge

`Shapes.Derived` could not ask `Bodies.ImportedDefinitions` as it stood: that key read its import list from `Shapes.Desugared`, which reads `Derived`, so the ask went through itself. It now reads the resolved module. Imports are written down and are not something desugaring or settling decides, so the earliest answer carrying them is the right one to read.

The names in an invariant are still bare at `Derived`, and the table is keyed qualified, so the invariant half of `qualifyImports` is split out as `withQualifiedInvariants` and run first. It reads what a name denotes rather than how it is spelled, so running it again for the bodies below says the same thing.

## The discharge analysis reads the same table

Two readers — `Shapes.InvariantsForDischarge` and `Shapes.InvariantCapabilities` — were building their table from the module's own helpers, so a clause whose bound was imported was classified as a rule the check could not read, and a construction that bound rejects compiled silently:

```souther
data Money = Decimal
    invariant value >= floor          // floor imported

behavior calc : (m: Money) -> Money constructs Money
let calc (m) = Money(0m) - Money(1m)  // should be E2010, was silent
```

A clause written here is this module's clause whatever it names, so it stays inside the statically dischargeable fragment. What falls outside it is still a clause of an imported *type*, which arrives already expanded.

## Out of scope

The qualified spelling. `limits.maxLen` with no import line is not accepted in a behavior body either — qualified reference is a rule about types — and an invariant reaching further than a body is not the shape to fix that in.

## Tests

`CompileInvariantImportedDefinitionTest`, seven cases: an imported value named, an imported helper called, the imported bound checked at run time, a published helper keeping its own dependencies where the reader spells one the same way, an unexposed value still refused, the imported bound read by the discharge analysis, and the whole thing across a project boundary.

Full suite green (compiler 1662, lsp 98, others 37). `souther-examples` builds and tests green against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
