### PR TITLE
A lambda handed to a combinator reaches a method-lowered helper

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -275,9 +275,9 @@ final class HelperParams {
             // A recursive helper's call is left standing rather than expanded, so the neighbouring
             // expression a parameter takes its type from can be one — `x + count(t)` reads `count(t)`
             // to type `x`. Its signature goes in here, once, and every inner scope is derived from
-            // this one (spec 13.1).
-            Map<String, Type> scope = new HashMap<>(env);
-            scope.putAll(recursiveHelperFns);
+            // this one (spec 13.1). What is bound wins over it, as it does everywhere else.
+            Map<String, Type> scope = new HashMap<>(recursiveHelperFns);
+            scope.putAll(env);
             visit(body, scope, name);
             return pinned;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -272,7 +272,13 @@ final class HelperParams {
         Type typeOf(String name, Ast.Expr body, Map<String, Type> env) {
             this.pinned = null;
             this.openUse = null;
-            visit(body, env, name);
+            // A recursive helper's call is left standing rather than expanded, so the neighbouring
+            // expression a parameter takes its type from can be one — `x + count(t)` reads `count(t)`
+            // to type `x`. Its signature goes in here, once, and every inner scope is derived from
+            // this one (spec 13.1).
+            Map<String, Type> scope = new HashMap<>(env);
+            scope.putAll(recursiveHelperFns);
+            visit(body, scope, name);
             return pinned;
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -91,9 +91,11 @@ public final class HelperTyping {
             // into the environment before anything reads the body (spec 13.1). Every reader of the
             // body needs it, not just the elaboration below: a call to a method-lowered helper can sit
             // in a lambda handed to a combinator, and the check of that lambda reads the environment
-            // it is given.
-            Map<String, Type> tenv = new HashMap<>(env);
-            tenv.putAll(recursiveHelperFns);
+            // it is given. A parameter of the same name wins: a binding in force wins over the
+            // declaration it shadows (spec §fn-rules), so `let use (depth: Int)` reads its `depth` as
+            // the Int it declares and not as the helper it is spelled like.
+            Map<String, Type> tenv = new HashMap<>(recursiveHelperFns);
+            tenv.putAll(env);
             // a helper that returns a function (e.g. `let adder (n) = (x) -> x + n`) has no application
             // here to infer the lambda's parameter types from; it is checked where it is inlined and
             // applied (spec §blocks).

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -86,10 +86,18 @@ public final class HelperTyping {
                 // body is caught here, at the helper, not only where it is later inlined.
                 typeFromBody(h, inferred, env, body, symbols, reqSigs, recursiveHelperFns);
             }
+            // A recursive helper is lowered to a method, so a self- or mutual call is left standing
+            // rather than expanded; its signature is what a call to it is typed against, so it goes
+            // into the environment before anything reads the body (spec 13.1). Every reader of the
+            // body needs it, not just the elaboration below: a call to a method-lowered helper can sit
+            // in a lambda handed to a combinator, and the check of that lambda reads the environment
+            // it is given.
+            Map<String, Type> tenv = new HashMap<>(env);
+            tenv.putAll(recursiveHelperFns);
             // a helper that returns a function (e.g. `let adder (n) = (x) -> x + n`) has no application
             // here to infer the lambda's parameter types from; it is checked where it is inlined and
             // applied (spec §blocks).
-            checkFunctionArgs(h.body(), env, symbols, reqSigs, inliner);
+            checkFunctionArgs(h.body(), tenv, symbols, reqSigs, inliner);
             if (Elaborator.producesFunction(body)) {
                 continue;
             }
@@ -98,10 +106,6 @@ public final class HelperTyping {
                 // cannot reach an injected behavior — put the effect in the behavior that calls it.
                 rejectInjectedCalls(body, h.name(), reqSigs.keySet());
             }
-            // self- and mutual calls resolve through the helper signatures, so the recursion type-checks
-            // without a fixpoint (each declares its return type, spec 13.1).
-            Map<String, Type> tenv = new HashMap<>(env);
-            tenv.putAll(recursiveHelperFns);
             // push a declared return type into the body so an empty-collection body (Map.empty(), [])
             // takes the declared element/value type rather than a bottom
             Type declaredReturn = h.declaredReturn() == null ? null : TypeOps.successType(h.declaredReturn(), symbols);

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -297,8 +297,10 @@ public final class SpecChecker {
         Type output = TypeOps.successType(spec.ret(), symbols);
         // recursive helpers this behavior calls resolve through their signatures (spec 13.1); merged
         // only for typing, so the construction and dependency walks below still see the business params alone.
-        Map<String, Type> tenv = new HashMap<>(env);
-        tenv.putAll(recursiveHelperFns);
+        // A parameter of the same name wins: a binding in force wins over the declaration it shadows
+        // (spec §fn-rules), so an input written `depth` is the input and not the helper spelled that way.
+        Map<String, Type> tenv = new HashMap<>(recursiveHelperFns);
+        tenv.putAll(env);
         // Check functions passed to helper parameters (e.g. a combinator's predicate) against their
         // declared types first, so a mismatch names the parameter, not the derivation it expands to.
         // A nested fold reaches `List.foldFrom` inside a block, so its signature must be in scope here.

--- a/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
@@ -481,6 +481,55 @@ class CompileRecursiveHelperTest {
     }
 
     @Test
+    void aParameterSpelledLikeARecursiveHelperIsTheParameter() {
+        // A recursive helper's signature is in scope wherever its call may stand, but a binding in
+        // force wins over the declaration it shadows (spec §fn-rules). `depth` here is the Int
+        // parameter, so `depth + 1` is arithmetic — not a function where a number goes.
+        String src = ORG.replace("let measureDepth (e) = Depth(depth(e))", """
+                let bump (depth: Int): Int = depth + 1
+                let measureDepth (e) = Depth(bump(depth(e)))
+                """);
+        assertDoesNotThrow(() -> Compiler.compile(src));
+    }
+
+    @Test
+    void aBehaviorInputSpelledLikeARecursiveHelperIsTheInput() {
+        // The same rule on the behavior side: the input named `depth` is an Employee, so its field
+        // reads, rather than being read as the helper spelled that way.
+        String src = """
+                module demo
+                data Employee = { boss: Employee?, name: String }
+                data Out = { name: String }
+                let depth (e: Employee): Int =
+                    match e.boss with
+                        | Some b -> depth(b) + 1
+                        | None -> 1
+                behavior go : (depth: Employee) -> Out constructs Out
+                let go (depth) = Out { name = depth.name }
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(src));
+    }
+
+    @Test
+    void applyingAParameterThatShadowsARecursiveHelperIsRejected() {
+        // The other direction of the same rule, and the one that costs something: `count(2)` reaches
+        // the parameter, which is an Int, so it is not applied to anything. The helper spelled that
+        // way is out of reach here — a name is one thing at a time, and the binding is what it is.
+        String src = """
+                module demo
+                data In = { n: Int }
+                data Out = { d: Int }
+                partial let count (n: Int): Int = if n == 0 then 0 else count(n - 1) + 1
+                let use (count: Int): Int = count(2)
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { d = use(i.n) }
+                """;
+        CompileException ex = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        assertTrue(ex.getMessage().contains("count") && ex.getMessage().contains("not a function"),
+                ex.getMessage());
+    }
+
+    @Test
     void anUnannotatedParameterTakesItsTypeFromANeighbouringRecursiveHelperCall() {
         // The type a parameter is left to take from the body can come from a call that is left
         // standing — `x + depth(e)` types `x` from what `depth` returns (spec 13.1).

--- a/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
@@ -394,6 +394,103 @@ class CompileRecursiveHelperTest {
         assertTrue(ex.getMessage().contains("Tag"), ex.getMessage());
     }
 
+    // A tree walk that produces a list is written with `concatMap`, and the recursive call sits in the
+    // lambda `concatMap` is handed. `concatMap` is a prelude helper expanded into its caller, so the
+    // lambda is checked against the parameter type before that expansion runs — and the call in it is
+    // to a helper that is lowered to a method and so stays a call. It is typed against the recursive
+    // helper's signature, the same way the helper's own body is.
+    private static final String TREE = """
+            module demo
+            data Node = { n: Int, kids: List<Node> }
+            data Out = { xs: List<Int> }
+
+            let flatten (t: Node): List<Int> =
+                [t.n] ++ List.concatMap(k -> flatten(k), t.kids)
+
+            behavior go : (t: Node) -> Out constructs Out
+            let go (t) = Out { xs = flatten(t) }
+            """;
+
+    @Test
+    void aCombinatorLambdaInAHelperReachesARecursiveHelper() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(TREE), getClass().getClassLoader());
+        Object tree = Codecs.decoded(loader, "demo.Node", Map.of(
+                "n", 1L, "kids", java.util.List.of(
+                        Map.of("n", 2L, "kids", java.util.List.of(Map.of("n", 4L, "kids", java.util.List.of()))),
+                        Map.of("n", 3L, "kids", java.util.List.of()))));
+
+        Object behavior = loader.loadClass("demo.Go" + "$Impl").getConstructor().newInstance();
+        Object out = Codecs.apply(behavior, tree);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> encoded = (Map<String, Object>) Codecs.encode(loader, "demo.Out", out);
+        assertEquals(java.util.List.of(1L, 2L, 4L, 3L), encoded.get("xs"),
+                "the walk visits each node before its children");
+    }
+
+    @Test
+    void aCombinatorLambdaReachesARecursiveHelperThroughAnInlinedOne() {
+        // The lambda names `labelled`, which is not recursive and so is expanded into it — and what the
+        // expansion leaves behind is the call to `flatten`, which is. What the lambda reaches matters,
+        // not what it spells.
+        String src = TREE.replace("let go (t) = Out { xs = flatten(t) }", """
+                let labelled (t: Node): List<Int> = flatten(t)
+                let roster (t: Node): List<Int> = List.concatMap(k -> labelled(k), t.kids)
+                let go (t) = Out { xs = roster(t) }
+                """);
+        assertDoesNotThrow(() -> Compiler.compile(src));
+    }
+
+    @Test
+    void aCombinatorLambdaReachesAPartialRecursiveHelper() {
+        // What lowers a helper to a method is recursion, not `partial`: a `partial` helper that does
+        // not recurse is inlined like any other. `countDown` walks an Int down to zero, which is not
+        // structural, so `partial` is what lets the recursion be written at all — and the recursion
+        // is what leaves the call standing in the lambda.
+        String src = """
+                module demo
+                data Bag = { ns: List<Int> }
+                data Out = { xs: List<Int> }
+                partial let countDown (n: Int): List<Int> =
+                    if n == 0 then [] else [n] ++ countDown(n - 1)
+                let all (b: Bag): List<Int> = List.concatMap(n -> countDown(n), b.ns)
+                behavior go : (b: Bag) -> Out constructs Out
+                let go (b) = Out { xs = all(b) }
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(src));
+    }
+
+    @Test
+    void aCombinatorLambdaReachesAnImportedRecursiveHelper() {
+        // A recursive helper another module publishes is emitted as a method of the reader, so a call
+        // to it in the reader's lambda is the same call, under the qualified name.
+        String lib = """
+                module lib exposing ( Node, flatten )
+                data Node = { n: Int, kids: List<Node> }
+                let flatten (t: Node): List<Int> = [t.n] ++ List.concatMap(k -> flatten(k), t.kids)
+                """;
+        String app = """
+                module app
+                import lib ( Node, flatten )
+                data Out = { xs: List<Int> }
+                let roster (t: Node): List<Int> = List.concatMap(k -> flatten(k), t.kids)
+                behavior go : (t: Node) -> Out constructs Out
+                let go (t) = Out { xs = roster(t) }
+                """;
+        assertDoesNotThrow(() -> Compiler.compileModules(java.util.List.of(lib, app)));
+    }
+
+    @Test
+    void anUnannotatedParameterTakesItsTypeFromANeighbouringRecursiveHelperCall() {
+        // The type a parameter is left to take from the body can come from a call that is left
+        // standing — `x + depth(e)` types `x` from what `depth` returns (spec 13.1).
+        String src = ORG.replace("let measureDepth (e) = Depth(depth(e))", """
+                let bump (x, e: Employee) = x + depth(e)
+                let measureDepth (e) = Depth(bump(1, e))
+                """);
+        assertDoesNotThrow(() -> Compiler.compile(src));
+    }
+
     @Test
     void aMandatorySelfReferenceIsRejectedAsUninhabitable() {
         // `boss: Employee` (no `?`, no List) is a base-less cycle: building an Employee would need an


### PR DESCRIPTION
Fixes #258, and a second reader with the same hole, and the shadowing order the fix would otherwise have widened.

## What was wrong

A recursive helper is lowered to a method, so a call to it is left standing rather than expanded, and it is typed against the helper's signature. Three places read a body that can hold such a call. Two of them were not given the signature, and a call reaching either aborted the compiler with an `IllegalStateException` and no diagnostic.

**The check of a function handed to a helper's function parameter.** It runs before the combinator is expanded, so `List.concatMap(k -> flatten(k), t.kids)` inside another helper checks the lambda against `concatMap`'s declared parameter type — with `flatten` left standing in it. This is the issue's repro. `SpecChecker` already merged the signatures in for the same reason on the behavior side, which is why the same call written in a behavior's `let` compiled. `List.fold` was exempt only because it is rewritten to `List.foldFrom` during inlining, so this check never had a helper to look up; `Option.map` is a built-in.

**The typing that gives an unannotated parameter its type from the body.** Not in the issue. `let bump (x, t: Node) = x + count(t)` reads `count(t)` to type `x`, and that call is left standing too. The first fix does not reach it.

The issue's table lists `partial` as a separate trigger. It is not one: what lowers a helper to a method is recursion, and a `partial` helper that does not recurse is inlined like any other. `partial` appears in these shapes because a walk that is not structural cannot be written without it.

## What else came out

The signatures were merged *over* what was already bound, so a parameter spelled like a recursive helper came out as the helper — `let bump (depth: Int): Int = depth + 1` was told its `depth` is a function where a number goes, and a behavior input written `(depth: Employee)` could not read its own field. This reproduces on `develop` and is independent of #258, but the first commit would have carried the wrong order into a third reader, so it is fixed here. A binding in force wins over the declaration it shadows (spec §fn-rules); that is the order the invariant check and the backend already use, so the three now agree.

The other direction of that rule costs something. A parameter that shadows a recursive helper and is then applied — `let use (count: Int): Int = count(2)` — used to reach the helper and now reports that `count` is not a function here. That is the rule rather than a regression, and there is a test for it, but the report names neither the shadowed helper nor the binding that shadowed it. Saying so would mean carrying the helper table into `CheckContext`, which is a separate change.

## Scope

Type-checking only — no bytecode change. Every other reader was checked and already correct: the helper body's own elaboration, the behavior body, the invariant clause, and the backend. Decoders and encoders are derived from a data's shape rather than written, so they hold no helper call.

Probed and compiling: value definitions, `example` rows, `>->`, imported recursive helpers, nested combinator lambdas, `Map.map`, a combinator inside an invariant, and a local `let` shadowing a helper.

## Verification

`mvn clean test` green across all modules, 1820 compiler tests. Eight regression tests in `CompileRecursiveHelperTest`; each was confirmed to fail on `develop` first. The issue's BOM-explosion example compiles, and the `concatMap` tree walk is run end to end for its result rather than only compiled.

The `IllegalStateException` in `CallElaborator.unelaborated` is left as the internal assertion it is documented to be — reaching it means the compiler disagrees with itself, which is not something an author can act on. This change makes the shapes that reached it stop reaching it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
