### PR TITLE
Type an application against a declared signature once

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -222,8 +222,9 @@ public final class Prelude {
 
     /** The resolved signature of {@code fn}. A zero-parameter declaration is a value whose type
      *  only the signature can answer — {@code libraryValue} reads it with no call whose arguments
-     *  could pin it — so a value that writes no return type is refused here rather than filed as an
-     *  entry whose type nothing states. */
+     *  could pin it — and a kernel's calls are checked against the declared result with no body to
+     *  infer one from. Either would be an entry answering a type question with nothing, so a
+     *  declaration of either kind that writes no return type is refused here. */
     static Signature signatureOf(Ast.FnDef fn, String qualified, Symbols symbols) {
         List<Type> params = new ArrayList<>();
         for (Ast.FnParam p : fn.params()) {
@@ -231,9 +232,11 @@ public final class Prelude {
         }
         Type result = fn.declaredReturn() == null
                 ? null : TypeOps.successType(fn.declaredReturn(), symbols);
-        if (fn.params().isEmpty() && result == null) {
-            throw new IllegalStateException(
-                    "a zero-parameter prelude value must declare its return type: `" + qualified + "`");
+        if (result == null
+                && (fn.params().isEmpty() || fn.body() instanceof Ast.FnBody.Intrinsic)) {
+            throw new IllegalStateException("a prelude "
+                    + (fn.params().isEmpty() ? "value" : "kernel")
+                    + " must declare its return type: `" + qualified + "`");
         }
         return new Signature(params, result);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -174,6 +174,18 @@ public final class CallElaborator {
             Elaborator.requireType(args.get(i), c.type(), expected, ctx.symbols(), what);
         }
 
+        /** Argument {@code i}, elaborated once by {@link #type}, required to fit {@code required}
+         *  now that the signature's variables are settled. Reads the stored core — the
+         *  expression's own type did not change, only what is asked of it — so nothing is
+         *  elaborated twice. */
+        void requireTyped(int i, Type required, String what) {
+            if (cores[i] == null) {
+                throw new IllegalStateException(
+                        "argument " + (i + 1) + " required before it was typed");
+            }
+            Elaborator.requireType(args.get(i), cores[i].type(), required, ctx.symbols(), what);
+        }
+
         /** Argument {@code i} as a block (or a function value standing in for one), returning the
          * result type the block yields at {@code paramTypes}. */
         Type block(int i, String fnName, List<Type> paramTypes) {
@@ -286,6 +298,102 @@ public final class CallElaborator {
      * the library, then a function-typed binding, then an injected behavior — and a name that could
      * be read two ways was whichever came first.
      */
+    /** What one application of a declared signature settled: the declared result with the
+     *  signature's variables substituted, and that substitution itself — for the checks a kernel
+     *  runs on the outcome. Settled at construction: the map is copied, not shared with the
+     *  unifier. */
+    private record Applied(Type result, Map<String, Type> substitution) {
+        private Applied {
+            substitution = Map.copyOf(substitution);
+        }
+    }
+
+    /**
+     * Types an application against a declared signature — the same four steps whichever holds the
+     * signature, a kernel declaration or a function type in scope (a function-typed parameter, a
+     * recursive helper's signature):
+     *
+     * <ol>
+     *   <li>pin the result's type variables from the expected type, only where a function argument
+     *       waits on them — a fold whose seed is {@code []}/{@code Map.empty} has its accumulator
+     *       bound from the context before the step is checked (issue #70). With no function
+     *       argument nothing waits, and pinning anyway would answer an argument mismatch against
+     *       the type the context wanted rather than the one the declaration asks for;</li>
+     *   <li>type the value arguments and unify each with its declared parameter. A parameter typed
+     *       {@code RoundingMode} is not an expression but a name the operation reads, so it is
+     *       checked as one and recorded untyped ([#stdlib-decimal]); no function type in scope can
+     *       carry that parameter, since the type is writable only by the library's own
+     *       signatures;</li>
+     *   <li>type the function arguments last, against parameter types the earlier arguments
+     *       settled. A failure that is genuinely an empty-collection seed nothing typed — one that
+     *       reported the unresolved bottom — is re-pointed at the seed rather than at the
+     *       arithmetic the bottom reached; an unrelated error in the step is rethrown untouched
+     *       (issue #70);</li>
+     *   <li>require each value argument against its settled parameter type, and substitute into
+     *       the declared result.</li>
+     * </ol>
+     *
+     * <p>Arity is the caller's to check first, in its own words; this throws where the two
+     * disagree rather than walking off the shorter list.
+     */
+    private static Applied applySignature(Ast.Apply call, Type.FnOf signature, CallArgs ca,
+                                          Type expected, Scope env, CheckContext ctx) {
+        List<Ast.Expr> args = call.args();
+        if (args.size() != signature.params().size()) {
+            throw new IllegalStateException("`" + call.written() + "` reached signature application"
+                    + " with " + args.size() + " argument(s) against " + signature.params().size());
+        }
+        boolean takesAFunction = signature.params().stream().anyMatch(Type.FnOf.class::isInstance);
+        Map<String, Type> bind = new HashMap<>();
+        if (takesAFunction) {
+            BottomInfer.pinResultTypeVars(signature.result(), expected, bind, ctx.symbols(),
+                    call.pos(), "result of " + call.written());
+        }
+        for (int i = 0; i < args.size(); i++) {
+            Type param = signature.params().get(i);
+            if (param instanceof Type.FnOf) {
+                continue;
+            }
+            if (isRoundingMode(param)) {
+                requireRoundingMode(call.written(), args.get(i));
+                ca.untyped(i);
+                continue;
+            }
+            TypeOps.unify(param, ca.type(i), bind, ctx.symbols(),
+                    call.pos(), "argument " + (i + 1) + " of " + call.written());
+        }
+        try {
+            for (int i = 0; i < args.size(); i++) {
+                if (signature.params().get(i) instanceof Type.FnOf declaredStep) {
+                    ca.put(i, Elaborator.resolveStepBinding(call.written(), declaredStep,
+                            args.get(i), bind, env, ctx));
+                }
+            }
+        } catch (CompileException stepError) {
+            int seed = BottomInfer.untypedEmptySeed(args, signature, bind, call.pos());
+            if (seed < 0 || !BottomInfer.reportsUnresolvedBottom(stepError)) {
+                throw stepError;
+            }
+            Diagnostic.Builder b = Diagnostic.of(null, "check.fold.seed.untyped")
+                    .title("check.fold.seed.title")
+                    .at(args.get(seed).pos(), Elaborator.width(args.get(seed)));
+            if (stepError.diagnostic() != null && stepError.diagnostic().region() != null) {
+                b.secondary(stepError.diagnostic().region(), "check.fold.seed.here");
+            }
+            throw CompileException.of(b.build(),
+                    "cannot infer the element type of the empty collection seeding `"
+                            + call.written() + "`; annotate the declaration it feeds");
+        }
+        for (int i = 0; i < args.size(); i++) {
+            Type param = signature.params().get(i);
+            if (!(param instanceof Type.FnOf) && !isRoundingMode(param)) {
+                ca.requireTyped(i, TypeOps.substitute(param, bind),
+                        "argument " + (i + 1) + " of " + call.written());
+            }
+        }
+        return new Applied(TypeOps.substitute(signature.result(), bind), bind);
+    }
+
     static Type typeOfCall(CallArgs ca, Ast.Apply call, Scope env, CheckContext ctx, Type expected) {
         List<Ast.Expr> args = call.args();
         if (call.denotes() == null) {
@@ -324,50 +432,25 @@ public final class CallElaborator {
                         call.written() + " takes " + intrinsic.params().size()
                                 + " argument(s) but is called with " + args.size());
             }
-            // The same three steps a helper's signature takes, for the same reasons: the context
-            // pins what it can before anything is read, the value arguments fix the rest, and a
-            // function argument is typed last — against parameter types the others have settled, so
-            // a block written there has them to be checked at.
-            //
-            // The pin is for the step's sake. With no function argument there is nothing waiting on
-            // it, and pinning anyway would answer an argument mismatch against the type the context
-            // wanted rather than against the one the declaration asks for.
-            boolean takesAFunction = intrinsic.params().stream().anyMatch(Type.FnOf.class::isInstance);
-            Map<String, Type> bindings = new HashMap<>();
-            if (takesAFunction) {
-                BottomInfer.pinResultTypeVars(intrinsic.result(), expected, bindings, ctx.symbols(),
-                        call.pos(), "result of " + call.written());
-            }
-            for (int i = 0; i < args.size(); i++) {
-                if (intrinsic.params().get(i) instanceof Type.FnOf) {
-                    continue;
-                }
-                // A rounding mode is not an expression: it is a name the operation taking it reads,
-                // so it is checked as one and carries no type of its own ([#stdlib-decimal]).
-                if (isRoundingMode(intrinsic.params().get(i))) {
-                    requireRoundingMode(call.written(), args.get(i));
-                    ca.untyped(i);
-                    continue;
-                }
-                TypeOps.unify(intrinsic.params().get(i), ca.type(i), bindings, ctx.symbols(),
-                        call.pos(), "argument " + (i + 1) + " of " + call.written());
-            }
-            for (int i = 0; i < args.size(); i++) {
-                if (intrinsic.params().get(i) instanceof Type.FnOf declaredStep) {
-                    ca.put(i, Elaborator.resolveStepBinding(call.written(), declaredStep, args.get(i),
-                            bindings, env, ctx));
-                    requiresOrderedKey(kernel.key(), call, declaredStep, bindings, ctx);
+            Applied applied = applySignature(call,
+                    new Type.FnOf(intrinsic.params(), intrinsic.result()), ca, expected, env, ctx);
+            // What remains is the kernel's own: constraints its key names on the outcome the
+            // signature could not state, and the emitter's special cases. They read the settled
+            // substitution and result — they are checks on what the application became, not part
+            // of how an application is typed.
+            for (Type param : intrinsic.params()) {
+                if (param instanceof Type.FnOf declaredStep) {
+                    requiresOrderedKey(kernel.key(), call, declaredStep, applied.substitution(), ctx);
                 }
             }
-            Type result = TypeOps.substitute(intrinsic.result(), bindings);
-            requiresOrdering(kernel.key(), call, result, ctx);
+            requiresOrdering(kernel.key(), call, applied.result(), ctx);
             if (kernel.key().equals("list.sum") || kernel.key().equals("list.product")) {
-                return numericFold(call, result, expected);
+                return numericFold(call, applied.result(), expected);
             }
             if (kernel.key().equals("string.matches")) {
                 validateRegexPattern(args.get(0));
             }
-            return result;
+            return applied.result();
         }
         return switch (library ? call.reaches() : "") {
             case "Date", "DateTime" -> {
@@ -390,62 +473,7 @@ public final class CallElaborator {
                                 "`" + call.written() + "` takes " + fn.params().size()
                                         + " argument(s) but is applied to " + args.size());
                     }
-                    // Resolve the signature's type variables from the value (non-function) arguments
-                    // first — a generic recursive helper like `foldFrom(step, seed, xs, i)` fixes `'acc`
-                    // from the seed and `'a` from the list. An empty-collection seed ([], Map.empty)
-                    // binds the accumulator to a bottom; the step's result then grows it to the concrete
-                    // type, so a function argument's result refines the binding (as the old fold did).
-                    Map<String, Type> bind = new HashMap<>();
-                    // Pin the result-type variables from the surrounding context first (issue #70): a
-                    // fold whose seed is Map.empty/[] has its accumulator `'acc` bound to the expected
-                    // result BEFORE the step (and any inlined Map.upsert closure) is checked, so the
-                    // seed's bottom no longer drives the step's parameter types.
-                    BottomInfer.pinResultTypeVars(fn.result(), expected, bind, ctx.symbols(), call.pos(),
-                            "result of " + call.written());
-                    for (int i = 0; i < args.size(); i++) {
-                        if (!(fn.params().get(i) instanceof Type.FnOf)) {
-                            Type at = ca.type(i);
-                            TypeOps.unify(fn.params().get(i), at, bind, ctx.symbols(), call.pos(), "argument " + (i + 1));
-                        }
-                    }
-                    // Type the step (function) arguments. A fold over an empty-collection seed whose
-                    // step needs the accumulator's element/value type can only get it from context;
-                    // with no expected type the accumulator stays a bottom and the step fails deep in
-                    // its (possibly inlined) body. Point at the seed — the empty collection whose type
-                    // could not be inferred — rather than the arithmetic/match the bottom reached (#70).
-                    try {
-                        for (int i = 0; i < args.size(); i++) {
-                            if (fn.params().get(i) instanceof Type.FnOf fp0) {
-                                ca.put(i, Elaborator.resolveStepBinding(call.written(), fp0, args.get(i), bind, env, ctx));
-                            }
-                        }
-                    } catch (CompileException stepError) {
-                        // Only re-point at the seed when the failure is genuinely the unresolved bottom:
-                        // an empty-collection seed whose accumulator type nothing fixed, and an error
-                        // that actually reported that bottom (`_`). An unrelated error in the step (an
-                        // unknown identifier, a real type clash) is rethrown untouched so it is not
-                        // masked. This fires whether or not a context type was pushed — an expected type
-                        // that did not fit still leaves the accumulator a bottom (issue #70).
-                        int seed = BottomInfer.untypedEmptySeed(args, fn, bind, call.pos());
-                        if (seed < 0 || !BottomInfer.reportsUnresolvedBottom(stepError)) {
-                            throw stepError;
-                        }
-                        Diagnostic.Builder b = Diagnostic.of(null, "check.fold.seed.untyped")
-                                .title("check.fold.seed.title")
-                                .at(args.get(seed).pos(), Elaborator.width(args.get(seed)));
-                        if (stepError.diagnostic() != null && stepError.diagnostic().region() != null) {
-                            b.secondary(stepError.diagnostic().region(), "check.fold.seed.here");
-                        }
-                        throw CompileException.of(b.build(),
-                                "cannot infer the element type of the empty collection seeding `"
-                                        + call.written() + "`; annotate the declaration it feeds");
-                    }
-                    for (int i = 0; i < args.size(); i++) {
-                        if (!(fn.params().get(i) instanceof Type.FnOf)) {
-                            ca.require(i, TypeOps.substitute(fn.params().get(i), bind), "argument " + (i + 1) + " of " + call.written());
-                        }
-                    }
-                    yield TypeOps.substitute(fn.result(), bind);
+                    yield applySignature(call, fn, ca, expected, env, ctx).result();
                 }
                 // a library qualifier that matched no builtin or intrinsic above is a wrong stdlib
                 // call (spec §stdlib) — report it as such, not as a missing behavior.

--- a/souther-compiler/src/test/java/souther/compiler/CompileSignatureApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSignatureApplicationTest.java
@@ -1,0 +1,75 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * An application is typed against a declared signature by one routine, whichever holds the
+ * signature — a kernel declaration or a function type in scope (issue #276). These programs walk
+ * both holders through the same shapes: a function argument typed against parameters the value
+ * arguments settled, and the empty-seed re-pointing that used to belong to only one of them.
+ */
+class CompileSignatureApplicationTest {
+
+    private static Diagnostic diagnosticOf(String src) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
+        return e.diagnostic();
+    }
+
+    /** The same application shape through both holders in one program: {@code Option.map} is a
+     *  kernel taking a function, {@code g} is a function type in scope. Both settle the function
+     *  argument's parameter from a value argument and both answer the declared result. */
+    @Test
+    void aKernelAndAFunctionValueTypeTheSameApplication() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
+                module demo
+
+                data In = { xs: List<Int> }
+                data Out = { viaKernel: Int, viaValue: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+
+                let twice (g: (Int) -> Int, n: Int) = g(g(n))
+
+                let run (i) = {
+                    Out {
+                        viaKernel = List.get(0, i.xs) |> Option.map(n -> n + 1) |> Option.withDefault(0),
+                        viaValue = twice(n -> n + 1, 40)
+                    }
+                }
+                """), getClass().getClassLoader());
+
+        Object in = Codecs.decoded(loader, "demo.In", Map.of("xs", List.of(1L)));
+        Object behavior = loader.loadClass("demo.Run$Impl").getConstructor().newInstance();
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(behavior, in));
+
+        assertEquals(2L, out.get("viaKernel"), "the kernel typed its step against the settled element");
+        assertEquals(42L, out.get("viaValue"), "the function value typed its argument the same way");
+    }
+
+    /** A kernel taking a function over an empty seed it cannot type: the failure is re-pointed at
+     *  the seed, exactly as it is for a fold written against a signature in scope. The re-pointing
+     *  used to live only on the in-scope side. */
+    @Test
+    void anEmptySeedFailureInAKernelStepIsRepointedAtTheSeed() {
+        Diagnostic d = diagnosticOf("""
+                module demo
+                data Out = { xs: List<Int> }
+                behavior run : (i: Int) -> Out constructs Out
+                let run (i) = {
+                    let sorted = List.sortBy(x -> x + 1, [])
+                    Out { xs = sorted }
+                }
+                """);
+        assertEquals("check.fold.seed.title", d.titleKey());
+        assertEquals(5, d.pos().line());
+    }
+}


### PR DESCRIPTION
## Summary

Issue #276: `CallElaborator` typed an application against a declared signature by two copies of the same four steps — kernel declaration and `Type.FnOf` in scope — and a step missing from one copy is what blocked every kernel taking a function until #273 added it there separately.

One private routine now does the four steps (pin from the expected type, unify the value arguments, type the function arguments against what those settled, substitute into the declared result) and returns `Applied(result, substitution)` — the substitution copied at construction. Each wrapper keeps its own arity words ("called with" / "applied to"), and the routine fixes arity agreement as a precondition with an explicit check.

The issue's proposed `SideConstraints` parameter turned out unnecessary: the rounding-mode argument is recognised by its declared type, not by kernel key, so it lives in the routine; every other kernel-own check (`sortBy`'s ordered key, the orderings on `sort`/`max`/`min`, the numeric folds, the regex validation) reads the settled result and substitution after the routine returns — checks on what the application became, not part of how one is typed.

Three asymmetries the two copies had grown are unified, with the existing 1944 tests arbitrating (zero regressions):

- the pin of the result's type variables runs only where a function argument waits on it (the kernel side's rule, with its rationale, now on both);
- the empty-seed re-pointing reaches kernel steps too — `List.sortBy(x -> x + 1, [])` now names the seed instead of failing inside the key (new test);
- the final require of value arguments reads the already-elaborated core (`CallArgs.requireTyped`) instead of elaborating every value argument a second time, which the in-scope path did.

A companion guard in `Prelude.signatureOf`: a kernel that writes no return type is refused at load, beside the zero-parameter value — the routine checks kernel calls against the declared result and there is no body to infer one from.

## Testing

- `mvn clean install`: all modules green (souther-compiler 1946 tests, 2 new)
- souther-examples compiles against the built compiler
- New `CompileSignatureApplicationTest`: the same application shape through both signature holders in one program, and the kernel-side seed re-pointing

🤖 Generated with [Claude Code](https://claude.com/claude-code)
