### PR TITLE
What a value constructs belongs to its definition

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -1,6 +1,7 @@
 package souther.compiler.ast;
 
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -690,22 +691,26 @@ public interface Ast {
      * not go back to matching the spelling against the module's own definitions.
      */
     /**
-     * A construction. {@code publishedBy} is the module whose published value or helper carried it
-     * here, and null where the body being read wrote it.
+     * A construction. {@code origin} says where it came from: written here, or carried in by a
+     * published body or by a value this body named.
      *
-     * <p>Expansion makes the two look alike: a construction spliced in from another module's
-     * published body is the same node the reader's own would be, and the permission check reading
-     * that body would ask the reader to declare `constructs` for a type it may have no name for. So
-     * the construction says where it came from. Every rebuild of this node carries it — the component
-     * has no default, which is what stops a pass from quietly dropping it and turning a carried
-     * construction back into the reader's own.
+     * <p>Expansion makes the two look alike: a construction spliced in from another body is the same
+     * node the reader's own would be, and the permission check reading that body would ask the
+     * reader to answer for it. So the construction says where it came from. Every rebuild of this
+     * node carries it — the component has no default, which is what stops a pass from quietly
+     * dropping it and turning a carried construction back into the reader's own.
      */
-    record NewData(Name typeName, List<FieldInit> inits, List<ValueRef> spreads, String publishedBy,
-                   SourcePos pos) implements Expr {
+    record NewData(Name typeName, List<FieldInit> inits, List<ValueRef> spreads,
+                   ConstructionOrigin origin, SourcePos pos) implements Expr {
 
         /** The same construction, carried into a reader by {@code module}'s published body. */
         public NewData publishedBy(String module) {
-            return new NewData(typeName, inits, spreads, module, pos);
+            return new NewData(typeName, inits, spreads, origin.publishedIn(module), pos);
+        }
+
+        /** The same construction, carried into a body by a value that body named. */
+        public NewData carriedByValue() {
+            return new NewData(typeName, inits, spreads, origin.carriedByValue(), pos);
         }
     }
 
@@ -805,7 +810,7 @@ public interface Ast {
                 for (FieldInit i : nd.inits()) {
                     inits.add(new FieldInit(i.name(), f.apply(i.value()), i.pos()));
                 }
-                yield new NewData(nd.typeName(), inits, nd.spreads(), nd.publishedBy(), nd.pos());
+                yield new NewData(nd.typeName(), inits, nd.spreads(), nd.origin(), nd.pos());
             }
             case Match m -> {
                 List<Case> cases = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -761,15 +761,23 @@ public interface Ast {
      * behavior, a function-typed parameter, or the type a newtype construction wraps — answered once
      * during resolution.
      */
-    record Call(String fn, ValueName denotes, List<Expr> args, SourcePos pos) implements Expr {
+    record Call(String fn, ValueName denotes, List<Expr> args, ConstructionOrigin origin,
+                SourcePos pos) implements Expr {
 
         /** A call as the parser read it, before resolution has said what {@code fn} denotes. */
         public Call(String fn, List<Expr> args, SourcePos pos) {
-            this(fn, null, args, pos);
+            this(fn, null, args, ConstructionOrigin.own(), pos);
         }
 
         public Call denoting(ValueName resolved) {
-            return new Call(fn, resolved, args, pos);
+            return new Call(fn, resolved, args, origin, pos);
+        }
+
+        /** The same call, carried into a body by a value that body named. A recursive helper is
+         * lowered to a method rather than expanded, so a value reaching one leaves a call where its
+         * constructions would otherwise stand, and the call is what has to say where it came from. */
+        public Call carriedByValue() {
+            return new Call(fn, denotes, args, origin.carriedByValue(), pos);
         }
     }
 
@@ -794,7 +802,7 @@ public interface Ast {
             case Neg n -> new Neg(f.apply(n.operand()), n.pos());
             case FieldAccess fa -> new FieldAccess(f.apply(fa.target()), fa.field(), fa.pos());
             case Binary b -> new Binary(b.op(), f.apply(b.left()), f.apply(b.right()), b.pos());
-            case Call c -> new Call(c.fn(), c.denotes(), mapExprs(c.args(), f), c.pos());
+            case Call c -> new Call(c.fn(), c.denotes(), mapExprs(c.args(), f), c.origin(), c.pos());
             case If iff -> new If(f.apply(iff.cond()), f.apply(iff.then()), f.apply(iff.els()), iff.pos());
             case IfConstructed ic -> new IfConstructed(f.apply(ic.construct()), ic.binder(),
                     f.apply(ic.then()), mapArms(ic.els(), f), ic.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -144,10 +144,9 @@ public final class DataChecker {
         out.putAll(all.originated());
     }
 
-    /** Whether {@code nd} was carried here by a published body of the module that declares
-     * {@code built} — the one case where the origination is already stated elsewhere. */
-    private static boolean declaredBy(Ast.NewData nd, TypeName built) {
-        return nd.publishedBy() != null && nd.publishedBy().equals(built.module());
+    /** Whether {@code nd} arrived here already made, rather than being written here. */
+    private static boolean carried(Ast.NewData nd, TypeName built) {
+        return nd.origin().carried(built);
     }
 
     static void collectConstructs(Ast.Expr e, Constructs out, Symbols symbols,
@@ -161,13 +160,16 @@ public final class DataChecker {
                 collectConstructs(li.body(), out, symbols, inner, recConstructs);
             }
             case Ast.NewData nd -> {
-                // A construction carried in by a module's published value or helper is that module's,
-                // not this body's: publishing the definition is what states the origination, and the
-                // reader has no name to declare a type the module keeps to itself by. What the mark
-                // does not cover is a type of some *other* module the published body happened to
-                // build — that origination is neither the reader's nor the publisher's to state, so it
-                // stays this behavior's to declare, which it can (ADR-0059).
-                Map<TypeName, String> side = declaredBy(nd, nd.typeName().denotes())
+                // A construction this body was handed is not this body's. It is handed one two ways.
+                // A module's published value or helper carries its own: publishing the definition is
+                // what states that origination, and the reader has no name to declare a type the
+                // module keeps to itself by. What that does not cover is a type of some *other*
+                // module the published body happened to build — that origination is neither the
+                // reader's nor the publisher's to state, so it stays this behavior's to declare,
+                // which it can. A value carries the construction its definition made, whatever module
+                // declares the type: the definition is where the value is made, and a body that names
+                // it compares against a limit rather than setting one.
+                Map<TypeName, String> side = carried(nd, nd.typeName().denotes())
                         ? out.carried() : out.originated();
                 side.putIfAbsent(nd.typeName().denotes(), nd.typeName().written());
                 for (Ast.FieldInit init : nd.inits()) {
@@ -237,8 +239,7 @@ public final class DataChecker {
             case Ast.Var v when !bound.contains(v.name())
                     && v.denotes() instanceof ValueName.OfType named
                     && symbols.get(named.type()) instanceof Ast.UnitData -> {
-                Map<TypeName, String> side = named.publishedBy() != null
-                        && named.publishedBy().equals(named.type().module())
+                Map<TypeName, String> side = named.origin().carried(named.type())
                         ? out.carried() : out.originated();
                 side.putIfAbsent(named.type(), v.name());
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -115,6 +115,14 @@ public final class DataChecker {
             return new Constructs(new LinkedHashMap<>(originated), new LinkedHashMap<>(carried));
         }
 
+        /** The same set with everything counted as carried — what a body reached through something
+         * it was handed rather than wrote, and so answers for none of. */
+        public Constructs allCarried() {
+            Map<TypeName, String> all = new LinkedHashMap<>(carried);
+            originated.forEach(all::putIfAbsent);
+            return new Constructs(new LinkedHashMap<>(), all);
+        }
+
         /** Takes on everything {@code other} builds, each kind staying the kind it is, and answers
          * whether that added anything. */
         public boolean absorb(Constructs other) {
@@ -183,10 +191,13 @@ public final class DataChecker {
                 // a recursive helper is not inlined, so its own (transitive) constructions are
                 // attributed to the behavior that calls it, exactly as an inlined helper's would be —
                 // each as the kind it already is, so one another module published stays that
-                // module's here as it does when the body is expanded.
+                // module's here as it does when the body is expanded. Where the call itself came in
+                // on a value, none of them are this body's: the value's definition is what reached
+                // the helper, and the call is standing in for constructions that would have been
+                // marked had the helper been expandable.
                 Constructs viaHelper = recConstructs.get(call.fn());
                 if (viaHelper != null) {
-                    out.absorb(viaHelper);
+                    out.absorb(call.origin().viaValueReference() ? viaHelper.allCarried() : viaHelper);
                 }
                 call.args().forEach(a -> collectConstructs(a, out, symbols, bound, recConstructs));
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -129,7 +129,7 @@ public final class Exposing {
                 for (Ast.FieldInit fi : nd.inits()) {
                     inits.add(new Ast.FieldInit(fi.name(), rw(fi.value()), fi.pos()));
                 }
-                yield new Ast.NewData(nd.typeName(), inits, nd.spreads(), nd.publishedBy(), nd.pos());
+                yield new Ast.NewData(nd.typeName(), inits, nd.spreads(), nd.origin(), nd.pos());
             }
             case Ast.LetIn li -> new Ast.LetIn(li.name(), rw(li.value()), li.declaredType(), li.annotated(), li.opens(),
                     rw(li.body()), li.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
+import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
 import souther.compiler.diag.CompileException;
@@ -380,6 +381,13 @@ public final class HelperInliner {
      * definition's however the type got its declaration, and a behavior reading the name is not the
      * one that made it either way. A helper is the other case and stays the other case: its body is
      * checked as though it had been written inline, which is what tells a helper from a behavior.
+     *
+     * <p>Three things can stand for a construction and each takes the mark. A construction node
+     * carries its own; a unit data is constructed by being named, so the name carries it; and a
+     * recursive helper is lowered to a method rather than expanded, so what it builds stays behind a
+     * call, and the call carries it. Without the third, whether a value's constructions belonged to
+     * the value would turn on whether a helper on the way could be expanded — the substitution
+     * showing through the rule again, in the one place expansion cannot reach.
      */
     private static Ast.Expr carriedByValue(Ast.Expr e) {
         Ast.Expr rebuilt = Ast.mapChildren(e, HelperInliner::carriedByValue);
@@ -387,6 +395,7 @@ public final class HelperInliner {
             case Ast.NewData nd -> nd.carriedByValue();
             case Ast.Var v when v.denotes() instanceof ValueName.OfType named ->
                     v.denoting(named.carriedByValue());
+            case Ast.Call call -> call.carriedByValue();
             default -> rebuilt;
         };
     }
@@ -501,6 +510,7 @@ public final class HelperInliner {
         return switch (rebuilt) {
             case Ast.Call call when foreign(call.denotes(), which) ->
                     new Ast.Call(qualifiedName(call.denotes()), call.denotes(), call.args(),
+                            call.origin(),
                             call.pos());
             case Ast.Var v when foreign(v.denotes(), which) ->
                     new Ast.Var(qualifiedName(v.denotes()), v.denotes(), v.pos());
@@ -685,6 +695,7 @@ public final class HelperInliner {
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.add(new Ast.IntLit(0, call.pos()));
         return new Ast.Call("List.foldFrom", new ValueName.Stdlib("List.foldFrom"), args,
+                ConstructionOrigin.own(),
                 call.pos());
     }
 
@@ -886,7 +897,7 @@ public final class HelperInliner {
                     // builtin, injected behavior, a function-typed parameter, or a recursive helper —
                     // a recursive helper is lowered to a method, so its call stays a Call (spec 13.1);
                     // only its args inline.
-                    yield new Ast.Call(call.fn(), call.denotes(), args, call.pos());
+                    yield new Ast.Call(call.fn(), call.denotes(), args, call.origin(), call.pos());
                 }
                 if (args.size() != helper.params().size()) {
                     LambdaOrigin origin = lambdaOrigins.get(helper.name());
@@ -1086,7 +1097,7 @@ public final class HelperInliner {
                 args.add(Ast.Var.local(p, v.pos()));
             }
             return inline(new Ast.Block(params,
-                    new Ast.Call(v.name(), v.denotes(), args, v.pos()), v.pos()));
+                    new Ast.Call(v.name(), v.denotes(), args, ConstructionOrigin.own(), v.pos()), v.pos()));
         }
         if (recursive.contains(v.name())) {
             return v;
@@ -1169,10 +1180,10 @@ public final class HelperInliner {
             callArgs.add(Ast.Var.local(p, v.pos()));
         }
         Ast.Block block = new Ast.Block(params,
-                new Ast.Call(v.name(), v.denotes(), callArgs, v.pos()), v.pos());
+                new Ast.Call(v.name(), v.denotes(), callArgs, ConstructionOrigin.own(), v.pos()), v.pos());
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.set(idx, block);
-        return new Ast.Call(call.fn(), call.denotes(), args, call.pos());
+        return new Ast.Call(call.fn(), call.denotes(), args, call.origin(), call.pos());
     }
 
     /**
@@ -1215,6 +1226,7 @@ public final class HelperInliner {
                         ? substDenotes.getOrDefault(call.fn(), new ValueName.Local(callee, at(at, call.pos())))
                         : call.denotes();
                 yield new Ast.Call(callee, denotes, renameList(call.args(), subst, substDenotes, fnParams, at),
+                        call.origin(),
                         at(at, call.pos()));
             }
             case Ast.Binary bin -> new Ast.Binary(bin.op(), rename(bin.left(), subst, substDenotes, fnParams, at), rename(bin.right(), subst, substDenotes, fnParams, at), at(at, bin.pos()));

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -365,6 +365,32 @@ public final class HelperInliner {
         };
     }
 
+    /**
+     * {@code e} with every construction in it marked as one a value made.
+     *
+     * <p>A value is substituted at each reference, so what its definition built ends up standing in
+     * the body that named it, as the node that body's own construction would be. The mark is what
+     * keeps the permission check reading the model rather than the substitution: a behavior stating a
+     * rule against a named limit compares against a value, and originates none of it. A limit is
+     * written as a value so that the figure has one place to live and one comment saying where it
+     * comes from, and naming it is not supposed to cost every rule that reads it an authority it does
+     * not use.
+     *
+     * <p>Unlike a published body's mark this names no module. What the value built is the value
+     * definition's however the type got its declaration, and a behavior reading the name is not the
+     * one that made it either way. A helper is the other case and stays the other case: its body is
+     * checked as though it had been written inline, which is what tells a helper from a behavior.
+     */
+    private static Ast.Expr carriedByValue(Ast.Expr e) {
+        Ast.Expr rebuilt = Ast.mapChildren(e, HelperInliner::carriedByValue);
+        return switch (rebuilt) {
+            case Ast.NewData nd -> nd.carriedByValue();
+            case Ast.Var v when v.denotes() instanceof ValueName.OfType named ->
+                    v.denoting(named.carriedByValue());
+            default -> rebuilt;
+        };
+    }
+
     /** How a definition of {@code module} is named outside it. */
     public static String qualified(String module, String name) {
         return module + "." + name;
@@ -493,7 +519,7 @@ public final class HelperInliner {
                 }
                 yield changed
                         ? new Ast.NewData(nd.typeName(), nd.inits(), spreads,
-                                nd.publishedBy(), nd.pos())
+                                nd.origin(), nd.pos())
                         : nd;
             }
             default -> rebuilt;
@@ -1065,7 +1091,7 @@ public final class HelperInliner {
         if (recursive.contains(v.name())) {
             return v;
         }
-        return inline(value.body());
+        return carriedByValue(inline(value.body()));
     }
 
     /**
@@ -1088,11 +1114,11 @@ public final class HelperInliner {
             }
             String name = "$s" + counter++ + "_" + spread.bare();
             bound.add(name);
-            values.add(inline(value.body()));
+            values.add(carriedByValue(inline(value.body())));
             spreads.add(Ast.ValueRef.local(name, spread.pos()));
         }
         Ast.Expr built = new Ast.NewData(nd.typeName(), inlineInits(nd.inits()), spreads,
-                nd.publishedBy(), nd.pos());
+                nd.origin(), nd.pos());
         for (int i = bound.size() - 1; i >= 0; i--) {
             built = new Ast.LetIn(bound.get(i), values.get(i), null, false, null, built, nd.pos());
         }
@@ -1204,7 +1230,7 @@ public final class HelperInliner {
                     String renamed = subst.get(s.bare());
                     spreads.add(renamed == null ? s : Ast.ValueRef.local(renamed, at(at, s.pos())));
                 }
-                yield new Ast.NewData(nd.typeName(), inits, spreads, nd.publishedBy(), at(at, nd.pos()));
+                yield new Ast.NewData(nd.typeName(), inits, spreads, nd.origin(), at(at, nd.pos()));
             }
             case Ast.Match m -> {
                 List<Ast.Case> cases = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1203,7 +1203,7 @@ public final class InvariantChecker {
     private static Ast.Call withArg(Ast.Call call, int at, Ast.Expr arg) {
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.set(at, arg);
-        return new Ast.Call(call.fn(), call.denotes(), args, call.pos());
+        return new Ast.Call(call.fn(), call.denotes(), args, call.origin(), call.pos());
     }
 
     /** An emptiness check as the comparison it means, or {@code e} unchanged. */
@@ -1211,6 +1211,7 @@ public final class InvariantChecker {
         if (e instanceof Ast.Call call && call.args().size() == 1
                 && EMPTINESS.containsKey(call.fn())) {
             Ast.Call size = new Ast.Call(EMPTINESS.get(call.fn()), call.denotes(), call.args(),
+                    call.origin(),
                     call.pos());
             return new Ast.Binary(Ast.BinOp.EQ, size, new Ast.IntLit(0, call.pos()), call.pos());
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
 
@@ -80,7 +81,7 @@ public final class NewtypeDesugar {
                     yield new Ast.NewData(
                             new Ast.Name(call.fn(), built, call.pos()),
                             List.of(new Ast.FieldInit("value", args.get(0), call.pos())),
-                            List.of(), null, call.pos());
+                            List.of(), ConstructionOrigin.own(), call.pos());
                 }
                 yield new Ast.Call(call.fn(), call.denotes(), args, call.pos());
             }
@@ -89,7 +90,7 @@ public final class NewtypeDesugar {
                 for (Ast.FieldInit fi : nd.inits()) {
                     inits.add(new Ast.FieldInit(fi.name(), go(fi.value(), symbols), fi.pos()));
                 }
-                yield new Ast.NewData(nd.typeName(), inits, nd.spreads(), nd.publishedBy(), nd.pos());
+                yield new Ast.NewData(nd.typeName(), inits, nd.spreads(), nd.origin(), nd.pos());
             }
             case Ast.Neg neg -> new Ast.Neg(go(neg.operand(), symbols), neg.pos());
             case Ast.Binary bin ->

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -83,7 +83,7 @@ public final class NewtypeDesugar {
                             List.of(new Ast.FieldInit("value", args.get(0), call.pos())),
                             List.of(), ConstructionOrigin.own(), call.pos());
                 }
-                yield new Ast.Call(call.fn(), call.denotes(), args, call.pos());
+                yield new Ast.Call(call.fn(), call.denotes(), args, call.origin(), call.pos());
             }
             case Ast.NewData nd -> {
                 List<Ast.FieldInit> inits = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -477,7 +478,7 @@ public final class Resolve {
                     spreads.add(s.denotes() != null ? s : s.denoting(
                             answered(s.written(), s.pos(), valueName(s.written(), s.pos(), bound))));
                 }
-                yield new Ast.NewData(type(nd.typeName()), inits, spreads, nd.publishedBy(), nd.pos());
+                yield new Ast.NewData(type(nd.typeName()), inits, spreads, nd.origin(), nd.pos());
             }
             // a binding's pattern may write Option's `Some`, which the binding check then rejects
             // for what it is — a name that opens nothing — rather than as a name nothing declares
@@ -543,7 +544,7 @@ public final class Resolve {
         }
         TypeName type = symbols.resolve(written);
         if (type != null && !type.isUnresolved()) {
-            return new ValueName.OfType(written, type, null);
+            return new ValueName.OfType(written, type, ConstructionOrigin.own());
         }
         // a helper or a behavior named without being applied — handed to a combinator by name,
         // which the inliner expands into a block that applies it

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -465,7 +465,7 @@ public final class Resolve {
                     valueName(v.name(), v.pos(), bound)));
             case Ast.Call call -> new Ast.Call(call.fn(),
                     answered(call.fn(), call.pos(), calledName(call, bound)),
-                    exprs(call.args(), bound), call.pos());
+                    exprs(call.args(), bound), call.origin(), call.pos());
             case Ast.NewData nd -> {
                 List<Ast.FieldInit> inits = new ArrayList<>();
                 for (Ast.FieldInit i : nd.inits()) {

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -10,6 +10,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -864,7 +865,7 @@ public final class AstBuilder {
                 inits.add(new Ast.FieldInit(field, v, pos(c)));
             }
         }
-        Ast.Expr built = new Ast.NewData(typeName, inits, spreads, null, pos(n));
+        Ast.Expr built = new Ast.NewData(typeName, inits, spreads, ConstructionOrigin.own(), pos(n));
         for (int i = pathNames.size() - 1; i >= 0; i--) {
             built = new Ast.LetIn(pathNames.get(i), pathValues.get(i), built, pos(n));
         }

--- a/souther-compiler/src/main/java/souther/compiler/types/ConstructionOrigin.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ConstructionOrigin.java
@@ -1,0 +1,43 @@
+package souther.compiler.types;
+
+/**
+ * Where a construction standing in a body came from — what a permission check needs in order to tell
+ * a construction the body makes from one that arrived in it already made.
+ *
+ * <p>Expansion is why the question has to be answered at all. A value is substituted at each
+ * reference and a published body is spliced into its reader, so a construction written somewhere
+ * else ends up as the same node one written here would be. Asking the node is the only way left.
+ *
+ * <p>The two ways in are recorded apart because they are not answered alike. A published body names
+ * the module that published it, and that module hands over only what it declares: a construction of
+ * a third module's type is nobody's to hand over, so the module is compared against the type's. A
+ * value reference names no module — the construction belongs to the definition of the value, and the
+ * behavior reading the name originates nothing whatever module declared the type.
+ */
+public record ConstructionOrigin(String publishedBy, boolean viaValueReference) {
+
+    private static final ConstructionOrigin OWN = new ConstructionOrigin(null, false);
+
+    /** A construction written where it stands. */
+    public static ConstructionOrigin own() {
+        return OWN;
+    }
+
+    /** The same construction, carried into a reader by {@code module}'s published body. */
+    public ConstructionOrigin publishedIn(String module) {
+        return new ConstructionOrigin(module, viaValueReference);
+    }
+
+    /** The same construction, carried into a body by a value that body named. */
+    public ConstructionOrigin carriedByValue() {
+        return new ConstructionOrigin(publishedBy, true);
+    }
+
+    /**
+     * Whether the body holding this construction of {@code built} was handed it rather than making
+     * it, and so answers for none of it.
+     */
+    public boolean carried(TypeName built) {
+        return viaValueReference || (publishedBy != null && publishedBy.equals(built.module()));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -66,17 +66,21 @@ public sealed interface ValueName {
      * A type written where a value goes: a unit data as a value, or a newtype applied to the value
      * it wraps. Which of the two is decided by what the type is, not by how the name was written.
      *
-     * <p>{@code publishedBy} is the module whose published value or helper carried this name here,
-     * and null where the body being read wrote it. A unit data is *constructed* by being named, and
-     * a construction says where it came from ({@link souther.compiler.ast.Ast.NewData}) so that the
-     * permission check can tell the reader's own from one it was handed; a unit data has no node of
-     * its own to say it on, so the name says it.
+     * <p>{@code origin} says where the construction came from. A unit data is *constructed* by being
+     * named, and a construction says where it came from ({@link souther.compiler.ast.Ast.NewData}) so
+     * that the permission check can tell the reader's own from one it was handed; a unit data has no
+     * node of its own to say it on, so the name says it.
      */
-    record OfType(String name, TypeName type, String publishedBy) implements ValueName {
+    record OfType(String name, TypeName type, ConstructionOrigin origin) implements ValueName {
 
         /** The same name, carried into a reader by {@code module}'s published body. */
         public OfType publishedBy(String module) {
-            return new OfType(name, type, module);
+            return new OfType(name, type, origin.publishedIn(module));
+        }
+
+        /** The same name, carried into a body by a value that body named. */
+        public OfType carriedByValue() {
+            return new OfType(name, type, origin.carriedByValue());
         }
 
         @Override

--- a/souther-compiler/src/test/java/souther/compiler/CompileValueConstructionAuthorityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileValueConstructionAuthorityTest.java
@@ -177,6 +177,77 @@ class CompileValueConstructionAuthorityTest {
                 """));
     }
 
+    /** A recursive helper is lowered to a method rather than expanded, so a value reaching one
+     * leaves a call standing where the constructions would have been. What the value made is the
+     * value's either way — whether a helper on the way could be expanded into it is not something
+     * the reading behavior's declaration should turn on. */
+    @Test
+    void aValueReachingARecursiveHelperCarriesWhatItBuilds() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                partial let makeFloor (n: Int) : Hours =
+                    if n == 0 then Hours(20.0m) else makeFloor(n - 1)
+
+                let floorHours = makeFloor(1)
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """));
+    }
+
+    /** The same helper called by the behavior itself. The mark is on the call the value brought in,
+     * not on the helper, so one module may do both and each call answers for what it is. */
+    @Test
+    void callingThatRecursiveHelperDirectlyStillNeedsAuthority() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                partial let makeFloor (n: Int) : Hours =
+                    if n == 0 then Hours(20.0m) else makeFloor(n - 1)
+
+                let floorHours = makeFloor(1)
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    makeFloor(2)
+                }
+                """));
+
+        assertEquals("E1002", e.code(), e.getMessage());
+    }
+
+    /** A unit data is constructed by being named, so it has no construction node to carry the mark
+     * — the name carries it. A value standing for one reaches the reading behavior by that path. */
+    @Test
+    void aUnitDataNamedByAValueIsCarriedToo() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m
+
+                data Marker
+                data In = { n: Int }
+                data Out = { n: Int }
+
+                let mark = Marker
+
+                behavior go : (i: In) -> Out | Marker
+                    constructs Out
+                let go (i) = if i.n > 0 then Out { n = i.n } else mark
+                """));
+    }
+
     /** A behavior that writes the construction itself still answers for it. */
     @Test
     void constructingTheLimitInTheBodyStillNeedsAuthority() {

--- a/souther-compiler/src/test/java/souther/compiler/CompileValueConstructionAuthorityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileValueConstructionAuthorityTest.java
@@ -1,0 +1,250 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A threshold a rule is stated against is written once as a value, and a behavior that compares
+ * against it originates nothing: the one construction on that path is the value's own, made where
+ * the value is defined. Reading the name is not making the thing, so `constructs` stays what it is
+ * for — telling a behavior that creates a value from one that passes an existing value through.
+ *
+ * <p>A value is substituted at each reference, and what the substitution brings in used to become
+ * the reading behavior's own construction. It is marked as carried instead, the way a construction
+ * that arrives in a published body already is. Carried is not absent: a behavior that declares the
+ * authority anyway is still taken at its word, so this loosens nothing that was checked before.
+ *
+ * <p>What a helper builds stays the caller's, because a helper body is checked as though it had
+ * been written inline.
+ */
+class CompileValueConstructionAuthorityTest {
+
+    private static final String LIMIT = """
+            module limit exposing ( Hours, floorHours )
+
+            data Hours = Decimal invariant value >= 0.0m
+
+            let floorHours = Hours(20.0m)
+            """;
+
+    @Test
+    void aBehaviorComparingAgainstAValueNeedsNoAuthorityForTheValuesType() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let floorHours = Hours(20.0m)
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """));
+    }
+
+    /** Publication is not what settles the question: the same value read in the module that
+     * declares it is read the same way as one read from outside. */
+    @Test
+    void aValueThisModulePublishesIsReadInItTheSameWay() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m exposing ( Hours, TooShort, floorHours, judge )
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let floorHours = Hours(20.0m)
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """));
+    }
+
+    /** The value is this module's and the type it builds is another module's. What the reading
+     * behavior originates does not depend on where the type was declared. */
+    @Test
+    void aValueOfThisModuleMayBuildAnImportedType() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
+                module limit exposing ( Hours )
+
+                data Hours = Decimal invariant value >= 0.0m
+                """, """
+                module m
+
+                import limit ( Hours )
+
+                data TooShort
+
+                let floorHours = Hours(20.0m)
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """)));
+    }
+
+    /** Three modules: the type is declared in one, the value naming it in a second, and the value
+     * that reads that one in a third. The reading behavior originates none of it. */
+    @Test
+    void aValueReachedThroughAnotherModulesValueCarriesTheSameWay() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(LIMIT, """
+                module alias exposing ( floor )
+
+                import limit ( Hours, floorHours )
+
+                let floor = floorHours
+                """, """
+                module m
+
+                import limit ( Hours )
+                import alias ( floor )
+
+                data TooShort
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floor else TooShort
+                    h
+                }
+                """)));
+    }
+
+    /** A published value building a third module's type. What a published *helper* builds of a third
+     * module's type stays the reader's to declare — the publisher hands over only what it declares —
+     * but a value hands over nothing: it was built where the value is defined, and the behavior
+     * naming it is no more the maker for a type declared elsewhere than for one declared here. */
+    @Test
+    void aPublishedValueBuildingAThirdModulesTypeIsCarriedToo() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
+                module money exposing ( Yen )
+
+                data Yen = Int
+                """, """
+                module pricing exposing ( standard )
+
+                import money ( Yen )
+
+                let standard = Yen(1000)
+                """, """
+                module order exposing ( Receipt, bill )
+
+                import money ( Yen )
+                import pricing ( standard )
+
+                data Receipt = { total: Yen }
+
+                behavior bill : (n: Int) -> Receipt constructs Receipt
+                let bill (n) = Receipt { total = standard }
+                """)));
+    }
+
+    /** Carried, not absent: an author who writes the authority is not told the behavior builds
+     * nothing, the same answer a construction arriving in a published body gets. */
+    @Test
+    void theAuthorityMayStillBeDeclared() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let floorHours = Hours(20.0m)
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort, Hours
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """));
+    }
+
+    /** A behavior that writes the construction itself still answers for it. */
+    @Test
+    void constructingTheLimitInTheBodyStillNeedsAuthority() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= Hours(20.0m) else TooShort
+                    h
+                }
+                """));
+
+        assertEquals("E1002", e.code(), e.getMessage());
+    }
+
+    /** A helper body is checked as though it had been written inline, so what it builds is the
+     * caller's. That is what tells a helper from a behavior, and it is unchanged. */
+    @Test
+    void aHelperThatBuildsTheLimitStillChargesItsCaller() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let floorOf (d) = Hours(d)
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorOf(20.0m) else TooShort
+                    h
+                }
+                """));
+
+        assertEquals("E1002", e.code(), e.getMessage());
+    }
+
+    /** The limit is read at run time, not merely accepted by the checker. */
+    @Test
+    void theLimitIsCompared() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let floorHours = Hours(20.0m)
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """), getClass().getClassLoader());
+
+        Object behavior = loader.loadClass("m.Judge$Impl").getConstructor().newInstance();
+
+        Object kept = Codecs.apply(behavior, Codecs.decoded(loader, "m.Hours", new java.math.BigDecimal("40.0")));
+        assertEquals(new java.math.BigDecimal("40.0"), Codecs.encode(loader, "m.Hours", kept));
+
+        Object rejected = Codecs.apply(behavior, Codecs.decoded(loader, "m.Hours", new java.math.BigDecimal("10.0")));
+        assertEquals("TooShort", rejected.getClass().getSimpleName());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileValueDefinitionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileValueDefinitionTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -65,11 +66,12 @@ class CompileValueDefinitionTest {
         assertEquals(101L, bumped(loader, 1));
     }
 
-    /** A value is substituted where it is named, so what it builds is built by the behavior that
-     * names it — the same transitive construction set a helper's body contributes. */
+    /** A value is substituted where it is named, but what it builds is built by the definition it
+     * was substituted from. The behavior that names it reads a value it did not make and answers for
+     * none of it — a helper is the other case, and its body's constructions are its caller's. */
     @Test
-    void whatAValueConstructsIsTheConstructionSetOfTheBehaviorThatNamesIt() {
-        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+    void whatAValueBuildsIsNotTheNamingBehaviorsToDeclare() {
+        assertDoesNotThrow(() -> Compiler.compile("""
                 module demo
 
                 data In = { n: Int }
@@ -80,8 +82,6 @@ class CompileValueDefinitionTest {
                 behavior bump : (i: In) -> Out constructs Out
                 let bump (i) = Out { n = i.n + origin.n }
                 """));
-
-        assertTrue(e.getMessage().contains("constructs In"), e.getMessage());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileValueSpreadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileValueSpreadTest.java
@@ -1,14 +1,11 @@
 package souther.compiler;
 
-import souther.compiler.diag.CompileException;
-
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A spread names a value the same way any other position does. An {@code example} row and a behavior
@@ -109,10 +106,12 @@ class CompileValueSpreadTest {
         assertEquals("local", out.get("name"));
     }
 
-    /** A spread builds the value it copies, so what the value constructs is constructed here. */
+    /** A spread names a value the way any other position does, so what that value built came in
+     * with it. The spreading behavior copies fields out of something already made, and the `Person`
+     * behind the spread is the value definition's. */
     @Test
-    void aValueSpreadContributesItsConstructions() {
-        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+    void aValueSpreadIsNotTheSpreadingBehaviorsConstruction() {
+        assertDoesNotThrow(() -> Compiler.compile("""
                 module demo
 
                 data In = { n: Int }
@@ -124,7 +123,5 @@ class CompileValueSpreadTest {
                 behavior go : (i: In) -> Stamped constructs Stamped
                 let go (i) = Stamped { ...base, age = 21 }
                 """));
-
-        assertTrue(e.getMessage().contains("constructs Person"), e.getMessage());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -31,7 +32,8 @@ class CallElaboratorNoCalleeTest {
 
     private static RuntimeException answerFor(ValueName denotes) {
         return CallElaborator.noCallee(
-                new Ast.Call("f", denotes, List.of(new Ast.IntLit(1, AT)), AT));
+                new Ast.Call("f", denotes, List.of(new Ast.IntLit(1, AT)),
+                        ConstructionOrigin.own(), AT));
     }
 
     /** A behavior named from a helper `let` or a `>->` composition, neither of which reaches one. */

--- a/specification.adoc
+++ b/specification.adoc
@@ -254,6 +254,8 @@ A published definition MAY reach a *recursive* helper. Closing cannot remove one
 
 A published value is substituted where it is named and a published helper expanded where it is called, exactly as one of the reader's own is (<<fn-value-semantics>>, <<fn-rules>>). What such a body builds is *not* the reader's to declare in `+constructs+`: publishing the definition is what states that origination, and the reader may have no name for the type. A type of some *third* module that the body happens to build is neither the reader's nor the publisher's to hand over, so that one stays the reader's to declare — which it can, since the module declaring it exposed it (<<closed-construction>>).
 
+A published *value* rests on none of that. What a value builds belongs to its definition whatever module declares the type, so reading one across a boundary answers the same as reading one within a module (<<fn-value-semantics>>). Crossing the boundary is what the paragraph above is about, and a value never needed it.
+
 A published body's source travels in the jar and is read back by the importing compiler (<<published-modules>>). What that source means is therefore part of what a compiled module promises, and is recorded under the same boundary version as the rest of it.
 
 [#exposed-surface]
@@ -1509,6 +1511,8 @@ Creating a type that does not appear in the output also shows here. The `+constr
 
 A helper `+let+` (with no corresponding behavior) may also construct data, but a helper `+let+` is not a specification statement and does not declare its own `+constructs+`. Its *construction set is inferred transitively* (folding in any helper `+let+` it calls). If the calling behavior writes `+constructs+`, it MUST include that set (E1002 if it does not); if omitted, that set is folded into the inference. A block is the same, constructing under the enclosing behavior's authority (<<blocks>>).
 
+A *value* is the other case. It too is substituted where it is named (<<fn-value-semantics>>), but what it builds is built by its definition: a behavior stating a rule against a named limit originates none of it, and the limit does not belong in that behavior's `+constructs+`. This is what lets a threshold be named at all — the figure gets one place to live and one comment saying where it comes from, and the rules reading it go on saying what they do. Writing the entry anyway is accepted, the same answer a construction another module's published body carried in gets (<<exposed-values>>).
+
 A dependency (`+depends on+`) is different and MUST *always* be written (<<depends-on>>). `+depends on+` is an outward contract to the caller and injector; leaving it to inference would let the contract change silently. `+constructs+` is an internal authority invisible to callers, so they diverge here. Thus `+depends on+` is a declaration and `+constructs+` (for a behavior with a `+let+` implementation) is optional. A `+>->+` composition infers both output and requirements (<<composition-with-requirements>>).
 
 [#record-literal]
@@ -1791,7 +1795,7 @@ A value is not module state. Its expression is elaborated in the module that dec
 * It is evaluated at each reference. A value's body obeys a helper's rules — it cannot call an injected behavior (<<depends-on>>) — so it is pure and total, and re-evaluation is not observable.
 * Two references may yield distinct values. Nothing observes that: there is no reference identity in the language, and comparison is structural (<<newtype-comparison>>).
 * An invariant a value breaks is reported at the value, whether or not anything names it.
-* What a value constructs is constructed by the behavior that names it, and belongs in that behavior's `+constructs+` — the transitive rule a helper's body already follows (<<constructs>>). A spread of a value constructs it too, so it contributes the same way.
+* What a value constructs is the value's own. A behavior that names one reads something already made, so the construction stays with the definition and is not required in that behavior's `+constructs+` (<<constructs>>). A spread of a value reads one the same way. This is where a value parts from a helper, whose construction set does fold into its caller.
 * A spread names a value like any other position: `+Drafting { ...standardRequest, estimatedCost = Amount(50000) }+` reads the same in a behavior's body and in an `+example+` row. A binding in force wins there too, so a parameter or a `+let+` sharing a value's name is what the spread copies.
 * A value MUST NOT reach itself, through naming another value, spreading one, or calling a helper that does. A helper on a call cycle is lowered to a method and recurses (<<fn-rules>>); a value has no such form, so a cycle through one is a compile error naming the path it goes round. This is reported apart from the recursion check, which would ask for a return type the author never wrote.
 


### PR DESCRIPTION
Fixes #240.

A threshold a rule is stated against is written once as a value — the figure gets one place to live
and one comment saying where it comes from. But a value is substituted at each reference, so the
construction in its body ended up standing in the reading behavior as the node that behavior's own
construction would be. `constructs` was counting what the substitution reached rather than what the
model says:

```souther
let floorHours = Hours(20.0m)

behavior judge : (h: Hours) -> Hours | TooShort
    constructs TooShort          -- E1002: `constructs Hours` was required here
let judge (h) = {
    guard h >= floorHours else TooShort
    h
}
```

`judge` originates no `Hours`. It returns the one it was given, and the only one built on that path
is the limit's own. The charge landed on the clause whose stated purpose is to tell those two apart.

## What the six cases measured

The asymmetry was with a behavior, not with reading — and the split was not the one the
specification describes.

| Case | Before | After |
| --- | --- | --- |
| Construct `Hours(20.0m)` in the behavior body | E1002 | E1002 |
| Read a private value of this module | E1002 | accepted |
| Read a value **this module publishes**, from within it | E1002 | accepted |
| Read a published value of another module | accepted | accepted |
| Call a helper that constructs `Hours` | E1002 | E1002 |
| Call a behavior that constructs `Hours` | accepted | accepted |

`[#exposed-values]` explains the cross-module row as publication stating the origination, but the
implementation branched on the module boundary: the same published value cost a reader nothing from
another module and an entry from its own. It now answers the same from either side.

A helper is unchanged and is the other case. Its body is checked as though written inline, which is
what tells a helper from a behavior.

## Provenance instead of the published-body mark

A construction now records where it came from rather than only whether it crossed a boundary, with
the two ways in kept apart because they are not answered alike. A published body hands over what its
module declares, so its mark names the module and is compared against the one declaring the type — a
third module's type stays the reader's to declare. A value hands over what its definition made
whatever module declares the type, so its mark names none.

Reusing the published-body mark was refused. It means crossed-a-boundary and not-originated-here at
once, and only the second is wanted; being compared against the *type's* module it would also still
charge a value of this module that builds an imported type, which is one of the cases the new tests
pin.

The entry stays legal if written. A construction a body was handed is carried, not absent — the
answer one arriving in a published body already gets. Making a value's stricter would leave two
answers to one question, decided opposite ways by which seam the construction came in on; whether
`carried` should be declarable at all is a question about that seam and belongs with it.

## Not an ADR

Reversing this costs a flag and it constrains nothing after it, so it does not meet the bar
`docs/adr/README.md` now states. The rule it changes is in `specification.adoc`
(`[#constructs]`, `[#fn-value-semantics]`, `[#exposed-values]`); the reason is here. The bullet in
ADR-0072 charging the naming behavior described the substitution mechanism rather than a chosen
design, and is withdrawn.

## Verification

`mvn clean install` then `mvn test`: 1757 compiler, 98 language server, 1 benchmark, all green.
`souther-examples` builds and tests green against this compiler.

Nine new cases in `CompileValueConstructionAuthorityTest`. Two existing tests stated the old rule
directly and are inverted rather than deleted — what they cover still happens, it is carried now
instead of originated.

Follow-up in `souther-examples` once this merges: `example.employmentinsurance` drops
`WeeklyScheduledHours` from `judgeInsuredStatus` and the comment explaining that the clause does not
mean what it says (recorded there as finding F31).
