### PR TITLE
A lambda given to a combinator keeps the positions it was written at

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1051,9 +1051,8 @@ public final class HelperInliner {
                 }
                 scopedLambdas.forEach(helpers::put);
                 // a prelude helper's body is stamped with the call site, so errors inside it point at
-                // the user's call, not at the shipped source of souther.* (a module-own helper keeps
-                // its own positions, which already lie in the user's file).
-                SourcePos at = own.containsKey(helper.name()) ? null : call.pos();
+                // the user's call, not at the shipped source of souther.*
+                SourcePos at = keepsItsPositions(helper.name()) ? null : call.pos();
                 Ast.Expr body = inline(rename(helper.body(), subst, substDenotes, fnParams, at));   // expand nested helpers too
                 scopedLambdas.keySet().forEach(helpers::remove);
                 body = keepDeclaredReturn(helper, body, call.pos(), k);
@@ -1262,8 +1261,9 @@ public final class HelperInliner {
      * <p>{@code at}, when non-null, is stamped onto every rebuilt node in place of its own position.
      * A prelude helper is expanded with the call site as {@code at}, so a type error inside its body
      * points at the user's call — {@code filter(xs, x -> x * 2)} — not at a line of {@code souther.list}
-     * the user never wrote. A module-own helper passes {@code null} and keeps its own positions. The
-     * caller's argument expressions, spliced in separately, keep their own positions either way.
+     * the user never wrote. A module-own helper, and a lambda given to a fn parameter, pass {@code
+     * null} and keep the positions their bodies have ({@link #keepsItsPositions}). The caller's
+     * argument expressions, spliced in separately, keep their own positions either way.
      */
     private Ast.Expr rename(Ast.Expr e, Map<String, String> subst,
                             Map<String, ValueName> substDenotes, Set<String> fnParams,
@@ -1356,8 +1356,21 @@ public final class HelperInliner {
         };
     }
 
+    /**
+     * Whether expanding this helper leaves the positions in its body alone. A module-own helper does:
+     * its body lies in the user's file, so it is already where a diagnostic should point. A lambda
+     * given to a fn parameter does too: it is the caller's own code, and a lambda written in a prelude
+     * body was stamped with the call site when that body was renamed, so either way its positions are
+     * the ones to report. Everything else is a prelude helper, whose body lies in the shipped source of
+     * {@code souther.*} and is stamped with the call site instead.
+     */
+    private boolean keepsItsPositions(String helper) {
+        return own.containsKey(helper) || lambdaOrigins.containsKey(helper)
+                || scopedLambdaNames.contains(helper);
+    }
+
     /** The position to stamp on a rebuilt node: the override {@code at} for a prelude helper, or the
-     * node's own position when {@code at} is null (a module-own helper keeps its positions). */
+     * node's own position when {@code at} is null (see {@link #keepsItsPositions}). */
     private static SourcePos at(SourcePos at, SourcePos own) {
         return at != null ? at : own;
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileConstructionInInvariantTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileConstructionInInvariantTest.java
@@ -167,14 +167,13 @@ class CompileConstructionInInvariantTest {
     }
 
     /**
-     * A helper the clause reaches through a combinator is pointed at the combinator rather than at
-     * its own body, because expanding a prelude helper stamps the call site on everything it splices
-     * in — the caller''s lambda and the helper inlined into it included. That is the inliner''s rule
-     * for every diagnostic inside a combinator, not this one''s; it is pinned here so the day it is
-     * made finer this test says so.
+     * A combinator between the clause and the construction changes nothing about where the error is
+     * put. Expanding a prelude helper stamps the call site on the prelude''s own body, so a diagnostic
+     * from there points at the user''s call rather than at the shipped source of {@code souther.*};
+     * what the caller handed it keeps the positions the author wrote it at.
      */
     @Test
-    void aConstructionReachedThroughACombinatorIsPointedAtTheCombinator() {
+    void aConstructionReachedThroughACombinatorIsPointedAtTheConstruction() {
         CompileException e = err("""
                 module m
                 data Yen = Int invariant value >= 0
@@ -183,7 +182,27 @@ class CompileConstructionInInvariantTest {
                     invariant ok = List.all(x -> atLeastZero(x), value)
                 """);
         assertEquals("check.invariant.construct.named", e.diagnostic().messageKey());
+        assertEquals(3, e.diagnostic().region().start().line());
+        assertEquals(34, e.diagnostic().region().start().column(),
+                "the construction in the helper, not the combinator the clause calls");
+    }
+
+    /** With no helper anywhere, the lambda handed to the combinator is caller code all the way down.
+     *  It is written on a line of its own, so a call site stamped over it shows up in the line and
+     *  not only in the column. */
+    @Test
+    void aConstructionWrittenInTheLambdaGivenToACombinatorKeepsItsPlace() {
+        CompileException e = err("""
+                module m
+                data Yen = Int invariant value >= 0
+                data Table = List<Int>
+                    invariant ok = List.all(
+                        x -> Yen(0).value <= x,
+                        value)
+                """);
+        assertEquals("check.invariant.construct.named", e.diagnostic().messageKey());
         assertEquals(5, e.diagnostic().region().start().line());
+        assertEquals(14, e.diagnostic().region().start().column());
     }
 
     /** Written in the clause itself there is one place, and labelling it twice says nothing. */


### PR DESCRIPTION
Refs #248.

A diagnostic reported inside a combinator was put on the combinator instead of on the code that is wrong. `Yen(0)` on line 3, reached through `List.all`, was reported on line 5 with a caret three columns wide — sized for `Yen` — landing on `Lis`, and the label naming the clause that reaches it disappeared because the construction and the clause had been made the same line.

## Where it went

Expanding a helper decides one position for the whole expansion: the call site for a prelude helper, so a diagnostic from `souther.list` points at the user's call and not at a line of the shipped source; the node's own position for a module-own helper, whose body is already in the user's file.

A lambda given to a fn parameter fell on the wrong side of that. `inline` expands the arguments first, so the lambda arrives with the caller's positions throughout — including those of a module-own helper already inlined into it — and is then registered as a scoped helper. Expanding it found no entry in `own` and took the call site, stamping the caller's own code.

Its exercise is the combinators derived from `fold`. A direct `List.fold` does not show it: `foldFrom` is recursive and lowered to a method, so its callback is never rebuilt inside the expansion.

## What decides it now

Whether the override applies is asked of the definition being expanded, not of the expansion:

```java
private boolean keepsItsPositions(String helper) {
    return own.containsKey(helper) || lambdaOrigins.containsKey(helper)
            || scopedLambdaNames.contains(helper);
}
```

Per definition is enough. Positions mix only where code is spliced in, and splicing goes through a helper definition, so a body is of one origin by the time it is registered: a module-own helper's is in the user's file, and a lambda's is either the caller's own code or a lambda written in a prelude body, whose positions were stamped with the call site when that body was renamed. Both are already where a diagnostic should point.

A `let`-bound lambda had the same loss — a construction in `let p = (x) -> Yen(0).value <= x` was reported at `p(n)` — and the same rule fixes it.

## Checked

The construction is reported where it was written whether the clause reaches it directly, through a combinator, through a helper passed to one by name, or in a lambda with no helper at all; the secondary label naming the clause comes back with it. It is not specific to that check: a type error written in a lambda is now reported in the lambda, while an error arising in the prelude body — `List.all(x -> x, s)` against a `String` — still points at the user's call, which is what the override is for.

`CompileConstructionInInvariantTest` pinned the old position; it now asserts the construction's own line and column, and a case with no helper anywhere was added beside it, written on its own line so a stamped call site would show in the line and not only in the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
