### PR TITLE
Resolve settles what a binding is, and nothing reads a spelling to disagree

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -1139,14 +1139,14 @@ public final class ExampleVerifier {
                     throw new FixtureException("`" + v.name()
                             + "` is bound to no value a fixture can name");
                 }
-                yield expandedValue(v.name(), held, expected);
+                yield expandedValue(local, held, expected);
             }
-            case ValueName.Helper _ -> {
+            case ValueName.Helper helper -> {
                 Ast.Expr value = valueBody(v.name());
                 if (value == null) {
                     throw new FixtureException("`" + v.name() + "` is not a value a fixture can name");
                 }
-                yield expandedValue(v.name(), value, expected);
+                yield expandedValue(helper, value, expected);
             }
             case null, default ->
                     throw new FixtureException("`" + v.name() + "` is not a value a fixture can name");
@@ -1214,17 +1214,24 @@ public final class ExampleVerifier {
         return imported != null && imported.params().isEmpty() ? imported.body() : null;
     }
 
-    /** The names being expanded, innermost last — a value that reaches itself has no fixture to be. */
-    private final Deque<String> expanding = new ArrayDeque<>();
+    /**
+     * What is being expanded, innermost last — a value that reaches itself has no fixture to be.
+     *
+     * <p>Held as what each one is rather than as what it is called: two bindings of one spelling are
+     * two values, and reading the second while the first is open is not a value reaching itself. The
+     * spelling is what the report shows, and decides nothing.
+     */
+    private final Deque<ValueName> expanding = new ArrayDeque<>();
 
-    private Object expandedValue(String name, Ast.Expr body, Type expected) {
-        if (expanding.contains(name)) {
-            List<String> cycle = new ArrayList<>(expanding);
-            cycle.add(name);
-            throw new FixtureException("`" + name + "` is defined in terms of itself ("
+    private Object expandedValue(ValueName named, Ast.Expr body, Type expected) {
+        if (expanding.contains(named)) {
+            List<String> cycle = new ArrayList<>();
+            expanding.forEach(open -> cycle.add(open.name()));
+            cycle.add(named.name());
+            throw new FixtureException("`" + named.name() + "` is defined in terms of itself ("
                     + String.join(" -> ", cycle) + ")");
         }
-        expanding.addLast(name);
+        expanding.addLast(named);
         try {
             return raw(body, expected);
         } finally {
@@ -1387,7 +1394,8 @@ public final class ExampleVerifier {
                 throw new FixtureException("`" + spread
                         + "` is not a value a fixture can spread");
             }
-            Object copied = expandedValue(spread, value, Type.ref(nd.typeName().denotes()));
+            Object copied = expandedValue(ref.denotes(), value,
+                    Type.ref(nd.typeName().denotes()));
             if (!(copied instanceof Map<?, ?> fields)) {
                 throw new FixtureException("`" + spread + "` is not a record, so it has no fields to"
                         + " spread");

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -4,6 +4,8 @@ import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.Symbols;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Sig;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.ValueName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.CallElaborator;
@@ -748,11 +750,8 @@ public final class ExampleVerifier {
      * under, so a row spelling that type qualified asserts the same case.
      */
     private String caseOnly(Ast.Expr expected) {
-        if (!(expected instanceof Ast.Var v)) {
-            return null;
-        }
-        TypeName type = symbols.resolveCase(v.name());
-        return type == null ? null : type.name();
+        return expected instanceof Ast.Var v && v.denotes() instanceof ValueName.OfType named
+                ? named.type().name() : null;
     }
 
     /** The expected value built the same way as an input, so structural equality compares like with
@@ -794,7 +793,13 @@ public final class ExampleVerifier {
         return switch (e) {
             case Ast.Call c when appliedHelper(c) instanceof Ast.FnDef helper -> answered(c, helper);
             case Ast.LetIn let -> helperAnswer(let.body(), followed);
-            case Ast.Var v when symbols.resolveCase(v.name()) == null -> {
+            // a binding holds what it was bound to; a value stands for the body it was defined as.
+            // A name that denotes a type is a case, and no helper answered it.
+            case Ast.Var v when v.denotes() instanceof ValueName.Local local -> {
+                Ast.Expr held = bindings.get(local.id());
+                yield held == null ? null : helperAnswer(held, followed);
+            }
+            case Ast.Var v when v.denotes() instanceof ValueName.Helper -> {
                 Ast.Expr body = followed.add(v.name()) ? valueBody(v.name()) : null;
                 yield body == null ? null : helperAnswer(body, followed);
             }
@@ -870,20 +875,26 @@ public final class ExampleVerifier {
             case Ast.NewData nd -> nd.typeName().denotes();
             case Ast.Call c when neutral.isNewtype(c.fn()) -> symbols.resolveCase(c.fn());
             case Ast.LetIn let -> constructedCase(let.body(), followed);
-            case Ast.Var v -> namedCase(v.name(), followed);
+            case Ast.Var v -> namedCase(v, followed);
             case null, default -> null;
         };
     }
 
     /** The case a bare name stands for: the type it denotes where it denotes one — a unit case, or a
-     * case written bare — and otherwise the case the value it names constructs. */
-    private TypeName namedCase(String name, Set<String> followed) {
-        TypeName type = symbols.resolveCase(name);
-        if (type != null) {
-            return type;
-        }
-        Ast.Expr body = followed.add(name) ? valueBody(name) : null;
-        return body == null ? null : constructedCase(body, followed);
+     * case written bare — and otherwise the case the value or binding it names constructs. */
+    private TypeName namedCase(Ast.Var v, Set<String> followed) {
+        return switch (v.denotes()) {
+            case ValueName.OfType named -> named.type();
+            case ValueName.Local local -> {
+                Ast.Expr held = bindings.get(local.id());
+                yield held == null ? null : constructedCase(held, followed);
+            }
+            case ValueName.Helper _ -> {
+                Ast.Expr body = followed.add(v.name()) ? valueBody(v.name()) : null;
+                yield body == null ? null : constructedCase(body, followed);
+            }
+            case null, default -> null;
+        };
     }
 
     /** The expectation, rendered as the value it stands for: a bare case stays the case name, anything
@@ -1083,7 +1094,7 @@ public final class ExampleVerifier {
             case Ast.Neg n -> negate(raw(n.operand()));
             case Ast.Binary bin -> fold(bin);
             case Ast.Call c -> collectionOrNewtype(c, expected);
-            case Ast.Var v -> unitInput(v.name(), expected);
+            case Ast.Var v -> named(v, expected);
             case Ast.NewData nd -> record(nd);
             case Ast.LetIn let -> bound(let, expected);
             case Ast.ListLit l -> {
@@ -1108,16 +1119,45 @@ public final class ExampleVerifier {
         };
     }
 
-    /** A bare name in a fixture is only meaningful as a unit case (no fields) or the built-in {@code
-     * None}; a unit's decoder ignores the input, so an empty map stands in, and {@code None} maps to
-     * a null, which the optional decoder reads as the absent optional (spec 8, absent/null -> None),
-     * the same as omitting a `T?` field — mirroring how a `let` body writes an empty optional. */
-    private Object unitInput(String name, Type expected) {
-        if (name.equals("None")) {
-            return null;
-        }
-        if (symbols.declaration(name) instanceof Ast.UnitData) {
-            TypeName caseName = symbols.resolve(name);
+    /**
+     * A bare name in a fixture, read as what it denotes.
+     *
+     * <p>Which of the four it is was settled where the name was written, so it is not worked out
+     * again here: a binding in force is the value it holds, whatever else bears its spelling.
+     */
+    private Object named(Ast.Var v, Type expected) {
+        return switch (v.denotes()) {
+            // `None` maps to a null, which the optional decoder reads as the absent optional
+            // (spec 8, absent/null -> None), the same as omitting a `T?` field
+            case ValueName.Builtin b when b.name().equals("None") -> null;
+            case ValueName.OfType named
+                    when symbols.get(named.type()) instanceof Ast.UnitData ->
+                    unitInput(named.type(), expected);
+            case ValueName.Local local -> {
+                Ast.Expr held = bindings.get(local.id());
+                if (held == null) {
+                    throw new FixtureException("`" + v.name()
+                            + "` is bound to no value a fixture can name");
+                }
+                yield expandedValue(v.name(), held, expected);
+            }
+            case ValueName.Helper _ -> {
+                Ast.Expr value = valueBody(v.name());
+                if (value == null) {
+                    throw new FixtureException("`" + v.name() + "` is not a value a fixture can name");
+                }
+                yield expandedValue(v.name(), value, expected);
+            }
+            case null, default ->
+                    throw new FixtureException("`" + v.name() + "` is not a value a fixture can name");
+        };
+    }
+
+    /** A unit case as a fixture writes it: a unit's decoder ignores the input, so an empty map
+     * stands in. */
+    private Object unitInput(TypeName caseName, Type expected) {
+        {
+            String name = caseName.name();
             // A fixture is built in the neutral form the boundary reads, so a case of an enumeration
             // is written the way that sum travels: its name, bare (issue #161). The same unit data may
             // be a case of an enumeration and of a sum that has a field-bearing case, and those travel
@@ -1130,11 +1170,6 @@ public final class ExampleVerifier {
             neutral.tagged(name, unit);   // a unit case of a sum still needs the tag its decoder reads
             return unit;
         }
-        Ast.Expr value = valueBody(name);
-        if (value != null) {
-            return expandedValue(name, value, expected);
-        }
-        throw new FixtureException("`" + name + "` is not a value a fixture can name");
     }
 
     /**
@@ -1145,20 +1180,18 @@ public final class ExampleVerifier {
      * local already has. That binding is what the spread then names, so a fixture reads one the way it
      * reads a value: the position says what type to read it as.
      */
-    private final Map<String, Ast.Expr> bindings = new LinkedHashMap<>();
+    private final Map<BindingId, Ast.Expr> bindings = new LinkedHashMap<>();
 
     /** A {@code let} inside a fixture: its name stands for what it was bound to while the body is
      * built, and a binding of the same spelling that was already in force is put back afterwards. */
     private Object bound(Ast.LetIn let, Type expected) {
-        Ast.Expr shadowed = bindings.put(let.name(), let.value());
+        BindingId binding = let.binder().id();
+        bindings.put(binding, let.value());
         try {
             return raw(let.body(), expected);
         } finally {
-            if (shadowed == null) {
-                bindings.remove(let.name());
-            } else {
-                bindings.put(let.name(), shadowed);
-            }
+            // a binding of its own, so there is nothing of an outer one to put back
+            bindings.remove(binding);
         }
     }
 
@@ -1172,10 +1205,6 @@ public final class ExampleVerifier {
      * values holds.
      */
     private Ast.Expr valueBody(String name) {
-        Ast.Expr binding = bindings.get(name);
-        if (binding != null) {
-            return binding;   // a binding in force is what the name means here
-        }
         for (Ast.FnDef fn : module.fns()) {
             if (fn.name().equals(name) && fn.params().isEmpty() && fn.body() != null) {
                 return fn.body();
@@ -1346,12 +1375,14 @@ public final class ExampleVerifier {
         // `...base` copies the fields of a value, and the fields written after it replace what it
         // brought.
         for (Ast.ValueRef ref : nd.spreads()) {
-            // The name as this row spells it, which is what the values a fixture may name are keyed by:
-            // a definition of this module by its own name, one another module published by that module's
-            // name and its own. `bare()` is the name it was *declared* under, which is not that key for
-            // an imported value — so a row could name one but not spread it (issue #212).
+            // A spread names a value in force, so what it copies is what that name denotes: a binding
+            // holds what it was bound to, and a definition stands for its body. A definition is
+            // reached by the name this row spells it with — a definition of this module by its own
+            // name, one another module published by that module's name and its own. `bare()` is the
+            // name it was *declared* under, which is not that key for an imported value (issue #212).
             String spread = ref.written();
-            Ast.Expr value = valueBody(spread);
+            Ast.Expr value = ref.denotes() instanceof ValueName.Local local
+                    ? bindings.get(local.id()) : valueBody(spread);
             if (value == null) {
                 throw new FixtureException("`" + spread
                         + "` is not a value a fixture can spread");

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -1,6 +1,8 @@
 package souther.compiler.ast;
 
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
@@ -22,6 +24,91 @@ public interface Ast {
 
     /** The source position of this node. Every record below provides it. */
     SourcePos pos();
+
+    /**
+     * A name a body binds: a parameter, a {@code let}, a lambda's parameter, a {@code match} arm's
+     * binding. Every node below that introduces one holds this rather than a bare spelling, so what a
+     * name under it means is the binding and not the text.
+     *
+     * <p>The two forms are the two states a binder is in. The parser writes {@link Written}, which is
+     * the spelling and nothing more; {@code Resolve} answers it with {@link Bound}, which carries the
+     * {@link BindingId} every name that resolves to it also carries. There is no third state and no
+     * absent identity: a binder with an identity and a binder without one are different types, so a
+     * reader cannot mistake one for the other, and nothing downstream tests for a missing one.
+     */
+    sealed interface Binder extends Ast {
+
+        /** How the binding was written. A diagnostic quotes this, and a generated local is named
+         * after it; nothing decides identity by it. */
+        String name();
+
+        /** A binder as the parser read it, before resolution has said which binding it is. */
+        static Binder written(String name, SourcePos pos) {
+            return new Written(name, pos);
+        }
+
+        /**
+         * The binding, for a reader that is asking which one this is.
+         *
+         * <p>A binder still {@link Written} here is a pass reading a body it was handed before
+         * resolution answered it, which is a fault in the compiler rather than in the source, so it
+         * is refused outright. This is the one place that says so.
+         */
+        default BindingId id() {
+            if (this instanceof Bound bound) {
+                return bound.binding();
+            }
+            throw new IllegalStateException("`" + name() + "` at " + pos()
+                    + " was read as a binding before it was resolved");
+        }
+
+        /** A binder as the parser read it. */
+        record Written(String name, SourcePos pos) implements Binder {
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        }
+
+        /** A binder resolution answered, and the binding it introduces. */
+        record Bound(String name, BindingId binding, SourcePos pos) implements Binder {
+
+            public Bound {
+                if (binding == null) {
+                    throw new IllegalArgumentException("a bound binder is a binding: " + name);
+                }
+            }
+
+            @Override
+            public String toString() {
+                return name;
+            }
+        }
+    }
+
+    /**
+     * Mints the binders a pass writes into a body that has already been resolved.
+     *
+     * <p>Such a pass cannot leave a binder {@link Binder.Written}: nothing runs after it to answer
+     * one. So it says which binding each is, and the bindings it makes belong to it — to
+     * {@code owner} — rather than to the definition whose text it is writing into, which is what
+     * keeps two of them apart when one body is written into twice.
+     */
+    final class Binders {
+
+        private final BindingOwner owner;
+        private int next;
+
+        public Binders(BindingOwner owner) {
+            this.owner = owner;
+        }
+
+        /** A binding nothing else has, under this pass's owner. */
+        public Binder binder(String name, SourcePos pos) {
+            return new Binder.Bound(name, new BindingId(owner, next++), pos);
+        }
+    }
 
     /**
      * A name that denotes a declared type, in both forms it has: {@code written} as the source spelled
@@ -75,9 +162,10 @@ public interface Ast {
             return new ValueRef(written, null, pos);
         }
 
-        /** A name a pass introduced, bound where it put it — the counterpart of {@link Var#local}. */
-        public static ValueRef local(String name, SourcePos pos) {
-            return new ValueRef(name, new ValueName.Local(name, pos), pos);
+        /** A name a pass introduced, reading the binding it bound it to — the counterpart of
+         * {@link Var#local}. */
+        public static ValueRef local(Binder binder, SourcePos pos) {
+            return new ValueRef(binder.name(), new ValueName.Local(binder.name(), binder.id()), pos);
         }
 
         /** The same name, resolved to what it denotes. */
@@ -248,10 +336,24 @@ public interface Ast {
      * carries no type ({@code type} is null). {@code typeFromPattern} marks a type read off a
      * constructor pattern in parameter position rather than written beside the name — a behavior's
      * implementation may write the pattern, and its type still comes from the behavior. */
-    record FnParam(String name, RetType type, boolean typeFromPattern, SourcePos pos) implements Ast {
+    record FnParam(Binder binder, RetType type, boolean typeFromPattern) implements Ast {
         /** A parameter whose type, if any, the author wrote (the common case). */
+        public FnParam(Binder binder, RetType type) {
+            this(binder, type, false);
+        }
+
+        /** A parameter as the parser read it. */
         public FnParam(String name, RetType type, SourcePos pos) {
-            this(name, type, false, pos);
+            this(Binder.written(name, pos), type, false);
+        }
+
+        public String name() {
+            return binder.name();
+        }
+
+        @Override
+        public SourcePos pos() {
+            return binder.pos();
         }
     }
 
@@ -402,10 +504,15 @@ public interface Ast {
 
     /** {@code decoder from Text|Int as <input> { <stmts> <construct> }} (single value). */
     record PrimDecoder(RawKind from,
-                       String inputName,
+                       Binder input,
                        List<DecStmt> stmts,
                        Construct result,
-                       SourcePos pos) implements DecoderDef {}
+                       SourcePos pos) implements DecoderDef {
+
+        public String inputName() {
+            return input.name();
+        }
+    }
 
     /** {@code decoder from Object { <binds> <construct> }} (multi-field, accumulating). */
     record ObjectDecoder(List<Bind> binds, Construct result, SourcePos pos) implements DecoderDef {}
@@ -416,11 +523,21 @@ public interface Ast {
      * {@code X}. {@code X}'s external representation is {@code Y}'s — an object or a discriminated
      * sum, not {@code {value: ...}}.
      */
-    record NewtypeDecoder(DecRef inner, String inputName, Construct result, SourcePos pos)
-            implements DecoderDef {}
+    record NewtypeDecoder(DecRef inner, Binder input, Construct result, SourcePos pos)
+            implements DecoderDef {
+
+        public String inputName() {
+            return input.name();
+        }
+    }
 
     /** {@code name <- field("key", <decRef>)} inside an object decoder. */
-    record Bind(String name, String key, DecRef ref, SourcePos pos) implements Ast {}
+    record Bind(Binder binder, String key, DecRef ref, SourcePos pos) implements Ast {
+
+        public String name() {
+            return binder.name();
+        }
+    }
 
     /** The decoder referenced by a bind: a primitive, another data's {@code .decoder}, or a list. */
     sealed interface DecRef extends Ast
@@ -451,7 +568,12 @@ public interface Ast {
     /** A statement in a single-value decoder body. */
     sealed interface DecStmt extends Ast permits Let {}
 
-    record Let(String name, Expr value, SourcePos pos) implements DecStmt {}
+    record Let(Binder binder, Expr value, SourcePos pos) implements DecStmt {
+
+        public String name() {
+            return binder.name();
+        }
+    }
 
     /** A typed record literal {@code TypeName { ..src, field: expr, ... }} — a construction. */
     record Construct(Name typeName, List<FieldInit> inits, List<String> spreads, SourcePos pos)
@@ -462,7 +584,12 @@ public interface Ast {
 
     // --- encoders ---
 
-    record EncoderDef(String selfName, RawExpr result, SourcePos pos) implements Ast {}
+    record EncoderDef(Binder self, RawExpr result, SourcePos pos) implements Ast {
+
+        public String selfName() {
+            return self.name();
+        }
+    }
 
     /** A Raw-building expression. */
     sealed interface RawExpr extends Ast
@@ -477,7 +604,12 @@ public interface Ast {
 
     /** Encodes an optional field: {@code None} becomes {@code Raw.Null}, {@code Some(v)} encodes
      * {@code v} via {@code inner}, which reads the unwrapped value bound to {@code elemVar}. */
-    record OptionRaw(Expr access, RawExpr inner, String elemVar, SourcePos pos) implements RawExpr {}
+    record OptionRaw(Expr access, RawExpr inner, Binder elem, SourcePos pos) implements RawExpr {
+
+        public String elemVar() {
+            return elem.name();
+        }
+    }
 
     record TextRaw(Expr arg, SourcePos pos) implements RawExpr {}
 
@@ -548,7 +680,26 @@ public interface Ast {
      * field, or bound by {@code let}. The parser only accepts one in an argument position, and
      * because it cannot escape, the backend inlines it rather than building a closure.
      */
-    record Block(List<String> params, Expr body, SourcePos pos) implements Expr {}
+    record Block(List<Binder> params, Expr body, SourcePos pos) implements Expr {
+
+        /** A block as the parser read it. */
+        public static Block written(List<String> params, Expr body, SourcePos pos) {
+            List<Binder> binders = new ArrayList<>();
+            for (String p : params) {
+                binders.add(Binder.written(p, pos));
+            }
+            return new Block(binders, body, pos);
+        }
+
+        /** How the parameters were written, in order. */
+        public List<String> paramNames() {
+            List<String> names = new ArrayList<>();
+            for (Binder p : params) {
+                names.add(p.name());
+            }
+            return names;
+        }
+    }
 
     /**
      * {@code let name = value} followed by {@code body} — what a body's {@code let} desugars to
@@ -562,21 +713,30 @@ public interface Ast {
      * declared type, bound to the argument at the call site) is not: the argument's own type and
      * the call-site check already cover it.
      */
-    record LetIn(String name, Expr value, RetType declaredType, boolean annotated, Name opens,
+    record LetIn(Binder binder, Expr value, RetType declaredType, boolean annotated, Name opens,
                  Expr body, SourcePos pos) implements Expr {
         /** An ordinary {@code let x = e}: the bound name takes {@code e}'s inferred type. */
+        public LetIn(Binder binder, Expr value, Expr body, SourcePos pos) {
+            this(binder, value, null, false, null, body, pos);
+        }
+
+        /** The same, as the parser read it. */
         public LetIn(String name, Expr value, Expr body, SourcePos pos) {
-            this(name, value, null, false, null, body, pos);
+            this(Binder.written(name, pos), value, null, false, null, body, pos);
         }
 
         /** A binding carrying an inlined helper parameter's declared type. */
-        public LetIn(String name, Expr value, RetType declaredType, Expr body, SourcePos pos) {
-            this(name, value, declaredType, false, null, body, pos);
+        public LetIn(Binder binder, Expr value, RetType declaredType, Expr body, SourcePos pos) {
+            this(binder, value, declaredType, false, null, body, pos);
         }
 
         /** {@code let x: T = value} — a binding the source annotated. */
         public static LetIn annotated(String name, Expr value, RetType type, Expr body, SourcePos pos) {
-            return new LetIn(name, value, type, true, null, body, pos);
+            return new LetIn(Binder.written(name, pos), value, type, true, null, body, pos);
+        }
+
+        public String name() {
+            return binder.name();
         }
 
         /**
@@ -586,7 +746,7 @@ public interface Ast {
          * behind it, so the name is carried here for the checker to hold against the value's type.
          */
         public static LetIn opening(String name, Expr value, Name opens, Expr body, SourcePos pos) {
-            return new LetIn(name, value, null, false, opens, body, pos);
+            return new LetIn(Binder.written(name, pos), value, null, false, opens, body, pos);
         }
 
         /** The type the source wrote on this binding, or null when it wrote none. An annotation is an
@@ -634,12 +794,22 @@ public interface Ast {
      * That it is one, and that its type carries an invariant to attempt, are checked once the names
      * are resolved.
      */
-    record IfConstructed(Expr construct, String binder, Expr then, List<ElseArm> els, SourcePos pos)
+    record IfConstructed(Expr construct, Binder binder, Expr then, List<ElseArm> els, SourcePos pos)
             implements Expr {
 
         /** The attempt whose failure is not told apart: one arm, naming no clause. */
-        public IfConstructed(Expr construct, String binder, Expr then, Expr els, SourcePos pos) {
+        public IfConstructed(Expr construct, Binder binder, Expr then, Expr els, SourcePos pos) {
             this(construct, binder, then, List.of(ElseArm.any(els)), pos);
+        }
+
+        /** The same, as the parser read it. */
+        public IfConstructed(Expr construct, String binder, Expr then, Expr els, SourcePos pos) {
+            this(construct, Binder.written(binder, pos), then, List.of(ElseArm.any(els)), pos);
+        }
+
+        /** How the binding was written. */
+        public String binderName() {
+            return binder.name();
         }
 
         /** Whether the failure is departed from per clause, rather than by one value for any of them. */
@@ -686,10 +856,22 @@ public interface Ast {
      * destructure; an empty list is the single-layer form {@code X(v)}. The {@code TypeChecker}
      * verifies every opened layer is a newtype and that each name matches the layer it opens.
      */
-    record Case(List<Name> caseTypes, String binding, Expr body, List<Name> unwrapAsserts,
+    record Case(List<Name> caseTypes, Binder binding, Expr body, List<Name> unwrapAsserts,
                 SourcePos pos) implements Ast {
-        public Case(List<Name> caseTypes, String binding, Expr body, SourcePos pos) {
+        public Case(List<Name> caseTypes, Binder binding, Expr body, SourcePos pos) {
             this(caseTypes, binding, body, null, pos);
+        }
+
+        /** An arm as the parser read it; {@code binding} is null where the arm binds nothing. */
+        public static Case written(List<Name> caseTypes, String binding, Expr body,
+                                   List<Name> unwrapAsserts, SourcePos pos) {
+            return new Case(caseTypes, binding == null ? null : Binder.written(binding, pos), body,
+                    unwrapAsserts, pos);
+        }
+
+        /** How the binding was written, or null where the arm binds nothing. */
+        public String bindingName() {
+            return binding == null ? null : binding.name();
         }
     }
 
@@ -751,12 +933,11 @@ public interface Ast {
          * A read of something bound in the body, as a pass that put the binding there writes it.
          *
          * <p>A pass that runs after resolution says what it means rather than leaving a spelling for
-         * a reader to work out. The binder it gives is where this pass put the name, which is
-         * identity within the tree it built and nothing beyond it — an editor reads the resolved
-         * tree, where a binder is where the author wrote it.
+         * a reader to work out, so it is given the binder it is reading and answers with that
+         * binding. There is no way to write one of these without having the binding in hand.
          */
-        public static Var local(String name, SourcePos pos) {
-            return new Var(name, new ValueName.Local(name, pos), pos);
+        public static Var local(Binder binder, SourcePos pos) {
+            return new Var(binder.name(), new ValueName.Local(binder.name(), binder.id()), pos);
         }
 
         public Var denoting(ValueName resolved) {
@@ -817,7 +998,7 @@ public interface Ast {
             case If iff -> new If(f.apply(iff.cond()), f.apply(iff.then()), f.apply(iff.els()), iff.pos());
             case IfConstructed ic -> new IfConstructed(f.apply(ic.construct()), ic.binder(),
                     f.apply(ic.then()), mapArms(ic.els(), f), ic.pos());
-            case LetIn li -> new LetIn(li.name(), f.apply(li.value()), li.declaredType(), li.annotated(),
+            case LetIn li -> new LetIn(li.binder(), f.apply(li.value()), li.declaredType(), li.annotated(),
                     li.opens(), f.apply(li.body()), li.pos());
             case Block bl -> new Block(bl.params(), f.apply(bl.body()), bl.pos());
             case ListLit l -> new ListLit(mapExprs(l.elements(), f), l.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
@@ -19,12 +19,12 @@ public final class BinaryElaborator {
     private BinaryElaborator() {}
 
     /** Whether either side of {@code bin} has a type the compiler could not work out. */
-    private static boolean erroneousOperand(Ast.Binary bin, Map<String, Type> env,
+    private static boolean erroneousOperand(Ast.Binary bin, Scope env,
                                             CheckContext ctx) {
         return erroneous(bin.left(), env, ctx) || erroneous(bin.right(), env, ctx);
     }
 
-    private static boolean erroneous(Ast.Expr operand, Map<String, Type> env, CheckContext ctx) {
+    private static boolean erroneous(Ast.Expr operand, Scope env, CheckContext ctx) {
         try {
             return Elaborator.elaborate(operand, env, ctx).type() instanceof Type.Erroneous;
         } catch (CompileException _) {
@@ -32,7 +32,7 @@ public final class BinaryElaborator {
         }
     }
 
-    static Core elaborateBinary(Ast.Binary bin, Map<String, Type> env, CheckContext ctx) {
+    static Core elaborateBinary(Ast.Binary bin, Scope env, CheckContext ctx) {
         // An operator wants a particular shape of type — Int or Decimal to add, two lists or two
         // strings to append — and an operand the compiler could not work out has no shape. Absorbing
         // is for a comparison, which can answer "no disagreement"; there is no answer to give here, so

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -96,7 +96,7 @@ public final class CallElaborator {
          * reads its name and never asks for its type. */
         void untyped(int i) {
             Ast.Var name = (Ast.Var) args.get(i);
-            cores[i] = new Core.Var(name.name(), null, name.pos());
+            cores[i] = new Core.Builtin(name.name(), name.pos());
         }
 
         /** The elaborated arguments. Every argument must have been reached: a rule that yields a type

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -38,6 +38,14 @@ public final class CallElaborator {
                                       Type expected) {
         CallArgs ca = new CallArgs(call.args(), env, ctx);
         Type result = typeOfCall(ca, call, env, ctx, expected);
+        // applying something this body binds is a different operation from calling something
+        // declared elsewhere, and it is the only one that carries a binding into the emitted tree
+        if (call.denotes() instanceof ValueName.Local local
+                && env.get(call.fn()) instanceof Type.FnOf) {
+            return new Core.Apply(
+                    new Core.Read(call.fn(), local.id(), env.get(call.fn()), call.pos()),
+                    ca.cores(), result, call.pos());
+        }
         return new Core.Call(call.fn(), ca.cores(), result, call.pos());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -34,16 +34,16 @@ public final class CallElaborator {
                 List.of(TypeName.primitive(Type.show(head)), TypeName.runtime(errorCase)));
     }
 
-    static Core elaborateCall(Ast.Call call, Map<String, Type> env, CheckContext ctx,
+    static Core elaborateCall(Ast.Call call, Scope env, CheckContext ctx,
                                       Type expected) {
         CallArgs ca = new CallArgs(call.args(), env, ctx);
         Type result = typeOfCall(ca, call, env, ctx, expected);
         // applying something this body binds is a different operation from calling something
         // declared elsewhere, and it is the only one that carries a binding into the emitted tree
         if (call.denotes() instanceof ValueName.Local local
-                && env.get(call.fn()) instanceof Type.FnOf) {
+                && env.typeOf(local.id()) instanceof Type.FnOf) {
             return new Core.Apply(
-                    new Core.Read(call.fn(), local.id(), env.get(call.fn()), call.pos()),
+                    new Core.Read(call.fn(), local.id(), env.typeOf(local.id()), call.pos()),
                     ca.cores(), result, call.pos());
         }
         return new Core.Call(call.fn(), ca.cores(), result, call.pos());
@@ -58,10 +58,10 @@ public final class CallElaborator {
     static final class CallArgs {
         private final List<Ast.Expr> args;
         private final Core[] cores;
-        private final Map<String, Type> env;
+        private final Scope env;
         private final CheckContext ctx;
 
-        CallArgs(List<Ast.Expr> args, Map<String, Type> env, CheckContext ctx) {
+        CallArgs(List<Ast.Expr> args, Scope env, CheckContext ctx) {
             this.args = args;
             this.cores = new Core[args.size()];
             this.env = env;
@@ -190,7 +190,7 @@ public final class CallElaborator {
      * the library, then a function-typed binding, then an injected behavior — and a name that could
      * be read two ways was whichever came first.
      */
-    static Type typeOfCall(CallArgs ca, Ast.Call call, Map<String, Type> env, CheckContext ctx, Type expected) {
+    static Type typeOfCall(CallArgs ca, Ast.Call call, Scope env, CheckContext ctx, Type expected) {
         List<Ast.Expr> args = call.args();
         if (call.denotes() == null) {
             throw new IllegalStateException(
@@ -428,7 +428,9 @@ public final class CallElaborator {
                 // a function-typed value in scope (a helper's function parameter) applied to
                 // arguments — f(x) (spec §fn-declaration). A newtype construction 金額(500) never
                 // reaches here — NewtypeDesugar has lowered it to a NewData literal.
-                if (env.get(call.fn()) instanceof Type.FnOf fn) {
+                // a function value in force, or a recursive helper's signature: which of the two
+                // is the denotation's to say, and only one of them is bound here
+                if (env.of(call.denotes(), call.fn()) instanceof Type.FnOf fn) {
                     if (args.size() != fn.params().size()) {
                         throw CompileException.of(
                                 Diagnostic.of(null, "check.arity").title("check.arity.title")

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -620,11 +620,13 @@ public final class DataChecker {
                     "decoder for `" + ctx.data().name() + "` must construct `" + ctx.data().name()
                             + "`, but constructs `" + c.typeName().written() + "`");
         }
-        checkConstruction(c.typeName().written(), c.inits(), c.spreads(), c.pos(), fields, env, ctx);
+        // a decoder's construction gives every field a value of its own; nothing builds one with a
+        // spread, so there is no binding to copy from here
+        checkConstruction(c.typeName().written(), c.inits(), List.of(), c.pos(), fields, env, ctx);
     }
 
     static List<Core.FieldInit> checkConstruction(String typeName, List<Ast.FieldInit> inits,
-                                          List<String> spreads,
+                                          List<Core.Read> spreads,
                                           SourcePos pos, Map<String, Type> fields, Scope env,
                                           CheckContext ctx) {
         Map<String, Ast.FieldInit> byName = new HashMap<>();
@@ -667,8 +669,9 @@ public final class DataChecker {
         // of — all of them, because naming one of several would pick by position and send the author
         // to open a sum whose cases never had the field
         Set<String> fromSums = new LinkedHashSet<>();
-        for (String sp : spreads) {
-            Type bound = env.byName().get(sp);
+        for (Core.Read spread : spreads) {
+            String sp = spread.name();
+            Type bound = env.typeOf(spread.binding());
             if (bound instanceof Type.Ref ref
                     && ctx.symbols().get(ref.name()) instanceof Ast.SumData sum) {
                 fromSums.add(Type.show(bound));

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -6,6 +6,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -550,8 +551,7 @@ public final class DataChecker {
             // A total recursive helper — the stdlib fold behind the list quantifiers, or a user helper
             // proven total — is callable from an invariant, so its signature must be in scope here. A
             // field of the same name as a helper wins: a bare name in an invariant is a field reference.
-            Map<String, Type> invEnv = new HashMap<>(recursiveHelperFns);
-            invEnv.putAll(fields);
+            Scope invEnv = fieldScope(ctx).reaching(recursiveHelperFns);
             Type t = Elaborator.typeOf(clause.expr(), invEnv, ctx);
             if (t != Type.BOOL) {
                 throw CompileException.of(
@@ -566,29 +566,37 @@ public final class DataChecker {
         ctx.data().encoder().ifPresent(enc -> checkEncoder(enc, ctx));
     }
 
+    /** The bindings a declaration's own invariant reads: its fields, each as the binding it is. */
+    private static Scope fieldScope(CheckContext ctx) {
+        Map<String, Type> types = TypeOps.fieldTypes(ctx.data(), ctx.symbols());
+        Map<BindingId, Scope.Binding> bindings = new LinkedHashMap<>();
+        TypeOps.fieldBindings(ctx.data(), ctx.symbols()).forEach((name, binding) ->
+                bindings.put(binding, new Scope.Binding(name, types.get(name))));
+        return Scope.of(bindings);
+    }
+
     private static void checkDecoder(Ast.DecoderDef dec, CheckContext ctx, Map<String, Type> fields) {
         switch (dec) {
             case Ast.PrimDecoder prim -> {
                 Type inputType = TypeOps.primType(prim.from());
-                Map<String, Type> env = new HashMap<>();
-                env.put(prim.inputName(), inputType);
+                Scope env = Scope.NONE.with(prim.input(), inputType);
                 for (Ast.DecStmt stmt : prim.stmts()) {
                     switch (stmt) {
-                        case Ast.Let let -> env.put(let.name(), Elaborator.typeOf(let.value(), env, ctx));
+                        case Ast.Let let ->
+                                env = env.with(let.binder(), Elaborator.typeOf(let.value(), env, ctx));
                     }
                 }
                 checkConstruct(prim.result(), ctx, fields, env);
             }
             case Ast.ObjectDecoder obj -> {
-                Map<String, Type> env = new HashMap<>();
+                Scope env = Scope.NONE;
                 for (Ast.Bind bind : obj.binds()) {
-                    env.put(bind.name(), decRefType(bind.ref(), ctx.symbols()));
+                    env = env.with(bind.binder(), decRefType(bind.ref(), ctx.symbols()));
                 }
                 checkConstruct(obj.result(), ctx, fields, env);
             }
             case Ast.NewtypeDecoder nt -> {
-                Map<String, Type> env = new HashMap<>();
-                env.put(nt.inputName(), decRefType(nt.inner(), ctx.symbols()));
+                Scope env = Scope.NONE.with(nt.input(), decRefType(nt.inner(), ctx.symbols()));
                 checkConstruct(nt.result(), ctx, fields, env);
             }
         }
@@ -619,7 +627,7 @@ public final class DataChecker {
     }
 
     private static void checkConstruct(Ast.Construct c, CheckContext ctx, Map<String, Type> fields,
-                                       Map<String, Type> env) {
+                                       Scope env) {
         if (!c.typeName().denotes().equals(ctx.symbols().own(ctx.data().name()))) {
             throw CompileException.of(
                     Diagnostic.of(null, "check.codec.mustconstruct").title("check.codec.title")
@@ -632,7 +640,7 @@ public final class DataChecker {
 
     static List<Core.FieldInit> checkConstruction(String typeName, List<Ast.FieldInit> inits,
                                           List<String> spreads,
-                                          SourcePos pos, Map<String, Type> fields, Map<String, Type> env,
+                                          SourcePos pos, Map<String, Type> fields, Scope env,
                                           CheckContext ctx) {
         Map<String, Ast.FieldInit> byName = new HashMap<>();
         List<Core.FieldInit> elaborated = new ArrayList<>();
@@ -675,7 +683,7 @@ public final class DataChecker {
         // to open a sum whose cases never had the field
         Set<String> fromSums = new LinkedHashSet<>();
         for (String sp : spreads) {
-            Type bound = env.get(sp);
+            Type bound = env.byName().get(sp);
             if (bound instanceof Type.Ref ref
                     && ctx.symbols().get(ref.name()) instanceof Ast.SumData sum) {
                 fromSums.add(Type.show(bound));
@@ -743,11 +751,11 @@ public final class DataChecker {
     }
 
     private static void checkEncoder(Ast.EncoderDef enc, CheckContext ctx) {
-        Map<String, Type> env = Map.of(enc.selfName(), Type.ref(ctx.symbols().own(ctx.data().name())));
+        Scope env = Scope.NONE.with(enc.self(), Type.ref(ctx.symbols().own(ctx.data().name())));
         checkRawExpr(enc.result(), env, ctx);
     }
 
-    private static void checkRawExpr(Ast.RawExpr raw, Map<String, Type> env, CheckContext ctx) {
+    private static void checkRawExpr(Ast.RawExpr raw, Scope env, CheckContext ctx) {
         switch (raw) {
             case Ast.TextRaw t -> Elaborator.requireType(t.arg(), Type.STRING, env, ctx,
                     "argument of Text");
@@ -774,9 +782,7 @@ public final class DataChecker {
                                     .at(o.pos()).args(Type.show(at)).build(),
                             "optional encoder expects an Option, got " + at);
                 }
-                Map<String, Type> inner = new HashMap<>(env);
-                inner.put(o.elemVar(), oo.element());
-                checkRawExpr(o.inner(), inner, ctx);
+                checkRawExpr(o.inner(), env.with(o.elem(), oo.element()), ctx);
             }
             case Ast.ObjectRaw o -> {
                 for (Ast.RawEntry entry : o.entries()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -211,7 +211,7 @@ public final class DataChecker {
                 for (Ast.Case c : m.cases()) {
                     Set<String> inner = new HashSet<>(bound);
                     if (c.binding() != null) {
-                        inner.add(c.binding());
+                        inner.add(c.bindingName());
                     }
                     collectConstructs(c.body(), out, symbols, inner, recConstructs);
                 }
@@ -226,7 +226,7 @@ public final class DataChecker {
             case Ast.IfConstructed ic -> {
                 collectConstructs(ic.construct(), out, symbols, bound, recConstructs);
                 Set<String> inner = new HashSet<>(bound);
-                inner.add(ic.binder());
+                inner.add(ic.binderName());
                 collectConstructs(ic.then(), out, symbols, inner, recConstructs);
                 ic.els().forEach(arm ->
                         collectConstructs(arm.body(), out, symbols, bound, recConstructs));
@@ -239,7 +239,7 @@ public final class DataChecker {
             case Ast.Block block -> {
                 // a block builds under the enclosing behavior's permission (spec 12.5)
                 Set<String> inner = new HashSet<>(bound);
-                inner.addAll(block.params());
+                inner.addAll(block.paramNames());
                 collectConstructs(block.body(), out, symbols, inner, recConstructs);
             }
             // a bare name that denotes a unit data is that unit's construction (spec 8.4). Read off

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -146,10 +146,9 @@ public final class DataChecker {
      * Without it, a parameter named after a unit data was read as constructing that unit.
      */
     static void collectConstructs(Ast.Expr e, Map<TypeName, String> out, Symbols symbols,
-                                  Set<String> bound,
                                   Map<String, Constructs> recConstructs) {
         Constructs all = Constructs.empty();
-        collectConstructs(e, all, symbols, bound, recConstructs);
+        collectConstructs(e, all, symbols, recConstructs);
         out.putAll(all.originated());
     }
 
@@ -159,14 +158,11 @@ public final class DataChecker {
     }
 
     static void collectConstructs(Ast.Expr e, Constructs out, Symbols symbols,
-                                          Set<String> bound,
                                           Map<String, Constructs> recConstructs) {
         switch (e) {
             case Ast.LetIn li -> {
-                collectConstructs(li.value(), out, symbols, bound, recConstructs);
-                Set<String> inner = new HashSet<>(bound);
-                inner.add(li.name());
-                collectConstructs(li.body(), out, symbols, inner, recConstructs);
+                collectConstructs(li.value(), out, symbols, recConstructs);
+                collectConstructs(li.body(), out, symbols, recConstructs);
             }
             case Ast.NewData nd -> {
                 // A construction this body was handed is not this body's. It is handed one two ways.
@@ -182,12 +178,12 @@ public final class DataChecker {
                         ? out.carried() : out.originated();
                 side.putIfAbsent(nd.typeName().denotes(), nd.typeName().written());
                 for (Ast.FieldInit init : nd.inits()) {
-                    collectConstructs(init.value(), out, symbols, bound, recConstructs);
+                    collectConstructs(init.value(), out, symbols, recConstructs);
                 }
             }
-            case Ast.FieldAccess fa -> collectConstructs(fa.target(), out, symbols, bound, recConstructs);
-            case Ast.Tuple tup -> tup.elements().forEach(el -> collectConstructs(el, out, symbols, bound, recConstructs));
-            case Ast.TupleGet tg -> collectConstructs(tg.tuple(), out, symbols, bound, recConstructs);
+            case Ast.FieldAccess fa -> collectConstructs(fa.target(), out, symbols, recConstructs);
+            case Ast.Tuple tup -> tup.elements().forEach(el -> collectConstructs(el, out, symbols, recConstructs));
+            case Ast.TupleGet tg -> collectConstructs(tg.tuple(), out, symbols, recConstructs);
             case Ast.Call call -> {
                 // a recursive helper is not inlined, so its own (transitive) constructions are
                 // attributed to the behavior that calls it, exactly as an inlined helper's would be —
@@ -200,56 +196,45 @@ public final class DataChecker {
                 if (viaHelper != null) {
                     out.absorb(call.origin().viaValueReference() ? viaHelper.allCarried() : viaHelper);
                 }
-                call.args().forEach(a -> collectConstructs(a, out, symbols, bound, recConstructs));
+                call.args().forEach(a -> collectConstructs(a, out, symbols, recConstructs));
             }
             case Ast.Binary bin -> {
-                collectConstructs(bin.left(), out, symbols, bound, recConstructs);
-                collectConstructs(bin.right(), out, symbols, bound, recConstructs);
+                collectConstructs(bin.left(), out, symbols, recConstructs);
+                collectConstructs(bin.right(), out, symbols, recConstructs);
             }
-            case Ast.Neg neg -> collectConstructs(neg.operand(), out, symbols, bound, recConstructs);
+            case Ast.Neg neg -> collectConstructs(neg.operand(), out, symbols, recConstructs);
             case Ast.Match m -> {
-                collectConstructs(m.scrutinee(), out, symbols, bound, recConstructs);
+                collectConstructs(m.scrutinee(), out, symbols, recConstructs);
                 for (Ast.Case c : m.cases()) {
-                    Set<String> inner = new HashSet<>(bound);
-                    if (c.binding() != null) {
-                        inner.add(c.bindingName());
-                    }
-                    collectConstructs(c.body(), out, symbols, inner, recConstructs);
+                    collectConstructs(c.body(), out, symbols, recConstructs);
                 }
             }
             case Ast.If iff -> {
-                collectConstructs(iff.cond(), out, symbols, bound, recConstructs);
-                collectConstructs(iff.then(), out, symbols, bound, recConstructs);
-                collectConstructs(iff.els(), out, symbols, bound, recConstructs);
+                collectConstructs(iff.cond(), out, symbols, recConstructs);
+                collectConstructs(iff.then(), out, symbols, recConstructs);
+                collectConstructs(iff.els(), out, symbols, recConstructs);
             }
             // an attempt builds the value on its success branch, so it needs the same permission a
             // plain construction does — what it does not do is abort when it fails
             case Ast.IfConstructed ic -> {
-                collectConstructs(ic.construct(), out, symbols, bound, recConstructs);
-                Set<String> inner = new HashSet<>(bound);
-                inner.add(ic.binderName());
-                collectConstructs(ic.then(), out, symbols, inner, recConstructs);
+                collectConstructs(ic.construct(), out, symbols, recConstructs);
+                collectConstructs(ic.then(), out, symbols, recConstructs);
                 ic.els().forEach(arm ->
-                        collectConstructs(arm.body(), out, symbols, bound, recConstructs));
+                        collectConstructs(arm.body(), out, symbols, recConstructs));
             }
-            case Ast.ListLit lit -> lit.elements().forEach(el -> collectConstructs(el, out, symbols, bound, recConstructs));
+            case Ast.ListLit lit -> lit.elements().forEach(el -> collectConstructs(el, out, symbols, recConstructs));
             case Ast.ListComp comp -> {
-                collectConstructs(comp.element(), out, symbols, bound, recConstructs);
-                comp.guards().forEach(g -> collectConstructs(g, out, symbols, bound, recConstructs));
+                collectConstructs(comp.element(), out, symbols, recConstructs);
+                comp.guards().forEach(g -> collectConstructs(g, out, symbols, recConstructs));
             }
-            case Ast.Block block -> {
-                // a block builds under the enclosing behavior's permission (spec 12.5)
-                Set<String> inner = new HashSet<>(bound);
-                inner.addAll(block.paramNames());
-                collectConstructs(block.body(), out, symbols, inner, recConstructs);
-            }
+            // a block builds under the enclosing behavior's permission (spec 12.5)
+            case Ast.Block block -> collectConstructs(block.body(), out, symbols, recConstructs);
             // a bare name that denotes a unit data is that unit's construction (spec 8.4). Read off
             // what the name denotes rather than resolved again from its spelling: a reader with a
             // unit data spelled like the one another module's published body builds was recording
             // its own type as the one built. Carried or not is asked of the name for the same reason
             // it is asked of a construction node — it is the same question about the same thing.
-            case Ast.Var v when !bound.contains(v.name())
-                    && v.denotes() instanceof ValueName.OfType named
+            case Ast.Var v when v.denotes() instanceof ValueName.OfType named
                     && symbols.get(named.type()) instanceof Ast.UnitData -> {
                 Map<TypeName, String> side = named.origin().carried(named.type())
                         ? out.carried() : out.originated();

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -6,6 +6,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -167,7 +168,7 @@ public final class Elaborator {
                     if (annotation != null) {
                         throw functionAnnotation(li);   // an ordinary type does not describe a function
                     }
-                    List<Type> paramTypes = inferFnParamTypes(li.name(), li.body(), env, ctx);
+                    List<Type> paramTypes = inferFnParamTypes(li.binder(), li.body(), env, ctx);
                     value = elaborateFunctionValue(li.value(), paramTypes, env, ctx);
                     bindType = value.type();
                 } else if (annotation != null) {
@@ -239,17 +240,15 @@ public final class Elaborator {
                 // by here every spread names a binding in force: a value spread was bound ahead of
                 // the construction when it was inlined, so Core reads the binding it copies from
                 List<Core.Read> spreads = new ArrayList<>();
-                List<String> spreadNames = new ArrayList<>();
                 for (Ast.ValueRef s : nd.spreads()) {
                     if (!(s.denotes() instanceof ValueName.Local local)) {
                         throw new IllegalStateException("`" + s.written()
                                 + "` is spread but names no binding, at " + s.pos());
                     }
                     spreads.add(new Core.Read(s.bare(), local.id(), env.typeOf(local.id()), s.pos()));
-                    spreadNames.add(s.bare());
                 }
                 List<Core.FieldInit> inits = DataChecker.checkConstruction(built.written(), nd.inits(),
-                        spreadNames, nd.pos(), TypeOps.fieldTypes(owner, ctx.symbols()), env, ctx);
+                        spreads, nd.pos(), TypeOps.fieldTypes(owner, ctx.symbols()), env, ctx);
                 yield new Core.NewData(built.denotes(), inits, spreads,
                         Type.ref(built.denotes()), nd.pos());
             }
@@ -682,26 +681,27 @@ public final class Elaborator {
     /** Infers a let-bound function's parameter types from how the body applies it: every
      * {@code f(args)} in the body must agree on the argument types (spec §blocks). A function that
      * is never applied cannot have its type inferred. */
-    static List<Type> inferFnParamTypes(String name, Ast.Expr body, Scope env,
+    static List<Type> inferFnParamTypes(Ast.Binder binder, Ast.Expr body, Scope env,
                                                 CheckContext ctx) {
         List<List<Type>> uses = new ArrayList<>();
-        collectApplications(name, body, env, ctx, uses, Set.of());
+        collectApplications(binder, body, env, ctx, uses, Set.of());
         if (uses.isEmpty()) {
             throw CompileException.of(
                     Diagnostic.of(null, "check.fn.noinfer").title("check.fn.title")
-                            .at(body.pos()).args(name).build(),
-                    "cannot infer the type of the function `" + name + "`: write its type (`let "
-                            + name + ": (Int) -> Bool = ...`), or apply it in this scope so the"
-                            + " parameter types can be read off the application");
+                            .at(body.pos()).args(binder.name()).build(),
+                    "cannot infer the type of the function `" + binder.name() + "`: write its type"
+                            + " (`let " + binder.name() + ": (Int) -> Bool = ...`), or apply it in"
+                            + " this scope so the parameter types can be read off the application");
         }
         List<Type> first = uses.get(0);
         for (List<Type> u : uses) {
             if (!u.equals(first)) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.fn.difftypes").title("check.fn.title")
-                                .at(body.pos()).args(name, first.toString(), u.toString()).build(),
-                        "the function `" + name + "` is applied with different argument types: "
-                                + first + " vs " + u);
+                                .at(body.pos()).args(binder.name(), first.toString(), u.toString())
+                                .build(),
+                        "the function `" + binder.name() + "` is applied with different argument"
+                                + " types: " + first + " vs " + u);
             }
         }
         return first;
@@ -721,10 +721,11 @@ public final class Elaborator {
      * <p>Every other application is typed against {@code env}, so a mistake inside its arguments is
      * still reported as the mistake it is.
      */
-    static void collectApplications(String name, Ast.Expr e, Scope env,
+    static void collectApplications(Ast.Binder binder, Ast.Expr e, Scope env,
                                             CheckContext ctx, List<List<Type>> out,
-                                            Set<String> inner) {
-        if (e instanceof Ast.Call call && call.fn().equals(name)
+                                            Set<BindingId> inner) {
+        if (e instanceof Ast.Call call && call.denotes() instanceof ValueName.Local applied
+                && applied.id().equals(binder.id())
                 && call.args().stream().noneMatch(a -> reaches(a, inner))) {
             List<Type> argTypes = new ArrayList<>();
             for (Ast.Expr a : call.args()) {
@@ -733,73 +734,71 @@ public final class Elaborator {
             out.add(argTypes);
         }
         switch (e) {
-            case Ast.Block b -> collectApplications(name, b.body(), env, ctx, out,
-                    with(inner, b.paramNames()));
+            case Ast.Block b -> collectApplications(binder, b.body(), env, ctx, out,
+                    with(inner, b.params()));
             case Ast.LetIn li -> {
-                collectApplications(name, li.value(), env, ctx, out, inner);
-                collectApplications(name, li.body(), env, ctx, out, with(inner, List.of(li.name())));
+                collectApplications(binder, li.value(), env, ctx, out, inner);
+                collectApplications(binder, li.body(), env, ctx, out, with(inner, List.of(li.binder())));
             }
             case Ast.IfConstructed ic -> {
-                collectApplications(name, ic.construct(), env, ctx, out, inner);
-                collectApplications(name, ic.then(), env, ctx, out,
-                        with(inner, List.of(ic.binderName())));
+                collectApplications(binder, ic.construct(), env, ctx, out, inner);
+                collectApplications(binder, ic.then(), env, ctx, out,
+                        with(inner, List.of(ic.binder())));
                 for (Ast.ElseArm arm : ic.els()) {
-                    collectApplications(name, arm.body(), env, ctx, out, inner);
+                    collectApplications(binder, arm.body(), env, ctx, out, inner);
                 }
             }
             case Ast.Match m -> {
-                collectApplications(name, m.scrutinee(), env, ctx, out, inner);
+                collectApplications(binder, m.scrutinee(), env, ctx, out, inner);
                 for (Ast.Case c : m.cases()) {
-                    collectApplications(name, c.body(), env, ctx, out,
-                            c.binding() == null ? inner : with(inner, List.of(c.bindingName())));
+                    collectApplications(binder, c.body(), env, ctx, out,
+                            c.binding() == null ? inner : with(inner, List.of(c.binding())));
                 }
             }
             default -> TypeChecker.forEachChild(e,
-                    sub -> collectApplications(name, sub, env, ctx, out, inner));
+                    sub -> collectApplications(binder, sub, env, ctx, out, inner));
         }
     }
 
-    private static Set<String> with(Set<String> names, List<String> added) {
+    /** {@code bindings} with what {@code added} introduces. */
+    private static Set<BindingId> with(Set<BindingId> bindings, List<Ast.Binder> added) {
         if (added.isEmpty()) {
-            return names;
+            return bindings;
         }
-        Set<String> out = new HashSet<>(names);
-        out.addAll(added);
+        Set<BindingId> out = new HashSet<>(bindings);
+        added.forEach(binder -> out.add(binder.id()));
         return out;
     }
 
     /**
-     * Whether {@code e} reads a name a binder below the inference point introduced — that is, whether
-     * its <em>free</em> variables meet {@code inner}. A binder inside {@code e} takes its own name off
-     * the set for what it covers, so a name rebound there is that binding's and not the outer one's:
-     * {@code f(match m with | Some y -> y | None -> 0)} does not read an enclosing {@code y}, and
-     * whether the case happens to spell its binding {@code y} or {@code z} decides nothing.
+     * Whether {@code e} reads a binding a binder below the inference point introduced. A binder
+     * inside {@code e} introduces another binding, so nothing has to be taken off the set for what it
+     * covers: how either happens to be spelled decides nothing.
      */
-    private static boolean reaches(Ast.Expr e, Set<String> inner) {
+    private static boolean reaches(Ast.Expr e, Set<BindingId> inner) {
         if (inner.isEmpty()) {
             return false;
         }
-        if (e instanceof Ast.Var v && inner.contains(v.name())) {
-            return true;
-        }
-        if (e instanceof Ast.Call c && inner.contains(c.fn())) {
+        ValueName denotes = switch (e) {
+            case Ast.Var v -> v.denotes();
+            case Ast.Call c -> c.denotes();
+            default -> null;
+        };
+        if (denotes instanceof ValueName.Local local && inner.contains(local.id())) {
             return true;
         }
         return switch (e) {
-            case Ast.Block b -> reaches(b.body(), without(inner, b.paramNames()));
-            case Ast.LetIn li -> reaches(li.value(), inner)
-                    || reaches(li.body(), without(inner, List.of(li.name())));
+            case Ast.Block b -> reaches(b.body(), inner);
+            case Ast.LetIn li -> reaches(li.value(), inner) || reaches(li.body(), inner);
             case Ast.IfConstructed ic -> reaches(ic.construct(), inner)
-                    || reaches(ic.then(), without(inner, List.of(ic.binderName())))
+                    || reaches(ic.then(), inner)
                     || ic.els().stream().anyMatch(arm -> reaches(arm.body(), inner));
             case Ast.Match m -> {
                 if (reaches(m.scrutinee(), inner)) {
                     yield true;
                 }
                 for (Ast.Case c : m.cases()) {
-                    Set<String> arm = c.binding() == null
-                            ? inner : without(inner, List.of(c.bindingName()));
-                    if (reaches(c.body(), arm)) {
+                    if (reaches(c.body(), inner)) {
                         yield true;
                     }
                 }
@@ -813,14 +812,7 @@ public final class Elaborator {
         };
     }
 
-    private static Set<String> without(Set<String> names, List<String> removed) {
-        if (names.isEmpty() || removed.isEmpty()) {
-            return names;
-        }
-        Set<String> out = new HashSet<>(names);
-        out.removeAll(removed);
-        return out;
-    }
+
 
     /**
      * Types a function value against inferred parameter types: a lambda binds its parameters and

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -238,13 +238,19 @@ public final class Elaborator {
                             "cannot construct `" + built.written() + "`");
                 }
                 // by here every spread names a binding in force: a value spread was bound ahead of
-                // the construction when it was inlined, so Core reads the name it copies
-                List<String> spreads = new ArrayList<>();
+                // the construction when it was inlined, so Core reads the binding it copies from
+                List<Core.Read> spreads = new ArrayList<>();
+                List<String> spreadNames = new ArrayList<>();
                 for (Ast.ValueRef s : nd.spreads()) {
-                    spreads.add(s.bare());
+                    if (!(s.denotes() instanceof ValueName.Local local)) {
+                        throw new IllegalStateException("`" + s.written()
+                                + "` is spread but names no binding, at " + s.pos());
+                    }
+                    spreads.add(new Core.Read(s.bare(), local.id(), env.get(s.bare()), s.pos()));
+                    spreadNames.add(s.bare());
                 }
                 List<Core.FieldInit> inits = DataChecker.checkConstruction(built.written(), nd.inits(),
-                        spreads, nd.pos(), TypeOps.fieldTypes(owner, ctx.symbols()), env, ctx);
+                        spreadNames, nd.pos(), TypeOps.fieldTypes(owner, ctx.symbols()), env, ctx);
                 yield new Core.NewData(built.denotes(), inits, spreads,
                         Type.ref(built.denotes()), nd.pos());
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -187,7 +187,7 @@ public final class Elaborator {
                 Map<String, Type> inner = new HashMap<>(env);
                 inner.put(li.name(), bindType);
                 Core body = elaborate(li.body(), inner, ctx, expected);
-                yield new Core.LetIn(li.name(), value, body, body.type(), li.pos());
+                yield new Core.LetIn(li.binder(), value, body, body.type(), li.pos());
             }
             // reached only where a block escapes: it may be passed as an argument, or bound to a
             // `let` and applied, but it is not a value that can be returned or stored, because that
@@ -209,11 +209,11 @@ public final class Elaborator {
                         "`" + v.name() + "` reached the check unresolved, at " + v.pos());
                 // A binding with no type here is not a naming question: an inference probe types a
                 // body before the binding it asks about has one, and reads the report to find out.
-                case ValueName.Local _ when env.get(v.name()) != null ->
-                        new Core.Var(v.name(), env.get(v.name()), v.pos());
+                case ValueName.Local local when env.get(v.name()) != null ->
+                        new Core.Read(v.name(), local.id(), env.get(v.name()), v.pos());
                 case ValueName.OfType named
                         when ctx.symbols().get(named.type()) instanceof Ast.UnitData ->
-                        new Core.Var(v.name(), Type.ref(named.type()), v.pos());
+                        new Core.UnitValue(named.type(), Type.ref(named.type()), v.pos());
                 // `None` where a `?` field is being given a value: the empty optional (spec 7.3).
                 // What puts it here is the field, which the context says (ADR-0011) — not the expected
                 // type, since a model may name `Option<T>` where it reads one and an expectation would
@@ -331,7 +331,7 @@ public final class Elaborator {
                     }
                     joined = next;
                 }
-                yield new Core.IfConstructed(construct, ic.binderName(), then, arms, joined, ic.pos());
+                yield new Core.IfConstructed(construct, ic.binder(), then, arms, joined, ic.pos());
             }
             case Ast.ListLit lit -> {
                 if (lit.elements().isEmpty()) {
@@ -537,7 +537,7 @@ public final class Elaborator {
             inner.put(block.params().get(i).name(), paramTypes.get(i));
         }
         Core body = elaborate(block.body(), inner, ctx);
-        return new Core.Block(block.paramNames(), body, Type.fn(paramTypes, body.type()), block.pos());
+        return new Core.Block(block.params(), body, Type.fn(paramTypes, body.type()), block.pos());
     }
 
     /** Whether an expression bound to a {@code let} is a function value: a lambda, or an {@code if}
@@ -846,7 +846,7 @@ public final class Elaborator {
                     inner.put(b.params().get(i).name(), paramTypes.get(i));
                 }
                 Core body = elaborate(b.body(), inner, ctx);
-                yield new Core.Block(b.paramNames(), body, Type.fn(paramTypes, body.type()), b.pos());
+                yield new Core.Block(b.params(), body, Type.fn(paramTypes, body.type()), b.pos());
             }
             case Ast.If iff -> {
                 Core cond = requireTyped(iff.cond(), Type.BOOL, env, ctx, "if condition");
@@ -868,7 +868,7 @@ public final class Elaborator {
                 Map<String, Type> inner = new HashMap<>(env);
                 inner.put(li.name(), bound.type());
                 Core body = elaborateFunctionValue(li.body(), paramTypes, inner, ctx);
-                yield new Core.LetIn(li.name(), bound, body, body.type(), li.pos());
+                yield new Core.LetIn(li.binder(), bound, body, body.type(), li.pos());
             }
             default -> elaborate(value, env, ctx);
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -306,7 +306,7 @@ public final class Elaborator {
                 // The binder names the built value, so the success branch reads it at the data's own
                 // type — with the invariant established, which is why the discharge check may seed it.
                 Map<String, Type> inner = new HashMap<>(env);
-                inner.put(ic.binder(), construct.type());
+                inner.put(ic.binderName(), construct.type());
                 Core then = liftIntoOption(elaborate(ic.then(), inner, ctx, expected), expected,
                         ctx.symbols());
                 List<Core.ElseArm> arms = new ArrayList<>();
@@ -331,7 +331,7 @@ public final class Elaborator {
                     }
                     joined = next;
                 }
-                yield new Core.IfConstructed(construct, ic.binder(), then, arms, joined, ic.pos());
+                yield new Core.IfConstructed(construct, ic.binderName(), then, arms, joined, ic.pos());
             }
             case Ast.ListLit lit -> {
                 if (lit.elements().isEmpty()) {
@@ -534,10 +534,10 @@ public final class Elaborator {
         }
         Map<String, Type> inner = new HashMap<>(env);
         for (int i = 0; i < paramTypes.size(); i++) {
-            inner.put(block.params().get(i), paramTypes.get(i));
+            inner.put(block.params().get(i).name(), paramTypes.get(i));
         }
         Core body = elaborate(block.body(), inner, ctx);
-        return new Core.Block(block.params(), body, Type.fn(paramTypes, body.type()), block.pos());
+        return new Core.Block(block.paramNames(), body, Type.fn(paramTypes, body.type()), block.pos());
     }
 
     /** Whether an expression bound to a {@code let} is a function value: a lambda, or an {@code if}
@@ -730,7 +730,7 @@ public final class Elaborator {
         }
         switch (e) {
             case Ast.Block b -> collectApplications(name, b.body(), env, ctx, out,
-                    with(inner, b.params()));
+                    with(inner, b.paramNames()));
             case Ast.LetIn li -> {
                 collectApplications(name, li.value(), env, ctx, out, inner);
                 collectApplications(name, li.body(), env, ctx, out, with(inner, List.of(li.name())));
@@ -738,7 +738,7 @@ public final class Elaborator {
             case Ast.IfConstructed ic -> {
                 collectApplications(name, ic.construct(), env, ctx, out, inner);
                 collectApplications(name, ic.then(), env, ctx, out,
-                        with(inner, List.of(ic.binder())));
+                        with(inner, List.of(ic.binderName())));
                 for (Ast.ElseArm arm : ic.els()) {
                     collectApplications(name, arm.body(), env, ctx, out, inner);
                 }
@@ -747,7 +747,7 @@ public final class Elaborator {
                 collectApplications(name, m.scrutinee(), env, ctx, out, inner);
                 for (Ast.Case c : m.cases()) {
                     collectApplications(name, c.body(), env, ctx, out,
-                            c.binding() == null ? inner : with(inner, List.of(c.binding())));
+                            c.binding() == null ? inner : with(inner, List.of(c.bindingName())));
                 }
             }
             default -> TypeChecker.forEachChild(e,
@@ -782,11 +782,11 @@ public final class Elaborator {
             return true;
         }
         return switch (e) {
-            case Ast.Block b -> reaches(b.body(), without(inner, b.params()));
+            case Ast.Block b -> reaches(b.body(), without(inner, b.paramNames()));
             case Ast.LetIn li -> reaches(li.value(), inner)
                     || reaches(li.body(), without(inner, List.of(li.name())));
             case Ast.IfConstructed ic -> reaches(ic.construct(), inner)
-                    || reaches(ic.then(), without(inner, List.of(ic.binder())))
+                    || reaches(ic.then(), without(inner, List.of(ic.binderName())))
                     || ic.els().stream().anyMatch(arm -> reaches(arm.body(), inner));
             case Ast.Match m -> {
                 if (reaches(m.scrutinee(), inner)) {
@@ -794,7 +794,7 @@ public final class Elaborator {
                 }
                 for (Ast.Case c : m.cases()) {
                     Set<String> arm = c.binding() == null
-                            ? inner : without(inner, List.of(c.binding()));
+                            ? inner : without(inner, List.of(c.bindingName()));
                     if (reaches(c.body(), arm)) {
                         yield true;
                     }
@@ -843,10 +843,10 @@ public final class Elaborator {
                 }
                 Map<String, Type> inner = new HashMap<>(env);
                 for (int i = 0; i < paramTypes.size(); i++) {
-                    inner.put(b.params().get(i), paramTypes.get(i));
+                    inner.put(b.params().get(i).name(), paramTypes.get(i));
                 }
                 Core body = elaborate(b.body(), inner, ctx);
-                yield new Core.Block(b.params(), body, Type.fn(paramTypes, body.type()), b.pos());
+                yield new Core.Block(b.paramNames(), body, Type.fn(paramTypes, body.type()), b.pos());
             }
             case Ast.If iff -> {
                 Core cond = requireTyped(iff.cond(), Type.BOOL, env, ctx, "if condition");
@@ -909,7 +909,7 @@ public final class Elaborator {
                 rejectBuiltinShadowing(li.body());
             }
             case Ast.Block b -> {
-                for (String p : b.params()) {
+                for (String p : b.paramNames()) {
                     rejectBuiltinShadow(p, b.pos());
                 }
                 rejectBuiltinShadowing(b.body());
@@ -918,7 +918,7 @@ public final class Elaborator {
                 rejectBuiltinShadowing(m.scrutinee());
                 for (Ast.Case c : m.cases()) {
                     if (c.binding() != null) {
-                        rejectBuiltinShadow(c.binding(), c.pos());
+                        rejectBuiltinShadow(c.bindingName(), c.pos());
                     }
                     rejectBuiltinShadowing(c.body());
                 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -36,17 +36,17 @@ public final class Elaborator {
     static final Map<String, ReqSig> NO_REQS = Map.of();
 
 
-    public static Type typeOf(Ast.Expr e, Map<String, Type> env, CheckContext ctx) {
+    public static Type typeOf(Ast.Expr e, Scope env, CheckContext ctx) {
         return typeOf(e, env, ctx, null);
     }
 
     /** The type of {@code e}, discarding the Core the elaboration produced — for the checks that ask
      * only whether an expression types (a decoder, an invariant, a helper's standalone check). */
-    public static Type typeOf(Ast.Expr e, Map<String, Type> env, CheckContext ctx, Type expected) {
+    public static Type typeOf(Ast.Expr e, Scope env, CheckContext ctx, Type expected) {
         return elaborate(e, env, ctx, expected).type();
     }
 
-    public static Core elaborate(Ast.Expr e, Map<String, Type> env, CheckContext ctx) {
+    public static Core elaborate(Ast.Expr e, Scope env, CheckContext ctx) {
         return elaborate(e, env, ctx, null);
     }
 
@@ -61,7 +61,7 @@ public final class Elaborator {
      * and a generic call pre-binds its result-type variables from it, so a fold whose seed is an
      * empty collection has its accumulator pinned by context before the step is checked.
      */
-    public static Core elaborate(Ast.Expr e, Map<String, Type> env, CheckContext ctx, Type expected) {
+    public static Core elaborate(Ast.Expr e, Scope env, CheckContext ctx, Type expected) {
         return equatableCollections(elaborating(e, env, ctx, expected), ctx);
     }
 
@@ -88,7 +88,7 @@ public final class Elaborator {
                         + ", and a function has no value to compare");
     }
 
-    private static Core elaborating(Ast.Expr e, Map<String, Type> env, CheckContext ctx,
+    private static Core elaborating(Ast.Expr e, Scope env, CheckContext ctx,
                                     Type expected) {
         return switch (e) {
             case Ast.IntLit x -> new Core.Int(x.value(), Type.INT, x.pos());
@@ -184,8 +184,7 @@ public final class Elaborator {
                     checkOpens(li, bindType, ctx.symbols());
                 }
                 // the binding is visible only inside the body, so a sibling branch cannot see it
-                Map<String, Type> inner = new HashMap<>(env);
-                inner.put(li.name(), bindType);
+                Scope inner = env.with(li.binder(), bindType);
                 Core body = elaborate(li.body(), inner, ctx, expected);
                 yield new Core.LetIn(li.binder(), value, body, body.type(), li.pos());
             }
@@ -209,8 +208,8 @@ public final class Elaborator {
                         "`" + v.name() + "` reached the check unresolved, at " + v.pos());
                 // A binding with no type here is not a naming question: an inference probe types a
                 // body before the binding it asks about has one, and reads the report to find out.
-                case ValueName.Local local when env.get(v.name()) != null ->
-                        new Core.Read(v.name(), local.id(), env.get(v.name()), v.pos());
+                case ValueName.Local local when env.typeOf(local.id()) != null ->
+                        new Core.Read(v.name(), local.id(), env.typeOf(local.id()), v.pos());
                 case ValueName.OfType named
                         when ctx.symbols().get(named.type()) instanceof Ast.UnitData ->
                         new Core.UnitValue(named.type(), Type.ref(named.type()), v.pos());
@@ -246,7 +245,7 @@ public final class Elaborator {
                         throw new IllegalStateException("`" + s.written()
                                 + "` is spread but names no binding, at " + s.pos());
                     }
-                    spreads.add(new Core.Read(s.bare(), local.id(), env.get(s.bare()), s.pos()));
+                    spreads.add(new Core.Read(s.bare(), local.id(), env.typeOf(local.id()), s.pos()));
                     spreadNames.add(s.bare());
                 }
                 List<Core.FieldInit> inits = DataChecker.checkConstruction(built.written(), nd.inits(),
@@ -311,8 +310,7 @@ public final class Elaborator {
                 checkArmsAnswerClauses(ic, construct.typeName(), ctx.symbols());
                 // The binder names the built value, so the success branch reads it at the data's own
                 // type — with the invariant established, which is why the discharge check may seed it.
-                Map<String, Type> inner = new HashMap<>(env);
-                inner.put(ic.binderName(), construct.type());
+                Scope inner = env.with(ic.binder(), construct.type());
                 Core then = liftIntoOption(elaborate(ic.then(), inner, ctx, expected), expected,
                         ctx.symbols());
                 List<Core.ElseArm> arms = new ArrayList<>();
@@ -373,14 +371,14 @@ public final class Elaborator {
 
     /** Elaborates {@code e} and checks it against {@code expected}, returning its Core. The check is
      * bottom-up, as {@link #requireType} is: the expected type is not pushed into the expression. */
-    static Core requireTyped(Ast.Expr e, Type expected, Map<String, Type> env, CheckContext ctx, String what) {
+    static Core requireTyped(Ast.Expr e, Type expected, Scope env, CheckContext ctx, String what) {
         Core c = elaborate(e, env, ctx);
         requireType(e, c.type(), expected, ctx.symbols(), what);
         return c;
     }
 
 
-    static Core elaborateFieldAccess(Ast.FieldAccess fa, Map<String, Type> env, CheckContext ctx) {
+    static Core elaborateFieldAccess(Ast.FieldAccess fa, Scope env, CheckContext ctx) {
         Core targetCore = elaborate(fa.target(), env, ctx);
         Type target = targetCore.type();
         if (target instanceof Type.Ref ref && ctx.symbols().get(ref.name()) instanceof Ast.Data owner) {
@@ -451,7 +449,7 @@ public final class Elaborator {
      * resolve identically.
      */
     public static Core resolveStepBinding(String fnName, Type.FnOf declaredStep, Ast.Expr stepArg,
-                                          Map<String, Type> bind, Map<String, Type> env, CheckContext ctx) {
+                                          Map<String, Type> bind, Scope env, CheckContext ctx) {
         Type.FnOf narrow = (Type.FnOf) TypeOps.substitute(declaredStep, bind);
         Core narrowCore = null;
         Type narrowGot = null;
@@ -498,7 +496,7 @@ public final class Elaborator {
     /** Elaborates a block argument at {@code paramTypes}; the node it returns carries the
      * {@link Type.FnOf} of the block — the parameter types the call fixed, and the body's result. */
     static Core elaborateBlockArg(String fnName, Ast.Expr arg, List<Type> paramTypes,
-                                  Map<String, Type> env, CheckContext ctx) {
+                                  Scope env, CheckContext ctx) {
         if (!(arg instanceof Ast.Block block)) {
             // a function-typed value — a helper's function parameter (spec §fn-declaration) —
             // stands in for a block: check its shape and yield its result type.
@@ -538,9 +536,9 @@ public final class Elaborator {
                     "this block takes " + paramTypes.size() + " parameter(s), got "
                             + block.params().size());
         }
-        Map<String, Type> inner = new HashMap<>(env);
+        Scope inner = env;
         for (int i = 0; i < paramTypes.size(); i++) {
-            inner.put(block.params().get(i).name(), paramTypes.get(i));
+            inner = inner.with(block.params().get(i), paramTypes.get(i));
         }
         Core body = elaborate(block.body(), inner, ctx);
         return new Core.Block(block.params(), body, Type.fn(paramTypes, body.type()), block.pos());
@@ -684,7 +682,7 @@ public final class Elaborator {
     /** Infers a let-bound function's parameter types from how the body applies it: every
      * {@code f(args)} in the body must agree on the argument types (spec §blocks). A function that
      * is never applied cannot have its type inferred. */
-    static List<Type> inferFnParamTypes(String name, Ast.Expr body, Map<String, Type> env,
+    static List<Type> inferFnParamTypes(String name, Ast.Expr body, Scope env,
                                                 CheckContext ctx) {
         List<List<Type>> uses = new ArrayList<>();
         collectApplications(name, body, env, ctx, uses, Set.of());
@@ -723,7 +721,7 @@ public final class Elaborator {
      * <p>Every other application is typed against {@code env}, so a mistake inside its arguments is
      * still reported as the mistake it is.
      */
-    static void collectApplications(String name, Ast.Expr e, Map<String, Type> env,
+    static void collectApplications(String name, Ast.Expr e, Scope env,
                                             CheckContext ctx, List<List<Type>> out,
                                             Set<String> inner) {
         if (e instanceof Ast.Call call && call.fn().equals(name)
@@ -835,7 +833,7 @@ public final class Elaborator {
      * {@code None} — this drops the permission as well, so the rule holds here on its own rather than
      * resting on how an argument happens to be typed elsewhere.
      */
-    static Core elaborateFunctionValue(Ast.Expr value, List<Type> paramTypes, Map<String, Type> env,
+    static Core elaborateFunctionValue(Ast.Expr value, List<Type> paramTypes, Scope env,
                                           CheckContext outer) {
         CheckContext ctx = outer.makingAnOptional(false);
         return switch (value) {
@@ -847,9 +845,9 @@ public final class Elaborator {
                             "this lambda takes " + b.params().size() + " parameter(s) but is applied with "
                                     + paramTypes.size());
                 }
-                Map<String, Type> inner = new HashMap<>(env);
+                Scope inner = env;
                 for (int i = 0; i < paramTypes.size(); i++) {
-                    inner.put(b.params().get(i).name(), paramTypes.get(i));
+                    inner = inner.with(b.params().get(i), paramTypes.get(i));
                 }
                 Core body = elaborate(b.body(), inner, ctx);
                 yield new Core.Block(b.params(), body, Type.fn(paramTypes, body.type()), b.pos());
@@ -871,8 +869,7 @@ public final class Elaborator {
             case Ast.LetIn li -> {
                 // a capture binding around the function (e.g. `let $n = 5 in (x) -> x + $n`)
                 Core bound = elaborate(li.value(), env, ctx);
-                Map<String, Type> inner = new HashMap<>(env);
-                inner.put(li.name(), bound.type());
+                Scope inner = env.with(li.binder(), bound.type());
                 Core body = elaborateFunctionValue(li.body(), paramTypes, inner, ctx);
                 yield new Core.LetIn(li.binder(), bound, body, body.type(), li.pos());
             }
@@ -933,7 +930,7 @@ public final class Elaborator {
         }
     }
 
-    static void requireType(Ast.Expr e, Type expected, Map<String, Type> env, CheckContext ctx, String what) {
+    static void requireType(Ast.Expr e, Type expected, Scope env, CheckContext ctx, String what) {
         requireType(e, typeOf(e, env, ctx), expected, ctx.symbols(), what);
     }
 
@@ -982,7 +979,7 @@ public final class Elaborator {
      * data, a function named without being applied, or one of Option's cases outside the one place
      * an optional is made.
      */
-    private static RuntimeException notAValue(Ast.Var v, Map<String, Type> env) {
+    private static RuntimeException notAValue(Ast.Var v, Scope env) {
         if (v.denotes() instanceof ValueName.Unresolved) {
             // reported where the name was written; this definition has no meaning to work out
             return new Unanswerable(v.pos());
@@ -993,9 +990,9 @@ public final class Elaborator {
                         .title("check.unknown.title")
                         .at(v.pos(), v.name().length())
                         .args(v.name())
-                        .suggestion(Suggest.candidate(v.name(), env.keySet()))
+                        .suggestion(Suggest.candidate(v.name(), env.spellings()))
                         .build(),
-                "unknown identifier `" + v.name() + "`" + Suggest.hint(v.name(), env.keySet()));
+                "unknown identifier `" + v.name() + "`" + Suggest.hint(v.name(), env.spellings()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -131,7 +131,7 @@ public final class Exposing {
                 }
                 yield new Ast.NewData(nd.typeName(), inits, nd.spreads(), nd.origin(), nd.pos());
             }
-            case Ast.LetIn li -> new Ast.LetIn(li.name(), rw(li.value()), li.declaredType(), li.annotated(), li.opens(),
+            case Ast.LetIn li -> new Ast.LetIn(li.binder(), rw(li.value()), li.declaredType(), li.annotated(), li.opens(),
                     rw(li.body()), li.pos());
             case Ast.Block bl -> new Ast.Block(bl.params(), rw(bl.body()), bl.pos());
             case Ast.ListLit ll -> {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1024,7 +1024,11 @@ public final class HelperInliner {
                     args.add(inline(a));
                 }
                 Ast.FnDef helper = appliedHelper(call);
-                if (helper == null || recursive.contains(call.fn())) {
+                // a recursive helper is reached by the name it is declared under; a lambda a binding
+                // holds is not one, whatever it is called
+                boolean standing = !(call.denotes() instanceof ValueName.Local)
+                        && recursive.contains(call.fn());
+                if (helper == null || standing) {
                     // builtin, injected behavior, a function-typed parameter, or a recursive helper —
                     // a recursive helper is lowered to a method, so its call stays a Call (spec 13.1);
                     // only its args inline.
@@ -1054,11 +1058,11 @@ public final class HelperInliner {
                                     + " argument(s) but is called with " + args.size());
                 }
                 int k = counter++;
-                Map<String, String> subst = new HashMap<>();
+                Map<BindingId, String> subst = new HashMap<>();
                 // what each substituted callee resolved to at the call site, so the expansion carries
                 // the argument's own answer rather than deciding one for it
-                Map<String, ValueName> substDenotes = new HashMap<>();
-                Set<String> fnParams = new HashSet<>();
+                Map<BindingId, ValueName> substDenotes = new HashMap<>();
+                Set<BindingId> fnParams = new HashSet<>();
                 List<BindingId> given = new ArrayList<>();   // the lambdas given to fn params
                 List<Ast.Binder> letBinders = new ArrayList<>();
                 List<Ast.Expr> letValues = new ArrayList<>();
@@ -1072,14 +1076,14 @@ public final class HelperInliner {
                         // registered under a fresh name as a scoped helper, so each application of the
                         // parameter β-reduces to the lambda's body, as a let-bound lambda does (spec 12.5).
                         if (arg instanceof Ast.Var fnName) {
-                            subst.put(p.name(), fnName.name());
-                            substDenotes.put(p.name(), fnName.denotes());
-                            fnParams.add(p.name());
+                            subst.put(p.binder().id(), fnName.name());
+                            substDenotes.put(p.binder().id(), fnName.denotes());
+                            fnParams.add(p.binder().id());
                         } else if (arg instanceof Ast.Block lambda) {
                             Ast.Binder f = binders.binder("$" + k + "_" + p.name(), lambda.pos());
-                            subst.put(p.name(), f.name());
-                            substDenotes.put(p.name(), new ValueName.Local(f.name(), f.id()));
-                            fnParams.add(p.name());
+                            subst.put(p.binder().id(), f.name());
+                            substDenotes.put(p.binder().id(), new ValueName.Local(f.name(), f.id()));
+                            fnParams.add(p.binder().id());
                             given.add(f.id());
                             List<Ast.FnParam> lparams = new ArrayList<>();
                             for (Ast.Binder lp : lambda.params()) {
@@ -1115,8 +1119,8 @@ public final class HelperInliner {
                         // body are answered with it, so a read says which binding it is rather than
                         // where it happens to be written
                         Ast.Binder f = binders.binder(p.name(), call.pos());
-                        subst.put(p.name(), f.name());
-                        substDenotes.put(p.name(), new ValueName.Local(f.name(), f.id()));
+                        subst.put(p.binder().id(), f.name());
+                        substDenotes.put(p.binder().id(), new ValueName.Local(f.name(), f.id()));
                         letBinders.add(f);
                         letValues.add(arg);
                         // carry the parameter's declared type onto the binding, so a value known to
@@ -1397,26 +1401,25 @@ public final class HelperInliner {
      * null} and keep the positions their bodies have ({@link #keepsItsPositions}). The caller's
      * argument expressions, spliced in separately, keep their own positions either way.
      */
-    private Ast.Expr rename(Ast.Expr e, Map<String, String> subst,
-                            Map<String, ValueName> substDenotes, Set<String> fnParams,
+    private Ast.Expr rename(Ast.Expr e, Map<BindingId, String> subst,
+                            Map<BindingId, ValueName> substDenotes, Set<BindingId> fnParams,
                             SourcePos at, Copy copy) {
         return switch (e) {
             // a substituted name keeps what the argument resolved to, so a named function handed to a
             // combinator stays the helper it is rather than becoming a binding of that spelling
-            case Ast.Var v -> subst.containsKey(v.name())
-                    ? new Ast.Var(subst.get(v.name()), substituted(substDenotes, v.name()),
-                            at(at, v.pos()))
-                    : v.denoting(copy.of(v.denotes()));
+            case Ast.Var v when v.denotes() instanceof ValueName.Local p
+                    && subst.containsKey(p.id()) ->
+                    new Ast.Var(subst.get(p.id()), substituted(substDenotes, p.id()), at(at, v.pos()));
+            case Ast.Var v -> v.denoting(copy.of(v.denotes()));
             case Ast.FieldAccess fa -> new Ast.FieldAccess(rename(fa.target(), subst, substDenotes, fnParams, at, copy), fa.field(), at(at, fa.pos()));
             case Ast.Call call -> {
-                boolean renamed = fnParams.contains(call.fn()) && subst.containsKey(call.fn());
-                String callee = renamed ? subst.get(call.fn()) : call.fn();
-                // a renamed callee is the function argument this parameter was bound to, under the
-                // name this expansion gave it; anything else keeps what the call already denoted
-                // the argument's own answer where this expansion substituted one; a scoped lambda
-                // was registered as a local just above, and a named function stays what it is
+                // a substituted callee is the function argument this parameter was bound to, under
+                // the name this expansion gave it; anything else keeps what the call already denoted
+                BindingId param = call.denotes() instanceof ValueName.Local p ? p.id() : null;
+                boolean renamed = param != null && fnParams.contains(param);
+                String callee = renamed ? subst.get(param) : call.fn();
                 ValueName denotes = renamed
-                        ? substituted(substDenotes, call.fn()) : copy.of(call.denotes());
+                        ? substituted(substDenotes, param) : copy.of(call.denotes());
                 yield new Ast.Call(callee, denotes, renameList(call.args(), subst, substDenotes, fnParams, at, copy),
                         call.origin(),
                         at(at, call.pos()));
@@ -1431,9 +1434,10 @@ public final class HelperInliner {
                 List<Ast.ValueRef> spreads = new ArrayList<>();
                 for (Ast.ValueRef s : nd.spreads()) {
                     // `..param` copies the renamed binding, and stays the binding it now names
-                    String renamed = subst.get(s.bare());
-                    spreads.add(renamed == null ? s.denoting(copy.of(s.denotes()))
-                            : new Ast.ValueRef(renamed, substituted(substDenotes, s.bare()),
+                    BindingId spread = s.denotes() instanceof ValueName.Local p ? p.id() : null;
+                    spreads.add(spread == null || !subst.containsKey(spread)
+                            ? s.denoting(copy.of(s.denotes()))
+                            : new Ast.ValueRef(subst.get(spread), substituted(substDenotes, spread),
                                     at(at, s.pos())));
                 }
                 yield new Ast.NewData(nd.typeName(), inits, spreads, nd.origin(), at(at, nd.pos()));
@@ -1441,10 +1445,9 @@ public final class HelperInliner {
             case Ast.Match m -> {
                 List<Ast.Case> cases = new ArrayList<>();
                 for (Ast.Case c : m.cases()) {
-                    Map<String, String> inner = c.binding() == null ? subst : without(subst, c.bindingName());
                     cases.add(new Ast.Case(c.caseTypes(),
                             c.binding() == null ? null : copy.of(c.binding()),
-                            rename(c.body(), inner, substDenotes, fnParams, at, copy),
+                            rename(c.body(), subst, substDenotes, fnParams, at, copy),
                             c.unwrapAsserts(), at(at, c.pos())));
                 }
                 yield new Ast.Match(rename(m.scrutinee(), subst, substDenotes, fnParams, at, copy), cases, at(at, m.pos()));
@@ -1454,12 +1457,12 @@ public final class HelperInliner {
             // there and left standing over the construction and the else value
             case Ast.IfConstructed ic -> new Ast.IfConstructed(
                     rename(ic.construct(), subst, substDenotes, fnParams, at, copy), copy.of(ic.binder()),
-                    rename(ic.then(), without(subst, ic.binderName()), substDenotes, fnParams, at, copy),
+                    rename(ic.then(), subst, substDenotes, fnParams, at, copy),
                     Ast.mapArms(ic.els(), body -> rename(body, subst, substDenotes, fnParams, at, copy)),
                     at(at, ic.pos()));
             case Ast.LetIn li -> {
                 Ast.Expr value = rename(li.value(), subst, substDenotes, fnParams, at, copy);
-                Ast.Expr body = rename(li.body(), without(subst, li.name()), substDenotes, fnParams, at, copy);
+                Ast.Expr body = rename(li.body(), subst, substDenotes, fnParams, at, copy);
                 yield new Ast.LetIn(copy.of(li.binder()), value, li.declaredType(), li.annotated(),
                         li.opens(), body, at(at, li.pos()));
             }
@@ -1468,21 +1471,13 @@ public final class HelperInliner {
             case Ast.TupleGet tg -> new Ast.TupleGet(rename(tg.tuple(), subst, substDenotes, fnParams, at, copy), tg.index(), tg.arity(), at(at, tg.pos()));
             case Ast.ListComp comp -> new Ast.ListComp(rename(comp.element(), subst, substDenotes, fnParams, at, copy), renameList(comp.guards(), subst, substDenotes, fnParams, at, copy), at(at, comp.pos()));
             case Ast.Block block -> {
-                // α-rename the block's own parameters to fresh `$`-names. Caller code — a lambda passed
-                // to a function parameter — is spliced into this block's scope during inlining; if the
-                // block bound a plain name (`acc`/`x`, as the derived combinators do) it would capture a
-                // caller variable of the same name. Fresh `$`-names cannot collide with caller code.
-                Map<String, String> inner = subst;
-                Map<String, ValueName> innerDenotes = substDenotes;
-                List<Ast.Binder> freshParams = new ArrayList<>();
+                List<Ast.Binder> params = new ArrayList<>();
                 for (Ast.Binder p : block.params()) {
-                    Ast.Binder fresh = binders.binder(p.name(), at(at, p.pos()));
-                    freshParams.add(fresh);
-                    inner = with(inner, p.name(), fresh.name());
-                    innerDenotes = new HashMap<>(innerDenotes);
-                    innerDenotes.put(p.name(), new ValueName.Local(fresh.name(), fresh.id()));
+                    params.add(copy.of(p));
                 }
-                yield new Ast.Block(freshParams, rename(block.body(), inner, innerDenotes, fnParams, at, copy), at(at, block.pos()));
+                yield new Ast.Block(params,
+                        rename(block.body(), subst, substDenotes, fnParams, at, copy),
+                        at(at, block.pos()));
             }
             case Ast.IntLit _ -> e;
             case Ast.DecimalLit _ -> e;
@@ -1518,9 +1513,9 @@ public final class HelperInliner {
         return at != null ? at : own;
     }
 
-    private List<Ast.Expr> renameList(List<Ast.Expr> es, Map<String, String> subst,
-                                      Map<String, ValueName> substDenotes,
-                                      Set<String> fnParams, SourcePos at, Copy copy) {
+    private List<Ast.Expr> renameList(List<Ast.Expr> es, Map<BindingId, String> subst,
+                                      Map<BindingId, ValueName> substDenotes,
+                                      Set<BindingId> fnParams, SourcePos at, Copy copy) {
         List<Ast.Expr> out = new ArrayList<>();
         for (Ast.Expr e : es) {
             out.add(rename(e, subst, substDenotes, fnParams, at, copy));
@@ -1535,28 +1530,12 @@ public final class HelperInliner {
      * argument's own, or the binding this expansion made for it — so there is no name to be answered
      * with a guess. One missing is a substitution written without saying what it means.
      */
-    private static ValueName substituted(Map<String, ValueName> substDenotes, String name) {
-        ValueName denotes = substDenotes.get(name);
+    private static ValueName substituted(Map<BindingId, ValueName> substDenotes, BindingId param) {
+        ValueName denotes = substDenotes.get(param);
         if (denotes == null) {
-            throw new IllegalStateException("`" + name + "` was substituted without an answer");
+            throw new IllegalStateException(param + " was substituted without an answer");
         }
         return denotes;
-    }
-
-    private static Map<String, String> without(Map<String, String> subst, String name) {
-        if (!subst.containsKey(name)) {
-            return subst;
-        }
-        Map<String, String> copy = new HashMap<>(subst);
-        copy.remove(name);
-        return copy;
-    }
-
-    /** {@code subst} with {@code name} rebound to {@code fresh} (a copy; the original is untouched). */
-    private static Map<String, String> with(Map<String, String> subst, String name, String fresh) {
-        Map<String, String> copy = new HashMap<>(subst);
-        copy.put(name, fresh);
-        return copy;
     }
 
     /** Records the module's own helpers that lie on a call cycle (self or mutual). A recursive helper

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1114,7 +1114,7 @@ public final class HelperInliner {
                         // the binding the argument is bound to; the reads of the parameter inside the
                         // body are answered with it, so a read says which binding it is rather than
                         // where it happens to be written
-                        Ast.Binder f = binders.binder("$" + k + "_" + p.name(), call.pos());
+                        Ast.Binder f = binders.binder(p.name(), call.pos());
                         subst.put(p.name(), f.name());
                         substDenotes.put(p.name(), new ValueName.Local(f.name(), f.id()));
                         letBinders.add(f);
@@ -1476,8 +1476,7 @@ public final class HelperInliner {
                 Map<String, ValueName> innerDenotes = substDenotes;
                 List<Ast.Binder> freshParams = new ArrayList<>();
                 for (Ast.Binder p : block.params()) {
-                    Ast.Binder fresh = binders.binder("$b" + (counter++) + "_" + p.name(),
-                            at(at, p.pos()));
+                    Ast.Binder fresh = binders.binder(p.name(), at(at, p.pos()));
                     freshParams.add(fresh);
                     inner = with(inner, p.name(), fresh.name());
                     innerDenotes = new HashMap<>(innerDenotes);

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -2,6 +2,8 @@ package souther.compiler.check;
 
 import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -36,11 +38,18 @@ import java.util.function.Predicate;
  */
 public final class HelperInliner {
 
+    /** The module whose bodies this expands into. A binding an expansion makes belongs to a
+     * definition of this module, which is what tells it from the same helper expanded elsewhere. */
+    private final String module;
     private final Map<String, Ast.FnDef> helpers;   // prelude + module-own, keyed by name (inlining)
     private final Map<String, Ast.FnDef> own;       // the module's own helpers (standalone check)
     private final Set<String> recursive = new HashSet<>();   // own helpers on a call cycle (spec 13.1)
     private final Map<String, LambdaOrigin> lambdaOrigins = new HashMap<>();   // $k_p -> where it was written
     private int counter = 0;
+    /** The body being expanded, and the bindings this expansion introduces into it. An expansion
+     * writes bindings no source wrote, so they belong to it rather than to the definition whose text
+     * it is splicing, which is what keeps two copies of one helper's body apart. */
+    private Ast.Binders binders;
 
     /** Where a lambda given to a function parameter was written: the parameter it fills, the helper
      * that declares that parameter, and the lambda's own position. The lambda is inlined under a
@@ -48,9 +57,15 @@ public final class HelperInliner {
      * reported against these instead. */
     private record LambdaOrigin(String param, String owner, SourcePos pos) {}
 
-    private HelperInliner(Map<String, Ast.FnDef> helpers, Map<String, Ast.FnDef> own) {
+    private HelperInliner(String module, Map<String, Ast.FnDef> helpers, Map<String, Ast.FnDef> own) {
+        this.module = module;
         this.helpers = helpers;
         this.own = own;
+    }
+
+    /** The body of {@code fn} in this module — what an expansion written into it belongs to. */
+    public BindingOwner bodyOf(String fn) {
+        return new BindingOwner.OfValue(module, fn);
     }
 
     /** A helper is a fn whose name is not a behavior's; behavior fns are lowered on their own. The
@@ -74,7 +89,8 @@ public final class HelperInliner {
         Map<String, Ast.FnDef> own = helpersOf(module);
         Map<String, Ast.FnDef> table = new LinkedHashMap<>(imported);
         table.putAll(own);
-        HelperInliner inliner = new HelperInliner(withPrelude(table), new LinkedHashMap<>(own));
+        HelperInliner inliner = new HelperInliner(module.name(), withPrelude(table),
+                new LinkedHashMap<>(own));
         inliner.classifyRecursion();
         inliner.rejectValueCycles();
         inliner.computeReferencedPreludeRecursive(module);
@@ -91,8 +107,8 @@ public final class HelperInliner {
      * one call, and {@link #forModule} is what answers it. A module that has already taken those on as
      * its own fns has them here like any other helper, so both say the same thing about it.
      */
-    public static HelperInliner forHelpers(Map<String, Ast.FnDef> own) {
-        return forHelpers(own, InliningPolicy.FULL);
+    public static HelperInliner forHelpers(String module, Map<String, Ast.FnDef> own) {
+        return forHelpers(module, own, InliningPolicy.FULL);
     }
 
     /**
@@ -102,8 +118,9 @@ public final class HelperInliner {
      * one of its operations is not a helper call here and survives as written. Nothing else changes:
      * a module's own helper is expanded, and a recursive call is left standing, by the same rules.
      */
-    public static HelperInliner forHelpers(Map<String, Ast.FnDef> own, InliningPolicy policy) {
-        return forHelpers(own, Map.of(), policy);
+    public static HelperInliner forHelpers(String module, Map<String, Ast.FnDef> own,
+                                           InliningPolicy policy) {
+        return forHelpers(module, own, Map.of(), policy);
     }
 
     /**
@@ -112,7 +129,7 @@ public final class HelperInliner {
      * <p>They are in the table and not in {@code own}, as they are for {@link #forModule}: an imported
      * definition is one this module expands and not one it declares.
      */
-    public static HelperInliner forHelpers(Map<String, Ast.FnDef> own,
+    public static HelperInliner forHelpers(String module, Map<String, Ast.FnDef> own,
                                            Map<String, Ast.FnDef> imported, InliningPolicy policy) {
         // In the order they are written, so a module with two helpers to complain about complains
         // about the earlier one first.
@@ -120,7 +137,7 @@ public final class HelperInliner {
         joined.putAll(own);
         Map<String, Ast.FnDef> table = policy == InliningPolicy.FULL
                 ? withPrelude(joined) : joined;
-        HelperInliner inliner = new HelperInliner(table, new LinkedHashMap<>(own));
+        HelperInliner inliner = new HelperInliner(module, table, new LinkedHashMap<>(own));
         inliner.classifyRecursion();
         inliner.rejectValueCycles();
         return inliner;
@@ -235,7 +252,7 @@ public final class HelperInliner {
      */
     public static Set<String> exampleHelpers(Ast.Module module, Map<String, Ast.FnDef> table) {
         Set<String> called = new LinkedHashSet<>();
-        HelperInliner reader = new HelperInliner(table, table);
+        HelperInliner reader = new HelperInliner(module.name(), table, table);
         // A row may name a value rather than write the input again (ADR-0072), and that value's body
         // is read the way the row's own text is — so a helper it applies is applied when the row is
         // evaluated. The bodies are followed as far as they name each other, which is how a chain of
@@ -339,7 +356,8 @@ public final class HelperInliner {
      * body of something else it imported.
      */
     public Ast.FnDef closeAcross(Ast.FnDef fn, String module) {
-        Ast.Expr closed = recursive.contains(fn.name()) ? inlineRecursiveBody(fn) : inline(fn.body());
+        Ast.Expr closed = recursive.contains(fn.name())
+                ? inlineRecursiveBody(fn) : inline(fn.body(), bodyOf(fn.name()));
         return new Ast.FnDef(qualified(module, fn.name()), fn.params(), fn.declaredReturn(), null,
                 publishedBy(qualifyHelpersOf(closed, module), module), fn.partial(), fn.pos());
     }
@@ -632,12 +650,13 @@ public final class HelperInliner {
             Ast.Module m, Symbols symbols, Map<String, Ast.FnDef> published) {
         Ast.Module settled = withQualifiedInvariants(HelperParams.settle(m, symbols, Map.of()));
         HelperInliner inliner =
-                forHelpers(helpersOf(settled), published, InliningPolicy.DISCHARGE);
+                forHelpers(m.name(), helpersOf(settled), published, InliningPolicy.DISCHARGE);
         Map<TypeName, List<Ast.InvariantClause>> out = new LinkedHashMap<>();
         for (Ast.Def def : settled.defs()) {
             if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
-                out.put(new TypeName(m.name(), d.name()),
-                        Ast.mapClauses(d.invariants(), inliner::inline));
+                TypeName declared = new TypeName(m.name(), d.name());
+                out.put(declared, Ast.mapClauses(d.invariants(),
+                        clause -> inliner.inline(clause, new BindingOwner.OfData(declared))));
             }
         }
         return out;
@@ -647,8 +666,9 @@ public final class HelperInliner {
         List<Ast.Def> defs = new ArrayList<>();
         for (Ast.Def def : m.defs()) {
             if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
+                BindingOwner declared = new BindingOwner.OfData(new TypeName(m.name(), d.name()));
                 defs.add(new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(),
-                        Ast.mapClauses(d.invariants(), this::inline),
+                        Ast.mapClauses(d.invariants(), clause -> inline(clause, declared)),
                         d.decoder(), d.encoder(), d.pos()));
             } else {
                 defs.add(def);
@@ -713,7 +733,7 @@ public final class HelperInliner {
             }
         }
         try {
-            return inline(h.body());
+            return inline(h.body(), bodyOf(h.name()));
         } finally {
             helpers.putAll(shadowed);
         }
@@ -737,8 +757,8 @@ public final class HelperInliner {
                 || mentionsTypeVar(declared.cases().get(0))) {
             return body;
         }
-        String bound = "$r" + k;
-        return Ast.LetIn.annotated(bound, body, declared, Ast.Var.local(bound, pos), pos);
+        Ast.Binder bound = binders.binder("$r" + k, pos);
+        return new Ast.LetIn(bound, body, declared, true, null, Ast.Var.local(bound, pos), pos);
     }
 
     /** Whether a written type has a collection anywhere inside it — the types whose element/value type
@@ -900,7 +920,7 @@ public final class HelperInliner {
      * both call the wrong thing and report a value as an uncallable name.
      */
     private List<Ast.Expr> forwardDependencies(Ast.FnDef callee, List<Ast.Expr> args) {
-        if (callee == null || dependencyBinders.isEmpty()) {
+        if (callee == null || dependencies.isEmpty()) {
             return args;
         }
         List<Ast.Expr> out = new ArrayList<>(args);
@@ -909,16 +929,16 @@ public final class HelperInliner {
             Ast.FnType want = declared == null ? null : declared.asFn();
             if (want == null || !(out.get(i) instanceof Ast.Var v)
                     || !(v.denotes() instanceof ValueName.Local local)
-                    || !dependencyBinders.contains(local.binder())) {
+                    || !dependencies.contains(local.id())) {
                 continue;
             }
-            List<String> params = new ArrayList<>();
+            List<Ast.Binder> params = new ArrayList<>();
             List<Ast.Expr> forwarded = new ArrayList<>();
             for (int j = 0; j < want.params().size(); j++) {
                 // a source identifier never starts with `$`, so these cannot capture a caller local
-                String p = "$" + counter++ + "_" + v.name();
+                Ast.Binder p = binders.binder("$" + counter++ + "_" + v.name(), v.pos());
                 params.add(p);
-                forwarded.add(new Ast.Var(p, new ValueName.Local(p, v.pos()), v.pos()));
+                forwarded.add(Ast.Var.local(p, v.pos()));
             }
             out.set(i, new Ast.Block(params,
                     new Ast.Call(v.name(), v.denotes(), forwarded, ConstructionOrigin.own(), v.pos()),
@@ -927,24 +947,44 @@ public final class HelperInliner {
         return out;
     }
 
-    /** Where the {@code depends on} parameters of the behavior {@code let} being expanded are bound.
-     * Empty while expanding anything else: only a behavior's {@code let} has them (spec §depends-on). */
-    private Set<SourcePos> dependencyBinders = Set.of();
+    /** Which bindings the {@code depends on} parameters of the behavior {@code let} being expanded
+     * are. Empty while expanding anything else: only a behavior's {@code let} has them
+     * (spec §depends-on). */
+    private Set<BindingId> dependencies = Set.of();
 
     /** As {@link #inline(Ast.Expr)}, for the body of a behavior {@code let} whose {@code depends on}
      * parameters are bound at {@code binders}. */
-    public Ast.Expr inline(Ast.Expr e, Set<SourcePos> binders) {
-        Set<SourcePos> outer = this.dependencyBinders;
-        this.dependencyBinders = binders;
+    public Ast.Expr inline(Ast.Expr e, Set<BindingId> dependencies, BindingOwner into) {
+        Set<BindingId> outer = this.dependencies;
+        this.dependencies = dependencies;
         try {
-            return inline(e);
+            return inline(e, into);
         } finally {
-            this.dependencyBinders = outer;
+            this.dependencies = outer;
         }
     }
 
-    /** Rewrites every helper call in {@code e} to its inlined body. */
+    /**
+     * Rewrites every helper call in {@code e} to its inlined body, into {@code into}.
+     *
+     * <p>{@code into} is the body being written: the bindings an expansion introduces belong to it,
+     * so two copies of one helper's body spliced into two definitions do not answer as one binding.
+     */
+    public Ast.Expr inline(Ast.Expr e, BindingOwner into) {
+        Ast.Binders outer = binders;
+        binders = new Ast.Binders(new BindingOwner.Synthesized(into, BindingOwner.Pass.INLINER, 0));
+        try {
+            return inline(e);
+        } finally {
+            binders = outer;
+        }
+    }
+
+    /** Rewrites every helper call in {@code e} to its inlined body, into the body already named. */
     public Ast.Expr inline(Ast.Expr e) {
+        if (binders == null) {
+            throw new IllegalStateException("nothing said which body this expansion is written into");
+        }
         return switch (e) {
             case Ast.Call rawCall -> {
                 checkFunctionArgumentPlacement(rawCall);
@@ -990,7 +1030,7 @@ public final class HelperInliner {
                 Map<String, ValueName> substDenotes = new HashMap<>();
                 Set<String> fnParams = new HashSet<>();
                 Map<String, Ast.FnDef> scopedLambdas = new HashMap<>();   // lambdas given to fn params
-                List<String> letNames = new ArrayList<>();
+                List<Ast.Binder> letBinders = new ArrayList<>();
                 List<Ast.Expr> letValues = new ArrayList<>();
                 List<Ast.RetType> letTypes = new ArrayList<>();
                 for (int i = 0; i < helper.params().size(); i++) {
@@ -1006,18 +1046,19 @@ public final class HelperInliner {
                             substDenotes.put(p.name(), fnName.denotes());
                             fnParams.add(p.name());
                         } else if (arg instanceof Ast.Block lambda) {
-                            String f = "$" + k + "_" + p.name();
-                            subst.put(p.name(), f);
-                            substDenotes.put(p.name(), new ValueName.Local(f, lambda.pos()));
+                            Ast.Binder f = binders.binder("$" + k + "_" + p.name(), lambda.pos());
+                            subst.put(p.name(), f.name());
+                            substDenotes.put(p.name(), new ValueName.Local(f.name(), f.id()));
                             fnParams.add(p.name());
                             List<Ast.FnParam> lparams = new ArrayList<>();
-                            for (String lp : lambda.params()) {
-                                lparams.add(new Ast.FnParam(lp, null, lambda.pos()));
+                            for (Ast.Binder lp : lambda.params()) {
+                                lparams.add(new Ast.FnParam(lp, null));
                             }
                             // the lambda's body is caller code, so it is not renamed by this helper's
                             // substitution — only the enclosing helper body is.
-                            scopedLambdas.put(f, new Ast.FnDef(f, lparams, null, null, lambda.body(), lambda.pos()));
-                            lambdaOrigins.put(f, new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
+                            scopedLambdas.put(f.name(),
+                                    new Ast.FnDef(f.name(), lparams, null, null, lambda.body(), lambda.pos()));
+                            lambdaOrigins.put(f.name(), new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
                         } else {
                             // Neither a name nor a lambda: a value written where the function goes —
                             // the argument-order mistake made with a named helper rather than a
@@ -1039,9 +1080,13 @@ public final class HelperInliner {
                                                     : ". Write `" + rawCall.fn() + "(" + shape + ")`."));
                         }
                     } else {
-                        String f = "$" + k + "_" + p.name();
-                        subst.put(p.name(), f);
-                        letNames.add(f);
+                        // the binding the argument is bound to; the reads of the parameter inside the
+                        // body are answered with it, so a read says which binding it is rather than
+                        // where it happens to be written
+                        Ast.Binder f = binders.binder("$" + k + "_" + p.name(), call.pos());
+                        subst.put(p.name(), f.name());
+                        substDenotes.put(p.name(), new ValueName.Local(f.name(), f.id()));
+                        letBinders.add(f);
                         letValues.add(arg);
                         // carry the parameter's declared type onto the binding, so a value known to
                         // be a sum (an annotated `s: S`) is not narrowed to the argument's specific
@@ -1057,8 +1102,8 @@ public final class HelperInliner {
                 scopedLambdas.keySet().forEach(helpers::remove);
                 body = keepDeclaredReturn(helper, body, call.pos(), k);
                 // wrap innermost-first so the value parameters bind in declared order
-                for (int i = letNames.size() - 1; i >= 0; i--) {
-                    body = new Ast.LetIn(letNames.get(i), letValues.get(i), letTypes.get(i), body, call.pos());
+                for (int i = letBinders.size() - 1; i >= 0; i--) {
+                    body = new Ast.LetIn(letBinders.get(i), letValues.get(i), letTypes.get(i), body, call.pos());
                 }
                 yield body;
             }
@@ -1089,8 +1134,8 @@ public final class HelperInliner {
                                     + " would not bottom out when expanded inline");
                 }
                 List<Ast.FnParam> params = new ArrayList<>();
-                for (String p : lambda.params()) {
-                    params.add(new Ast.FnParam(p, null, lambda.pos()));
+                for (Ast.Binder p : lambda.params()) {
+                    params.add(new Ast.FnParam(p, null));
                 }
                 Ast.FnDef synth = new Ast.FnDef(li.name(), params, null, null, lambda.body(), li.pos());
                 Ast.FnDef shadowed = helpers.put(li.name(), synth);
@@ -1108,10 +1153,10 @@ public final class HelperInliner {
                 // escapes, which needs a runtime closure. Keep the binding so the "a block is not a
                 // value" check reports it.
                 yield mentions(body, li.name())
-                        ? new Ast.LetIn(li.name(), inline(lambda), li.declaredType(), li.annotated(), li.opens(), body, li.pos())
+                        ? new Ast.LetIn(li.binder(), inline(lambda), li.declaredType(), li.annotated(), li.opens(), body, li.pos())
                         : body;
             }
-            case Ast.LetIn li -> new Ast.LetIn(li.name(), inline(li.value()), li.declaredType(), li.annotated(), li.opens(),
+            case Ast.LetIn li -> new Ast.LetIn(li.binder(), inline(li.value()), li.declaredType(), li.annotated(), li.opens(),
                     inline(li.body()), li.pos());
             case Ast.ListLit lit -> new Ast.ListLit(inlineList(lit.elements()), lit.pos());
             case Ast.Tuple tup -> new Ast.Tuple(inlineList(tup.elements()), tup.pos());
@@ -1151,10 +1196,10 @@ public final class HelperInliner {
             // spelling the lambda, so nothing downstream has to know which of the two was written.
             // A recursive helper eta-expands too — the call inside stays the call it has to be.
             int k = counter++;
-            List<String> params = new ArrayList<>();
+            List<Ast.Binder> params = new ArrayList<>();
             List<Ast.Expr> args = new ArrayList<>();
             for (int i = 0; i < value.params().size(); i++) {
-                String p = "$v" + k + "_" + i;
+                Ast.Binder p = binders.binder("$v" + k + "_" + i, v.pos());
                 params.add(p);
                 args.add(Ast.Var.local(p, v.pos()));
             }
@@ -1176,7 +1221,7 @@ public final class HelperInliner {
      * already has, so nothing downstream learns a new one.
      */
     private Ast.Expr newData(Ast.NewData nd) {
-        List<String> bound = new ArrayList<>();
+        List<Ast.Binder> bound = new ArrayList<>();
         List<Ast.Expr> values = new ArrayList<>();
         List<Ast.ValueRef> spreads = new ArrayList<>();
         for (Ast.ValueRef spread : nd.spreads()) {
@@ -1185,7 +1230,7 @@ public final class HelperInliner {
                 spreads.add(spread);
                 continue;
             }
-            String name = "$s" + counter++ + "_" + spread.bare();
+            Ast.Binder name = binders.binder("$s" + counter++ + "_" + spread.bare(), spread.pos());
             bound.add(name);
             values.add(carriedByValue(inline(value.body())));
             spreads.add(Ast.ValueRef.local(name, spread.pos()));
@@ -1234,10 +1279,10 @@ public final class HelperInliner {
             return call;   // a bare name that is not a helper is left for the type checker to report
         }
         int k = counter++;
-        List<String> params = new ArrayList<>();
+        List<Ast.Binder> params = new ArrayList<>();
         List<Ast.Expr> callArgs = new ArrayList<>();
         for (int i = 0; i < helper.params().size(); i++) {
-            String p = "$b" + k + "_" + i;
+            Ast.Binder p = binders.binder("$b" + k + "_" + i, v.pos());
             params.add(p);
             callArgs.add(Ast.Var.local(p, v.pos()));
         }
@@ -1272,9 +1317,7 @@ public final class HelperInliner {
             // a substituted name keeps what the argument resolved to, so a named function handed to a
             // combinator stays the helper it is rather than becoming a binding of that spelling
             case Ast.Var v -> subst.containsKey(v.name())
-                    ? new Ast.Var(subst.get(v.name()),
-                            substDenotes.getOrDefault(v.name(),
-                                    new ValueName.Local(subst.get(v.name()), at(at, v.pos()))),
+                    ? new Ast.Var(subst.get(v.name()), substituted(substDenotes, v.name()),
                             at(at, v.pos()))
                     : e;
             case Ast.FieldAccess fa -> new Ast.FieldAccess(rename(fa.target(), subst, substDenotes, fnParams, at), fa.field(), at(at, fa.pos()));
@@ -1285,9 +1328,7 @@ public final class HelperInliner {
                 // name this expansion gave it; anything else keeps what the call already denoted
                 // the argument's own answer where this expansion substituted one; a scoped lambda
                 // was registered as a local just above, and a named function stays what it is
-                ValueName denotes = renamed
-                        ? substDenotes.getOrDefault(call.fn(), new ValueName.Local(callee, at(at, call.pos())))
-                        : call.denotes();
+                ValueName denotes = renamed ? substituted(substDenotes, call.fn()) : call.denotes();
                 yield new Ast.Call(callee, denotes, renameList(call.args(), subst, substDenotes, fnParams, at),
                         call.origin(),
                         at(at, call.pos()));
@@ -1303,14 +1344,16 @@ public final class HelperInliner {
                 for (Ast.ValueRef s : nd.spreads()) {
                     // `..param` copies the renamed binding, and stays the binding it now names
                     String renamed = subst.get(s.bare());
-                    spreads.add(renamed == null ? s : Ast.ValueRef.local(renamed, at(at, s.pos())));
+                    spreads.add(renamed == null ? s
+                            : new Ast.ValueRef(renamed, substituted(substDenotes, s.bare()),
+                                    at(at, s.pos())));
                 }
                 yield new Ast.NewData(nd.typeName(), inits, spreads, nd.origin(), at(at, nd.pos()));
             }
             case Ast.Match m -> {
                 List<Ast.Case> cases = new ArrayList<>();
                 for (Ast.Case c : m.cases()) {
-                    Map<String, String> inner = c.binding() == null ? subst : without(subst, c.binding());
+                    Map<String, String> inner = c.binding() == null ? subst : without(subst, c.bindingName());
                     cases.add(new Ast.Case(c.caseTypes(), c.binding(), rename(c.body(), inner, substDenotes, fnParams, at),
                             c.unwrapAsserts(), at(at, c.pos())));
                 }
@@ -1321,13 +1364,13 @@ public final class HelperInliner {
             // there and left standing over the construction and the else value
             case Ast.IfConstructed ic -> new Ast.IfConstructed(
                     rename(ic.construct(), subst, substDenotes, fnParams, at), ic.binder(),
-                    rename(ic.then(), without(subst, ic.binder()), substDenotes, fnParams, at),
+                    rename(ic.then(), without(subst, ic.binderName()), substDenotes, fnParams, at),
                     Ast.mapArms(ic.els(), body -> rename(body, subst, substDenotes, fnParams, at)),
                     at(at, ic.pos()));
             case Ast.LetIn li -> {
                 Ast.Expr value = rename(li.value(), subst, substDenotes, fnParams, at);
                 Ast.Expr body = rename(li.body(), without(subst, li.name()), substDenotes, fnParams, at);
-                yield new Ast.LetIn(li.name(), value, li.declaredType(), li.annotated(), li.opens(), body, at(at, li.pos()));
+                yield new Ast.LetIn(li.binder(), value, li.declaredType(), li.annotated(), li.opens(), body, at(at, li.pos()));
             }
             case Ast.ListLit lit -> new Ast.ListLit(renameList(lit.elements(), subst, substDenotes, fnParams, at), at(at, lit.pos()));
             case Ast.Tuple tup -> new Ast.Tuple(renameList(tup.elements(), subst, substDenotes, fnParams, at), at(at, tup.pos()));
@@ -1339,13 +1382,17 @@ public final class HelperInliner {
                 // block bound a plain name (`acc`/`x`, as the derived combinators do) it would capture a
                 // caller variable of the same name. Fresh `$`-names cannot collide with caller code.
                 Map<String, String> inner = subst;
-                List<String> freshParams = new ArrayList<>();
-                for (String p : block.params()) {
-                    String fresh = "$b" + (counter++) + "_" + p;
+                Map<String, ValueName> innerDenotes = substDenotes;
+                List<Ast.Binder> freshParams = new ArrayList<>();
+                for (Ast.Binder p : block.params()) {
+                    Ast.Binder fresh = binders.binder("$b" + (counter++) + "_" + p.name(),
+                            at(at, p.pos()));
                     freshParams.add(fresh);
-                    inner = with(inner, p, fresh);
+                    inner = with(inner, p.name(), fresh.name());
+                    innerDenotes = new HashMap<>(innerDenotes);
+                    innerDenotes.put(p.name(), new ValueName.Local(fresh.name(), fresh.id()));
                 }
-                yield new Ast.Block(freshParams, rename(block.body(), inner, substDenotes, fnParams, at), at(at, block.pos()));
+                yield new Ast.Block(freshParams, rename(block.body(), inner, innerDenotes, fnParams, at), at(at, block.pos()));
             }
             case Ast.IntLit _ -> e;
             case Ast.DecimalLit _ -> e;
@@ -1383,6 +1430,21 @@ public final class HelperInliner {
             out.add(rename(e, subst, substDenotes, fnParams, at));
         }
         return out;
+    }
+
+    /**
+     * What this expansion substituted for {@code name}.
+     *
+     * <p>Every name the substitution rewrites was given an answer when it was put there — the
+     * argument's own, or the binding this expansion made for it — so there is no name to be answered
+     * with a guess. One missing is a substitution written without saying what it means.
+     */
+    private static ValueName substituted(Map<String, ValueName> substDenotes, String name) {
+        ValueName denotes = substDenotes.get(name);
+        if (denotes == null) {
+            throw new IllegalStateException("`" + name + "` was substituted without an answer");
+        }
+        return denotes;
     }
 
     private static Map<String, String> without(Map<String, String> subst, String name) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -41,8 +41,18 @@ public final class HelperInliner {
     /** The module whose bodies this expands into. A binding an expansion makes belongs to a
      * definition of this module, which is what tells it from the same helper expanded elsewhere. */
     private final String module;
-    private final Map<String, Ast.FnDef> helpers;   // prelude + module-own, keyed by name (inlining)
+    private final Map<String, Ast.FnDef> helpers;   // prelude + module-own, by the name they are reached by
     private final Map<String, Ast.FnDef> own;       // the module's own helpers (standalone check)
+    /**
+     * The lambdas this pass expands as helpers, each under the binding it is bound to: a lambda a
+     * block's {@code let} binds, and a lambda handed to a function parameter.
+     *
+     * <p>Apart from {@link #helpers} because they are apart: a declaration is reached by a name, a
+     * lambda is reached by a binding. Held together, a lambda bound to {@code f} took the place of a
+     * declared {@code f} for as long as it was in scope, which is why applying it had to be told from
+     * applying the declaration by a spelling and why a lambda naming itself had to be refused.
+     */
+    private final Map<BindingId, Ast.FnDef> scopedLambdas = new HashMap<>();
     private final Set<String> recursive = new HashSet<>();   // own helpers on a call cycle (spec 13.1)
     private final Map<String, LambdaOrigin> lambdaOrigins = new HashMap<>();   // $k_p -> where it was written
     private int counter = 0;
@@ -50,6 +60,8 @@ public final class HelperInliner {
      * writes bindings no source wrote, so they belong to it rather than to the definition whose text
      * it is splicing, which is what keeps two copies of one helper's body apart. */
     private Ast.Binders binders;
+    /** The body being expanded into, which the copies of a helper's bindings belong under. */
+    private BindingOwner into;
 
     /** Where a lambda given to a function parameter was written: the parameter it fills, the helper
      * that declares that parameter, and the lambda's own position. The lambda is inlined under a
@@ -881,26 +893,35 @@ public final class HelperInliner {
     }
 
     /**
-     * The helper a call applies, or null where it applies something else.
+     * The body a call applies, or null where it applies something no body stands behind.
      *
-     * <p>A call that resolved to a binding applies that binding, whatever else bears the name: a
-     * helper's function-typed parameter is a binding, and expanding it as the helper it is spelled
-     * like reported the wrong arity. The one binding that is expanded here is a lambda this pass
-     * registered for a function parameter, under a {@code $}-name a source identifier cannot have —
-     * it is bound to the lambda the caller wrote, so applying it is applying that lambda.
+     * <p>What is applied follows from what the call denotes. A binding applies the lambda bound
+     * there, if one is; a declared name applies the declaration it reaches. Neither is asked of the
+     * other, so a parameter spelled like a helper is the parameter, and a lambda bound to a name a
+     * module declares is the lambda — with nothing to tell the two apart by.
      */
     private Ast.FnDef appliedHelper(Ast.Call call) {
-        if (call.denotes() instanceof ValueName.Local
-                && !call.fn().startsWith("$") && !scopedLambdaNames.contains(call.fn())) {
-            return null;
-        }
-        return helpers.get(call.fn());
+        return expands(call.denotes(), call.fn());
     }
 
-    /** Bindings this pass registered as helpers while their body is expanded: a lambda bound by a
-     * block's {@code let}, which is applied where it is bound and so β-reduces like a named helper.
-     * A {@code $}-name from a function argument is one too, and is told apart by its prefix. */
-    private final Set<String> scopedLambdaNames = new HashSet<>();
+    /**
+     * The body {@code denotes} stands for here, or null where no body stands behind it.
+     *
+     * <p>The one place that answers it, so a name applied and a name handed over get the same answer.
+     * {@code reachedBy} is how the name is written here — bare for a definition of this module,
+     * qualified for the library and for what another module publishes — which is the namespace the
+     * table is keyed by; which namespace to look in is decided by the denotation, never by the text.
+     */
+    private Ast.FnDef expands(ValueName denotes, String reachedBy) {
+        return switch (denotes) {
+            case ValueName.Local local -> scopedLambdas.get(local.id());
+            case ValueName.Helper _, ValueName.Stdlib _ -> helpers.get(reachedBy);
+            // a construction, an injected behavior, `None`, or a name that denotes nothing: each is
+            // applied by something other than an expansion, and each is reported where it belongs
+            case ValueName.OfType _, ValueName.Behavior _, ValueName.Builtin _,
+                    ValueName.Unresolved _ -> null;
+        };
+    }
 
     /**
      * The arguments of a call that stays a call, with a dependency handed over by name replaced by
@@ -971,12 +992,15 @@ public final class HelperInliner {
      * so two copies of one helper's body spliced into two definitions do not answer as one binding.
      */
     public Ast.Expr inline(Ast.Expr e, BindingOwner into) {
-        Ast.Binders outer = binders;
+        Ast.Binders outerBinders = binders;
+        BindingOwner outerInto = this.into;
+        this.into = into;
         binders = new Ast.Binders(new BindingOwner.Synthesized(into, BindingOwner.Pass.INLINER, 0));
         try {
             return inline(e);
         } finally {
-            binders = outer;
+            binders = outerBinders;
+            this.into = outerInto;
         }
     }
 
@@ -1029,7 +1053,7 @@ public final class HelperInliner {
                 // the argument's own answer rather than deciding one for it
                 Map<String, ValueName> substDenotes = new HashMap<>();
                 Set<String> fnParams = new HashSet<>();
-                Map<String, Ast.FnDef> scopedLambdas = new HashMap<>();   // lambdas given to fn params
+                List<BindingId> given = new ArrayList<>();   // the lambdas given to fn params
                 List<Ast.Binder> letBinders = new ArrayList<>();
                 List<Ast.Expr> letValues = new ArrayList<>();
                 List<Ast.RetType> letTypes = new ArrayList<>();
@@ -1050,13 +1074,14 @@ public final class HelperInliner {
                             subst.put(p.name(), f.name());
                             substDenotes.put(p.name(), new ValueName.Local(f.name(), f.id()));
                             fnParams.add(p.name());
+                            given.add(f.id());
                             List<Ast.FnParam> lparams = new ArrayList<>();
                             for (Ast.Binder lp : lambda.params()) {
                                 lparams.add(new Ast.FnParam(lp, null));
                             }
                             // the lambda's body is caller code, so it is not renamed by this helper's
                             // substitution — only the enclosing helper body is.
-                            scopedLambdas.put(f.name(),
+                            scopedLambdas.put(f.id(),
                                     new Ast.FnDef(f.name(), lparams, null, null, lambda.body(), lambda.pos()));
                             lambdaOrigins.put(f.name(), new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
                         } else {
@@ -1094,12 +1119,12 @@ public final class HelperInliner {
                         letTypes.add(p.type());
                     }
                 }
-                scopedLambdas.forEach(helpers::put);
                 // a prelude helper's body is stamped with the call site, so errors inside it point at
                 // the user's call, not at the shipped source of souther.*
-                SourcePos at = keepsItsPositions(helper.name()) ? null : call.pos();
-                Ast.Expr body = inline(rename(helper.body(), subst, substDenotes, fnParams, at));   // expand nested helpers too
-                scopedLambdas.keySet().forEach(helpers::remove);
+                SourcePos at = keepsItsPositions(call) ? null : call.pos();
+                Copy copy = new Copy(new BindingOwner.Expansion(into, call.denotes(), k));
+                Ast.Expr body = inline(rename(helper.body(), subst, substDenotes, fnParams, at, copy));   // expand nested helpers too
+                given.forEach(scopedLambdas::remove);
                 body = keepDeclaredReturn(helper, body, call.pos(), k);
                 // wrap innermost-first so the value parameters bind in declared order
                 for (int i = letBinders.size() - 1; i >= 0; i--) {
@@ -1122,37 +1147,27 @@ public final class HelperInliner {
             case Ast.IfConstructed ic -> new Ast.IfConstructed(inline(ic.construct()), ic.binder(),
                     inline(ic.then()), Ast.mapArms(ic.els(), this::inline), ic.pos());
             case Ast.LetIn li when li.value() instanceof Ast.Block lambda -> {
-                // a lambda bound to a local: register it as a scoped helper so each application in
-                // the body expands inline (β-reduction), exactly like a named helper. Its parameters
-                // are untyped, so their types flow in from the arguments at expansion. No runtime
-                // closure is built as long as the lambda does not escape.
-                if (mentions(lambda.body(), li.name())) {
-                    throw CompileException.of(
-                            Diagnostic.of(null, "check.fn.recursivelambda").title("check.fn.title")
-                                    .at(lambda.pos()).args(li.name()).build(),
-                            "the lambda bound to `" + li.name() + "` refers to itself; a recursive lambda"
-                                    + " would not bottom out when expanded inline");
-                }
+                // a lambda bound to a local: registered under that binding, so each application of it
+                // in the body expands inline (β-reduction) exactly as a named helper does. Its
+                // parameters are untyped, so their types flow in from the arguments at expansion. No
+                // runtime closure is built as long as the lambda does not escape.
+                //
+                // The lambda cannot reach itself: a `let` does not bind its own name in its value
+                // (spec 16.1), so a name inside spelled like it is whatever it was outside, and
+                // expansion follows what a name denotes rather than how it is spelled.
                 List<Ast.FnParam> params = new ArrayList<>();
                 for (Ast.Binder p : lambda.params()) {
                     params.add(new Ast.FnParam(p, null));
                 }
-                Ast.FnDef synth = new Ast.FnDef(li.name(), params, null, null, lambda.body(), li.pos());
-                Ast.FnDef shadowed = helpers.put(li.name(), synth);
-                boolean fresh = scopedLambdaNames.add(li.name());
+                BindingId bound = li.binder().id();
+                scopedLambdas.put(bound,
+                        new Ast.FnDef(li.name(), params, null, null, lambda.body(), li.pos()));
                 Ast.Expr body = inline(li.body());
-                if (fresh) {
-                    scopedLambdaNames.remove(li.name());
-                }
-                if (shadowed == null) {
-                    helpers.remove(li.name());
-                } else {
-                    helpers.put(li.name(), shadowed);
-                }
-                // if the name still occurs, the lambda was used as a value, not just applied — it
+                scopedLambdas.remove(bound);
+                // if the binding is still read, the lambda was used as a value, not just applied — it
                 // escapes, which needs a runtime closure. Keep the binding so the "a block is not a
                 // value" check reports it.
-                yield mentions(body, li.name())
+                yield references(body, bound)
                         ? new Ast.LetIn(li.binder(), inline(lambda), li.declaredType(), li.annotated(), li.opens(), body, li.pos())
                         : body;
             }
@@ -1274,9 +1289,9 @@ public final class HelperInliner {
                 || !(call.args().get(idx) instanceof Ast.Var v)) {
             return call;
         }
-        Ast.FnDef helper = helpers.get(v.name());
+        Ast.FnDef helper = expands(v.denotes(), v.name());
         if (helper == null) {
-            return call;   // a bare name that is not a helper is left for the type checker to report
+            return call;   // a bare name that stands for no body is left for the type checker to report
         }
         int k = counter++;
         List<Ast.Binder> params = new ArrayList<>();
@@ -1291,6 +1306,40 @@ public final class HelperInliner {
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.set(idx, block);
         return new Ast.Call(call.fn(), call.denotes(), args, call.origin(), call.pos());
+    }
+
+    /**
+     * One copy of a body, and the bindings it has of its own.
+     *
+     * <p>A body spliced into a caller brings its bindings with it, and a second splice brings them
+     * again — so each copy owns them rather than the definition they were written in. A binding met
+     * in the copy is answered with the copy's, and every name that read it in the original reads the
+     * copy's too; a name the substitution answers is the caller's and is left alone.
+     */
+    private final class Copy {
+
+        private final Ast.Binders binders;
+        private final Map<BindingId, BindingId> mine = new HashMap<>();
+
+        private Copy(BindingOwner owner) {
+            this.binders = new Ast.Binders(owner);
+        }
+
+        /** This copy's binder for one the body has. */
+        Ast.Binder of(Ast.Binder binder) {
+            BindingId here = mine.computeIfAbsent(binder.id(),
+                    original -> binders.binder(binder.name(), binder.pos()).id());
+            return new Ast.Binder.Bound(binder.name(), here, binder.pos());
+        }
+
+        /** The same, for a name that reads one. Anything else is not this body's to answer. */
+        ValueName of(ValueName denotes) {
+            if (!(denotes instanceof ValueName.Local local)) {
+                return denotes;
+            }
+            BindingId here = mine.get(local.id());
+            return here == null ? denotes : new ValueName.Local(local.name(), here);
+        }
     }
 
     /**
@@ -1312,15 +1361,15 @@ public final class HelperInliner {
      */
     private Ast.Expr rename(Ast.Expr e, Map<String, String> subst,
                             Map<String, ValueName> substDenotes, Set<String> fnParams,
-                            SourcePos at) {
+                            SourcePos at, Copy copy) {
         return switch (e) {
             // a substituted name keeps what the argument resolved to, so a named function handed to a
             // combinator stays the helper it is rather than becoming a binding of that spelling
             case Ast.Var v -> subst.containsKey(v.name())
                     ? new Ast.Var(subst.get(v.name()), substituted(substDenotes, v.name()),
                             at(at, v.pos()))
-                    : e;
-            case Ast.FieldAccess fa -> new Ast.FieldAccess(rename(fa.target(), subst, substDenotes, fnParams, at), fa.field(), at(at, fa.pos()));
+                    : v.denoting(copy.of(v.denotes()));
+            case Ast.FieldAccess fa -> new Ast.FieldAccess(rename(fa.target(), subst, substDenotes, fnParams, at, copy), fa.field(), at(at, fa.pos()));
             case Ast.Call call -> {
                 boolean renamed = fnParams.contains(call.fn()) && subst.containsKey(call.fn());
                 String callee = renamed ? subst.get(call.fn()) : call.fn();
@@ -1328,23 +1377,24 @@ public final class HelperInliner {
                 // name this expansion gave it; anything else keeps what the call already denoted
                 // the argument's own answer where this expansion substituted one; a scoped lambda
                 // was registered as a local just above, and a named function stays what it is
-                ValueName denotes = renamed ? substituted(substDenotes, call.fn()) : call.denotes();
-                yield new Ast.Call(callee, denotes, renameList(call.args(), subst, substDenotes, fnParams, at),
+                ValueName denotes = renamed
+                        ? substituted(substDenotes, call.fn()) : copy.of(call.denotes());
+                yield new Ast.Call(callee, denotes, renameList(call.args(), subst, substDenotes, fnParams, at, copy),
                         call.origin(),
                         at(at, call.pos()));
             }
-            case Ast.Binary bin -> new Ast.Binary(bin.op(), rename(bin.left(), subst, substDenotes, fnParams, at), rename(bin.right(), subst, substDenotes, fnParams, at), at(at, bin.pos()));
-            case Ast.Neg neg -> new Ast.Neg(rename(neg.operand(), subst, substDenotes, fnParams, at), at(at, neg.pos()));
+            case Ast.Binary bin -> new Ast.Binary(bin.op(), rename(bin.left(), subst, substDenotes, fnParams, at, copy), rename(bin.right(), subst, substDenotes, fnParams, at, copy), at(at, bin.pos()));
+            case Ast.Neg neg -> new Ast.Neg(rename(neg.operand(), subst, substDenotes, fnParams, at, copy), at(at, neg.pos()));
             case Ast.NewData nd -> {
                 List<Ast.FieldInit> inits = new ArrayList<>();
                 for (Ast.FieldInit i : nd.inits()) {
-                    inits.add(new Ast.FieldInit(i.name(), rename(i.value(), subst, substDenotes, fnParams, at), at(at, i.pos())));
+                    inits.add(new Ast.FieldInit(i.name(), rename(i.value(), subst, substDenotes, fnParams, at, copy), at(at, i.pos())));
                 }
                 List<Ast.ValueRef> spreads = new ArrayList<>();
                 for (Ast.ValueRef s : nd.spreads()) {
                     // `..param` copies the renamed binding, and stays the binding it now names
                     String renamed = subst.get(s.bare());
-                    spreads.add(renamed == null ? s
+                    spreads.add(renamed == null ? s.denoting(copy.of(s.denotes()))
                             : new Ast.ValueRef(renamed, substituted(substDenotes, s.bare()),
                                     at(at, s.pos())));
                 }
@@ -1354,28 +1404,31 @@ public final class HelperInliner {
                 List<Ast.Case> cases = new ArrayList<>();
                 for (Ast.Case c : m.cases()) {
                     Map<String, String> inner = c.binding() == null ? subst : without(subst, c.bindingName());
-                    cases.add(new Ast.Case(c.caseTypes(), c.binding(), rename(c.body(), inner, substDenotes, fnParams, at),
+                    cases.add(new Ast.Case(c.caseTypes(),
+                            c.binding() == null ? null : copy.of(c.binding()),
+                            rename(c.body(), inner, substDenotes, fnParams, at, copy),
                             c.unwrapAsserts(), at(at, c.pos())));
                 }
-                yield new Ast.Match(rename(m.scrutinee(), subst, substDenotes, fnParams, at), cases, at(at, m.pos()));
+                yield new Ast.Match(rename(m.scrutinee(), subst, substDenotes, fnParams, at, copy), cases, at(at, m.pos()));
             }
-            case Ast.If iff -> new Ast.If(rename(iff.cond(), subst, substDenotes, fnParams, at), rename(iff.then(), subst, substDenotes, fnParams, at), rename(iff.els(), subst, substDenotes, fnParams, at), at(at, iff.pos()));
+            case Ast.If iff -> new Ast.If(rename(iff.cond(), subst, substDenotes, fnParams, at, copy), rename(iff.then(), subst, substDenotes, fnParams, at, copy), rename(iff.els(), subst, substDenotes, fnParams, at, copy), at(at, iff.pos()));
             // the binder shadows in the success branch alone, so it is dropped from the substitution
             // there and left standing over the construction and the else value
             case Ast.IfConstructed ic -> new Ast.IfConstructed(
-                    rename(ic.construct(), subst, substDenotes, fnParams, at), ic.binder(),
-                    rename(ic.then(), without(subst, ic.binderName()), substDenotes, fnParams, at),
-                    Ast.mapArms(ic.els(), body -> rename(body, subst, substDenotes, fnParams, at)),
+                    rename(ic.construct(), subst, substDenotes, fnParams, at, copy), copy.of(ic.binder()),
+                    rename(ic.then(), without(subst, ic.binderName()), substDenotes, fnParams, at, copy),
+                    Ast.mapArms(ic.els(), body -> rename(body, subst, substDenotes, fnParams, at, copy)),
                     at(at, ic.pos()));
             case Ast.LetIn li -> {
-                Ast.Expr value = rename(li.value(), subst, substDenotes, fnParams, at);
-                Ast.Expr body = rename(li.body(), without(subst, li.name()), substDenotes, fnParams, at);
-                yield new Ast.LetIn(li.binder(), value, li.declaredType(), li.annotated(), li.opens(), body, at(at, li.pos()));
+                Ast.Expr value = rename(li.value(), subst, substDenotes, fnParams, at, copy);
+                Ast.Expr body = rename(li.body(), without(subst, li.name()), substDenotes, fnParams, at, copy);
+                yield new Ast.LetIn(copy.of(li.binder()), value, li.declaredType(), li.annotated(),
+                        li.opens(), body, at(at, li.pos()));
             }
-            case Ast.ListLit lit -> new Ast.ListLit(renameList(lit.elements(), subst, substDenotes, fnParams, at), at(at, lit.pos()));
-            case Ast.Tuple tup -> new Ast.Tuple(renameList(tup.elements(), subst, substDenotes, fnParams, at), at(at, tup.pos()));
-            case Ast.TupleGet tg -> new Ast.TupleGet(rename(tg.tuple(), subst, substDenotes, fnParams, at), tg.index(), tg.arity(), at(at, tg.pos()));
-            case Ast.ListComp comp -> new Ast.ListComp(rename(comp.element(), subst, substDenotes, fnParams, at), renameList(comp.guards(), subst, substDenotes, fnParams, at), at(at, comp.pos()));
+            case Ast.ListLit lit -> new Ast.ListLit(renameList(lit.elements(), subst, substDenotes, fnParams, at, copy), at(at, lit.pos()));
+            case Ast.Tuple tup -> new Ast.Tuple(renameList(tup.elements(), subst, substDenotes, fnParams, at, copy), at(at, tup.pos()));
+            case Ast.TupleGet tg -> new Ast.TupleGet(rename(tg.tuple(), subst, substDenotes, fnParams, at, copy), tg.index(), tg.arity(), at(at, tg.pos()));
+            case Ast.ListComp comp -> new Ast.ListComp(rename(comp.element(), subst, substDenotes, fnParams, at, copy), renameList(comp.guards(), subst, substDenotes, fnParams, at, copy), at(at, comp.pos()));
             case Ast.Block block -> {
                 // α-rename the block's own parameters to fresh `$`-names. Caller code — a lambda passed
                 // to a function parameter — is spliced into this block's scope during inlining; if the
@@ -1392,7 +1445,7 @@ public final class HelperInliner {
                     innerDenotes = new HashMap<>(innerDenotes);
                     innerDenotes.put(p.name(), new ValueName.Local(fresh.name(), fresh.id()));
                 }
-                yield new Ast.Block(freshParams, rename(block.body(), inner, innerDenotes, fnParams, at), at(at, block.pos()));
+                yield new Ast.Block(freshParams, rename(block.body(), inner, innerDenotes, fnParams, at, copy), at(at, block.pos()));
             }
             case Ast.IntLit _ -> e;
             case Ast.DecimalLit _ -> e;
@@ -1411,9 +1464,15 @@ public final class HelperInliner {
      * the ones to report. Everything else is a prelude helper, whose body lies in the shipped source of
      * {@code souther.*} and is stamped with the call site instead.
      */
-    private boolean keepsItsPositions(String helper) {
-        return own.containsKey(helper) || lambdaOrigins.containsKey(helper)
-                || scopedLambdaNames.contains(helper);
+    private boolean keepsItsPositions(Ast.Call call) {
+        return switch (call.denotes()) {
+            // a lambda, wherever it came from: the caller wrote it, or a prelude body wrote it and
+            // was stamped with the call site when that body was renamed
+            case ValueName.Local _ -> true;
+            case ValueName.Helper helper -> helper.module().equals(module);
+            case ValueName.Stdlib _, ValueName.Behavior _, ValueName.OfType _,
+                    ValueName.Builtin _, ValueName.Unresolved _ -> false;
+        };
     }
 
     /** The position to stamp on a rebuilt node: the override {@code at} for a prelude helper, or the
@@ -1424,10 +1483,10 @@ public final class HelperInliner {
 
     private List<Ast.Expr> renameList(List<Ast.Expr> es, Map<String, String> subst,
                                       Map<String, ValueName> substDenotes,
-                                      Set<String> fnParams, SourcePos at) {
+                                      Set<String> fnParams, SourcePos at, Copy copy) {
         List<Ast.Expr> out = new ArrayList<>();
         for (Ast.Expr e : es) {
-            out.add(rename(e, subst, substDenotes, fnParams, at));
+            out.add(rename(e, subst, substDenotes, fnParams, at, copy));
         }
         return out;
     }
@@ -1607,18 +1666,24 @@ public final class HelperInliner {
         return false;
     }
 
-    /** Whether {@code name} occurs as a variable or a call target anywhere in {@code e}. Used to
-     * spot a self-referencing lambda and to tell whether a let-bound lambda escapes (is used as a
-     * value) after its applications have been expanded away. */
-    private static boolean mentions(Ast.Expr e, String name) {
-        if (e instanceof Ast.Var v && v.name().equals(name)) {
-            return true;
-        }
-        if (e instanceof Ast.Call c && c.fn().equals(name)) {
+    /**
+     * Whether anything in {@code e} reads {@code binding}.
+     *
+     * <p>It asks what each name denotes, so a binder inside {@code e} that spells its name the same
+     * is another binding and answers no. Nothing here tracks scope, because the tree already carries
+     * the answer scope decided: that is what resolution is for.
+     */
+    private static boolean references(Ast.Expr e, BindingId binding) {
+        ValueName denotes = switch (e) {
+            case Ast.Var v -> v.denotes();
+            case Ast.Call c -> c.denotes();
+            default -> null;
+        };
+        if (denotes instanceof ValueName.Local local && local.id().equals(binding)) {
             return true;
         }
         boolean[] found = {false};
-        forEachChild(e, child -> found[0] |= mentions(child, name));
+        forEachChild(e, child -> found[0] |= references(child, binding));
         return found[0];
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -701,11 +701,17 @@ public final class HelperInliner {
         return List.of(e);
     }
 
-    /** Looks up a helper by name across the prelude and the module's own helpers, or null if the
-     * name is not a helper (a builtin, injected behavior, or unknown). Used to type-check a function
-     * passed to a helper's function parameter against the declared type, at the call site. */
+    /** The declaration reached by {@code name} across the prelude and the module's own helpers, or
+     * null where the name reaches none. For a reader walking a set of names this pass answered with —
+     * the recursive helpers, say. A reader holding a call asks {@link #applied} instead, because what
+     * a call applies is not decided by how it is spelled. */
     public Ast.FnDef helper(String name) {
         return helpers.get(name);
+    }
+
+    /** The body {@code call} applies, or null where it applies something no body stands behind. */
+    public Ast.FnDef applied(Ast.Call call) {
+        return appliedHelper(call);
     }
 
     /** {@code fold} is the one privileged loop primitive that takes a block (spec 18.4); its block is
@@ -1122,7 +1128,8 @@ public final class HelperInliner {
                 // a prelude helper's body is stamped with the call site, so errors inside it point at
                 // the user's call, not at the shipped source of souther.*
                 SourcePos at = keepsItsPositions(call) ? null : call.pos();
-                Copy copy = new Copy(new BindingOwner.Expansion(into, call.denotes(), k));
+                Copy copy = new Copy(helper.body(),
+                        new BindingOwner.Expansion(into, call.denotes(), k));
                 Ast.Expr body = inline(rename(helper.body(), subst, substDenotes, fnParams, at, copy));   // expand nested helpers too
                 given.forEach(scopedLambdas::remove);
                 body = keepDeclaredReturn(helper, body, call.pos(), k);
@@ -1316,23 +1323,30 @@ public final class HelperInliner {
      * in the copy is answered with the copy's, and every name that read it in the original reads the
      * copy's too; a name the substitution answers is the caller's and is left alone.
      */
-    private final class Copy {
+    private static final class Copy {
 
-        private final Ast.Binders binders;
         private final Map<BindingId, BindingId> mine = new HashMap<>();
 
-        private Copy(BindingOwner owner) {
-            this.binders = new Ast.Binders(owner);
+        /**
+         * Every binding the body introduces, given one of this copy's, before any of it is written.
+         *
+         * <p>Assigned in one pass so that a binder and the names that read it are moved together
+         * whatever order the copy is written in: a read met before its binder would otherwise be
+         * left on the original while the binder moved, and the two would no longer be one binding.
+         */
+        private Copy(Ast.Expr body, BindingOwner owner) {
+            Ast.Binders binders = new Ast.Binders(owner);
+            eachBinder(body, binder ->
+                    mine.put(binder.id(), binders.binder(binder.name(), binder.pos()).id()));
         }
 
         /** This copy's binder for one the body has. */
         Ast.Binder of(Ast.Binder binder) {
-            BindingId here = mine.computeIfAbsent(binder.id(),
-                    original -> binders.binder(binder.name(), binder.pos()).id());
-            return new Ast.Binder.Bound(binder.name(), here, binder.pos());
+            return new Ast.Binder.Bound(binder.name(), mine.get(binder.id()), binder.pos());
         }
 
-        /** The same, for a name that reads one. Anything else is not this body's to answer. */
+        /** The same, for a name that reads one. A name bound outside the body — a parameter, which
+         * the substitution answers — is not this copy's to move. */
         ValueName of(ValueName denotes) {
             if (!(denotes instanceof ValueName.Local local)) {
                 return denotes;
@@ -1340,6 +1354,30 @@ public final class HelperInliner {
             BindingId here = mine.get(local.id());
             return here == null ? denotes : new ValueName.Local(local.name(), here);
         }
+    }
+
+    /**
+     * Every binder written inside {@code e}, itself included where {@code e} is one.
+     *
+     * <p>The node kinds that introduce a binding are named here and nowhere else in this pass, so a
+     * kind added later is added once. The walk into the children is {@link Ast#forEachChild}, which
+     * is exhaustive over the expression kinds, so a new one cannot be missed.
+     */
+    private static void eachBinder(Ast.Expr e, java.util.function.Consumer<Ast.Binder> f) {
+        switch (e) {
+            case Ast.LetIn li -> f.accept(li.binder());
+            case Ast.Block b -> b.params().forEach(f);
+            case Ast.IfConstructed ic -> f.accept(ic.binder());
+            case Ast.Match m -> {
+                for (Ast.Case c : m.cases()) {
+                    if (c.binding() != null) {
+                        f.accept(c.binding());
+                    }
+                }
+            }
+            default -> { }
+        }
+        forEachChild(e, child -> eachBinder(child, f));
     }
 
     /**
@@ -1691,9 +1729,7 @@ public final class HelperInliner {
         // Applying a function-typed parameter, or a binding holding a function, is not a call to
         // whatever else bears that name. The call carries what it resolved to, so it is asked rather
         // than matched against the helper table — a parameter named like a helper was reaching the
-        // graph as a call to that helper, which made `let f (g: (Int) -> Int) = g(1)` recursive. A
-        // call that resolved to nothing keeps the table's answer: the prelude's own bodies are read
-        // here before their names have been through resolution.
+        // graph as a call to that helper, which made `let f (g: (Int) -> Int) = g(1)` recursive.
         if (e instanceof Ast.Call call && !(call.denotes() instanceof ValueName.Local)) {
             // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches the
             // recursive `foldFrom` — recursion classification and prelude-injection must see that.

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -132,7 +132,7 @@ final class HelperParams {
             if (open.isEmpty()) {
                 return null;
             }
-            body = inliner.inline(h.body());
+            body = inliner.inline(h.body(), inliner.bodyOf(h.name()));
         } catch (CompileException _) {
             return null;   // a written type or a call that does not resolve; the check reports it
         }
@@ -146,9 +146,9 @@ final class HelperParams {
             Ast.FnParam p = h.params().get(i);
             Type t = found.get(i);
             params.add(t == null ? p
-                    : new Ast.FnParam(p.name(),
+                    : new Ast.FnParam(p.binder(),
                             new Ast.RetType(List.of(Ast.TypeRef.of(t, p.pos())), p.pos()),
-                            p.typeFromPattern(), p.pos()));
+                            p.typeFromPattern()));
         }
         return new Ast.FnDef(h.name(), params, h.declaredReturn(), h.intrinsicKey(), h.body(),
                 h.partial(), h.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -118,7 +118,7 @@ final class HelperParams {
     private static Ast.FnDef settle(Ast.FnDef h, HelperInliner inliner, Symbols symbols,
                                     Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns) {
         List<Integer> open = new ArrayList<>();
-        Map<String, Type> env = new HashMap<>();
+        Scope env = Scope.NONE;
         Ast.Expr body;
         try {
             for (int i = 0; i < h.params().size(); i++) {
@@ -126,7 +126,7 @@ final class HelperParams {
                 if (p.type() == null) {
                     open.add(i);
                 } else {
-                    env.put(p.name(), TypeOps.resolveParamType(p.type(), symbols));
+                    env = env.with(p.binder(), TypeOps.resolveParamType(p.type(), symbols));
                 }
             }
             if (open.isEmpty()) {
@@ -160,7 +160,7 @@ final class HelperParams {
      * so the rounds run to a fixpoint. {@code env} is completed as they are found, and
      * {@code openUses} collects, for each parameter still open, a use of it that named no type.
      */
-    static Map<Integer, Type> determine(Ast.FnDef h, List<Integer> open, Map<String, Type> env,
+    static Map<Integer, Type> determine(Ast.FnDef h, List<Integer> open, Scope env,
                                         Ast.Expr body, Symbols symbols, Map<String, ReqSig> reqSigs,
                                         Map<String, Type> recursiveHelperFns,
                                         Map<Integer, Ast.Var> openUses) {
@@ -178,15 +178,16 @@ final class HelperParams {
         while (progress) {
             progress = false;
             for (int idx : value) {
-                String name = h.params().get(idx).name();
-                if (env.containsKey(name)) {
+                Ast.Binder param = h.params().get(idx).binder();
+                String name = param.name();
+                if (env.holds(param.id())) {
                     continue;
                 }
                 Type t = typing.typeOf(name, body, env);
                 if (t == null) {
                     openUses.put(idx, typing.openUse());
                 } else {
-                    env.put(name, t);
+                    env = env.with(param, t);
                     found.put(idx, t);
                     progress = true;
                 }
@@ -269,16 +270,14 @@ final class HelperParams {
         }
 
         /** The type {@code body} gives {@code name}, or null when it gives none. */
-        Type typeOf(String name, Ast.Expr body, Map<String, Type> env) {
+        Type typeOf(String name, Ast.Expr body, Scope env) {
             this.pinned = null;
             this.openUse = null;
             // A recursive helper's call is left standing rather than expanded, so the neighbouring
             // expression a parameter takes its type from can be one — `x + count(t)` reads `count(t)`
             // to type `x`. Its signature goes in here, once, and every inner scope is derived from
             // this one (spec 13.1). What is bound wins over it, as it does everywhere else.
-            Map<String, Type> scope = new HashMap<>(recursiveHelperFns);
-            scope.putAll(env);
-            visit(body, scope, name);
+            visit(body, env.reaching(recursiveHelperFns), name);
             return pinned;
         }
 
@@ -287,7 +286,7 @@ final class HelperParams {
             return openUse;
         }
 
-        private void visit(Ast.Expr e, Map<String, Type> env, String name) {
+        private void visit(Ast.Expr e, Scope env, String name) {
             if (pinned != null) {
                 return;
             }
@@ -334,7 +333,7 @@ final class HelperParams {
          * {@code x} through {@code y}, which is the shape a call to another body-typed helper inlines
          * to. A binding of the parameter's own name shadows it, so its body is not walked for it.
          */
-        private void visitLet(Ast.LetIn li, Map<String, Type> env, String name) {
+        private void visitLet(Ast.LetIn li, Scope env, String name) {
             Type demanded = li.declaredType() == null ? null
                     : TypeOps.resolveParamType(li.declaredType(), symbols);
             if (isParam(li.value(), name)) {
@@ -354,16 +353,11 @@ final class HelperParams {
                 return;
             }
             Type bound = demanded != null ? demanded : carried(li, env);
-            Map<String, Type> inner = env;
-            if (bound != null) {
-                inner = new HashMap<>(env);
-                inner.put(li.name(), bound);
-            }
-            visit(li.body(), inner, name);
+            visit(li.body(), bound == null ? env : env.with(li.binder(), bound), name);
         }
 
         /** The type a binding carries into its body, or null where this scope cannot type its value. */
-        private Type carried(Ast.LetIn li, Map<String, Type> env) {
+        private Type carried(Ast.LetIn li, Scope env) {
             Type value = typed(li.value(), env);
             return value == null ? null : Elaborator.carriedType(li, value, symbols);
         }
@@ -434,7 +428,7 @@ final class HelperParams {
         }
 
         /** The type of a neighbouring expression, or null where this scope cannot type it. */
-        private Type typed(Ast.Expr e, Map<String, Type> env) {
+        private Type typed(Ast.Expr e, Scope env) {
             try {
                 return Elaborator.typeOf(e, env, ctx);
             } catch (CompileException _) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -477,12 +477,8 @@ public final class HelperTyping {
         Map<String, Set<String>> calls = new HashMap<>();
         for (String h : recursive) {
             Ast.Expr body = loweredBodies.get(h);
-            Set<String> bound = new HashSet<>();
-            for (Ast.FnParam p : inliner.helper(h).params()) {
-                bound.add(p.name());
-            }
             DataChecker.Constructs c = DataChecker.Constructs.empty();
-            DataChecker.collectConstructs(body, c, symbols, bound, Map.of());   // recursive calls opaque here
+            DataChecker.collectConstructs(body, c, symbols, Map.of());   // recursive calls opaque here
             own.put(h, c);
             Set<String> callees = new LinkedHashSet<>();
             collectCalls(body, callees, recursive);

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -329,9 +329,11 @@ public final class HelperTyping {
 
     private static void checkHelperCallFnArgs(Ast.Call call, Map<String, Type> env, Symbols symbols,
                                               Map<String, ReqSig> reqs, HelperInliner inliner) {
-        Ast.FnDef h = inliner.helper(call.fn());
+        // what the call applies, which a binding of a helper's spelling is not: applying a
+        // function-typed parameter is not a call to the helper it happens to be named after
+        Ast.FnDef h = inliner.applied(call);
         if (h == null || call.args().size() != h.params().size()) {
-            return;   // not a helper, or an arity mismatch the inliner reports
+            return;   // applies no body, or an arity mismatch the inliner reports
         }
         List<Type> declared = new ArrayList<>();
         boolean hasFn = false;

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -42,7 +42,7 @@ public final class HelperTyping {
                                      TypeChecker.Elaborated elaborated) {
         for (Ast.FnDef h : inliner.helpers().values()) {
             boolean recursive = recursiveHelperFns.containsKey(h.name());
-            Map<String, Type> env = new HashMap<>();
+            Scope env = Scope.NONE;
             List<Integer> inferred = new ArrayList<>();
             for (int i = 0; i < h.params().size(); i++) {
                 Ast.FnParam p = h.params().get(i);
@@ -61,7 +61,7 @@ public final class HelperTyping {
                     inferred.add(i);
                     continue;
                 }
-                env.put(p.name(), TypeOps.resolveParamType(p.type(), symbols));
+                env = env.with(p.binder(), TypeOps.resolveParamType(p.type(), symbols));
             }
             Elaborator.rejectBuiltinShadowing(h.body());
             // A helper the lowered module carries is one the backend emits — a recursive one, and one
@@ -94,8 +94,7 @@ public final class HelperTyping {
             // it is given. A parameter of the same name wins: a binding in force wins over the
             // declaration it shadows (spec §fn-rules), so `let use (depth: Int)` reads its `depth` as
             // the Int it declares and not as the helper it is spelled like.
-            Map<String, Type> tenv = new HashMap<>(recursiveHelperFns);
-            tenv.putAll(env);
+            Scope tenv = env.reaching(recursiveHelperFns);
             // a helper that returns a function (e.g. `let adder (n) = (x) -> x + n`) has no application
             // here to infer the lambda's parameter types from; it is checked where it is inlined and
             // applied (spec §blocks).
@@ -143,7 +142,7 @@ public final class HelperTyping {
      * settles back onto the parameter — so what reaches here open is what it could not settle. Reading
      * it again is what turns "not settled" into a report that names the use that named no type.
      */
-    private static void typeFromBody(Ast.FnDef h, List<Integer> open, Map<String, Type> env,
+    private static void typeFromBody(Ast.FnDef h, List<Integer> open, Scope env,
             Ast.Expr body, Symbols symbols, Map<String, ReqSig> reqSigs,
             Map<String, Type> recursiveHelperFns) {
         // A parameter used as a function is one, and neither applying it nor handing it to a
@@ -166,7 +165,7 @@ public final class HelperTyping {
         HelperParams.determine(h, open, env, body, symbols, reqSigs, recursiveHelperFns, openUses);
         for (int idx : open) {
             Ast.FnParam p = h.params().get(idx);
-            if (env.containsKey(p.name())) {
+            if (env.holds(p.binder().id())) {
                 continue;
             }
             Diagnostic.Builder d = Diagnostic.of(null, "check.helper.infer").title("check.helper.title")
@@ -319,7 +318,7 @@ public final class HelperTyping {
      * argument's type cannot be determined in the available scope (a value bound further out), it is
      * skipped and the ordinary inlined check still applies.
      */
-    static void checkFunctionArgs(Ast.Expr e, Map<String, Type> env, Symbols symbols,
+    static void checkFunctionArgs(Ast.Expr e, Scope env, Symbols symbols,
                                           Map<String, ReqSig> reqs, HelperInliner inliner) {
         if (e instanceof Ast.Call call) {
             checkHelperCallFnArgs(call, env, symbols, reqs, inliner);
@@ -327,7 +326,7 @@ public final class HelperTyping {
         TypeChecker.forEachChild(e, sub -> checkFunctionArgs(sub, env, symbols, reqs, inliner));
     }
 
-    private static void checkHelperCallFnArgs(Ast.Call call, Map<String, Type> env, Symbols symbols,
+    private static void checkHelperCallFnArgs(Ast.Call call, Scope env, Symbols symbols,
                                               Map<String, ReqSig> reqs, HelperInliner inliner) {
         // what the call applies, which a binding of a helper's spelling is not: applying a
         // function-typed parameter is not a call to the helper it happens to be named after
@@ -412,7 +411,7 @@ public final class HelperTyping {
     }
 
     private static void checkFunctionArg(Ast.FnDef h, String paramName, Type.FnOf want, Ast.Expr arg,
-                                         Map<String, Type> env, Symbols symbols,
+                                         Scope env, Symbols symbols,
                                          Map<String, ReqSig> reqs, HelperInliner inliner,
                                          Map<String, Type> bind) {
         if (arg instanceof Ast.Block lambda) {
@@ -425,12 +424,12 @@ public final class HelperTyping {
                                 + want.params().size() + " argument(s) but is written with "
                                 + lambda.params().size());
             }
-            Map<String, Type> lenv = new HashMap<>(env);
+            Scope lenv = env;
             for (int j = 0; j < lambda.params().size(); j++) {
                 if (isOpen(want.params().get(j))) {
                     return;   // the parameter type is still open; nothing concrete to check
                 }
-                lenv.put(lambda.params().get(j).name(), want.params().get(j));
+                lenv = lenv.with(lambda.params().get(j), want.params().get(j));
             }
             Type got;
             try {
@@ -454,7 +453,8 @@ public final class HelperTyping {
             if (!TypeOps.assignable(got, want.result(), symbols)) {
                 throw blockReturnMismatch(h, paramName, want.result(), got, lambda.pos());
             }
-        } else if (arg instanceof Ast.Var v && env.get(v.name()) instanceof Type vt && !(vt instanceof Type.FnOf)) {
+        } else if (arg instanceof Ast.Var v
+                && env.of(v.denotes(), v.name()) instanceof Type vt && !(vt instanceof Type.FnOf)) {
             throw CompileException.of(
                     Diagnostic.of(null, "check.fn.notfunction").title("check.fn.title")
                             .at(arg.pos()).args(paramName, h.name(), v.name()).build(),

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -72,7 +72,7 @@ public final class HelperTyping {
             // expansion runs (foldFrom's `step` is a parameter, not a same-named user helper).
             // Expanded once: the body an un-annotated parameter takes its type from is the same tree.
             Ast.Expr emitted = loweredBodies.get(h.name());
-            Ast.Expr body = emitted != null ? emitted : inliner.inline(h.body());
+            Ast.Expr body = emitted != null ? emitted : inliner.inline(h.body(), inliner.bodyOf(h.name()));
             if (recursive && body == null) {
                 // Lower keeps every recursive helper as a fn of the lowered module, and the backend
                 // emits from that same list, so a recursive helper without a lowered body would leave
@@ -353,7 +353,8 @@ public final class HelperTyping {
                 continue;
             }
             try {
-                Type at = Elaborator.typeOf(inliner.inline(call.args().get(i)), env, new CheckContext(symbols, null, reqs));
+                Type at = Elaborator.typeOf(inliner.inline(call.args().get(i), inliner.bodyOf(h.name())),
+                        env, new CheckContext(symbols, null, reqs));
                 TypeOps.unify(declared.get(i), at, bind, symbols, call.pos(), "argument " + (i + 1));
             } catch (CompileException _) {
                 return;   // can't pin the types here; leave it to the inlined check
@@ -427,11 +428,12 @@ public final class HelperTyping {
                 if (isOpen(want.params().get(j))) {
                     return;   // the parameter type is still open; nothing concrete to check
                 }
-                lenv.put(lambda.params().get(j), want.params().get(j));
+                lenv.put(lambda.params().get(j).name(), want.params().get(j));
             }
             Type got;
             try {
-                got = Elaborator.typeOf(inliner.inline(lambda.body()), lenv, new CheckContext(symbols, null, reqs));
+                got = Elaborator.typeOf(inliner.inline(lambda.body(), inliner.bodyOf(h.name())), lenv,
+                        new CheckContext(symbols, null, reqs));
             } catch (CompileException _) {
                 return;   // best-effort; the inlined check reports a genuine error with full context
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -268,7 +268,7 @@ public final class InvariantChecker {
         Set<String> inner = bound;
         if (e instanceof Ast.Block b && !b.params().isEmpty()) {
             inner = new java.util.HashSet<>(bound);
-            inner.addAll(b.params());
+            inner.addAll(b.paramNames());
         } else if (e instanceof Ast.LetIn li) {
             inner = new java.util.HashSet<>(bound);
             inner.add(li.name());
@@ -335,11 +335,11 @@ public final class InvariantChecker {
                 checkIfConstruction(ic.construct(), k, types, true);
                 Ast.forEachChild(ic.construct(), child -> walk(child, k, types));
                 Map<String, Type> t2 = new HashMap<>(types);
-                Known k2 = rebind(k, ic.binder());
+                Known k2 = rebind(k, ic.binderName());
                 Type built = typeExpr(ic.construct(), types);
                 if (built != null) {
-                    t2.put(ic.binder(), built);
-                    k2 = seedParam(ic.binder(), built, k2);   // on this branch the invariant holds
+                    t2.put(ic.binderName(), built);
+                    k2 = seedParam(ic.binderName(), built, k2);   // on this branch the invariant holds
                 }
                 walk(ic.then(), k2, t2);
                 // Each departure stands where the invariant did not hold, and nothing was built
@@ -366,11 +366,11 @@ public final class InvariantChecker {
                     Map<String, Type> t2 = new HashMap<>(types);
                     Known k2 = k;
                     if (c.binding() != null) {
-                        k2 = rebind(k, c.binding());
+                        k2 = rebind(k, c.bindingName());
                         if (c.caseTypes().size() == 1) {
                             Type bound = MatchElaborator.caseBindType(c.caseTypes().get(0).denotes());
                             if (bound != null) {
-                                t2.put(c.binding(), bound);
+                                t2.put(c.bindingName(), bound);
                             }
                         }
                     }
@@ -393,7 +393,7 @@ public final class InvariantChecker {
                     && combo.listArg() < call.args().size()) {
                 Type elem = elementType(typeExpr(call.args().get(combo.listArg()), types));
                 Map<String, Type> t2 = new HashMap<>(types);
-                String p = step.params().get(combo.elementParam());
+                String p = step.params().get(combo.elementParam()).name();
                 Known k2 = rebind(k, p);
                 if (elem != null) {
                     t2.put(p, elem);
@@ -1104,12 +1104,12 @@ public final class InvariantChecker {
                 || !(closure instanceof Ast.Block step) || step.params().size() != 1) {
             return null;
         }
-        String element = step.params().get(0);
-        List<String> read = new Reads(proj.params().get(0)).chain(proj.body());
+        Ast.Binder element = step.params().get(0);
+        List<String> read = new Reads(proj.params().get(0).name()).chain(proj.body());
         if (read == null) {
             return null;
         }
-        Reads reads = new Reads(element);
+        Reads reads = new Reads(element.name());
         Ast.Expr made = reads.produced(step.body());
         List<String> traced;
         if (read.isEmpty()) {
@@ -1258,7 +1258,7 @@ public final class InvariantChecker {
             case Ast.If iff -> elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
                     site, bound, depth, ")");
             case Ast.Block b -> {
-                Map<String, String> inner = binding(bound, b.params(), depth);
+                Map<String, String> inner = binding(bound, b.paramNames(), depth);
                 yield wrap("\\" + b.params().size(), termKey(b.body(), site, inner, depth + 1));
             }
             case Ast.LetIn li -> {

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.types.BindingId;
 import souther.compiler.diag.SourcePos;
 
 import java.util.ArrayList;
@@ -70,22 +71,22 @@ public final class Lower {
                                  Set<String> dependencies) {
         Ast.Expr expanded = recursive
                 ? inliner.inlineRecursiveBody(fn)
-                : inliner.inline(fn.body(), dependencyBinders(fn, dependencies));
+                : inliner.inline(fn.body(), dependencies(fn, dependencies), inliner.bodyOf(fn.name()));
         return new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
                 desugar(expanded), fn.partial(), fn.pos());
     }
 
-    /** Where each {@code depends on} name is bound: the trailing parameter that carries it. A name in
-     * the body is that parameter only when it was answered by this binder — a binding in force wins
-     * over the declaration it shadows (spec §fn-rules), so the spelling alone does not say. */
-    private static Set<SourcePos> dependencyBinders(Ast.FnDef fn, Set<String> dependencies) {
-        Set<SourcePos> binders = new HashSet<>();
+    /** Which bindings the {@code depends on} names are: the trailing parameters that carry them. A
+     * name in the body is one of them only when it was answered with that binding — a binding in force
+     * wins over the declaration it shadows (spec §fn-rules), so the spelling alone does not say. */
+    private static Set<BindingId> dependencies(Ast.FnDef fn, Set<String> dependencies) {
+        Set<BindingId> bindings = new HashSet<>();
         for (Ast.FnParam p : fn.params()) {
             if (dependencies.contains(p.name())) {
-                binders.add(p.pos());
+                bindings.add(p.binder().id());
             }
         }
-        return binders;
+        return bindings;
     }
 
     /** {@code module} with {@code fns} as its fns and every data invariant desugared — the tree the

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -112,9 +112,9 @@ public final class MatchElaborator {
                 checkUnwrapAsserts(c, ctx.symbols());
             }
             Core body = Elaborator.liftIntoOption(
-                    Elaborator.elaborate(c.body(), bound(env, c.binding(), bindType), ctx, expected),
+                    Elaborator.elaborate(c.body(), bound(env, c.bindingName(), bindType), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(denoted(c.caseTypes()), c.binding(), body, bindType, c.pos()));
+            arms.add(new Core.Case(denoted(c.caseTypes()), c.bindingName(), body, bindType, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();
@@ -179,9 +179,9 @@ public final class MatchElaborator {
                         "`" + caseType + "` is matched by more than one case");
             }
             Core body = Elaborator.liftIntoOption(
-                    Elaborator.elaborate(c.body(), bound(env, c.binding(), bind), ctx, expected),
+                    Elaborator.elaborate(c.body(), bound(env, c.bindingName(), bind), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(denoted(c.caseTypes()), c.binding(), body, bind, c.pos()));
+            arms.add(new Core.Case(denoted(c.caseTypes()), c.bindingName(), body, bind, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -23,7 +23,7 @@ public final class MatchElaborator {
 
     private MatchElaborator() {}
 
-    static Core elaborateMatch(Ast.Match m, Map<String, Type> env, CheckContext ctx,
+    static Core elaborateMatch(Ast.Match m, Scope env, CheckContext ctx,
                                        Type expected) {
         Core scrutinee = Elaborator.elaborate(m.scrutinee(), env, ctx);
         Type st = scrutinee.type();
@@ -83,7 +83,7 @@ public final class MatchElaborator {
      * exactly once (E1201; a second cover is an overlap error). */
     static Core elaborateCasesMatch(Ast.Match m, Core scrutineeCore, Set<TypeName> cases,
                                         String what, Type scrutinee,
-                                        Map<String, Type> env, CheckContext ctx, Type expected) {
+                                        Scope env, CheckContext ctx, Type expected) {
         Set<TypeName> covered = new HashSet<>();
         List<Core.Case> arms = new ArrayList<>();
         Type branchType = null;
@@ -112,7 +112,7 @@ public final class MatchElaborator {
                 checkUnwrapAsserts(c, ctx.symbols());
             }
             Core body = Elaborator.liftIntoOption(
-                    Elaborator.elaborate(c.body(), bound(env, c.bindingName(), bindType), ctx, expected),
+                    Elaborator.elaborate(c.body(), bound(env, c.binding(), bindType), ctx, expected),
                     expected, ctx.symbols());
             arms.add(new Core.Case(denoted(c.caseTypes()), c.binding(), body, bindType, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
@@ -139,7 +139,7 @@ public final class MatchElaborator {
     /** Match over {@code Option<element>}: cases are {@code Some} (binds the element) and
      * {@code None}; both must be present (spec 16.3). */
     static Core elaborateOptionMatch(Ast.Match m, Core scrutineeCore, Type element,
-                                          Map<String, Type> env, CheckContext ctx, Type expected) {
+                                          Scope env, CheckContext ctx, Type expected) {
         Set<TypeName> covered = new HashSet<>();
         List<Core.Case> arms = new ArrayList<>();
         Type branchType = null;
@@ -179,7 +179,7 @@ public final class MatchElaborator {
                         "`" + caseType + "` is matched by more than one case");
             }
             Core body = Elaborator.liftIntoOption(
-                    Elaborator.elaborate(c.body(), bound(env, c.bindingName(), bind), ctx, expected),
+                    Elaborator.elaborate(c.body(), bound(env, c.binding(), bind), ctx, expected),
                     expected, ctx.symbols());
             arms.add(new Core.Case(denoted(c.caseTypes()), c.binding(), body, bind, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
@@ -290,14 +290,10 @@ public final class MatchElaborator {
         }
     }
 
-    /** Extends {@code env} with {@code name -> type} when both are present; otherwise returns it as is. */
-    static Map<String, Type> bound(Map<String, Type> env, String name, Type type) {
-        if (name == null || type == null) {
-            return env;
-        }
-        Map<String, Type> benv = new HashMap<>(env);
-        benv.put(name, type);
-        return benv;
+    /** Extends {@code env} with {@code binding} when both it and its type are present; otherwise
+     * returns it as is. */
+    static Scope bound(Scope env, Ast.Binder binding, Type type) {
+        return binding == null || type == null ? env : env.with(binding, type);
     }
 
     static Type mergeBranch(Ast.Match m, Type branchType, Type bt, Ast.Case c, Type expected) {

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -114,7 +114,7 @@ public final class MatchElaborator {
             Core body = Elaborator.liftIntoOption(
                     Elaborator.elaborate(c.body(), bound(env, c.bindingName(), bindType), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(denoted(c.caseTypes()), c.bindingName(), body, bindType, c.pos()));
+            arms.add(new Core.Case(denoted(c.caseTypes()), c.binding(), body, bindType, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();
@@ -181,7 +181,7 @@ public final class MatchElaborator {
             Core body = Elaborator.liftIntoOption(
                     Elaborator.elaborate(c.body(), bound(env, c.bindingName(), bind), ctx, expected),
                     expected, ctx.symbols());
-            arms.add(new Core.Case(denoted(c.caseTypes()), c.bindingName(), body, bind, c.pos()));
+            arms.add(new Core.Case(denoted(c.caseTypes()), c.binding(), body, bind, c.pos()));
             branchType = mergeBranch(m, branchType, body.type(), c, expected);
         }
         List<String> missing = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -100,7 +100,7 @@ public final class NewtypeDesugar {
             case Ast.ListComp comp ->
                     new Ast.ListComp(go(comp.element(), symbols), mapExprs(comp.guards(), symbols), comp.pos());
             case Ast.LetIn li ->
-                    new Ast.LetIn(li.name(), go(li.value(), symbols), li.declaredType(), li.annotated(), li.opens(),
+                    new Ast.LetIn(li.binder(), go(li.value(), symbols), li.declaredType(), li.annotated(), li.opens(),
                             go(li.body(), symbols), li.pos());
             case Ast.If iff ->
                     new Ast.If(go(iff.cond(), symbols), go(iff.then(), symbols), go(iff.els(), symbols), iff.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -336,9 +336,12 @@ public final class Resolve {
             case Ast.UnitData u -> u;
             // an invariant reads the fields of the data it belongs to, which are what bind its
             // names — `value > 0` is about this declaration's `value`, whatever else is in scope
-            case Ast.Data d -> new Ast.Data(d.name(), d.newtype(), names(d.includes()), fields(d.fields()),
-                    Ast.mapClauses(d.invariants(), inv -> expr(inv, boundFields(d))),
-                    d.decoder().map(this::decoder), d.encoder().map(this::encoder), d.pos());
+            case Ast.Data d -> {
+                declareFields(d);
+                yield new Ast.Data(d.name(), d.newtype(), names(d.includes()), fields(d.fields()),
+                        Ast.mapClauses(d.invariants(), inv -> expr(inv, boundFields(d))),
+                        d.decoder().map(this::decoder), d.encoder().map(this::encoder), d.pos());
+            }
             case Ast.SumData s -> new Ast.SumData(s.name(), sumCases(s), s.decoder().map(this::discriminate),
                     s.encoder().map(this::sumEncoder), s.pos());
         };
@@ -370,6 +373,24 @@ public final class Resolve {
      * the ones a spread brings in, which are as much this declaration's fields as the written ones
      * (and are what a spread-in invariant was written against).
      */
+    /**
+     * Where each field this declaration writes is written, against the binding it introduces inside
+     * an invariant.
+     *
+     * <p>Recorded whether or not this declaration has an invariant of its own: a declaration that
+     * includes it reads these fields in <em>its</em> invariant, and the binding a field is stays the
+     * declaring declaration's, so this is where an editor is answered from either way.
+     */
+    private void declareFields(Ast.Data d) {
+        Map<String, BindingId> bindings = TypeOps.fieldBindings(d, symbols);
+        for (Ast.Field field : d.fields()) {
+            BindingId binding = bindings.get(field.name());
+            if (binding != null) {
+                binders.put(binding, field.pos());
+            }
+        }
+    }
+
     private Bindings boundFields(Ast.Data d) {
         Bindings bound = Bindings.NONE;
         // which binding each field is is answered in one place, so the pass that emits this

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -4,6 +4,8 @@ import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
@@ -46,10 +48,58 @@ public final class Resolve {
     private final List<ValueUse> values0 = new ArrayList<>();
     /** Every name it could not answer, as the error it would once have thrown. */
     private final List<CompileException> unresolved = new ArrayList<>();
+    /** Where each binding this pass gave an identity to is written. */
+    private final Map<BindingId, SourcePos> binders = new LinkedHashMap<>();
+    /** How many bindings each definition has been given, so the next one gets the next number. */
+    private final Map<BindingOwner, Integer> counts = new HashMap<>();
+    /** The definition whose text is being read. Every binding met belongs to it. */
+    private BindingOwner owner;
 
     private Resolve(Symbols symbols, Values values) {
         this.symbols = symbols;
         this.values = values;
+    }
+
+    /** The value definition of this spelling in this module. */
+    private BindingOwner ownerOfValue(String name) {
+        return new BindingOwner.OfValue(values.module(), name);
+    }
+
+    /** A binder answered, and the bindings that hold under it. */
+    private record Answered(Ast.Binder binder, Bindings bound) {}
+
+    /**
+     * {@code binder} given a binding of its own, and {@code bound} extended with it.
+     *
+     * <p>The binding is what the names under it are answered with, so two bindings of one spelling
+     * are two answers however they were written. Where it was written is kept aside, for a reader
+     * that is asking about the source rather than about the program.
+     */
+    private Answered bind(Bindings bound, Ast.Binder binder) {
+        int ordinal = counts.merge(owner, 1, Integer::sum) - 1;
+        BindingId id = new BindingId(owner, ordinal);
+        binders.put(id, binder.pos());
+        return new Answered(new Ast.Binder.Bound(binder.name(), id, binder.pos()),
+                bound.and(binder.name(), new ValueName.Local(binder.name(), id)));
+    }
+
+    /** The bindings under {@code binder}, where the binder itself is not carried on. */
+    private Bindings binding(Bindings bound, Ast.Binder binder) {
+        return bind(bound, binder).bound();
+    }
+
+    /** Several binders answered, and the bindings that hold under all of them. */
+    private record AnsweredAll(List<Ast.Binder> binders, Bindings bound) {}
+
+    /** The same as {@link #bind}, for the names one binder writes at once — a block's parameters. */
+    private AnsweredAll bindAll(Bindings bound, List<Ast.Binder> written) {
+        List<Ast.Binder> out = new ArrayList<>();
+        for (Ast.Binder b : written) {
+            Answered a = bind(bound, b);
+            bound = a.bound();
+            out.add(a.binder());
+        }
+        return new AnsweredAll(out, bound);
     }
 
     /**
@@ -105,9 +155,13 @@ public final class Resolve {
      * which becomes {@link souther.compiler.types.Type#ERRONEOUS}, and the rest of the module is
      * resolved as if the mistake were not there — so an author is told about every unknown name at
      * once instead of one per compile, and an editor can still say what the names around it mean.
+     *
+     * <p>{@code binders} says where each binding was written. A binding is not its position — a pass
+     * that expands a helper stamps the call site over the positions in the copy — so the two are kept
+     * apart, and a reader asking about the source rather than about the program reads this.
      */
     public record Resolved(Ast.Module module, List<Denotation> denotations, List<ValueUse> values,
-                           List<CompileException> unresolved) {}
+                           List<CompileException> unresolved, Map<BindingId, SourcePos> binders) {}
 
     /** {@code m} with every name it writes resolved against its own definitions — a module compiled
      * with nothing else in sight. */
@@ -155,6 +209,7 @@ public final class Resolve {
         }
         List<Ast.Example> examples = new ArrayList<>();
         for (Ast.Example e : m.examples()) {
+            r.owner = r.ownerOfValue(e.target());
             List<Ast.ExampleRow> rows = new ArrayList<>();
             for (Ast.ExampleRow row : e.rows()) {
                 List<Ast.With> withs = new ArrayList<>();
@@ -168,6 +223,7 @@ public final class Resolve {
         }
         List<Ast.Fake> fakes = new ArrayList<>();
         for (Ast.Fake f : m.fakes()) {
+            r.owner = r.ownerOfValue(f.target());
             List<Ast.FakeRow> rows = new ArrayList<>();
             for (Ast.FakeRow row : f.rows()) {
                 rows.add(new Ast.FakeRow(row.inputs() == null ? null : r.exprs(row.inputs()),
@@ -182,15 +238,18 @@ public final class Resolve {
         return new Resolved(
                 new Ast.Module(m.name(), m.exposing(), exposedOutputs, m.imports(), defs,
                         behaviors, fns, examples, fakes, m.exampleFileTarget(), m.pos()),
-                List.copyOf(r.denotations), List.copyOf(r.values0), List.copyOf(r.unresolved));
+                List.copyOf(r.denotations), List.copyOf(r.values0), List.copyOf(r.unresolved),
+                Map.copyOf(r.binders));
     }
 
     private Ast.FnDef fn(Ast.FnDef f) {
+        owner = ownerOfValue(f.name());
         List<Ast.FnParam> params = new ArrayList<>();
         Bindings bound = Bindings.NONE;
         for (Ast.FnParam p : f.params()) {
-            params.add(new Ast.FnParam(p.name(), paramType(p.type()), p.typeFromPattern(), p.pos()));
-            bound = bound.and(p.name(), p.pos());
+            Answered a = bind(bound, p.binder());
+            params.add(new Ast.FnParam(a.binder(), paramType(p.type()), p.typeFromPattern()));
+            bound = a.bound();
         }
         return new Ast.FnDef(f.name(), params, retType(f.declaredReturn()), f.intrinsicKey(),
                 f.body() == null ? null : expr(f.body(), bound), f.partial(), f.pos());
@@ -272,6 +331,7 @@ public final class Resolve {
     // --- definitions ---
 
     private Ast.Def def(Ast.Def def) {
+        owner = new BindingOwner.OfData(symbols.own(def.name()));
         return switch (def) {
             case Ast.UnitData u -> u;
             // an invariant reads the fields of the data it belongs to, which are what bind its
@@ -316,7 +376,7 @@ public final class Resolve {
 
     private Bindings boundFields(Ast.Data d, Bindings bound, Set<TypeName> spread) {
         for (Ast.Field f : d.fields()) {
-            bound = bound.and(f.name(), f.pos());
+            bound = binding(bound, Ast.Binder.written(f.name(), f.pos()));
         }
         for (Ast.Name include : d.includes()) {
             TypeName source = include.denotes() != null
@@ -354,30 +414,37 @@ public final class Resolve {
     private Ast.DecoderDef decoder(Ast.DecoderDef d) {
         return switch (d) {
             case Ast.PrimDecoder p -> {
-                Bindings bound = Bindings.NONE.and(p.inputName(), p.pos());
+                Answered input = bind(Bindings.NONE, p.input());
+                Bindings bound = input.bound();
                 List<Ast.DecStmt> stmts = new ArrayList<>();
                 for (Ast.DecStmt s : p.stmts()) {
                     if (s instanceof Ast.Let let) {
-                        stmts.add(new Ast.Let(let.name(), expr(let.value(), bound), let.pos()));
-                        bound = bound.and(let.name(), let.pos());
+                        Ast.Expr value = expr(let.value(), bound);
+                        Answered a = bind(bound, let.binder());
+                        stmts.add(new Ast.Let(a.binder(), value, let.pos()));
+                        bound = a.bound();
                     } else {
                         stmts.add(s);
                     }
                 }
-                yield new Ast.PrimDecoder(p.from(), p.inputName(), stmts,
+                yield new Ast.PrimDecoder(p.from(), input.binder(), stmts,
                         construct(p.result(), bound), p.pos());
             }
             case Ast.ObjectDecoder o -> {
                 List<Ast.Bind> binds = new ArrayList<>();
                 Bindings bound = Bindings.NONE;
                 for (Ast.Bind b : o.binds()) {
-                    binds.add(new Ast.Bind(b.name(), b.key(), decRef(b.ref()), b.pos()));
-                    bound = bound.and(b.name(), b.pos());
+                    Answered a = bind(bound, b.binder());
+                    binds.add(new Ast.Bind(a.binder(), b.key(), decRef(b.ref()), b.pos()));
+                    bound = a.bound();
                 }
                 yield new Ast.ObjectDecoder(binds, construct(o.result(), bound), o.pos());
             }
-            case Ast.NewtypeDecoder n -> new Ast.NewtypeDecoder(decRef(n.inner()), n.inputName(),
-                    construct(n.result(), Bindings.NONE.and(n.inputName(), n.pos())), n.pos());
+            case Ast.NewtypeDecoder n -> {
+                Answered input = bind(Bindings.NONE, n.input());
+                yield new Ast.NewtypeDecoder(decRef(n.inner()), input.binder(),
+                        construct(n.result(), input.bound()), n.pos());
+            }
         };
     }
 
@@ -404,8 +471,8 @@ public final class Resolve {
 
     /** An encoder reads the value it is encoding under the name it gives it. */
     private Ast.EncoderDef encoder(Ast.EncoderDef e) {
-        return new Ast.EncoderDef(e.selfName(),
-                rawExpr(e.result(), Bindings.NONE.and(e.selfName(), e.pos())), e.pos());
+        Answered self = bind(Bindings.NONE, e.self());
+        return new Ast.EncoderDef(self.binder(), rawExpr(e.result(), self.bound()), e.pos());
     }
 
     private Ast.RawExpr rawExpr(Ast.RawExpr r, Bindings bound) {
@@ -422,8 +489,11 @@ public final class Resolve {
             case Ast.MapEnc m -> new Ast.MapEnc(expr(m.source(), bound), encElem(m.elem()),
                     encElem(m.key()), m.pos());
             // the inner expression reads the element the option holds, under the name given here
-            case Ast.OptionRaw o -> new Ast.OptionRaw(expr(o.access(), bound),
-                    rawExpr(o.inner(), bound.and(o.elemVar(), o.pos())), o.elemVar(), o.pos());
+            case Ast.OptionRaw o -> {
+                Answered elem = bind(bound, o.elem());
+                yield new Ast.OptionRaw(expr(o.access(), bound),
+                        rawExpr(o.inner(), elem.bound()), elem.binder(), o.pos());
+            }
             case Ast.ObjectRaw o -> {
                 List<Ast.RawEntry> entries = new ArrayList<>();
                 for (Ast.RawEntry entry : o.entries()) {
@@ -482,23 +552,32 @@ public final class Resolve {
             }
             // a binding's pattern may write Option's `Some`, which the binding check then rejects
             // for what it is — a name that opens nothing — rather than as a name nothing declares
-            case Ast.LetIn li -> new Ast.LetIn(li.name(), expr(li.value(), bound),
-                    paramType(li.declaredType()), li.annotated(),
-                    li.opens() == null ? null : caseName(li.opens()),
-                    expr(li.body(), bound.and(li.name(), li.pos())), li.pos());
-            case Ast.Block b -> new Ast.Block(b.params(),
-                    expr(b.body(), bound.andAll(b.params(), b.pos())), b.pos());
+            case Ast.LetIn li -> {
+                Ast.Expr value = expr(li.value(), bound);
+                Answered a = bind(bound, li.binder());
+                yield new Ast.LetIn(a.binder(), value,
+                        paramType(li.declaredType()), li.annotated(),
+                        li.opens() == null ? null : caseName(li.opens()),
+                        expr(li.body(), a.bound()), li.pos());
+            }
+            case Ast.Block b -> {
+                AnsweredAll ps = bindAll(bound, b.params());
+                yield new Ast.Block(ps.binders(), expr(b.body(), ps.bound()), b.pos());
+            }
             // an attempt's binder names the value only where there is one to name — the success
             // branch. The construction and the else value are outside it.
-            case Ast.IfConstructed ic -> new Ast.IfConstructed(expr(ic.construct(), bound),
-                    ic.binder(), expr(ic.then(), bound.and(ic.binder(), ic.pos())),
-                    arms(ic.els(), bound), ic.pos());
+            case Ast.IfConstructed ic -> {
+                Answered a = bind(bound, ic.binder());
+                yield new Ast.IfConstructed(expr(ic.construct(), bound), a.binder(),
+                        expr(ic.then(), a.bound()), arms(ic.els(), bound), ic.pos());
+            }
             case Ast.Match m -> {
                 List<Ast.Case> cases = new ArrayList<>();
                 for (Ast.Case c : m.cases()) {
-                    Bindings inArm = c.binding() == null ? bound : bound.and(c.binding(), c.pos());
-                    cases.add(new Ast.Case(caseNames(c.caseTypes()), c.binding(),
-                            expr(c.body(), inArm),
+                    Answered a = c.binding() == null ? null : bind(bound, c.binding());
+                    Bindings inArm = a == null ? bound : a.bound();
+                    cases.add(new Ast.Case(caseNames(c.caseTypes()),
+                            a == null ? null : a.binder(), expr(c.body(), inArm),
                             c.unwrapAsserts() == null ? null : names(c.unwrapAsserts()), c.pos()));
                 }
                 yield new Ast.Match(expr(m.scrutinee(), bound), cases, m.pos());
@@ -534,9 +613,9 @@ public final class Resolve {
      * bind a name a module declares, and the binding is what the name means there.
      */
     private ValueName valueName(String written, SourcePos pos, Bindings bound) {
-        SourcePos binder = bound.binderOf(written);
-        if (binder != null) {
-            return new ValueName.Local(written, binder);
+        ValueName.Local binding = bound.binderOf(written);
+        if (binding != null) {
+            return binding;
         }
         if (Elaborator.ROUNDING_MODES.contains(written) || written.equals("None")
                 || written.equals("Some")) {
@@ -562,9 +641,9 @@ public final class Resolve {
     /** What the name a call applies denotes. */
     private ValueName calledName(Ast.Call call, Bindings bound) {
         String written = call.fn();
-        SourcePos binder = bound.binderOf(written);
-        if (binder != null) {
-            return new ValueName.Local(written, binder);   // a function-typed parameter, applied
+        ValueName.Local binding = bound.binderOf(written);
+        if (binding != null) {
+            return binding;   // a function-typed parameter, applied
         }
         if (written.equals("Some") || written.equals("None")) {
             return new ValueName.Builtin(written);   // Option's cases, which are not calls (E1303)
@@ -662,28 +741,20 @@ public final class Resolve {
     }
 
     /**
-     * The names bound at a point in a body, each with where it was bound. Persistent: extending it
+     * The names bound at a point in a body, each with the binding it is. Persistent: extending it
      * leaves the outer scope as it was, which is what an inner binding shadowing an outer one is.
      */
-    record Bindings(Map<String, SourcePos> byName) {
+    record Bindings(Map<String, ValueName.Local> byName) {
 
         static final Bindings NONE = new Bindings(Map.of());
 
-        Bindings and(String name, SourcePos binder) {
-            Map<String, SourcePos> next = new HashMap<>(byName);
-            next.put(name, binder);
+        Bindings and(String name, ValueName.Local binding) {
+            Map<String, ValueName.Local> next = new HashMap<>(byName);
+            next.put(name, binding);
             return new Bindings(Map.copyOf(next));
         }
 
-        Bindings andAll(List<String> names, SourcePos binder) {
-            Map<String, SourcePos> next = new HashMap<>(byName);
-            for (String name : names) {
-                next.put(name, binder);
-            }
-            return new Bindings(Map.copyOf(next));
-        }
-
-        SourcePos binderOf(String name) {
+        ValueName.Local binderOf(String name) {
             return byName.get(name);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -372,8 +372,8 @@ public final class Resolve {
      */
     private Bindings boundFields(Ast.Data d) {
         Bindings bound = Bindings.NONE;
-        // the one walk that says what fields a declaration has, so the emitter reaches the same
-        // bindings without walking the includes again on its own account
+        // which binding each field is is answered in one place, so the pass that emits this
+        // invariant reaches the same ones without working them out again
         for (Map.Entry<String, BindingId> f : TypeOps.fieldBindings(d, symbols).entrySet()) {
             bound = bound.and(f.getKey(), new ValueName.Local(f.getKey(), f.getValue()));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -371,22 +371,11 @@ public final class Resolve {
      * (and are what a spread-in invariant was written against).
      */
     private Bindings boundFields(Ast.Data d) {
-        return boundFields(d, Bindings.NONE, new LinkedHashSet<>());
-    }
-
-    private Bindings boundFields(Ast.Data d, Bindings bound, Set<TypeName> spread) {
-        for (Ast.Field f : d.fields()) {
-            bound = binding(bound, Ast.Binder.written(f.name(), f.pos()));
-        }
-        for (Ast.Name include : d.includes()) {
-            TypeName source = include.denotes() != null
-                    ? include.denotes() : symbols.resolve(include.written());
-            // a spread of a spread reaches the fields underneath; a spread that names nothing, or
-            // names its way back round, is reported where the declaration is checked
-            if (source != null && spread.add(source)
-                    && symbols.get(source) instanceof Ast.Data src) {
-                bound = boundFields(src, bound, spread);
-            }
+        Bindings bound = Bindings.NONE;
+        // the one walk that says what fields a declaration has, so the emitter reaches the same
+        // bindings without walking the includes again on its own account
+        for (Map.Entry<String, BindingId> f : TypeOps.fieldBindings(d, symbols).entrySet()) {
+            bound = bound.and(f.getKey(), new ValueName.Local(f.getKey(), f.getValue()));
         }
         return bound;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Scope.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Scope.java
@@ -1,0 +1,109 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What a body may name where an expression is being typed: the bindings in force, and the
+ * declarations a name reaches without one.
+ *
+ * <p>The two are held apart, and which of them a name reads is decided by what the name denotes. A
+ * binding is found by the binding it is, not by how it is spelled — an expansion splices a body
+ * written in one scope into another, so a name in the copy would otherwise be answered by whatever
+ * the scope it landed in binds under that spelling. That is not shadowing: the copy's names were
+ * settled where they were written, and moving the code does not change what they mean.
+ *
+ * <p>A spelling is still what an author reads, so a name is kept beside each binding for a
+ * diagnostic to quote and for a did-you-mean to offer. Nothing is found by it.
+ */
+public record Scope(Map<BindingId, Binding> bindings, Map<String, Type> declared) {
+
+    /** One binding in force: what it is, and what it is called. */
+    public record Binding(String name, Type type) {}
+
+    public static final Scope NONE = new Scope(Map.of(), Map.of());
+
+    /** The bindings a body starts with — a helper's parameters, a declaration's fields. */
+    public static Scope of(Map<BindingId, Binding> bindings) {
+        return new Scope(Map.copyOf(bindings), Map.of());
+    }
+
+    /** The same, with the signatures of the declarations a name may reach without a binding: a
+     * recursive helper, which is emitted as a method rather than expanded. */
+    public Scope reaching(Map<String, Type> declarations) {
+        return new Scope(bindings, Map.copyOf(declarations));
+    }
+
+    /**
+     * The type of what {@code denotes} names here, or null where nothing here does.
+     *
+     * <p>{@code reachedBy} is how a declaration is written here, which is the namespace the
+     * signatures are keyed by. Which namespace to look in is the denotation's to decide.
+     */
+    public Type of(ValueName denotes, String reachedBy) {
+        return switch (denotes) {
+            case ValueName.Local local -> typeOf(local.id());
+            case ValueName.Helper _, ValueName.Stdlib _, ValueName.Behavior _ ->
+                    declared.get(reachedBy);
+            case ValueName.OfType _, ValueName.Builtin _, ValueName.Unresolved _ -> null;
+            case null -> null;
+        };
+    }
+
+    /** The type of one binding, or null where this scope does not hold it. */
+    public Type typeOf(BindingId binding) {
+        Binding bound = bindings.get(binding);
+        return bound == null ? null : bound.type();
+    }
+
+    public boolean holds(BindingId binding) {
+        return bindings.containsKey(binding);
+    }
+
+    /** This scope with {@code binder} bound to {@code type}; the outer one is left as it was. */
+    public Scope with(Ast.Binder binder, Type type) {
+        return with(binder.id(), binder.name(), type);
+    }
+
+    public Scope with(BindingId binding, String name, Type type) {
+        Map<BindingId, Binding> next = new LinkedHashMap<>(bindings);
+        next.put(binding, new Binding(name, type));
+        return new Scope(next, declared);
+    }
+
+    /** The same, for several at once. */
+    public Scope withAll(Map<BindingId, Binding> more) {
+        Map<BindingId, Binding> next = new LinkedHashMap<>(bindings);
+        next.putAll(more);
+        return new Scope(next, declared);
+    }
+
+    /** What the names in force are called — for a diagnostic that offers what the author might have
+     * meant, and for nothing else. */
+    public List<String> spellings() {
+        List<String> names = new ArrayList<>();
+        for (Binding bound : bindings.values()) {
+            names.add(bound.name());
+        }
+        names.addAll(declared.keySet());
+        return names;
+    }
+
+    /** A name-to-type view of the bindings, for a reader that has only a spelling to go on. Two
+     * bindings of one spelling collapse, which is why nothing that decides meaning may use it. */
+    public Map<String, Type> byName() {
+        Map<String, Type> byName = new HashMap<>(declared);
+        for (Binding bound : bindings.values()) {
+            byName.put(bound.name(), bound.type());
+        }
+        return byName;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -286,21 +286,21 @@ public final class SpecChecker {
             }
         }
 
-        Map<String, Type> env = new HashMap<>();
+        Scope env = Scope.NONE;
         for (Ast.FnParam p : fn.params()) {
             Elaborator.rejectBuiltinShadow(p.name(), p.pos());
         }
         Elaborator.rejectBuiltinShadowing(fn.body());
         for (int i = 0; i < nBusiness; i++) {
-            env.put(fn.params().get(i).name(), TypeOps.successType(spec.params().get(i).type(), symbols));
+            env = env.with(fn.params().get(i).binder(),
+                    TypeOps.successType(spec.params().get(i).type(), symbols));
         }
         Type output = TypeOps.successType(spec.ret(), symbols);
         // recursive helpers this behavior calls resolve through their signatures (spec 13.1); merged
         // only for typing, so the construction and dependency walks below still see the business params alone.
         // A parameter of the same name wins: a binding in force wins over the declaration it shadows
         // (spec §fn-rules), so an input written `depth` is the input and not the helper spelled that way.
-        Map<String, Type> tenv = new HashMap<>(recursiveHelperFns);
-        tenv.putAll(env);
+        Scope tenv = env.reaching(recursiveHelperFns);
         // Check functions passed to helper parameters (e.g. a combinator's predicate) against their
         // declared types first, so a mismatch names the parameter, not the derivation it expands to.
         // A nested fold reaches `List.foldFrom` inside a block, so its signature must be in scope here.
@@ -326,7 +326,8 @@ public final class SpecChecker {
         // One expression (spec 16.4): this single walk sees every construction, including under a
         // desugared `guard`.
         DataChecker.Constructs constructed = DataChecker.Constructs.empty();
-        DataChecker.collectConstructs(body, constructed, symbols, new HashSet<>(env.keySet()), recHelperConstructs);
+        DataChecker.collectConstructs(body, constructed, symbols, new HashSet<>(env.spellings()),
+                recHelperConstructs);
         // `constructs` on an fn-backed behavior is optional: its construction permission is internal
         // (invisible to callers, unlike `depends on`), so with the body visible the set can be inferred
         // (ADR-0002). Omit it and inference stands. Declare it and it must match the body exactly —
@@ -391,7 +392,9 @@ public final class SpecChecker {
         // A guard-discharged one is silent; an unproven one is a warning (a possible abort); one the
         // guards prove must fail on a reachable path is an error (the path-sensitive generalization of
         // the constant `金額(-5)` check).
-        InvariantChecker.Findings inv = InvariantChecker.analyze(discharge, env, symbols);
+        // the invariant analysis reads its own atoms off the spellings a body writes, so it is
+        // handed the name view rather than the bindings
+        InvariantChecker.Findings inv = InvariantChecker.analyze(discharge, env.byName(), symbols);
         warnings.addAll(inv.warnings());
         if (!inv.errors().isEmpty()) {
             throw inv.errors().get(0);

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -326,8 +326,7 @@ public final class SpecChecker {
         // One expression (spec 16.4): this single walk sees every construction, including under a
         // desugared `guard`.
         DataChecker.Constructs constructed = DataChecker.Constructs.empty();
-        DataChecker.collectConstructs(body, constructed, symbols, new HashSet<>(env.spellings()),
-                recHelperConstructs);
+        DataChecker.collectConstructs(body, constructed, symbols, recHelperConstructs);
         // `constructs` on an fn-backed behavior is optional: its construction permission is internal
         // (invisible to callers, unlike `depends on`), so with the body visible the set can be inferred
         // (ADR-0002). Omit it and inference stands. Declare it and it must match the body exactly —

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -1,6 +1,8 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.ValueName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 
@@ -160,11 +162,13 @@ final class TotalityChecker {
         for (String f : group) {
             Ast.FnDef def = own.get(f);
             List<Ast.FnParam> params = def.params();
-            Set<String> paramNames = new HashSet<>();
-            Map<String, Integer> idxOf = new HashMap<>();
+            // which bindings the parameters are, not what they are spelled: a `let` inside the
+             // body may write a parameter's name, and it is another value
+            Set<BindingId> paramNames = new HashSet<>();
+            Map<BindingId, Integer> idxOf = new HashMap<>();
             for (int i = 0; i < params.size(); i++) {
-                paramNames.add(params.get(i).name());
-                idxOf.put(params.get(i).name(), i);
+                paramNames.add(params.get(i).binder().id());
+                idxOf.put(params.get(i).binder().id(), i);
             }
             List<RecCall> calls = new ArrayList<>();
             walk(def.body(), group, paramNames, Map.of(), Map.of(), calls);
@@ -175,12 +179,12 @@ final class TotalityChecker {
                 int cols = Math.min(toArity, rc.call().args().size());
                 for (int j = 0; j < cols; j++) {
                     Ast.Expr arg = rc.call().args().get(j);
-                    Set<String> strict = strictSmaller(arg, rc.lt(), rc.eq(), paramNames);
-                    Set<String> root = rootParams(arg, rc.lt(), rc.eq(), paramNames);
-                    for (String p : strict) {
+                    Set<BindingId> strict = strictSmaller(arg, rc.lt(), rc.eq(), paramNames);
+                    Set<BindingId> root = rootParams(arg, rc.lt(), rc.eq(), paramNames);
+                    for (BindingId p : strict) {
                         m[idxOf.get(p)][j] = Rel.LT;
                     }
-                    for (String p : root) {
+                    for (BindingId p : root) {
                         if (!strict.contains(p) && m[idxOf.get(p)][j] == null) {
                             m[idxOf.get(p)][j] = Rel.EQ;
                         }
@@ -277,7 +281,8 @@ final class TotalityChecker {
     /** A recorded recursive call to a group member, with the callee and the smaller-than / equal-to
      * relations ({@code lt} / {@code eq}) in scope where it appears. */
     private record RecCall(String callee, Ast.Call call,
-                           Map<String, Set<String>> lt, Map<String, Set<String>> eq) {}
+                           Map<BindingId, Set<BindingId>> lt,
+                           Map<BindingId, Set<BindingId>> eq) {}
 
     /**
      * A standard-library combinator that hands the contents of its container argument to a closure:
@@ -337,27 +342,29 @@ final class TotalityChecker {
      * strictly smaller part of the parameters the scrutinee is rooted at; a {@code let} carries the
      * strict or equal relation of its value forward.
      */
-    private static void walk(Ast.Expr e, Set<String> group, Set<String> paramNames,
-                             Map<String, Set<String>> lt, Map<String, Set<String>> eq,
+    private static void walk(Ast.Expr e, Set<String> group, Set<BindingId> paramNames,
+                             Map<BindingId, Set<BindingId>> lt, Map<BindingId, Set<BindingId>> eq,
                              List<RecCall> calls) {
         switch (e) {
             case Ast.Match m -> {
                 walk(m.scrutinee(), group, paramNames, lt, eq, calls);
-                Set<String> rooted = rootParams(m.scrutinee(), lt, eq, paramNames);
+                Set<BindingId> rooted = rootParams(m.scrutinee(), lt, eq, paramNames);
                 for (Ast.Case c : m.cases()) {
-                    Map<String, Set<String>> inner = lt;
+                    Map<BindingId, Set<BindingId>> inner = lt;
                     if (c.binding() != null && !rooted.isEmpty()) {
-                        inner = with(lt, c.bindingName(), rooted);   // the bound value is smaller than each root
+                        inner = with(lt, c.binding().id(), rooted);   // the bound value is smaller than each root
                     }
                     walk(c.body(), group, paramNames, inner, eq, calls);
                 }
             }
             case Ast.LetIn li -> {
                 walk(li.value(), group, paramNames, lt, eq, calls);
-                Set<String> smaller = strictSmaller(li.value(), lt, eq, paramNames);
-                Set<String> equal = eqRoots(li.value(), eq, paramNames);
-                Map<String, Set<String>> ltInner = smaller.isEmpty() ? lt : with(lt, li.name(), smaller);
-                Map<String, Set<String>> eqInner = equal.isEmpty() ? eq : with(eq, li.name(), equal);
+                Set<BindingId> smaller = strictSmaller(li.value(), lt, eq, paramNames);
+                Set<BindingId> equal = eqRoots(li.value(), eq, paramNames);
+                Map<BindingId, Set<BindingId>> ltInner =
+                        smaller.isEmpty() ? lt : with(lt, li.binder().id(), smaller);
+                Map<BindingId, Set<BindingId>> eqInner =
+                        equal.isEmpty() ? eq : with(eq, li.binder().id(), equal);
                 walk(li.body(), group, paramNames, ltInner, eqInner, calls);
             }
             case Ast.Call call -> {
@@ -374,11 +381,11 @@ final class TotalityChecker {
                         // element, or an option's unwrapped payload) is a sub-term of that container, so
                         // if the container is (part of) a parameter, the value is a strictly smaller
                         // part of it. Bind the element parameter accordingly for the step body.
-                        Set<String> elemRoots =
+                        Set<BindingId> elemRoots =
                                 rootParams(call.args().get(combo.containerArg()), lt, eq, paramNames);
-                        Map<String, Set<String>> inner = elemRoots.isEmpty()
+                        Map<BindingId, Set<BindingId>> inner = elemRoots.isEmpty()
                                 ? lt
-                                : with(lt, step.params().get(combo.elementParam()).name(), elemRoots);
+                                : with(lt, step.params().get(combo.elementParam()).id(), elemRoots);
                         walk(step.body(), group, paramNames, inner, eq, calls);
                     } else {
                         walk(arg, group, paramNames, lt, eq, calls);
@@ -393,16 +400,16 @@ final class TotalityChecker {
      * alias of one (through {@code eq}), a field chain rooted at one, or a local already known to be
      * smaller than one. Used for a {@code match} scrutinee: unwrapping a case of such a value yields a
      * strictly smaller part. */
-    private static Set<String> rootParams(Ast.Expr e, Map<String, Set<String>> lt,
-                                          Map<String, Set<String>> eq, Set<String> paramNames) {
+    private static Set<BindingId> rootParams(Ast.Expr e, Map<BindingId, Set<BindingId>> lt,
+                                          Map<BindingId, Set<BindingId>> eq, Set<BindingId> paramNames) {
         return switch (e) {
-            case Ast.Var v -> {
-                Set<String> s = new HashSet<>();
-                if (paramNames.contains(v.name())) {
-                    s.add(v.name());
+            case Ast.Var v when v.denotes() instanceof ValueName.Local local -> {
+                Set<BindingId> s = new HashSet<>();
+                if (paramNames.contains(local.id())) {
+                    s.add(local.id());
                 }
-                s.addAll(lt.getOrDefault(v.name(), Set.of()));
-                s.addAll(eq.getOrDefault(v.name(), Set.of()));
+                s.addAll(lt.getOrDefault(local.id(), Set.of()));
+                s.addAll(eq.getOrDefault(local.id(), Set.of()));
                 yield s;
             }
             case Ast.FieldAccess fa -> rootParams(fa.target(), lt, eq, paramNames);
@@ -413,10 +420,11 @@ final class TotalityChecker {
     /** The parameters {@code e} is a <em>strictly</em> smaller part of — a field access (a field is
      * strictly smaller than its target), or a local already known to be smaller. A bare parameter, or
      * an exact alias of one, is not strictly smaller than itself. */
-    private static Set<String> strictSmaller(Ast.Expr e, Map<String, Set<String>> lt,
-                                             Map<String, Set<String>> eq, Set<String> paramNames) {
+    private static Set<BindingId> strictSmaller(Ast.Expr e, Map<BindingId, Set<BindingId>> lt,
+                                             Map<BindingId, Set<BindingId>> eq, Set<BindingId> paramNames) {
         return switch (e) {
-            case Ast.Var v -> lt.getOrDefault(v.name(), Set.of());
+            case Ast.Var v when v.denotes() instanceof ValueName.Local local ->
+                    lt.getOrDefault(local.id(), Set.of());
             case Ast.FieldAccess fa -> rootParams(fa.target(), lt, eq, paramNames);
             default -> Set.of();
         };
@@ -424,21 +432,23 @@ final class TotalityChecker {
 
     /** The parameters {@code e} is <em>exactly equal</em> to — a bare parameter or an alias of one. A
      * field access is strictly smaller, not equal, so it is not here (it is in {@link #strictSmaller}). */
-    private static Set<String> eqRoots(Ast.Expr e, Map<String, Set<String>> eq, Set<String> paramNames) {
-        if (e instanceof Ast.Var v) {
-            Set<String> s = new HashSet<>();
-            if (paramNames.contains(v.name())) {
-                s.add(v.name());
+    private static Set<BindingId> eqRoots(Ast.Expr e, Map<BindingId, Set<BindingId>> eq,
+                                          Set<BindingId> paramNames) {
+        if (e instanceof Ast.Var v && v.denotes() instanceof ValueName.Local local) {
+            Set<BindingId> s = new HashSet<>();
+            if (paramNames.contains(local.id())) {
+                s.add(local.id());
             }
-            s.addAll(eq.getOrDefault(v.name(), Set.of()));
+            s.addAll(eq.getOrDefault(local.id(), Set.of()));
             return s;
         }
         return Set.of();
     }
 
-    private static Map<String, Set<String>> with(Map<String, Set<String>> env, String name, Set<String> params) {
-        Map<String, Set<String>> copy = new HashMap<>(env);
-        copy.put(name, params);
+    private static Map<BindingId, Set<BindingId>> with(Map<BindingId, Set<BindingId>> env,
+                                                       BindingId binding, Set<BindingId> params) {
+        Map<BindingId, Set<BindingId>> copy = new HashMap<>(env);
+        copy.put(binding, params);
         return copy;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -347,7 +347,7 @@ final class TotalityChecker {
                 for (Ast.Case c : m.cases()) {
                     Map<String, Set<String>> inner = lt;
                     if (c.binding() != null && !rooted.isEmpty()) {
-                        inner = with(lt, c.binding(), rooted);   // the bound value is smaller than each root
+                        inner = with(lt, c.bindingName(), rooted);   // the bound value is smaller than each root
                     }
                     walk(c.body(), group, paramNames, inner, eq, calls);
                 }
@@ -378,7 +378,7 @@ final class TotalityChecker {
                                 rootParams(call.args().get(combo.containerArg()), lt, eq, paramNames);
                         Map<String, Set<String>> inner = elemRoots.isEmpty()
                                 ? lt
-                                : with(lt, step.params().get(combo.elementParam()), elemRoots);
+                                : with(lt, step.params().get(combo.elementParam()).name(), elemRoots);
                         walk(step.body(), group, paramNames, inner, eq, calls);
                     } else {
                         walk(arg, group, paramNames, lt, eq, calls);

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -4,6 +4,8 @@ import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
@@ -714,6 +716,53 @@ public final class TypeOps {
     }
 
     /** Effective field name → type (included data flattened first, then own fields). */
+    /**
+     * The binding each of {@code data}'s fields introduces inside its own invariant, in the order
+     * {@link #fieldTypes} lists them.
+     *
+     * <p>An invariant reads its declaration's fields, and reads them as the bindings they are. Which
+     * binding each is follows from the one walk that says what fields a declaration has — the same
+     * one that gives their types — so the pass that resolves the invariant and the pass that emits it
+     * do not each work it out. A field name is unique within a declaration, which is what lets the
+     * walk be keyed by it.
+     */
+    public static Map<String, BindingId> fieldBindings(Ast.Data data, Symbols symbols) {
+        Map<String, BindingId> bindings = new LinkedHashMap<>();
+        walkFields(data, symbols.own(data.name()), symbols, new LinkedHashSet<>(), bindings);
+        return bindings;
+    }
+
+    /**
+     * Every field {@code data} has, each with the binding the declaration that declares it gives it.
+     *
+     * <p>A field brought in by an include keeps the binding of the declaration it was written in,
+     * because the invariant that reads it was written there too and is carried in with it. So a
+     * declaration binds its own fields and the fields underneath, and an invariant reads the same
+     * binding wherever it is checked or emitted.
+     *
+     * <p>Apart from {@link #fieldTypes} because it answers where that one cannot: this runs while the
+     * declaration is being resolved, where an include may not yet say what it denotes, and a field
+     * has a name whether or not its type has been worked out. An include that names nothing is
+     * skipped — the declaration is refused where it is checked, and refusing it twice says nothing
+     * more.
+     */
+    private static void walkFields(Ast.Data data, TypeName declared, Symbols symbols,
+                                   Set<TypeName> seen, Map<String, BindingId> out) {
+        BindingOwner owner = new BindingOwner.OfFields(declared);
+        int ordinal = 0;
+        for (Ast.Field field : data.fields()) {
+            out.putIfAbsent(field.name(), new BindingId(owner, ordinal++));
+        }
+        for (Ast.Name include : data.includes()) {
+            TypeName source = include.denotes() != null
+                    ? include.denotes() : symbols.resolve(include.written());
+            if (source != null && seen.add(source)
+                    && symbols.get(source) instanceof Ast.Data included) {
+                walkFields(included, source, symbols, seen, out);
+            }
+        }
+    }
+
     public static Map<String, Type> fieldTypes(Ast.Data data, Symbols symbols) {
         Map<String, Type> types = new LinkedHashMap<>();
         for (Ast.Name inc : data.includes()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -715,16 +715,18 @@ public final class TypeOps {
         }
     }
 
-    /** Effective field name → type (included data flattened first, then own fields). */
     /**
-     * The binding each of {@code data}'s fields introduces inside its own invariant, in the order
-     * {@link #fieldTypes} lists them.
+     * The binding each of {@code data}'s fields introduces inside its own invariant.
      *
      * <p>An invariant reads its declaration's fields, and reads them as the bindings they are. Which
-     * binding each is follows from the one walk that says what fields a declaration has — the same
-     * one that gives their types — so the pass that resolves the invariant and the pass that emits it
-     * do not each work it out. A field name is unique within a declaration, which is what lets the
-     * walk be keyed by it.
+     * binding each is is answered here and nowhere else, so the pass that resolves an invariant and
+     * the pass that emits it reach the same one. A field name is unique within a declaration, which
+     * is what lets the answer be keyed by it; the order the map iterates in says nothing, and no
+     * reader may take one from it.
+     *
+     * <p>What is fixed is the numbering: a field is numbered among the fields of the declaration
+     * that declares it, in the order that declaration writes them. An include brings a field in
+     * without renumbering it, so the two passes agree however either of them reaches it.
      */
     public static Map<String, BindingId> fieldBindings(Ast.Data data, Symbols symbols) {
         Map<String, BindingId> bindings = new LinkedHashMap<>();
@@ -740,11 +742,13 @@ public final class TypeOps {
      * declaration binds its own fields and the fields underneath, and an invariant reads the same
      * binding wherever it is checked or emitted.
      *
-     * <p>Apart from {@link #fieldTypes} because it answers where that one cannot: this runs while the
-     * declaration is being resolved, where an include may not yet say what it denotes, and a field
-     * has a name whether or not its type has been worked out. An include that names nothing is
-     * skipped — the declaration is refused where it is checked, and refusing it twice says nothing
-     * more.
+     * <p>A walk of its own, not the one {@link #fieldTypes} makes, because it answers where that one
+     * cannot: this runs while the declaration is being resolved, where an include may not yet say
+     * what it denotes, and a field has a name whether or not its type has been worked out. It
+     * therefore reaches the fields in an order of its own, which is why nothing reads one off the
+     * result. An include that names nothing is skipped, and a name an include repeats keeps the
+     * declaration's own — both are refused where the declaration is checked, and refusing them twice
+     * says nothing more.
      */
     private static void walkFields(Ast.Data data, TypeName declared, Symbols symbols,
                                    Set<TypeName> seen, Map<String, BindingId> out) {
@@ -763,6 +767,7 @@ public final class TypeOps {
         }
     }
 
+    /** Effective field name → type (included data flattened first, then own fields). */
     public static Map<String, Type> fieldTypes(Ast.Data data, Symbols symbols) {
         Map<String, Type> types = new LinkedHashMap<>();
         for (Ast.Name inc : data.includes()) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -390,7 +390,7 @@ public final class Backend {
                         code.aload(i);
                         int slot = gen.slot(pt);
                         unbox(code, pt, slot);
-                        gen.bind(h.params().get(i).name(), slot, pt);
+                        gen.bind(h.params().get(i).binder(), slot, pt);
                     }
                     // A tail-position call to this same helper loops back here instead of recursing,
                     // so a self-tail-recursive helper runs in constant stack.
@@ -908,7 +908,7 @@ public final class Backend {
                     code.aload(i + 1);
                     int slot = gen.slot(pt);
                     unbox(code, pt, slot);
-                    gen.bind(fn.params().get(i).name(), slot, pt);
+                    gen.bind(fn.params().get(i).binder(), slot, pt);
                 }
                 // thread the behavior's declared output so a tail-position fold over an empty seed
                 // materialises its step at the output type, not a bottom (issue #70)

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -10,6 +10,7 @@ import souther.compiler.check.Elaborator;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.Lower;
 import souther.compiler.check.ReqSig;
+import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeOps;
@@ -26,6 +27,7 @@ import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -93,7 +95,17 @@ final class BodyGen {
         private final CodeBuilder code;
         private final Ast.Data data;
         private final ClassDesc cdName;
-        private final Map<String, Var> env = new HashMap<>();
+        /**
+         * Where each binding this body holds lives.
+         *
+         * <p>Keyed by the binding rather than by its spelling, so an inner binding of the same
+         * spelling takes a slot of its own and leaves the outer one where it was. Nothing has to be
+         * put back when a scope ends, which is what a name-keyed table needed and did not always do.
+         */
+        private final Map<BindingId, Var> locals = new HashMap<>();
+        /** Where each injected behavior a lambda captured lives. Declared rather than bound, so it is
+         * reached by the name it is declared under. */
+        private final Map<String, Var> captured = new HashMap<>();
         private int nextSlot;
         private Set<String> reqNames = Set.of();
         private Map<String, Type> reqSuccess = Map.of();
@@ -151,19 +163,22 @@ final class BodyGen {
             return sigs;
         }
 
-        void bind(String name, int slot, Type type) {
-            env.put(name, new Var(slot, type));
-            nextSlot = Math.max(nextSlot, slot + width(type));
+        void bind(Ast.Binder binder, int slot, Type type) {
+            bind(binder.id(), binder.name(), slot, type);
         }
 
-        /** Restores a name to the binding it had before a block shadowed it (or removes it if it had
-         * none), so a block's parameters do not leak past the block (see {@link #fold}). */
-        private void restore(String name, Var previous) {
-            if (previous == null) {
-                env.remove(name);
-            } else {
-                env.put(name, previous);
-            }
+        void bind(BindingId binding, String name, int slot, Type type) {
+            put(locals, binding, new Var(slot, type, name));
+        }
+
+        /** Where an injected behavior a lambda captured was put. */
+        void bindCaptured(String injected, int slot, Type type) {
+            put(captured, injected, new Var(slot, type, injected));
+        }
+
+        private <K> void put(Map<K, Var> where, K key, Var var) {
+            where.put(key, var);
+            nextSlot = Math.max(nextSlot, var.slot() + width(var.type()));
         }
 
         int slot(Type type) {
@@ -231,24 +246,24 @@ final class BodyGen {
         /** Generates a synthetic {@code Fn} class for an escaping lambda: captured free variables become
          * {@code final} fields set by the constructor, and the body compiles into {@code apply}, which
          * unboxes its arguments from the {@code Object[]} and boxes its result (spec §blocks). */
-        private byte[] generateLambdaClass(ClassDesc cd, List<String> params, Core body,
+        private byte[] generateLambdaClass(ClassDesc cd, List<Ast.Binder> params, Core body,
                                            List<Type> paramTypes,
-                                           Type resultType, List<String> valueNames, List<Type> valueTypes,
+                                           Type resultType, List<Core.Read> captures,
                                            List<String> injectedNames, Map<String, Type> reqSuccess,
                                            Map<String, List<Type>> reqParams) {
             return build(cd, cb -> {
                 cb.withFlags(ClassFile.ACC_FINAL | ClassFile.ACC_SUPER);
                 cb.withInterfaceSymbols(CD_Fn);
-                for (int i = 0; i < valueNames.size(); i++) {
-                    cb.withField(captureField(i), jvmType(valueTypes.get(i)),
+                for (int i = 0; i < captures.size(); i++) {
+                    cb.withField(captureField(i), jvmType(captures.get(i).type()),
                             ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL);
                 }
                 for (String inj : injectedNames) {   // named after the behavior so requiredCall reads it
                     cb.withField(inj, ctx.requiredFieldType(inj), ClassFile.ACC_PRIVATE | ClassFile.ACC_FINAL);
                 }
                 List<ClassDesc> ctor = new ArrayList<>();
-                for (Type t : valueTypes) {
-                    ctor.add(jvmType(t));
+                for (Core.Read c : captures) {
+                    ctor.add(jvmType(c.type()));
                 }
                 for (String inj : injectedNames) {
                     ctor.add(ctx.requiredFieldType(inj));
@@ -258,11 +273,12 @@ final class BodyGen {
                     code.aload(0);
                     code.invokespecial(CD_Object, "<init>", MTD_void);
                     int slot = 1;
-                    for (int i = 0; i < valueNames.size(); i++) {
+                    for (int i = 0; i < captures.size(); i++) {
+                        Type ct = captures.get(i).type();
                         code.aload(0);
-                        load(code, slot, valueTypes.get(i));
-                        code.putfield(cd, captureField(i), jvmType(valueTypes.get(i)));
-                        slot += width(valueTypes.get(i));
+                        load(code, slot, ct);
+                        code.putfield(cd, captureField(i), jvmType(ct));
+                        slot += width(ct);
                     }
                     for (String inj : injectedNames) {
                         code.aload(0);
@@ -272,7 +288,7 @@ final class BodyGen {
                     }
                     code.return_();
                 });
-                if (valueNames.isEmpty() && injectedNames.isEmpty()) {
+                if (captures.isEmpty() && injectedNames.isEmpty()) {
                     // Captures are this class's only fields, so capturing nothing makes it stateless
                     // and one instance per lambda site is enough. Two sites never share one, and
                     // Souther has no function equality, so this is unobservable. Package-private:
@@ -301,13 +317,13 @@ final class BodyGen {
                         unbox(code, pt, s);
                         g.bind(params.get(i), s, pt);
                     }
-                    for (int i = 0; i < valueNames.size(); i++) {
-                        Type ct = valueTypes.get(i);
-                        int s = g.slot(ct);
+                    for (int i = 0; i < captures.size(); i++) {
+                        Core.Read c = captures.get(i);
+                        int s = g.slot(c.type());
                         code.aload(0);
-                        code.getfield(cd, captureField(i), jvmType(ct));
-                        store(code, s, ct);
-                        g.bind(valueNames.get(i), s, ct);
+                        code.getfield(cd, captureField(i), jvmType(c.type()));
+                        store(code, s, c.type());
+                        g.bind(c.binding(), c.name(), s, c.type());
                     }
                     Type rt = g.genExpr(body);
                     box(code, rt);
@@ -348,7 +364,7 @@ final class BodyGen {
                         requiredCall(call);
                         int vSlot = slot(letType);
                         store(code, vSlot, letType);
-                        bind(li.name(), vSlot, letType);
+                        bind(li.binder(), vSlot, letType);
                     } else {
                         Type vt = li.value().type();
                         if (vt instanceof Type.FnOf fn) {
@@ -360,7 +376,7 @@ final class BodyGen {
                         }
                         int slot = slot(vt);
                         store(code, slot, vt);
-                        bind(li.name(), slot, vt);
+                        bind(li.binder(), slot, vt);
                     }
                     emitTail(li.body(), cdB, requiredNames, requiredSuccess, expected);
                 }
@@ -377,10 +393,8 @@ final class BodyGen {
                 // the value emitter would leave the recursive call a real call and grow the stack.
                 case Core.IfConstructed ic -> {
                     Attempt a = emitAttempt(ic);
-                    Var shadowed = env.get(ic.binder().name());
-                    bind(ic.binder().name(), a.slot(), ic.construct().type());
+                    bind(ic.binder(), a.slot(), ic.construct().type());
                     emitTail(ic.then(), cdB, requiredNames, requiredSuccess, expected);
-                    restore(ic.binder().name(), shadowed);
                     code.labelBinding(a.elseLabel());
                     // Each departure is in tail position too, so it returns on its own and needs no
                     // jump past the ones emitted after it.
@@ -394,7 +408,7 @@ final class BodyGen {
                 case Core.NewData nd when DataChecker.isInvariantBearing(nd.typeName(), symbols) -> {
                     ClassDesc cdType = cd(nd.typeName());
                     Map<String, Type> flds = fieldTypes((Ast.Data) symbols.get(nd.typeName()));
-                    emitFieldValues(flds, nd.inits(), nd.spreadNames());
+                    emitFieldValues(flds, nd.inits(), nd.spreads());
                     emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                     code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(flds)));
                     code.invokestatic(CD_ConstraintViolation, "orThrow", MTD_orThrow);
@@ -435,7 +449,7 @@ final class BodyGen {
         private void emitSelfTailCall(Core.Call call) {
             List<Var> params = new ArrayList<>(tcoParams.size());
             for (Ast.FnParam p : tcoParams) {
-                params.add(env.get(p.name()));
+                params.add(locals.get(p.binder().id()));
             }
             for (int i = 0; i < call.args().size(); i++) {
                 Type at = genExpr(call.args().get(i));
@@ -452,7 +466,8 @@ final class BodyGen {
 
         /** Pushes each field's value in declaration order: an explicit initializer, else the field
          * carried over from a spread source (ADR-0021). */
-        void emitFieldValues(Map<String, Type> fields, List<Core.FieldInit> inits, List<String> spreads) {
+        void emitFieldValues(Map<String, Type> fields, List<Core.FieldInit> inits,
+                             List<Core.Read> spreads) {
             Map<String, Core.FieldInit> byName = new HashMap<>();
             for (Core.FieldInit init : inits) {
                 byName.put(init.name(), init);
@@ -465,7 +480,7 @@ final class BodyGen {
                     genExpr(init.value(), fields.get(field));
                     continue;
                 }
-                for (String sp : spreads) {
+                for (Core.Read sp : spreads) {
                     if (spreadableFields(((Type.Ref) varType(sp)).name()).containsKey(field)) {
                         spreadField(sp, field);
                         break;
@@ -588,7 +603,7 @@ final class BodyGen {
                     if (x.value()) code.iconst_1(); else code.iconst_0();
                 }
                 case Core.Read v -> {
-                    Var var = env.get(v.name());
+                    Var var = locals.get(v.binding());
                     if (var == null) {
                         throw new CompileException(v.pos(), "unbound identifier `" + v.name() + "`");
                     }
@@ -628,10 +643,8 @@ final class BodyGen {
                 case Core.IfConstructed ic -> {
                     Attempt a = emitAttempt(ic);
                     Label end = code.newLabel();
-                    Var shadowed = env.get(ic.binder().name());
-                    bind(ic.binder().name(), a.slot(), ic.construct().type());
+                    bind(ic.binder(), a.slot(), ic.construct().type());
                     genExpr(ic.then(), shapeOf(ic, expected));
-                    restore(ic.binder().name(), shadowed);
                     code.goto_(end);
 
                     code.labelBinding(a.elseLabel());
@@ -669,7 +682,7 @@ final class BodyGen {
                     }
                     int s = slot(vt);
                     store(code, s, vt);
-                    bind(li.name(), s, vt);
+                    bind(li.binder(), s, vt);
                     genExpr(li.body(), expected);
                 }
                 // a block has no value of its own; it is inlined by the call it is passed to
@@ -740,11 +753,10 @@ final class BodyGen {
                 Label nextCase = code.newLabel();
                 // A case binding is scoped to its arm: save any outer binding it shadows and restore it
                 // after the arm, or a later arm reusing the name would resolve to this arm's slot.
-                Var prevBinding = c.binding() != null ? env.get(c.bindingName()) : null;
+
                 emitCaseGuard(c, sSlot, st, element, nextCase);
                 genExpr(c.body(), want);
                 if (c.binding() != null) {
-                    restore(c.bindingName(), prevBinding);
                 }
                 code.goto_(end);
                 code.labelBinding(nextCase);
@@ -767,11 +779,10 @@ final class BodyGen {
                 Label nextCase = code.newLabel();
                 // A case binding is scoped to its arm (see {@link #match}): restore any outer binding it
                 // shadows before the next arm's dispatch.
-                Var prevBinding = c.binding() != null ? env.get(c.bindingName()) : null;
+
                 emitCaseGuard(c, sSlot, st, element, nextCase);
                 emitTail(c.body(), cdB, requiredNames, requiredSuccess, expected);
                 if (c.binding() != null) {
-                    restore(c.bindingName(), prevBinding);
                 }
                 code.labelBinding(nextCase);
             }
@@ -797,7 +808,7 @@ final class BodyGen {
                     int bslot = slot(element);
                     unbox(code, element, bslot);
                     if (c.binding() != null) {
-                        bind(c.bindingName(), bslot, element);
+                        bind(c.binding(), bslot, element);
                     }
                 }
             } else if (cases.size() == 1) {
@@ -810,7 +821,7 @@ final class BodyGen {
                     code.aload(sSlot);
                     int bslot = slot(bt);
                     unbox(code, bt, bslot);
-                    bind(c.bindingName(), bslot, bt);
+                    bind(c.binding(), bslot, bt);
                 }
             } else {
                 // or-pattern: run the body if the value is any of the cases; the binding (if any)
@@ -824,7 +835,7 @@ final class BodyGen {
                 code.goto_(nextCase);
                 code.labelBinding(body);
                 if (c.binding() != null) {
-                    bind(c.bindingName(), sSlot, st);
+                    bind(c.binding(), sSlot, st);
                 }
             }
         }
@@ -850,7 +861,7 @@ final class BodyGen {
                 // construction goes through __construct just as it does in tail (see emitTail): the
                 // invariant runs and orThrow either yields the value or aborts with a
                 // ConstraintViolation. orThrow returns Object, so narrow it back to the value type.
-                emitFieldValues(flds, nd.inits(), nd.spreadNames());
+                emitFieldValues(flds, nd.inits(), nd.spreads());
                 emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                 finishInvariantConstruct(cdType, flds);
                 return;
@@ -859,7 +870,7 @@ final class BodyGen {
             if (!walksInside(nd)) {
                 code.new_(cdType);
                 code.dup();
-                emitFieldValues(flds, nd.inits(), nd.spreadNames());
+                emitFieldValues(flds, nd.inits(), nd.spreads());
                 code.invokespecial(cdType, "<init>", ctor);
                 return;
             }
@@ -868,7 +879,7 @@ final class BodyGen {
             // `<init>`, and the verifier will not carry one over a jump. So the fields are built first
             // and held in slots, exactly as a newtype's single field already is, and the construction
             // itself is the straight line at the end.
-            emitFieldValues(flds, nd.inits(), nd.spreadNames());
+            emitFieldValues(flds, nd.inits(), nd.spreads());
             List<Type> fieldTypes = new ArrayList<>(flds.values());
             int[] held = new int[fieldTypes.size()];
             for (int i = fieldTypes.size() - 1; i >= 0; i--) {
@@ -915,7 +926,7 @@ final class BodyGen {
             Core.NewData nd = ic.construct();
             Map<String, Type> flds = fieldTypes((Ast.Data) symbols.get(nd.typeName()));
             ClassDesc cdType = cd(nd.typeName());
-            emitFieldValues(flds, nd.inits(), nd.spreadNames());
+            emitFieldValues(flds, nd.inits(), nd.spreads());
             emitLine(ic);   // re-pin: a field init may have moved the line off the construction
             code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(flds)));
 
@@ -1027,12 +1038,12 @@ final class BodyGen {
             return Type.ref(ntName);
         }
 
-        Type varType(String name) {
-            return env.get(name).type();
+        Type varType(Core.Read read) {
+            return locals.get(read.binding()).type();
         }
 
-        void spreadField(String spreadVar, String field) {
-            Var v = env.get(spreadVar);
+        void spreadField(Core.Read spreadVar, String field) {
+            Var v = locals.get(spreadVar.binding());
             TypeName srcName = ((Type.Ref) v.type()).name();
             load(code, v.slot(), v.type());
             emitFieldRead(code, srcName, field, spreadableFields(srcName).get(field));
@@ -1184,8 +1195,8 @@ final class BodyGen {
                     // field of the enclosing behavior, and is applied as the value it is. This asks
                     // where the value is, not what the name means: what it means was settled when
                     // the call was elaborated, and an injected behavior is not a binding.
-                    Var captured = env.get(call.fn());
-                    if (captured != null && captured.type() instanceof Type.FnOf fnType) {
+                    Var behavior = captured.get(call.fn());
+                    if (behavior != null && behavior.type() instanceof Type.FnOf fnType) {
                         applyCaptured(call, fnType);
                     } else if (ctx.emittedHelpers.containsKey(call.fn())) {
                         // The one loop the language has is emitted where it stands, not called.
@@ -1344,10 +1355,10 @@ final class BodyGen {
             // would otherwise stay bound after the walk — and a step that destructures its accumulator
             // binds ordinary names (`let (i, ys) = acc`), which are the caller's names as often as not.
             // The whole scope is put back, the slots it took staying taken.
-            Map<String, Var> enclosing = new HashMap<>(env);
-            bind(step.params().get(0).name(), acc, accType);
+            Map<BindingId, Var> enclosing = new HashMap<>(locals);
+            bind(step.params().get(0), acc, accType);
             int element = slot(elementType);
-            bind(step.params().get(1).name(), element, elementType);
+            bind(step.params().get(1), element, elementType);
 
             Label next = code.newLabel();
             Label done = code.newLabel();
@@ -1364,8 +1375,8 @@ final class BodyGen {
             code.goto_(next);
             code.labelBinding(done);
 
-            env.clear();
-            env.putAll(enclosing);
+            locals.clear();
+            locals.putAll(enclosing);
             load(code, acc, accType);
             answer.run();
             return true;
@@ -1774,7 +1785,8 @@ final class BodyGen {
         /** A name-to-type view of this scope, for the checker's inference helpers. */
         private Map<String, Type> typesEnv() {
             Map<String, Type> t = new HashMap<>();
-            env.forEach((k, v) -> t.put(k, v.type()));
+            locals.values().forEach(v -> t.put(v.name(), v.type()));
+            captured.forEach((name, v) -> t.put(name, v.type()));
             return t;
         }
 
@@ -1819,7 +1831,7 @@ final class BodyGen {
                     Type vt = genExpr(li.value());
                     int s = slot(vt);
                     store(code, s, vt);
-                    bind(li.name(), s, vt);
+                    bind(li.binder(), s, vt);
                     emitFunctionValue(li.body(), paramTypes);
                 }
                 default -> genExpr(value);
@@ -1830,31 +1842,21 @@ final class BodyGen {
          * captured free variables (and any injected behaviors it calls) to its constructor. Its
          * parameter and result types are the ones the checker put on the block (issue #81). */
         private void emitLambda(Core.Block block, List<Type> paramTypes) {
-            emitLambda(block.paramNames(), block.body(), paramTypes,
+            emitLambda(block.params(), block.body(), paramTypes,
                     ((Type.FnOf) block.type()).result(), freeVars(block));
         }
 
-        private void emitLambda(List<String> params, Core body, List<Type> paramTypes,
-                                Type resultType, List<String> free) {
-            List<String> valueNames = new ArrayList<>();
-            List<Type> valueTypes = new ArrayList<>();
-            List<String> injectedNames = new ArrayList<>();
-            for (String c : free) {
-                if (env.containsKey(c)) {
-                    valueNames.add(c);
-                    valueTypes.add(env.get(c).type());
-                } else {
-                    injectedNames.add(c);   // an injected behavior the closure calls (spec 13.2)
-                }
-            }
+        private void emitLambda(List<Ast.Binder> params, Core body, List<Type> paramTypes,
+                                Type resultType, Reaches free) {
+            List<Core.Read> captures = free.bindings();
+            List<String> injectedNames = free.injected();
             String className = pkg + ".$Fn" + ctx.nextLambdaId();
             ClassDesc cd = ClassDesc.of(className);
             ctx.addSynth(className, generateLambdaClass(cd, params, body, paramTypes, resultType,
-                    valueNames, valueTypes, injectedNames, reqSuccess, reqParams));
+                    captures, injectedNames, reqSuccess, reqParams));
 
-            // `free` is partitioned into the two lists above, so this is the same condition
-            // generateLambdaClass interned on — it must stay the same one.
-            if (free.isEmpty()) {
+            // the same condition generateLambdaClass interned on — it must stay the same one
+            if (captures.isEmpty() && injectedNames.isEmpty()) {
                 loadSharedInstance(code, cd);
                 return;
             }
@@ -1862,9 +1864,9 @@ final class BodyGen {
             code.new_(cd);
             code.dup();
             List<ClassDesc> ctorDescs = new ArrayList<>();
-            for (int i = 0; i < valueNames.size(); i++) {
-                load(code, env.get(valueNames.get(i)).slot(), valueTypes.get(i));
-                ctorDescs.add(jvmType(valueTypes.get(i)));
+            for (Core.Read c : captures) {
+                load(code, locals.get(c.binding()).slot(), c.type());
+                ctorDescs.add(jvmType(c.type()));
             }
             for (String inj : injectedNames) {
                 code.aload(0);                              // the enclosing behavior instance
@@ -1878,12 +1880,12 @@ final class BodyGen {
         /** Applies a first-class function value: {@code f.apply(new Object[]{args...})}, then casts
          * the {@code Object} result back to the function's result type. */
         private void applyFn(Core.Apply call, Type.FnOf fnType) {
-            applyValue(env.get(call.fn().name()), call.args(), fnType);
+            applyValue(locals.get(call.fn().binding()), call.args(), fnType);
         }
 
         /** The same, for an injected behavior a lambda captured into a slot of its own class. */
         private void applyCaptured(Core.Call call, Type.FnOf fnType) {
-            applyValue(env.get(call.fn()), call.args(), fnType);
+            applyValue(captured.get(call.fn()), call.args(), fnType);
         }
 
         private void applyValue(Var fv, List<Core> args, Type.FnOf fnType) {
@@ -1901,25 +1903,49 @@ final class BodyGen {
             stackCast(fnType.result());   // Object result -> the function's result type
         }
 
-        /** The free variables of a lambda: names its body reads that are bound in the enclosing
-         * scope (so must be captured), in first-seen order. */
-        private List<String> freeVars(Core.Block block) {
-            LinkedHashSet<String> free = new LinkedHashSet<>();
-            collectFree(block.body(), new HashSet<>(block.paramNames()), free);
-            return new ArrayList<>(free);
+        /**
+         * What a lambda's body reaches outside itself, and so what its class must be handed.
+         *
+         * <p>Two different things, kept apart rather than told apart afterwards: the bindings of the
+         * enclosing body it reads, and the injected behaviors it calls. One is bound here and the
+         * other is declared elsewhere, which is why one is held by binding and the other by name.
+         */
+        private static final class Reaches {
+
+            private final LinkedHashMap<BindingId, Core.Read> reads = new LinkedHashMap<>();
+            private final LinkedHashSet<String> behaviors = new LinkedHashSet<>();
+
+            List<Core.Read> bindings() {
+                return new ArrayList<>(reads.values());
+            }
+
+            List<String> injected() {
+                return new ArrayList<>(behaviors);
+            }
         }
 
-        private void collectFree(Core e, Set<String> bound, LinkedHashSet<String> free) {
+        /** What {@code block}'s body reaches outside itself, in first-seen order. */
+        private Reaches freeVars(Core.Block block) {
+            Reaches free = new Reaches();
+            Set<BindingId> bound = new HashSet<>();
+            block.params().forEach(p -> bound.add(p.id()));
+            collectFree(block.body(), bound, free);
+            return free;
+        }
+
+        private void collectFree(Core e, Set<BindingId> bound, Reaches free) {
             switch (e) {
-                case Core.Read v -> maybeFree(v.name(), bound, free);
+                case Core.Read v -> reaches(v, bound, free);
                 case Core.Call c -> {
-                    // an injected behavior the body calls is captured too: the lambda is a class of
-                    // its own, and what it reaches has to be handed to it
-                    maybeFree(c.fn(), bound, free);
+                    // an injected behavior the body calls is handed over too: the lambda is a class
+                    // of its own, and what it reaches has to reach it
+                    if (reqNames.contains(c.fn())) {
+                        free.behaviors.add(c.fn());
+                    }
                     c.args().forEach(a -> collectFree(a, bound, free));
                 }
                 case Core.Apply a -> {
-                    maybeFree(a.fn().name(), bound, free);   // the function value is captured too
+                    reaches(a.fn(), bound, free);
                     a.args().forEach(x -> collectFree(x, bound, free));
                 }
                 case Core.FieldAccess fa -> collectFree(fa.target(), bound, free);
@@ -1930,7 +1956,7 @@ final class BodyGen {
                 case Core.Neg neg -> collectFree(neg.operand(), bound, free);
                 case Core.NewData nd -> {
                     nd.inits().forEach(i -> collectFree(i.value(), bound, free));
-                    nd.spreads().forEach(sp -> maybeFree(sp.name(), bound, free));
+                    nd.spreads().forEach(sp -> reaches(sp, bound, free));
                 }
                 case Core.If iff -> {
                     collectFree(iff.cond(), bound, free);
@@ -1939,37 +1965,29 @@ final class BodyGen {
                 }
                 case Core.IfConstructed ic -> {
                     collectFree(ic.construct(), bound, free);
-                    Set<String> inner = new HashSet<>(bound);
-                    inner.add(ic.binder().name());
-                    collectFree(ic.then(), inner, free);
+                    collectFree(ic.then(), with(bound, ic.binder().id()), free);
                     ic.els().forEach(arm -> collectFree(arm.body(), bound, free));
                 }
                 case Core.LetIn li -> {
                     collectFree(li.value(), bound, free);
-                    Set<String> inner = new HashSet<>(bound);
-                    inner.add(li.name());
-                    collectFree(li.body(), inner, free);
+                    collectFree(li.body(), with(bound, li.binder().id()), free);
                 }
                 case Core.Match m -> {
                     collectFree(m.scrutinee(), bound, free);
                     for (Core.Case c : m.cases()) {
-                        Set<String> inner = bound;
-                        if (c.binding() != null) {
-                            inner = new HashSet<>(bound);
-                            inner.add(c.bindingName());
-                        }
-                        collectFree(c.body(), inner, free);
+                        collectFree(c.body(), c.binding() == null
+                                ? bound : with(bound, c.binding().id()), free);
                     }
                 }
                 case Core.Block b -> {
-                    Set<String> inner = new HashSet<>(bound);
-                    inner.addAll(b.paramNames());
+                    Set<BindingId> inner = new HashSet<>(bound);
+                    b.params().forEach(p -> inner.add(p.id()));
                     collectFree(b.body(), inner, free);
                 }
                 case Core.ListLit lit -> lit.elements().forEach(x -> collectFree(x, bound, free));
-                case Core.Tuple tup -> tup.elements().forEach(x -> collectFree(x, bound, free));
+                case Core.OptionSome so -> collectFree(so.value(), bound, free);
+                case Core.Tuple t -> t.elements().forEach(x -> collectFree(x, bound, free));
                 case Core.TupleGet tg -> collectFree(tg.tuple(), bound, free);
-                case Core.OptionSome s -> collectFree(s.value(), bound, free);
                 case Core.OptionNone _ -> { }
                 case Core.Int _ -> { }
                 case Core.Decimal _ -> { }
@@ -1982,11 +2000,20 @@ final class BodyGen {
             }
         }
 
-        private void maybeFree(String name, Set<String> bound, LinkedHashSet<String> free) {
-            if (!bound.contains(name) && (env.containsKey(name) || reqNames.contains(name))) {
-                free.add(name);
+        private static Set<BindingId> with(Set<BindingId> bound, BindingId binding) {
+            Set<BindingId> inner = new HashSet<>(bound);
+            inner.add(binding);
+            return inner;
+        }
+
+        /** A read of something bound outside the lambda is captured; one of its own is not. */
+        private void reaches(Core.Read read, Set<BindingId> bound, Reaches free) {
+            if (!bound.contains(read.binding()) && locals.containsKey(read.binding())) {
+                free.reads.putIfAbsent(read.binding(), read);
             }
         }
 
-    private record Var(int slot, Type type) {}
+    /** Where a value lives and what it is. {@code name} is what it is called — a diagnostic quotes
+     * it, and the checker's inference helpers are handed a view keyed by it; nothing is found by it. */
+    private record Var(int slot, Type type, String name) {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -377,10 +377,10 @@ final class BodyGen {
                 // the value emitter would leave the recursive call a real call and grow the stack.
                 case Core.IfConstructed ic -> {
                     Attempt a = emitAttempt(ic);
-                    Var shadowed = env.get(ic.binder());
-                    bind(ic.binder(), a.slot(), ic.construct().type());
+                    Var shadowed = env.get(ic.binder().name());
+                    bind(ic.binder().name(), a.slot(), ic.construct().type());
                     emitTail(ic.then(), cdB, requiredNames, requiredSuccess, expected);
-                    restore(ic.binder(), shadowed);
+                    restore(ic.binder().name(), shadowed);
                     code.labelBinding(a.elseLabel());
                     // Each departure is in tail position too, so it returns on its own and needs no
                     // jump past the ones emitted after it.
@@ -587,23 +587,21 @@ final class BodyGen {
                 case Core.Bool x -> {
                     if (x.value()) code.iconst_1(); else code.iconst_0();
                 }
-                case Core.Var v -> {
+                case Core.Read v -> {
                     Var var = env.get(v.name());
-                    if (var != null) {
-                        load(code, var.slot(), var.type());
-                    } else if (v.type() instanceof Type.Ref ref
-                            && symbols.get(ref.name()) instanceof Ast.UnitData) {
-                        // A unit data name in an expression constructs it (spec §unit-data), and a
-                        // unit type has exactly one value. Which unit is read off the type the name
-                        // was given rather than resolved again from its spelling: a body expanded in
-                        // from another module's published helper names that module's unit, which this
-                        // module need not declare at all — and, if it declares one spelled the same,
-                        // is not the same unit.
-                        loadSharedInstance(code, cd(ref.name()));
-                    } else {
+                    if (var == null) {
                         throw new CompileException(v.pos(), "unbound identifier `" + v.name() + "`");
                     }
+                    load(code, var.slot(), var.type());
                 }
+                // a unit type has exactly one value, and naming it is that value (spec §unit-data).
+                // Which unit is on the node: a body expanded in from another module's published
+                // helper names that module's unit, which this module need not declare at all — and,
+                // if it declares one spelled the same, is not the same unit.
+                case Core.UnitValue u -> loadSharedInstance(code, cd(u.data()));
+                case Core.Builtin b -> throw new IllegalStateException(
+                        "`" + b.name() + "` is read by the operation that takes it, not emitted, at "
+                                + b.pos());
                 case Core.Neg n -> {
                     if (genExpr(n.operand()) == Type.DECIMAL) {
                         code.invokevirtual(CD_BigDecimal, "negate", MethodTypeDesc.of(CD_BigDecimal));
@@ -630,10 +628,10 @@ final class BodyGen {
                 case Core.IfConstructed ic -> {
                     Attempt a = emitAttempt(ic);
                     Label end = code.newLabel();
-                    Var shadowed = env.get(ic.binder());
-                    bind(ic.binder(), a.slot(), ic.construct().type());
+                    Var shadowed = env.get(ic.binder().name());
+                    bind(ic.binder().name(), a.slot(), ic.construct().type());
                     genExpr(ic.then(), shapeOf(ic, expected));
-                    restore(ic.binder(), shadowed);
+                    restore(ic.binder().name(), shadowed);
                     code.goto_(end);
 
                     code.labelBinding(a.elseLabel());
@@ -741,11 +739,11 @@ final class BodyGen {
                 Label nextCase = code.newLabel();
                 // A case binding is scoped to its arm: save any outer binding it shadows and restore it
                 // after the arm, or a later arm reusing the name would resolve to this arm's slot.
-                Var prevBinding = c.binding() != null ? env.get(c.binding()) : null;
+                Var prevBinding = c.binding() != null ? env.get(c.bindingName()) : null;
                 emitCaseGuard(c, sSlot, st, element, nextCase);
                 genExpr(c.body(), want);
                 if (c.binding() != null) {
-                    restore(c.binding(), prevBinding);
+                    restore(c.bindingName(), prevBinding);
                 }
                 code.goto_(end);
                 code.labelBinding(nextCase);
@@ -768,11 +766,11 @@ final class BodyGen {
                 Label nextCase = code.newLabel();
                 // A case binding is scoped to its arm (see {@link #match}): restore any outer binding it
                 // shadows before the next arm's dispatch.
-                Var prevBinding = c.binding() != null ? env.get(c.binding()) : null;
+                Var prevBinding = c.binding() != null ? env.get(c.bindingName()) : null;
                 emitCaseGuard(c, sSlot, st, element, nextCase);
                 emitTail(c.body(), cdB, requiredNames, requiredSuccess, expected);
                 if (c.binding() != null) {
-                    restore(c.binding(), prevBinding);
+                    restore(c.bindingName(), prevBinding);
                 }
                 code.labelBinding(nextCase);
             }
@@ -798,7 +796,7 @@ final class BodyGen {
                     int bslot = slot(element);
                     unbox(code, element, bslot);
                     if (c.binding() != null) {
-                        bind(c.binding(), bslot, element);
+                        bind(c.bindingName(), bslot, element);
                     }
                 }
             } else if (cases.size() == 1) {
@@ -811,7 +809,7 @@ final class BodyGen {
                     code.aload(sSlot);
                     int bslot = slot(bt);
                     unbox(code, bt, bslot);
-                    bind(c.binding(), bslot, bt);
+                    bind(c.bindingName(), bslot, bt);
                 }
             } else {
                 // or-pattern: run the body if the value is any of the cases; the binding (if any)
@@ -825,7 +823,7 @@ final class BodyGen {
                 code.goto_(nextCase);
                 code.labelBinding(body);
                 if (c.binding() != null) {
-                    bind(c.binding(), sSlot, st);
+                    bind(c.bindingName(), sSlot, st);
                 }
             }
         }
@@ -1342,9 +1340,9 @@ final class BodyGen {
             // binds ordinary names (`let (i, ys) = acc`), which are the caller's names as often as not.
             // The whole scope is put back, the slots it took staying taken.
             Map<String, Var> enclosing = new HashMap<>(env);
-            bind(step.params().get(0), acc, accType);
+            bind(step.params().get(0).name(), acc, accType);
             int element = slot(elementType);
-            bind(step.params().get(1), element, elementType);
+            bind(step.params().get(1).name(), element, elementType);
 
             Label next = code.newLabel();
             Label done = code.newLabel();
@@ -1467,7 +1465,7 @@ final class BodyGen {
             code.aload(bSlot);
             genExpr(call.args().get(2));              // scale (Int, a long)
             code.l2i();
-            String mode = ((Core.Var) call.args().get(3)).name();
+            String mode = ((Core.Builtin) call.args().get(3)).name();
             code.getstatic(CD_RoundingMode, mode, CD_RoundingMode);
             code.invokevirtual(CD_BigDecimal, "divide", MTD_bdDivide);
             code.goto_(end);
@@ -1480,7 +1478,7 @@ final class BodyGen {
          * the call as `divide`'s is. The kernel aborts on a value too large for an Int. */
         private void decimalToInt(Core.Call call) {
             genExpr(call.args().get(0));
-            String mode = ((Core.Var) call.args().get(1)).name();
+            String mode = ((Core.Builtin) call.args().get(1)).name();
             code.getstatic(CD_RoundingMode, mode, CD_RoundingMode);
             code.invokestatic(CD_DecimalMath, "toInt",
                     MethodTypeDesc.of(ConstantDescs.CD_long, CD_BigDecimal, CD_RoundingMode));
@@ -1493,7 +1491,7 @@ final class BodyGen {
             genExpr(call.args().get(0));
             genExpr(call.args().get(1));   // scale (Int, a long)
             code.l2i();
-            String mode = ((Core.Var) call.args().get(2)).name();
+            String mode = ((Core.Builtin) call.args().get(2)).name();
             code.getstatic(CD_RoundingMode, mode, CD_RoundingMode);
             code.invokevirtual(CD_BigDecimal, "setScale",
                     MethodTypeDesc.of(CD_BigDecimal, ConstantDescs.CD_int, CD_RoundingMode));
@@ -1827,7 +1825,7 @@ final class BodyGen {
          * captured free variables (and any injected behaviors it calls) to its constructor. Its
          * parameter and result types are the ones the checker put on the block (issue #81). */
         private void emitLambda(Core.Block block, List<Type> paramTypes) {
-            emitLambda(block.params(), block.body(), paramTypes,
+            emitLambda(block.paramNames(), block.body(), paramTypes,
                     ((Type.FnOf) block.type()).result(), freeVars(block));
         }
 
@@ -1894,13 +1892,13 @@ final class BodyGen {
          * scope (so must be captured), in first-seen order. */
         private List<String> freeVars(Core.Block block) {
             LinkedHashSet<String> free = new LinkedHashSet<>();
-            collectFree(block.body(), new HashSet<>(block.params()), free);
+            collectFree(block.body(), new HashSet<>(block.paramNames()), free);
             return new ArrayList<>(free);
         }
 
         private void collectFree(Core e, Set<String> bound, LinkedHashSet<String> free) {
             switch (e) {
-                case Core.Var v -> maybeFree(v.name(), bound, free);
+                case Core.Read v -> maybeFree(v.name(), bound, free);
                 case Core.Call c -> {
                     maybeFree(c.fn(), bound, free);   // an applied function value is captured too
                     c.args().forEach(a -> collectFree(a, bound, free));
@@ -1923,7 +1921,7 @@ final class BodyGen {
                 case Core.IfConstructed ic -> {
                     collectFree(ic.construct(), bound, free);
                     Set<String> inner = new HashSet<>(bound);
-                    inner.add(ic.binder());
+                    inner.add(ic.binder().name());
                     collectFree(ic.then(), inner, free);
                     ic.els().forEach(arm -> collectFree(arm.body(), bound, free));
                 }
@@ -1939,14 +1937,14 @@ final class BodyGen {
                         Set<String> inner = bound;
                         if (c.binding() != null) {
                             inner = new HashSet<>(bound);
-                            inner.add(c.binding());
+                            inner.add(c.bindingName());
                         }
                         collectFree(c.body(), inner, free);
                     }
                 }
                 case Core.Block b -> {
                     Set<String> inner = new HashSet<>(bound);
-                    inner.addAll(b.params());
+                    inner.addAll(b.paramNames());
                     collectFree(b.body(), inner, free);
                 }
                 case Core.ListLit lit -> lit.elements().forEach(x -> collectFree(x, bound, free));
@@ -1959,6 +1957,9 @@ final class BodyGen {
                 case Core.Str _ -> { }
                 case Core.Bool _ -> { }
                 case Core.Unreachable _ -> { }
+                // neither reads anything the enclosing body binds
+                case Core.UnitValue _ -> { }
+                case Core.Builtin _ -> { }
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1,5 +1,6 @@
 package souther.compiler.codegen;
 
+import souther.compiler.check.Scope;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
@@ -204,7 +205,7 @@ final class BodyGen {
          * emitter in the shape it emits from. {@code expected} is the type the position wants, as the
          * checker pushes a field's declared type into its initialiser. */
         Core elaborate(Ast.Expr e, Type expected) {
-            return Elaborator.elaborate(Lower.desugarExpr(e), typesEnvWithHelpers(),
+            return Elaborator.elaborate(Lower.desugarExpr(e), scope(),
                     new CheckContext(symbols, data, reqSigs()), expected);
         }
 
@@ -1782,32 +1783,35 @@ final class BodyGen {
             code.labelBinding(end);
         }
 
-        /** A name-to-type view of this scope, for the checker's inference helpers. */
-        private Map<String, Type> typesEnv() {
-            Map<String, Type> t = new HashMap<>();
-            locals.values().forEach(v -> t.put(v.name(), v.type()));
-            captured.forEach((name, v) -> t.put(name, v.type()));
-            return t;
+        /** What the body may name here: the bindings this emitter holds, and the injected behaviors
+         * a lambda captured, which a call reaches by the name they are declared under. */
+        private Scope bound() {
+            Map<BindingId, Scope.Binding> held = new LinkedHashMap<>();
+            locals.forEach((binding, v) -> held.put(binding, new Scope.Binding(v.name(), v.type())));
+            Map<String, Type> declared = new HashMap<>();
+            captured.forEach((name, v) -> declared.put(name, v.type()));
+            return Scope.of(held).reaching(declared);
         }
 
-        /** {@link #typesEnv} plus the recursive helpers' signatures, so re-typing an expression that
+        /** {@link #bound} plus the recursive helpers' signatures, so re-typing an expression that
          * calls one (a nested {@code foldFrom} in a fold's seed) resolves it as a function. Only a
          * recursive helper's signature can be read here, and a recursive helper declares its return
          * type (spec 13.1); an example-applied helper is emitted beside them without declaring one, and
          * no standing call names it — it is expanded wherever a body calls it. */
-        private Map<String, Type> typesEnvWithHelpers() {
-            Map<String, Type> t = typesEnv();
+        private Scope scope() {
+            Scope held = bound();
+            Map<String, Type> declared = new HashMap<>(held.declared());
             ctx.emittedHelpers.forEach((name, h) -> {
-                if (t.containsKey(name) || h.declaredReturn() == null) {
-                    return;   // a local of the same name shadows the helper, as it does in the checker
+                if (declared.containsKey(name) || h.declaredReturn() == null) {
+                    return;
                 }
                 List<Type> params = new ArrayList<>();
                 for (Ast.FnParam p : h.params()) {
                     params.add(TypeOps.resolveParamType(p.type(), symbols));
                 }
-                t.put(name, Type.fn(params, successType(h.declaredReturn())));
+                declared.put(name, Type.fn(params, successType(h.declaredReturn())));
             });
-            return t;
+            return held.reaching(declared);
         }
 
         /** Emits a function value from its elaborated node: the parameter and result types are the

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -394,7 +394,7 @@ final class BodyGen {
                 case Core.NewData nd when DataChecker.isInvariantBearing(nd.typeName(), symbols) -> {
                     ClassDesc cdType = cd(nd.typeName());
                     Map<String, Type> flds = fieldTypes((Ast.Data) symbols.get(nd.typeName()));
-                    emitFieldValues(flds, nd.inits(), nd.spreads());
+                    emitFieldValues(flds, nd.inits(), nd.spreadNames());
                     emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                     code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(flds)));
                     code.invokestatic(CD_ConstraintViolation, "orThrow", MTD_orThrow);
@@ -656,6 +656,7 @@ final class BodyGen {
                 case Core.NewData nd -> newData(nd);
                 case Core.Match m -> match(m, expected);
                 case Core.Call c -> call(c, expected);
+                case Core.Apply a -> applyFn(a, (Type.FnOf) a.fn().type());
                 case Core.LetIn li -> {
                     // a `let` outside tail position: bind, then value the body
                     Type vt = li.value().type();
@@ -849,7 +850,7 @@ final class BodyGen {
                 // construction goes through __construct just as it does in tail (see emitTail): the
                 // invariant runs and orThrow either yields the value or aborts with a
                 // ConstraintViolation. orThrow returns Object, so narrow it back to the value type.
-                emitFieldValues(flds, nd.inits(), nd.spreads());
+                emitFieldValues(flds, nd.inits(), nd.spreadNames());
                 emitLine(nd);   // re-pin: a field init may have moved the line off the construction
                 finishInvariantConstruct(cdType, flds);
                 return;
@@ -858,7 +859,7 @@ final class BodyGen {
             if (!walksInside(nd)) {
                 code.new_(cdType);
                 code.dup();
-                emitFieldValues(flds, nd.inits(), nd.spreads());
+                emitFieldValues(flds, nd.inits(), nd.spreadNames());
                 code.invokespecial(cdType, "<init>", ctor);
                 return;
             }
@@ -867,7 +868,7 @@ final class BodyGen {
             // `<init>`, and the verifier will not carry one over a jump. So the fields are built first
             // and held in slots, exactly as a newtype's single field already is, and the construction
             // itself is the straight line at the end.
-            emitFieldValues(flds, nd.inits(), nd.spreads());
+            emitFieldValues(flds, nd.inits(), nd.spreadNames());
             List<Type> fieldTypes = new ArrayList<>(flds.values());
             int[] held = new int[fieldTypes.size()];
             for (int i = fieldTypes.size() - 1; i >= 0; i--) {
@@ -914,7 +915,7 @@ final class BodyGen {
             Core.NewData nd = ic.construct();
             Map<String, Type> flds = fieldTypes((Ast.Data) symbols.get(nd.typeName()));
             ClassDesc cdType = cd(nd.typeName());
-            emitFieldValues(flds, nd.inits(), nd.spreads());
+            emitFieldValues(flds, nd.inits(), nd.spreadNames());
             emitLine(ic);   // re-pin: a field init may have moved the line off the construction
             code.invokestatic(cdType, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(flds)));
 
@@ -1179,9 +1180,13 @@ final class BodyGen {
                 case "Decimal.toInt" -> decimalToInt(call);
                 case "Decimal.round" -> decimalRound(call);
                 default -> {
-                    Var fv = env.get(call.fn());
-                    if (fv != null && fv.type() instanceof Type.FnOf fnType) {
-                        applyFn(call, fnType);
+                    // an injected behavior a lambda captured arrives in a slot rather than in a
+                    // field of the enclosing behavior, and is applied as the value it is. This asks
+                    // where the value is, not what the name means: what it means was settled when
+                    // the call was elaborated, and an injected behavior is not a binding.
+                    Var captured = env.get(call.fn());
+                    if (captured != null && captured.type() instanceof Type.FnOf fnType) {
+                        applyCaptured(call, fnType);
                     } else if (ctx.emittedHelpers.containsKey(call.fn())) {
                         // The one loop the language has is emitted where it stands, not called.
                         if (!call.fn().equals(FOLD) || !folded(call)) {
@@ -1872,15 +1877,23 @@ final class BodyGen {
 
         /** Applies a first-class function value: {@code f.apply(new Object[]{args...})}, then casts
          * the {@code Object} result back to the function's result type. */
-        private void applyFn(Core.Call call, Type.FnOf fnType) {
-            Var fv = env.get(call.fn());
+        private void applyFn(Core.Apply call, Type.FnOf fnType) {
+            applyValue(env.get(call.fn().name()), call.args(), fnType);
+        }
+
+        /** The same, for an injected behavior a lambda captured into a slot of its own class. */
+        private void applyCaptured(Core.Call call, Type.FnOf fnType) {
+            applyValue(env.get(call.fn()), call.args(), fnType);
+        }
+
+        private void applyValue(Var fv, List<Core> args, Type.FnOf fnType) {
             load(code, fv.slot(), fv.type());   // the Fn receiver
-            pushInt(code, call.args().size());
+            pushInt(code, args.size());
             code.anewarray(CD_Object);
-            for (int i = 0; i < call.args().size(); i++) {
+            for (int i = 0; i < args.size(); i++) {
                 code.dup();
                 pushInt(code, i);
-                Type at = genExpr(call.args().get(i));
+                Type at = genExpr(args.get(i));
                 box(code, at);
                 code.aastore();
             }
@@ -1900,8 +1913,14 @@ final class BodyGen {
             switch (e) {
                 case Core.Read v -> maybeFree(v.name(), bound, free);
                 case Core.Call c -> {
-                    maybeFree(c.fn(), bound, free);   // an applied function value is captured too
+                    // an injected behavior the body calls is captured too: the lambda is a class of
+                    // its own, and what it reaches has to be handed to it
+                    maybeFree(c.fn(), bound, free);
                     c.args().forEach(a -> collectFree(a, bound, free));
+                }
+                case Core.Apply a -> {
+                    maybeFree(a.fn().name(), bound, free);   // the function value is captured too
+                    a.args().forEach(x -> collectFree(x, bound, free));
                 }
                 case Core.FieldAccess fa -> collectFree(fa.target(), bound, free);
                 case Core.Binary bin -> {
@@ -1911,7 +1930,7 @@ final class BodyGen {
                 case Core.Neg neg -> collectFree(neg.operand(), bound, free);
                 case Core.NewData nd -> {
                     nd.inits().forEach(i -> collectFree(i.value(), bound, free));
-                    nd.spreads().forEach(sp -> maybeFree(sp, bound, free));
+                    nd.spreads().forEach(sp -> maybeFree(sp.name(), bound, free));
                 }
                 case Core.If iff -> {
                     collectFree(iff.cond(), bound, free);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -884,7 +884,7 @@ final class CodecGen {
         code.invokevirtual(CD_ROk, "value", MTD_Object);
         int inputSlot = gen.slot(inputType);
         unbox(code, inputType, inputSlot);
-        gen.bind(prim.inputName(), inputSlot, inputType);
+        gen.bind(prim.input(), inputSlot, inputType);
 
         for (Ast.DecStmt stmt : prim.stmts()) {
             switch (stmt) {
@@ -892,7 +892,7 @@ final class CodecGen {
                     Type t = gen.expr(let.value());
                     int slot = gen.slot(t);
                     store(code, slot, t);
-                    gen.bind(let.name(), slot, t);
+                    gen.bind(let.binder(), slot, t);
                 }
             }
         }
@@ -928,7 +928,7 @@ final class CodecGen {
         Type innerType = bindType(dec.inner());
         int inSlot = gen.slot(innerType);
         unbox(code, innerType, inSlot);                             // cast Object -> Y, store
-        gen.bind(dec.inputName(), inSlot, innerType);
+        gen.bind(dec.input(), inSlot, innerType);
         emitConstructCall(code, gen, cdName, dec.result(), fields);
     }
 
@@ -991,11 +991,11 @@ final class CodecGen {
                 code.invokestatic(CD_Option, "ofOptional", MTD_ofOptional, true);
                 int vSlot = gen.slot(t);
                 code.astore(vSlot);
-                gen.bind(bind.name(), vSlot, t);
+                gen.bind(bind.binder(), vSlot, t);
             } else {
                 int vSlot = gen.slot(t);
                 unbox(code, t, vSlot);
-                gen.bind(bind.name(), vSlot, t);
+                gen.bind(bind.binder(), vSlot, t);
             }
         }
         emitConstructCall(code, gen, cdName, obj.result(), fields);
@@ -1299,7 +1299,9 @@ final class CodecGen {
             inits.add(new Core.FieldInit(init.name(),
                     gen.elaborate(init.value(), fields.get(init.name())), init.pos()));
         }
-        gen.emitFieldValues(fields, inits, construct.spreads());
+        // a decoder's construction gives every field a value of its own; nothing builds one with a
+        // spread, so there is no binding to copy from here
+        gen.emitFieldValues(fields, inits, List.of());
         code.invokestatic(cdName, "__construct", MethodTypeDesc.of(CD_Result, fieldDescs(fields)));
         // Souther construction Result -> Raoh boundary Result. An invariant failure becomes a
         // Raoh failure (spec 9.4, 10.1); success wraps the constructed value.
@@ -1348,7 +1350,7 @@ final class CodecGen {
                 code.checkcast(cdName);
                 int selfSlot = gen.slot(Type.ref(symbols.own(data.name())));
                 code.astore(selfSlot);
-                gen.bind(enc.selfName(), selfSlot, Type.ref(symbols.own(data.name())));
+                gen.bind(enc.self(), selfSlot, Type.ref(symbols.own(data.name())));
                 emitRawExpr(code, gen, enc.result());
                 code.areturn();
             });
@@ -1388,7 +1390,7 @@ final class CodecGen {
                 code.invokevirtual(CD_OptionSome, "value", MTD_Object);
                 int slot = gen.slot(elemType);
                 unbox(code, elemType, slot);
-                gen.bind(o.elemVar(), slot, elemType);
+                gen.bind(o.elem(), slot, elemType);
                 emitRawExpr(code, gen, o.inner());          // Some(v) -> encode v
                 code.goto_(end);
                 code.labelBinding(none);
@@ -1457,7 +1459,7 @@ final class CodecGen {
         code.invokevirtual(CD_OptionSome, "value", MTD_Object);   // map, valueObj
         int slot = gen.slot(elemType);
         unbox(code, elemType, slot);                    // map (value bound to local)
-        gen.bind(o.elemVar(), slot, elemType);
+        gen.bind(o.elem(), slot, elemType);
         code.dup();                                     // map, map
         code.loadConstant(key);                         // map, map, key
         emitRawExpr(code, gen, o.inner());              // map, map, key, encoded

--- a/souther-compiler/src/main/java/souther/compiler/codegen/InvariantConstraints.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/InvariantConstraints.java
@@ -1,6 +1,7 @@
 package souther.compiler.codegen;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.types.ValueName;
 import souther.compiler.check.ConstEval;
 import souther.compiler.types.Type;
 
@@ -295,10 +296,14 @@ final class InvariantConstraints {
     }
 
     /** Whether a projection hands back what it was given — {@code x -> x}, however the parameter is
-     * spelled. A block with one parameter is how a lambda arrives here (spec §blocks). */
+     * spelled. A block with one parameter is how a lambda arrives here (spec §blocks). The body reads
+     * the parameter when it reads that binding; a name spelled like it, bound elsewhere, is another
+     * value. */
     private static boolean isIdentity(Ast.Expr e) {
         return e instanceof Ast.Block b && b.params().size() == 1
-                && b.body() instanceof Ast.Var v && v.name().equals(b.params().get(0));
+                && b.body() instanceof Ast.Var v
+                && v.denotes() instanceof ValueName.Local local
+                && local.id().equals(b.params().get(0).id());
     }
 
     private static Ast.BinOp mirrored(Ast.BinOp op) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -2,6 +2,7 @@ package souther.compiler.codegen;
 
 import souther.compiler.check.Symbols;
 import souther.compiler.ast.Ast;
+import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeOps;
@@ -161,8 +162,9 @@ final class ValueClassGen {
                 ClassFile.ACC_STATIC | ClassFile.ACC_PUBLIC, code -> {
                     BodyGen gen = new BodyGen(ctx, code, data, cdName, 0);
                     int slot = 0;
+                    Map<String, BindingId> bound = TypeOps.fieldBindings(data, symbols);
                     for (Map.Entry<String, Type> f : fields.entrySet()) {
-                        gen.bind(f.getKey(), slot, f.getValue());
+                        gen.bind(bound.get(f.getKey()), f.getKey(), slot, f.getValue());
                         slot += width(f.getValue());
                     }
                     for (Ast.InvariantClause clause : clauses) {
@@ -655,8 +657,9 @@ final class ValueClassGen {
                     mb.withCode(code -> {
                         BodyGen gen = new BodyGen(ctx, code, data, cdName, 0);
                         int slot = 0;
+                        Map<String, BindingId> bound = TypeOps.fieldBindings(data, symbols);
                         for (Map.Entry<String, Type> f : fields.entrySet()) {
-                            gen.bind(f.getKey(), slot, f.getValue());
+                            gen.bind(bound.get(f.getKey()), f.getKey(), slot, f.getValue());
                             slot += width(f.getValue());
                         }
 

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -1,5 +1,6 @@
 package souther.compiler.core;
 
+import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.diag.SourcePos;
@@ -21,8 +22,13 @@ import java.util.Optional;
  * <p>Every node carries {@link #type()}: the type the checker decided for it (issue #81). The
  * checker is the only producer of Core — it builds the tree as it types a body
  * ({@code Elaborator.elaborate}) — so the backend reads those decisions instead of inferring the
- * same types a second time. The one node with no type is the rounding mode of {@code divide}, a
- * built-in identifier the emitter reads by name rather than as a value (spec 18.3).
+ * same types a second time. The one node with no type is {@link Builtin}, a name the language gives
+ * a meaning that the emitter reads rather than evaluates (spec 18.3).
+ *
+ * <p>A name in a body is one of three nodes, not one: a read of something the body binds, a unit
+ * data written as its own value, and a name the language defines. They were one, and the emitter
+ * told them apart by looking the spelling up in its slots and falling back when it found nothing —
+ * which is an answer about a name, decided by its text.
  *
  * <p>A surface-only node (a list comprehension) never appears — the Lower stage has already
  * rewritten it.
@@ -43,7 +49,24 @@ public sealed interface Core {
 
     record Bool(boolean value, Type type, SourcePos pos) implements Core {}
 
-    record Var(String name, Type type, SourcePos pos) implements Core {}
+    /** A read of something the body binds: a parameter, a {@code let}, a lambda's parameter, a
+     * {@code match} arm's binding. {@code binding} is which one; {@code name} is what to call the
+     * local it is emitted as, and what a diagnostic quotes. */
+    record Read(String name, BindingId binding, Type type, SourcePos pos) implements Core {}
+
+    /** A unit data written where a value goes: the type has one value, and naming it is that value
+     * (spec §unit-data). Which unit is on the node, so nothing resolves a spelling again. */
+    record UnitValue(TypeName data, Type type, SourcePos pos) implements Core {}
+
+    /** A name the language gives a meaning, which the emitter reads rather than evaluates: the
+     * rounding mode of {@code divide} (spec 18.3). It is not a value, so it has no type. */
+    record Builtin(String name, SourcePos pos) implements Core {
+
+        @Override
+        public Type type() {
+            return null;
+        }
+    }
 
     record Neg(Core operand, Type type, SourcePos pos) implements Core {}
 
@@ -67,8 +90,8 @@ public sealed interface Core {
      * the {@code Result} carries selects one; the checker has already established that every named
      * clause is answered, so one always matches.
      */
-    record IfConstructed(NewData construct, String binder, Core then, List<ElseArm> els, Type type,
-                         SourcePos pos) implements Core {}
+    record IfConstructed(NewData construct, Ast.Binder binder, Core then, List<ElseArm> els,
+                         Type type, SourcePos pos) implements Core {}
 
     /** One departure of an attempted construction: the clause it answers ({@link Optional#empty()}
      * for any failure) and the value taken. */
@@ -77,13 +100,24 @@ public sealed interface Core {
     /** A local binding. What the source wrote as its type — {@code let x: T = e} — is already in
      * {@code value}'s type: the checker pushed the annotation into the value when it typed it, so an
      * empty collection bound here materialises at the written type rather than a bottom (issue #71). */
-    record LetIn(String name, Core value, Core body, Type type, SourcePos pos) implements Core {}
+    record LetIn(Ast.Binder binder, Core value, Core body, Type type, SourcePos pos) implements Core {
+
+        public String name() {
+            return binder.name();
+        }
+    }
 
     /** A second-class block: a step passed to a recursive combinator, or an escaping lambda a {@code
      * let} binds (a closure). Kept as its own node until closure conversion gets an explicit Core form.
      * Its {@code type} is the {@link Type.FnOf} the checker gave it — the parameter types the context
      * fixed, and the body's result type. */
-    record Block(List<String> params, Core body, Type type, SourcePos pos) implements Core {}
+    record Block(List<Ast.Binder> params, Core body, Type type, SourcePos pos) implements Core {
+
+        /** How the parameters were written, in order. */
+        public List<String> paramNames() {
+            return params.stream().map(Ast.Binder::name).toList();
+        }
+    }
 
     record ListLit(List<Core> elements, Type type, SourcePos pos) implements Core {}
 
@@ -109,7 +143,14 @@ public sealed interface Core {
 
     /** {@code bindType} is the type the case binding takes inside the arm — the case type a union
      * narrows to, or the element a {@code Some x} opens. */
-    record Case(List<TypeName> caseTypes, String binding, Core body, Type bindType, SourcePos pos) {}
+    record Case(List<TypeName> caseTypes, Ast.Binder binding, Core body, Type bindType,
+                SourcePos pos) {
+
+        /** How the binding was written, or null where the arm binds nothing. */
+        public String bindingName() {
+            return binding == null ? null : binding.name();
+        }
+    }
 
     record Match(Core scrutinee, List<Case> cases, Type type, SourcePos pos) implements Core {}
 
@@ -129,7 +170,9 @@ public sealed interface Core {
             case Decimal x -> x;
             case Str x -> x;
             case Bool x -> x;
-            case Var x -> x;
+            case Read x -> x;
+            case UnitValue x -> x;
+            case Builtin x -> x;
             case OptionNone x -> x;
             case Unreachable x -> x;
             case Neg n -> new Neg(f.apply(n.operand()), n.type(), n.pos());
@@ -142,7 +185,7 @@ public sealed interface Core {
                     ic.binder(), f.apply(ic.then()),
                     ic.els().stream().map(arm -> new ElseArm(arm.clause(), f.apply(arm.body()))).toList(),
                     ic.type(), ic.pos());
-            case LetIn li -> new LetIn(li.name(), f.apply(li.value()), f.apply(li.body()),
+            case LetIn li -> new LetIn(li.binder(), f.apply(li.value()), f.apply(li.body()),
                     li.type(), li.pos());
             case Block b -> new Block(b.params(), f.apply(b.body()), b.type(), b.pos());
             case ListLit lit -> new ListLit(lit.elements().stream().map(f).toList(), lit.type(), lit.pos());

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -74,8 +74,21 @@ public sealed interface Core {
 
     record Binary(Ast.BinOp op, Core left, Core right, Type type, SourcePos pos) implements Core {}
 
-    /** A call to a builtin, an injected behavior, or an intrinsic (a helper fn is already inlined). */
+    /** A call to a builtin, an injected behavior, an intrinsic, or a recursive helper emitted as a
+     * method — each reached by the name it is declared under, none of them bound by this body. A
+     * non-recursive helper is already inlined. */
     record Call(String fn, List<Core> args, Type type, SourcePos pos) implements Core {}
+
+    /**
+     * Applying a function value the body holds: a helper's function parameter, or a lambda a
+     * {@code let} bound that escaped.
+     *
+     * <p>Apart from {@link Call} because it is a different operation — one loads a value and invokes
+     * it, the other names something declared elsewhere — and because only this one applies something
+     * the body binds. Held together, which of the two a node was had to be worked out downstream by
+     * looking the name up among the locals, and the binding was lost on the way.
+     */
+    record Apply(Read fn, List<Core> args, Type type, SourcePos pos) implements Core {}
 
     record If(Core cond, Core then, Core els, Type type, SourcePos pos) implements Core {}
 
@@ -138,8 +151,16 @@ public sealed interface Core {
 
     record FieldInit(String name, Core value, SourcePos pos) {}
 
-    record NewData(TypeName typeName, List<FieldInit> inits, List<String> spreads, Type type,
-                   SourcePos pos) implements Core {}
+    /** {@code spreads} are the bindings the construction copies fields from — reads, not binders:
+     * a spread names a value in force, it does not introduce one. */
+    record NewData(TypeName typeName, List<FieldInit> inits, List<Read> spreads, Type type,
+                   SourcePos pos) implements Core {
+
+        /** How each spread source was written, in order. */
+        public List<String> spreadNames() {
+            return spreads.stream().map(Read::name).toList();
+        }
+    }
 
     /** {@code bindType} is the type the case binding takes inside the arm — the case type a union
      * narrows to, or the element a {@code Some x} opens. */
@@ -179,6 +200,7 @@ public sealed interface Core {
             case FieldAccess fa -> new FieldAccess(f.apply(fa.target()), fa.field(), fa.type(), fa.pos());
             case Binary b -> new Binary(b.op(), f.apply(b.left()), f.apply(b.right()), b.type(), b.pos());
             case Call c -> new Call(c.fn(), c.args().stream().map(f).toList(), c.type(), c.pos());
+            case Apply a -> new Apply(a.fn(), a.args().stream().map(f).toList(), a.type(), a.pos());
             case If iff -> new If(f.apply(iff.cond()), f.apply(iff.then()), f.apply(iff.els()),
                     iff.type(), iff.pos());
             case IfConstructed ic -> new IfConstructed((NewData) mapChildren(ic.construct(), f),

--- a/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
@@ -117,7 +117,7 @@ public final class GrowingFold {
         if (!(binding.body() instanceof Core.Call outer) || !outer.fn().equals(BUILD)
                 || !(outer.args().get(1) instanceof Core.Read walked)
                 || !walked.binding().equals(binding.binder().id())
-                || uses(binding.body(), binding.binder()) != 1) {
+                || uses(binding.body(), binding.binder().id()) != 1) {
             return null;
         }
         List<Core.LetIn> kept = new ArrayList<>();
@@ -130,7 +130,7 @@ public final class GrowingFold {
             return null;
         }
         for (Core.LetIn k : kept) {
-            if (uses(outer.args().get(0), k.binder()) > 0) {
+            if (uses(outer.args().get(0), k.binder().id()) > 0) {
                 return null;
             }
         }
@@ -193,7 +193,7 @@ public final class GrowingFold {
         if (!(step instanceof Core.Block block) || block.params().size() != 2) {
             return null;
         }
-        Accumulated acc = aliases(block.body(), block.params().get(0));
+        Set<BindingId> acc = aliases(block.body(), block.params().get(0));
         int[] found = {0};
         Core putting = answers(block.body(), acc, found, GrowingFold::inserted);
         if (putting == null
@@ -214,16 +214,16 @@ public final class GrowingFold {
      * see through. A binding of a binding is followed the same way, so the set is closed rather than
      * one level deep.
      */
-    private static Accumulated aliases(Core body, Ast.Binder acc) {
-        Accumulated names = new Accumulated();
-        names.add(acc);
+    private static Set<BindingId> aliases(Core body, Ast.Binder acc) {
+        Set<BindingId> names = new LinkedHashSet<>();
+        names.add(acc.id());
         int before;
         do {
             before = names.size();
             count(body, e -> {
                 if (e instanceof Core.LetIn li && li.value() instanceof Core.Read v
                         && names.contains(v.binding())) {
-                    names.add(li.binder());
+                    names.add(li.binder().id());
                 }
                 return false;
             }, new int[1]);
@@ -231,42 +231,11 @@ public final class GrowingFold {
         return names;
     }
 
-    /**
-     * The accumulator and everything bound to it.
-     *
-     * <p>Which bindings they are is what a read is held against. Core still carries a name where a
-     * call applies one and where a construction spreads one, so those are held against the names as
-     * well; a name that happens to match only ever refuses a rewrite.
-     */
-    private static final class Accumulated {
-
-        private final Set<BindingId> bindings = new LinkedHashSet<>();
-        private final List<Ast.Binder> binders = new ArrayList<>();
-
-        void add(Ast.Binder binder) {
-            if (bindings.add(binder.id())) {
-                binders.add(binder);
-            }
-        }
-
-        boolean contains(BindingId binding) {
-            return bindings.contains(binding);
-        }
-
-        int size() {
-            return bindings.size();
-        }
-
-        List<Ast.Binder> binders() {
-            return binders;
-        }
-    }
-
     /** How many times one of {@code acc}'s bindings is reached anywhere in {@code e}. */
-    private static int mentions(Core e, Accumulated acc) {
+    private static int mentions(Core e, Set<BindingId> acc) {
         int n = 0;
-        for (Ast.Binder binder : acc.binders()) {
-            n += uses(e, binder);
+        for (BindingId binding : acc) {
+            n += uses(e, binding);
         }
         return n;
     }
@@ -274,7 +243,7 @@ public final class GrowingFold {
     /** How many times the accumulator is read as a map rather than written to — the {@code Map.get} of
      *  an {@code upsert}, a {@code containsKey} guarding an insert. Each of those is one of the
      *  mentions {@link #puttingStep} counts, and a mention that is none of the three refuses the walk. */
-    private static int reads(Core e, Accumulated acc) {
+    private static int reads(Core e, Set<BindingId> acc) {
         int[] n = {0};
         count(e, c -> c instanceof Core.Call call && READS.contains(call.fn())
                 && !call.args().isEmpty()
@@ -284,7 +253,7 @@ public final class GrowingFold {
 
     /** How many times the accumulator is mentioned as the value another name is bound to — the
      *  mentions {@link #aliases} followed. */
-    private static int aliased(Core e, Accumulated acc) {
+    private static int aliased(Core e, Set<BindingId> acc) {
         int[] n = {0};
         count(e, c -> c instanceof Core.LetIn li && li.value() instanceof Core.Read v
                 && acc.contains(v.binding()), n);
@@ -378,7 +347,7 @@ public final class GrowingFold {
         if (!(step instanceof Core.Block block) || block.params().size() != 2) {
             return null;
         }
-        Accumulated acc = aliases(block.body(), block.params().get(0));
+        Set<BindingId> acc = aliases(block.body(), block.params().get(0));
         int[] found = {0};
         Core grown = answers(block.body(), acc, found, GrowingFold::appended);
         if (grown == null || found[0] + aliased(block.body(), acc) != mentions(block.body(), acc)) {
@@ -393,11 +362,11 @@ public final class GrowingFold {
     /** What an answering position of a growing step may hold besides the accumulator itself: the one
      *  operation that grows it, rewritten to the one that writes into the builder. Null refuses. */
     private interface Growth {
-        Core at(Core e, Accumulated acc);
+        Core at(Core e, Set<BindingId> acc);
     }
 
     /** {@code acc ++ rhs} as an add to the builder. */
-    private static Core appended(Core e, Accumulated acc) {
+    private static Core appended(Core e, Set<BindingId> acc) {
         if (!(e instanceof Core.Binary b) || b.op() != Ast.BinOp.CONCAT
                 || !(b.left() instanceof Core.Read v) || !acc.contains(v.binding())) {
             return null;
@@ -406,7 +375,7 @@ public final class GrowingFold {
     }
 
     /** {@code Map.insert(key, value, acc)} as a write into the builder. */
-    private static Core inserted(Core e, Accumulated acc) {
+    private static Core inserted(Core e, Set<BindingId> acc) {
         if (!(e instanceof Core.Call c) || !c.fn().equals(INSERT) || c.args().size() != 3
                 || !(c.args().get(2) instanceof Core.Read v) || !acc.contains(v.binding())) {
             return null;
@@ -424,7 +393,7 @@ public final class GrowingFold {
      * ordinary code the rewrite leaves alone — what matters is what the accumulator does there, which
      * the counts in {@link #grownStep} and {@link #puttingStep} settle.
      */
-    private static Core answers(Core e, Accumulated acc, int[] found, Growth growth) {
+    private static Core answers(Core e, Set<BindingId> acc, int[] found, Growth growth) {
         switch (e) {
             case Core.Read v -> {
                 if (!acc.contains(v.binding())) {
@@ -473,19 +442,21 @@ public final class GrowingFold {
     }
 
     /**
-     * How many times the binding {@code binder} introduces is reached anywhere in {@code e} — read
-     * as a value, applied, or spread.
+     * How many times {@code binding} is reached anywhere in {@code e} — read as a value, applied, or
+     * spread.
      *
-     * <p>A read says which binding it is, so a binding of the same spelling further in is not one of
-     * these. A call and a spread still carry a name in Core, so those two are counted by it; a name
-     * that happens to match only ever refuses a rewrite.
+     * <p>Every one of the three says which binding it is, so a binding of the same spelling further
+     * in is not one of these. Undercounting is what this must not do: the rewrite is allowed when
+     * every way the accumulator is reached is one of the growths found, so a way that went uncounted
+     * would let it through.
      */
-    private static int uses(Core e, Ast.Binder binder) {
+    private static int uses(Core e, BindingId binding) {
         int[] n = {0};
         count(e, node -> switch (node) {
-            case Core.Read v -> v.binding().equals(binder.id());
-            case Core.Call c -> c.fn().equals(binder.name());
-            case Core.NewData nd -> nd.spreads().contains(binder.name());
+            case Core.Read v -> v.binding().equals(binding);
+            case Core.Apply a -> a.fn().binding().equals(binding);
+            case Core.NewData nd ->
+                    nd.spreads().stream().anyMatch(s -> s.binding().equals(binding));
             default -> false;
         }, n);
         return n[0];

--- a/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
@@ -1,6 +1,7 @@
 package souther.compiler.core;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 
 import java.util.ArrayList;
@@ -114,9 +115,9 @@ public final class GrowingFold {
      */
     private static Core joinedThroughBinding(Core.LetIn binding) {
         if (!(binding.body() instanceof Core.Call outer) || !outer.fn().equals(BUILD)
-                || !(outer.args().get(1) instanceof Core.Var walked)
-                || !walked.name().equals(binding.name())
-                || uses(binding.body(), binding.name()) != 1) {
+                || !(outer.args().get(1) instanceof Core.Read walked)
+                || !walked.binding().equals(binding.binder().id())
+                || uses(binding.body(), binding.binder()) != 1) {
             return null;
         }
         List<Core.LetIn> kept = new ArrayList<>();
@@ -129,7 +130,7 @@ public final class GrowingFold {
             return null;
         }
         for (Core.LetIn k : kept) {
-            if (uses(outer.args().get(0), k.name()) > 0) {
+            if (uses(outer.args().get(0), k.binder()) > 0) {
                 return null;
             }
         }
@@ -141,7 +142,7 @@ public final class GrowingFold {
         }
         for (int i = kept.size() - 1; i >= 0; i--) {
             Core.LetIn k = kept.get(i);
-            joined = new Core.LetIn(k.name(), k.value(), joined, joined.type(), k.pos());
+            joined = new Core.LetIn(k.binder(), k.value(), joined, joined.type(), k.pos());
         }
         return joined;
     }
@@ -186,13 +187,13 @@ public final class GrowingFold {
     private static Core puttingStep(Core step) {
         if (step instanceof Core.LetIn li) {
             Core inner = puttingStep(li.body());
-            return inner == null ? null : new Core.LetIn(li.name(), li.value(), inner,
+            return inner == null ? null : new Core.LetIn(li.binder(), li.value(), inner,
                     li.type(), li.pos());
         }
         if (!(step instanceof Core.Block block) || block.params().size() != 2) {
             return null;
         }
-        Set<String> acc = aliases(block.body(), block.params().get(0));
+        Accumulated acc = aliases(block.body(), block.params().get(0));
         int[] found = {0};
         Core putting = answers(block.body(), acc, found, GrowingFold::inserted);
         if (putting == null
@@ -213,16 +214,16 @@ public final class GrowingFold {
      * see through. A binding of a binding is followed the same way, so the set is closed rather than
      * one level deep.
      */
-    private static Set<String> aliases(Core body, String acc) {
-        Set<String> names = new LinkedHashSet<>();
+    private static Accumulated aliases(Core body, Ast.Binder acc) {
+        Accumulated names = new Accumulated();
         names.add(acc);
         int before;
         do {
             before = names.size();
             count(body, e -> {
-                if (e instanceof Core.LetIn li && li.value() instanceof Core.Var v
-                        && names.contains(v.name())) {
-                    names.add(li.name());
+                if (e instanceof Core.LetIn li && li.value() instanceof Core.Read v
+                        && names.contains(v.binding())) {
+                    names.add(li.binder());
                 }
                 return false;
             }, new int[1]);
@@ -230,11 +231,42 @@ public final class GrowingFold {
         return names;
     }
 
-    /** How many times one of {@code acc}'s names is mentioned anywhere in {@code e}. */
-    private static int mentions(Core e, Set<String> acc) {
+    /**
+     * The accumulator and everything bound to it.
+     *
+     * <p>Which bindings they are is what a read is held against. Core still carries a name where a
+     * call applies one and where a construction spreads one, so those are held against the names as
+     * well; a name that happens to match only ever refuses a rewrite.
+     */
+    private static final class Accumulated {
+
+        private final Set<BindingId> bindings = new LinkedHashSet<>();
+        private final List<Ast.Binder> binders = new ArrayList<>();
+
+        void add(Ast.Binder binder) {
+            if (bindings.add(binder.id())) {
+                binders.add(binder);
+            }
+        }
+
+        boolean contains(BindingId binding) {
+            return bindings.contains(binding);
+        }
+
+        int size() {
+            return bindings.size();
+        }
+
+        List<Ast.Binder> binders() {
+            return binders;
+        }
+    }
+
+    /** How many times one of {@code acc}'s bindings is reached anywhere in {@code e}. */
+    private static int mentions(Core e, Accumulated acc) {
         int n = 0;
-        for (String name : acc) {
-            n += uses(e, name);
+        for (Ast.Binder binder : acc.binders()) {
+            n += uses(e, binder);
         }
         return n;
     }
@@ -242,20 +274,20 @@ public final class GrowingFold {
     /** How many times the accumulator is read as a map rather than written to — the {@code Map.get} of
      *  an {@code upsert}, a {@code containsKey} guarding an insert. Each of those is one of the
      *  mentions {@link #puttingStep} counts, and a mention that is none of the three refuses the walk. */
-    private static int reads(Core e, Set<String> acc) {
+    private static int reads(Core e, Accumulated acc) {
         int[] n = {0};
         count(e, c -> c instanceof Core.Call call && READS.contains(call.fn())
                 && !call.args().isEmpty()
-                && call.args().getLast() instanceof Core.Var v && acc.contains(v.name()), n);
+                && call.args().getLast() instanceof Core.Read v && acc.contains(v.binding()), n);
         return n[0];
     }
 
     /** How many times the accumulator is mentioned as the value another name is bound to — the
      *  mentions {@link #aliases} followed. */
-    private static int aliased(Core e, Set<String> acc) {
+    private static int aliased(Core e, Accumulated acc) {
         int[] n = {0};
-        count(e, c -> c instanceof Core.LetIn li && li.value() instanceof Core.Var v
-                && acc.contains(v.name()), n);
+        count(e, c -> c instanceof Core.LetIn li && li.value() instanceof Core.Read v
+                && acc.contains(v.binding()), n);
         return n[0];
     }
 
@@ -340,13 +372,13 @@ public final class GrowingFold {
     private static Core grownStep(Core step) {
         if (step instanceof Core.LetIn li) {
             Core inner = grownStep(li.body());
-            return inner == null ? null : new Core.LetIn(li.name(), li.value(), inner,
+            return inner == null ? null : new Core.LetIn(li.binder(), li.value(), inner,
                     li.type(), li.pos());
         }
         if (!(step instanceof Core.Block block) || block.params().size() != 2) {
             return null;
         }
-        Set<String> acc = aliases(block.body(), block.params().get(0));
+        Accumulated acc = aliases(block.body(), block.params().get(0));
         int[] found = {0};
         Core grown = answers(block.body(), acc, found, GrowingFold::appended);
         if (grown == null || found[0] + aliased(block.body(), acc) != mentions(block.body(), acc)) {
@@ -361,22 +393,22 @@ public final class GrowingFold {
     /** What an answering position of a growing step may hold besides the accumulator itself: the one
      *  operation that grows it, rewritten to the one that writes into the builder. Null refuses. */
     private interface Growth {
-        Core at(Core e, Set<String> acc);
+        Core at(Core e, Accumulated acc);
     }
 
     /** {@code acc ++ rhs} as an add to the builder. */
-    private static Core appended(Core e, Set<String> acc) {
+    private static Core appended(Core e, Accumulated acc) {
         if (!(e instanceof Core.Binary b) || b.op() != Ast.BinOp.CONCAT
-                || !(b.left() instanceof Core.Var v) || !acc.contains(v.name())) {
+                || !(b.left() instanceof Core.Read v) || !acc.contains(v.binding())) {
             return null;
         }
         return new Core.Call(GROW, List.of(b.left(), b.right()), b.type(), b.pos());
     }
 
     /** {@code Map.insert(key, value, acc)} as a write into the builder. */
-    private static Core inserted(Core e, Set<String> acc) {
+    private static Core inserted(Core e, Accumulated acc) {
         if (!(e instanceof Core.Call c) || !c.fn().equals(INSERT) || c.args().size() != 3
-                || !(c.args().get(2) instanceof Core.Var v) || !acc.contains(v.name())) {
+                || !(c.args().get(2) instanceof Core.Read v) || !acc.contains(v.binding())) {
             return null;
         }
         return new Core.Call(PUT, List.of(c.args().get(2), c.args().get(0), c.args().get(1)),
@@ -392,10 +424,10 @@ public final class GrowingFold {
      * ordinary code the rewrite leaves alone — what matters is what the accumulator does there, which
      * the counts in {@link #grownStep} and {@link #puttingStep} settle.
      */
-    private static Core answers(Core e, Set<String> acc, int[] found, Growth growth) {
+    private static Core answers(Core e, Accumulated acc, int[] found, Growth growth) {
         switch (e) {
-            case Core.Var v -> {
-                if (!acc.contains(v.name())) {
+            case Core.Read v -> {
+                if (!acc.contains(v.binding())) {
                     return null;
                 }
                 found[0]++;
@@ -408,18 +440,18 @@ public final class GrowingFold {
                         : new Core.If(iff.cond(), then, els, iff.type(), iff.pos());
             }
             case Core.LetIn li -> {
-                if (acc.contains(li.name()) && !(li.value() instanceof Core.Var v
-                        && acc.contains(v.name()))) {
+                if (acc.contains(li.binder().id()) && !(li.value() instanceof Core.Read v
+                        && acc.contains(v.binding()))) {
                     return null;   // one of the accumulator's names now stands for something else
                 }
                 Core body = answers(li.body(), acc, found, growth);
                 return body == null ? null
-                        : new Core.LetIn(li.name(), li.value(), body, li.type(), li.pos());
+                        : new Core.LetIn(li.binder(), li.value(), body, li.type(), li.pos());
             }
             case Core.Match m -> {
                 List<Core.Case> cases = new ArrayList<>();
                 for (Core.Case c : m.cases()) {
-                    if (c.binding() != null && acc.contains(c.binding())) {
+                    if (c.binding() != null && acc.contains(c.binding().id())) {
                         return null;
                     }
                     Core body = answers(c.body(), acc, found, growth);
@@ -440,15 +472,20 @@ public final class GrowingFold {
         }
     }
 
-    /** How many times {@code name} is mentioned anywhere in {@code e} — as a value, as the function
-     *  a call applies, or as a spread. A binding of the same name further in is counted too, which
-     *  only ever refuses a rewrite. */
-    private static int uses(Core e, String name) {
+    /**
+     * How many times the binding {@code binder} introduces is reached anywhere in {@code e} — read
+     * as a value, applied, or spread.
+     *
+     * <p>A read says which binding it is, so a binding of the same spelling further in is not one of
+     * these. A call and a spread still carry a name in Core, so those two are counted by it; a name
+     * that happens to match only ever refuses a rewrite.
+     */
+    private static int uses(Core e, Ast.Binder binder) {
         int[] n = {0};
         count(e, node -> switch (node) {
-            case Core.Var v -> v.name().equals(name);
-            case Core.Call c -> c.fn().equals(name);
-            case Core.NewData nd -> nd.spreads().contains(name);
+            case Core.Read v -> v.binding().equals(binder.id());
+            case Core.Call c -> c.fn().equals(binder.name());
+            case Core.NewData nd -> nd.spreads().contains(binder.name());
             default -> false;
         }, n);
         return n[0];

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -5,6 +5,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.ast.Ast;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeChecker;
@@ -62,10 +63,19 @@ public final class Deriver {
             // a type like this is never emitted.
             return d;
         }
+        // the decoder and the encoder each read the value under a name of their own, so each owns
+        // the bindings it writes rather than sharing the declaration's
+        BindingOwner declared = new BindingOwner.OfData(symbols.own(d.name()));
         Optional<Ast.DecoderDef> decoder = d.decoder().isPresent()
-                ? d.decoder() : Optional.of(deriveDecoder(d, fields, isCase, symbols));
+                ? d.decoder()
+                : Optional.of(deriveDecoder(d, fields, isCase, symbols,
+                        new Ast.Binders(new BindingOwner.Synthesized(declared,
+                                BindingOwner.Pass.DERIVER, 0))));
         Optional<Ast.EncoderDef> encoder = d.encoder().isPresent()
-                ? d.encoder() : Optional.of(deriveEncoder(d, fields, isCase));
+                ? d.encoder()
+                : Optional.of(deriveEncoder(d, fields, isCase,
+                        new Ast.Binders(new BindingOwner.Synthesized(declared,
+                                BindingOwner.Pass.DERIVER, 1))));
         return new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(), d.invariants(),
                 decoder, encoder, d.pos());
     }
@@ -73,7 +83,7 @@ public final class Deriver {
     // --- decoder derivation ---
 
     private static Ast.DecoderDef deriveDecoder(Ast.Data d, Map<String, Type> fields, boolean isCase,
-                                               Symbols symbols) {
+                                               Symbols symbols, Ast.Binders binders) {
         SourcePos pos = d.pos();
         Ast.Name self = Ast.Name.resolved(symbols.own(d.name()), pos);
         // only an explicit newtype `data X = Y` is bare; a braced record is always an object, even
@@ -81,27 +91,30 @@ public final class Deriver {
         Map.Entry<String, Type> single = bareField(d, fields, isCase);
         if (single != null) {
             Ast.RawKind kind = rawKind(single.getValue());
+            Ast.Binder input = binders.binder("__in", pos);
             Ast.Construct result = new Ast.Construct(self,
-                    List.of(new Ast.FieldInit(single.getKey(), Ast.Var.local("__in", pos), pos)),
+                    List.of(new Ast.FieldInit(single.getKey(), Ast.Var.local(input, pos), pos)),
                     List.of(), pos);
-            return new Ast.PrimDecoder(kind, "__in", List.of(), result, pos);
+            return new Ast.PrimDecoder(kind, input, List.of(), result, pos);
         }
         // a newtype over a non-primitive Y delegates the whole input to Y's decoder (spec 8.7)
         if (d.newtype() && !isCase) {
             Map.Entry<String, Type> only = fields.entrySet().iterator().next();
+            Ast.Binder input = binders.binder("__in", pos);
             Ast.Construct result = new Ast.Construct(self,
-                    List.of(new Ast.FieldInit(only.getKey(), Ast.Var.local("__in", pos), pos)),
+                    List.of(new Ast.FieldInit(only.getKey(), Ast.Var.local(input, pos), pos)),
                     List.of(), pos);
             return new Ast.NewtypeDecoder(
                     decRef(only.getValue(), d, only.getKey(), fieldPos(d, only.getKey())),
-                    "__in", result, pos);
+                    input, result, pos);
         }
         List<Ast.Bind> binds = new ArrayList<>();
         List<Ast.FieldInit> inits = new ArrayList<>();
         for (Map.Entry<String, Type> f : fields.entrySet()) {
-            binds.add(new Ast.Bind(f.getKey(), f.getKey(),
+            Ast.Binder took = binders.binder(f.getKey(), pos);
+            binds.add(new Ast.Bind(took, f.getKey(),
                     decRef(f.getValue(), d, f.getKey(), fieldPos(d, f.getKey())), pos));
-            inits.add(new Ast.FieldInit(f.getKey(), Ast.Var.local(f.getKey(), pos), pos));
+            inits.add(new Ast.FieldInit(f.getKey(), Ast.Var.local(took, pos), pos));
         }
         return new Ast.ObjectDecoder(binds, new Ast.Construct(self, inits, List.of(), pos), pos);
     }
@@ -169,28 +182,30 @@ public final class Deriver {
 
     // --- encoder derivation ---
 
-    private static Ast.EncoderDef deriveEncoder(Ast.Data d, Map<String, Type> fields, boolean isCase) {
+    private static Ast.EncoderDef deriveEncoder(Ast.Data d, Map<String, Type> fields, boolean isCase,
+                                                Ast.Binders binders) {
         SourcePos pos = d.pos();
+        Ast.Binder self = binders.binder("self", pos);
         Map.Entry<String, Type> single = bareField(d, fields, isCase);
         if (single != null) {
-            Ast.Expr access = new Ast.FieldAccess(Ast.Var.local("self", pos), single.getKey(), pos);
-            return new Ast.EncoderDef("self", primRaw(single.getValue(), access, pos), pos);
+            Ast.Expr access = new Ast.FieldAccess(Ast.Var.local(self, pos), single.getKey(), pos);
+            return new Ast.EncoderDef(self, primRaw(single.getValue(), access, pos), pos);
         }
         // a newtype over a non-primitive Y encodes self.value as Y writes itself — Y's
         // representation, not `{value: ...}` (spec 8.7). Y is a named data, a sum, or a collection,
         // so this is the same choice a field of type Y makes.
         if (d.newtype() && !isCase) {
             Map.Entry<String, Type> only = fields.entrySet().iterator().next();
-            Ast.Expr access = new Ast.FieldAccess(Ast.Var.local("self", pos), only.getKey(), pos);
-            return new Ast.EncoderDef("self",
-                    rawForAccess(only.getValue(), access, d, only.getKey(), pos), pos);
+            Ast.Expr access = new Ast.FieldAccess(Ast.Var.local(self, pos), only.getKey(), pos);
+            return new Ast.EncoderDef(self,
+                    rawForAccess(only.getValue(), access, d, only.getKey(), pos, binders), pos);
         }
         List<Ast.RawEntry> entries = new ArrayList<>();
         for (Map.Entry<String, Type> f : fields.entrySet()) {
             entries.add(new Ast.RawEntry(f.getKey(),
-                    rawFor(f.getValue(), f.getKey(), d, fieldPos(d, f.getKey())), pos));
+                    rawFor(f.getValue(), f.getKey(), d, fieldPos(d, f.getKey()), self, binders), pos));
         }
-        return new Ast.EncoderDef("self", new Ast.ObjectRaw(entries, pos), pos);
+        return new Ast.EncoderDef(self, new Ast.ObjectRaw(entries, pos), pos);
     }
 
     private static Ast.RawExpr primRaw(Type t, Ast.Expr access, SourcePos pos) {
@@ -214,13 +229,14 @@ public final class Deriver {
                 || t == Type.DECIMAL || t == Type.DATE || t == Type.DATETIME;
     }
 
-    private static Ast.RawExpr rawFor(Type t, String field, Ast.Data d, SourcePos pos) {
-        return rawForAccess(t, new Ast.FieldAccess(Ast.Var.local("self", pos), field, pos),
-                d, field, pos);
+    private static Ast.RawExpr rawFor(Type t, String field, Ast.Data d, SourcePos pos,
+                                      Ast.Binder self, Ast.Binders binders) {
+        return rawForAccess(t, new Ast.FieldAccess(Ast.Var.local(self, pos), field, pos),
+                d, field, pos, binders);
     }
 
     private static Ast.RawExpr rawForAccess(Type t, Ast.Expr access, Ast.Data d, String field,
-                                            SourcePos pos) {
+                                            SourcePos pos, Ast.Binders binders) {
         if (isPrim(t)) {
             return primRaw(t, access, pos);
         }
@@ -234,9 +250,10 @@ public final class Deriver {
             return new Ast.SetEnc(access, encElem(so.element(), d, field, pos), pos);
         }
         if (t instanceof Type.OptionOf oo) {
-            String elemVar = "$opt";
-            Ast.RawExpr inner = rawForAccess(oo.element(), Ast.Var.local(elemVar, pos), d, field, pos);
-            return new Ast.OptionRaw(access, inner, elemVar, pos);
+            Ast.Binder elem = binders.binder("$opt", pos);
+            Ast.RawExpr inner = rawForAccess(oo.element(), Ast.Var.local(elem, pos), d, field, pos,
+                    binders);
+            return new Ast.OptionRaw(access, inner, elem, pos);
         }
         if (t instanceof Type.MapOf mo) {
             return new Ast.MapEnc(access, encElem(mo.value(), d, field, pos), mapKeyEnc(mo, d, field, pos), pos);

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -434,8 +434,8 @@ public final class AstBuilder {
         // would name a definition's parameter something the author never wrote.
         if (params.isEmpty() && bodyNode.kind() == SyntaxKind.LAMBDA_EXPR
                 && body instanceof Ast.Block lambda) {
-            for (String p : lambda.params()) {
-                params.add(new Ast.FnParam(p, null, false, lambda.pos()));
+            for (Ast.Binder p : lambda.params()) {
+                params.add(new Ast.FnParam(p, null, false));
             }
             body = lambda.body();
         }
@@ -465,7 +465,7 @@ public final class AstBuilder {
             // only repeat what the pattern already named
             SourcePos at = pos(pat);
             type = new Ast.RetType(List.of(new Ast.TypeRef(qualifiedNameText(pat), null, at)), at);
-            return new Ast.FnParam(name, type, true, pos(p));
+            return new Ast.FnParam(Ast.Binder.written(name, pos(p)), type, true);
         }
         return new Ast.FnParam(name, type, pos(p));
     }
@@ -747,7 +747,8 @@ public final class AstBuilder {
         String binder = attemptBinder(n);
         List<Ast.ElseArm> arms = elseArms(n, binder);
         if (arms != null) {
-            return new Ast.IfConstructed(expr(exprs.get(0)), binder, expr(exprs.get(1)), arms, pos(n));
+            return new Ast.IfConstructed(expr(exprs.get(0)), Ast.Binder.written(binder, pos(n)),
+                    expr(exprs.get(1)), arms, pos(n));
         }
         return binder == null
                 ? new Ast.If(expr(exprs.get(0)), expr(exprs.get(1)), expr(exprs.get(2)), pos(n))
@@ -826,7 +827,7 @@ public final class AstBuilder {
                 body = bindPattern(pats.get(i), new Ast.Var(params.get(i), at), body, at);
             }
         }
-        return new Ast.Block(params, body, pos);
+        return Ast.Block.written(params, body, pos);
     }
 
     private Ast.Expr fieldGetter(SyntaxNode n) {
@@ -838,7 +839,7 @@ public final class AstBuilder {
         SourcePos pos = pos(n);
         String param = "$g" + (getterCounter++);
         Ast.Expr body = new Ast.FieldAccess(new Ast.Var(param, pos), field.text(), posOf(field));
-        return new Ast.Block(List.of(param), body, pos);
+        return Ast.Block.written(List.of(param), body, pos);
     }
 
     private Ast.Expr newData(SyntaxNode n) {
@@ -863,8 +864,9 @@ public final class AstBuilder {
                     }
                     pathNames.add(bound);
                     pathValues.add(value);
-                    // the path was bound just above, so what the construction spreads is that binding
-                    spreads.add(Ast.ValueRef.local(bound, posOf(path.get(0))));
+                    // the path is bound just outside the construction, so this name is answered
+                    // against that binding like any other the source wrote
+                    spreads.add(Ast.ValueRef.written(bound, posOf(path.get(0))));
                 }
             } else if (c.kind() == SyntaxKind.FIELD_INIT) {
                 String field = firstIdentText(c);
@@ -1046,7 +1048,7 @@ public final class AstBuilder {
         List<Ast.Name> unwrapAsserts = unwrapNames.isEmpty()
                 ? null
                 : new ArrayList<>(unwrapNames.subList(0, unwrapNames.size() - 1));
-        return new Ast.Case(caseTypes, binding, body, unwrapAsserts, casePos);
+        return Ast.Case.written(caseTypes, binding, body, unwrapAsserts, casePos);
     }
 
     /** A brace block: its {@code let}/{@code guard} statements folded into the result expression. */
@@ -1083,7 +1085,8 @@ public final class AstBuilder {
                 Ast.Expr rest = foldStatements(stmts, index + 1, result);
                 List<Ast.ElseArm> arms = elseArms(s, binder);
                 if (arms != null) {
-                    yield new Ast.IfConstructed(expr(exprs.get(0)), binder, rest, arms, pos);
+                    yield new Ast.IfConstructed(expr(exprs.get(0)), Ast.Binder.written(binder, pos),
+                            rest, arms, pos);
                 }
                 yield binder == null
                         ? new Ast.If(expr(exprs.get(0)), rest, expr(exprs.get(1)), pos)

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -570,7 +570,7 @@ public final class Bodies {
         HelperInliner inliner = null;
         for (Ast.FnDef fn : publishable(from, wanted)) {
             if (inliner == null) {
-                inliner = HelperInliner.forHelpers(table);
+                inliner = HelperInliner.forHelpers(from.name(), table);
             }
             Ast.FnDef closed = inliner.closeAcross(fn, from.name());
             out.put(closed.name(), closed);
@@ -594,7 +594,7 @@ public final class Bodies {
         if (out.isEmpty()) {
             return out;
         }
-        HelperInliner inliner = HelperInliner.forHelpers(table);
+        HelperInliner inliner = HelperInliner.forHelpers(from.name(), table);
         Deque<String> work = new ArrayDeque<>(out.keySet());
         while (!work.isEmpty()) {
             for (ValueName.Helper reached : HelperInliner.helpersReached(out.get(work.poll()).body())) {
@@ -657,7 +657,7 @@ public final class Bodies {
             if (!helpers.present()) {
                 return Answer.absent();
             }
-            return Answer.of(HelperInliner.forHelpers(helpers.value()).recursiveHelpers());
+            return Answer.of(HelperInliner.forHelpers(name, helpers.value()).recursiveHelpers());
         }
     }
 
@@ -726,7 +726,8 @@ public final class Bodies {
                 return Answer.absent();
             }
             try {
-                return Answer.of(Lower.body(def.value(), HelperInliner.forHelpers(helpers.value()),
+                return Answer.of(Lower.body(def.value(),
+                        HelperInliner.forHelpers(module, helpers.value()),
                         recursive.value().contains(fn), dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);
@@ -755,7 +756,7 @@ public final class Bodies {
             }
             try {
                 return Answer.of(Lower.body(def.value(),
-                        HelperInliner.forHelpers(helpers.value(), InliningPolicy.DISCHARGE),
+                        HelperInliner.forHelpers(module, helpers.value(), InliningPolicy.DISCHARGE),
                         recursive.value().contains(fn), dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);
@@ -832,7 +833,7 @@ public final class Bodies {
             }
             try {
                 return Answer.of(TypeChecker.recursiveHelperSigs(
-                        HelperInliner.forHelpers(helpers.value()), scope.value()));
+                        HelperInliner.forHelpers(name, helpers.value()), scope.value()));
             } catch (CompileException e) {
                 // A recursive helper that does not say what it returns costs the signatures of all of
                 // them, and there is no module to check without them.
@@ -868,7 +869,7 @@ public final class Bodies {
             }
             try {
                 return Answer.of(TypeChecker.recursiveHelperConstructs(sigs.value().keySet(), bodies,
-                        HelperInliner.forHelpers(helpers.value()), scope.value()));
+                        HelperInliner.forHelpers(name, helpers.value()), scope.value()));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -964,7 +965,7 @@ public final class Bodies {
             try {
                 Core core = TypeChecker.checkBehavior(spec.value(), fn.value(), body.value().body(),
                         dischargeSource, scope.value(), calleeSigs.value(), reqSigs.value(),
-                        HelperInliner.forHelpers(helpers.value()), sigs.value(), constructs.value(),
+                        HelperInliner.forHelpers(module, helpers.value()), sigs.value(), constructs.value(),
                         warnings);
                 List<Report> reports = new ArrayList<>();
                 for (Diagnostic warning : warnings) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -913,15 +913,23 @@ public final class Names {
             return switch (denoted) {
                 case ValueName.Helper h -> h.module();
                 case ValueName.Behavior b -> b.module();
-                case ValueName.Local _, ValueName.Stdlib _, ValueName.OfType _,
+                case ValueName.Local l -> l.id().owner().module();
+                case ValueName.Stdlib _, ValueName.OfType _,
                         ValueName.Builtin _, ValueName.Unresolved _ -> null;
             };
         }
 
         @Override
         public Answer<SourcePos> compute(Db db) {
+            // a binding is not a position, so where it was written is asked of the pass that
+            // answered it rather than read off the name
             if (denoted instanceof ValueName.Local local) {
-                return local.binder() == null ? Answer.absent() : Answer.of(local.binder());
+                Answer<Resolve.Resolved> resolution = db.ask(new Resolution(local.id().owner().module()));
+                if (!resolution.present()) {
+                    return Answer.absent();
+                }
+                SourcePos binder = resolution.value().binders().get(local.id());
+                return binder == null ? Answer.absent() : Answer.of(binder);
             }
             String in = module();
             if (in == null) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -11,6 +11,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.derive.Deriver;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
@@ -275,7 +276,7 @@ public final class Shapes {
                     // The clause is classified in the representation the check reads, and reported at
                     // the position it is written — an expansion carries positions of its own, and the
                     // author is looking at the source.
-                    HelperInliner inliner = HelperInliner.forHelpers(
+                    HelperInliner inliner = HelperInliner.forHelpers(name,
                             HelperInliner.helpersOf(declaring), published, InliningPolicy.DISCHARGE);
                     List<ClauseDischarge> clauses = new ArrayList<>();
                     // A declared clause is one rule to depart by and may still be several conjuncts to
@@ -283,7 +284,9 @@ public final class Shapes {
                     // discharges each half is what an author needs, and the name is what a caller reads.
                     for (Ast.InvariantClause declared : data.invariants()) {
                         for (Ast.Expr written : HelperInliner.conjunctsOf(declared.expr())) {
-                            clauses.add(InvariantChecker.capabilityOf(inliner.inline(written),
+                            clauses.add(InvariantChecker.capabilityOf(
+                                    inliner.inline(written, new BindingOwner.OfData(
+                                            new TypeName(name, data.name()))),
                                     leftmost(written), data, scope.value()).named(declared.name()));
                         }
                     }

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingId.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingId.java
@@ -1,0 +1,33 @@
+package souther.compiler.types;
+
+/**
+ * Which binding a name is. A parameter, a {@code let}, a lambda's parameter, a {@code match} arm's
+ * binding: each is one of these, and two of them are the same binding when they are equal.
+ *
+ * <p>What a binding is cannot be worked out from how it was spelled — a body may bind a name a
+ * module declares, and two bodies may bind one spelling — nor from where it was written, since a
+ * pass that expands a helper stamps the call site over the positions in the copy. So the binder
+ * carries this, every name that resolves to it carries the same value, and asking whether a name is
+ * that binding is asking whether the two are equal. There is nothing else to compare.
+ *
+ * <p>It is a value, not a token: the query database decides that an answer is unchanged by comparing
+ * it, and an {@code Ast.Module} is what many keys answer, so an identity that differed between two
+ * readings of one source would make every edit look like a change to everything downstream.
+ *
+ * <p>{@code ordinal} counts the bindings of {@code owner} in the order they are written. It is not
+ * stable against an edit — binding something ahead of it moves it — but the movement stops at the
+ * definition, which is the unit the queries already ask in.
+ */
+public record BindingId(BindingOwner owner, int ordinal) {
+
+    public BindingId {
+        if (owner == null) {
+            throw new IllegalArgumentException("a binding belongs to something: " + ordinal);
+        }
+    }
+
+    @Override
+    public String toString() {
+        return owner + "." + ordinal;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
@@ -1,0 +1,89 @@
+package souther.compiler.types;
+
+/**
+ * What a binding belongs to — the definition whose text introduced it, or the copy of a body that a
+ * pass placed inside one.
+ *
+ * <p>An owner is named by what already identifies a definition across the whole compiler: the
+ * declaring module and the name declared there, which is what {@link TypeName} is for a type. None of
+ * them is a bare spelling, so neither is a {@link BindingId}: two modules that both declare
+ * {@code f} own different bindings, and saying so needs no comparison of text.
+ *
+ * <p>The interface is sealed and the switches over it carry no {@code default}, so a case added here
+ * is a compile error at every place that reads one.
+ */
+public sealed interface BindingOwner {
+
+    /** The module that declares what this belongs to. A copy is owned where it was placed, so it
+     * answers with the module that reads it rather than the one the body was written in. */
+    default String module() {
+        return switch (this) {
+            case OfValue v -> v.module();
+            case OfData d -> d.declared().module();
+            case Expansion e -> e.within().module();
+            case Synthesized s -> s.within().module();
+        };
+    }
+
+    /**
+     * The body of a value definition: a module's own {@code let}, or a behavior's implementation.
+     *
+     * <p>Which of the two it is says nothing about identity, because a module cannot declare both
+     * under one name — a {@code let} whose name a behavior declares <em>is</em> that behavior's
+     * implementation. So the pair names the definition, as {@link TypeName} names a declared type.
+     */
+    record OfValue(String module, String name) implements BindingOwner {
+
+        public OfValue {
+            if (module == null || name == null) {
+                throw new IllegalArgumentException("module and name are required: " + module + "."
+                        + name);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return module + "." + name;
+        }
+    }
+
+    /** What a data declaration writes for itself: an invariant, a decoder, an encoder. */
+    record OfData(TypeName declared) implements BindingOwner {
+
+        @Override
+        public String toString() {
+            return declared.toString();
+        }
+    }
+
+    /**
+     * A copy of {@code expanded}'s body, placed inside {@code within}.
+     *
+     * <p>Expanding a helper puts a second copy of its bindings in one body, so the copy owns them
+     * rather than the definition they were written in: a binding of the original keeps the ordinal it
+     * was given and changes owner. {@code ordinal} tells apart two expansions of the same thing in
+     * one place, so adding an expansion elsewhere moves nothing here, and an expansion inside an
+     * expansion is told apart by {@code within} without anything counting across the two.
+     */
+    record Expansion(BindingOwner within, ValueName expanded, int ordinal) implements BindingOwner {
+
+
+        @Override
+        public String toString() {
+            return within + "/" + expanded + "#" + ordinal;
+        }
+    }
+
+    /** Bindings {@code pass} made inside {@code within}, which no source wrote. */
+    record Synthesized(BindingOwner within, Pass pass, int ordinal) implements BindingOwner {
+
+        @Override
+        public String toString() {
+            return within + "/" + pass + "#" + ordinal;
+        }
+    }
+
+    /** The passes that introduce a binding of their own. Named here rather than by each pass, so
+     * that what may mint one is a closed list. */
+    enum Pass { DERIVER, NEWTYPE_DESUGAR, HELPER_PARAMS, INLINER, LOWER }
+}

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
@@ -20,6 +20,7 @@ public sealed interface BindingOwner {
         return switch (this) {
             case OfValue v -> v.module();
             case OfData d -> d.declared().module();
+            case OfFields f -> f.declared().module();
             case Expansion e -> e.within().module();
             case Synthesized s -> s.within().module();
         };
@@ -44,6 +45,23 @@ public sealed interface BindingOwner {
         @Override
         public String toString() {
             return module + "." + name;
+        }
+    }
+
+    /**
+     * The fields of a data declaration, which its own invariant reads as bindings.
+     *
+     * <p>Apart from {@link OfData} because these are not numbered by reading the declaration's text:
+     * a field spread in from elsewhere is bound here too, and the declaration it came from may not
+     * have been resolved. They are numbered by the one walk that says what fields a declaration has,
+     * so the pass that resolves the invariant and the pass that emits it agree without either
+     * repeating the other.
+     */
+    record OfFields(TypeName declared) implements BindingOwner {
+
+        @Override
+        public String toString() {
+            return declared + ".fields";
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BindingOwner.java
@@ -59,11 +59,11 @@ public sealed interface BindingOwner {
     /**
      * A copy of {@code expanded}'s body, placed inside {@code within}.
      *
-     * <p>Expanding a helper puts a second copy of its bindings in one body, so the copy owns them
-     * rather than the definition they were written in: a binding of the original keeps the ordinal it
-     * was given and changes owner. {@code ordinal} tells apart two expansions of the same thing in
-     * one place, so adding an expansion elsewhere moves nothing here, and an expansion inside an
-     * expansion is told apart by {@code within} without anything counting across the two.
+     * <p>Expanding a helper puts a second copy of its bindings into one body, so the copy owns them
+     * rather than the definition they were written in — otherwise two copies of one {@code let} would
+     * answer as one binding. {@code ordinal} tells apart two copies of the same body in one place, so
+     * expanding something elsewhere moves nothing here, and a copy inside a copy is told apart by
+     * {@code within} without anything counting across the two.
      */
     record Expansion(BindingOwner within, ValueName expanded, int ordinal) implements BindingOwner {
 

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -1,7 +1,5 @@
 package souther.compiler.types;
 
-import souther.compiler.diag.SourcePos;
-
 /**
  * What a name written in the value namespace denotes — the answer {@link TypeName} gives for the
  * type namespace.
@@ -23,10 +21,10 @@ public sealed interface ValueName {
 
     /**
      * A name bound inside a body: a parameter, a {@code let}, a {@code match} arm's binding, or a
-     * block's parameter. {@code binder} is where the binding that introduced it is written, which is
-     * what tells two bindings of one spelling apart.
+     * block's parameter. {@code id} is the binding it was answered with, which is what tells two
+     * bindings of one spelling apart; {@code name} is only how it was written.
      */
-    record Local(String name, SourcePos binder) implements ValueName {
+    record Local(String name, BindingId id) implements ValueName {
 
         @Override
         public String toString() {

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -403,7 +403,6 @@ check.temporal.literal=`{0}(...)` takes a written string, e.g. `Date("2026-07-01
 check.temporal.malformed=`{1}` is not a {0}. Write `Date("2026-07-01")` / `DateTime("2026-07-01T09:00")`.
 check.newtype.arity=`{0}` wraps one value, but is applied to {1} argument(s).
 check.helper.arity=Helper `let {0}` takes {1} argument(s), but is called with {2}.
-check.fn.recursivelambda=The lambda bound to `{0}` refers to itself; a recursive lambda would not bottom out when expanded inline.
 check.fn.annotation=The binding `{0}` is a function, and a function type may be written only in a helper parameter.
 check.fn.annotation.hint=Remove the annotation.
 check.behavior.collision.data=behavior `{0}`''s first letter is capitalized to form the JVM class `{1}` (spec 19.5), which collides with data `{1}`; rename one so their class names differ.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -402,7 +402,6 @@ check.temporal.literal=`{0}(...)` は書かれた文字列を取ります（例:
 check.temporal.malformed=`{1}` は {0} として読めません。`Date("2026-07-01")` / `DateTime("2026-07-01T09:00")` の形で書いてください。
 check.newtype.arity=`{0}` は値を1つ包みますが、{1} 個の引数で適用されています。
 check.helper.arity=ヘルパ `let {0}` は引数を {1} 個取りますが、{2} 個で呼ばれています。
-check.fn.recursivelambda=`{0}` に束縛されたラムダが自分自身を参照しています。再帰ラムダはインライン展開時に停止しません。
 check.fn.annotation=束縛 `{0}` は関数です。関数型はヘルパの引数位置にしか書けません。
 check.fn.annotation.hint=型注釈を外してください。
 check.behavior.collision.data=behavior `{0}` は先頭が大文字化され JVM クラス `{1}` になり（spec 19.5）、data `{1}` と衝突します。クラス名が異なるよう、どちらかをリネームしてください。

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperShadowingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperShadowingTest.java
@@ -5,7 +5,11 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 import java.util.Map;
 
+import souther.compiler.diag.CompileException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A binding is what a name is, so what a program means does not depend on how its bindings are
@@ -75,6 +79,61 @@ class CompileHelperShadowingTest {
                 "`acc` is the binding written here, through both expansions");
         assertEquals(List.of(12L, 13L), run(source.replace("BOUND", "x"), input),
                 "and so is `x`, which both steps bind an element under");
+    }
+
+    /**
+     * A helper applies a function it was given, under a parameter spelled like the helper it is
+     * handed. What is applied is the parameter, whatever the two are called.
+     */
+    @Test
+    void applyingAFunctionParameterIsTheParameterWhateverItIsSpelled() throws Exception {
+        String source = """
+                module demo
+                data In = { xs: List<Int>, n: Int }
+                data Out = { ys: List<Int> }
+
+                let twice (f: (Int) -> Int, v: Int): Int = f(f(v))
+                let once (NAME: (Int) -> Int, v: Int): Int = NAME(v)
+
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { ys = [once(e -> e + 1, i.n), twice(e -> e + 1, i.n)] }
+                """;
+        assertEquals(List.of(11L, 12L),
+                run(source.replace("NAME", "apply"), Map.of("xs", List.of(), "n", 10L)));
+        assertEquals(List.of(11L, 12L),
+                run(source.replace("NAME", "twice"), Map.of("xs", List.of(), "n", 10L)),
+                "`twice` is the parameter here, not the helper of that name");
+    }
+
+    /**
+     * A unit data written where a value goes is that construction, and the permission the behavior
+     * declares covers it — whatever something around it happens to bind under that spelling.
+     */
+    @Test
+    void aUnitDataNamedAsAValueIsThatConstructionWhateverIsBoundAround() {
+        String source = """
+                module demo
+                data In = { xs: List<Int>, n: Int }
+                data Missing
+                data Out = { ys: List<Int> }
+
+                let pick (v: Int): Out | Missing =
+                    if v > 0 then Out { ys = [v] } else Missing
+
+                behavior go : (i: In) -> Out | Missing constructs Out, DECLARED
+                let go (i) = {
+                    let NAME = i.n + 1
+                    pick(NAME)
+                }
+                """;
+        for (String spelled : List.of("held", "Missing")) {
+            String src = source.replace("NAME", spelled);
+            assertDoesNotThrow(() -> Compiler.compile(src.replace("DECLARED", "Missing")),
+                    "`Missing` is the construction it is, with a binding spelled " + spelled);
+            assertThrows(CompileException.class,
+                    () -> Compiler.compile(src.replace("constructs Out, DECLARED", "constructs Out")),
+                    "and the permission for it is still required, with a binding spelled " + spelled);
+        }
     }
 
     /** Two expansions of one helper into one body each bring their own bindings, so the second does

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperShadowingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperShadowingTest.java
@@ -1,0 +1,98 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A binding is what a name is, so what a program means does not depend on how its bindings are
+ * spelled.
+ *
+ * <p>Expanding a helper splices a body written in one scope into another. Where a name meant a
+ * binding, it goes on meaning it: the copy's names were settled where they were written, and moving
+ * the code does not change what they say. Each of these writes one program twice — once with names
+ * that collide with the ones the expansion brings in, once with names that do not — and runs both.
+ */
+class CompileHelperShadowingTest {
+
+    private static Object run(String source, Map<String, Object> input) throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(source),
+                CompileHelperShadowingTest.class.getClassLoader());
+        Object go = loader.loadClass("demo.Go" + "$Impl").getDeclaredConstructor().newInstance();
+        Object in = Codecs.decoded(loader, "demo.In", input);
+        return ((Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(go, in))).get("ys");
+    }
+
+    /**
+     * The lambda given to {@code List.map} reads a parameter of the helper that passes it. The
+     * derived combinator folds with a step written {@code (acc, x) -> ...}, and the lambda is
+     * spliced inside that step — so naming the parameter {@code acc} puts a binding of that spelling
+     * around a body that already reads another.
+     */
+    @Test
+    void aLambdaReadsWhatItsOwnScopeBoundEvenWhereTheExpansionBindsThatSpelling() throws Exception {
+        String source = """
+                module demo
+                data In = { xs: List<Int>, n: Int }
+                data Out = { ys: List<Int> }
+
+                let shifted (xs: List<Int>, %s: Int): List<Int> = List.map(e -> e + %s, xs)
+
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { ys = shifted(i.xs, i.n) }
+                """;
+        Map<String, Object> input = Map.of("xs", List.of(1L, 2L), "n", 10L);
+
+        assertEquals(List.of(11L, 12L), run(source.formatted("bump", "bump"), input));
+        assertEquals(List.of(11L, 12L), run(source.formatted("acc", "acc"), input),
+                "`acc` is the parameter, not the accumulator the fold binds around it");
+        assertEquals(List.of(11L, 12L), run(source.formatted("x", "x"), input),
+                "`x` is the parameter, not the element the step binds around it");
+    }
+
+    /** The same for a binding the caller writes rather than a parameter, read through two
+     * expansions nested one inside the other. */
+    @Test
+    void aBindingReadsWhatItsOwnScopeBoundThroughTwoExpansions() throws Exception {
+        String source = """
+                module demo
+                data In = { xs: List<Int>, n: Int }
+                data Out = { ys: List<Int> }
+
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = {
+                    let BOUND = i.n + 1
+                    Out { ys = List.map(y -> y + BOUND, List.filter(z -> z > 0, i.xs)) }
+                }
+                """;
+        Map<String, Object> input = Map.of("xs", List.of(1L, 2L), "n", 10L);
+
+        assertEquals(List.of(12L, 13L), run(source.replace("BOUND", "bump"), input));
+        assertEquals(List.of(12L, 13L), run(source.replace("BOUND", "acc"), input),
+                "`acc` is the binding written here, through both expansions");
+        assertEquals(List.of(12L, 13L), run(source.replace("BOUND", "x"), input),
+                "and so is `x`, which both steps bind an element under");
+    }
+
+    /** Two expansions of one helper into one body each bring their own bindings, so the second does
+     * not answer for the first. */
+    @Test
+    void twoExpansionsOfOneHelperKeepTheirOwnBindings() throws Exception {
+        String source = """
+                module demo
+                data In = { xs: List<Int>, n: Int }
+                data Out = { ys: List<Int> }
+
+                let scaled (by: Int, xs: List<Int>): List<Int> = List.map(x -> x * by, xs)
+
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { ys = scaled(2, i.xs) ++ scaled(3, i.xs) }
+                """;
+        assertEquals(List.of(2L, 4L, 3L, 6L),
+                run(source, Map.of("xs", List.of(1L, 2L), "n", 0L)),
+                "the second expansion's `by` is 3 and the first's is still 2");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileLambdaNamesItselfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLambdaNamesItselfTest.java
@@ -1,0 +1,70 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code let} does not bind its own name in its value (spec 16.1), so a name inside a lambda bound
+ * by one is whatever that name was outside it.
+ *
+ * <p>The inliner used to hold declared helpers and let-bound lambdas in one table keyed by spelling,
+ * where a lambda took the place of a declaration of the same name; a lambda whose body wrote its own
+ * name would then have expanded into itself forever, and was refused for that reason. Held apart —
+ * a declaration by the name it is reached by, a lambda by the binding it is bound to — the name
+ * inside reaches what it always denoted, so there is nothing to refuse.
+ */
+class CompileLambdaNamesItselfTest {
+
+    /** A lambda whose body writes its own name applies the helper of that name, and terminates. */
+    @Test
+    void aLambdaWritingItsOwnNameAppliesTheHelperOfThatName() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                data Order = { v: Int }
+                data Result = { n: Int }
+
+                let twice (x: Int) = x * 2
+
+                behavior check : (o: Order) -> Result
+                    constructs Result
+
+                let check (o) = {
+                    let twice = (x) -> twice(x) + 1
+                    Result { n = twice(o.v) }
+                }
+                """), getClass().getClassLoader());
+        Object check = loader.loadClass("demo.Check" + "$Impl").getDeclaredConstructor().newInstance();
+        Object order = Codecs.decoded(loader, "demo.Order", Map.of("v", 5L));
+        Map<?, ?> result = (Map<?, ?>) Codecs.encode(loader, "demo.Result",
+                Codecs.apply(check, order));
+        assertEquals(11L, result.get("n"), "the inner `twice` is the helper: 5 * 2 + 1");
+    }
+
+    /** With no declaration of that name to reach, the name is reported where it is written. */
+    @Test
+    void aLambdaWritingANameNothingDeclaresIsReportedThere() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data Order = { v: Int }
+                data Result = { n: Int }
+
+                behavior check : (o: Order) -> Result
+                    constructs Result
+
+                let check (o) = {
+                    let step = (x) -> step(x) + 1
+                    Result { n = step(o.v) }
+                }
+                """));
+        assertTrue(e.getMessage().contains("step"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
@@ -511,6 +511,24 @@ class CompileRecursiveHelperTest {
     }
 
     @Test
+    void applyingAFunctionParameterSpelledLikeAHelperIsNotACallToThatHelper() {
+        // The function-argument check reads what a call applies, not how it is spelled: `apply` is
+        // the parameter here, so `apply(n)` applies the function it was given. The helper of that
+        // name takes a function of two parameters, and holding the argument against it would refuse
+        // a program the language allows.
+        String src = """
+                module demo
+                data In = { n: Int }
+                data Out = { d: Int }
+                let apply (f: (Int) -> Int, a: Int): Int = f(a)
+                let once (apply: (Int, Int) -> Int, n: Int): Int = apply(n, n)
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { d = once((x, y) -> x + y, i.n) }
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(src));
+    }
+
+    @Test
     void applyingAParameterThatShadowsARecursiveHelperIsRejected() {
         // The other direction of the same rule, and the one that costs something: `count(2)` reaches
         // the parameter, which is an Int, so it is not applied to anything. The helper spelled that

--- a/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRecursiveHelperTest.java
@@ -511,6 +511,31 @@ class CompileRecursiveHelperTest {
     }
 
     @Test
+    void aLetSpelledLikeTheParameterDoesNotMakeARecursiveCallDecrease() {
+        // The size a structural recursion decreases is the parameter's, and `t` here is not the
+        // parameter: it is a value built from it, which may be bigger. Read as the parameter, the
+        // arm binding counted as a strictly smaller part of it and `flatten(k)` was accepted as
+        // walking the tree down — a program that never bottoms out.
+        String src = """
+                module demo
+                data Node = { n: Int, kids: List<Node> }
+                data Out = { xs: List<Int> }
+
+                let grow (t: Node): Node = Node { n = t.n, kids = [t, t] }
+
+                let flatten (t: Node): List<Int> = {
+                    let t = grow(t)
+                    [t.n] ++ List.concatMap(k -> flatten(k), t.kids)
+                }
+
+                behavior go : (t: Node) -> Out constructs Out, Node
+                let go (t) = Out { xs = flatten(t) }
+                """;
+        CompileException ex = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        assertTrue(ex.getMessage().contains("flatten"), ex.getMessage());
+    }
+
+    @Test
     void applyingAFunctionParameterSpelledLikeAHelperIsNotACallToThatHelper() {
         // The function-argument check reads what a call applies, not how it is spelled: `apply` is
         // the parameter here, so `apply(n)` applies the function it was given. The helper of that

--- a/souther-compiler/src/test/java/souther/compiler/ExampleFixtureShadowingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleFixtureShadowingTest.java
@@ -4,7 +4,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
+import souther.compiler.diag.CompileException;
+
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A fixture reads a bare name as what it denotes, so what a row builds does not depend on how the
@@ -67,5 +71,54 @@ class ExampleFixtureShadowingTest {
             assertDoesNotThrow(() -> Compiler.compile(source.replace("NAME", spelled)),
                     "the fixture holds `Box { n = 1 }`, with a binding spelled " + spelled);
         }
+    }
+
+    /**
+     * Two bindings of one spelling, one holding the other. Not a value reaching itself — the second
+     * reads the first, which is closed by the time the second is open — so it is not refused as one.
+     */
+    @Test
+    void twoBindingsOfOneSpellingAreNotAValueReachingItself() {
+        String source = """
+                module demo
+                data Box = { n: Int }
+                data Out = { n: Int }
+
+                let fixture = {
+                    let x = Box { n = 1 }
+                    let NAME = x
+                    NAME
+                }
+
+                behavior go : (b: Box) -> Out constructs Out
+                let go (b) = Out { n = b.n }
+
+                example go
+                    | "one" : (fixture) -> Out { n = 1 }
+                """;
+        for (String spelled : List.of("y", "x")) {
+            assertDoesNotThrow(() -> Compiler.compile(source.replace("NAME", spelled)),
+                    "the inner binding reads the outer one, spelled " + spelled);
+        }
+    }
+
+    /** A value that does reach itself is still refused, and named. */
+    @Test
+    void aValueDefinedInTermsOfItselfIsStillRefused() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data Box = { n: Int }
+                data Out = { n: Int }
+
+                let fixture = other
+                let other = fixture
+
+                behavior go : (b: Box) -> Out constructs Out
+                let go (b) = Out { n = b.n }
+
+                example go
+                    | "one" : (fixture) -> Out { n = 1 }
+                """));
+        assertTrue(e.getMessage().contains("itself"), e.getMessage());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ExampleFixtureShadowingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleFixtureShadowingTest.java
@@ -1,0 +1,71 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * A fixture reads a bare name as what it denotes, so what a row builds does not depend on how the
+ * bindings around it are spelled.
+ *
+ * <p>A fixture's names used to be worked out again where the row was built — `None`, then a unit
+ * data of that spelling, then a binding in force, then a value the module defines — so a binding
+ * spelled like a unit data was read as that unit and the row built the wrong value.
+ */
+class ExampleFixtureShadowingTest {
+
+    private static final String MODULE = """
+            module demo
+            data Empty
+            data Box = { n: Int }
+            data Out = { n: Int }
+
+            let fixture = {
+                let NAME = Box { n = 1 }
+                NAME
+            }
+
+            behavior go : (b: Box) -> Out constructs Out
+            let go (b) = Out { n = b.n }
+
+            example go
+                | "one" : (fixture) -> Out { n = 1 }
+            """;
+
+    @Test
+    void aFixtureBindingSpelledLikeAUnitDataIsStillTheBinding() {
+        for (String spelled : List.of("held", "Empty")) {
+            assertDoesNotThrow(() -> Compiler.compile(MODULE.replace("NAME", spelled)),
+                    "the fixture holds a Box, with a binding spelled " + spelled);
+        }
+    }
+
+    /** And a binding spelled like a value the module defines is the binding, not that value. */
+    @Test
+    void aFixtureBindingSpelledLikeAValueIsStillTheBinding() {
+        String source = """
+                module demo
+                data Box = { n: Int }
+                data Out = { n: Int }
+
+                let other = Box { n = 9 }
+
+                let fixture = {
+                    let NAME = Box { n = 1 }
+                    NAME
+                }
+
+                behavior go : (b: Box) -> Out constructs Out
+                let go (b) = Out { n = b.n }
+
+                example go
+                    | "one" : (fixture) -> Out { n = 1 }
+                """;
+        for (String spelled : List.of("held", "other")) {
+            assertDoesNotThrow(() -> Compiler.compile(source.replace("NAME", spelled)),
+                    "the fixture holds `Box { n = 1 }`, with a binding spelled " + spelled);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
@@ -5,6 +5,8 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -68,7 +70,8 @@ class CallElaboratorNoCalleeTest {
      */
     @Test
     void aBindingIsToldItIsNotAFunction() {
-        RuntimeException e = answerFor(new ValueName.Local("f", AT));
+        RuntimeException e = answerFor(new ValueName.Local("f",
+                new BindingId(new BindingOwner.OfValue("m.a", "g"), 0)));
         assertEquals("check.apply.notfunction",
                 assertInstanceOf(CompileException.class, e).diagnostic().messageKey());
     }

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -1,6 +1,8 @@
 package souther.compiler.query;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.check.Resolve;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ValueName;
@@ -332,5 +334,52 @@ class ResolvedValueNamesTest {
         ValueName.Local local = assertInstanceOf(ValueName.Local.class, denoted);
         assertEquals(new BindingOwner.OfValue("m.a", "g"), local.id().owner(),
                 "`m` is bound by `g`, so `g` is what it belongs to");
+    }
+
+    /** What a name in {@code source} denotes, and where the editor says it was declared. */
+    private static SourcePos declaredAt(String source, String written) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", source);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        for (Resolve.ValueUse use : c.db().ask(new Names.Resolution("m.a")).value().values()) {
+            if (use.written().equals(written) && use.denotes() instanceof ValueName.Local local) {
+                return c.db().ask(new Names.ValueDeclaredAt(local)).value();
+            }
+        }
+        throw new AssertionError("nothing named `" + written + "` is a binding here");
+    }
+
+    /**
+     * An invariant reads its declaration's fields as the bindings they are, so an editor asked where
+     * one is declared answers with the field.
+     */
+    @Test
+    void aFieldAnInvariantReadsIsDeclaredWhereTheFieldIsWritten() {
+        assertEquals(new SourcePos(4, 7), declaredAt("""
+                module m.a exposing ( Amount )
+
+                data Amount = {
+                      value: Int
+                }
+                    invariant value >= 0
+                """, "value"), "the field on line 4");
+    }
+
+    /** A field an include brings in keeps the binding of the declaration that wrote it, so it is
+     * declared there and not where it was spread in. */
+    @Test
+    void aFieldAnIncludeBringsInIsDeclaredWhereItWasWritten() {
+        assertEquals(new SourcePos(4, 7), declaredAt("""
+                module m.a exposing ( Priced )
+
+                data Money = {
+                      cost: Int
+                }
+
+                data Priced = {
+                      ...Money
+                }
+                    invariant cost >= 0
+                """, "cost"), "the field on line 4, in the declaration that wrote it");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.meta.ModulePath;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -88,8 +89,8 @@ class ResolvedValueNamesTest {
                 """, "n");
         ValueName.Local local = assertInstanceOf(ValueName.Local.class, denoted);
         assertEquals("n", local.name());
-        assertEquals(m.fns().get(0).params().get(0).pos(), local.binder(),
-                "the binder is the parameter it was bound by");
+        assertEquals(m.fns().get(0).params().get(0).binder().id(), local.id(),
+                "the name is the binding the parameter introduced");
     }
 
     /** A body may bind a name the module declares, and inside the binding that is what it means. */
@@ -279,5 +280,57 @@ class ResolvedValueNamesTest {
                 "the construction `Amount(n)` in the body: " + amount);
         assertTrue(approved.stream().anyMatch(d -> d.pos().line() == 8),
                 "the unit value `Approved` in the body: " + approved);
+    }
+
+    /**
+     * Two bindings that spell their name the same are two bindings, and each name under them is
+     * answered with the one in force. Nothing here compares text, so the answer does not depend on
+     * how either was spelled.
+     */
+    @Test
+    void twoBindingsOfOneSpellingAreTwoBindings() {
+        Ast.Module m = resolve("""
+                module m.a exposing ( f )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = {
+                    let x = n + 1
+                    let y = (m) -> {
+                        let x = m + 2
+                        x
+                    }
+                    x + y(n)
+                }
+                """);
+
+        List<ValueName.Local> reads = new ArrayList<>();
+        for (Ast.Expr e : named(m)) {
+            if (e instanceof Ast.Var v && v.name().equals("x")
+                    && v.denotes() instanceof ValueName.Local local) {
+                reads.add(local);
+            }
+        }
+
+        assertEquals(2, reads.size(), "both reads of `x`: " + reads);
+        assertNotEquals(reads.get(0).id(), reads.get(1).id(),
+                "the inner `x` is not the outer one, though they are spelled alike");
+    }
+
+    /** A binding belongs to the definition whose text introduced it, so an edit to one definition
+     * leaves the bindings of the definitions beside it where they were. */
+    @Test
+    void aBindingBelongsToTheDefinitionThatIntroducedIt() {
+        ValueName denoted = denotationOf("""
+                module m.a exposing ( f, g )
+
+                behavior f : (n: Int) -> Int
+                let f (n) = n
+
+                behavior g : (m: Int) -> Int
+                let g (m) = m
+                """, "m");
+        ValueName.Local local = assertInstanceOf(ValueName.Local.class, denoted);
+        assertEquals(new BindingOwner.OfValue("m.a", "g"), local.id().owner(),
+                "`m` is bound by `g`, so `g` is what it belongs to");
     }
 }


### PR DESCRIPTION
Closes the class #268 opened, and the reason it kept coming back.

## What was wrong

`HelperInliner` decided "is this name that binding" three ways — by spelling, by a set of
`SourcePos`, and by what the name denotes — and which one a piece of code used was remembered
rather than stated. The same correction had landed five times.

The three notions were the symptom. Underneath, **lexical binding identity was not represented,
and not preserved to the passes that needed it**, so each of them reconstructed it from the
spelling. What made that work was the inliner's α-renaming: every binding it spliced was given a
`$`-name no source can write, so nothing a spelling-keyed reader held could collide with it.

That renaming was not untidy code to sweep away once bindings had identities. It *was* the
identity, implemented in names, for readers that had none. So the order here is: give bindings an
identity, preserve it through every transformation, make every consumer ask for it — and only then
can the renaming go.

## What the model predicted, and what was found

The explanation predicts specific failures, and each was reproduced before being fixed.

| Prediction | Found |
|---|---|
| a spelling-keyed environment captures under splicing | `List.map(e -> e + acc, xs)` typed `acc` as the fold's accumulator |
| a flat name set confuses shadowing | the totality check proved a non-terminating helper total |
| an incomplete copy splits binder from reference | a `let`'s reads kept the original id while its binder moved |
| an independent lookup disagrees with Resolve | the function-argument check refused a program the language allows |
| a spelling veto in front of a settled answer | a unit data's construction was dropped from the permission it needs |

Three of these are bugs on `develop` today, not latent ones:

- **Totality is unsound.** `let t = grow(t)` inside a recursive helper was read as the parameter,
  so unwrapping a case counted as reaching a strictly smaller part of it. A helper that never
  bottoms out compiled as total. This is what raises #268 from "occasional wrong programs" to
  "binding identity is part of the soundness boundary".
- **The function-argument check** reached the wrong declaration where the arities matched, and
  refused `let once (apply: (Int, Int) -> Int, n: Int) = apply(n, n)` beside a helper `apply`.
- **The construction-permission walk** vetoed by spelling before reading the denotation, so a unit
  data named inside an expansion, under a binding of that spelling at the site, was not counted.

## What is in place now

`BindingId` says which binding a name is; `BindingOwner` says what it belongs to, named by the
module and the name declared there — never assembled from a spelling. `Ast.Binder` is `Written` or
`Bound`, so there is no absent identity to test for. Resolve numbers each definition's bindings, and
keeps where each was written aside so an editor still gets a position while nothing decides identity
by one. Numbering per definition also stops an edit from renumbering the definitions beside it,
which a `SourcePos` did not.

Identity survives to where it is consumed. Core carries the binding a name reads, the one a body
applies, and the one a construction spreads; no `String` in Core stands for a lexical binding. A
copy of a body assigns its bindings in one pass before writing any of it, so a binder and every name
that reads it move together whatever order the copy is written in.

Three nodes came out of one along the way, each because holding them together forced a consumer to
work out which it had: a read, a unit data, and a name the language defines were all `Core.Var`;
applying a function value and calling something declared elsewhere were both `Core.Call`; a
declaration reached by name and a lambda reached by a binding shared one table in the inliner. Each
split removed a fallback chain rather than adding a case.

`check.fn.recursivelambda` is deleted. It existed because a `let`-bound lambda took the place of a
declaration of its spelling; with the two apart, the state it described cannot be built.

## What still reads a spelling, deliberately

A diagnostic's quoted name and its did-you-mean, a field name, a case name, the name a module
reaches a declaration by, the rule that a binding may not be spelled `None`, and the name a local is
emitted under. The audit asked one question of every spelling read: *if this name were spelled
differently and denoted the same thing, may this decision change?* These are the ones where it may.

The invariant analysis keys its atoms by the text of the path they name. It is sound — shadowing
makes it forget facts, never derive them — and measuring it with the renaming gone showed no loss,
because the body it reads leaves the library unexpanded and so holds no second copy of anything.
Left as it is, and recorded rather than changed.

## The invariant this leaves behind

> Resolve settles what a lexical binding is, once. Every transformation preserves it. No consumer
> may reinterpret a spelling as identity, or use one to change, restrict or reclassify the answer.

## Checked

Compiler suite 1855 green, and the reactor's other modules (73 / 98 / 1). Every fix is pinned by a
test that fails when the corresponding answer is taken away. The shadowing tests are metamorphic:
one program written twice, differing only in a binder's spelling, run both ways.

`souther-examples` passes whole — the eight Maven modules, the Clojure project, the Kotlin one.

`souther-bench` shows no regression: `crm` warm median 114.9 ms, and the incremental edit that
worried me most — a definition in an imported module — at 80.3 ms against a 79 ms baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
