### PR TITLE
A reported cycle says where it closes

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/query/Key.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Key.java
@@ -53,9 +53,10 @@ public interface Key<T> {
      * it, once, at the point the chain came back round to it; it is not repeated at the end. The
      * keys before it are the ones that asked, which need not be part of the cycle at all.
      *
-     * <p>An answer given here is handed to the caller that asked and nothing more. Every key that
-     * took part in the cycle is left uncomputed, so this answer is not kept, and the reports it
-     * carries are not there afterwards to be collected through {@link Db#allReports()}. A caller
+     * <p>An answer given here is handed to the caller that asked and nothing more. Every key in
+     * progress when the cycle was found is left uncomputed — the ones that only asked as much as
+     * the ones the cycle runs through — so this answer is not kept, and the reports it carries are
+     * not there afterwards to be collected through {@link Db#allReports()}. A caller
      * reading reports off the answer it was handed sees them; one reading them back from the store
      * does not. This is not a way to turn a cycle into a diagnostic.
      *

--- a/souther-compiler/src/main/java/souther/compiler/query/Key.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Key.java
@@ -53,14 +53,49 @@ public interface Key<T> {
      * it, once, at the point the chain came back round to it; it is not repeated at the end. The
      * keys before it are the ones that asked, which need not be part of the cycle at all.
      *
+     * <p>An answer given here is handed to the caller that asked and nothing more. Every key that
+     * took part in the cycle is left uncomputed, so this answer is not kept, and the reports it
+     * carries are not there afterwards to be collected through {@link Db#allReports()}. A caller
+     * reading reports off the answer it was handed sees them; one reading them back from the store
+     * does not. This is not a way to turn a cycle into a diagnostic.
+     *
      * <p>A key kind that can be part of a cycle must say what a cycle means for it: modules that
      * import each other, helpers that call each other. Left unimplemented it is a programming error,
      * because the alternative is answering with something arbitrary and letting a later pass make
      * sense of it.
      */
     default Answer<T> onCycle(List<Key<?>> cycle) {
-        throw new IllegalStateException(
-                "the query " + this + " depends on itself and says nothing about what that means: "
-                        + cycle);
+        throw new IllegalStateException(describeCycle(cycle));
+    }
+
+    /**
+     * What the default answer to a cycle says: the keys that only asked, then the cycle itself,
+     * closing where it came back round.
+     */
+    private String describeCycle(List<Key<?>> cycle) {
+        // Where this key first appears is where the chain closes, and there is only one place to
+        // find: the ask that would put a key on the chain a second time is the ask that is answered
+        // here instead, so no two keys in the chain are equal.
+        int closes = cycle.indexOf(this);
+        if (closes < 0) {
+            // Not a shape of cycle: a chain that does not hold the key it closed on says nothing
+            // about what depends on what, and whether this key depends on itself is not something
+            // it can be read for.
+            return "a query cycle was reported for " + this
+                    + ", but its dependency chain does not contain it: " + cycle;
+        }
+        StringBuilder said = new StringBuilder("the query ").append(this)
+                .append(" depends on itself and says nothing about what that means.");
+        if (closes > 0) {
+            said.append("\n  asked by:");
+            for (Key<?> asker : cycle.subList(0, closes)) {
+                said.append("\n    ").append(asker);
+            }
+        }
+        said.append("\n  cycle:");
+        for (Key<?> member : cycle.subList(closes, cycle.size())) {
+            said.append("\n    ").append(member);
+        }
+        return said.append("\n    -> back to ").append(this).toString();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/CyclicModulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/CyclicModulesTest.java
@@ -101,6 +101,21 @@ class CyclicModulesTest {
     }
 
     @Test
+    void whatAModuleReachesIsWorkedOutWithoutAskingAboutEachModuleReached() {
+        Compilation compilation = Compilation.ofDocuments(documents(A, B), Set.of(),
+                souther.compiler.meta.ModulePath.EMPTY);
+        compilation.diagnostics();
+
+        Output.Reaches reaches = new Output.Reaches("m.a");
+        assertEquals(List.of("m.a", "m.b"), compilation.db().ask(reaches).value(),
+                "the walk follows the imports round to a module it has seen and stops there");
+        assertTrue(compilation.db().isComputed(reaches),
+                "it answered without being asked through itself, so the answer is kept — a walk"
+                        + " that asked about each module it reached would be one of these two"
+                        + " modules asking what it reaches through the other");
+    }
+
+    @Test
     void aBatchCompileStopsAtTheCycle() {
         CompileException e = assertThrows(CompileException.class,
                 () -> Compiler.compileModules(List.of(A, B)));

--- a/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/DbTest.java
@@ -182,10 +182,72 @@ class DbTest {
         assertFalse(db.isComputed(new Ping(1)));
     }
 
+    /** A key that only asks: it reaches the knot below and takes no part in the cycle there. */
+    record Asks(int step) implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            return step < 2 ? db.ask(new Asks(step + 1)) : db.ask(new Knot(0));
+        }
+    }
+
+    /** Two keys that read each other, with nothing to say about it. */
+    record Knot(int step) implements Key<String> {
+        @Override
+        public Answer<String> compute(Db db) {
+            return db.ask(new Knot(1 - step));
+        }
+    }
+
     @Test
     void aCycleWithNoAnswerIsAProgrammingError() {
         Db db = new Db();
         assertThrows(IllegalStateException.class, () -> db.ask(new Loop()));
+    }
+
+    @Test
+    void aCycleSaysWhichKeysOnlyAskedAndWhereItClosed() {
+        Db db = new Db();
+        IllegalStateException raised =
+                assertThrows(IllegalStateException.class, () -> db.ask(new Asks(0)));
+
+        // The three Asks are on the chain because they were being answered, not because they are
+        // part of anything that depends on itself. Only what follows the closing key is the cycle.
+        assertEquals("""
+                the query Knot[step=0] depends on itself and says nothing about what that means.
+                  asked by:
+                    Asks[step=0]
+                    Asks[step=1]
+                    Asks[step=2]
+                  cycle:
+                    Knot[step=0]
+                    Knot[step=1]
+                    -> back to Knot[step=0]""", raised.getMessage());
+    }
+
+    @Test
+    void aCycleReachedFirstThingHasNoAskers() {
+        Db db = new Db();
+        IllegalStateException raised =
+                assertThrows(IllegalStateException.class, () -> db.ask(new Loop()));
+
+        assertEquals("""
+                the query Loop[] depends on itself and says nothing about what that means.
+                  cycle:
+                    Loop[]
+                    -> back to Loop[]""", raised.getMessage());
+    }
+
+    @Test
+    void aChainWithoutTheKeyThatClosedIsReportedAsThat() {
+        // Db hands over the chain it found the key on, so this cannot arise from asking. What it
+        // guards is the reader: a chain like this says nothing about what depends on what, and a
+        // report that claimed a query depends on itself from it would be claiming what it cannot
+        // show.
+        IllegalStateException raised = assertThrows(IllegalStateException.class,
+                () -> new Knot(0).onCycle(List.of(new Asks(0))));
+
+        assertEquals("a query cycle was reported for Knot[step=0], but its dependency chain does"
+                + " not contain it: [Asks[step=0]]", raised.getMessage());
     }
 
     /** Two files joined, so an edit to one can be watched for its effect on the other. */


### PR DESCRIPTION
Part of #250, first item only. The second item — reporting a cycle at `Output.Examples` or
`Shapes.DerivedDef` as a source diagnostic — is not implemented here; see the issue for why.

## `Key.onCycle`'s default message

`Db.ask` reaches `onCycle` only at `Db.java:134-138` and passes `List.copyOf(inProgress)`, so the
chain necessarily holds the key that closed the cycle. `Key.java:53-54` also says the keys before
it need not be part of the cycle at all. The message printed the key and the chain as two separate
things, leaving both facts for the reader to reconstruct.

It now names the two regions:

```
the query Knot[step=0] depends on itself and says nothing about what that means.
  asked by:
    Asks[step=0]
    Asks[step=1]
    Asks[step=2]
  cycle:
    Knot[step=0]
    Knot[step=1]
    -> back to Knot[step=0]
```

A cycle reached with nothing above it prints no `asked by:` section.

A chain that does not hold the key it closed on gets its own message rather than a fallback to
this one. It cannot claim the query depends on itself, because the chain it was handed does not
show that:

```
a query cycle was reported for Knot[step=0], but its dependency chain does not contain it: [Asks[step=0]]
```

## What `onCycle` may return

The javadoc now states the lifetime of the answer. Every key in progress when a cycle is found is
left uncomputed (`Db.java:136`, `Db.java:165-169`) — the keys that only asked on the way in as much
as the ones the cycle runs through, which is more than the cycle itself. So an answer given to a
cycle is handed to the caller and not kept, and reports carried only in it are not there afterwards
for `Db#allReports()` to collect. Returning an answer with a diagnostic in it is not a way to turn
a cycle into a compiler diagnostic, and the signature should stop reading as though it were.

## Tests

`DbTest` pins the three message shapes. `CyclicModulesTest` pins `Output.Reaches`: over two modules
that import each other it answers with both and is kept, which is what says the iterative walk did
not go through a question that answers itself.

An `answerEverything()` fixture with an example row was tried and left out. On two modules in a
cycle, `Output.Examples` stops at an absent `Shapes.Prepared` and `Output.Reaches` is never
computed, so the fixture would pin nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
