### PR TITLE
Refuse a value too deep for the boundary with a path, not Jackson's words

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -585,6 +585,14 @@ public final class Runner {
             StreamWriteConstraints.defaults().getMaxNestingDepth();
 
     /**
+     * The depth a context stands at when its side has just refused a value for nesting. The two
+     * sides count differently, measured: reading stands on the level it refused to enter, and
+     * writing on the last level it accepted.
+     */
+    private static final int READ_REFUSAL_DEPTH = READ_DEPTH_LIMIT + 1;
+    private static final int WRITE_REFUSAL_DEPTH = WRITE_DEPTH_LIMIT;
+
+    /**
      * Parses {@code --input}.
      *
      * <p>The parser is made here rather than left to {@code readTree(String)} because the exception a
@@ -599,14 +607,17 @@ public final class Runner {
         JsonParser parser = JSON.createParser(input);
         try {
             JsonNode tree = JSON.readTree(parser);
-            parser.close();
             return tree == null ? JSON.missingNode() : tree;
-        } catch (StreamConstraintsException _) {
-            throw tooDeep("run.input.toodeep", "--input nests deeper than this boundary accepts",
-                    parser.streamReadContext(), READ_DEPTH_LIMIT);
         } catch (Exception e) {
+            TokenStreamContext where = parser.streamReadContext();
+            if (refusedForDepth(e, where, READ_REFUSAL_DEPTH)) {
+                throw tooDeep("run.input.toodeep", "--input nests deeper than this boundary accepts",
+                        where, READ_DEPTH_LIMIT);
+            }
             throw fail("run.input.badjson", "--input is not valid JSON: " + e.getMessage(),
                     e.getMessage());
+        } finally {
+            parser.close();
         }
     }
 
@@ -616,16 +627,39 @@ public final class Runner {
         JsonGenerator generator = JSON.createGenerator(out);
         try {
             JSON.writeValue(generator, tree);
-            generator.close();
             return out.toString();
-        } catch (StreamConstraintsException _) {
-            throw tooDeep("run.output.toodeep",
-                    "the output nests deeper than this boundary can render",
-                    generator.streamWriteContext(), WRITE_DEPTH_LIMIT);
         } catch (Exception e) {
+            // read before the close in `finally`, which resets the generator's context to the root
+            TokenStreamContext where = generator.streamWriteContext();
+            if (refusedForDepth(e, where, WRITE_REFUSAL_DEPTH)) {
+                throw tooDeep("run.output.toodeep",
+                        "the output nests deeper than this boundary can render",
+                        where, WRITE_DEPTH_LIMIT);
+            }
             throw fail("run.output.json", "could not render the output as JSON: " + e.getMessage(),
                     e.getMessage());
+        } finally {
+            generator.close();
         }
+    }
+
+    /**
+     * Whether {@code failure} is the reader or writer refusing a value for its depth.
+     *
+     * <p>{@code StreamConstraintsException} is not the depth refusal alone: the reader raises the
+     * same type for a number too long, a name too long, a string too long, a document too long and a
+     * token count too high. Which limit it was is asked of the context's own depth rather than of
+     * the exception's text, which is prose Jackson is free to rewrite.
+     *
+     * <p>Standing at {@code refusalDepth} is the depth refusal and can be nothing else. A value
+     * refused for another reason stands shallower: the reader admits scalars at every level up to
+     * the limit, so the deepest a long number can be refused at is one level short of where a
+     * refusal for depth stands. Every other constraint keeps the wording it had.
+     */
+    private static boolean refusedForDepth(Exception failure, TokenStreamContext where,
+                                           int refusalDepth) {
+        return failure instanceof StreamConstraintsException
+                && where.getNestingDepth() >= refusalDepth;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -19,10 +19,17 @@ import net.unit8.raoh.encode.ObjectEncoders;
 
 import souther.runtime.Sets;
 
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.StreamWriteConstraints;
+import tools.jackson.core.TokenStreamContext;
+import tools.jackson.core.exc.StreamConstraintsException;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -169,7 +176,7 @@ public final class Runner {
         }
 
         Object result = invoke(loader, module.name(), spec.name(), args);
-        Object encoded = encode(loader, module.name(), spec.name(), sig.out(), result);
+        Object encoded = encodeOutput(loader, module.name(), spec.name(), sig.out(), result);
         return writeJson(encoded);
     }
 
@@ -418,6 +425,24 @@ public final class Runner {
     }
 
     /**
+     * The whole output, encoded.
+     *
+     * <p>Encoding descends the value by recursion, so a value that nests deeply enough runs the stack
+     * out before the writer ever counts a level. A behavior can build a value deeper than anything it
+     * was handed, so this is reached from input the boundary accepted. A {@code StackOverflowError}
+     * is not a {@code RunException}, so left alone it reaches the caller as a stack trace.
+     */
+    private static Object encodeOutput(MemoryClassLoader loader, String pkg, String behavior,
+                                       Type out, Object result) {
+        try {
+            return encode(loader, pkg, behavior, out, result);
+        } catch (StackOverflowError _) {
+            throw fail("run.encode.toodeep",
+                    "the output nests too deeply for this boundary to encode.");
+        }
+    }
+
+    /**
      * The output as its declared type writes it. Which encoder that is follows the type the behavior
      * declared, never the class the answer happens to have arrived in: a case of a sum carries no
      * discriminator on its own encoder — only the sum's writes one — so taking the encoder off the
@@ -553,21 +578,92 @@ public final class Runner {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
+    /** How deep the mapper reads and writes before it refuses, counted in levels of JSON. */
+    private static final int READ_DEPTH_LIMIT =
+            StreamReadConstraints.defaults().getMaxNestingDepth();
+    private static final int WRITE_DEPTH_LIMIT =
+            StreamWriteConstraints.defaults().getMaxNestingDepth();
+
+    /**
+     * Parses {@code --input}.
+     *
+     * <p>The parser is made here rather than left to {@code readTree(String)} because the exception a
+     * depth refusal throws carries neither a location nor the parser that raised it. Holding the
+     * parser is what lets the refusal name the path it gave up at, the way every other thing the
+     * boundary rejects is named.
+     *
+     * <p>Input with nothing in it reads as the missing node rather than as no node at all, so an
+     * empty {@code --input} reaches the same refusal as input of the wrong shape.
+     */
     private static JsonNode parseJson(String input) {
+        JsonParser parser = JSON.createParser(input);
         try {
-            return JSON.readTree(input);
+            JsonNode tree = JSON.readTree(parser);
+            parser.close();
+            return tree == null ? JSON.missingNode() : tree;
+        } catch (StreamConstraintsException _) {
+            throw tooDeep("run.input.toodeep", "--input nests deeper than this boundary accepts",
+                    parser.streamReadContext(), READ_DEPTH_LIMIT);
         } catch (Exception e) {
             throw fail("run.input.badjson", "--input is not valid JSON: " + e.getMessage(),
                     e.getMessage());
         }
     }
 
+    /** Renders the encoded output. The generator is held for the same reason the parser is. */
     private static String writeJson(Object tree) {
+        StringWriter out = new StringWriter();
+        JsonGenerator generator = JSON.createGenerator(out);
         try {
-            return JSON.writeValueAsString(tree);
+            JSON.writeValue(generator, tree);
+            generator.close();
+            return out.toString();
+        } catch (StreamConstraintsException _) {
+            throw tooDeep("run.output.toodeep",
+                    "the output nests deeper than this boundary can render",
+                    generator.streamWriteContext(), WRITE_DEPTH_LIMIT);
         } catch (Exception e) {
             throw fail("run.output.json", "could not render the output as JSON: " + e.getMessage(),
                     e.getMessage());
         }
+    }
+
+    /**
+     * A value that nests deeper than the boundary handles, reported where it stopped.
+     *
+     * <p>The limit is named rather than the value's own depth: reading and writing both stop at the
+     * level that crosses the limit, so how much deeper the value goes was never counted. What is
+     * counted is levels of JSON, which is not levels of the data — one level of a self-referential
+     * data spends a level for its object and another for the list that carries the next one.
+     */
+    private static RunException tooDeep(String key, String english, TokenStreamContext where,
+                                        int limit) {
+        String path = depthPath(where);
+        return fail(key, english + ": " + path + " and below (JSON nesting past " + limit
+                + " levels)", path, limit);
+    }
+
+    /** How much of the path to the deepest level is worth reading. */
+    private static final int DEPTH_PATH_SEGMENTS = 8;
+
+    /**
+     * The path the depth limit was reached at, cut short. Nesting that deep is nesting that repeats,
+     * so the whole pointer runs to hundreds of segments of the same few names; the head is the part
+     * that says which branch went deep.
+     */
+    private static String depthPath(TokenStreamContext where) {
+        String pointer = where.pathAsPointer().toString();
+        if (pointer.isEmpty()) {
+            return "(root)";
+        }
+        int cut = 0;
+        for (int i = 0; i < DEPTH_PATH_SEGMENTS; i++) {
+            int next = pointer.indexOf('/', cut + 1);
+            if (next < 0) {
+                return pointer;
+            }
+            cut = next;
+        }
+        return pointer.substring(0, cut) + "/…";
     }
 }

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -527,6 +527,7 @@ run.input.missing=`{0}` takes {1} input(s) — pass --input
 run.input.notarray=`{0}` takes {1} inputs — --input must be a JSON array of that length
 run.input.count=`{0}` takes {1} inputs, but --input has {2}
 run.input.badjson=--input is not valid JSON: {0}
+run.input.toodeep=--input nests deeper than this boundary accepts: {0} and below (JSON nesting past {1} levels). One level of a data can spend more than one level of JSON.
 run.decode.failed=input #{0} could not be decoded — {1}
 run.decode.nodecoder=cannot obtain a decoder for `{0}`: {1}
 run.decode.unsupported=input #{0} has type `{1}`, which `run` cannot decode yet (only a data type, a primitive, or a collection of those).
@@ -536,6 +537,8 @@ run.encode.unsupported=the output has type `{0}`, which `run` cannot encode yet 
 run.encode.raw=the output is the reserved Raw type, which `run` cannot encode.
 run.read.failed=cannot read {0}: {1}
 run.output.json=could not render the output as JSON: {0}
+run.output.toodeep=the output nests deeper than this boundary can render: {0} and below (JSON nesting past {1} levels). One level of a data can spend more than one level of JSON.
+run.encode.toodeep=the output nests too deeply for this boundary to encode.
 run.decode.malformed=input #{0} is not shaped like `{1}` — check --input
 
 # a behavior that reaches itself (E1608)

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -526,6 +526,7 @@ run.input.missing=`{0}` は入力を {1} 個取ります。--input を渡して�
 run.input.notarray=`{0}` は入力を {1} 個取ります。--input はその長さの JSON 配列にしてください。
 run.input.count=`{0}` は入力を {1} 個取りますが、--input には {2} 個あります。
 run.input.badjson=--input が正しい JSON ではありません: {0}
+run.input.toodeep=--input はこの境界が受け取れる深さを超えています: {0} 以下（JSON の入れ子が {1} レベルを超えました）。data の1レベルが JSON の複数レベルを使うことがあります。
 run.decode.failed=入力 #{0} をデコードできませんでした — {1}
 run.decode.nodecoder=`{0}` のデコーダを取得できません: {1}
 run.decode.unsupported=入力 #{0} の型は `{1}` で、`run` はまだデコードできません（data・プリミティブ・それらのコレクションのみ）。
@@ -533,8 +534,10 @@ run.decode.raw=入力 #{0} は予約型 Raw で、`run` はデコードできま
 run.encode.noencoder=出力 `{0}` のエンコーダを取得できません: {1}
 run.encode.unsupported=出力の型は `{0}` で、`run` はまだエンコードできません（data・プリミティブ・それらのコレクションのみ）。
 run.encode.raw=出力が予約型 Raw で、`run` はエンコードできません。
+run.encode.toodeep=出力が深く入れ子になりすぎていて、この境界ではエンコードできません。
 run.read.failed={0} を読めません: {1}
 run.output.json=出力を JSON にできませんでした: {0}
+run.output.toodeep=出力はこの境界が書き出せる深さを超えています: {0} 以下（JSON の入れ子が {1} レベルを超えました）。data の1レベルが JSON の複数レベルを使うことがあります。
 run.decode.malformed=入力 #{0} は `{1}` の形になっていません。--input を確認してください。
 
 # behavior が自分に到達する（E1608）

--- a/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
@@ -376,4 +376,102 @@ class RunnerTest {
         // The generated class lands in the file-stem package; driving it confirms the name resolves.
         assertEquals("\"ok\"", Runner.run(file, "id", "\"ok\""));
     }
+
+    /** {@code --input} with nothing in it is input of the wrong shape, which is a refusal the reader
+     * can act on rather than a null the runner then walks into. */
+    @Test
+    void anEmptyInputIsReportedRatherThanThrown() throws Exception {
+        Path file = write("pair.sou", """
+                data Pair = { left: Int, right: Int }
+                behavior mkPair : (a: Int, b: Int) -> Pair constructs Pair
+                let mkPair (a, b) = Pair { left = a, right = b }
+                """);
+        Runner.RunException e = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "mkPair", "   "));
+        assertEquals(1, e.exitCode);
+        assertTrue(e.getMessage().contains("must be a JSON array"), e.getMessage());
+    }
+
+    // --- depth at the boundary ------------------------------------------------------------------
+
+    /** {@code levels} levels of {@code {"n": 1, "kids": [ ... ]}}, the shape self-referential data
+     * arrives in. Each level spends two levels of JSON: the object and the list. */
+    private static String nestedTree(int levels) {
+        return "{\"n\":1,\"kids\":[".repeat(levels) + "]}".repeat(levels);
+    }
+
+    /** A JSON array of {@code count} numbers — flat input, whatever the behavior builds from it. */
+    private static String counting(int count) {
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < count; i++) {
+            json.append(i == 0 ? "" : ",").append(i);
+        }
+        return json.append("]").toString();
+    }
+
+    /**
+     * Input deeper than the boundary reads is a decode failure like any other: it names the path it
+     * gave up at, and counts the nesting in JSON rather than in the parser's words.
+     */
+    @Test
+    void anInputDeeperThanTheBoundaryReadsNamesThePathItGaveUpAt() throws Exception {
+        Path file = write("tree.sou", """
+                data Node = { n: Int, kids: List<Node> }
+                data Out = { n: Int }
+                behavior top : (t: Node) -> Out constructs Out
+                let top (t) = Out { n = t.n }
+                """);
+        assertEquals("{\"n\":1}", Runner.run(file, "top", nestedTree(250)));
+
+        Runner.RunException e = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "top", nestedTree(251)));
+        assertEquals(1, e.exitCode);
+        assertTrue(e.getMessage().contains("/kids/0/kids"), e.getMessage());
+        assertTrue(e.getMessage().contains("past 500 levels"), e.getMessage());
+        assertFalse(e.getMessage().contains("StreamReadConstraints"), e.getMessage());
+        assertTrue(e.localized(java.util.Locale.JAPANESE).contains("深さ"),
+                e.localized(java.util.Locale.JAPANESE));
+    }
+
+    /**
+     * Output deeper than the boundary writes is reported the same way. A behavior can build a value
+     * deeper than anything it was handed, so this is reachable from input the boundary accepted.
+     */
+    @Test
+    void anOutputDeeperThanTheBoundaryWritesNamesThePathItGaveUpAt() throws Exception {
+        Path file = write("nest.sou", """
+                data Node = { kids: List<Node> }
+                behavior nest : (xs: List<Int>) -> Node constructs Node
+                let nest (xs) = List.fold((acc, x) -> Node { kids = [acc] }, Node { kids = [] }, xs)
+                """);
+        assertEquals("{\"kids\":[{\"kids\":[]}]}", Runner.run(file, "nest", "[1]"));
+
+        Runner.RunException e = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "nest", counting(600)));
+        assertEquals(1, e.exitCode);
+        assertTrue(e.getMessage().contains("/kids/0/kids"), e.getMessage());
+        assertFalse(e.getMessage().contains("StreamWriteConstraints"), e.getMessage());
+        assertFalse(e.getMessage().contains("java.util"), e.getMessage());
+        assertTrue(e.localized(java.util.Locale.JAPANESE).contains("深さ"),
+                e.localized(java.util.Locale.JAPANESE));
+    }
+
+    /**
+     * Deeper still, the encoder runs out of stack before the writer ever counts a level. That is not
+     * a {@code RuntimeException}, so left alone it reaches the caller as a stack trace.
+     */
+    @Test
+    void anOutputTooDeepToEncodeIsReportedRatherThanThrown() throws Exception {
+        Path file = write("nest.sou", """
+                data Node = { kids: List<Node> }
+                behavior nest : (xs: List<Int>) -> Node constructs Node
+                let nest (xs) = List.fold((acc, x) -> Node { kids = [acc] }, Node { kids = [] }, xs)
+                """);
+        Runner.RunException e = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "nest", counting(20000)));
+        assertEquals(1, e.exitCode);
+        assertTrue(e.getMessage().contains("encode"), e.getMessage());
+        assertTrue(e.localized(java.util.Locale.JAPANESE).contains("エンコード"),
+                e.localized(java.util.Locale.JAPANESE));
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
@@ -434,6 +434,41 @@ class RunnerTest {
     }
 
     /**
+     * Depth is one of the limits the reader holds, not the only one: a number too long and a name
+     * too long are refused by the same exception type at a depth of nothing. Each keeps the wording
+     * it had rather than being told it nests too deeply.
+     */
+    @Test
+    void aLimitOtherThanDepthIsNotReportedAsDepth() throws Exception {
+        Path file = write("tree.sou", """
+                data Node = { n: Int, kids: List<Node> }
+                data Out = { n: Int }
+                behavior top : (t: Node) -> Out constructs Out
+                let top (t) = Out { n = t.n }
+                """);
+        // A number longer than StreamReadConstraints.getMaxNumberLength(), written at the 500th
+        // level — the deepest a value the reader accepts the nesting of can stand, and one level
+        // short of where a refusal for depth stands. Reading the exception's text instead of the
+        // context's depth, or reading the depth as `at the limit` rather than `past it`, calls this
+        // one too deeply nested.
+        String longNumber = "[".repeat(500) + "1".repeat(1001) + "]".repeat(500);
+        Runner.RunException tooLongANumber = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "top", longNumber));
+        assertTrue(tooLongANumber.getMessage().contains("is not valid JSON"),
+                tooLongANumber.getMessage());
+        assertFalse(tooLongANumber.getMessage().contains("nests deeper"),
+                tooLongANumber.getMessage());
+
+        // longer than StreamReadConstraints.getMaxNameLength()
+        String longName = "{\"" + "n".repeat(50001) + "\":1}";
+        Runner.RunException tooLongAName = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "top", longName));
+        assertTrue(tooLongAName.getMessage().contains("is not valid JSON"),
+                tooLongAName.getMessage());
+        assertFalse(tooLongAName.getMessage().contains("nests deeper"), tooLongAName.getMessage());
+    }
+
+    /**
      * Output deeper than the boundary writes is reported the same way. A behavior can build a value
      * deeper than anything it was handed, so this is reachable from input the boundary accepted.
      */


### PR DESCRIPTION
Closes #262 once merged (a PR onto `develop` does not fire the keyword; the issue is closed by hand).

Everything else the decoder rejects is named at its JSON pointer — `/bins/A0: must be exactly 3 characters`. A refusal for depth was the one that read `StreamReadConstraints.getMaxNestingDepth()`, which is not a name a model author works in, and said nothing about which branch went deep.

## Three doors, not one

The issue names the reading side. Measuring found two more, and fixing only the first moves the reader to a worse report at the second:

| | before | after |
|---|---|---|
| reading past 500 levels | `Document nesting depth (501) exceeds the maximum allowed (500, from \`StreamReadConstraints.getMaxNestingDepth()\`)` | `--input nests deeper than this boundary accepts: /kids/0/kids/0/kids/0/kids/0/… and below (JSON nesting past 500 levels)` |
| writing past 500 levels | the same words, plus a few hundred `java.util.ImmutableCollections$ListN[0]` of reference chain | `the output nests deeper than this boundary can render: …` |
| encoding deeper still | a bare `StackOverflowError` stack trace | `the output nests too deeply for this boundary to encode.` |

A behavior can build a value deeper than anything it was handed — `List.fold((acc, x) -> Node { kids = [acc] }, …)` over a flat list — so the second and third are reached from input the boundary accepted.

## How the path is got

The exception a depth refusal throws carries neither a location nor the parser that raised it, so the parser and the generator are made in `Runner` rather than left to `readTree(String)` and `writeValueAsString`. Holding them is what gives `streamReadContext().pathAsPointer()`. The generator's context is read before it is closed — closing resets it to the root, where the parser's survives.

The path is cut after eight segments: nesting that deep is nesting that repeats, so the whole pointer runs to hundreds of segments of the same few names, and the head is the part that says which branch went deep.

No depth is claimed, only the limit. Reading and writing both stop at the level that crosses it, so how much deeper the value goes was never counted; reporting the context's own count read `500 levels, the limit is 500` on the writing side.

## The limit itself

It stays at 500 and is not made settable. Raising it was measured: 1000 levels of tree answer, and 3000 die inside the codecs with no diagnostic at all. Five hundred does not guard a real limit, but what sits behind it is reported worse than what sits in front, so raising it is a question about how deep the codecs can recurse, not about this.

## Also

Reading through a parser answers no node at all where reading a string answered the missing node, which a multi-input `--input` then walked into. Empty input now reaches the same refusal as input of the wrong shape.

## Testing

Four tests in `RunnerTest` covering all three doors and the empty input; each also asserts the Jackson class name never reaches the reader. Full suite green (2106).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
