### PR TITLE
Evaluate a rounding mode as an ordinary value

### DIFF
--- a/docs/adr/0086-a-function-name-is-a-value-and-application-is-an-operation-on-one.md
+++ b/docs/adr/0086-a-function-name-is-a-value-and-application-is-an-operation-on-one.md
@@ -1,6 +1,7 @@
 # ADR-0086: A function name is a value, and application is an operation on one
 
-Status: Accepted.
+Status: Accepted. The rounding-mode entry under "what is still refused" is superseded by
+ADR-0087, which makes `RoundingMode` an ordinary value type.
 
 ## Context
 
@@ -60,7 +61,7 @@ Five passes were rebuilding an application from its name and discarding whatever
 What is still refused, and why:
 
 - A behavior's name bound to a `let` — `let f = twice`. Handing the same name to a combinator works and goes through the behavior's class, so this is the decision above with one position missing, not a rule. What blocks it is that η-expansion happens in the inliner, which holds the helper table and not the behavior signatures, so the arity to expand to is not in hand there (issue #271).
-- The three functions taking a rounding mode, handed over by name. Their argument is an identifier read as itself rather than an expression, so an η-expansion would turn it into a binding and the side condition would reject it. When `RoundingMode` becomes an ordinary value type this restriction goes with it (issue #270).
+- The three functions taking a rounding mode, handed over by name. Their argument is an identifier read as itself rather than an expression, so an η-expansion would turn it into a binding and the side condition would reject it. When `RoundingMode` becomes an ordinary value type this restriction goes with it (issue #270). *It did: ADR-0087 declares `RoundingMode` as ordinary data, and this restriction is gone.*
 - A function whose type nothing settles, stored in a collection. The measurement that named this is worth recording: a plain lambda and a library name are refused *identically* when stored, so the rule is about a function whose type is unknown at the point it is stored, not about recursion or about escaping. Applying one through a combinator is a separate gap that predates this change (issue #272). That gap is closed — the list above records what was still refused when this decision was taken; issue #272 was a stale binding in the inliner, not a rule.
 
 `Core.FunctionRef` was considered and left out (issue #277). Folding a function reference into a compact IR node rather than expanding it to a `Core.Block` every time is a representation choice, not a semantic one; it belongs with the explicit closure-conversion form `Core.Block`'s javadoc is waiting for. What is permanent is that a function reference in value position becomes a function value.

--- a/docs/adr/0087-a-rounding-mode-is-an-ordinary-value-of-a-core-declared-data.md
+++ b/docs/adr/0087-a-rounding-mode-is-an-ordinary-value-of-a-core-declared-data.md
@@ -52,8 +52,16 @@ data RoundingMode = HALF_UP | HALF_EVEN | HALF_DOWN | UP | DOWN | CEILING | FLOO
   required — a field of another data, an example fixture. A rounding policy is a computation's
   input, not a value that crosses a serialization boundary. The refusal is the ordinary
   missing-codec diagnostic, and tests pin both surfaces so the type never quietly gains an
-  external representation. (An enumeration that wants one derives it from a written
-  `decoder`/`encoder` clause; this declaration writes none.)
+  external representation.
+
+  The absence follows from where the declaration lives, and it is worth being exact about why,
+  because the obvious reading is wrong: an ordinary enumeration receives a default codec *through
+  derivation even when it writes no `decoder`/`encoder` clause* — `Deriver.deriveSum` supplies one
+  — so writing no clause would not keep a codec away. What keeps it away is that a runtime-backed
+  declaration belongs to no compiled module and therefore never enters derivation at all. The
+  consequence is that "no codec" cannot be arranged by omitting a clause from a module's own data,
+  and that routing a runtime-backed declaration through derivation would both produce a codec and
+  emit calls to codec factories on handwritten classes that have none.
 - **Shadowing follows the unit-data rules.** Rounding-mode cases are ordinary unit data; a binding
   may take a case's name and the local takes precedence. Shadowed cases have no qualified escape
   syntax — the same is true of every unit data, and this change does not add one.

--- a/docs/adr/0087-a-rounding-mode-is-an-ordinary-value-of-a-core-declared-data.md
+++ b/docs/adr/0087-a-rounding-mode-is-an-ordinary-value-of-a-core-declared-data.md
@@ -1,0 +1,102 @@
+# ADR-0087: A rounding mode is an ordinary value of a core-declared data
+
+Status: Accepted. Supersedes the rounding-mode entry under "what is still refused" in ADR-0086,
+and the "this argument is a rounding mode" side condition it kept in the compiler.
+
+## Context
+
+Issue #270. `RoundingMode` was the last argument in Souther that was not a value. It was written
+at the call and read as the identifier it was written as, never evaluated, so three Decimal
+operations were special forms rather than functions: a model could not state a rounding policy
+once and pass it, could not choose one from a business rule, and could not hand the operation to a
+combinator — three restrictions with one cause. It was also the only exception left in ADR-0086's
+rule that a declared function is a value.
+
+The machinery enforcing it was spread over the checker (`requireRoundingMode`, an argument-typing
+skip, a resolution ladder rung for the seven names, a refusal of η-expansion), the IR (a typeless
+`Core.Builtin` node), and the backend (a `getstatic` of the `java.math.RoundingMode` constant
+spelled like the identifier).
+
+## Decision
+
+**Rounding mode arguments are ordinary evaluated values of the core-declared `RoundingMode` data
+type. The compiler does not recognize rounding-mode case names or inspect their syntax at call
+sites.**
+
+```sou
+// souther/decimal.sou
+data RoundingMode = HALF_UP | HALF_EVEN | HALF_DOWN | UP | DOWN | CEILING | FLOOR
+```
+
+- A prelude module resolves against its own declarations, through the same two-phase name
+  collection every module gets (`Symbols.of`), so a core signature may name a data the module
+  declares. `Symbols.none()` remains only for sources with no declarations.
+- **Runtime-backed data.** The declaration is the checker's source of truth; the JVM
+  implementation is provided by hand in souther-runtime rather than generated. The classification
+  is a single registration in `Prelude` — declaration in `decimal.sou`, implementation
+  `souther.runtime.RoundingMode`, generated: no — and everything follows from it: the declared
+  names anchor to the runtime namespace (where `DivisionByZero` and `NotANumber` already live),
+  `Symbols` answers lookups for them from the registration, and, because the declarations belong
+  to no compiled module, they never enter derivation or code generation. No other place in the
+  compiler may branch on the type's name; a name-based conditional appearing outside the
+  registration is this decision failing.
+- **The implementation mirrors the generated shape.** Registering the declaration makes
+  `RoundingMode` the first runtime-backed enumeration (`isUnitOnlySum` is true), so the emitter
+  calls `__tag` / `__order` / `__ordering` on it and reads `INSTANCE` off its cases exactly as it
+  does on a generated sum. The handwritten classes are empty records carrying that shape, and a
+  pairwise test (`RoundingModeAbiTest`) compares every observable — the static methods, equality,
+  hash, text form — against a generated enumeration, so a change to either side that the other
+  does not follow fails a test rather than surfacing as a linkage error.
+- **No codec, intentionally.** `RoundingMode` is ordinary data for typing, evaluation, composition
+  and ordering, but it does not provide a codec and therefore cannot appear where a codec is
+  required — a field of another data, an example fixture. A rounding policy is a computation's
+  input, not a value that crosses a serialization boundary. The refusal is the ordinary
+  missing-codec diagnostic, and tests pin both surfaces so the type never quietly gains an
+  external representation. (An enumeration that wants one derives it from a written
+  `decoder`/`encoder` clause; this declaration writes none.)
+- **Shadowing follows the unit-data rules.** Rounding-mode cases are ordinary unit data; a binding
+  may take a case's name and the local takes precedence. Shadowed cases have no qualified escape
+  syntax — the same is true of every unit data, and this change does not add one.
+- The `java.math.RoundingMode` mapping is one `switch` in `DecimalMath`, on the Decimal runtime
+  rather than on the value: `java.math` is that backend's implementation detail, not part of what
+  a rounding mode is.
+
+## Consequences
+
+The checker's side condition is gone: `requireRoundingMode`, the argument-typing skip, the
+resolution rung, the η-expansion refusal, the built-in-shadow rule for the seven names, and the
+type-name fallback are all deleted, and `Core.Builtin` is deleted from the IR — nothing produced
+it any more. The three operations type against their declared signatures like every other
+function; a wrong argument is an ordinary type mismatch, and an applied case (`HALF_UP(x)`) is the
+ordinary answer for a type written where a call goes.
+
+The two kernels' JVM descriptors derive from the declaration (`Prelude.kernelSignature`, the
+boundary form of each declared type), so the signature exists once. Deriving a descriptor from
+the observed argument types only ever agreed with the declaration while every parameter type was
+invariant; a sum-typed parameter ends that — an argument's type may be the case it happens to be
+while the declaration names the sum — so the descriptor comes from the callee.
+
+`constructs` does not govern a rounding-mode case, stated as the general rule rather than a
+namespace check: the discipline governs what the compilation declares
+(`Symbols.declaredByCompilation`), and a declaration the language gives is vocabulary — as
+`None` is.
+
+The reserved namespace's qualifier list moved to a dependency-free constant (`Reserved`). The
+frontend read it off `Prelude`, whose loading parses prelude sources back through the frontend;
+that cycle was latent while no prelude source declared data, and the first `data` in one closed
+it. A fact of the language now sits where both sides read it without initializing each other.
+
+A mode is evaluated at the call like any argument: bound to a name, chosen by an `if`, computed by
+a helper, or fixed by the function value `Decimal.toInt` evaluates to — each pinned by a test
+through a different one of the three operations.
+
+Generation of runtime implementations from prelude declarations was considered and deferred: with
+one runtime-backed data, a generator is more mechanism than the ABI test it would replace. The
+registration records the classification either way, so a second runtime-backed data is the point
+to revisit, not to re-decide.
+
+## References
+
+- Issue #270; ADR-0086 (a function name is a value — this removes its last exception),
+  ADR-0053 (the declaration is the single source of truth for a signature)
+- Specification: `[#stdlib-decimal]`, `[#stdlib]`, `[#unit-data]`, `[#intrinsics]`

--- a/docs/adr/0087-a-rounding-mode-is-an-ordinary-value-of-a-core-declared-data.md
+++ b/docs/adr/0087-a-rounding-mode-is-an-ordinary-value-of-a-core-declared-data.md
@@ -84,6 +84,24 @@ the observed argument types only ever agreed with the declaration while every pa
 invariant; a sum-typed parameter ends that — an argument's type may be the case it happens to be
 while the declaration names the sum — so the descriptor comes from the callee.
 
+The other 61 kernels that build a descriptor from the call were audited against that invariant and
+none breaks it, but the reason is worth recording because it is not a rule anyone stated: every
+other declared parameter is a primitive or a container, whose boundary form the type settles on
+its own, or a type variable in a slot the emitter erases to `Object` — which is what the
+declaration would have given. So the agreement is a property of the declarations that exist, not
+of the mechanism, and registering a second runtime-backed data and writing it into a kernel's
+parameters reproduces #270 exactly. `KernelDescriptorsComeFromDeclarationsTest` turns that into a
+checked invariant: a kernel reading its descriptor off the call may not declare a parameter whose
+boundary form depends on which value arrives. It was verified to fail by putting `decimal.toInt`
+back on the observed-type emitter.
+
+Generalising the declaration-read descriptor to the rest is a separate design problem, not left
+undone by oversight: an emitter reading the declaration must still answer the call's Souther type,
+and for a polymorphic kernel those are two different sources (the declaration says `List<'a>`, the
+caller needs the element it actually holds). Ten kernels also permute their arguments and nine
+erase a slot and box it, neither of which the declaration states. Until those are separated, a
+mechanical migration would move type variables into places that expect settled types.
+
 `constructs` does not govern a rounding-mode case, stated as the general rule rather than a
 namespace check: the discipline governs what the compilation declares
 (`Symbols.declaredByCompilation`), and a declaration the language gives is vocabulary — as

--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -1,9 +1,12 @@
 package souther.compiler;
 
+import souther.compiler.check.Registry;
 import souther.compiler.check.Resolve;
 import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeChecker;
 import souther.compiler.ast.Ast;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeOps;
 import souther.compiler.frontend.CstFrontend;
 
@@ -13,7 +16,9 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -51,10 +56,9 @@ public final class Prelude {
             Map.entry("souther.decimal", "Decimal"),
             Map.entry("souther.option", "Option"));
 
-    /** Every qualifier a call may carry: the four prelude modules plus the arithmetic built-in
-     *  namespaces {@code Int}/{@code Decimal} (spec §stdlib). */
-    private static final Set<String> QUALIFIERS =
-            Set.of("List", "String", "Map", "Set", "Bool", "Int", "Decimal", "Date", "DateTime", "Option");
+    /** Every qualifier a call may carry — the language's constant ({@link Reserved}), read from
+     *  there so nothing has to initialize this class to know it. */
+    private static final Set<String> QUALIFIERS = Reserved.QUALIFIERS;
 
     /** A declaration's resolved signature: its parameter types, and the success type of its declared
      *  return — or null where the declaration writes no return type and leaves its result to its
@@ -76,6 +80,25 @@ public final class Prelude {
 
     /** Every declaration the library ships, keyed by qualified name ({@code "List.map"}). */
     private static final Map<String, PreludeEntry> ENTRIES = new LinkedHashMap<>();
+
+    /**
+     * The data declarations whose JVM implementation souther-runtime provides by hand rather than
+     * the backend generating. The classification is made once, here: it anchors the declared names
+     * to the runtime namespace ({@code souther.runtime.RoundingMode} is the class shipped there),
+     * answers {@link Symbols}' lookups for them, and — because the declarations belong to no
+     * compiled module — keeps them out of derivation and code generation, which is why such a data
+     * has no codec. A prelude data not registered here is refused at load: nothing would emit its
+     * classes.
+     */
+    private static final Set<String> RUNTIME_BACKED_DATA = Set.of("RoundingMode");
+
+    /** The resolved runtime-backed declarations — the sums and their cases — keyed by bare name. */
+    private static final Map<String, Ast.Def> RUNTIME_DEFS = new LinkedHashMap<>();
+
+    /** Each kernel's declared signature, keyed by its intrinsic key ({@code "decimal.toInt"}) —
+     *  the projection of {@link #ENTRIES} the backend reads to derive a kernel's JVM descriptor
+     *  from the declaration rather than repeating it. */
+    private static final Map<String, Signature> KERNELS = new LinkedHashMap<>();
 
     /** Bare stdlib name → a qualified suggestion, so a bare call gets a "did you mean" hint. The
      *  checker built-ins (which are not in the prelude sources) are listed here explicitly. */
@@ -154,16 +177,26 @@ public final class Prelude {
     }
 
     private static void load() {
-        Symbols noSymbols = Symbols.none();   // prelude signatures use only primitives / 'a
         for (String resource : RESOURCES) {
-            // The prelude is resolved like any other module (issue #177). Its signatures name only
-            // primitives, type variables and Option's cases, so `Symbols.none()` answers them all;
-            // a prelude body naming a data type would be reported here, where it is unanswerable.
-            Ast.Module module = Resolve.module(CstFrontend.parse(read(resource)), noSymbols);
+            // The prelude is resolved like any other module (issue #177): its own declarations are
+            // collected first, then everything is resolved against them, so a signature may name a
+            // data the module declares. What it declares must be runtime-backed (see
+            // RUNTIME_BACKED_DATA), and the names anchor to the runtime namespace where the
+            // implementation classes live.
+            Ast.Module parsed = CstFrontend.parse(read(resource));
+            Symbols symbols = symbolsOf(parsed, resource);
+            Ast.Module module = Resolve.module(parsed, symbols);
             String alias = MODULE_TO_ALIAS.get(module.name());
             if (alias == null) {
                 throw new IllegalStateException("prelude resource " + resource
                         + " declares unknown module " + module.name());
+            }
+            for (Ast.Def def : module.defs()) {
+                if (RUNTIME_DEFS.containsKey(def.name())) {
+                    throw new IllegalStateException(
+                            "the standard library declares `" + def.name() + "` twice");
+                }
+                RUNTIME_DEFS.put(def.name(), def);
             }
             for (Ast.FnDef fn : module.fns()) {
                 String qualified = alias + "." + fn.name();
@@ -175,7 +208,11 @@ public final class Prelude {
                     throw new IllegalStateException(
                             "the standard library declares `" + qualified + "` twice");
                 }
-                ENTRIES.put(qualified, new PreludeEntry(fn, signatureOf(fn, qualified, noSymbols)));
+                Signature signature = signatureOf(fn, qualified, symbols);
+                ENTRIES.put(qualified, new PreludeEntry(fn, signature));
+                if (fn.body() instanceof Ast.FnBody.Intrinsic intrinsic) {
+                    KERNELS.put(intrinsic.key(), signature);
+                }
                 BARE_TO_QUALIFIED.putIfAbsent(fn.name(), qualified);
             }
         }
@@ -218,6 +255,61 @@ public final class Prelude {
         BARE_TO_QUALIFIED.put("subtract", "Int.subtract` or `Decimal.subtract");
         BARE_TO_QUALIFIED.put("multiply", "Int.multiply` or `Decimal.multiply");
         BARE_TO_QUALIFIED.put("divide", "Int.divide` or `Decimal.divide");
+    }
+
+    /**
+     * What names mean while a prelude source is resolved: its own declarations, anchored to the
+     * runtime namespace. Anchoring happens here and nowhere else — every reader below (the scope
+     * fallback, the definition lookup) reads what this wrote. A prelude data outside
+     * {@link #RUNTIME_BACKED_DATA} is refused: its cases would have no implementation classes.
+     * A case of a registered sum is registered with it.
+     */
+    private static Symbols symbolsOf(Ast.Module m, String resource) {
+        Map<String, Ast.Def> declared = TypeChecker.ownDefs(m);
+        if (declared.isEmpty()) {
+            return Symbols.none();   // signatures over primitives and type variables only
+        }
+        Set<String> covered = new LinkedHashSet<>();
+        for (Ast.Def def : declared.values()) {
+            if (def instanceof Ast.SumData sum && RUNTIME_BACKED_DATA.contains(sum.name())) {
+                covered.add(sum.name());
+                for (Ast.Name c : sum.cases()) {
+                    covered.add(c.written());
+                }
+            }
+        }
+        Map<String, TypeName> scope = new HashMap<>();
+        for (String name : declared.keySet()) {
+            if (!covered.contains(name)) {
+                throw new IllegalStateException("prelude resource " + resource + " declares `"
+                        + name + "`, which is not registered as runtime-backed data");
+            }
+            scope.put(name, TypeName.runtime(name));
+        }
+        return Symbols.of(TypeName.RUNTIME,
+                Registry.of(Map.of(TypeName.RUNTIME, m)), scope, Map.of());
+    }
+
+    /** The runtime-backed declaration {@code name} denotes, or null when there is none. */
+    public static Ast.Def runtimeBackedDef(TypeName name) {
+        return TypeName.RUNTIME.equals(name.module()) ? RUNTIME_DEFS.get(name.name()) : null;
+    }
+
+    /** The runtime-namespace name a bare {@code written} denotes, or null when it denotes none.
+     *  The lowest rung of a module's scope: its own declarations and its imports come first. */
+    public static TypeName runtimeBackedType(String written) {
+        return RUNTIME_DEFS.containsKey(written) ? TypeName.runtime(written) : null;
+    }
+
+    /** Every runtime-backed declaration, keyed by bare name — what the runtime namespace declares. */
+    public static Map<String, Ast.Def> runtimeBackedDefs() {
+        return Collections.unmodifiableMap(RUNTIME_DEFS);
+    }
+
+    /** The declared signature of the kernel behind {@code intrinsic "key"}, or null where no core
+     *  declaration writes that key. */
+    public static Signature kernelSignature(String key) {
+        return KERNELS.get(key);
     }
 
     /** The resolved signature of {@code fn}. A zero-parameter declaration is a value whose type

--- a/souther-compiler/src/main/java/souther/compiler/Reserved.java
+++ b/souther-compiler/src/main/java/souther/compiler/Reserved.java
@@ -1,0 +1,20 @@
+package souther.compiler;
+
+import java.util.Set;
+
+/**
+ * The reserved standard-library namespace (ADR-0028, spec §stdlib): the qualifiers a call or an
+ * import may write. A fact of the language, not of the loaded library — held with no dependencies
+ * so the frontend and the prelude both read it without one initializing the other. {@link Prelude}
+ * loads the modules behind these names and parses them through the frontend, so a constant of the
+ * language that lived on either side would put the two in an initialization cycle.
+ */
+public final class Reserved {
+
+    private Reserved() {}
+
+    /** Every qualifier a call may carry: the prelude modules plus the arithmetic built-in
+     *  namespaces {@code Int}/{@code Decimal} (spec §stdlib). */
+    public static final Set<String> QUALIFIERS =
+            Set.of("List", "String", "Map", "Set", "Bool", "Int", "Decimal", "Date", "DateTime", "Option");
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -67,11 +67,6 @@ public final class CallElaborator {
                         + element + " — use its ordered field instead (e.g. map to it first)");
     }
 
-    /** Whether a declared parameter takes a rounding mode rather than a value. */
-    private static boolean isRoundingMode(Type t) {
-        return t instanceof Type.Ref r && r.name().equals(TypeOps.ROUNDING_MODE);
-    }
-
     /**
      * Refuses a sort key with no natural order. The constraint is on what the key answers, not on
      * what the list holds, so it reads the binding the key's declared result took rather than the
@@ -198,15 +193,6 @@ public final class CallElaborator {
             cores[i] = c;
         }
 
-        /** Records argument {@code i} as carrying no type: it is not an expression at all, but a
-         * built-in identifier the call reads by name — the rounding mode of {@code divide}
-         * (spec 18.3), which {@code requireRoundingMode} has already checked is one. The emitter
-         * reads its name and never asks for its type. */
-        void untyped(int i) {
-            Ast.Var name = (Ast.Var) args.get(i);
-            cores[i] = new Core.Builtin(name.name(), name.pos());
-        }
-
         /** The elaborated arguments. Every argument must have been reached: a rule that yields a type
          * without touching one of its arguments would leave the emitter a node with no type. */
         List<Core> cores() {
@@ -270,9 +256,8 @@ public final class CallElaborator {
                             + " arguments");
             case ValueName.Helper _ -> unelaborated("a helper", call);
             case ValueName.Stdlib _ -> unelaborated("a standard-library function", call);
-            // A name the language itself gives, applied. `Some`/`None` are told apart earlier (E1303),
-            // so this is a rounding mode: a bare identifier the operation taking it reads, and not a
-            // function. Reachable from the moment one ladder answers a name wherever it is written.
+            // A name the language itself gives (`None`), applied. `Some`/`None` applications are
+            // told apart earlier (E1303), so reaching here is a value position no rewrite covers.
             case ValueName.Builtin b -> CompileException.of(
                     Diagnostic.of(null, "check.builtin.notfunction")
                             .title("check.apply.notfunction.title")
@@ -319,11 +304,7 @@ public final class CallElaborator {
      *       bound from the context before the step is checked (issue #70). With no function
      *       argument nothing waits, and pinning anyway would answer an argument mismatch against
      *       the type the context wanted rather than the one the declaration asks for;</li>
-     *   <li>type the value arguments and unify each with its declared parameter. A parameter typed
-     *       {@code RoundingMode} is not an expression but a name the operation reads, so it is
-     *       checked as one and recorded untyped ([#stdlib-decimal]); no function type in scope can
-     *       carry that parameter, since the type is writable only by the library's own
-     *       signatures;</li>
+     *   <li>type the value arguments and unify each with its declared parameter;</li>
      *   <li>type the function arguments last, against parameter types the earlier arguments
      *       settled. A failure that is genuinely an empty-collection seed nothing typed — one that
      *       reported the unresolved bottom — is re-pointed at the seed rather than at the
@@ -354,11 +335,6 @@ public final class CallElaborator {
             if (param instanceof Type.FnOf) {
                 continue;
             }
-            if (isRoundingMode(param)) {
-                requireRoundingMode(call.written(), args.get(i));
-                ca.untyped(i);
-                continue;
-            }
             TypeOps.unify(param, ca.type(i), bind, ctx.symbols(),
                     call.pos(), "argument " + (i + 1) + " of " + call.written());
         }
@@ -386,7 +362,7 @@ public final class CallElaborator {
         }
         for (int i = 0; i < args.size(); i++) {
             Type param = signature.params().get(i);
-            if (!(param instanceof Type.FnOf) && !isRoundingMode(param)) {
+            if (!(param instanceof Type.FnOf)) {
                 ca.requireTyped(i, TypeOps.substitute(param, bind),
                         "argument " + (i + 1) + " of " + call.written());
             }
@@ -524,18 +500,6 @@ public final class CallElaborator {
             return ConstEval.eval(nd.inits().get(0).value());
         }
         return Optional.empty();
-    }
-
-    /** A rounding mode is one of the built-in identifiers, written bare — not an ordinary
-     * expression ([#stdlib-decimal]). {@code of} is the operation taking it. */
-    static void requireRoundingMode(String of, Ast.Expr e) {
-        if (!(e instanceof Ast.Var v) || !Elaborator.ROUNDING_MODES.contains(v.name())) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.divide.rounding").title("check.type.mismatch.title")
-                            .at(e.pos()).args(of).build(),
-                    "the rounding mode of `" + of + "` must be one of HALF_UP, HALF_EVEN, HALF_DOWN,"
-                            + " UP, DOWN, CEILING, FLOOR ([#stdlib-decimal])");
-        }
     }
 
     /** The pattern of {@code String.matches} must evaluate to a string at compile time, so it is

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -234,7 +234,10 @@ public final class DataChecker {
             // unit data spelled like the one another module's published body builds was recording
             // its own type as the one built. Carried or not is asked of the name for the same reason
             // it is asked of a construction node — it is the same question about the same thing.
+            // `constructs` governs what this compilation declares; a unit the language gives
+            // (`HALF_UP`) is vocabulary, not business data — as `None` is.
             case Ast.Var v when v.denotes() instanceof ValueName.OfType named
+                    && symbols.declaredByCompilation(named.type())
                     && symbols.get(named.type()) instanceof Ast.UnitData -> {
                 Map<TypeName, String> side = named.origin().carried(named.type())
                         ? out.carried() : out.originated();

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -878,20 +878,11 @@ public final class Elaborator {
         };
     }
 
-    /** The built-in rounding modes (spec 18.3), each a bare identifier resolving to a
-     * {@code java.math.RoundingMode} — like {@code None}, a built-in value, not a data (spec 8.4). */
-    public static final Set<String> ROUNDING_MODES = Set.of(
-            "HALF_UP", "HALF_EVEN", "HALF_DOWN", "UP", "DOWN", "CEILING", "FLOOR");
-
-    /** Built-in values written as bare identifiers ({@code None}, the rounding modes): a binding may
-     * not take one of these names, because it would shadow the built-in and make it unreachable. */
-    static final Set<String> BUILTIN_VALUES = builtinValues();
-
-    static Set<String> builtinValues() {
-        Set<String> s = new HashSet<>(ROUNDING_MODES);
-        s.add("None");
-        return Set.copyOf(s);
-    }
+    /** Built-in values written as bare identifiers ({@code None}): a binding may not take one of
+     * these names, because it would shadow the built-in and make it unreachable. A unit data name
+     * — a rounding mode included — is ordinary and may be bound, the local taking precedence
+     * ([#unit-data]). */
+    static final Set<String> BUILTIN_VALUES = Set.of("None");
 
     static void rejectBuiltinShadow(String name, SourcePos pos) {
         if (BUILTIN_VALUES.contains(name)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1305,18 +1305,6 @@ public final class HelperInliner {
         if (arity <= 0) {
             return v;   // a value, or a name the library does not declare — reported where it is used
         }
-        // A rounding mode is written at the call and read by name, so a block standing in for one of
-        // these would have to pass a binding where a name has to be. Said here rather than left to
-        // the arity mismatch the expansion would otherwise cause.
-        if (takesARoundingMode(declared)) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.stdlib.roundingmode.byname")
-                            .title("check.apply.notfunction.title")
-                            .at(v.pos(), v.name().length()).args(lib.qualified()).build(),
-                    "`" + lib.qualified() + "` takes a rounding mode, which is written at the call"
-                            + " and not passed as a value, so it cannot be handed over by name —"
-                            + " wrap it in a block that writes the mode");
-        }
         int k = counter++;
         List<Ast.Binder> params = new ArrayList<>();
         List<Ast.Expr> args = new ArrayList<>();
@@ -1328,18 +1316,6 @@ public final class HelperInliner {
         return inline(new Ast.Block(params,
                 new Ast.Apply(v.name(), v.denotes(), args, ConstructionOrigin.own(), v.pos()),
                 v.pos()));
-    }
-
-    /** Whether a declaration takes a rounding mode — a name the operation reads, not a value. */
-    private static boolean takesARoundingMode(Ast.FnDef declared) {
-        for (Ast.FnParam p : declared.params()) {
-            if (p.type() != null && p.type().cases().size() == 1
-                    && p.type().cases().get(0) instanceof Ast.TypeRef ref
-                    && ref.name().equals(TypeOps.ROUNDING_MODE.name())) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -662,10 +662,8 @@ public final class Resolve {
         if (binding != null) {
             return binding;
         }
-        // names the language itself gives: Option's two cases, and the rounding modes an operation
-        // taking one reads rather than evaluates
-        if (Elaborator.ROUNDING_MODES.contains(written) || written.equals("None")
-                || written.equals("Some")) {
+        // names the language itself gives: Option's two cases
+        if (written.equals("None") || written.equals("Some")) {
             return new ValueName.Builtin(written);
         }
         // A library qualifier makes this a library reference — `Date(...)`, whose namespace is the

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.types.TypeName;
 
@@ -86,13 +87,24 @@ public final class Symbols {
         return new TypeName(module, name);
     }
 
-    /** The definition of {@code name}, or null when no module declares it. */
+    /** The definition of {@code name}, or null when no module declares it. The runtime namespace
+     * declares the prelude's runtime-backed data ({@code RoundingMode}), which no module of the
+     * compilation holds, so it is answered from the prelude's registration. */
     public Ast.Def get(TypeName name) {
-        return registry.declaration(name);
+        Ast.Def def = registry.declaration(name);
+        return def != null ? def : Prelude.runtimeBackedDef(name);
     }
 
     public boolean contains(TypeName name) {
         return get(name) != null;
+    }
+
+    /** Whether {@code name} is declared by a module of this compilation — as opposed to a
+     * declaration the language gives (the prelude's runtime-backed data), which resolves and types
+     * like any other but belongs to no module here. The construction discipline asks this: what a
+     * compilation declares is governed by {@code constructs}; the language's vocabulary is not. */
+    public boolean declaredByCompilation(TypeName name) {
+        return registry.declaration(name) != null;
     }
 
     /** The definition the written name {@code written} denotes here, or null when nothing does. The
@@ -132,7 +144,10 @@ public final class Symbols {
     public TypeName resolve(String written) {
         int dot = written.lastIndexOf('.');
         if (dot < 0) {
-            return scope.get(written);
+            TypeName name = scope.get(written);
+            // The prelude's runtime-backed data is nameable everywhere, on the lowest rung: a
+            // module's own declaration or import of the same name is what the name means there.
+            return name != null ? name : Prelude.runtimeBackedType(written);
         }
         String target = moduleOfQualifier(written.substring(0, dot));
         if (target == null) {
@@ -187,8 +202,12 @@ public final class Symbols {
         return new LinkedHashSet<>(scope.values());
     }
 
-    /** Every definition of one module, keyed by the name written there. */
+    /** Every definition of one module, keyed by the name written there. The runtime namespace
+     * answers with the prelude's runtime-backed data. */
     public Map<String, Ast.Def> declaredIn(String moduleName) {
+        if (TypeName.RUNTIME.equals(moduleName)) {
+            return Prelude.runtimeBackedDefs();
+        }
         return registry.declaredIn(moduleName);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -28,10 +28,6 @@ import java.util.function.Function;
  */
 public final class TypeOps {
 
-    /** The type of a rounding mode. Declared by no module: the modes are names the language gives
-     *  ([#stdlib-decimal]), and this is what a core declaration writes to take one. */
-    public static final TypeName ROUNDING_MODE = TypeName.runtime("RoundingMode");
-
     private TypeOps() {}
 
     /** Resolves a written type. Kept for the readers that name a parameter's type as such. */
@@ -1270,11 +1266,6 @@ public final class TypeOps {
                 TypeName asCase = symbols.resolveCase(ref.name());
                 if (asCase != null && !asCase.isUnresolved()) {
                     yield Type.ref(asCase);
-                }
-                // A rounding mode is a name the language gives, and the operations taking one are
-                // core declarations, so their parameter type has to be nameable there.
-                if (ref.name().equals(ROUNDING_MODE.name())) {
-                    yield Type.ref(ROUNDING_MODE);
                 }
                 throw unknownType(ref, symbols);
             }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -615,9 +615,6 @@ final class BodyGen {
                 // helper names that module's unit, which this module need not declare at all — and,
                 // if it declares one spelled the same, is not the same unit.
                 case Core.UnitValue u -> loadSharedInstance(code, cd(u.data()));
-                case Core.Builtin b -> throw new IllegalStateException(
-                        "`" + b.name() + "` is read by the operation that takes it, not emitted, at "
-                                + b.pos());
                 case Core.Neg n -> {
                     if (genExpr(n.operand()) == Type.DECIMAL) {
                         code.invokevirtual(CD_BigDecimal, "negate", MethodTypeDesc.of(CD_BigDecimal));
@@ -1072,12 +1069,6 @@ final class BodyGen {
             emitFunctionValue(value, paramTypes);
         }
 
-        /** Puts the JDK rounding constant a mode names on the stack. The mode is read by name, not
-         * evaluated; see {@link Intrinsics.TakesARoundingMode}. */
-        void emitRoundingMode(Core arg) {
-            code.getstatic(CD_RoundingMode, ((Core.Builtin) arg).name(), CD_RoundingMode);
-        }
-
         /** Narrows an {@code Int} (a {@code long}) to a JVM {@code int}, for a JDK method taking an
          * {@code int} index. */
         void emitL2i() {
@@ -1421,7 +1412,7 @@ final class BodyGen {
         }
 
         /** {@code divide(a, b, scale, mode)} on Decimal: a zero divisor takes the DivisionByZero
-         * case, otherwise {@code a.divide(b, scale, RoundingMode.mode)} (spec 18.3). */
+         * case, otherwise {@code a.divide(b, scale, toJava(mode))} (spec 18.3). */
         private void decimalDivide(Core.Call call) {
             genExpr(call.args().get(0));
             int aSlot = slot(Type.DECIMAL);
@@ -1438,8 +1429,8 @@ final class BodyGen {
             code.aload(bSlot);
             genExpr(call.args().get(2));              // scale (Int, a long)
             code.l2i();
-            String mode = ((Core.Builtin) call.args().get(3)).name();
-            code.getstatic(CD_RoundingMode, mode, CD_RoundingMode);
+            genExpr(call.args().get(3));              // mode, an ordinary value
+            code.invokestatic(CD_DecimalMath, "toJava", MTD_toJavaRoundingMode);
             code.invokevirtual(CD_BigDecimal, "divide", MTD_bdDivide);
             code.goto_(end);
             code.labelBinding(zero);
@@ -1931,9 +1922,8 @@ final class BodyGen {
                 case Core.Str _ -> { }
                 case Core.Bool _ -> { }
                 case Core.Unreachable _ -> { }
-                // neither reads anything the enclosing body binds
+                // reads nothing the enclosing body binds
                 case Core.UnitValue _ -> { }
-                case Core.Builtin _ -> { }
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
@@ -136,10 +136,15 @@ final class Descriptors {
     /** {@code DecimalMath.divide(BigDecimal, BigDecimal) -> BigDecimal}: the Decimal `/` operator. */
     static final MethodTypeDesc MTD_bdDivideOp =
             MethodTypeDesc.of(CD_BigDecimal, CD_BigDecimal, CD_BigDecimal);
-    static final ClassDesc CD_RoundingMode = ClassDesc.of("java.math.RoundingMode");
+    /** The Souther value ([#stdlib-decimal]); the runtime maps it to {@code java.math.RoundingMode}. */
+    static final ClassDesc CD_RoundingMode = ClassDesc.of("souther.runtime.RoundingMode");
+    static final ClassDesc CD_JavaRoundingMode = ClassDesc.of("java.math.RoundingMode");
+    /** {@code DecimalMath.toJava(RoundingMode)}: the Java constant a mode value denotes. */
+    static final MethodTypeDesc MTD_toJavaRoundingMode =
+            MethodTypeDesc.of(CD_JavaRoundingMode, CD_RoundingMode);
     /** {@code BigDecimal.divide(BigDecimal, int, RoundingMode)} (spec 18.3). */
     static final MethodTypeDesc MTD_bdDivide =
-            MethodTypeDesc.of(CD_BigDecimal, CD_BigDecimal, ConstantDescs.CD_int, CD_RoundingMode);
+            MethodTypeDesc.of(CD_BigDecimal, CD_BigDecimal, ConstantDescs.CD_int, CD_JavaRoundingMode);
     static final ClassDesc CD_LocalDate = ClassDesc.of("java.time.LocalDate");
     static final ClassDesc CD_LocalDateTime = ClassDesc.of("java.time.LocalDateTime");
     static final ClassDesc CD_Lists = ClassDesc.of("souther.runtime.Lists");

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
@@ -220,6 +220,11 @@ final class Intrinsics {
         return TABLE.keySet();
     }
 
+    /** How each key is emitted — read by the test that holds the descriptor invariant. */
+    static Map<String, Emit> emitters() {
+        return Map.copyOf(TABLE);
+    }
+
     private static int[] order(int... a) {
         return a;
     }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
@@ -1,7 +1,9 @@
 package souther.compiler.codegen;
 
+import souther.compiler.Prelude;
 import souther.compiler.diag.CompileException;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 import souther.compiler.core.Core;
 
 import java.lang.constant.ClassDesc;
@@ -43,42 +45,35 @@ final class Intrinsics {
         if (e == null) {
             throw new CompileException(call.pos(), "unknown intrinsic `" + key + "`");
         }
-        return e.emit(g, call);
+        return e.emit(g, key, call);
     }
 
     sealed interface Emit permits RuntimeStatic, JdkVirtual, NumericFold, TakesAFunction,
-            TakesARoundingMode {
-        Type emit(BodyGen g, Core.Call call);
+            DeclaredStatic {
+        Type emit(BodyGen g, String key, Core.Call call);
     }
 
     /**
-     * A kernel taking a rounding mode. The mode is a name the language gives, read by the operation
-     * that takes it rather than evaluated, so it is emitted as the JDK constant it names rather than
-     * as an expression ([#stdlib-decimal]).
-     *
-     * <p>{@code l2iArgs} narrows an argument from Souther's Int to a JVM {@code int}; {@code owner}
-     * and {@code virtual} say whether the kernel is a static or a method on the value.
+     * An {@code invokestatic} whose descriptor comes from the kernel's core declaration: each
+     * parameter is the boundary form of the declared parameter type, the return the boundary form
+     * of the declared result. A descriptor belongs to the callee — deriving one from the observed
+     * argument types only ever agreed with it while every parameter type was invariant, and a
+     * sum-typed parameter ({@code RoundingMode}) ends that: the argument's type may be the case it
+     * happens to be, while the declaration names the sum.
      */
-    record TakesARoundingMode(ClassDesc owner, String method, boolean virtual, int mode,
-                              Set<Integer> l2iArgs, ClassDesc[] params, Type result) implements Emit {
-        public Type emit(BodyGen g, Core.Call call) {
-            for (int i = 0; i < call.args().size(); i++) {
-                if (i == mode) {
-                    g.emitRoundingMode(call.args().get(i));
-                    continue;
-                }
-                g.genExpr(call.args().get(i));
-                if (l2iArgs.contains(i)) {
-                    g.emitL2i();
-                }
+    record DeclaredStatic(ClassDesc owner, String method) implements Emit {
+        public Type emit(BodyGen g, String key, Core.Call call) {
+            Prelude.Signature declared = Prelude.kernelSignature(key);
+            ClassDesc[] params = new ClassDesc[declared.params().size()];
+            for (int i = 0; i < params.length; i++) {
+                params[i] = boundaryDesc(declared.params().get(i));
             }
-            MethodTypeDesc desc = MethodTypeDesc.of(boundaryDesc(result), params);
-            if (virtual) {
-                g.emitInvokeVirtual(owner, method, desc);
-            } else {
-                g.emitInvokeStatic(owner, method, desc);
+            for (Core arg : call.args()) {
+                g.genExpr(arg);
             }
-            return result;
+            g.emitInvokeStatic(owner, method,
+                    MethodTypeDesc.of(boundaryDesc(declared.result()), params));
+            return declared.result();
         }
     }
 
@@ -94,7 +89,7 @@ final class Intrinsics {
     record TakesAFunction(ClassDesc owner, String method, int container,
                           Function<Type, List<Type>> paramTypes,
                           Function<List<Type>, Type> result) implements Emit {
-        public Type emit(BodyGen g, Core.Call call) {
+        public Type emit(BodyGen g, String key, Core.Call call) {
             Type held = call.args().get(container).type();
             g.emitFn(call.args().get(0), paramTypes.apply(held));
             g.genExpr(call.args().get(container));
@@ -115,7 +110,7 @@ final class Intrinsics {
      */
     record RuntimeStatic(ClassDesc owner, String method, int[] argOrder,
                          Set<Integer> objectSlots, Function<List<Type>, Type> result) implements Emit {
-        public Type emit(BodyGen g, Core.Call call) {
+        public Type emit(BodyGen g, String key, Core.Call call) {
             int n = argOrder.length;
             Type[] byArg = new Type[n];
             ClassDesc[] params = new ClassDesc[n];
@@ -142,7 +137,7 @@ final class Intrinsics {
      */
     record JdkVirtual(ClassDesc owner, String method, MethodTypeDesc desc, int[] argOrder,
                       Set<Integer> l2iArgs, Type result) implements Emit {
-        public Type emit(BodyGen g, Core.Call call) {
+        public Type emit(BodyGen g, String key, Core.Call call) {
             for (int src : argOrder) {
                 g.genExpr(call.args().get(src));
                 if (l2iArgs.contains(src)) {
@@ -162,7 +157,7 @@ final class Intrinsics {
      * position the call was written in.
      */
     record NumericFold(String intMethod, String decimalMethod) implements Emit {
-        public Type emit(BodyGen g, Core.Call call) {
+        public Type emit(BodyGen g, String key, Core.Call call) {
             Type result = call.type();
             if (result != Type.INT && result != Type.DECIMAL) {
                 // the checker admits these two and nothing else; anything here is this compiler
@@ -206,6 +201,11 @@ final class Intrinsics {
         // declares it, so the descriptor has to name it or the call finds no such method.
         if (t instanceof Type.OptionOf) {
             return CD_Option;
+        }
+        // So is a name of the runtime namespace ({@code RoundingMode}): it is the real package of
+        // the classes souther-runtime ships (see TypeName.RUNTIME), so a kernel taking one names it.
+        if (t instanceof Type.Ref r && TypeName.RUNTIME.equals(r.name().module())) {
+            return ClassDesc.of(r.name().qualified());
         }
         return CD_Object;   // Ref, Var, Tuple, Union, Nothing
     }
@@ -284,11 +284,10 @@ final class Intrinsics {
         t.put("string.padRight", rt(CD_Strings, "padRight", order(2, 0, 1), ts -> Type.STRING));
         t.put("string.fromDecimal", rt(CD_Strings, "fromDecimal", order(0), ts -> Type.STRING));
 
+        t.put("decimal.toInt", new DeclaredStatic(CD_DecimalMath, "toInt"));
+        t.put("decimal.round", new DeclaredStatic(CD_DecimalMath, "round"));
+
         // List
-        t.put("decimal.toInt", new TakesARoundingMode(CD_DecimalMath, "toInt", false, 1,
-                Set.of(), new ClassDesc[] {CD_BigDecimal, CD_RoundingMode}, Type.INT));
-        t.put("decimal.round", new TakesARoundingMode(CD_BigDecimal, "setScale", true, 2,
-                Set.of(1), new ClassDesc[] {ConstantDescs.CD_int, CD_RoundingMode}, Type.DECIMAL));
         t.put("list.sortBy", new TakesAFunction(CD_Lists, "sortBy", 1,
                 held -> List.of(((Type.ListOf) held).element()),
                 ts -> ts.get(1)));

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -22,13 +22,12 @@ import java.util.Optional;
  * <p>Every node carries {@link #type()}: the type the checker decided for it (issue #81). The
  * checker is the only producer of Core — it builds the tree as it types a body
  * ({@code Elaborator.elaborate}) — so the backend reads those decisions instead of inferring the
- * same types a second time. The one node with no type is {@link Builtin}, a name the language gives
- * a meaning that the emitter reads rather than evaluates (spec 18.3).
+ * same types a second time.
  *
- * <p>A name in a body is one of three nodes, not one: a read of something the body binds, a unit
- * data written as its own value, and a name the language defines. They were one, and the emitter
- * told them apart by looking the spelling up in its slots and falling back when it found nothing —
- * which is an answer about a name, decided by its text.
+ * <p>A name in a body is one of two nodes, not one: a read of something the body binds, and a unit
+ * data written as its own value. They were one, and the emitter told them apart by looking the
+ * spelling up in its slots and falling back when it found nothing — which is an answer about a
+ * name, decided by its text.
  *
  * <p>A surface-only node (a list comprehension) never appears — the Lower stage has already
  * rewritten it.
@@ -37,8 +36,7 @@ public sealed interface Core {
 
     SourcePos pos();
 
-    /** The type the checker decided for this expression (null only on a built-in identifier
-     * the emitter reads by name — see the class comment). */
+    /** The type the checker decided for this expression. */
     Type type();
 
     record Int(long value, Type type, SourcePos pos) implements Core {}
@@ -57,16 +55,6 @@ public sealed interface Core {
     /** A unit data written where a value goes: the type has one value, and naming it is that value
      * (spec §unit-data). Which unit is on the node, so nothing resolves a spelling again. */
     record UnitValue(TypeName data, Type type, SourcePos pos) implements Core {}
-
-    /** A name the language gives a meaning, which the emitter reads rather than evaluates: the
-     * rounding mode of {@code divide} (spec 18.3). It is not a value, so it has no type. */
-    record Builtin(String name, SourcePos pos) implements Core {
-
-        @Override
-        public Type type() {
-            return null;
-        }
-    }
 
     record Neg(Core operand, Type type, SourcePos pos) implements Core {}
 
@@ -193,7 +181,6 @@ public sealed interface Core {
             case Bool x -> x;
             case Read x -> x;
             case UnitValue x -> x;
-            case Builtin x -> x;
             case OptionNone x -> x;
             case Unreachable x -> x;
             case Neg n -> new Neg(f.apply(n.operand()), n.type(), n.pos());

--- a/souther-compiler/src/main/java/souther/compiler/frontend/ImplicitUnits.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/ImplicitUnits.java
@@ -1,6 +1,6 @@
 package souther.compiler.frontend;
 
-import souther.compiler.Prelude;
+import souther.compiler.Reserved;
 import souther.compiler.ast.Ast;
 import souther.compiler.diag.SourcePos;
 
@@ -33,17 +33,20 @@ public final class ImplicitUnits {
     }
 
     /** Names that mean something without a declaration: the primitives and library namespaces, the
-     * runtime's arithmetic failure cases, and Option's two cases (which a module may not declare). */
+     * runtime's arithmetic failure cases, and Option's two cases (which a module may not declare).
+     * The namespaces come from {@link Reserved} — the language's constant — rather than from
+     * {@code Prelude}, whose loading parses sources back through {@link #expand} and so must not
+     * be what this class initializes against. */
     private static final Set<String> BUILT_IN = builtIn();
 
     private static Set<String> builtIn() {
-        Set<String> names = new HashSet<>(Prelude.qualifiers());
+        Set<String> names = new HashSet<>(Reserved.QUALIFIERS);
         names.add("Raw");
         names.add("DivisionByZero");
         names.add("NotANumber");
         names.add("Some");
         names.add("None");
-        return names;
+        return Set.copyOf(names);
     }
 
     /** {@code module} with a unit data added for each name it introduces and does not declare. */

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -148,7 +148,6 @@ check.construct.position=`{0}` is a type, so `{0}(...)` constructs one, and a co
 check.apply.notfunction.title=NOT A FUNCTION
 check.apply.notfunction=`{0}` is not a function here, so it cannot be applied to arguments.
 check.stdlib.value.hint=Write `{0}` on its own.
-check.stdlib.roundingmode.byname=`{0}` takes a rounding mode, which is written at the call rather than passed as a value, so it cannot be handed over by name. Wrap it in a block that writes the mode.
 check.builtin.notfunction=`{0}` is a name the language gives, not a function, so it cannot be applied to arguments.
 check.stdlib.qualified.msg=`{0}` is a standard-library function and must be called qualified, as `{1}`.
 
@@ -317,7 +316,6 @@ check.pipe.boundary=decode/encode are boundary edges, not pipeline stages; `>->`
 check.pipe.selfcompose=Pipeline `{0}` composes with itself (a cycle).
 check.reserved.title=RESERVED NAME
 check.builtin.shadow=`{0}` is a built-in value and cannot be used as a binding name — it would shadow the built-in; choose another name.
-check.divide.rounding=The rounding mode of `{0}` must be one of HALF_UP, HALF_EVEN, HALF_DOWN, UP, DOWN, CEILING, FLOOR.
 check.matches.constant=The pattern of `String.matches` must evaluate to a string at compile time, so it can be validated there: write a string literal, or join literals and values named by a top-level `let` with `++`.
 check.matches.regex=`String.matches` pattern is not a valid regular expression: {0}
 check.union.members=`{0}` cannot be a union member: a member is a type a `match` arm can name — one of the primitives, or a data type declared here or imported.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -147,7 +147,6 @@ check.construct.position=`{0}` は型なので `{0}(...)` はその構築です�
 check.apply.notfunction.title=関数ではありません
 check.apply.notfunction=`{0}` はここでは関数ではないので、引数に適用できません。
 check.stdlib.value.hint=`{0}` とだけ書いてください。
-check.stdlib.roundingmode.byname=`{0}` は丸めモードを取ります。モードは値として渡すのではなく呼び出し位置に書くものなので、名前のまま渡すことはできません。モードを書くブロックで包んでください。
 check.builtin.notfunction=`{0}` は言語が与える名前であって関数ではないので、引数に適用できません。
 check.stdlib.qualified.msg=`{0}` は標準ライブラリの関数です。`{1}` のように修飾して呼んでください。
 
@@ -316,7 +315,6 @@ check.pipe.boundary=decode/encode は境界の縁であり、パイプライン�
 check.pipe.selfcompose=パイプライン `{0}` が自分自身と合成しています（循環）。
 check.reserved.title=予約された名前
 check.builtin.shadow=`{0}` は組み込みの値なので束縛名に使えません。組み込みを隠してしまいます。別の名前を選んでください。
-check.divide.rounding=`{0}` の丸めモードは HALF_UP, HALF_EVEN, HALF_DOWN, UP, DOWN, CEILING, FLOOR のいずれかでなければなりません。
 check.matches.constant=`String.matches` のパターンはコンパイル時に文字列として評価できなければなりません。そこで検証するためです。文字列リテラルを書くか、リテラルとトップレベルの `let` で名付けた値を `++` でつないでください。
 check.matches.regex=`String.matches` のパターンが正規表現として不正です: {0}
 check.union.members=`{0}` は直和のメンバーになれません。メンバーになれるのは `match` の腕が名前で指せる型 —— プリミティブか、このモジュールで宣言したか import した data 型です。

--- a/souther-compiler/src/main/resources/souther/decimal.sou
+++ b/souther-compiler/src/main/resources/souther/decimal.sou
@@ -7,6 +7,12 @@
 // implementation-location policy.
 module souther.decimal
 
+// An ordinary data: a mode is evaluated at the call like any other argument. The implementation is
+// runtime-provided (souther.runtime.RoundingMode) rather than generated — see Prelude's
+// runtime-backed registration. It has no codec: a rounding policy is a computation's input, not a
+// value that crosses a serialization boundary.
+data RoundingMode = HALF_UP | HALF_EVEN | HALF_DOWN | UP | DOWN | CEILING | FLOOR
+
 let divide (a: Decimal, b: Decimal, scale: Int, mode: RoundingMode) : Decimal | DivisionByZero
     = intrinsic "decimal.divide"
 let toInt (d: Decimal, mode: RoundingMode) : Int = intrinsic "decimal.toInt"
@@ -20,9 +26,8 @@ let multiply (a: Decimal, b: Decimal) : Decimal = intrinsic "decimal.multiply"
 let compare (a: Decimal, b: Decimal) : Int = intrinsic "decimal.compare"
 
 // `fromInt` widens an Int to a Decimal. It is exact — every Int is a Decimal — so nothing has to be
-// stated and it is an ordinary function. The narrowing back, `Decimal.toInt(d, mode)`, is not: it
-// drops a fraction, and by which rule is a domain decision, so the mode is written at the call and
-// the function stays compiler-integrated (like `divide`, whose mode is a bare built-in identifier).
+// stated and it is an ordinary function. The narrowing back, `Decimal.toInt(d, mode)`, drops a
+// fraction, and by which rule is a domain decision, so it takes the mode as an argument.
 //
 // There is no implicit widening. An arithmetic operator takes two operands of one type, so a rate
 // applied to an amount is written `Decimal.fromInt(税抜) * 税率` — the conversion is visible where the

--- a/souther-compiler/src/test/java/souther/compiler/CompileDecimalDivideTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDecimalDivideTest.java
@@ -105,8 +105,8 @@ class CompileDecimalDivideTest {
         assertThrows(CompileException.class, () -> Compiler.compile(src));
     }
 
-    /** A mode is a name the language gives, read by the operation that takes it. Applied, it is told
-     * what it is rather than shown a compiler bug. */
+    /** A mode is a unit data, so applying one to arguments is the ordinary answer for a type
+     * written where a call goes: naming it constructs it, and a construction is not a function. */
     @Test
     void aRoundingModeAppliedToArgumentsIsToldItIsNotAFunction() {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
@@ -116,6 +116,6 @@ class CompileDecimalDivideTest {
                 behavior go : (i: In) -> Out constructs Out
                 let go (i) = Out { n = HALF_UP(i.n) }
                 """));
-        assertEquals("check.builtin.notfunction", e.diagnostic().messageKey());
+        assertEquals("check.construct.position", e.diagnostic().messageKey());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileHigherOrderIntrinsicTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHigherOrderIntrinsicTest.java
@@ -186,11 +186,11 @@ class CompileHigherOrderIntrinsicTest {
     }
 
     /**
-     * A rounding mode is a name the language gives, read by the operation that takes it. A core
-     * declaration says so in its parameter type, and the report names the operation asking.
+     * A rounding mode is an ordinary value of the {@code RoundingMode} data, so an argument of
+     * another type is an ordinary type mismatch naming the operation and the type it asks for.
      */
     @Test
-    void aRoundingModeParameterTakesTheNameAndNotAnExpression() {
+    void aRoundingModeParameterIsTypedLikeAnyOther() {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
                 module demo
 
@@ -202,6 +202,6 @@ class CompileHigherOrderIntrinsicTest {
                 let run (i) = Out { n = Decimal.toInt(i.d, i.d) }
                 """));
         assertTrue(e.getMessage().contains("Decimal.toInt"), e.getMessage());
-        assertTrue(e.getMessage().contains("HALF_UP"), e.getMessage());
+        assertTrue(e.getMessage().contains("RoundingMode"), e.getMessage());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileLibraryFunctionByNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLibraryFunctionByNameTest.java
@@ -111,12 +111,12 @@ class CompileLibraryFunctionByNameTest {
     }
 
     /**
-     * A rounding mode is written at the call and read by name, so a block standing in for one of
-     * these would have to pass a binding where a name has to be. Told for that reason rather than
-     * as the argument-count mismatch the expansion would otherwise cause.
+     * An operation taking a rounding mode is an ordinary function, so handing it over expands like
+     * any other name — and a two-parameter function where {@code List.map} wants one is the
+     * ordinary arity mismatch, not a rule about the mode.
      */
     @Test
-    void anOperationTakingARoundingModeCannotBeHandedOverByName() {
+    void anOperationTakingARoundingModeExpandsLikeAnyOtherName() {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
                 module demo
 
@@ -128,8 +128,7 @@ class CompileLibraryFunctionByNameTest {
                 let go (i) = Out { ns = List.map(Decimal.toInt, i.ds) }
                 """));
 
-        assertEquals("check.stdlib.roundingmode.byname", e.diagnostic().messageKey());
-        assertTrue(e.getMessage().contains("Decimal.toInt"), e.getMessage());
+        assertEquals("check.fn.blockparam.arity", e.diagnostic().messageKey());
     }
 
     /** An empty collection is a declaration with no parameter list, so it is already the value it

--- a/souther-compiler/src/test/java/souther/compiler/CompileRoundingModeBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRoundingModeBoundaryTest.java
@@ -1,0 +1,48 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.diag.CompileException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * {@code RoundingMode} is ordinary data for typing, evaluation, composition and ordering, but it
+ * provides no codec, so it cannot appear where a codec is required. The absence is intentional: a
+ * rounding policy is a computation's input, not a value that crosses a serialization boundary, and
+ * these tests pin the refusal so the type never quietly gains an external representation.
+ */
+class CompileRoundingModeBoundaryTest {
+
+    /** A field of {@code RoundingMode} would need its decoder and encoder, and it has neither. */
+    @Test
+    void aFieldOfRoundingModeIsRefusedForItsMissingCodec() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data Policy = { mode: RoundingMode }
+                """));
+        assertEquals("check.codec.nodecoder", e.diagnostic().messageKey());
+        assertTrue(e.getMessage().contains("RoundingMode"), e.getMessage());
+    }
+
+    /** An example fixture would have to decode the mode, and there is no decoder to call. */
+    @Test
+    void anExampleOverARoundingModeParameterIsRefused() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data Out = { n: Int }
+
+                behavior g : (m: RoundingMode, d: Decimal) -> Out constructs Out
+                let g (m, d) = Out { n = Decimal.toInt(d, m) }
+
+                example g
+                    | "rounds up at the half" :
+                        (HALF_UP, 2.5m) -> Out { n = 3 }
+                """));
+        assertTrue(e.getMessage().contains("E1903"), e.getMessage());
+        assertTrue(e.getMessage().contains("no decoder for `RoundingMode`"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileRoundingModeValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRoundingModeValueTest.java
@@ -1,0 +1,128 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A rounding mode is an ordinary value of the {@code RoundingMode} data declared by core: it is
+ * evaluated at the call like any other argument, so a model can state a policy once and pass it,
+ * choose one from a business rule, or hand an operation taking one to a combinator. Each of the
+ * three Decimal operations takes its mode through a different route here, so all three are ordinary
+ * functions rather than special forms.
+ */
+class CompileRoundingModeValueTest {
+
+    private static Map<?, ?> run(String source, Map<String, Object> in) throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(source),
+                CompileRoundingModeValueTest.class.getClassLoader());
+        Object behavior = loader.loadClass("demo.Go$Impl").getConstructor().newInstance();
+        return (Map<?, ?>) Codecs.encode(loader, "demo.Out",
+                Codecs.apply(behavior, Codecs.decoded(loader, "demo.In", in)));
+    }
+
+    /** The mode reaches {@code divide} through a binding rather than being written at the call. */
+    @Test
+    void divideTakesAModeBoundToAName() throws Exception {
+        String src = """
+                module demo
+
+                import Decimal ( divide )
+
+                data In = { a: Decimal, b: Decimal }
+                data Out = { value: Decimal, ok: Bool }
+
+                behavior go : (i: In) -> Out constructs Out
+
+                let go (i) = {
+                    let mode = HALF_UP
+                    match divide(i.a, i.b, 2, mode) with
+                        | Decimal as q -> Out { value = q, ok = true }
+                        | DivisionByZero -> Out { value = i.a, ok = false }
+                }
+                """;
+        Map<?, ?> out = run(src,
+                Map.of("a", new BigDecimal("7"), "b", new BigDecimal("3")));
+        assertEquals(new BigDecimal("2.33"), out.get("value"));
+        assertEquals(true, out.get("ok"));
+    }
+
+    /** The mode reaches {@code round} as the value an {@code if} chose at run time. */
+    @Test
+    void roundTakesAModeChosenByAnIf() throws Exception {
+        String src = """
+                module demo
+
+                data In = { d: Decimal, up: Bool }
+                data Out = { r: Decimal }
+
+                behavior go : (i: In) -> Out constructs Out
+
+                let go (i) = Out { r = Decimal.round(i.d, 1, if i.up then CEILING else FLOOR) }
+                """;
+        assertEquals(new BigDecimal("86.5"),
+                run(src, Map.of("d", new BigDecimal("86.41"), "up", true)).get("r"));
+        assertEquals(new BigDecimal("86.4"),
+                run(src, Map.of("d", new BigDecimal("86.49"), "up", false)).get("r"));
+    }
+
+    /** {@code toInt} is handed over by name and applied through the binding. */
+    @Test
+    void toIntIsHandedOverAndAppliedThroughABinding() throws Exception {
+        String src = """
+                module demo
+
+                data In = { d: Decimal }
+                data Out = { n: Int }
+
+                behavior go : (i: In) -> Out constructs Out
+
+                let go (i) = {
+                    let convert = Decimal.toInt
+                    Out { n = convert(i.d, HALF_UP) }
+                }
+                """;
+        assertEquals(87L, run(src, Map.of("d", new BigDecimal("86.5"))).get("n"));
+    }
+
+    /** A mode is a value of a type a binding can be annotated with. */
+    @Test
+    void aModeIsAValueOfTheRoundingModeType() throws Exception {
+        String src = """
+                module demo
+
+                data In = { d: Decimal }
+                data Out = { n: Int }
+
+                behavior go : (i: In) -> Out constructs Out
+
+                let go (i) = {
+                    let mode: RoundingMode = FLOOR
+                    Out { n = Decimal.toInt(i.d, mode) }
+                }
+                """;
+        assertEquals(86L, run(src, Map.of("d", new BigDecimal("86.9"))).get("n"));
+    }
+
+    /** The mode is the result of an ordinary helper call, evaluated like any other argument. */
+    @Test
+    void aHelperComputesTheModeAtTheCall() throws Exception {
+        String src = """
+                module demo
+
+                data In = { d: Decimal, up: Bool }
+                data Out = { n: Int }
+
+                behavior go : (i: In) -> Out constructs Out
+
+                let pick (up: Bool): RoundingMode = if up then CEILING else FLOOR
+
+                let go (i) = Out { n = Decimal.toInt(i.d, pick(i.up)) }
+                """;
+        assertEquals(87L, run(src, Map.of("d", new BigDecimal("86.1"), "up", true)).get("n"));
+        assertEquals(86L, run(src, Map.of("d", new BigDecimal("86.9"), "up", false)).get("n"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileShadowingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileShadowingTest.java
@@ -8,9 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A binding may not take the name of a built-in value ({@code None}, a rounding mode). Those names
- * resolve to the built-in, so shadowing one silently makes it unreachable in that scope — always a
- * mistake, so it is rejected rather than allowed to shadow.
+ * A binding may not take the name of a built-in value ({@code None}). That name resolves to the
+ * built-in, so shadowing it silently makes it unreachable in that scope — always a mistake, so it
+ * is rejected rather than allowed to shadow. A unit data name is ordinary vocabulary and may be
+ * bound, the local taking precedence ([#unit-data]) — a rounding-mode case included.
  */
 class CompileShadowingTest {
 
@@ -30,16 +31,24 @@ class CompileShadowingTest {
         assertTrue(e.getMessage().contains("None"), e.getMessage());
     }
 
+    /** A rounding-mode case is a unit data, so a binding may take its name and is what the name
+     * means in that scope. */
     @Test
-    void aHelperParamCannotShadowARoundingMode() {
+    void aBindingMayShadowARoundingModeCase() throws Exception {
         String src = """
                 module demo
+                data In = { v: Int }
                 data Out = { v: Int }
-                behavior check : (o: Out) -> Out constructs Out
-                let check (o) = Out { v = twice(o.v) }
+                behavior check : (i: In) -> Out constructs Out
+                let check (i) = Out { v = twice(i.v) }
                 let twice (HALF_UP: Int) = HALF_UP + HALF_UP
                 """;
-        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertTrue(e.getMessage().contains("HALF_UP"), e.getMessage());
+        BytesClassLoader loader =
+                new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.In", java.util.Map.of("v", 21L));
+        Object check = loader.loadClass("demo.Check$Impl").getConstructor().newInstance();
+        java.util.Map<?, ?> out =
+                (java.util.Map<?, ?>) Codecs.encode(loader, "demo.Out", Codecs.apply(check, in));
+        org.junit.jupiter.api.Assertions.assertEquals(42L, out.get("v"));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/RoundingModeAbiTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/RoundingModeAbiTest.java
@@ -1,0 +1,102 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.runtime.CEILING;
+import souther.runtime.FLOOR;
+import souther.runtime.HALF_UP;
+import souther.runtime.RoundingMode;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Comparator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The handwritten {@code souther.runtime.RoundingMode} classes stand where generated ones would,
+ * so their shape must match what the compiler emits for a unit-only sum — the static methods on
+ * the sum, and the value contract on each case. Generated data is the reference: an enumeration is
+ * compiled here and each observable is asserted pairwise against the handwritten type, so a change
+ * to either side that the other does not follow fails this test rather than surfacing as a linkage
+ * or behavior difference in a program.
+ */
+class RoundingModeAbiTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Dir = NORTH | SOUTH | EAST | WEST
+            """;
+
+    private ClassLoader compiled() {
+        return new BytesClassLoader(Compiler.compile(MODULE), getClass().getClassLoader());
+    }
+
+    /** The sum's static surface: {@code __tag}, {@code __order}, {@code __ordering}, with the
+     * descriptors the emitter calls them by. */
+    @Test
+    void theSumCarriesTheSameStaticMethodsAsAGeneratedEnumeration() throws Exception {
+        Class<?> generated = compiled().loadClass("demo.Dir");
+        for (Class<?> sum : new Class<?>[] {generated, RoundingMode.class}) {
+            Method tag = sum.getMethod("__tag", Object.class);
+            assertEquals(String.class, tag.getReturnType(), sum.getName());
+            assertTrue(Modifier.isStatic(tag.getModifiers()), sum.getName());
+            Method order = sum.getMethod("__order", Object.class);
+            assertEquals(int.class, order.getReturnType(), sum.getName());
+            assertTrue(Modifier.isStatic(order.getModifiers()), sum.getName());
+            Method ordering = sum.getMethod("__ordering");
+            assertEquals(Comparator.class, ordering.getReturnType(), sum.getName());
+            assertTrue(Modifier.isStatic(ordering.getModifiers()), sum.getName());
+        }
+    }
+
+    /** {@code __tag} answers the case's name; {@code __order} its place in the declaration;
+     * {@code __ordering} sorts by it. */
+    @Test
+    void tagAndOrderAnswerTheDeclarationTheSameWay() throws Exception {
+        ClassLoader loader = compiled();
+        Class<?> dir = loader.loadClass("demo.Dir");
+        Object north = loader.loadClass("demo.NORTH").getField("INSTANCE").get(null);
+        Object east = loader.loadClass("demo.EAST").getField("INSTANCE").get(null);
+
+        assertEquals("NORTH", dir.getMethod("__tag", Object.class).invoke(null, north));
+        assertEquals("HALF_UP", RoundingMode.__tag(HALF_UP.INSTANCE));
+
+        assertEquals(0, dir.getMethod("__order", Object.class).invoke(null, north));
+        assertEquals(2, dir.getMethod("__order", Object.class).invoke(null, east));
+        assertEquals(0, RoundingMode.__order(HALF_UP.INSTANCE));
+        assertEquals(5, RoundingMode.__order(CEILING.INSTANCE));
+
+        @SuppressWarnings("unchecked")
+        Comparator<Object> generated =
+                (Comparator<Object>) dir.getMethod("__ordering").invoke(null);
+        assertTrue(generated.compare(north, east) < 0);
+        assertTrue(RoundingMode.__ordering().compare(HALF_UP.INSTANCE, FLOOR.INSTANCE) < 0);
+    }
+
+    /** The value contract of a unit case: a shared {@code INSTANCE} on a {@code Record} subclass,
+     * equality by case, the stable hash, and the record-style text form. */
+    @Test
+    void aCaseCarriesTheSameValueContractAsAGeneratedUnit() throws Exception {
+        ClassLoader loader = compiled();
+        Class<?> north = loader.loadClass("demo.NORTH");
+        Object generated = north.getField("INSTANCE").get(null);
+        // the emitter reaches a unit only through INSTANCE, so constructor visibility is not part
+        // of the shape; a second instance is made here only to observe the equality contract
+        java.lang.reflect.Constructor<?> ctor = north.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        Object another = ctor.newInstance();
+
+        assertTrue(Record.class.isAssignableFrom(north));
+        assertTrue(Record.class.isAssignableFrom(HALF_UP.class));
+
+        assertEquals(generated, another);
+        assertEquals(HALF_UP.INSTANCE, new HALF_UP());
+
+        assertEquals(generated.hashCode(), HALF_UP.INSTANCE.hashCode());
+
+        assertEquals("NORTH[]", generated.toString());
+        assertEquals("HALF_UP[]", HALF_UP.INSTANCE.toString());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/codegen/KernelDescriptorsComeFromDeclarationsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/KernelDescriptorsComeFromDeclarationsTest.java
@@ -1,0 +1,79 @@
+package souther.compiler.codegen;
+
+import souther.compiler.Prelude;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A kernel's JVM descriptor belongs to the kernel, not to the call — the callee's declaration
+ * decides it, and the arguments only supply values. {@link Intrinsics.DeclaredStatic} states that
+ * directly, reading the declared signature; {@link Intrinsics.RuntimeStatic} builds a descriptor
+ * from the types it observes at the call, and agrees with the declaration only where an observed
+ * type cannot differ from the declared one.
+ *
+ * <p>That held by accident until a declared parameter took a sum: every value flowing into
+ * {@code RoundingMode} is one of its cases, so the observed type named a case class and the
+ * declaration named the sum, and the call linked to no such method (issue #270). The two happened
+ * to agree everywhere else because every other parameter is either a primitive or a container —
+ * whose boundary form the type fixes on its own — or a type variable in a slot the emitter erases
+ * to {@code Object}, which is what the declaration would give.
+ *
+ * <p>This holds that shape rather than the coincidence. A declared parameter whose boundary form
+ * depends on which value arrives — a reference, a type variable, a union — may not be read off the
+ * call, so the entry taking one belongs on the declaration-reading emitter. Registering a second
+ * runtime-backed data ({@code Prelude}) and writing it into a kernel's parameters is the move that
+ * reproduces #270, and this is what stops it.
+ */
+class KernelDescriptorsComeFromDeclarationsTest {
+
+    @Test
+    void aKernelReadingItsDescriptorFromTheCallTakesNoTypeAValueCanNarrow() {
+        List<String> readOffTheCall = new ArrayList<>();
+        for (var entry : Intrinsics.emitters().entrySet()) {
+            if (!(entry.getValue() instanceof Intrinsics.RuntimeStatic kernel)) {
+                continue;
+            }
+            Prelude.Signature declared = Prelude.kernelSignature(entry.getKey());
+            for (int i = 0; i < declared.params().size(); i++) {
+                // An erased slot is passed as Object whatever arrives, which is what the declared
+                // type would give too, so the observed type cannot disagree there.
+                if (kernel.objectSlots().contains(i)) {
+                    continue;
+                }
+                Type param = declared.params().get(i);
+                if (!fixesItsOwnBoundaryForm(param)) {
+                    readOffTheCall.add(entry.getKey() + " parameter " + (i + 1)
+                            + " is declared " + Type.show(param));
+                }
+            }
+        }
+
+        assertEquals(List.of(), readOffTheCall,
+                "these kernels build a descriptor from the type observed at the call, for a"
+                        + " parameter whose declared type a value can arrive narrower than — move"
+                        + " them to DeclaredStatic, which reads the declaration");
+    }
+
+    /**
+     * Whether the type alone settles the JVM type a value of it takes at a kernel boundary.
+     *
+     * <p>A primitive and a container do: every value of {@code Decimal} is a {@code BigDecimal} and
+     * every value of {@code List<'a>} a {@code List}, whatever the element. A reference does not —
+     * a value of a sum is one of its cases — and neither does a type variable or a union, whose
+     * values are of the members. Listed rather than excluded so a type constructor added later is
+     * failed here and considered, rather than defaulting into the safe half.
+     */
+    private static boolean fixesItsOwnBoundaryForm(Type t) {
+        return t instanceof Type.Prim
+                || t instanceof Type.ListOf
+                || t instanceof Type.MapOf
+                || t instanceof Type.SetOf
+                || t instanceof Type.OptionOf;
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/CEILING.java
+++ b/souther-runtime/src/main/java/souther/runtime/CEILING.java
@@ -1,0 +1,24 @@
+package souther.runtime;
+
+/** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
+public record CEILING() implements RoundingMode {
+
+    public static final CEILING INSTANCE = new CEILING();
+
+    // The overrides pin the shape generated unit data has: equality by case, a stable hash,
+    // and the record-style text form.
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof CEILING;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public String toString() {
+        return "CEILING[]";
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/DOWN.java
+++ b/souther-runtime/src/main/java/souther/runtime/DOWN.java
@@ -1,0 +1,24 @@
+package souther.runtime;
+
+/** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
+public record DOWN() implements RoundingMode {
+
+    public static final DOWN INSTANCE = new DOWN();
+
+    // The overrides pin the shape generated unit data has: equality by case, a stable hash,
+    // and the record-style text form.
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof DOWN;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public String toString() {
+        return "DOWN[]";
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/DecimalMath.java
+++ b/souther-runtime/src/main/java/souther/runtime/DecimalMath.java
@@ -2,7 +2,6 @@ package souther.runtime;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
-import java.math.RoundingMode;
 
 /**
  * The {@code /} operator on Decimal (spec 18.1). A zero divisor aborts, like the other arithmetic
@@ -19,7 +18,24 @@ public final class DecimalMath {
     private DecimalMath() {}
 
     /** The rounding of the {@code /} operator: F#/.NET System.Decimal precision, half away from zero. */
-    private static final MathContext DIVIDE = new MathContext(29, RoundingMode.HALF_UP);
+    private static final MathContext DIVIDE = new MathContext(29, java.math.RoundingMode.HALF_UP);
+
+    /**
+     * The Java constant a {@link RoundingMode} value denotes. The mapping sits on the Decimal
+     * runtime rather than on the value: {@code java.math} is this backend's implementation detail,
+     * not part of what a rounding mode is.
+     */
+    public static java.math.RoundingMode toJava(RoundingMode mode) {
+        return switch (mode) {
+            case HALF_UP _ -> java.math.RoundingMode.HALF_UP;
+            case HALF_EVEN _ -> java.math.RoundingMode.HALF_EVEN;
+            case HALF_DOWN _ -> java.math.RoundingMode.HALF_DOWN;
+            case UP _ -> java.math.RoundingMode.UP;
+            case DOWN _ -> java.math.RoundingMode.DOWN;
+            case CEILING _ -> java.math.RoundingMode.CEILING;
+            case FLOOR _ -> java.math.RoundingMode.FLOOR;
+        };
+    }
 
     public static BigDecimal divide(BigDecimal a, BigDecimal b) {
         if (b.signum() == 0) {
@@ -41,18 +57,23 @@ public final class DecimalMath {
 
     /**
      * {@code Decimal.toInt(d, mode)}: the whole number {@code d} rounds to under {@code mode}. The
-     * mode is written at the call because dropping a fraction is a domain decision — a tax is
-     * truncated or rounded by rule, not by default — the same reason {@code Decimal.divide} states
-     * its scale and mode.
+     * mode is an argument because dropping a fraction is a domain decision — a tax is truncated or
+     * rounded by rule, not by default — the same reason {@code Decimal.divide} states its scale and
+     * mode.
      *
      * <p>A value too large for {@code Int} aborts, as an Int overflow does ({@link IntMath}): it is a
      * model bug rather than a business result.
      */
     public static long toInt(BigDecimal d, RoundingMode mode) {
         try {
-            return d.setScale(0, mode).longValueExact();
+            return d.setScale(0, toJava(mode)).longValueExact();
         } catch (ArithmeticException _) {
             throw new ConstraintViolation("Decimal does not fit in an Int: " + d.toPlainString());
         }
+    }
+
+    /** {@code Decimal.round(d, scale, mode)}: {@code d} rounded to {@code scale} places by {@code mode}. */
+    public static BigDecimal round(BigDecimal d, long scale, RoundingMode mode) {
+        return d.setScale((int) scale, toJava(mode));
     }
 }

--- a/souther-runtime/src/main/java/souther/runtime/FLOOR.java
+++ b/souther-runtime/src/main/java/souther/runtime/FLOOR.java
@@ -1,0 +1,24 @@
+package souther.runtime;
+
+/** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
+public record FLOOR() implements RoundingMode {
+
+    public static final FLOOR INSTANCE = new FLOOR();
+
+    // The overrides pin the shape generated unit data has: equality by case, a stable hash,
+    // and the record-style text form.
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof FLOOR;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public String toString() {
+        return "FLOOR[]";
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/HALF_DOWN.java
+++ b/souther-runtime/src/main/java/souther/runtime/HALF_DOWN.java
@@ -1,0 +1,24 @@
+package souther.runtime;
+
+/** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
+public record HALF_DOWN() implements RoundingMode {
+
+    public static final HALF_DOWN INSTANCE = new HALF_DOWN();
+
+    // The overrides pin the shape generated unit data has: equality by case, a stable hash,
+    // and the record-style text form.
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof HALF_DOWN;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public String toString() {
+        return "HALF_DOWN[]";
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/HALF_EVEN.java
+++ b/souther-runtime/src/main/java/souther/runtime/HALF_EVEN.java
@@ -1,0 +1,24 @@
+package souther.runtime;
+
+/** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
+public record HALF_EVEN() implements RoundingMode {
+
+    public static final HALF_EVEN INSTANCE = new HALF_EVEN();
+
+    // The overrides pin the shape generated unit data has: equality by case, a stable hash,
+    // and the record-style text form.
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof HALF_EVEN;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public String toString() {
+        return "HALF_EVEN[]";
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/HALF_UP.java
+++ b/souther-runtime/src/main/java/souther/runtime/HALF_UP.java
@@ -1,0 +1,24 @@
+package souther.runtime;
+
+/** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
+public record HALF_UP() implements RoundingMode {
+
+    public static final HALF_UP INSTANCE = new HALF_UP();
+
+    // The overrides pin the shape generated unit data has: equality by case, a stable hash,
+    // and the record-style text form.
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof HALF_UP;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public String toString() {
+        return "HALF_UP[]";
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/RoundingMode.java
+++ b/souther-runtime/src/main/java/souther/runtime/RoundingMode.java
@@ -1,0 +1,46 @@
+package souther.runtime;
+
+import java.util.Comparator;
+
+/**
+ * The rounding-mode enumeration core declares as {@code data RoundingMode} (spec 18.3). The
+ * declaration lives in {@code souther/decimal.sou}; the implementation is provided here rather than
+ * generated, like {@link Option} and {@link DivisionByZero}, so the static shape mirrors what the
+ * compiler emits for a unit-only sum: a sealed interface carrying {@code __tag}, {@code __order}
+ * and {@code __ordering}, and one record per case holding its {@code INSTANCE}.
+ */
+public sealed interface RoundingMode
+        permits HALF_UP, HALF_EVEN, HALF_DOWN, UP, DOWN, CEILING, FLOOR {
+
+    /** Which case a value of this enumeration is. */
+    static String __tag(Object v) {
+        return switch (v) {
+            case HALF_UP _ -> "HALF_UP";
+            case HALF_EVEN _ -> "HALF_EVEN";
+            case HALF_DOWN _ -> "HALF_DOWN";
+            case UP _ -> "UP";
+            case DOWN _ -> "DOWN";
+            case CEILING _ -> "CEILING";
+            case FLOOR _ -> "FLOOR";
+            default -> throw new IllegalStateException();
+        };
+    }
+
+    /** Where a value's case stands in the declaration. */
+    static int __order(Object v) {
+        return switch (v) {
+            case HALF_UP _ -> 0;
+            case HALF_EVEN _ -> 1;
+            case HALF_DOWN _ -> 2;
+            case UP _ -> 3;
+            case DOWN _ -> 4;
+            case CEILING _ -> 5;
+            case FLOOR _ -> 6;
+            default -> throw new IllegalStateException();
+        };
+    }
+
+    static Comparator<Object> __ordering() {
+        return Comparator.comparingInt(RoundingMode::__order);
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/UP.java
+++ b/souther-runtime/src/main/java/souther/runtime/UP.java
@@ -1,0 +1,24 @@
+package souther.runtime;
+
+/** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
+public record UP() implements RoundingMode {
+
+    public static final UP INSTANCE = new UP();
+
+    // The overrides pin the shape generated unit data has: equality by case, a stable hash,
+    // and the record-style text form.
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof UP;
+    }
+
+    @Override
+    public int hashCode() {
+        return 1;
+    }
+
+    @Override
+    public String toString() {
+        return "UP[]";
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -807,7 +807,7 @@ This is a guard comprehension (<<stdlib-list>>): it yields one `+ClientBorne+` i
 
 A bare identifier in an expression resolves as: a variable if a bound local exists; otherwise a built-in value (such as `+None+`; <<algebraic-types>>); otherwise the construction of a unit data of the same name; otherwise undefined. Souther does not distinguish identifiers syntactically by case (so that Japanese business vocabulary can be used as identifiers), so this resolution is done in the symbol table.
 
-Because a local shadowing a built-in value is always an error, using a *built-in value name* (`+None+`, rounding mode `+HALF_UP+`, etc.; <<stdlib-decimal>>) as a binding name — `+let+`, a `+match+` binding, or a lambda argument — is a compile error. This prevents a shadowed built-in from silently becoming unreachable. A unit data name is domain vocabulary and may be used as a binding, in which case the local takes precedence and constructing a unit data of that name is not writable in the same scope.
+Because a local shadowing a built-in value is always an error, using a *built-in value name* (`+None+`; <<algebraic-types>>) as a binding name — `+let+`, a `+match+` binding, or a lambda argument — is a compile error. This prevents a shadowed built-in from silently becoming unreachable. A unit data name is domain vocabulary and may be used as a binding, in which case the local takes precedence and constructing a unit data of that name is not writable in the same scope. The rounding-mode cases (<<stdlib-decimal>>) are ordinary unit data and follow this rule; a shadowed case has no qualified escape syntax.
 
 [#field-visibility]
 === Field visibility
@@ -2546,7 +2546,7 @@ An outside-world dependency is declared as a behavior with no implementation, an
 
 The standard library is bundled with the compiler and referenced by short qualifiers — `+List+` (list), `+Map+` (map), `+Set+` (set), `+String+` (string), `+Bool+` (boolean), `+Int+` / `+Decimal+` (numbers), `+Date+` / `+DateTime+` (temporal), `+Option+` (optional). Every function is called through this qualifier: `+List.map(f, xs)+`, `+String.trim(s)+`, `+List.length(xs)+`. There is no automatic import — names are not delivered implicitly. What may be written bare is operators (`+==+` `+<+` `+{plus}{plus}+`, etc.), `+if+` / `+match+`, literals, and the current module's helpers. Argument order follows the convention of <<pipe>> (primary subject last).
 
-A standard-library function is therefore never a bare name and never crosses what a module writes bare. What a module writes bare in a value position is one of: a binding in force, one of its own `+let+`s, a data of its own written as a value, a behavior it can reach, a name an import let it write without its qualifier, or a name the language gives (`+None+`, the rounding modes). One spelling means one of these — a `+let+` may not be named like a data (<<fn-rules>>), a name the language gives may not be taken, and a binding in force wins over a declaration.
+A standard-library function is therefore never a bare name and never crosses what a module writes bare. What a module writes bare in a value position is one of: a binding in force, one of its own `+let+`s, a data of its own written as a value, a behavior it can reach, a name an import let it write without its qualifier, a name the language gives (`+None+`), or a case of a data core declares (`+HALF_UP+`; <<stdlib-decimal>>). One spelling means one of these — a `+let+` may not be named like a data (<<fn-rules>>), a name the language gives may not be taken, and a binding in force wins over a declaration.
 
 A qualifier is the only spelling that reaches its library, so a *type* MUST NOT be named like one: `+data List = String+` is a compile error, as `+module souther.foo+` is. In expression position the qualifier still yields to a binding — a parameter or a `+let+` named `+Map+` makes `+Map.empty+` that binding's `+empty+` field — because a binding in force wins over everything.
 
@@ -2578,8 +2578,7 @@ An intrinsic MUST declare its return type (it cannot be inferred from `+intrinsi
 *Every* standard-library function is declared in a core module this way, whether its body is Souther (self-hosted, like `+List.map+` over `+foldFrom+`) or `+intrinsic "key"+` (a JVM kernel). The declaration is the single source of truth for the signature — there is no compiler table of signatures, and a function the compiler can call but a declaration does not describe does not exist. What stays in the compiler is what the *type language cannot say*, as a side condition on a declared signature rather than in place of one:
 
 * the operators (`{plus}` `+-+` `+*+` `+/+` `+==+` `+<+` `+<=+` `+>+` `+>=+`) are syntax, and the arithmetic ones carry the closed-newtype rules (<<newtype>>) a plain function does not;
-* "the element is an ordered value" — Souther has no `+comparable+` type class, so `+List.sort+` / `+max+` / `+min+` / `+sortBy+` declare `+List<'a>+` and the constraint on `+'a+` is checked in the compiler;
-* "this argument is a rounding mode" — `+Decimal.divide+` / `+Decimal.toInt+` / `+Decimal.round+` declare a `+RoundingMode+` parameter, a type only core may name, and the argument is read as the identifier it is written as rather than evaluated (<<stdlib-decimal>>). A name is therefore not a value here, so these three cannot be handed over by name the way any other function can (<<blocks>>).
+* "the element is an ordered value" — Souther has no `+comparable+` type class, so `+List.sort+` / `+max+` / `+min+` / `+sortBy+` declare `+List<'a>+` and the constraint on `+'a+` is checked in the compiler.
 
 Because a signature is a declaration and nothing else, a standard-library function is a function value like any other: `+List.map(String.trim, xs)+` and `+let f = String.length+` are ordinary (<<blocks>>). A value the library offers is declared the same way, with no parameter list — `+let empty : Map<'k, 'a> = intrinsic "map.empty"+` — and is written `+Map.empty+`.
 
@@ -2666,14 +2665,16 @@ add  subtract  multiply  divide  compare  fromInt  toInt  round
 abs  min  max  clamp
 ----
 
-Division makes the rounding scale and mode explicit as arguments. `+Decimal.divide(a, b, 2, HALF_UP)+` rounds HALF_UP at 2 decimal places. The mode is written as one of the identifiers below and read as that identifier: `+RoundingMode+` is a parameter type only core may name, and a binding of a mode's name is refused (<<unit-data>>).
+Division makes the rounding scale and mode explicit as arguments. `+Decimal.divide(a, b, 2, HALF_UP)+` rounds HALF_UP at 2 decimal places. The mode is an ordinary value of the data core declares:
 
 [,text]
 ----
-HALF_UP  HALF_EVEN  HALF_DOWN  UP  DOWN  CEILING  FLOOR
+data RoundingMode = HALF_UP | HALF_EVEN | HALF_DOWN | UP | DOWN | CEILING | FLOOR
 ----
 
-These correspond to `+java.math.RoundingMode+`. `+Decimal.divide(a, b)+` without scale and mode cannot be written — to surface rounding as a domain decision, the same position as "scale is incidental" in <<primitives>>. Division by zero returns `+Decimal | DivisionByZero+`, opened by `+| Decimal as d+` (<<primitive-arm>>).
+A mode argument is evaluated like any other, so a policy can be stated once and passed by name, chosen by an `+if+` or a `+match+`, or computed by a helper, and the three operations taking one are ordinary functions that can be handed over by name (<<blocks>>). The cases are unit data and follow the unit-data rules (<<unit-data>>): written bare, shadowable by a binding. The type provides no codec, so it cannot appear where one is required — a field of it, an example fixture over it — and this is intentional: a rounding policy is a computation's input, not a value that crosses a serialization boundary.
+
+The cases correspond to `+java.math.RoundingMode+`. `+Decimal.divide(a, b)+` without scale and mode cannot be written — to surface rounding as a domain decision, the same position as "scale is incidental" in <<primitives>>. Division by zero returns `+Decimal | DivisionByZero+`, opened by `+| Decimal as d+` (<<primitive-arm>>).
 
 `+Int+` and `+Decimal+` meet only where the conversion is written. `+Decimal.fromInt(n)+` widens an `+Int+`; it is exact, so nothing has to be stated. `+Decimal.toInt(d, mode)+` narrows back, and because that drops a fraction it names the rounding at the call, as `+divide+` does. There is no implicit widening: an arithmetic operator takes two operands of one type (<<primitives>>), so a rate applied to an amount in yen reads `+Decimal.fromInt(netAmount) * taxRate+` — the conversion sits where the value stops being an amount. A `+Decimal+` too large for an `+Int+` aborts, as an `+Int+` overflow does (<<primitives>>).
 


### PR DESCRIPTION
Issue #270. `RoundingMode` was the last argument in Souther that was not a value — written at the call, read as the identifier it was written as, never evaluated, making three Decimal operations special forms. It is now ordinary data core declares:

```sou
// souther/decimal.sou
data RoundingMode = HALF_UP | HALF_EVEN | HALF_DOWN | UP | DOWN | CEILING | FLOOR
```

A mode can be bound to a name, chosen by an `if`, computed by a helper, annotated as a type, and the three operations are ordinary functions that can be handed over by name. Each route is pinned through a different operation (`CompileRoundingModeValueTest`).

## How

- **Runtime-backed data.** One registration in `Prelude` classifies the declaration: source of truth in `decimal.sou`, implementation handwritten in `souther.runtime` (like `Option` / `DivisionByZero`), not generated. The registration anchors the names to the runtime namespace, answers `Symbols`' lookups, and — because the declaration belongs to no compiled module — keeps it out of derivation and codegen. No other place branches on the type's name.
- **No codec, intentionally.** A rounding policy is a computation's input, not a value that crosses a serialization boundary. A field of `RoundingMode` is refused with the ordinary missing-codec diagnostic and an example fixture with E1903; both are pinned (`CompileRoundingModeBoundaryTest`) so the type never quietly gains an external representation.
- **ABI.** The handwritten classes are empty records plus `__tag`/`__order`/`__ordering` on the sealed interface, mirroring the generated unit-only-sum shape. `RoundingModeAbiTest` compares every observable pairwise against a compiled enumeration, so drift on either side fails a test instead of surfacing as a linkage error.
- **Deleted.** `requireRoundingMode`, the argument-typing skip, the resolution rung for the seven names, the η-expansion refusal, the built-in-shadow rule for the modes (`let HALF_UP = …` is now an ordinary shadow, local takes precedence), the type-name fallback, `Core.Builtin`, and the `TakesARoundingMode` emit shape. `HALF_UP(x)` and a wrongly-typed mode argument get the ordinary diagnostics.

## Root-cause fixes surfaced by review

- The two kernels' JVM descriptors derive from the declared signature (`Prelude.kernelSignature`): a descriptor belongs to the callee, and deriving it from observed argument types only agreed with the declaration while every parameter type was invariant — a sum-typed parameter ends that.
- `constructs` exempts language-given vocabulary by the general rule (`Symbols.declaredByCompilation`), not a namespace check.
- The reserved-namespace qualifiers moved to the dependency-free `Reserved`: the frontend read them off `Prelude`, whose loading parses sources back through the frontend — a cycle latent until the first `data` in a prelude source.

Spec `[#stdlib-decimal]` / `[#stdlib]` / `[#unit-data]` / `[#intrinsics]` rewritten; ADR-0087 records the decision and supersedes ADR-0086's rounding-mode entry (cross-linked).

Full build green: compiler 1961 tests, runtime / fmt / lsp / cli / bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
