### PR TITLE
Reify a behavior's name where it is bound

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1282,9 +1282,9 @@ public final class HelperInliner {
      * <p>Empty covers a declaration taking nothing and every name that stands for no declaration at
      * all: a binding, a construction, a library name the library does not declare, and a behavior
      * this body may not name. Each of those is left as it was written and reported where it is
-     * used. A declaration taking nothing is two things under one answer — a library value, which is
-     * already the value it is, and a behavior taking no input, which has no function value because
-     * a block taking no parameter is not a shape this language writes.
+     * used. A declaration taking nothing has no function value to become rather than one this
+     * declines to make: a {@code let} with no parameter list is a value and is written without
+     * {@code ()}, and there is no block taking no parameter to expand it to.
      */
     private OptionalInt declarationArity(Ast.Var v) {
         int arity = switch (v.denotes()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -21,7 +21,9 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.Set;
+import java.util.function.IntFunction;
 import java.util.function.Predicate;
 
 /**
@@ -54,6 +56,17 @@ public final class HelperInliner {
      * applying the declaration by a spelling and why a lambda naming itself had to be refused.
      */
     private final Map<BindingId, Ast.FnDef> scopedLambdas = new HashMap<>();
+    /**
+     * The behaviors a body expanded here may name, with how many inputs each takes — the module's
+     * own callable ones and the ones it borrows (spec {@code [#calling-a-behavior]}).
+     *
+     * <p>Apart from {@link #helpers} because a behavior is never expanded: what stands behind its
+     * name may be a Java implementation, so a body that reached past it to the {@code let} would be
+     * a second answer to the same name. All this holds is what reifying the name needs, which is its
+     * arity; the query layer works out which behaviors are here, since which of them may be named is
+     * a fact about the module rather than about any one body.
+     */
+    private Map<String, Integer> callableBehaviors = Map.of();
     private final Set<String> recursive = new HashSet<>();   // own helpers on a call cycle (spec 13.1)
     private final Map<String, LambdaOrigin> lambdaOrigins = new HashMap<>();   // $k_p -> where it was written
     private int counter = 0;
@@ -154,6 +167,19 @@ public final class HelperInliner {
         inliner.classifyRecursion();
         inliner.rejectValueCycles();
         return inliner;
+    }
+
+    /**
+     * The same, told which behaviors a body expanded here may name and how many inputs each takes.
+     *
+     * <p>Told rather than worked out: which behaviors those are follows from the declarations of
+     * this module and of the ones it imports, which is not what this pass reads. A body expanded
+     * without being told names none of them, and a name it cannot reify is left as it was written
+     * for the check to report.
+     */
+    public HelperInliner namingBehaviors(Map<String, Integer> arities) {
+        this.callableBehaviors = Map.copyOf(arities);
+        return this;
     }
 
     /** prelude helpers are keyed by their qualified name (`List.map`); a module's own helpers by their
@@ -953,17 +979,7 @@ public final class HelperInliner {
                     || !dependencies.contains(local.id())) {
                 continue;
             }
-            List<Ast.Binder> params = new ArrayList<>();
-            List<Ast.Expr> forwarded = new ArrayList<>();
-            for (int j = 0; j < want.params().size(); j++) {
-                // a source identifier never starts with `$`, so these cannot capture a caller local
-                Ast.Binder p = binders.binder("$" + counter++ + "_" + v.name(), v.pos());
-                params.add(p);
-                forwarded.add(Ast.Var.local(p, v.pos()));
-            }
-            out.set(i, new Ast.Block(params,
-                    new Ast.Apply(v.name(), v.denotes(), forwarded, ConstructionOrigin.own(), v.pos()),
-                    v.pos()));
+            out.set(i, etaExpand(v, want.params().size(), _ -> "$" + counter++ + "_" + v.name()));
         }
         return out;
     }
@@ -1231,77 +1247,98 @@ public final class HelperInliner {
     }
 
     /**
-     * A name that denotes a value — a {@code let} written with no parameter list — expanded to the
-     * expression it was defined as. A value is not module state: its body is elaborated where it was
-     * declared and substituted at each reference, so nothing is held between them and there is no
-     * order in which the module's values come into being.
+     * {@code function} as the function value it names: a block taking as many parameters as the
+     * function takes and applying it to them. The same value the author would get by spelling the
+     * lambda, so nothing downstream has to know which of the two was written.
      *
-     * <p>A recursive value is left alone here; the recursion check reports it under its own name.
-     * Anything else — a helper handed to a combinator by name, a binding, a unit data — is the name
-     * itself.
+     * <p>{@code binderName} names the block's parameters, given the index of each. A source
+     * identifier never starts with {@code $}, so a name from any of the callers cannot capture a
+     * local of the body it is written into.
+     */
+    private Ast.Block etaExpand(Ast.Var function, int arity, IntFunction<String> binderName) {
+        List<Ast.Binder> params = new ArrayList<>();
+        List<Ast.Expr> args = new ArrayList<>();
+        for (int i = 0; i < arity; i++) {
+            Ast.Binder p = binders.binder(binderName.apply(i), function.pos());
+            params.add(p);
+            args.add(Ast.Var.local(p, function.pos()));
+        }
+        return new Ast.Block(params,
+                new Ast.Apply(function.name(), function.denotes(), args, ConstructionOrigin.own(),
+                        function.pos()),
+                function.pos());
+    }
+
+    /**
+     * How many inputs the declaration {@code v} reaches takes, where that declaration is one a name
+     * written in value position stands for — and empty where the name reaches no such declaration.
+     *
+     * <p>This asks the declaration and nothing else: not whether the implementation is a Souther
+     * body, a kernel or a Java one, which is what is on the other side of the name and not the
+     * name's business. A helper, a library function and a behavior differ in what stands behind
+     * them and not in what reification needs, which is how many arguments the block it becomes
+     * takes.
+     *
+     * <p>Empty covers a declaration taking nothing and every name that stands for no declaration at
+     * all: a binding, a construction, a library name the library does not declare, and a behavior
+     * this body may not name. Each of those is left as it was written and reported where it is
+     * used. A declaration taking nothing is two things under one answer — a library value, which is
+     * already the value it is, and a behavior taking no input, which has no function value because
+     * a block taking no parameter is not a shape this language writes.
+     */
+    private OptionalInt declarationArity(Ast.Var v) {
+        int arity = switch (v.denotes()) {
+            case ValueName.Stdlib lib -> {
+                Prelude.PreludeEntry entry = Prelude.entry(lib.qualified());
+                Ast.FnDef declared = entry == null ? null : entry.declaration();
+                yield declared == null ? 0 : declared.params().size();
+            }
+            case ValueName.Helper _ -> {
+                Ast.FnDef declared = helpers.get(v.reaches());
+                yield declared == null || declared.body() == null ? 0 : declared.params().size();
+            }
+            // A behavior's name handed over is the behavior: the block applies the behavior, so the
+            // emitted code goes through the behavior's class and not through the `let` that
+            // implements it. Only the ones a body may name are here — a behavior with a requirement
+            // is a binding by the time it can be written.
+            case ValueName.Behavior b -> callableBehaviors.getOrDefault(b.name(), 0);
+            // A binding holds whatever it was given; a construction, a checker built-in and a name
+            // that denotes nothing stand for no declaration at all.
+            case ValueName.Local _, ValueName.OfType _, ValueName.Builtin _,
+                    ValueName.Unresolved _ -> 0;
+            case null -> 0;
+        };
+        return arity == 0 ? OptionalInt.empty() : OptionalInt.of(arity);
+    }
+
+    /**
+     * A name written where a value goes, as the value it stands for.
+     *
+     * <p>A name that reaches a declaration taking arguments is the function it names, written out.
+     * A recursive helper is written out too — the call inside stays the call it has to be.
+     *
+     * <p>A name that denotes a value — a {@code let} written with no parameter list — is expanded to
+     * the expression it was defined as. A value is not module state: its body is elaborated where it
+     * was declared and substituted at each reference, so nothing is held between them and there is
+     * no order in which the module's values come into being. A recursive value is left alone here;
+     * the recursion check reports it under its own name.
+     *
+     * <p>Anything else — a binding, a unit data — is the name itself.
      */
     private Ast.Expr valueOf(Ast.Var v) {
-        if (v.denotes() instanceof ValueName.Stdlib lib) {
-            return libraryValueOf(v, lib);
+        OptionalInt arity = declarationArity(v);
+        if (arity.isPresent()) {
+            int k = counter++;
+            return inline(etaExpand(v, arity.getAsInt(), i -> "$v" + k + "_" + i));
         }
         if (!(v.denotes() instanceof ValueName.Helper)) {
             return v;
         }
         Ast.FnDef value = helpers.get(v.reaches());
-        if (value == null || value.body() == null) {
-            return v;
-        }
-        if (!value.params().isEmpty()) {
-            // A helper named where a value goes is the function it names, written out: a lambda that
-            // takes what the helper takes and applies it. The same value the author would get by
-            // spelling the lambda, so nothing downstream has to know which of the two was written.
-            // A recursive helper eta-expands too — the call inside stays the call it has to be.
-            int k = counter++;
-            List<Ast.Binder> params = new ArrayList<>();
-            List<Ast.Expr> args = new ArrayList<>();
-            for (int i = 0; i < value.params().size(); i++) {
-                Ast.Binder p = binders.binder("$v" + k + "_" + i, v.pos());
-                params.add(p);
-                args.add(Ast.Var.local(p, v.pos()));
-            }
-            return inline(new Ast.Block(params,
-                    new Ast.Apply(v.name(), v.denotes(), args, ConstructionOrigin.own(), v.pos()), v.pos()));
-        }
-        if (recursive.contains(v.name())) {
+        if (value == null || value.body() == null || recursive.contains(v.name())) {
             return v;
         }
         return carriedByValue(inline(value.written()));
-    }
-
-    /**
-     * A library name written where a value goes, as the function it names.
-     *
-     * <p>The library declares everything it ships, so this asks the declaration and nothing else —
-     * not whether the implementation is a Souther body or a kernel, which is what is on the other
-     * side of the name and not the name's business. What comes back is the block a reader would
-     * have written by hand, which is what the specification says the two spellings are.
-     *
-     * <p>An empty collection is not a function: it is a declaration with no parameter list, so it is
-     * already the value it is and is left alone.
-     */
-    private Ast.Expr libraryValueOf(Ast.Var v, ValueName.Stdlib lib) {
-        Prelude.PreludeEntry entry = Prelude.entry(lib.qualified());
-        Ast.FnDef declared = entry == null ? null : entry.declaration();
-        int arity = declared == null ? -1 : declared.params().size();
-        if (arity <= 0) {
-            return v;   // a value, or a name the library does not declare — reported where it is used
-        }
-        int k = counter++;
-        List<Ast.Binder> params = new ArrayList<>();
-        List<Ast.Expr> args = new ArrayList<>();
-        for (int i = 0; i < arity; i++) {
-            Ast.Binder p = binders.binder("$v" + k + "_" + i, v.pos());
-            params.add(p);
-            args.add(Ast.Var.local(p, v.pos()));
-        }
-        return inline(new Ast.Block(params,
-                new Ast.Apply(v.name(), v.denotes(), args, ConstructionOrigin.own(), v.pos()),
-                v.pos()));
     }
 
     /**
@@ -1371,15 +1408,7 @@ public final class HelperInliner {
             return call;   // a bare name that stands for no body is left for the type checker to report
         }
         int k = counter++;
-        List<Ast.Binder> params = new ArrayList<>();
-        List<Ast.Expr> callArgs = new ArrayList<>();
-        for (int i = 0; i < helper.params().size(); i++) {
-            Ast.Binder p = binders.binder("$b" + k + "_" + i, v.pos());
-            params.add(p);
-            callArgs.add(Ast.Var.local(p, v.pos()));
-        }
-        Ast.Block block = new Ast.Block(params,
-                new Ast.Apply(v.name(), v.denotes(), callArgs, ConstructionOrigin.own(), v.pos()), v.pos());
+        Ast.Block block = etaExpand(v, helper.params().size(), i -> "$b" + k + "_" + i);
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.set(idx, block);
         return new Ast.Apply(call.function(), args, call.origin(), call.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/InjectionSigs.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InjectionSigs.java
@@ -6,6 +6,7 @@ import souther.compiler.types.Type;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -108,5 +109,19 @@ public final class InjectionSigs {
             }
         }
         return sigs;
+    }
+
+    /**
+     * The same behaviors, with only how many inputs each takes — what turning one of their names
+     * into a function value needs (spec {@code [#blocks]}).
+     *
+     * <p>The expansion that does it is written before anything is typed, so it cannot read a
+     * signature. One projection rather than one per caller, so a body expanded for the backend and a
+     * helper expanded for its own check answer the same about the same name.
+     */
+    public static Map<String, Integer> arities(Map<String, ReqSig> sigs) {
+        Map<String, Integer> arities = new LinkedHashMap<>();
+        sigs.forEach((name, sig) -> arities.put(name, sig.params().size()));
+        return arities;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -194,7 +194,12 @@ public final class TypeChecker {
         // published helper is expanded at its call sites here exactly as one of this module's own is,
         // and it is not one of this module's own — which is what keeps a recursive one of them in
         // `injectedRecursiveHelpers`, to be emitted here rather than declared here.
-        HelperInliner inliner = HelperInliner.forModule(module, publishedToHere);
+        // A helper is checked standing on its own as well as expanded into what calls it, and both
+        // readings answer the same about a behavior's name: it becomes the function value it names,
+        // which a helper may then not apply (E1401). Told nothing, the standalone reading would
+        // refuse the name for being a name rather than for being a behavior a helper cannot reach.
+        HelperInliner inliner = HelperInliner.forModule(module, publishedToHere)
+                .namingBehaviors(InjectionSigs.arities(calleeSigs));
         // An invariant runs on every construction and must terminate (spec §invariant-expressions).
         // A total recursive helper does terminate, so it is admissible — including the stdlib fold
         // (`List.foldFrom`) that backs the list quantifiers `List.all`/`any`/`member`/`distinct`,

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -434,6 +434,37 @@ public final class Bodies {
         }
     }
 
+    /**
+     * How many inputs each behavior a body of this module may name takes.
+     *
+     * <p>A name written where a value goes becomes the function it names, and all that becoming one
+     * needs is how many arguments it takes (spec {@code [#blocks]}). {@link CalleeSigs} already says
+     * which behaviors may be named here and what they take; this is that answer with the types
+     * dropped, because the expansion is written before anything is typed.
+     *
+     * <p>Its own question rather than a read of {@link CalleeSigs} at the expansion, so a change to a
+     * behavior's input <em>types</em> does not expand every body of the module again.
+     */
+    public record NamedBehaviorArity(String name) implements Key<Map<String, Integer>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Integer>> compute(Db db) {
+            Answer<Map<String, ReqSig>> sigs = db.ask(new CalleeSigs(name));
+            if (!sigs.present()) {
+                return Answer.absent();
+            }
+            Map<String, Integer> arities = new LinkedHashMap<>();
+            for (Map.Entry<String, ReqSig> e : sigs.value().entrySet()) {
+                arities.put(e.getKey(), e.getValue().params().size());
+            }
+            return Answer.of(Ordered.map(arities));
+        }
+    }
+
     /** A module with every helper parameter the author left unwritten carrying the type its body
      * gives it — the surface tree the check reads its declarations from. */
     public record Settled(String name) implements Key<Ast.Module> {
@@ -723,12 +754,15 @@ public final class Bodies {
             Answer<Ast.FnDef> def = db.ask(new SettledFn(module, fn));
             Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(module));
             Answer<Set<String>> recursive = db.ask(new RecursiveHelpers(module));
-            if (!def.present() || !helpers.present() || !recursive.present()) {
+            Answer<Map<String, Integer>> behaviors = db.ask(new NamedBehaviorArity(module));
+            if (!def.present() || !helpers.present() || !recursive.present()
+                    || !behaviors.present()) {
                 return Answer.absent();
             }
             try {
                 return Answer.of(Lower.body(def.value(),
-                        HelperInliner.forHelpers(module, helpers.value()),
+                        HelperInliner.forHelpers(module, helpers.value())
+                                .namingBehaviors(behaviors.value()),
                         recursive.value().contains(fn), dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -457,11 +457,7 @@ public final class Bodies {
             if (!sigs.present()) {
                 return Answer.absent();
             }
-            Map<String, Integer> arities = new LinkedHashMap<>();
-            for (Map.Entry<String, ReqSig> e : sigs.value().entrySet()) {
-                arities.put(e.getKey(), e.getValue().params().size());
-            }
-            return Answer.of(Ordered.map(arities));
+            return Answer.of(Ordered.map(InjectionSigs.arities(sigs.value())));
         }
     }
 
@@ -786,12 +782,15 @@ public final class Bodies {
             Answer<Ast.FnDef> def = db.ask(new SettledFn(module, fn));
             Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(module));
             Answer<Set<String>> recursive = db.ask(new RecursiveHelpers(module));
-            if (!def.present() || !helpers.present() || !recursive.present()) {
+            Answer<Map<String, Integer>> behaviors = db.ask(new NamedBehaviorArity(module));
+            if (!def.present() || !helpers.present() || !recursive.present()
+                    || !behaviors.present()) {
                 return Answer.absent();
             }
             try {
                 return Answer.of(Lower.body(def.value(),
-                        HelperInliner.forHelpers(module, helpers.value(), InliningPolicy.DISCHARGE),
+                        HelperInliner.forHelpers(module, helpers.value(), InliningPolicy.DISCHARGE)
+                                .namingBehaviors(behaviors.value()),
                         recursive.value().contains(fn), dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);

--- a/souther-compiler/src/test/java/souther/compiler/CompileBehaviorByNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileBehaviorByNameTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -179,6 +180,87 @@ class CompileBehaviorByNameTest {
                 """, Map.of("xs", List.of(1L, 2L)));
 
         assertEquals(List.of(2L, 3L), out.get("ys"));
+    }
+
+    /**
+     * A helper reaches no behavior, and that is one answer for the name however it is written. The
+     * helper is checked standing on its own as well as expanded into what calls it, so both
+     * readings have to say the same thing — a name in an argument said E1401 and the same name
+     * bound to a {@code let} first said it could not be held as a value, which sends the reader
+     * after a rule about bindings that does not exist.
+     */
+    @Test
+    void aHelperReachesNoBehaviorInEitherPosition() {
+        String helper = """
+                module demo
+
+                data In = { xs: List<Int> }
+                data Out = { ys: List<Int> }
+
+                behavior twice : (n: Int) -> Int
+                let twice (n) = n * 2
+
+                let mapped (xs: List<Int>) = %s
+
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { ys = mapped(i.xs) }
+                """;
+
+        CompileException handed = assertThrows(CompileException.class,
+                () -> Compiler.compile(helper.formatted("List.map(twice, xs)")));
+        CompileException bound = assertThrows(CompileException.class,
+                () -> Compiler.compile(helper.formatted("""
+                        {
+                            let f = twice
+                            List.map(f, xs)
+                        }""")));
+
+        assertEquals("E1401", handed.diagnostic().code());
+        assertEquals(handed.diagnostic().code(), bound.diagnostic().code());
+    }
+
+    /**
+     * The same behavior in both positions, whichever one the name reaches. A module declaring a
+     * behavior and importing one of the same spelling is the case where the two could come apart:
+     * the arity a name is expanded to and the behavior a call lands on are read from two tables,
+     * and a binding must not be the position where they disagree.
+     */
+    @Test
+    void aBoundNameAndAWrittenNameReachTheSameBehavior() {
+        String up = """
+                module up exposing ( twice )
+
+                behavior twice : (n: Int) -> Int
+                let twice (n) = n * 2
+                """;
+        String demo = """
+                module demo
+
+                import up ( twice )
+
+                data In = { n: Int }
+                data Out = { n: Int }
+
+                behavior twice : (a: Int, b: Int) -> Int
+                let twice (a, b) = a * b
+
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = %s
+                """;
+
+        assertEquals(reached(up, demo.formatted("Out { n = twice(i.n, 3) }")),
+                reached(up, demo.formatted("""
+                        {
+                            let f = twice
+                            Out { n = f(i.n, 3) }
+                        }""")));
+    }
+
+    /** Which behavior classes the emitted body of {@code demo.go} references. */
+    private static List<String> reached(String up, String demo) {
+        String impl = new String(Compiler.compileModules(List.of(up, demo)).get("demo.Go$Impl"),
+                java.nio.charset.StandardCharsets.ISO_8859_1);
+        return Stream.of("demo/Twice", "up/Twice").filter(impl::contains).toList();
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileBehaviorByNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileBehaviorByNameTest.java
@@ -1,0 +1,238 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A behavior's name handed over is the behavior (spec {@code [#blocks]}), and that holds in every
+ * position a name may be written — an argument, a binding, a branch of a choice.
+ *
+ * <p>The name reaches the behavior's class rather than the {@code let} behind it. A Java
+ * implementation replaces the behavior, so a value that reached past it to the helper body would be
+ * a second answer to the same name.
+ *
+ * <p>Only a behavior whose requirement set is empty is one a body may name. One that requires
+ * something arrives as a {@code depends on} parameter and is a binding by the time it can be
+ * written, so there is no declaration for a name to stand for.
+ */
+class CompileBehaviorByNameTest {
+
+    private static Map<String, byte[]> classes(String source) {
+        return Compiler.compile(source);
+    }
+
+    private static Object run(String source, Map<String, Object> in) throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(classes(source),
+                CompileBehaviorByNameTest.class.getClassLoader());
+        Object behavior = loader.loadClass("demo.Go$Impl").getConstructor().newInstance();
+        return Codecs.encode(loader, "demo.Out",
+                Codecs.apply(behavior, Codecs.decoded(loader, "demo.In", in)));
+    }
+
+    private static final String TWICE = """
+            module demo
+
+            data In = { xs: List<Int> }
+            data Out = { ys: List<Int> }
+
+            behavior twice : (n: Int) -> Int
+            let twice (n) = n * 2
+
+            behavior go : (i: In) -> Out constructs Out
+            """;
+
+    /** The position that already worked: the name written where the combinator takes a function. */
+    @Test
+    void aBehaviorIsHandedToACombinatorByName() throws Exception {
+        Map<?, ?> out = (Map<?, ?>) run(TWICE + """
+
+                let go (i) = Out { ys = List.map(twice, i.xs) }
+                """, Map.of("xs", List.of(1L, 2L, 3L)));
+
+        assertEquals(List.of(2L, 4L, 6L), out.get("ys"));
+    }
+
+    /** The position that did not: the same name, bound to a {@code let} first. */
+    @Test
+    void aBehaviorIsBoundToALetAndHandedOver() throws Exception {
+        Map<?, ?> out = (Map<?, ?>) run(TWICE + """
+
+                let go (i) = {
+                    let f = twice
+                    Out { ys = List.map(f, i.xs) }
+                }
+                """, Map.of("xs", List.of(1L, 2L, 3L)));
+
+        assertEquals(List.of(2L, 4L, 6L), out.get("ys"));
+    }
+
+    /** Bound and then applied, which is the other thing a binding holding a function is for. */
+    @Test
+    void aBehaviorBoundToALetIsApplied() throws Exception {
+        Map<?, ?> out = (Map<?, ?>) run(TWICE + """
+
+                let go (i) = {
+                    let f = twice
+                    Out { ys = [f(21)] }
+                }
+                """, Map.of("xs", List.of()));
+
+        assertEquals(List.of(42L), out.get("ys"));
+    }
+
+    /**
+     * A behavior and a block the author wrote are one kind of value: chosen between at run time and
+     * then handed over. Nothing downstream tells which branch the value came from.
+     */
+    @Test
+    void aBehaviorAndAWrittenBlockAreOneKindOfValue() throws Exception {
+        String src = """
+                module demo
+
+                data In = { n: Int, flag: Bool }
+                data Out = { ys: List<Int> }
+
+                behavior twice : (n: Int) -> Int
+                let twice (n) = n * 2
+
+                behavior go : (i: In) -> Out constructs Out
+
+                let go (i) = {
+                    let f = if i.flag then twice else (n) -> n + 1
+                    Out { ys = [f(i.n)] }
+                }
+                """;
+
+        assertEquals(List.of(42L),
+                ((Map<?, ?>) run(src, Map.of("n", 21L, "flag", true))).get("ys"));
+        assertEquals(List.of(22L),
+                ((Map<?, ?>) run(src, Map.of("n", 21L, "flag", false))).get("ys"));
+    }
+
+    /** A behavior another module declares, bound to a {@code let} in the module that imports it. */
+    @Test
+    void anImportedBehaviorIsBoundToALetAndHandedOver() throws Exception {
+        Map<String, byte[]> classes = Compiler.compileModules(List.of("""
+                module up exposing ( twice )
+
+                behavior twice : (n: Int) -> Int
+                let twice (n) = n * 2
+                """, """
+                module demo
+
+                import up ( twice )
+
+                data In = { xs: List<Int> }
+                data Out = { ys: List<Int> }
+
+                behavior go : (i: In) -> Out constructs Out
+
+                let go (i) = {
+                    let f = twice
+                    Out { ys = List.map(f, i.xs) }
+                }
+                """));
+        BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
+        Object behavior = loader.loadClass("demo.Go$Impl").getConstructor().newInstance();
+        assertEquals(List.of(2L, 4L),
+                ((Map<?, ?>) Codecs.encode(loader, "demo.Out",
+                        Codecs.apply(behavior, Codecs.decoded(loader, "demo.In",
+                                Map.of("xs", List.of(1L, 2L)))))).get("ys"));
+    }
+
+    /**
+     * The value goes through the behavior's class. A behavior is what a Java implementation
+     * replaces, so a value that reached the {@code let} instead would keep running the Souther body
+     * after the behavior had been replaced.
+     */
+    @Test
+    void theBoundNameReachesTheBehaviorAndNotTheLetBehindIt() {
+        String bound = new String(classes(TWICE + """
+
+                let go (i) = {
+                    let f = twice
+                    Out { ys = List.map(f, i.xs) }
+                }
+                """).get("demo.Go$Impl"), java.nio.charset.StandardCharsets.ISO_8859_1);
+
+        assertTrue(bound.contains("demo/Twice"), "the expansion does not reach `demo.Twice`");
+    }
+
+    /** A binding in force wins over the declaration it shadows, here as anywhere else. */
+    @Test
+    void aBindingSpelledLikeABehaviorIsTheBinding() throws Exception {
+        Map<?, ?> out = (Map<?, ?>) run(TWICE + """
+
+                let go (i) = {
+                    let twice = (n) -> n + 1
+                    let f = twice
+                    Out { ys = List.map(f, i.xs) }
+                }
+                """, Map.of("xs", List.of(1L, 2L)));
+
+        assertEquals(List.of(2L, 3L), out.get("ys"));
+    }
+
+    /**
+     * A behavior that requires something is not a name a body may stand for. It is reached through
+     * the {@code depends on} clause that names it, which makes it a binding rather than a
+     * declaration — so there is nothing here for a value to be.
+     */
+    @Test
+    void aBehaviorThatRequiresSomethingIsNotBoundByName() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data In = { xs: List<Int> }
+                data Out = { ys: List<Int> }
+
+                behavior scale : (n: Int) -> Int
+
+                behavior go : (i: In) -> Out
+                    constructs Out
+                    depends on scale
+
+                let go (i, scaled) = {
+                    let f = scale
+                    Out { ys = List.map(f, i.xs) }
+                }
+                """));
+        assertTrue(e.getMessage().contains("`scale`"), e.getMessage());
+    }
+
+    /** A composition is composed with, not handed over: its requirements are inferred rather than
+     * written, so a body resting on one would take on a set that changes with an upstream stage. */
+    @Test
+    void aCompositionIsNotBoundByName() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo exposing ( In, Mid, Out, one, two, chain : Out, go )
+
+                data In = { n: Int }
+                data Mid = { n: Int }
+                data Out = { n: Int }
+
+                behavior one : (i: In) -> Mid constructs Mid
+                let one (i) = Mid { n = i.n }
+
+                behavior two : (m: Mid) -> Out constructs Out
+                let two (m) = Out { n = m.n }
+
+                behavior chain = one >-> two
+
+                behavior go : (i: In) -> Out
+                let go (i) = {
+                    let f = chain
+                    f(i)
+                }
+                """));
+        assertTrue(e.getMessage().contains("`chain` is a behavior"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
@@ -141,20 +141,28 @@ class CompileImportedNameTest {
         assertTrue(!e.getMessage().contains("String.trim"), e.getMessage());
     }
 
-    /** A name that was answered is not an unknown one, whatever it turns out to denote. */
+    /**
+     * A name that was answered is not an unknown one, whatever it turns out to denote. A composition
+     * is answered and is still not a value — its requirements are inferred from its stages, so a
+     * body holding one would take on a set that changes when an upstream stage does.
+     */
     @Test
     void aNameThatDenotesSomethingUnusableSaysWhatItDenotes() {
         CompileException e = assertThrows(CompileException.class,
                 () -> Compiler.compile("""
-                module demo
+                module demo exposing ( In, Mid, Out, one, two, chain : Out, go )
                 data In = { n: Int }
-                data Out = { m: Int }
-                behavior twice : (n: Int) -> Int
-                let twice (n) = n * 2
-                behavior go : (i: In) -> Out constructs Out
+                data Mid = { n: Int }
+                data Out = { n: Int }
+                behavior one : (i: In) -> Mid constructs Mid
+                let one (i) = Mid { n = i.n }
+                behavior two : (m: Mid) -> Out constructs Out
+                let two (m) = Out { n = m.n }
+                behavior chain = one >-> two
+                behavior go : (i: In) -> Out
                 let go (i) = {
-                    let f = twice
-                    Out { m = f(i.n) }
+                    let f = chain
+                    f(i)
                 }
                 """));
         assertTrue(e.getMessage().contains("is a behavior"), e.getMessage());


### PR DESCRIPTION
A behavior's name handed to a combinator reaches the behavior's class; the same name bound to a `let` first was refused. One name, two positions, two answers — with one position left (#271).

## What was in the way

Reifying a name — turning a named function into the function value it names — is written four times in `HelperInliner`, and each gets its arity from a different place:

| | arity from |
|---|---|
| `valueOf` | the helper's `FnDef` |
| `libraryValueOf` | the library declaration |
| `forwardDependencies` | the callee's declared `Ast.FnType` |
| `desugarNamedBlock` | the helper a `fold` step names |

A behavior is the case none of the four covers, and the inliner is built from the helper table, so the arity to expand to was not in hand there.

## What this does

The four share one `etaExpand` — the block, its parameters and the application it wraps — while keeping their own entry points. A name standing for a declaration and a `depends on` binding forwarded to its callee decide arity for different reasons, and one lookup rule over `ValueName` would have hidden that.

`declarationArity` answers for a helper, a library function and a behavior alike. What reification needs is how many arguments the block takes; what stands behind the name — a Souther body, a shipped kernel, a Java implementation — is not the name's business.

Which behaviors a body may name is a fact about the module, so the query layer works it out. `Bodies.NamedBehaviorArity` reads `CalleeSigs` and drops the types, because the expansion is written before anything is typed; asking its own question keeps a change to a behavior's input types from expanding every body of the module again.

## What is still refused

A behavior with a requirement, and a composition. Both are reached through the clause that names them rather than by standing for a declaration, so there is nothing for a name to be. `CompileImportedNameTest.aNameThatDenotesSomethingUnusableSaysWhatItDenotes` pinned the binding position that this fixes; it now pins a composition, which is still answered and still not a value.

A behavior taking no input is refused too: a block taking no parameter is not a shape this language writes.

## Evidence

`CompileBehaviorByNameTest` — the argument position, the binding position, bound and applied, chosen between at run time, imported, shadowed by a local, and the two refusals. Five of its nine fail on `develop` with ``​`twice` is a behavior, and cannot be held as a value here``. One reads the emitted `demo.Go$Impl` for `demo/Twice`, so the value reaching the behavior rather than the `let` is checked rather than assumed.

Full suite green (1982 tests). `souther-examples` builds and verifies against this.

Closes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
