### PR TITLE
A case value is bound with `as`

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -948,11 +948,22 @@ public final class AstBuilder {
             }
             i = at[0];
         }
+        boolean isSome = caseTypes.size() == 1 && caseTypes.get(0).written().equals("Some");
         // Option's positional binding `Some v`: a bare identifier before `{` / `as` / `->`. It never
         // follows a constructor destructure, so a trailing ident after the parens is not consumed here.
+        // Option is the one case with a payload to reach, so every other case binds its value with
+        // `as` and a bare identifier beside its name binds nothing.
         String someBinding = null;
         if (unwrapNames.isEmpty() && i < es.size() && isToken(es.get(i), SyntaxKind.IDENT)) {
-            someBinding = tokenText(es.get(i++));
+            String ident = tokenText(es.get(i));
+            if (!isSome) {
+                throw error(posOf((SyntaxToken) es.get(i)), "parse.case.positional",
+                        "a case value is bound with `as`: write `| " + caseTypes.get(caseTypes.size() - 1).written()
+                                + " as " + ident + "`",
+                        caseTypes.get(caseTypes.size() - 1).written(), ident);
+            }
+            someBinding = ident;
+            i++;
         }
         // field destructuring `{ field [= var], ... }`
         List<String> fieldNames = new ArrayList<>();
@@ -982,7 +993,6 @@ public final class AstBuilder {
             i++;
             asBinding = tokenText(es.get(i++));
         }
-        boolean isSome = caseTypes.size() == 1 && caseTypes.get(0).written().equals("Some");
         if (isSome && asBinding != null) {
             throw error(casePos, "parse.option.positional",
                     "Option's wrapped value is bound positionally: write `| Some v`, not `| Some as v`");

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -420,6 +420,7 @@ parse.expr=I expected an expression here.
 parse.block.noresult=A block ends in one expression, which is its value; this one has only `let`/`guard` lines. Layout does not end a statement, so a result on its own line may continue the line above.
 parse.orpattern=An or-pattern binds the sum type and cannot destructure a case's fields.
 parse.option.positional=Option's wrapped value is bound positionally: write `| Some v`, not `| Some as v`.
+parse.case.positional=A case value is bound with `as`: write `| {0} as {1}`, not `| {0} {1}`. Only `Some` carries a payload to bind positionally.
 parse.case.record.direct=A record's fields are destructured directly: write `| Some { field }`, not `| Some(Type { field })`. The parens open a newtype.
 parse.newtype.tuple=A newtype takes the external representation of what it wraps, and a tuple has none. Wrap a named data instead.
 parse.newtype.fntype=A newtype takes the external representation of what it wraps, and a function has none.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -419,6 +419,7 @@ parse.expr=ここには式が必要です。
 parse.block.noresult=ブロックは最後に値となる式を1つ置きますが、このブロックには `let`／`guard` の行しかありません。改行は文の区切りではないので、独立した行に書いた結果式が上の行の続きとして読まれることがあります。
 parse.orpattern=or パターンは直和型を束縛するため、ケースのフィールドを分解できません。
 parse.option.positional=Option の中身は位置で束縛します。`| Some as v` ではなく `| Some v` と書きます。
+parse.case.positional=ケースの値は `as` で束縛します。`| {0} {1}` ではなく `| {0} as {1}` と書いてください。位置で束縛できる中身を持つのは `Some` だけです。
 parse.case.record.direct=レコードのフィールドは直接分解します。`| Some(型 { field })` ではなく `| Some { field }` と書いてください。括弧は newtype を開く形です。
 parse.newtype.tuple=newtype は包んだ型の外部表現をそのまま受け取りますが、タプルには外部表現がありません。名前付きの data を包んでください。
 parse.newtype.fntype=newtype は包んだ型の外部表現をそのまま受け取りますが、関数には外部表現がありません。

--- a/souther-compiler/src/test/java/souther/compiler/CompileBottomJoinTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileBottomJoinTest.java
@@ -109,7 +109,7 @@ class CompileBottomJoinTest {
                     let (positives, _) = fold((acc, x) -> {
                         let (ps, ns) = acc
                         match Int.remainder(x, 2) with
-                            | Int r -> (ps ++ [r], ns)
+                            | Int as r -> (ps ++ [r], ns)
                             | DivisionByZero -> (ps, ns ++ [x])
                     }, ([], []), i.xs)
                     Out { ys = positives }

--- a/souther-compiler/src/test/java/souther/compiler/CompileCallBehaviorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileCallBehaviorTest.java
@@ -90,8 +90,8 @@ class CompileCallBehaviorTest {
                 behavior use : (i: In) -> Out | Refused
                     constructs Out
                 let use (i) = match classify(i) with
-                    | Ok o -> Out { o = o.n }
-                    | Refused r -> r
+                    | Ok as o -> Out { o = o.n }
+                    | Refused as r -> r
                 """));
     }
 
@@ -140,9 +140,9 @@ class CompileCallBehaviorTest {
                     depends on load
                     constructs Person, Missing
                 let fetch (id, load) = match load(id) with
-                    | Row r -> if r.active then Person { id = r.id, name = r.name }
+                    | Row as r -> if r.active then Person { id = r.id, name = r.name }
                                else Missing { id = id }
-                    | Missing m -> m
+                    | Missing as m -> m
                 """, """
                 module orders exposing ( Order, Placed, Unknown, place )
 
@@ -156,8 +156,8 @@ class CompileCallBehaviorTest {
                     depends on fetch
                     constructs Placed, Unknown
                 let place (o, fetch) = match fetch(o.by) with
-                    | Person p -> Placed { by = p.id, name = p.name }
-                    | Missing m -> Unknown { by = o.by }
+                    | Person as p -> Placed { by = p.id, name = p.name }
+                    | Missing as m -> Unknown { by = o.by }
                 """, """
                 module billing exposing ( Invoice, Issued, NoSuch, issue )
 
@@ -171,8 +171,8 @@ class CompileCallBehaviorTest {
                     depends on fetch
                     constructs Issued, NoSuch
                 let issue (i, fetch) = match fetch(i.to) with
-                    | Person p -> Issued { to = p.id, name = p.name }
-                    | Missing m -> NoSuch { to = i.to }
+                    | Person as p -> Issued { to = p.id, name = p.name }
+                    | Missing as m -> NoSuch { to = i.to }
                 """)));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileCaseBoundWithAsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileCaseBoundWithAsTest.java
@@ -1,0 +1,120 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A match case's value is bound with {@code as}. A bare identifier beside the case name is the
+ * positional binding of {@code Option}'s payload and is written only there — a user case is a named
+ * data with no payload layer, and a primitive case's value is the whole matched value. F# draws the
+ * same line: {@code | Some x} binds a payload, while a type test binds with {@code as}
+ * ({@code | :? int as n}, where {@code | :? int n} does not parse).
+ */
+class CompileCaseBoundWithAsTest {
+
+    private static final String DIVIDE = """
+            module p exposing ( run, In, Out )
+            data In = { a: Int, b: Int }
+            data Out = { r: Int }
+            behavior run : (i: In) -> Out constructs Out
+            let run (i) = {
+                let q = match Int.divide(i.a, i.b) with
+                    | DivisionByZero -> 0
+                    | Int %s -> n
+                Out { r = q }
+            }
+            """;
+
+    private static final String SUM = """
+            module p exposing ( run, In, Out, Draft, Sent )
+            data Draft = { id: Int }
+            data Sent = { id: Int }
+            data Application = Draft | Sent
+            data In = { a: Int }
+            data Out = { r: Int }
+            behavior run : (i: In) -> Out constructs Out, Draft, Sent
+            let run (i) = {
+                let app = if i.a > 0 then Draft { id = i.a } else Sent { id = i.a }
+                let n = match app with
+                    | Draft %1$s -> %2$s.id
+                    | Sent as s -> s.id
+                Out { r = n }
+            }
+            """;
+
+    /** The arm of a primitive-headed union binds with `as`, the form the spec shows. */
+    @Test
+    void aPrimitiveArmBindsWithAs() throws Exception {
+        Compiler.compile(DIVIDE.formatted("as n"));
+    }
+
+    /** A bare identifier beside a primitive case is not a binding, and the message says so. */
+    @Test
+    void aPrimitiveArmRejectsABareIdentifier() {
+        String rendered = render(assertThrows(CompileException.class,
+                () -> Compiler.compile(DIVIDE.formatted("n"))));
+        assertTrue(rendered.contains("| Int as n"), rendered);
+    }
+
+    /** A user case is bound the same way — the bare form is not a second spelling of `as`. */
+    @Test
+    void aUserCaseRejectsABareIdentifier() {
+        String rendered = render(assertThrows(CompileException.class,
+                () -> Compiler.compile(SUM.formatted("d", "d"))));
+        assertTrue(rendered.contains("| Draft as d"), rendered);
+    }
+
+    @Test
+    void aUserCaseBindsWithAs() throws Exception {
+        Compiler.compile(SUM.formatted("as d", "d"));
+    }
+
+    /** An or-pattern binds the sum type, and it binds it with `as` too. */
+    @Test
+    void anOrPatternRejectsABareIdentifier() {
+        String rendered = render(assertThrows(CompileException.class, () -> Compiler.compile("""
+                module p exposing ( run, In, Out, Draft, Sent )
+                data Draft = { id: Int }
+                data Sent = { id: Int }
+                data Application = Draft | Sent
+                data In = { a: Int }
+                data Out = { r: Int }
+                behavior run : (i: In) -> Out constructs Out, Draft, Sent
+                let run (i) = {
+                    let app = if i.a > 0 then Draft { id = i.a } else Sent { id = i.a }
+                    let n = match app with
+                        | Draft | Sent x -> i.a
+                    Out { r = n }
+                }
+                """)));
+        assertTrue(rendered.contains("| Sent as x"), rendered);
+    }
+
+    /** Option keeps the positional binding; it is the one case with a payload to bind. */
+    @Test
+    void optionKeepsItsPositionalBinding() throws Exception {
+        Compiler.compile("""
+                module p exposing ( run, In, Out )
+                data In = { xs: List<Int> }
+                data Out = { r: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = {
+                    let n = match List.get(0, i.xs) with
+                        | Some v -> v
+                        | None   -> 0
+                    Out { r = n }
+                }
+                """);
+    }
+
+    private static String render(CompileException ex) {
+        return new HumanRenderer(false).render(ex.diagnostic(), null, Locale.ENGLISH);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileQualifiedTypeRefTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQualifiedTypeRefTest.java
@@ -147,8 +147,8 @@ class CompileQualifiedTypeRefTest {
                 behavior read : (v: probe.sum.Verdict) -> Out constructs Out
                 let read (v) =
                     match v with
-                    | probe.sum.Good g -> Out { n = g.n }
-                    | probe.sum.Bad b -> Out { n = 0 }
+                    | probe.sum.Good as g -> Out { n = g.n }
+                    | probe.sum.Bad as b -> Out { n = 0 }
                 """));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileSumParamMatchTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSumParamMatchTest.java
@@ -27,8 +27,8 @@ class CompileSumParamMatchTest {
                 data B = { y: Int }
                 data S = A | B
                 let use (s: S) : Int = match s with
-                    | A a -> a.x
-                    | B b -> b.y
+                    | A as a -> a.x
+                    | B as b -> b.y
                 let caller : Int = use(A { x = 1 })
                 """));
     }
@@ -40,8 +40,8 @@ class CompileSumParamMatchTest {
                 data A = { x: Int }
                 data B = { y: Int }
                 let use (s: A | B) : Int = match s with
-                    | A a -> a.x
-                    | B b -> b.y
+                    | A as a -> a.x
+                    | B as b -> b.y
                 let caller : Int = use(A { x = 1 })
                 """));
     }
@@ -56,8 +56,8 @@ class CompileSumParamMatchTest {
                 data C = { z: Int }
                 data S = A | B
                 let use (s: S) : Int = match s with
-                    | A a -> a.x
-                    | B b -> b.y
+                    | A as a -> a.x
+                    | B as b -> b.y
                 let caller : Int = use(C { z = 1 })
                 """));
     }
@@ -86,10 +86,10 @@ class CompileSumParamMatchTest {
                 else NotFound { missing = line.sku }
 
             let step (acc: Acc, r: PriceResult) : Acc = match acc with
-                | NotFound n -> n
-                | PricedCart c -> match r with
-                    | Priced p -> PricedCart { lines = c.lines ++ [p] }
-                    | NotFound n -> n
+                | NotFound as n -> n
+                | PricedCart as c -> match r with
+                    | Priced as p -> PricedCart { lines = c.lines ++ [p] }
+                    | NotFound as n -> n
             """;
 
     @Test

--- a/specification.adoc
+++ b/specification.adoc
@@ -1672,8 +1672,8 @@ behavior 事前承認する : (申請: 事前承認待ち) -> 事前承認済み
 behavior 却下して通知する : (申請: 事前承認待ち) -> 通知済み | 承認権限なし
     depends on 事前承認する
 let 却下して通知する (申請, 事前承認する) = match 事前承認する(申請) with
-    | 事前承認済み 済 -> 通知済み { 宛先 = 済.申請者 }
-    | 承認権限なし 拒 -> 拒
+    | 事前承認済み as 済 -> 通知済み { 宛先 = 済.申請者 }
+    | 承認権限なし as 拒 -> 拒
 ----
 
 A call yields the behavior's declared output. Where that output is a sum, the caller opens it with `+match+`, and a case it does not handle is its own to declare in its output. Nothing departs on its own: departure is what `+>->+` does (<<type-routing>>), and a call is not a stage.
@@ -2250,7 +2250,7 @@ match 精算 with
 
 Nothing else reads indentation, and a misplaced arm cannot silently change meaning: a case is a named data (<<sum-data>>), and a name belongs to one data, so an arm that lands on the wrong match is a compile error naming the case and the sum. Where the two matches are on one line, the columns cannot separate them — write the inner one in a block (`+-> { match … }+`), which ends it explicitly.
 
-A case value is bound with `+as+` (the `+s+` in `+| 提出済み as s+` is 提出済み, read as `+s.提出日時+`). `+as+` binds the whole matched value.
+A case value is bound with `+as+` (the `+s+` in `+| 提出済み as s+` is 提出済み, read as `+s.提出日時+`). `+as+` binds the whole matched value. A bare identifier beside the case name is not a second spelling of it: `+| 提出済み s+` is a compile error naming the `+as+` form to write instead. A case is a reference to a named data (<<sum-data>>), so it carries no payload to bind positionally; the one case that does is Option's `+Some+`, and the positional form is written only there (below).
 
 Fields may be bound directly with a destructuring pattern, the inverse of construction. It uses the same `+{ }+`, `+,+`, `+=+` as construction `+会員 { id = x }+`, and `+{ id }+` is shorthand for binding to a same-named variable (paired with <<record-literal>>). Write only the fields used. Destructuring is possible only for a single named case; an or-pattern (below) binds to a sum type and has no fields. It may be combined with `+as+`: `+| 会員 { id } as 全体+` binds both fields and the whole.
 
@@ -2269,6 +2269,20 @@ match m with
     | アクティベート済み(メールアドレス(s)) -> s   // s is the base String, two layers opened
     | 未アクティベート(a)                 -> a.value   // a is メールアドレス, one layer opened
 ----
+
+[#primitive-arm]
+An arm may name a primitive type. A standard-library function that answers a value or a failure returns a union headed by a primitive — `+Int.divide+` / `+Int.remainder+` return `+Int | DivisionByZero+` (<<stdlib-int>>), `+Decimal.divide+` returns `+Decimal | DivisionByZero+` (<<stdlib-decimal>>), `+String.toInt+` / `+String.toDecimal+` return `+Int | NotANumber+` / `+Decimal | NotANumber+` (<<stdlib-string>>) — and the arm that takes the value names that primitive. Nothing wraps it: the matched value is the number itself, so `+as+` binds it as it binds any other case.
+
+[,text]
+----
+match Int.divide(i.分子, i.分母) with
+    | DivisionByZero -> 0
+    | Int as n       -> n
+----
+
+`+| Int(n)+` is rejected: the parens open a newtype (above) and a primitive is not one, so the message names the `+as+` form instead. `+| n -> n+` is not a fallthrough either — Souther has no `+_+` wildcard, every arm names a case, and `+n+` is looked up as a type name and not found. F# draws the same line for its type-test pattern, which also binds with `+as+`: `+| :? int as n+` is written, `+| :? int n+` does not parse.
+
+Where the model has already ruled the failure out — a `+require+` (<<attempted-construction>>) or the divisor type's own invariant keeps the divisor away from zero — the union need not arise: the operator `+/+` divides, and its abort on zero (<<stdlib-int>>) cannot be reached. The arm is for the divisor the model admits as an input.
 
 To route multiple cases to the same processing, list `+|+` within a case, `+| A | B -> ...+` (an or-pattern). It writes "these states are treated the same" for a state-machine sum in one line. The case-separator `+|+` and the or-pattern `+|+` are the same symbol, but `+->+` ends a case's pattern part, so they do not conflict.
 
@@ -2536,7 +2550,7 @@ The middle row is the core of Elm's String module expressible in Souther's types
 
 `+fromDecimal(d)+` renders a `+Decimal+` in plain notation, never in exponent form, keeping the scale the value carries: `+1000.00m+` is `+"1000.00"+`. Scale is incidental to the number (<<primitives>>) but not to how it is written, so a caller wanting a fixed number of places sets it first with `+Decimal.round(d, scale, mode)+` and names the rounding there. Grouping separators and a currency symbol are presentation and stay outside the domain. `+toDecimal(s)+` parses back, returning `+Decimal | NotANumber+` — the sibling of `+toInt+`, and a compiler built-in for the same reason.
 
-The bottom row gives character access without a `+Char+` type — a character is a length-1 `+String+`. `+toChars(s)+` is Elm's `+String.toList+`: the characters of `+s+`, one per Unicode code point, as single-character strings (`+toChars("a12")+` is `+["a", "1", "2"]+`), so `+List.fold+` can walk them. `+toCode(ch)+` is Elm's `+Char.toCode+` on such a character — its first code point, `+-1+` for the empty string. `+toInt(s)+` is Elm's `+String.toInt+`, returning `+Int | NotANumber+` in place of `+Maybe+`: a named case, since `+Maybe+` has no surface form (ADR-0011) — the same case-return the `+/+` operator and `+Int.divide+` draw between abort and case. `+toInt("007")+` is `+7+` (leading zeros kept, unlike a numeric parse-and-reformat); `+toInt("12x")+` is `+NotANumber+`. Because `+toInt+` returns a primitive-headed union it is a compiler built-in, not a core declaration (ADR-0053); `+toChars+` / `+toCode+` are ordinary intrinsics.
+The bottom row gives character access without a `+Char+` type — a character is a length-1 `+String+`. `+toChars(s)+` is Elm's `+String.toList+`: the characters of `+s+`, one per Unicode code point, as single-character strings (`+toChars("a12")+` is `+["a", "1", "2"]+`), so `+List.fold+` can walk them. `+toCode(ch)+` is Elm's `+Char.toCode+` on such a character — its first code point, `+-1+` for the empty string. `+toInt(s)+` is Elm's `+String.toInt+`, returning `+Int | NotANumber+` in place of `+Maybe+`: a named case, since `+Maybe+` has no surface form (ADR-0011) — the same case-return the `+/+` operator and `+Int.divide+` draw between abort and case. `+toInt("007")+` is `+7+` (leading zeros kept, unlike a numeric parse-and-reformat); `+toInt("12x")+` is `+NotANumber+`, and the parsed value is taken out with `+| Int as n+` (<<primitive-arm>>). Because `+toInt+` returns a primitive-headed union it is a compiler built-in, not a core declaration (ADR-0053); `+toChars+` / `+toCode+` are ordinary intrinsics.
 
 Together these make a checksum (Luhn, EAN, a mod-10 check digit) a plain `+let+` over `+List.fold+` in a behavior: validate the digits with `+matches("[0-9]+", value)+` in the type's invariant, read each digit as `+toCode(ch) - toCode("0")+` (total, because the invariant proved every character is a digit), and take the remainder with `+Int.modBy+`. A checksum is *not* an invariant — it folds, and an invariant may not recurse (<<invariant-expressions>>) — so it lives in a behavior, but a short one.
 
@@ -2551,7 +2565,7 @@ abs  min  max  clamp
 
 `+Int+` is signed 64-bit (<<primitives>>). If an operation exceeds that range it *aborts* — it does not wrap. Overflow is a model bug, not a business result, so like an invariant violation it throws `+ConstraintViolation+` (<<algebraic-types>>, <<violation-destination>>, <<jvm-abort>>).
 
-Division by zero returns `+Int | DivisionByZero+`. This is a possible input on the business flow (a divisor of 0), so it is returned as a case rather than aborting.
+Division by zero returns `+Int | DivisionByZero+`. This is a possible input on the business flow (a divisor of 0), so it is returned as a case rather than aborting. The arm that takes the quotient names the primitive and binds it with `+as+` — `+| Int as n+` (<<primitive-arm>>).
 
 The four operations may also be written with the operators `{plus}` `+-+` `+*+` `+/+` (the symbol table of <<primitives>>). `+/+` is truncating division and *aborts* on division by zero (like overflow). To receive `+Int | DivisionByZero+` as a case, use the functions `+divide+` / `+remainder+` — operator = casual and aborting, function = safe with a case.
 
@@ -2575,7 +2589,7 @@ Division makes the rounding scale and mode explicit as arguments. `+Decimal.divi
 HALF_UP  HALF_EVEN  HALF_DOWN  UP  DOWN  CEILING  FLOOR
 ----
 
-These correspond to `+java.math.RoundingMode+`. `+Decimal.divide(a, b)+` without scale and mode cannot be written — to surface rounding as a domain decision, the same position as "scale is incidental" in <<primitives>>. Division by zero returns `+Decimal | DivisionByZero+`.
+These correspond to `+java.math.RoundingMode+`. `+Decimal.divide(a, b)+` without scale and mode cannot be written — to surface rounding as a domain decision, the same position as "scale is incidental" in <<primitives>>. Division by zero returns `+Decimal | DivisionByZero+`, opened by `+| Decimal as d+` (<<primitive-arm>>).
 
 `+Int+` and `+Decimal+` meet only where the conversion is written. `+Decimal.fromInt(n)+` widens an `+Int+`; it is exact, so nothing has to be stated. `+Decimal.toInt(d, mode)+` narrows back, and because that drops a fraction it names the rounding at the call, as `+divide+` does. There is no implicit widening: an arithmetic operator takes two operands of one type (<<primitives>>), so a rate applied to an amount in yen reads `+Decimal.fromInt(税抜) * 税率+` — the conversion sits where the value stops being an amount. This is F#'s position for operators (`+n * 0.1m+` does not compile; `+decimal n * 0.1m+` does). A `+Decimal+` too large for an `+Int+` aborts, as an `+Int+` overflow does (<<primitives>>).
 


### PR DESCRIPTION
Issue #169: the specification says the standard-library functions answer a union headed by a primitive, but never showed the `match` that consumes one. The form that compiled was found by experiment, and it was not the form the specification states.

## What was wrong

`as` binds the whole matched value, and a case is a reference to a named data, so there is no payload to bind positionally. ADR-0035 put positional binding on Option's `Some` and nowhere else. The parser reads that positional slot without looking at which case precedes it, so a bare identifier after any case name was taken as a binding — `| Int n` compiled, and so did `| Draft d` on a user case. The specification's own example under a behavior call was written that way.

F# draws the line in the same place. A case carrying a payload binds it positionally (`| Some x`), a case carrying none rejects an argument outright (FS0725), and a type test — the closest thing F# has to an arm naming `Int` — binds with `as`: `| :? int as n` is written, `| :? int n` does not parse (FS0010). All three were measured with `dotnet fsi`.

## What changed

- `AstBuilder` takes the positional identifier only after `Some`, and otherwise reports `parse.case.positional`, naming the `as` form to write. The CST is untouched, so the tree stays lossless and the formatter is unaffected.
- The specification gains a section on the primitive arm, cross-referenced from `Int`, `Decimal` and `String`; the sentence on `as` says the bare form is not a second spelling; the example under a behavior call is corrected.
- 21 sites in the test suite move to the `as` form.

```
8|         | Int n -> n
                 ^
A case value is bound with `as`: write `| Int as n`, not `| Int n`. Only `Some` carries a payload to bind positionally.
```

No ADR is raised: ADR-0035 already decided that `as` binds the whole and that positional binding is Option's alone. This makes the implementation say what was decided.

## Verification

- `mvn clean install` green.
- `souther-examples` builds and tests green against this compiler; it had no bare-identifier bindings.
- All four primitive-headed unions (`Int.divide`, `Decimal.divide`, `String.toInt`, `String.toDecimal`) compiled through the CLI in the `as` form the specification now shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
