### PR TITLE
A dependency is handed to a recursive helper by name

### DIFF
--- a/docs/adr/0038-user-recursion-over-self-referential-data.md
+++ b/docs/adr/0038-user-recursion-over-self-referential-data.md
@@ -47,9 +47,13 @@ helpers.
 - **Mutual recursion is allowed.** Every member of a call cycle is lowered together, so
   `ping`/`pong` calling each other work the same as a self-call — the cycle detector already
   identifies the whole group.
-- **A recursive helper is pure.** It is a `static` method with no injected fields, so it cannot
-  call an injected behavior (a `depends on`); the effect belongs in the behavior that calls the
-  helper. Recursion is for traversing data, not for reaching the outside world.
+- **A recursive helper is pure.** Its own body may not call an injected behavior (a `depends on`);
+  the effect belongs in the behavior that calls the helper. Recursion is for traversing data, not
+  for reaching the outside world. What the helper may do is apply a function it is handed, and the
+  caller may hand it a dependency — the effect is then the caller's, declared in the caller's
+  `depends on` and carried in by the closure. The emitted form follows: the helper is a `static`
+  method with no injected fields, and the closure that holds the dependency is built by the
+  behavior and passed in as an argument.
 - **A recursive helper may construct data**, and its constructions are attributed to the behavior
   that calls it. Because the helper is not inlined, a caller's body shows only a call, not the
   construction inside it; the `constructs` inference follows the call into the helper (transitively,

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -882,6 +882,60 @@ public final class HelperInliner {
      * A {@code $}-name from a function argument is one too, and is told apart by its prefix. */
     private final Set<String> scopedLambdaNames = new HashSet<>();
 
+    /**
+     * The arguments of a call that stays a call, with a dependency handed over by name replaced by
+     * the block that forwards to it: {@code depth(code, fetch)} becomes {@code depth(code, (c) ->
+     * fetch(c))}, which spec §blocks says is the same thing.
+     *
+     * <p>Where the callee is expanded the two already are the same thing — the expansion substitutes
+     * the argument's name into the parameter's applications, so the name only ever stands in a call.
+     * A recursive helper is lowered to a method instead (spec 13.1), which leaves the argument
+     * standing as a value, and a {@code depends on} parameter is reached through the behavior it
+     * names rather than bound to a slot. Forwarding here is what makes the two callees say the same
+     * thing about the same argument.
+     */
+    private List<Ast.Expr> forwardDependencies(Ast.FnDef callee, List<Ast.Expr> args) {
+        if (callee == null || dependencies.isEmpty()) {
+            return args;
+        }
+        List<Ast.Expr> out = new ArrayList<>(args);
+        for (int i = 0; i < callee.params().size() && i < out.size(); i++) {
+            Ast.RetType declared = callee.params().get(i).type();
+            Ast.FnType want = declared == null ? null : declared.asFn();
+            if (want == null || !(out.get(i) instanceof Ast.Var v) || !dependencies.contains(v.name())) {
+                continue;
+            }
+            List<String> params = new ArrayList<>();
+            List<Ast.Expr> forwarded = new ArrayList<>();
+            for (int j = 0; j < want.params().size(); j++) {
+                // a source identifier never starts with `$`, so these cannot capture a caller local
+                String p = "$" + counter++ + "_" + v.name();
+                params.add(p);
+                forwarded.add(new Ast.Var(p, new ValueName.Local(p, v.pos()), v.pos()));
+            }
+            out.set(i, new Ast.Block(params,
+                    new Ast.Call(v.name(), v.denotes(), forwarded, ConstructionOrigin.own(), v.pos()),
+                    v.pos()));
+        }
+        return out;
+    }
+
+    /** The {@code depends on} parameters of the behavior {@code let} whose body is being expanded.
+     * Empty while expanding anything else: only a behavior's {@code let} has them (spec §depends-on). */
+    private Set<String> dependencies = Set.of();
+
+    /** As {@link #inline(Ast.Expr)}, for the body of a behavior {@code let} whose {@code depends on}
+     * names {@code dependencies} — the names that arrive as its trailing parameters. */
+    public Ast.Expr inline(Ast.Expr e, Set<String> dependencies) {
+        Set<String> outer = this.dependencies;
+        this.dependencies = dependencies;
+        try {
+            return inline(e);
+        } finally {
+            this.dependencies = outer;
+        }
+    }
+
     /** Rewrites every helper call in {@code e} to its inlined body. */
     public Ast.Expr inline(Ast.Expr e) {
         return switch (e) {
@@ -897,7 +951,8 @@ public final class HelperInliner {
                     // builtin, injected behavior, a function-typed parameter, or a recursive helper —
                     // a recursive helper is lowered to a method, so its call stays a Call (spec 13.1);
                     // only its args inline.
-                    yield new Ast.Call(call.fn(), call.denotes(), args, call.origin(), call.pos());
+                    yield new Ast.Call(call.fn(), call.denotes(), forwardDependencies(helper, args),
+                            call.origin(), call.pos());
                 }
                 if (args.size() != helper.params().size()) {
                     LambdaOrigin origin = lambdaOrigins.get(helper.name());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -893,16 +893,23 @@ public final class HelperInliner {
      * standing as a value, and a {@code depends on} parameter is reached through the behavior it
      * names rather than bound to a slot. Forwarding here is what makes the two callees say the same
      * thing about the same argument.
+     *
+     * <p>What is forwarded is the parameter, not every name spelled like it: the argument is matched
+     * against the binder its name was answered with. A binding in force wins over the declaration it
+     * shadows (spec §fn-rules), so a local named after a dependency is a local, and wrapping it would
+     * both call the wrong thing and report a value as an uncallable name.
      */
     private List<Ast.Expr> forwardDependencies(Ast.FnDef callee, List<Ast.Expr> args) {
-        if (callee == null || dependencies.isEmpty()) {
+        if (callee == null || dependencyBinders.isEmpty()) {
             return args;
         }
         List<Ast.Expr> out = new ArrayList<>(args);
         for (int i = 0; i < callee.params().size() && i < out.size(); i++) {
             Ast.RetType declared = callee.params().get(i).type();
             Ast.FnType want = declared == null ? null : declared.asFn();
-            if (want == null || !(out.get(i) instanceof Ast.Var v) || !dependencies.contains(v.name())) {
+            if (want == null || !(out.get(i) instanceof Ast.Var v)
+                    || !(v.denotes() instanceof ValueName.Local local)
+                    || !dependencyBinders.contains(local.binder())) {
                 continue;
             }
             List<String> params = new ArrayList<>();
@@ -920,19 +927,19 @@ public final class HelperInliner {
         return out;
     }
 
-    /** The {@code depends on} parameters of the behavior {@code let} whose body is being expanded.
+    /** Where the {@code depends on} parameters of the behavior {@code let} being expanded are bound.
      * Empty while expanding anything else: only a behavior's {@code let} has them (spec §depends-on). */
-    private Set<String> dependencies = Set.of();
+    private Set<SourcePos> dependencyBinders = Set.of();
 
     /** As {@link #inline(Ast.Expr)}, for the body of a behavior {@code let} whose {@code depends on}
-     * names {@code dependencies} — the names that arrive as its trailing parameters. */
-    public Ast.Expr inline(Ast.Expr e, Set<String> dependencies) {
-        Set<String> outer = this.dependencies;
-        this.dependencies = dependencies;
+     * parameters are bound at {@code binders}. */
+    public Ast.Expr inline(Ast.Expr e, Set<SourcePos> binders) {
+        Set<SourcePos> outer = this.dependencyBinders;
+        this.dependencyBinders = binders;
         try {
             return inline(e);
         } finally {
-            this.dependencies = outer;
+            this.dependencyBinders = outer;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -1,8 +1,10 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.diag.SourcePos;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -67,9 +69,23 @@ public final class Lower {
     public static Ast.FnDef body(Ast.FnDef fn, HelperInliner inliner, boolean recursive,
                                  Set<String> dependencies) {
         Ast.Expr expanded = recursive
-                ? inliner.inlineRecursiveBody(fn) : inliner.inline(fn.body(), dependencies);
+                ? inliner.inlineRecursiveBody(fn)
+                : inliner.inline(fn.body(), dependencyBinders(fn, dependencies));
         return new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
                 desugar(expanded), fn.partial(), fn.pos());
+    }
+
+    /** Where each {@code depends on} name is bound: the trailing parameter that carries it. A name in
+     * the body is that parameter only when it was answered by this binder — a binding in force wins
+     * over the declaration it shadows (spec §fn-rules), so the spelling alone does not say. */
+    private static Set<SourcePos> dependencyBinders(Ast.FnDef fn, Set<String> dependencies) {
+        Set<SourcePos> binders = new HashSet<>();
+        for (Ast.FnParam p : fn.params()) {
+            if (dependencies.contains(p.name())) {
+                binders.add(p.pos());
+            }
+        }
+        return binders;
     }
 
     /** {@code module} with {@code fns} as its fns and every data invariant desugared — the tree the

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -5,6 +5,7 @@ import souther.compiler.ast.Ast;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The Lower stage (ADR-0021): rewrites the surface AST toward the form the backend emits, so the
@@ -55,7 +56,18 @@ public final class Lower {
      * neither is fully inlined at its call sites and never emitted, so nothing asks for it here.
      */
     public static Ast.FnDef body(Ast.FnDef fn, HelperInliner inliner, boolean recursive) {
-        Ast.Expr expanded = recursive ? inliner.inlineRecursiveBody(fn) : inliner.inline(fn.body());
+        return body(fn, inliner, recursive, Set.of());
+    }
+
+    /**
+     * The same, for a behavior's implementation, told what its behavior declares in {@code depends
+     * on} — the names that arrive as the {@code let}'s trailing parameters (spec §depends-on). A
+     * helper has none, and neither has a recursive helper's own body.
+     */
+    public static Ast.FnDef body(Ast.FnDef fn, HelperInliner inliner, boolean recursive,
+                                 Set<String> dependencies) {
+        Ast.Expr expanded = recursive
+                ? inliner.inlineRecursiveBody(fn) : inliner.inline(fn.body(), dependencies);
         return new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
                 desugar(expanded), fn.partial(), fn.pos());
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -26,6 +26,7 @@ import souther.compiler.types.ValueName;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -726,7 +727,7 @@ public final class Bodies {
             }
             try {
                 return Answer.of(Lower.body(def.value(), HelperInliner.forHelpers(helpers.value()),
-                        recursive.value().contains(fn)));
+                        recursive.value().contains(fn), dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -755,7 +756,7 @@ public final class Bodies {
             try {
                 return Answer.of(Lower.body(def.value(),
                         HelperInliner.forHelpers(helpers.value(), InliningPolicy.DISCHARGE),
-                        recursive.value().contains(fn)));
+                        recursive.value().contains(fn), dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -888,6 +889,20 @@ public final class Bodies {
             return settled.present()
                     ? Answer.of(Names.behaviorNames(settled.value())) : Answer.absent();
         }
+    }
+
+    /** What {@code fn}'s behavior declares in {@code depends on}, or nothing where {@code fn}
+     * implements no behavior — a helper has no such parameters (spec §depends-on). */
+    private static Set<String> dependencyParams(Db db, String module, String fn) {
+        Answer<Ast.SpecBehavior> spec = db.ask(new Spec(module, fn));
+        if (!spec.present()) {
+            return Set.of();
+        }
+        Set<String> names = new HashSet<>();
+        for (Ast.ValueRef req : spec.value().dependsOn()) {
+            names.add(req.bare());
+        }
+        return names;
     }
 
     /** One behavior's declaration, so what a body is checked against is the behavior it implements

--- a/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.runtime.Behavior;
 
 import org.junit.jupiter.api.Test;
 
@@ -8,6 +9,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -229,6 +231,76 @@ class CompileRecursiveHelperTest {
                 }, n.value))
                 """;
         assertDoesNotThrow(() -> Compiler.compile(src));
+    }
+
+    @Test
+    void anInjectedBehaviorIsHandedToARecursiveHelperByName() throws Exception {
+        // A `depends on` parameter is an argument of the `let` like any other, so it may be handed to
+        // a helper by name — the same thing as wrapping it in `(x) -> twice(x)`. The helper is
+        // recursive and so is lowered to a method, which is the one shape where the argument stays a
+        // value instead of being rewritten into a call by inlining.
+        String src = """
+                module demo
+                data N = Int
+                data Out = Int
+                behavior twice : (n: N) -> N
+                behavior run : (n: N) -> Out depends on twice constructs Out
+                partial let applyTimes (f: (N) -> N, x: N, k: Int): N =
+                    if k == 0 then x else applyTimes(f, f(x), k - 1)
+                let run (n, twice) = Out(applyTimes(twice, n, 3).value)
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Behavior<Object, Object> twice = n -> {
+            try {
+                long v = (long) Codecs.encode(loader, "demo.N", n);
+                return Codecs.decoded(loader, "demo.N", v * 2);
+            } catch (Exception e) {
+                throw new AssertionError(e);
+            }
+        };
+        Object run = loader.loadClass("demo.Run" + "$Impl").getConstructor(Behavior.class).newInstance(twice);
+
+        Object out = Codecs.apply(run, Codecs.decoded(loader, "demo.N", 1L));
+
+        assertEquals(8L, (long) Codecs.encode(loader, "demo.Out", out));
+    }
+
+    @Test
+    void aMultiArgumentDependencyIsHandedToARecursiveHelperByName() {
+        // The forwarding takes as many arguments as the parameter's declared function type does, so a
+        // two-input dependency is handed over whole rather than losing its second argument.
+        String src = """
+                module demo
+                data A = { x: Int }
+                data B = { y: Int }
+                data R = { z: Int }
+                behavior send : (a: A, b: B) -> R constructs R
+                behavior use : (a: A, b: B) -> R depends on send
+                partial let retry (f: (A, B) -> R, a: A, b: B, k: Int): R =
+                    if k == 0 then f(a, b) else retry(f, a, b, k - 1)
+                let use (a, b, send) = retry(send, a, b, 1)
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(src));
+    }
+
+    @Test
+    void aBusinessParameterWhereAFunctionIsExpectedIsNotForwarded() {
+        // Only a `depends on` parameter is forwarded. A business input cannot be a function at all, so
+        // one written where a function goes stays the mismatch it is — it must not be turned into a
+        // block that calls it and reported as an uncallable name.
+        String src = """
+                module demo
+                data N = Int
+                data Out = Int
+                behavior run : (n: N) -> Out constructs Out
+                partial let applyTimes (f: (N) -> N, x: N, k: Int): N =
+                    if k == 0 then x else applyTimes(f, f(x), k - 1)
+                let run (n) = Out(applyTimes(n, n, 3).value)
+                """;
+        CompileException ex = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        assertFalse(ex.getMessage().contains("unknown identifier"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("n") || ex.getMessage().contains("applyTimes"),
+                ex.getMessage());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
@@ -304,6 +304,30 @@ class CompileRecursiveHelperTest {
     }
 
     @Test
+    void aLocalThatShadowsADependencyIsNotForwarded() {
+        // What is forwarded is the dependency parameter, not every name spelled like it. A binding in
+        // force wins over the declaration it shadows (spec §fn-rules), so this `twice` is the local —
+        // an `N` written where a function goes, which must stay that mismatch rather than become a
+        // block that calls a value.
+        String src = """
+                module demo
+                data N = Int
+                data Out = Int
+                behavior twice : (n: N) -> N
+                behavior run : (n: N) -> Out depends on twice constructs Out
+                partial let applyTimes (f: (N) -> N, x: N, k: Int): N =
+                    if k == 0 then x else applyTimes(f, f(x), k - 1)
+                let run (n, twice) = {
+                    let twice = n
+                    Out(applyTimes(twice, n, 3).value)
+                }
+                """;
+        CompileException ex = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        assertFalse(ex.getMessage().contains("unknown function"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("expects a block"), ex.getMessage());
+    }
+
+    @Test
     void aClosureCallingAnInjectedBehaviorStillNeedsTheBehaviorToDeclareRequires() {
         // The effect a closure performs is attributed to the behavior that builds it: `run` reaches
         // `now` through the closure but does not declare `depends on now`, so it is E1602 — the same rule


### PR DESCRIPTION
A `depends on` parameter handed to a recursive helper by name was reported as naming nothing:

```
18| let depthFrom (code, fetch) = depth(code, fetch)
                                              ^^^^^
I cannot find a value named `fetch` in scope.
```

`fetch` is the parameter written on that same line, and `depends on` fixes its spelling, so there was
no other name to try. The eta-expansion `(c) -> fetch(c)` was the whole workaround.

## What was wrong

Not that a dependency is not a value — `List.map(fetch, codes)` compiles, and so does handing a plain
`let` by name to the same recursive helper. The name was accepted wherever helper inlining rewrote the
occurrence into a call, and rejected where it survived to elaboration as a value expression. Inlining
substitutes a function-typed argument's name textually, so `read(c)` in the helper's body becomes
`fetch(c)` and the `Var` the author wrote is gone before anything asks what it denotes. A recursive
helper is lowered to a method rather than inlined, so the argument stayed a value and was looked up in
the behavior body's type environment — which holds the business parameters only.

The specification asks for the direct form. §depends-on writes the case out ("Even when used
indirectly by passing it to a helper `let`, the one passing is you, so you write it", and "In the
`let`, `now` is just an argument, not an effect or a special type"), and §blocks makes the two
spellings the same thing.

## The fix

`HelperInliner` builds the forwarding block where the recursive call keeps its `Call`: when the
callee's declared parameter type is a function and the corresponding argument is a bare name that the
behavior declares in `depends on`, the argument becomes `(c) -> fetch(c)` as AST. A bare name that
already denotes a value — a local, or a helper passed by name — is left alone, and so is a helper's
own function parameter, since a helper has no `depends on` and a recursive helper's own body is
expanded by a path that carries none.

What is forwarded is the parameter, not every name spelled like it: the argument is matched against
the binder its name was answered with, and the dependency parameters are located in the `let` being
lowered. A binding in force wins over the declaration it shadows, so `let twice = n` followed by
`applyTimes(twice, n, 3)` is the local and stays the mismatch it is. The dependency names come from
the behavior's own declaration (`Bodies.Spec`), so another behavior's dependency name is not swept in
either.

Everything after the rewrite runs unchanged. `SpecChecker.requiredCalls` counts the generated call, so
a dependency handed over only by name is not reported as declared and never used; the behavior body's
type environment needs no new entry; and the backend emits the closure it already emitted for the
lambda. No backend change.

## Verification

`depth(code, fetch)` and `depth(code, (c) -> fetch(c))` emit byte-identical classes — every generated
`.class` matches by SHA. The behavior implementation builds the closure from its injected field and
hands it to a `static` helper that has no injected fields of its own, which is the shape ADR-0038
asks for.

Four tests in `CompileRecursiveHelperTest`: a dependency handed by name and actually run through the
recursive helper; a two-input dependency, so the forwarding takes as many arguments as the declared
function type does; a local that shadows the dependency, which must not be forwarded; and a business
parameter written where a function goes. The first two fail on `develop` with the NAMING ERROR above;
the third fails against the first commit alone with `unknown function`.

souther/souther-examples both build and test green.

## ADR-0038

Second commit, separable from the first. The purity rule read as a consequence of the JVM shape — a
`static` method with no injected fields, therefore unable to call an injected behavior. The rule is
about what the body may call, and the shape follows from it; the ADR now says it that way, and says
the other half it always had: the helper may apply a function it is handed, and the caller may hand it
a dependency.

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)
