### PR TITLE
Make every walk and classification over Type exhaustive, with no default and no trailing cast

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1050,8 +1050,15 @@ public final class TypeOps {
     /** The ordered primitives: the ones the JVM carries as {@link Comparable}, so {@code <}/{@code >}
      * and {@code sort} work on them (spec §primitives, §stdlib-list). */
     static boolean isOrdered(Type t) {
-        return t == Type.INT || t == Type.STRING || t == Type.DECIMAL
-                || t == Type.DATE || t == Type.DATETIME;
+        return switch (t) {
+            case Type.Prim p -> switch (p) {
+                case INT, STRING, DECIMAL, DATE, DATETIME -> true;
+                case BOOL, RAW -> false;
+            };
+            case Type.Ref _, Type.ListOf _, Type.MapOf _, Type.SetOf _, Type.OptionOf _,
+                 Type.Union _, Type.FnOf _, Type.Var _, Type.Nothing _, Type.Never _,
+                 Type.TupleOf _, Type.Erroneous _ -> false;
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/codegen/JvmTypes.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/JvmTypes.java
@@ -38,15 +38,23 @@ final class JvmTypes {
         }
     }
 
-    /** The boxed JVM class for a primitive type, or {@code null} for a non-primitive. */
+    /** The boxed JVM class for a boxable primitive, or {@code null} where the type has none —
+     * a non-primitive, or {@code Raw}, which no stage produces. */
     static ClassDesc boxedPrim(Type t) {
-        if (t == Type.INT) return CD_Long;
-        if (t == Type.BOOL) return CD_Boolean;
-        if (t == Type.DECIMAL) return CD_BigDecimal;
-        if (t == Type.STRING) return CD_String;
-        if (t == Type.DATE) return CD_LocalDate;
-        if (t == Type.DATETIME) return CD_LocalDateTime;
-        return null;
+        return switch (t) {
+            case Type.Prim p -> switch (p) {
+                case INT -> CD_Long;
+                case BOOL -> CD_Boolean;
+                case DECIMAL -> CD_BigDecimal;
+                case STRING -> CD_String;
+                case DATE -> CD_LocalDate;
+                case DATETIME -> CD_LocalDateTime;
+                case RAW -> null;
+            };
+            case Type.Ref _, Type.ListOf _, Type.MapOf _, Type.SetOf _, Type.OptionOf _,
+                 Type.Union _, Type.FnOf _, Type.Var _, Type.Nothing _, Type.Never _,
+                 Type.TupleOf _, Type.Erroneous _ -> null;
+        };
     }
 
     /** True when {@code t} is carried as a reference on the JVM (everything but Int and Bool). */
@@ -185,26 +193,33 @@ final class JvmTypes {
     /** The JVM class carrying a value of {@code type}: primitives unboxed, containers as their raw
      * interface, a data reference through {@link CodegenContext#caseClass}. */
     static ClassDesc jvmType(Type type, CodegenContext ctx) {
-        if (type == Type.INT) return ConstantDescs.CD_long;
-        if (type == Type.STRING) return CD_String;
-        if (type == Type.BOOL) return ConstantDescs.CD_boolean;
-        if (type == Type.DECIMAL) return CD_BigDecimal;
-        if (type == Type.DATE) return CD_LocalDate;
-        if (type == Type.DATETIME) return CD_LocalDateTime;
-        if (type instanceof Type.OptionOf) return CD_Option;
-        if (type instanceof Type.ListOf) return CD_List;
-        if (type instanceof Type.MapOf) return CD_Map;
-        if (type instanceof Type.SetOf) return CD_Set;
-        if (type instanceof Type.Union) return CD_Object;
-        if (type instanceof Type.Var) return CD_Object;   // a type variable is erased to Object
-        if (type instanceof Type.Nothing) return CD_Object;   // an empty collection's element bottom
-        if (type instanceof Type.FnOf) return CD_Fn;
-        // a pair is typed as the pair, so its elements are read as fields rather than through the
-        // Tuple interface: every fold-carried tuple is one, and that read is per element
-        if (type instanceof Type.TupleOf tu) {
-            return tu.elements().size() == 2 ? CD_TuplePair : CD_Tuple;
-        }
-        return ctx.caseClass(((Type.Ref) type).name());
+        return switch (type) {
+            case Type.Prim p -> switch (p) {
+                case INT -> ConstantDescs.CD_long;
+                case STRING -> CD_String;
+                case BOOL -> ConstantDescs.CD_boolean;
+                case DECIMAL -> CD_BigDecimal;
+                case DATE -> CD_LocalDate;
+                case DATETIME -> CD_LocalDateTime;
+                // reserved: no stage produces one, so none reaches codegen
+                case RAW -> throw new IllegalStateException("no JVM carrier for Raw");
+            };
+            case Type.OptionOf _ -> CD_Option;
+            case Type.ListOf _ -> CD_List;
+            case Type.MapOf _ -> CD_Map;
+            case Type.SetOf _ -> CD_Set;
+            case Type.Union _ -> CD_Object;
+            case Type.Var _ -> CD_Object;   // a type variable is erased to Object
+            case Type.Nothing _ -> CD_Object;   // an empty collection's element bottom
+            case Type.FnOf _ -> CD_Fn;
+            // a pair is typed as the pair, so its elements are read as fields rather than through
+            // the Tuple interface: every fold-carried tuple is one, and that read is per element
+            case Type.TupleOf tu -> tu.elements().size() == 2 ? CD_TuplePair : CD_Tuple;
+            case Type.Ref r -> ctx.caseClass(r.name());
+            // the checker refuses both before emitting a module, so meeting one is a compiler fault
+            case Type.Never _ -> throw new IllegalStateException("no JVM carrier for Never");
+            case Type.Erroneous _ -> throw new IllegalStateException("no JVM carrier for ?");
+        };
     }
 
     static ClassDesc[] fieldDescs(Map<String, Type> fields, CodegenContext ctx) {

--- a/souther-compiler/src/main/java/souther/compiler/types/Type.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/Type.java
@@ -201,7 +201,7 @@ public sealed interface Type
                 f.params().forEach(p -> collectNames(p, out));
                 collectNames(f.result(), out);
             }
-            default -> { }
+            case Prim _, Var _, Nothing _, Never _, Erroneous _ -> { }
         }
     }
 
@@ -256,9 +256,11 @@ public sealed interface Type
     }
 
     /** Whether {@code t}, or any type nested inside it, satisfies {@code p}. Tests {@code t} itself
-     * first, then recurses through the collection types ({@code List}/{@code Set}/{@code Option}
-     * element, {@code Map} key and value, {@code Tuple} members). The single tree walk both
-     * "contains a tuple" and "still carries the empty-collection bottom" are expressed over. */
+     * first, then recurses through every position that holds a type: a collection's element,
+     * a {@code Map}'s key and value, a {@code Tuple}'s members, a function type's parameters and
+     * result. A {@code Union} ends the walk: its members are names, not nested types. The single
+     * tree walk both "contains a tuple" and "still carries the empty-collection bottom" are
+     * expressed over. */
     static boolean mentions(Type t, java.util.function.Predicate<Type> p) {
         if (p.test(t)) {
             return true;
@@ -269,7 +271,9 @@ public sealed interface Type
             case OptionOf o -> mentions(o.element(), p);
             case MapOf m -> mentions(m.key(), p) || mentions(m.value(), p);
             case TupleOf tu -> tu.elements().stream().anyMatch(e -> mentions(e, p));
-            default -> false;
+            case FnOf f -> f.params().stream().anyMatch(a -> mentions(a, p))
+                    || mentions(f.result(), p);
+            case Prim _, Ref _, Var _, Nothing _, Never _, Erroneous _, Union _ -> false;
         };
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/codegen/JvmTypesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/JvmTypesTest.java
@@ -1,0 +1,35 @@
+package souther.compiler.codegen;
+
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * The backend refuses a type that has no JVM carrier — the checker never lets one through, so
+ * meeting one here is a compiler fault and says which type it met, not a cast failure.
+ */
+class JvmTypesTest {
+
+    @Test
+    void aTypeWithNoCarrierIsRefusedByName() {
+        IllegalStateException never =
+                assertThrows(IllegalStateException.class, () -> JvmTypes.jvmType(Type.NEVER, null));
+        assertEquals("no JVM carrier for Never", never.getMessage());
+        IllegalStateException erroneous =
+                assertThrows(IllegalStateException.class,
+                        () -> JvmTypes.jvmType(Type.ERRONEOUS, null));
+        assertEquals("no JVM carrier for ?", erroneous.getMessage());
+        IllegalStateException raw =
+                assertThrows(IllegalStateException.class, () -> JvmTypes.jvmType(Type.RAW, null));
+        assertEquals("no JVM carrier for Raw", raw.getMessage());
+    }
+
+    @Test
+    void rawHasNoBoxedForm() {
+        assertNull(JvmTypes.boxedPrim(Type.RAW));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/types/TypeMentionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/TypeMentionsTest.java
@@ -1,0 +1,52 @@
+package souther.compiler.types;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code Type.mentions} walks every type nested inside a type: what a collection holds, what a
+ * tuple carries, and what a function type takes and answers. A name a {@code Union} lists is not
+ * a nested type — its members are names, not types — so the walk ends there.
+ */
+class TypeMentionsTest {
+
+    private static boolean isVar(Type t) {
+        return t instanceof Type.Var;
+    }
+
+    @Test
+    void aFunctionResultIsWalked() {
+        Type fn = Type.fn(List.of(Type.INT), Type.var("'a"));
+        assertTrue(Type.mentions(fn, TypeMentionsTest::isVar));
+    }
+
+    @Test
+    void aFunctionParameterIsWalked() {
+        Type fn = Type.fn(List.of(Type.var("'a")), Type.INT);
+        assertTrue(Type.mentions(fn, TypeMentionsTest::isVar));
+    }
+
+    @Test
+    void aFunctionInsideATupleIsWalked() {
+        Type carried = Type.tuple(List.of(Type.INT, Type.fn(List.of(Type.INT), Type.var("'a"))));
+        assertTrue(Type.mentions(carried, TypeMentionsTest::isVar));
+    }
+
+    @Test
+    void aUnionMemberIsANameNotANestedType() {
+        Type union = Type.union(Set.of(new TypeName("m", "A"), new TypeName("m", "B")));
+        assertFalse(Type.mentions(union, t -> t instanceof Type.Ref));
+    }
+
+    @Test
+    void aCollectionElementIsWalked() {
+        assertTrue(Type.mentions(Type.list(Type.var("'a")), TypeMentionsTest::isVar));
+        assertTrue(Type.mentions(Type.map(Type.STRING, Type.var("'a")), TypeMentionsTest::isVar));
+        assertFalse(Type.mentions(Type.list(Type.INT), TypeMentionsTest::isVar));
+    }
+}


### PR DESCRIPTION
Issue #266.

## What

When the universe of `Type` (or `Type.Prim`) is extended, every operation that has to mean something for the new constructor should stop compiling until a developer decides what it means. `Ast` already works this way; these five did not:

- `Type.mentions` — had a `default -> false`, so a new constructor holding a type answered "no children". Nine call sites read that answer for bottom inference, type-variable detection and boundary refusal.
- `Type.collectNames` — same shape, `default -> { }` (harmless today: only leaves fell into it).
- `JvmTypes.jvmType` — fifteen `if instanceof` ending in a cast to `Type.Ref`, so anything unnamed — a new constructor, but also `Never`/`Erroneous`/`Raw` — failed as a `ClassCastException`.
- `JvmTypes.boxedPrim` — same if-chain shape, ending in `return null`.
- `TypeOps.isOrdered` — `==` against five constants, so a primitive added to `Prim` was silently unordered.

All five are now switches over the sealed type with no `default`. Where two universes are involved (`jvmType`, `boxedPrim`, `isOrdered`), the switch is two-level — outer over `Type`, inner over `Prim` — and the inner switch enumerates every primitive (`BOOL, RAW -> false` in `isOrdered`, not a negation), so extending either universe stops the build.

In `jvmType`, the types that have no JVM carrier (`Raw`, `Never`, `Erroneous`) are refused by name with an `IllegalStateException`: the checker refuses each of them before emitting a module, so meeting one here is a compiler fault, and it now says which type it met instead of failing as a cast. This separates the unsupported-state arms from the unknown-future-constructor case, which the old trailing cast conflated.

## One semantic fix, called out separately

While making `mentions` exhaustive, this also exposes an existing omission: `FnOf` is recursive but was treated as a leaf, so a type variable or an empty-collection bottom inside a function type's parameters or result was never seen (`(Int) -> 'a` answered false to `mentions(t, isVar)`). The change intentionally fixes that behavior as well — it is the one part of this PR that is not a pure exhaustiveness rewrite. `Union` stays a leaf on purpose: its members are `TypeName`s, not nested types, and a test pins that distinction so the two walks' domains don't get re-litigated.

## Verification

- New unit tests: `TypeMentionsTest` (FnOf descent red-to-green; Union-as-leaf and collection descent pinned) and `JvmTypesTest` (`IllegalStateException` by name where a `ClassCastException` used to escape; `boxedPrim(RAW)` is null).
- Mutation check: added a temporary constructor to `Type` and confirmed each rewritten switch fails to compile as non-exhaustive. javac stops at the first file that fails flow analysis, so this was verified in waves (`Type.java`, then `TypeOps`, then `JvmTypes`) rather than as one build with five errors. The pre-existing exhaustive switches from #265 (`TypeOps.answers`, `Type.show`) stop the build too.
- Full `mvn clean test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
