### PR TITLE
File one prelude declaration into one entry

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -1206,12 +1206,14 @@ public final class ExampleVerifier {
      */
     private Ast.Expr valueBody(String name) {
         for (Ast.FnDef fn : module.fns()) {
-            if (fn.name().equals(name) && fn.params().isEmpty() && fn.body() != null) {
-                return fn.body();
+            if (fn.name().equals(name) && fn.params().isEmpty()
+                    && fn.body() instanceof Ast.FnBody.Written w) {
+                return w.expr();
             }
         }
         Ast.FnDef imported = values.get(name);
-        return imported != null && imported.params().isEmpty() ? imported.body() : null;
+        return imported != null && imported.params().isEmpty()
+                && imported.body() instanceof Ast.FnBody.Written w ? w.expr() : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -1289,7 +1289,7 @@ public final class ExampleVerifier {
      * A helper that has one is applied; the ones that never do are the standard library's intrinsics
      * and a helper whose body produces a function, and both read as this. */
     private boolean noMethod(String name) {
-        if (Prelude.hasQualified(name)) {
+        if (Prelude.isLibraryFunction(name)) {
             return true;   // a standard-library function: an intrinsic, or one nothing emitted here
         }
         for (Ast.FnDef fn : module.fns()) {

--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -12,6 +12,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,9 +58,10 @@ public final class Prelude {
 
     /** A declaration's resolved signature: its parameter types, and the success type of its declared
      *  return — or null where the declaration writes no return type and leaves its result to its
-     *  body, which a Souther-bodied helper may and a kernel never does. Resolved once at load; what
-     *  the failure cases of the return are is the checker's question about the call, not the
-     *  signature's. */
+     *  body, which a Souther-bodied helper with parameters may and a kernel never does. A
+     *  zero-parameter declaration is a value and always has a result here (see
+     *  {@link #signatureOf}). Resolved once at load; what the failure cases of the return are is the
+     *  checker's question about the call, not the signature's. */
     public record Signature(List<Type> params, Type result) {
         public Signature {
             params = List.copyOf(params);
@@ -136,7 +138,7 @@ public final class Prelude {
 
     /** Every entry, keyed by qualified name, in declaration order. */
     public static Map<String, PreludeEntry> entries() {
-        return java.util.Collections.unmodifiableMap(ENTRIES);
+        return Collections.unmodifiableMap(ENTRIES);
     }
 
     /** The Souther-bodied declarations (inlined at call sites), keyed by qualified name. */
@@ -172,13 +174,7 @@ public final class Prelude {
                     throw new IllegalStateException(
                             "the standard library declares `" + qualified + "` twice");
                 }
-                List<Type> params = new ArrayList<>();
-                for (Ast.FnParam p : fn.params()) {
-                    params.add(TypeOps.resolveParamType(p.type(), noSymbols));
-                }
-                Type result = fn.declaredReturn() == null
-                        ? null : TypeOps.successType(fn.declaredReturn(), noSymbols);
-                ENTRIES.put(qualified, new PreludeEntry(fn, new Signature(params, result)));
+                ENTRIES.put(qualified, new PreludeEntry(fn, signatureOf(fn, qualified, noSymbols)));
                 BARE_TO_QUALIFIED.putIfAbsent(fn.name(), qualified);
             }
         }
@@ -221,6 +217,24 @@ public final class Prelude {
         BARE_TO_QUALIFIED.put("subtract", "Int.subtract` or `Decimal.subtract");
         BARE_TO_QUALIFIED.put("multiply", "Int.multiply` or `Decimal.multiply");
         BARE_TO_QUALIFIED.put("divide", "Int.divide` or `Decimal.divide");
+    }
+
+    /** The resolved signature of {@code fn}. A zero-parameter declaration is a value whose type
+     *  only the signature can answer — {@code libraryValue} reads it with no call whose arguments
+     *  could pin it — so a value that writes no return type is refused here rather than filed as an
+     *  entry whose type nothing states. */
+    static Signature signatureOf(Ast.FnDef fn, String qualified, Symbols symbols) {
+        List<Type> params = new ArrayList<>();
+        for (Ast.FnParam p : fn.params()) {
+            params.add(TypeOps.resolveParamType(p.type(), symbols));
+        }
+        Type result = fn.declaredReturn() == null
+                ? null : TypeOps.successType(fn.declaredReturn(), symbols);
+        if (fn.params().isEmpty() && result == null) {
+            throw new IllegalStateException(
+                    "a zero-parameter prelude value must declare its return type: `" + qualified + "`");
+        }
+        return new Signature(params, result);
     }
 
     private static String read(String resource) {

--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -162,13 +162,13 @@ public final class Prelude {
                             "the standard library declares `" + qualified + "` twice");
                 }
                 DECLARATIONS.put(qualified, fn);
-                if (fn.isIntrinsic()) {
+                if (fn.body() instanceof Ast.FnBody.Intrinsic intrinsic) {
                     List<Type> params = new ArrayList<>();
                     for (Ast.FnParam p : fn.params()) {
                         params.add(TypeOps.resolveParamType(p.type(), noSymbols));
                     }
                     Type result = TypeOps.successType(fn.declaredReturn(), noSymbols);
-                    INTRINSICS.put(qualified, new IntrinsicSig(fn.name(), params, result, fn.intrinsicKey()));
+                    INTRINSICS.put(qualified, new IntrinsicSig(fn.name(), params, result, intrinsic.key()));
                 } else {
                     HELPERS.put(qualified, fn);
                 }

--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -93,7 +93,7 @@ public final class Prelude {
                 helpers.put(e.getKey(), e.getValue().declaration());
             }
         }
-        HELPERS = Map.copyOf(helpers);
+        HELPERS = Collections.unmodifiableMap(helpers);
     }
 
     private Prelude() {
@@ -141,7 +141,8 @@ public final class Prelude {
         return Collections.unmodifiableMap(ENTRIES);
     }
 
-    /** The Souther-bodied declarations (inlined at call sites), keyed by qualified name. */
+    /** The Souther-bodied declarations (inlined at call sites), keyed by qualified name, in
+     *  declaration order. */
     public static Map<String, Ast.FnDef> helpers() {
         return HELPERS;
     }

--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -19,20 +19,15 @@ import java.util.Set;
 
 /**
  * The standard library the compiler ships in the reserved {@code souther} namespace (ADR-0028,
- * spec §reserved-namespace). Its modules are packaged as resources and parsed once, and split into:
- *
- * <ul>
- *   <li>{@linkplain #helpers() helpers} — ordinary generic functions (e.g. {@code not}), expanded
- *       inline at each call site (see {@code check.HelperInliner});</li>
- *   <li>{@linkplain #intrinsics() intrinsics} — functions whose body is a named primitive
- *       ({@code = intrinsic "key"}). These behave like built-ins: the checker verifies a call against
- *       the declared signature and the backend emits the primitive for the key. They are neither
- *       inlined nor lowered.</li>
- * </ul>
+ * spec §reserved-namespace). Its modules are packaged as resources and parsed once, into one
+ * {@linkplain #entry(String) entry} per qualified name: the declaration as it was written and its
+ * resolved signature. What is behind the name — a Souther body, expanded inline at each call site
+ * (see {@code check.HelperInliner}), or a named kernel the backend emits — is the declaration's
+ * {@linkplain Ast.FnBody body}, not a second registry.
  *
  * <p>Everything is reached through a module qualifier — {@code List.map}, {@code String.trim} — since
- * the standard library carries no bare names (spec §stdlib). Helpers and intrinsics are therefore
- * keyed by their qualified name, e.g. {@code "List.map"} / {@code "String.trim"}.
+ * the standard library carries no bare names (spec §stdlib). Entries are therefore keyed by their
+ * qualified name.
  */
 public final class Prelude {
 
@@ -60,26 +55,43 @@ public final class Prelude {
     private static final Set<String> QUALIFIERS =
             Set.of("List", "String", "Map", "Set", "Bool", "Int", "Decimal", "Date", "DateTime", "Option");
 
-    /** A shipped primitive: its declared signature and the backend key naming its bytecode. */
-    public record IntrinsicSig(String name, List<Type> params, Type result, String key) {
+    /** A declaration's resolved signature: its parameter types, and the success type of its declared
+     *  return — or null where the declaration writes no return type and leaves its result to its
+     *  body, which a Souther-bodied helper may and a kernel never does. Resolved once at load; what
+     *  the failure cases of the return are is the checker's question about the call, not the
+     *  signature's. */
+    public record Signature(List<Type> params, Type result) {
+        public Signature {
+            params = List.copyOf(params);
+        }
     }
 
-    /** Every declaration the library ships, keyed by qualified name — the {@code let} as it was
-     *  written, whether its implementation is a Souther body or a shipped kernel. What is on the
-     *  other side of the name is not the name's business, so a reader asking what a library function
-     *  takes and answers asks this and stops. */
-    private static final Map<String, Ast.FnDef> DECLARATIONS = new LinkedHashMap<>();
+    /** Everything the library says under one qualified name: the {@code let} as it was written and
+     *  its resolved signature. Existence, declaration, signature and implementation are one answer —
+     *  a reader takes the projection it wants rather than picking a map. */
+    public record PreludeEntry(Ast.FnDef declaration, Signature signature) {
+    }
 
-    /** Helpers keyed by qualified name, e.g. {@code "List.map"}. */
-    private static final Map<String, Ast.FnDef> HELPERS = new LinkedHashMap<>();
-    /** Intrinsics keyed by qualified name, e.g. {@code "String.trim"}. */
-    private static final Map<String, IntrinsicSig> INTRINSICS = new LinkedHashMap<>();
+    /** Every declaration the library ships, keyed by qualified name ({@code "List.map"}). */
+    private static final Map<String, PreludeEntry> ENTRIES = new LinkedHashMap<>();
+
     /** Bare stdlib name → a qualified suggestion, so a bare call gets a "did you mean" hint. The
      *  checker built-ins (which are not in the prelude sources) are listed here explicitly. */
     private static final Map<String, String> BARE_TO_QUALIFIED = new LinkedHashMap<>();
 
+    /** The Souther-bodied declarations, as the inliner's table wants them: a materialized projection
+     *  of {@link #ENTRIES}, derived once after loading and never written again. */
+    private static final Map<String, Ast.FnDef> HELPERS;
+
     static {
         load();
+        Map<String, Ast.FnDef> helpers = new LinkedHashMap<>();
+        for (Map.Entry<String, PreludeEntry> e : ENTRIES.entrySet()) {
+            if (e.getValue().declaration().body() instanceof Ast.FnBody.Written) {
+                helpers.put(e.getKey(), e.getValue().declaration());
+            }
+        }
+        HELPERS = Map.copyOf(helpers);
     }
 
     private Prelude() {
@@ -109,28 +121,27 @@ public final class Prelude {
     }
 
     /** Whether {@code qualifiedName} (e.g. {@code "List.map"}) is a standard-library function — a
-     *  prelude helper, a prelude intrinsic, or a sugar for one. Every one of them is declared in a
-     *  core module: there is no longer a set of names whose signature lives only in the compiler
-     *  (ADR-0053). */
-    public static boolean hasQualified(String qualifiedName) {
-        return HELPERS.containsKey(qualifiedName)
-                || INTRINSICS.containsKey(qualifiedName)
-                || SUGARED.contains(qualifiedName);
+     *  declared one, or a sugar for one. Sugar has no declaration of its own, so this is wider than
+     *  {@link #entry(String)} answering: {@code List.fold} is a library function and has no entry. */
+    public static boolean isLibraryFunction(String qualifiedName) {
+        return ENTRIES.containsKey(qualifiedName) || SUGARED.contains(qualifiedName);
     }
 
-    /** The declaration of a library function, or null where the library declares no such name. */
-    public static Ast.FnDef declarationOf(String qualifiedName) {
-        return DECLARATIONS.get(qualifiedName);
+    /** The library's entry for {@code qualifiedName}, or null where the library declares no such
+     *  name — including for {@linkplain #sugared(String) sugar}, which is a rewrite, not a
+     *  declaration. */
+    public static PreludeEntry entry(String qualifiedName) {
+        return ENTRIES.get(qualifiedName);
     }
 
-    /** The helper functions of the prelude (inlined at call sites), keyed by qualified name. */
+    /** Every entry, keyed by qualified name, in declaration order. */
+    public static Map<String, PreludeEntry> entries() {
+        return java.util.Collections.unmodifiableMap(ENTRIES);
+    }
+
+    /** The Souther-bodied declarations (inlined at call sites), keyed by qualified name. */
     public static Map<String, Ast.FnDef> helpers() {
         return HELPERS;
-    }
-
-    /** The shipped primitives, keyed by their qualified name ({@code "String.trim"}). */
-    public static Map<String, IntrinsicSig> intrinsics() {
-        return INTRINSICS;
     }
 
     /** A qualified suggestion for a bare standard-library name ({@code "map"} → {@code "List.map"}),
@@ -157,21 +168,17 @@ public final class Prelude {
                 // reads two ways would have to be chosen between, and nothing at a value position
                 // could do the choosing. Put into a map, a second one would replace the first in
                 // silence, so it is refused where it is loaded.
-                if (INTRINSICS.containsKey(qualified) || HELPERS.containsKey(qualified)) {
+                if (ENTRIES.containsKey(qualified)) {
                     throw new IllegalStateException(
                             "the standard library declares `" + qualified + "` twice");
                 }
-                DECLARATIONS.put(qualified, fn);
-                if (fn.body() instanceof Ast.FnBody.Intrinsic intrinsic) {
-                    List<Type> params = new ArrayList<>();
-                    for (Ast.FnParam p : fn.params()) {
-                        params.add(TypeOps.resolveParamType(p.type(), noSymbols));
-                    }
-                    Type result = TypeOps.successType(fn.declaredReturn(), noSymbols);
-                    INTRINSICS.put(qualified, new IntrinsicSig(fn.name(), params, result, intrinsic.key()));
-                } else {
-                    HELPERS.put(qualified, fn);
+                List<Type> params = new ArrayList<>();
+                for (Ast.FnParam p : fn.params()) {
+                    params.add(TypeOps.resolveParamType(p.type(), noSymbols));
                 }
+                Type result = fn.declaredReturn() == null
+                        ? null : TypeOps.successType(fn.declaredReturn(), noSymbols);
+                ENTRIES.put(qualified, new PreludeEntry(fn, new Signature(params, result)));
                 BARE_TO_QUALIFIED.putIfAbsent(fn.name(), qualified);
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -309,25 +309,47 @@ public interface Ast {
      * sees one expression tree and has exactly one place where a value can be constructed.
      */
     /**
-     * A {@code let} definition. A behavior fn or a helper carries a {@code body} and no
-     * {@code declaredReturn}/{@code intrinsicKey}. A core intrinsic (spec §primitives) instead
-     * declares its return type and names a primitive: {@code let trim (s: String): String =
-     * intrinsic "string.trim"} — its {@code body} is null, {@code declaredReturn} its result type,
-     * and {@code intrinsicKey} the backend key. Intrinsics are written only in the {@code souther}
+     * What stands to the right of a definition's {@code =}: the expression the author wrote, or —
+     * in the reserved {@code souther} namespace only (spec §primitives) — the name of a shipped
+     * kernel, {@code intrinsic "string.trim"}. One or the other, never neither, so a reader
+     * switches rather than testing two fields for null.
+     */
+    sealed interface FnBody {
+        /** A written body. */
+        record Written(Expr expr) implements FnBody {
+        }
+
+        /** A named kernel; {@code key} is what the backend emits for. */
+        record Intrinsic(String key) implements FnBody {
+        }
+    }
+
+    /**
+     * A {@code let} definition. A behavior fn or a helper carries a {@link FnBody.Written written}
+     * body and no {@code declaredReturn}. A core intrinsic (spec §primitives) instead declares its
+     * return type and names a primitive: {@code let trim (s: String): String = intrinsic
+     * "string.trim"} — its body is {@link FnBody.Intrinsic}, written only in the {@code souther}
      * namespace. {@code partial} marks a helper that opts out of the totality check (spec
      * §fn-declaration): a recursive helper is checked for structural recursion unless it is
      * {@code partial}.
      */
-    record FnDef(String name, List<FnParam> params, RetType declaredReturn, String intrinsicKey,
-                 Expr body, boolean partial, SourcePos pos) implements Ast {
+    record FnDef(String name, List<FnParam> params, RetType declaredReturn, FnBody body,
+                 boolean partial, SourcePos pos) implements Ast {
         /** A fn with no {@code partial} marker (the common case; totality-checked if recursive). */
-        public FnDef(String name, List<FnParam> params, RetType declaredReturn, String intrinsicKey,
-                     Expr body, SourcePos pos) {
-            this(name, params, declaredReturn, intrinsicKey, body, false, pos);
+        public FnDef(String name, List<FnParam> params, RetType declaredReturn, FnBody body,
+                     SourcePos pos) {
+            this(name, params, declaredReturn, body, false, pos);
         }
 
-        public boolean isIntrinsic() {
-            return intrinsicKey != null;
+        /** The expression the author wrote. Asked from positions an intrinsic cannot reach — a
+         *  user module, or a helper already known written — which is said here rather than by a
+         *  silent null. */
+        public Expr written() {
+            return switch (body) {
+                case FnBody.Written w -> w.expr();
+                case FnBody.Intrinsic i -> throw new IllegalStateException(
+                        "`" + name + "` is an intrinsic and has no written body");
+            };
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
@@ -65,8 +65,8 @@ public final class BottomInfer {
         if (!(e instanceof Ast.Var v && v.denotes() instanceof ValueName.Stdlib lib)) {
             return false;
         }
-        Prelude.IntrinsicSig declared = Prelude.intrinsics().get(lib.qualified());
-        return declared != null && declared.params().isEmpty();
+        Prelude.PreludeEntry entry = Prelude.entry(lib.qualified());
+        return entry != null && entry.declaration().params().isEmpty();
     }
 
     /** Best-effort: bind the type variables of {@code result} from an {@code expected} type the context

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -110,15 +110,16 @@ public final class CallElaborator {
         if (!(v.denotes() instanceof ValueName.Stdlib lib)) {
             return null;
         }
-        Prelude.IntrinsicSig intrinsic = Prelude.intrinsics().get(lib.qualified());
-        if (intrinsic == null || !intrinsic.params().isEmpty()) {
+        Prelude.PreludeEntry entry = Prelude.entry(lib.qualified());
+        if (entry == null || !entry.declaration().params().isEmpty()) {
             return null;
         }
+        Type declared = entry.signature().result();
         Map<String, Type> bindings = new HashMap<>();
-        BottomInfer.pinResultTypeVars(intrinsic.result(), expected, bindings, ctx.symbols(),
+        BottomInfer.pinResultTypeVars(declared, expected, bindings, ctx.symbols(),
                 v.pos(), "the type of " + lib.qualified());
         return new Core.Call(lib.qualified(), List.of(),
-                TypeOps.toBottom(TypeOps.substitute(intrinsic.result(), bindings)), v.pos());
+                TypeOps.toBottom(TypeOps.substitute(declared, bindings)), v.pos());
     }
 
     static Core elaborateCall(Ast.Apply call, Scope env, CheckContext ctx,
@@ -296,13 +297,11 @@ public final class CallElaborator {
             throw new Unanswerable(call.pos());
         }
         boolean library = call.denotes() instanceof ValueName.Stdlib;
-        // A shipped intrinsic behaves like a built-in: check the call against its declared signature
-        // (from the prelude) and yield its result type; the backend emits the primitive for its key.
-        Prelude.IntrinsicSig intrinsic = library ? Prelude.intrinsics().get(call.reaches()) : null;
+        Prelude.PreludeEntry entry = library ? Prelude.entry(call.reaches()) : null;
         // A declaration written with no parameter list is a value ([#fn-declaration]), and an empty
         // `()` would be a second spelling of it. The library was the last place that spelling was
         // still accepted.
-        if (intrinsic != null && intrinsic.params().isEmpty()) {
+        if (entry != null && entry.declaration().params().isEmpty()) {
             throw CompileException.of(
                     Diagnostic.of(null, "check.apply.notfunction")
                             .title("check.apply.notfunction.title")
@@ -311,7 +310,12 @@ public final class CallElaborator {
                     "`" + call.written() + "` is a value, not a function, so it takes no `()` — write `"
                             + call.written() + "` on its own");
         }
-        if (intrinsic != null) {
+        // A shipped kernel behaves like a built-in: check the call against the declared signature
+        // and yield its result type; the backend emits the primitive for its key. A Souther-bodied
+        // library call — a recursive helper such as `List.foldFrom` — is not one of these and takes
+        // the paths below, as any helper does.
+        if (entry != null && entry.declaration().body() instanceof Ast.FnBody.Intrinsic kernel) {
+            Prelude.Signature intrinsic = entry.signature();
             if (args.size() != intrinsic.params().size()) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.arity").title("check.arity.title")
@@ -352,15 +356,15 @@ public final class CallElaborator {
                 if (intrinsic.params().get(i) instanceof Type.FnOf declaredStep) {
                     ca.put(i, Elaborator.resolveStepBinding(call.written(), declaredStep, args.get(i),
                             bindings, env, ctx));
-                    requiresOrderedKey(intrinsic.key(), call, declaredStep, bindings, ctx);
+                    requiresOrderedKey(kernel.key(), call, declaredStep, bindings, ctx);
                 }
             }
             Type result = TypeOps.substitute(intrinsic.result(), bindings);
-            requiresOrdering(intrinsic.key(), call, result, ctx);
-            if (intrinsic.key().equals("list.sum") || intrinsic.key().equals("list.product")) {
+            requiresOrdering(kernel.key(), call, result, ctx);
+            if (kernel.key().equals("list.sum") || kernel.key().equals("list.product")) {
                 return numericFold(call, result, expected);
             }
-            if (intrinsic.key().equals("string.matches")) {
+            if (kernel.key().equals("string.matches")) {
                 validateRegexPattern(args.get(0));
             }
             return result;

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -51,7 +51,7 @@ public final class DataChecker {
     public static List<ConstCheck> constNewtypeChecks(Ast.Module module, Symbols symbols) {
         List<ConstCheck> out = new ArrayList<>();
         for (Ast.FnDef fn : module.fns()) {
-            collectConstChecks(fn.body(), symbols, out);
+            collectConstChecks(fn.written(), symbols, out);
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -72,7 +72,7 @@ public final class Exposing {
             }
             for (String name : imp.names()) {
                 String qualified = imp.module() + "." + name;
-                if (!Prelude.hasQualified(qualified)) {
+                if (!Prelude.isLibraryFunction(qualified)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.import.notstdfn").title("check.module.title")
                                     .at(imp.pos()).args(name, imp.module()).build(),

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1302,7 +1302,8 @@ public final class HelperInliner {
      * already the value it is and is left alone.
      */
     private Ast.Expr libraryValueOf(Ast.Var v, ValueName.Stdlib lib) {
-        Ast.FnDef declared = Prelude.declarationOf(lib.qualified());
+        Prelude.PreludeEntry entry = Prelude.entry(lib.qualified());
+        Ast.FnDef declared = entry == null ? null : entry.declaration();
         int arity = declared == null ? -1 : declared.params().size();
         if (arity <= 0) {
             return v;   // a value, or a name the library does not declare — reported where it is used

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -196,7 +196,7 @@ public final class HelperInliner {
         Set<String> reachable = new HashSet<>();
         java.util.Deque<String> work = new java.util.ArrayDeque<>();
         for (Ast.FnDef fn : module.fns()) {
-            collectHelperCalls(fn.body(), reachable);
+            collectHelperCalls(fn.written(), reachable);
         }
         for (Ast.Def d : module.defs()) {
             if (d instanceof Ast.Data data) {
@@ -280,17 +280,18 @@ public final class HelperInliner {
             reader.collectValueRefs(e, named);
             for (String value : named) {
                 Ast.FnDef def = table.get(value);
-                if (def != null && def.params().isEmpty() && def.body() != null
+                if (def != null && def.params().isEmpty()
+                        && def.body() instanceof Ast.FnBody.Written w
                         && valuesRead.add(value)) {
-                    work.add(def.body());
+                    work.add(w.expr());
                 }
             }
         }
         Set<String> out = new LinkedHashSet<>();
         for (String name : called) {
             Ast.FnDef helper = table.get(name);
-            if (helper != null && helper.body() != null && helper.intrinsicKey() == null
-                    && !helper.params().isEmpty() && !Elaborator.producesFunction(helper.body())) {
+            if (helper != null && helper.body() instanceof Ast.FnBody.Written w
+                    && !helper.params().isEmpty() && !Elaborator.producesFunction(w.expr())) {
                 out.add(name);
             }
         }
@@ -313,7 +314,7 @@ public final class HelperInliner {
                 continue;
             }
             Ast.FnDef def = helpers.get(name);
-            out.put(name, new Ast.FnDef(name, def.params(), def.declaredReturn(), def.intrinsicKey(),
+            out.put(name, new Ast.FnDef(name, def.params(), def.declaredReturn(),
                     def.body(), def.partial(), def.pos()));
         }
         return out;
@@ -342,7 +343,7 @@ public final class HelperInliner {
         for (String qualified : referencedPreludeRecursive) {
             Ast.FnDef def = helpers.get(qualified);
             out.put(qualified, new Ast.FnDef(qualified, def.params(), def.declaredReturn(),
-                    def.intrinsicKey(), def.body(), def.partial(), def.pos()));
+                    def.body(), def.partial(), def.pos()));
         }
         return out;
     }
@@ -370,9 +371,10 @@ public final class HelperInliner {
      */
     public Ast.FnDef closeAcross(Ast.FnDef fn, String module) {
         Ast.Expr closed = recursive.contains(fn.name())
-                ? inlineRecursiveBody(fn) : inline(fn.body(), bodyOf(fn.name()));
-        return new Ast.FnDef(qualified(module, fn.name()), fn.params(), fn.declaredReturn(), null,
-                publishedBy(qualifyHelpersOf(closed, module), module), fn.partial(), fn.pos());
+                ? inlineRecursiveBody(fn) : inline(fn.written(), bodyOf(fn.name()));
+        return new Ast.FnDef(qualified(module, fn.name()), fn.params(), fn.declaredReturn(),
+                new Ast.FnBody.Written(publishedBy(qualifyHelpersOf(closed, module), module)),
+                fn.partial(), fn.pos());
     }
 
     /**
@@ -449,9 +451,11 @@ public final class HelperInliner {
     public static Ast.Module qualifyImports(Ast.Module m) {
         List<Ast.FnDef> fns = new ArrayList<>();
         for (Ast.FnDef fn : m.fns()) {
-            fns.add(fn.body() == null ? fn
-                    : new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
-                            qualifyForeign(fn.body(), m.name()), fn.partial(), fn.pos()));
+            fns.add(fn.body() instanceof Ast.FnBody.Written w
+                    ? new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(),
+                            new Ast.FnBody.Written(qualifyForeign(w.expr(), m.name())),
+                            fn.partial(), fn.pos())
+                    : fn);
         }
         List<Ast.Def> defs = qualifiedInvariants(m);
         List<Ast.Example> examples = new ArrayList<>();
@@ -752,7 +756,7 @@ public final class HelperInliner {
             }
         }
         try {
-            return inline(h.body(), bodyOf(h.name()));
+            return inline(h.written(), bodyOf(h.name()));
         } finally {
             helpers.putAll(shadowed);
         }
@@ -1114,7 +1118,8 @@ public final class HelperInliner {
                             // the lambda's body is caller code, so it is not renamed by this helper's
                             // substitution — only the enclosing helper body is.
                             scopedLambdas.put(f.id(),
-                                    new Ast.FnDef(f.name(), lparams, null, null, lambda.body(), lambda.pos()));
+                                    new Ast.FnDef(f.name(), lparams, null,
+                                            new Ast.FnBody.Written(lambda.body()), lambda.pos()));
                             lambdaOrigins.put(f.name(), new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
                         } else {
                             // Neither a name nor a lambda: a value written where the function goes —
@@ -1154,9 +1159,9 @@ public final class HelperInliner {
                 // a prelude helper's body is stamped with the call site, so errors inside it point at
                 // the user's call, not at the shipped source of souther.*
                 SourcePos at = keepsItsPositions(call) ? null : call.pos();
-                Copy copy = new Copy(helper.body(),
+                Copy copy = new Copy(helper.written(),
                         new BindingOwner.Expansion(into, call.denotes(), k));
-                Ast.Expr body = inline(rename(helper.body(), subst, substDenotes, fnParams, at, copy));   // expand nested helpers too
+                Ast.Expr body = inline(rename(helper.written(), subst, substDenotes, fnParams, at, copy));   // expand nested helpers too
                 given.forEach(scopedLambdas::remove);
                 body = keepDeclaredReturn(helper, body, call.pos(), k);
                 // wrap innermost-first so the value parameters bind in declared order
@@ -1216,7 +1221,8 @@ public final class HelperInliner {
                 }
                 BindingId bound = li.binder().id();
                 scopedLambdas.put(bound,
-                        new Ast.FnDef(li.name(), params, null, null, lambda.body(), li.pos()));
+                        new Ast.FnDef(li.name(), params, null,
+                                new Ast.FnBody.Written(lambda.body()), li.pos()));
                 Ast.Expr body = inline(li.body());
                 scopedLambdas.remove(bound);
                 // if the binding is still read, the function was used as a value, not just applied —
@@ -1281,7 +1287,7 @@ public final class HelperInliner {
         if (recursive.contains(v.name())) {
             return v;
         }
-        return carriedByValue(inline(value.body()));
+        return carriedByValue(inline(value.written()));
     }
 
     /**
@@ -1358,7 +1364,7 @@ public final class HelperInliner {
             }
             Ast.Binder name = binders.binder("$s" + counter++ + "_" + spread.bare(), spread.pos());
             bound.add(name);
-            values.add(carriedByValue(inline(value.body())));
+            values.add(carriedByValue(inline(value.written())));
             spreads.add(Ast.ValueRef.local(name, spread.pos()));
         }
         Ast.Expr built = new Ast.NewData(nd.typeName(), inlineInits(nd.inits()), spreads,
@@ -1655,7 +1661,7 @@ public final class HelperInliner {
         // self-call forever.
         for (Map.Entry<String, Ast.FnDef> e : helpers.entrySet()) {
             Set<String> called = new HashSet<>();
-            collectHelperCalls(e.getValue().body(), called);
+            collectHelperCalls(e.getValue().written(), called);
             callsOf.put(e.getKey(), called);
         }
         for (String name : helpers.keySet()) {
@@ -1679,7 +1685,7 @@ public final class HelperInliner {
         Map<String, Set<String>> edges = new LinkedHashMap<>();
         for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
             Set<String> out = new LinkedHashSet<>(callsOf.getOrDefault(e.getKey(), Set.of()));
-            collectValueRefs(e.getValue().body(), out);
+            collectValueRefs(e.getValue().written(), out);
             edges.put(e.getKey(), out);
         }
         for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
@@ -1693,7 +1699,7 @@ public final class HelperInliner {
             // and its parameters are the ones the written type names.
             boolean declaredAFunction = e.getValue().declaredReturn() != null
                     && e.getValue().declaredReturn().asFn() != null;
-            if (!declaredAFunction && e.getValue().body() instanceof Ast.Block block) {
+            if (!declaredAFunction && e.getValue().written() instanceof Ast.Block block) {
                 throw CompileException.of(
                         Diagnostic.of(null, "check.block.notvalue").title("check.block.title")
                                 .at(block.pos()).build(),

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -406,8 +406,11 @@ final class HelperParams {
             if (recursiveHelperFns.get(fn) instanceof Type.FnOf sig) {
                 return sig.params();
             }
-            Prelude.IntrinsicSig intrinsic = Prelude.intrinsics().get(fn);
-            return intrinsic == null ? null : intrinsic.params();
+            // Only a kernel's signature: a Souther-bodied library callee here is a recursive
+            // helper, and those are answered above with the types their call site instantiated.
+            Prelude.PreludeEntry entry = Prelude.entry(fn);
+            return entry != null && entry.declaration().body() instanceof Ast.FnBody.Intrinsic
+                    ? entry.signature().params() : null;
         }
 
         private boolean isParam(Ast.Expr e, String name) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -132,7 +132,7 @@ final class HelperParams {
             if (open.isEmpty()) {
                 return null;
             }
-            body = inliner.inline(h.body(), inliner.bodyOf(h.name()));
+            body = inliner.inline(h.written(), inliner.bodyOf(h.name()));
         } catch (CompileException _) {
             return null;   // a written type or a call that does not resolve; the check reports it
         }
@@ -150,7 +150,7 @@ final class HelperParams {
                             new Ast.RetType(List.of(Ast.TypeRef.of(t, p.pos())), p.pos()),
                             p.typeFromPattern()));
         }
-        return new Ast.FnDef(h.name(), params, h.declaredReturn(), h.intrinsicKey(), h.body(),
+        return new Ast.FnDef(h.name(), params, h.declaredReturn(), h.body(),
                 h.partial(), h.pos());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -63,7 +63,7 @@ public final class HelperTyping {
                 }
                 env = env.with(p.binder(), TypeOps.resolveParamType(p.type(), symbols));
             }
-            Elaborator.rejectBuiltinShadowing(h.body());
+            Elaborator.rejectBuiltinShadowing(h.written());
             // A helper the lowered module carries is one the backend emits — a recursive one, and one
             // an example row applies (ADR-0077) — so it is typed on the tree the backend emits from,
             // and the Core this check produces is what is emitted (issue #81). One that is only
@@ -72,7 +72,7 @@ public final class HelperTyping {
             // expansion runs (foldFrom's `step` is a parameter, not a same-named user helper).
             // Expanded once: the body an un-annotated parameter takes its type from is the same tree.
             Ast.Expr emitted = loweredBodies.get(h.name());
-            Ast.Expr body = emitted != null ? emitted : inliner.inline(h.body(), inliner.bodyOf(h.name()));
+            Ast.Expr body = emitted != null ? emitted : inliner.inline(h.written(), inliner.bodyOf(h.name()));
             if (recursive && body == null) {
                 // Lower keeps every recursive helper as a fn of the lowered module, and the backend
                 // emits from that same list, so a recursive helper without a lowered body would leave
@@ -98,7 +98,7 @@ public final class HelperTyping {
             // a helper that returns a function (e.g. `let adder (n) = (x) -> x + n`) has no application
             // here to infer the lambda's parameter types from; it is checked where it is inlined and
             // applied (spec §blocks).
-            checkFunctionArgs(h.body(), tenv, symbols, reqSigs, inliner);
+            checkFunctionArgs(h.written(), tenv, symbols, reqSigs, inliner);
             if (Elaborator.producesFunction(body)) {
                 continue;
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1285,7 +1285,7 @@ public final class InvariantChecker {
                 yield sb.append('}').toString();
             }
             // Only the library's own functions: they are pure, so one written call is one value.
-            case Ast.Apply c when Prelude.hasQualified(c.reaches()) ->
+            case Ast.Apply c when Prelude.isLibraryFunction(c.reaches()) ->
                     elementsKey(c.reaches() + "(", c.args(), site, bound, depth, ")");
             default -> null;
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -71,9 +71,9 @@ public final class Lower {
                                  Set<String> dependencies) {
         Ast.Expr expanded = recursive
                 ? inliner.inlineRecursiveBody(fn)
-                : inliner.inline(fn.body(), dependencies(fn, dependencies), inliner.bodyOf(fn.name()));
-        return new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
-                desugar(expanded), fn.partial(), fn.pos());
+                : inliner.inline(fn.written(), dependencies(fn, dependencies), inliner.bodyOf(fn.name()));
+        return new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(),
+                new Ast.FnBody.Written(desugar(expanded)), fn.partial(), fn.pos());
     }
 
     /** Which bindings the {@code depends on} names are: the trailing parameters that carry them. A

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -31,9 +31,12 @@ public final class NewtypeDesugar {
     public static Ast.Module rewrite(Ast.Module m, Symbols symbols) {
         List<Ast.FnDef> fns = new ArrayList<>();
         for (Ast.FnDef fn : m.fns()) {
-            Ast.Expr body = fn.body() == null ? null : go(fn.body(), symbols);
-            fns.add(new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), fn.intrinsicKey(),
-                    body, fn.partial(), fn.pos()));
+            Ast.FnBody body = switch (fn.body()) {
+                case Ast.FnBody.Written w -> new Ast.FnBody.Written(go(w.expr(), symbols));
+                case Ast.FnBody.Intrinsic i -> i;
+            };
+            fns.add(new Ast.FnDef(fn.name(), fn.params(), fn.declaredReturn(), body, fn.partial(),
+                    fn.pos()));
         }
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
                 m.defs(), m.behaviors(), fns, m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -257,8 +257,12 @@ public final class Resolve {
             params.add(new Ast.FnParam(a.binder(), paramType(p.type()), p.typeFromPattern()));
             bound = a.bound();
         }
-        return new Ast.FnDef(f.name(), params, retType(f.declaredReturn()), f.intrinsicKey(),
-                f.body() == null ? null : expr(f.body(), bound), f.partial(), f.pos());
+        Ast.FnBody body = switch (f.body()) {
+            case Ast.FnBody.Written w -> new Ast.FnBody.Written(expr(w.expr(), bound));
+            case Ast.FnBody.Intrinsic i -> i;
+        };
+        return new Ast.FnDef(f.name(), params, retType(f.declaredReturn()), body, f.partial(),
+                f.pos());
     }
 
     // --- written types ---

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -59,7 +59,7 @@ public final class SpecChecker {
                     }
                     Ast.FnDef fn = fns.get(spec.name());
                     if (fn != null) {
-                        for (String called : requiredCalls(fn.body(), names)) {
+                        for (String called : requiredCalls(fn.written(), names)) {
                             if (!out.contains(called)) {
                                 out.add(called);
                             }
@@ -290,7 +290,7 @@ public final class SpecChecker {
         for (Ast.FnParam p : fn.params()) {
             Elaborator.rejectBuiltinShadow(p.name(), p.pos());
         }
-        Elaborator.rejectBuiltinShadowing(fn.body());
+        Elaborator.rejectBuiltinShadowing(fn.written());
         for (int i = 0; i < nBusiness; i++) {
             env = env.with(fn.params().get(i).binder(),
                     TypeOps.successType(spec.params().get(i).type(), symbols));
@@ -304,7 +304,7 @@ public final class SpecChecker {
         // Check functions passed to helper parameters (e.g. a combinator's predicate) against their
         // declared types first, so a mismatch names the parameter, not the derivation it expands to.
         // A nested fold reaches `List.foldFrom` inside a block, so its signature must be in scope here.
-        HelperTyping.checkFunctionArgs(fn.body(), tenv, symbols, reqSigs, inliner);
+        HelperTyping.checkFunctionArgs(fn.written(), tenv, symbols, reqSigs, inliner);
         // The body arrives with helper calls already expanded (the Lower stage, ADR-0021): it is
         // checked as one expression, so a helper's constructions and injected calls count toward this
         // behavior's permission and dependencies — exactly as if the code had been written inline (12.5).
@@ -688,7 +688,7 @@ public final class SpecChecker {
         // A behavior's input and output are asked below, under its own name; a behavior's own `let`
         // is an implementation and not one of the module's definitions.
         for (Ast.FnDef fn : HelperInliner.helpersOf(module).values()) {
-            if (fn.body() == null || !exposed.contains(fn.name())) {
+            if (!(fn.body() instanceof Ast.FnBody.Written) || !exposed.contains(fn.name())) {
                 continue;
             }
             for (Ast.FnParam p : fn.params()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -171,7 +171,7 @@ final class TotalityChecker {
                 idxOf.put(params.get(i).binder().id(), i);
             }
             List<RecCall> calls = new ArrayList<>();
-            walk(def.body(), group, paramNames, Map.of(), Map.of(), calls);
+            walk(def.written(), group, paramNames, Map.of(), Map.of(), calls);
             for (RecCall rc : calls) {
                 firstCall.putIfAbsent(f, rc.call());
                 int toArity = own.get(rc.callee()).params().size();
@@ -471,7 +471,7 @@ final class TotalityChecker {
         Map<String, Set<String>> edges = new HashMap<>();
         for (Ast.FnDef h : own.values()) {
             Set<String> called = new HashSet<>();
-            collectOwnCalls(h.body(), own.keySet(), called);
+            collectOwnCalls(h.written(), own.keySet(), called);
             edges.put(h.name(), called);
         }
         return edges;

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -188,7 +188,7 @@ public final class TypeChecker {
                                         Map<String, Ast.FnDef> publishedToHere) {
         Map<String, Ast.Expr> loweredBodies = new HashMap<>();
         for (Ast.FnDef fn : lowered.fns()) {
-            loweredBodies.put(fn.name(), fn.body());
+            loweredBodies.put(fn.name(), fn.written());
         }
         // The imported definitions join the table this module's bodies are expanded against: a
         // published helper is expanded at its call sites here exactly as one of this module's own is,
@@ -357,7 +357,7 @@ public final class TypeChecker {
         // A binding whose value is a lambda takes no annotation (spec 16.1). Read on the surface bodies:
         // lowering has already expanded such a binding away at each of its applications.
         for (Ast.FnDef fn : module.fns()) {
-            collect(errors, abandoned, () -> Elaborator.checkAnnotatedLambdaBindings(fn.body(), symbols));
+            collect(errors, abandoned, () -> Elaborator.checkAnnotatedLambdaBindings(fn.written(), symbols));
         }
         // Helper fns (no matching behavior) are expanded inline at each call site (spec 12.5); a
         // helper is checked standalone against its own parameter types, which its body settles

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1130,9 +1130,9 @@ final class BodyGen {
                 }
                 default -> { }
             }
-            Prelude.IntrinsicSig intrinsic = Prelude.intrinsics().get(call.fn());
-            if (intrinsic != null) {
-                Intrinsics.emit(this, intrinsic.key(), call);
+            Prelude.PreludeEntry entry = Prelude.entry(call.fn());
+            if (entry != null && entry.declaration().body() instanceof Ast.FnBody.Intrinsic kernel) {
+                Intrinsics.emit(this, kernel.key(), call);
                 return;
             }
             switch (call.fn()) {

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -423,7 +423,8 @@ public final class AstBuilder {
                                 + " namespace may declare one (ADR-0028)");
             }
             String key = stringValue(intrinsic.get().token(SyntaxKind.STRING_LIT).orElseThrow().text());
-            return new Ast.FnDef(name, params, declaredReturn, key, null, partial, pos);
+            return new Ast.FnDef(name, params, declaredReturn, new Ast.FnBody.Intrinsic(key),
+                    partial, pos);
         }
         SyntaxNode bodyNode = onlyExpr(n);
         Ast.Expr body = expr(bodyNode);
@@ -455,7 +456,8 @@ public final class AstBuilder {
                 body = bindPattern(pat, new Ast.Var(params.get(i).name(), at), body, at);
             }
         }
-        return new Ast.FnDef(name, params, declaredReturn, null, body, partial, pos);
+        return new Ast.FnDef(name, params, declaredReturn, new Ast.FnBody.Written(body), partial,
+                pos);
     }
 
     private Ast.FnParam fnParam(SyntaxNode p, SyntaxNode pat) {

--- a/souther-compiler/src/main/java/souther/compiler/meta/ModuleMetadata.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/ModuleMetadata.java
@@ -189,9 +189,9 @@ public final class ModuleMetadata {
         // A behavior's body is not published — a reader has its signature and calls it — so a
         // behavior's own `let` is not carried whatever its shape.
         for (Ast.FnDef fn : HelperInliner.helpersOf(module).values()) {
-            if (exposed.contains(fn.name()) && fn.body() != null) {
+            if (exposed.contains(fn.name()) && fn.body() instanceof Ast.FnBody.Written w) {
                 reached.add(fn.name());
-                reach(fn.body(), own, reached);
+                reach(w.expr(), own, reached);
             }
         }
         List<String> texts = new ArrayList<>();
@@ -215,9 +215,9 @@ public final class ModuleMetadata {
             default -> null;
         };
         if (named != null && own.containsKey(named) && reached.add(named)) {
-            Ast.Expr body = own.get(named).body();
-            if (body != null) {   // an `intrinsic` helper is a name with nothing to walk into
-                reach(body, own, reached);
+            // an `intrinsic` helper is a name with nothing to walk into
+            if (own.get(named).body() instanceof Ast.FnBody.Written w) {
+                reach(w.expr(), own, reached);
             }
         }
         Ast.forEachChild(e, c -> reach(c, own, reached));

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -597,7 +597,7 @@ public final class Bodies {
         HelperInliner inliner = HelperInliner.forHelpers(from.name(), table);
         Deque<String> work = new ArrayDeque<>(out.keySet());
         while (!work.isEmpty()) {
-            for (ValueName.Helper reached : HelperInliner.helpersReached(out.get(work.poll()).body())) {
+            for (ValueName.Helper reached : HelperInliner.helpersReached(out.get(work.poll()).written())) {
                 String qualified = HelperInliner.qualified(reached.module(), reached.name());
                 if (out.containsKey(qualified)) {
                     continue;
@@ -636,7 +636,8 @@ public final class Bodies {
         Set<String> exposed = new java.util.HashSet<>(from.exposing());
         List<Ast.FnDef> out = new java.util.ArrayList<>();
         for (Ast.FnDef fn : HelperInliner.helpersOf(from).values()) {
-            if (fn.body() != null && exposed.contains(fn.name()) && wanted.contains(fn.name())) {
+            if (fn.body() instanceof Ast.FnBody.Written && exposed.contains(fn.name())
+                    && wanted.contains(fn.name())) {
                 out.add(fn);
             }
         }
@@ -865,7 +866,7 @@ public final class Bodies {
                 if (!body.present()) {
                     return Answer.absent();
                 }
-                bodies.put(helper, body.value().body());
+                bodies.put(helper, body.value().written());
             }
             try {
                 return Answer.of(TypeChecker.recursiveHelperConstructs(sigs.value().keySet(), bodies,
@@ -958,12 +959,12 @@ public final class Bodies {
             // invariants (spec §invariant-discharge). Where it is not available the check is skipped
             // rather than run against the emitted tree, whose operations are no longer operations.
             InvariantChecker.Source dischargeSource = discharge.present()
-                    ? new InvariantChecker.Source(discharge.value().body(),
+                    ? new InvariantChecker.Source(discharge.value().written(),
                             dischargeInvariants.present() ? dischargeInvariants.value() : Map.of())
                     : null;
             List<Diagnostic> warnings = new ArrayList<>();
             try {
-                Core core = TypeChecker.checkBehavior(spec.value(), fn.value(), body.value().body(),
+                Core core = TypeChecker.checkBehavior(spec.value(), fn.value(), body.value().written(),
                         dischargeSource, scope.value(), calleeSigs.value(), reqSigs.value(),
                         HelperInliner.forHelpers(module, helpers.value()), sigs.value(), constructs.value(),
                         warnings);

--- a/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
@@ -139,7 +139,7 @@ class CompilePostfixApplicationTest {
         Ast.FnDef def = souther.compiler.query.Compilation
                 .ofDocuments(byId, java.util.Set.of(), souther.compiler.meta.ModulePath.EMPTY)
                 .db().ask(new souther.compiler.query.Bodies.SettledFn("demo", "go")).value();
-        assertEquals(1, occurrences(def.body(), "pick"), "the callee was worked out more than once");
+        assertEquals(1, occurrences(def.written(), "pick"), "the callee was worked out more than once");
     }
 
     private static int occurrences(Ast.Expr e, String callee) {

--- a/souther-compiler/src/test/java/souther/compiler/PreludeValueDeclaresItsTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/PreludeValueDeclaresItsTypeTest.java
@@ -1,0 +1,43 @@
+package souther.compiler;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Symbols;
+import souther.compiler.diag.SourcePos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A zero-parameter prelude declaration is a value whose type only its signature can answer:
+ * {@code CallElaborator.libraryValue} reads the signature's result with no call whose arguments
+ * could pin it. So a shipped value that writes no return type is refused when the library is
+ * loaded, rather than filed as an entry whose type nothing states and read as a null.
+ */
+class PreludeValueDeclaresItsTypeTest {
+
+    @Test
+    void aValueWithoutAWrittenTypeIsRefusedAtLoad() {
+        SourcePos at = new SourcePos(1, 1);
+        Ast.FnDef value = new Ast.FnDef("someValue", List.of(), null,
+                new Ast.FnBody.Written(new Ast.IntLit(0, at)), at);
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> Prelude.signatureOf(value, "List.someValue", Symbols.none()));
+        assertTrue(refused.getMessage().contains("List.someValue"));
+    }
+
+    @Test
+    void everyShippedValueStatesItsType() {
+        for (Prelude.PreludeEntry entry : Prelude.entries().values()) {
+            if (entry.declaration().params().isEmpty()) {
+                assertNotNull(entry.signature().result(),
+                        "`" + entry.declaration().name() + "` is a value with no stated type");
+            }
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
@@ -229,7 +229,7 @@ class InvariantCombinatorRulesTest {
     @Test
     void everyRuleIsKeyedByANameTheAnalysisStillSees() {
         for (String fn : InvariantChecker.combinatorNames()) {
-            assertTrue(Prelude.hasQualified(fn), fn + " is not a standard-library operation");
+            assertTrue(Prelude.isLibraryFunction(fn), fn + " is not a standard-library operation");
             assertFalse(Prelude.sugared(fn),
                     fn + " is rewritten to another call before this tree is read, so its rule cannot"
                             + " fire — key the rule by what the rewrite leaves");

--- a/souther-compiler/src/test/java/souther/compiler/codegen/EveryKernelIsDeclaredTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/EveryKernelIsDeclaredTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.codegen;
 
 import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
 
 import org.junit.jupiter.api.Test;
 
@@ -22,12 +23,8 @@ class EveryKernelIsDeclaredTest {
 
     @Test
     void everyEmittedKernelHasADeclarationNamingIt() {
-        Set<String> declared = new LinkedHashSet<>();
-        for (Prelude.IntrinsicSig sig : Prelude.intrinsics().values()) {
-            declared.add(sig.key());
-        }
         Set<String> emittedWithNoDeclaration = new LinkedHashSet<>(Intrinsics.keys());
-        emittedWithNoDeclaration.removeAll(declared);
+        emittedWithNoDeclaration.removeAll(declaredKeys());
 
         assertEquals(Set.of(), emittedWithNoDeclaration,
                 "a kernel is emitted that no declaration describes");
@@ -40,13 +37,24 @@ class EveryKernelIsDeclaredTest {
         Set<String> writtenOut = Set.of("int.divide", "int.remainder", "decimal.divide");
 
         Set<String> declaredWithNoEmitter = new LinkedHashSet<>();
-        for (Prelude.IntrinsicSig sig : Prelude.intrinsics().values()) {
-            if (!Intrinsics.keys().contains(sig.key()) && !writtenOut.contains(sig.key())) {
-                declaredWithNoEmitter.add(sig.key());
+        for (String key : declaredKeys()) {
+            if (!Intrinsics.keys().contains(key) && !writtenOut.contains(key)) {
+                declaredWithNoEmitter.add(key);
             }
         }
 
         assertEquals(Set.of(), declaredWithNoEmitter,
                 "a kernel is declared that nothing emits");
+    }
+
+    /** The kernel keys the library's declarations name: the entries whose body is a kernel. */
+    private static Set<String> declaredKeys() {
+        Set<String> declared = new LinkedHashSet<>();
+        for (Prelude.PreludeEntry entry : Prelude.entries().values()) {
+            if (entry.declaration().body() instanceof Ast.FnBody.Intrinsic kernel) {
+                declared.add(kernel.key());
+            }
+        }
+        return declared;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/BodyForInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/BodyForInvariantDischargeTest.java
@@ -39,7 +39,7 @@ class BodyForInvariantDischargeTest {
         Map<String, String> byId = new LinkedHashMap<>();
         byId.put("a.sou", SOURCE);
         Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
-        return c.db().ask(key).value().body();
+        return c.db().ask(key).value().written();
     }
 
     private static List<String> calls(Ast.Expr e) {

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -42,8 +42,8 @@ class ResolvedValueNamesTest {
     private static List<Ast.Expr> named(Ast.Module m) {
         List<Ast.Expr> out = new ArrayList<>();
         for (Ast.FnDef fn : m.fns()) {
-            if (fn.body() != null) {
-                collect(fn.body(), out);
+            if (fn.body() instanceof Ast.FnBody.Written w) {
+                collect(w.expr(), out);
             }
         }
         return out;


### PR DESCRIPTION
## Summary

Issue #275: a standard-library declaration was filed into three maps (`DECLARATIONS` / `HELPERS` / `INTRINSICS`), and `hasQualified()` answered existence from different structures than the ones answering the declaration and the signature.

Two commits:

1. **`Ast.FnDef` holds its body as a sum.** The AST carried a nullable `body` and a nullable `intrinsicKey`, one of which was always null. The body position now holds `FnBody.Written(expr)` or `FnBody.Intrinsic(key)`, and readers standing where an intrinsic cannot appear ask `written()`, which says so instead of passing a null along. This is what lets the second commit drop the implementation registry entirely: the issue's proposed `Implementation` interface would have duplicated the kernel key the AST already carries, so the sum went into the AST instead.

2. **One `PreludeEntry` per qualified name.** `Prelude.entry("List.map")` answers existence, the declaration as written, and the resolved signature together; what is behind the name is the declaration's own body. `hasQualified` becomes `isLibraryFunction` (entry exists, or the `List.fold` sugar — a rewrite, not a declaration, so it has no entry). `helpers()` remains as an unmodifiable projection derived from the entries for the inliner's table. `EveryKernelIsDeclaredTest` keeps both directions of the kernel/declaration correspondence, reading kernel keys off the entries.

The two readers that said they consult the declaration but read `Prelude.intrinsics()` — `CallElaborator.libraryValue` and `BottomInfer.isEmptyCollectionLiteral` — now ask the declaration's parameter list, so a zero-parameter library value is one whichever way it is implemented.

One deviation from the issue text: `Signature.result` is null where the declaration writes no return type, which thirty Souther-bodied helpers do today (`Bool.not`, `List.map`, `List.zip`, …); every kernel writes one, and only kernel results are read. Annotating those thirty declarations would touch checking behaviour through the inliner's declared-return handling, so it is left for a separate issue.

## Testing

- `mvn clean install`: all modules green (souther-compiler 1942 tests)
- souther-examples compiles against the built compiler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
