### PR TITLE
Report a warning where it is, and to the build

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Located;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Db;
@@ -34,7 +35,7 @@ public final class Compiler {
     }
 
     /** A compiled module with any non-fatal diagnostics (invariant-discharge warnings, etc.). */
-    public record Compiled(Map<String, byte[]> classes, List<Diagnostic> warnings) {}
+    public record Compiled(Map<String, byte[]> classes, List<Located> warnings) {}
 
     /** Compiles and returns the classes together with any invariant-discharge warnings. */
     public static Compiled compileWithWarnings(String source) {
@@ -44,7 +45,7 @@ public final class Compiler {
     /** As {@link #compileWithWarnings(String)}, but a header-less source is named
      * {@code defaultModuleName} (so the CLI's filename-stem naming can surface warnings too). */
     public static Compiled compileWithWarnings(String source, String defaultModuleName) {
-        List<Diagnostic> warnings = new ArrayList<>();
+        List<Located> warnings = new ArrayList<>();
         Map<String, byte[]> classes = compile(source, defaultModuleName, warnings);
         return new Compiled(classes, warnings);
     }
@@ -55,7 +56,7 @@ public final class Compiler {
     }
 
     private static Map<String, byte[]> compile(String source, String defaultModuleName,
-                                               List<Diagnostic> warningsOut) {
+                                               List<Located> warningsOut) {
         try {
             return compiling(source, defaultModuleName, warningsOut);
         } catch (StackOverflowError _) {
@@ -89,7 +90,7 @@ public final class Compiler {
      * the one.
      */
     private static Map<String, byte[]> compiling(String source, String defaultModuleName,
-                                                 List<Diagnostic> warningsOut) {
+                                                 List<Located> warningsOut) {
         return classesOf(compiled(source, defaultModuleName, warningsOut));
     }
 
@@ -102,8 +103,10 @@ public final class Compiler {
         return compiled(source, defaultModuleName, new ArrayList<>());
     }
 
-    private static Compilation compiled(String source, String defaultModuleName,
-                                        List<Diagnostic> warningsOut) {
+    /** As {@link #compiled(String, String)}, collecting the compile's warnings into
+     *  {@code warningsOut}. */
+    static Compilation compiled(String source, String defaultModuleName,
+                                List<Located> warningsOut) {
         Compilation compilation = Compilation.ofSource(source, defaultModuleName);
         Db db = compilation.db();
 
@@ -170,12 +173,12 @@ public final class Compiler {
     /** As {@link #compileModulesWithWarnings(List)}, resolving against {@code path} as
      * {@link #compileModules(List, ModulePath)} does. */
     public static Compiled compileModulesWithWarnings(List<String> sources, ModulePath path) {
-        List<Diagnostic> warnings = new ArrayList<>();
+        List<Located> warnings = new ArrayList<>();
         return new Compiled(compileModules(sources, path, warnings), warnings);
     }
 
     private static Map<String, byte[]> compileModules(List<String> sources, ModulePath path,
-                                                      List<Diagnostic> warningsOut) {
+                                                      List<Located> warningsOut) {
         try {
             return linking(sources, path, warningsOut);
         } catch (StackOverflowError _) {
@@ -192,7 +195,7 @@ public final class Compiler {
      * (issue #114) — so a change to a widely-imported data says how far it reaches in one compile.
      */
     private static Map<String, byte[]> linking(List<String> sources, ModulePath path,
-                                               List<Diagnostic> warningsOut) {
+                                               List<Located> warningsOut) {
         Compilation compilation = Compilation.ofSources(sources, path);
         Db db = compilation.db();
 

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -34,8 +34,20 @@ public final class Compiler {
         return compile(source, "Main");
     }
 
-    /** A compiled module with any non-fatal diagnostics (invariant-discharge warnings, etc.). */
-    public record Compiled(Map<String, byte[]> classes, List<Located> warnings) {}
+    /**
+     * A compiled module with any non-fatal diagnostics (invariant-discharge warnings, etc.), each
+     * carrying the source it belongs to so a caller can quote the line it is about.
+     *
+     * @param classes the generated classes, by binary name
+     * @param locatedWarnings the warnings, each with the source that holds it
+     */
+    public record Compiled(Map<String, byte[]> classes, List<Located> locatedWarnings) {
+
+        /** The warnings on their own, for a caller that only reads what they say. */
+        public List<Diagnostic> warnings() {
+            return locatedWarnings.stream().map(Located::diagnostic).toList();
+        }
+    }
 
     /** Compiles and returns the classes together with any invariant-discharge warnings. */
     public static Compiled compileWithWarnings(String source) {

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -116,6 +116,9 @@ public final class Main {
             reportCompileError(e, sources, render);
             System.exit(1);
         } catch (IOException e) {
+            // The compile itself finished — these warnings are the whole set, and what stopped the
+            // command was writing the classes out, which says nothing about the source.
+            report(warnings, sources, render);
             System.err.println("io error: " + e.getMessage());
             System.exit(1);
         }
@@ -337,8 +340,12 @@ public final class Main {
      * Compiles the given source files together — a single file, or several linked through their
      * imports (spec 4) — and writes each generated class under {@code outDir}. Returns the paths
      * written, in order.
+     *
+     * <p>This is the {@code compile} subcommand's own wiring, not a way to embed the compiler: it
+     * hands its warnings to the caller to render rather than reporting them. Compiling from Java
+     * goes through {@link Compiler} or the annotation processor, both of which say what they found.
      */
-    public static List<Path> compileToDir(List<Path> sources, Path outDir) throws IOException {
+    static List<Path> compileToDir(List<Path> sources, Path outDir) throws IOException {
         return compileToDir(sources, outDir, List.of());
     }
 
@@ -347,7 +354,7 @@ public final class Main {
      * {@code sources} against the compiled modules on {@code classPath} — the directories and jars
      * of the projects this one depends on.
      */
-    public static List<Path> compileToDir(List<Path> sources, Path outDir, List<Path> classPath)
+    static List<Path> compileToDir(List<Path> sources, Path outDir, List<Path> classPath)
             throws IOException {
         return compileToDir(sources, outDir, classPath, new ArrayList<>());
     }
@@ -367,7 +374,7 @@ public final class Main {
         Compiler.Compiled compiled = texts.size() == 1 && classPath.isEmpty()
                 ? Compiler.compileWithWarnings(texts.get(0), Runner.moduleName(sources.get(0)))
                 : Compiler.compileModulesWithWarnings(texts, path);
-        warningsOut.addAll(compiled.warnings());
+        warningsOut.addAll(compiled.locatedWarnings());
         Map<String, byte[]> classes = compiled.classes();
         List<Path> written = new ArrayList<>();
         for (Map.Entry<String, byte[]> entry : classes.entrySet()) {

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -216,6 +216,10 @@ public final class Main {
             report(warnings, sources, render);
             System.out.println(output);
         } catch (Runner.RunException e) {
+            // The compile finished before the run began, so these warnings are the whole set — and a
+            // run that aborted on an invariant is where a warning that the construction was unproven
+            // is worth most. A usage error is raised before any of it and carries none.
+            report(warnings, sources, render);
             System.err.println(e.localized(Messages.resolveLocale(render.lang)));
             System.exit(e.exitCode);
         } catch (CompileException e) {

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -236,19 +236,7 @@ public final class Main {
 
     /** The file the {@code i}-th diagnostic should quote. */
     static Path sourceOf(List<Path> sources, CompileException e, int i) {
-        return sourceAt(sources, e.sourceIndexOf(i));
-    }
-
-    /**
-     * The file a diagnostic tagged with {@code index} should quote. A compile of one file names no
-     * source — the compilation drops the index, since the caller knows the file it handed over — so
-     * the single file it was given is the answer there however the diagnostic is tagged.
-     */
-    static Path sourceAt(List<Path> sources, int index) {
-        if (sources.size() == 1) {
-            return sources.get(0);
-        }
-        return index >= 0 && index < sources.size() ? sources.get(index) : null;
+        return Located.in(sources, e.sourceIndexOf(i));
     }
 
     /** A file as a snippet source, or null when it cannot be read — a snippet-less rendering is the
@@ -282,7 +270,7 @@ public final class Main {
         DiagnosticRenderer renderer = render.json()
                 ? new JsonRenderer() : new HumanRenderer(render.useColor());
         for (String line : DiagnosticRenderer.renderAll(
-                located, index -> read(sourceAt(sources, index)), renderer, locale)) {
+                located, index -> read(Located.in(sources, index)), renderer, locale)) {
             System.err.println(line);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -3,10 +3,10 @@ package souther.compiler;
 import souther.compiler.cst.CstError;
 import souther.compiler.cst.CstParser;
 import souther.compiler.diag.CompileException;
-import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.DiagnosticRenderer;
 import souther.compiler.diag.HumanRenderer;
 import souther.compiler.diag.JsonRenderer;
+import souther.compiler.diag.Located;
 import souther.compiler.diag.Messages;
 import souther.compiler.diag.SourceContext;
 import souther.compiler.fmt.Formatter;
@@ -103,8 +103,13 @@ public final class Main {
             System.exit(2);
             return;
         }
+        List<Located> warnings = new ArrayList<>();
         try {
-            for (Path file : compileToDir(sources, outDir, classPath)) {
+            List<Path> written = compileToDir(sources, outDir, classPath, warnings);
+            // Before the written files: the warnings are about the source, and a long list of paths
+            // between them and the command would bury them.
+            report(warnings, sources, render);
+            for (Path file : written) {
                 System.out.println("wrote " + file);
             }
         } catch (CompileException e) {
@@ -201,13 +206,20 @@ public final class Main {
     private static void runSubcommand(String[] rawArgs) {
         RenderOptions render = new RenderOptions();
         String[] args = render.extract(rawArgs);
+        Path source = firstSource(args);
+        List<Path> sources = source == null ? List.of() : List.of(source);
+        List<Located> warnings = new ArrayList<>();
         try {
-            System.out.println(Runner.runCli(args));
+            String output = Runner.runCli(args, warnings);
+            // The warnings go to stderr and the behavior's output to stdout, so a caller piping the
+            // result reads JSON and nothing else.
+            report(warnings, sources, render);
+            System.out.println(output);
         } catch (Runner.RunException e) {
             System.err.println(e.localized(Messages.resolveLocale(render.lang)));
             System.exit(e.exitCode);
         } catch (CompileException e) {
-            reportCompileError(e, firstSource(args) == null ? List.of() : List.of(firstSource(args)), render);
+            reportCompileError(e, sources, render);
             System.exit(1);
         }
     }
@@ -224,10 +236,18 @@ public final class Main {
 
     /** The file the {@code i}-th diagnostic should quote. */
     static Path sourceOf(List<Path> sources, CompileException e, int i) {
+        return sourceAt(sources, e.sourceIndexOf(i));
+    }
+
+    /**
+     * The file a diagnostic tagged with {@code index} should quote. A compile of one file names no
+     * source — the compilation drops the index, since the caller knows the file it handed over — so
+     * the single file it was given is the answer there however the diagnostic is tagged.
+     */
+    static Path sourceAt(List<Path> sources, int index) {
         if (sources.size() == 1) {
             return sources.get(0);
         }
-        int index = e.sourceIndexOf(i);
         return index >= 0 && index < sources.size() ? sources.get(index) : null;
     }
 
@@ -252,14 +272,18 @@ public final class Main {
             System.err.println(e.getMessage());
             return;
         }
+        report(e.locatedDiagnostics(), sources, render);
+    }
+
+    /** Prints each diagnostic to stderr as the chosen renderer renders it, quoting the file it
+     * belongs to. Errors and warnings take the same path; only where they come from differs. */
+    private static void report(List<Located> located, List<Path> sources, RenderOptions render) {
         Locale locale = Messages.resolveLocale(render.lang);
         DiagnosticRenderer renderer = render.json()
                 ? new JsonRenderer() : new HumanRenderer(render.useColor());
-        List<Diagnostic> ds = e.diagnostics();
-        for (int i = 0; i < ds.size(); i++) {
-            // Each diagnostic quotes its own file: a compile that reports several modules at once has
-            // one per module, and they do not share a source.
-            System.err.println(renderer.render(ds.get(i), read(sourceOf(sources, e, i)), locale));
+        for (String line : DiagnosticRenderer.renderAll(
+                located, index -> read(sourceAt(sources, index)), renderer, locale)) {
+            System.err.println(line);
         }
     }
 
@@ -333,6 +357,13 @@ public final class Main {
      */
     public static List<Path> compileToDir(List<Path> sources, Path outDir, List<Path> classPath)
             throws IOException {
+        return compileToDir(sources, outDir, classPath, new ArrayList<>());
+    }
+
+    /** As {@link #compileToDir(List, Path, List)}, collecting the compile's warnings into
+     *  {@code warningsOut} for the caller to render — the CLI does, with the flags it was given. */
+    static List<Path> compileToDir(List<Path> sources, Path outDir, List<Path> classPath,
+                                   List<Located> warningsOut) throws IOException {
         List<String> texts = new ArrayList<>();
         for (Path source : sources) {
             texts.add(Files.readString(source));
@@ -344,9 +375,7 @@ public final class Main {
         Compiler.Compiled compiled = texts.size() == 1 && classPath.isEmpty()
                 ? Compiler.compileWithWarnings(texts.get(0), Runner.moduleName(sources.get(0)))
                 : Compiler.compileModulesWithWarnings(texts, path);
-        for (Diagnostic w : compiled.warnings()) {
-            System.err.println("warning: " + DiagnosticRenderer.body(w, Locale.ENGLISH));
-        }
+        warningsOut.addAll(compiled.warnings());
         Map<String, byte[]> classes = compiled.classes();
         List<Path> written = new ArrayList<>();
         for (Map.Entry<String, byte[]> entry : classes.entrySet()) {

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -113,13 +113,9 @@ public final class Runner {
         return new RunException(key, message, 1, null, args);
     }
 
-    /** Parses the {@code run} subcommand's arguments (everything after {@code run}) and runs it. */
-    static String runCli(String[] args) {
-        return runCli(args, new ArrayList<>());
-    }
-
-    /** As {@link #runCli(String[])}, collecting the compile's warnings into {@code warningsOut} for
-     *  the caller to render — running a module says what compiling it would have said. */
+    /** Parses the {@code run} subcommand's arguments (everything after {@code run}) and runs it,
+     *  collecting the compile's warnings into {@code warningsOut} for the caller to render —
+     *  running a module says what compiling it would have said. */
     static String runCli(String[] args, List<Located> warningsOut) {
         Path file = null;
         String behaviorName = null;

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -6,6 +6,7 @@ import souther.compiler.check.Sig;
 import souther.compiler.types.Type;
 import souther.compiler.query.Compilation;
 import souther.compiler.codegen.Backend;
+import souther.compiler.diag.Located;
 import souther.compiler.diag.Messages;
 import net.unit8.raoh.Err;
 import net.unit8.raoh.Issues;
@@ -32,6 +33,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -113,6 +115,12 @@ public final class Runner {
 
     /** Parses the {@code run} subcommand's arguments (everything after {@code run}) and runs it. */
     static String runCli(String[] args) {
+        return runCli(args, new ArrayList<>());
+    }
+
+    /** As {@link #runCli(String[])}, collecting the compile's warnings into {@code warningsOut} for
+     *  the caller to render — running a module says what compiling it would have said. */
+    static String runCli(String[] args, List<Located> warningsOut) {
         Path file = null;
         String behaviorName = null;
         String inputJson = null;
@@ -134,7 +142,7 @@ public final class Runner {
         if (file == null) {
             throw usage("run.usage.nofile", "no source file given");
         }
-        return run(file, behaviorName, inputJson);
+        return run(file, behaviorName, inputJson, warningsOut);
     }
 
     private static String value(String[] args, int i, String option) {
@@ -153,13 +161,19 @@ public final class Runner {
      * encoded output as JSON text. {@code behaviorName} may be null when the module holds exactly
      * one runnable behavior; {@code inputJson} may be null for a zero-argument behavior. */
     public static String run(Path file, String behaviorName, String inputJson) {
+        return run(file, behaviorName, inputJson, new ArrayList<>());
+    }
+
+    /** As {@link #run(Path, String, String)}, collecting the compile's warnings into
+     *  {@code warningsOut}. */
+    static String run(Path file, String behaviorName, String inputJson, List<Located> warningsOut) {
         String source = read(file);
         String moduleName = moduleName(file);
 
         // One compilation answers all of it. Re-reading the source here to find the behavior and
         // its signature would resolve every name a second time, against a tree this compile has
         // already produced.
-        Compilation compilation = Compiler.compiled(source, moduleName);
+        Compilation compilation = Compiler.compiled(source, moduleName, warningsOut);
         Map<String, byte[]> classes = compilation.classes();
         Ast.Module module = compilation.module(compilation.modules().get(0));
         Map<String, Sig> sigs = compilation.signatures(module.name());

--- a/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
+++ b/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
@@ -92,7 +92,7 @@ public final class SoutherProcessor extends AbstractProcessor {
                     : Compiler.compileModulesWithWarnings(texts, path);
             // A warning is the whole of what the checker has to say about an unproven construction,
             // so a build that never reports one lets them accumulate while staying green.
-            for (String reported : render(compiled.warnings(), sources)) {
+            for (String reported : render(compiled.locatedWarnings(), sources)) {
                 processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, reported);
             }
             Map<String, byte[]> classes = compiled.classes();

--- a/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
+++ b/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
@@ -133,15 +133,10 @@ public final class SoutherProcessor extends AbstractProcessor {
                 located, index -> contextOf(sources, index), new HumanRenderer(false), locale);
     }
 
-    /**
-     * The source a diagnostic tagged with {@code index} came from, or null when it names none and
-     * there is more than one to choose from (so no line is quoted). A compile of one file names no
-     * source — the caller knows the file it handed over — so the single file it was given is the
-     * answer there however the diagnostic is tagged.
-     */
+    /** The text a diagnostic tagged with {@code index} should quote, or null when it names no
+     *  source this compilation has (so no line is quoted). */
     private static SourceContext contextOf(List<Source> sources, int index) {
-        Source origin = sources.size() == 1 ? sources.get(0)
-                : index >= 0 && index < sources.size() ? sources.get(index) : null;
+        Source origin = Located.in(sources, index);
         return origin == null ? null
                 : new SourceContext(origin.path().getFileName().toString(), origin.text());
     }

--- a/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
+++ b/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
@@ -1,7 +1,9 @@
 package souther.compiler.apt;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.DiagnosticRenderer;
 import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.Located;
 import souther.compiler.diag.Messages;
 import souther.compiler.diag.SourceContext;
 import souther.compiler.Compiler;
@@ -85,9 +87,15 @@ public final class SoutherProcessor extends AbstractProcessor {
             // one that names itself is a module set of one, and may import a module off the path.
             boolean selfContained =
                     texts.size() == 1 && Compiler.moduleNameFromHeader(texts.get(0)) == null;
-            Map<String, byte[]> classes = selfContained
-                    ? Compiler.compile(texts.get(0))
-                    : Compiler.compileModules(texts, path);
+            Compiler.Compiled compiled = selfContained
+                    ? Compiler.compileWithWarnings(texts.get(0))
+                    : Compiler.compileModulesWithWarnings(texts, path);
+            // A warning is the whole of what the checker has to say about an unproven construction,
+            // so a build that never reports one lets them accumulate while staying green.
+            for (String reported : render(compiled.warnings(), sources)) {
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, reported);
+            }
+            Map<String, byte[]> classes = compiled.classes();
             Filer filer = processingEnv.getFiler();
             for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
                 JavaFileObject file = filer.createClassFile(entry.getKey());
@@ -115,28 +123,27 @@ public final class SoutherProcessor extends AbstractProcessor {
         if (e.diagnostic() == null) {
             return List.of("souther: " + e.getMessage());   // not yet structured
         }
-        Locale locale = Messages.resolveLocale(processingEnv.getOptions().get("souther.lang"));
-        HumanRenderer renderer = new HumanRenderer(false);
-        List<String> reported = new ArrayList<>();
-        List<souther.compiler.diag.Diagnostic> ds = e.diagnostics();
-        for (int i = 0; i < ds.size(); i++) {
-            // Each diagnostic quotes its own file; a compile reporting several modules at once has
-            // one per module.
-            Source origin = originOf(e, sources, i);
-            SourceContext src = origin == null ? null
-                    : new SourceContext(origin.path().getFileName().toString(), origin.text());
-            reported.add(renderer.render(ds.get(i), src, locale));
-        }
-        return reported;
+        return render(e.locatedDiagnostics(), sources);
     }
 
-    /** The source the error came from, or null when it names none (so no line is quoted). */
-    private static Source originOf(CompileException e, List<Source> sources, int i) {
-        if (sources.size() == 1) {
-            return sources.get(0);
-        }
-        int index = e.sourceIndexOf(i);
-        return index >= 0 && index < sources.size() ? sources.get(index) : null;
+    /** The same rendering for a warning, which arrives already carrying the source it belongs to. */
+    private List<String> render(List<Located> located, List<Source> sources) {
+        Locale locale = Messages.resolveLocale(processingEnv.getOptions().get("souther.lang"));
+        return DiagnosticRenderer.renderAll(
+                located, index -> contextOf(sources, index), new HumanRenderer(false), locale);
+    }
+
+    /**
+     * The source a diagnostic tagged with {@code index} came from, or null when it names none and
+     * there is more than one to choose from (so no line is quoted). A compile of one file names no
+     * source — the caller knows the file it handed over — so the single file it was given is the
+     * answer there however the diagnostic is tagged.
+     */
+    private static SourceContext contextOf(List<Source> sources, int index) {
+        Source origin = sources.size() == 1 ? sources.get(0)
+                : index >= 0 && index < sources.size() ? sources.get(index) : null;
+        return origin == null ? null
+                : new SourceContext(origin.path().getFileName().toString(), origin.text());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.check.Sig;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Located;
 import souther.compiler.meta.ModulePath;
 
 import java.util.ArrayList;
@@ -307,12 +308,13 @@ public final class Compilation {
         return found.module() == null ? -1 : sourceIndexOf(found.module());
     }
 
-    /** The warnings among {@code found}, in order. */
-    public List<Diagnostic> warnings(List<Db.Found> found) {
-        List<Diagnostic> warnings = new ArrayList<>();
+    /** The warnings among {@code found}, in order, each tagged with the source it belongs to — the
+     *  same tag {@link #firstError} puts on an error, so a warning can be quoted where it is. */
+    public List<Located> warnings(List<Db.Found> found) {
+        List<Located> warnings = new ArrayList<>();
         for (Db.Found f : found) {
             if (!f.report().isError()) {
-                warnings.add(f.report().diagnostic());
+                warnings.add(new Located(f.report().diagnostic(), indexOf(f)));
             }
         }
         return warnings;

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -5,6 +5,7 @@
 
 # --- frame ---
 diag.error.title=ERROR
+diag.warning.title=WARNING
 diag.hint.label=Hint:
 diag.diff.found=It is:
 diag.diff.expected=But it needs to be:

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -4,6 +4,7 @@
 
 # --- 枠 ---
 diag.error.title=エラー
+diag.warning.title=警告
 diag.hint.label=ヒント:
 diag.diff.found=実際:
 diag.diff.expected=期待:

--- a/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
@@ -3,6 +3,7 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Located;
 import souther.compiler.diag.Severity;
 
 import java.util.List;
@@ -185,7 +186,7 @@ class CompileAttemptedConstructionTest {
                 }
                 """;
         Compiler.Compiled c = Compiler.compileWithWarnings(src);
-        assertEquals(0, c.warnings().stream()
+        assertEquals(0, c.warnings().stream().map(Located::diagnostic)
                         .filter(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code())).count(),
                 "the attempt cannot abort, so there is no possible violation to warn about");
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
@@ -186,7 +186,7 @@ class CompileAttemptedConstructionTest {
                 }
                 """;
         Compiler.Compiled c = Compiler.compileWithWarnings(src);
-        assertEquals(0, c.warnings().stream().map(Located::diagnostic)
+        assertEquals(0, c.warnings().stream()
                         .filter(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code())).count(),
                 "the attempt cannot abort, so there is no possible violation to warn about");
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import souther.compiler.diag.Located;
 import souther.compiler.diag.Severity;
 
 /**
@@ -221,7 +222,7 @@ class CompileImportedNameTest {
                     Out { v = NonEmpty(i.s) }
                 }
                 """);
-        assertEquals(0, c.warnings().stream()
+        assertEquals(0, c.warnings().stream().map(Located::diagnostic)
                         .filter(d -> d.severity() == Severity.WARNING).count(),
                 c.warnings().toString());
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
@@ -222,7 +222,7 @@ class CompileImportedNameTest {
                     Out { v = NonEmpty(i.s) }
                 }
                 """);
-        assertEquals(0, c.warnings().stream().map(Located::diagnostic)
+        assertEquals(0, c.warnings().stream()
                         .filter(d -> d.severity() == Severity.WARNING).count(),
                 c.warnings().toString());
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Located;
 import souther.compiler.diag.Severity;
 
 import org.junit.jupiter.api.Test;
@@ -20,11 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CompileInvariantDischargeTest {
 
     private static long warnings(Compiler.Compiled c) {
-        return c.warnings().stream().filter(d -> d.severity() == Severity.WARNING).count();
+        return c.warnings().stream().map(Located::diagnostic)
+                .filter(d -> d.severity() == Severity.WARNING).count();
     }
 
     private static boolean hasWarning(Compiler.Compiled c, String code) {
-        return c.warnings().stream()
+        return c.warnings().stream().map(Located::diagnostic)
                 .anyMatch(d -> d.severity() == Severity.WARNING && code.equals(d.code()));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -21,12 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class CompileInvariantDischargeTest {
 
     private static long warnings(Compiler.Compiled c) {
-        return c.warnings().stream().map(Located::diagnostic)
+        return c.warnings().stream()
                 .filter(d -> d.severity() == Severity.WARNING).count();
     }
 
     private static boolean hasWarning(Compiler.Compiled c, String code) {
-        return c.warnings().stream().map(Located::diagnostic)
+        return c.warnings().stream()
                 .anyMatch(d -> d.severity() == Severity.WARNING && code.equals(d.code()));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/ImportChangesNoMeaningTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ImportChangesNoMeaningTest.java
@@ -186,7 +186,7 @@ class ImportChangesNoMeaningTest {
     }
 
     private static List<String> codes(Compiler.Compiled c) {
-        return c.warnings().stream().map(Located::diagnostic).map(Diagnostic::code).sorted().toList();
+        return c.warnings().stream().map(Diagnostic::code).sorted().toList();
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/ImportChangesNoMeaningTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ImportChangesNoMeaningTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Located;
 
 import org.junit.jupiter.api.Test;
 
@@ -185,7 +186,7 @@ class ImportChangesNoMeaningTest {
     }
 
     private static List<String> codes(Compiler.Compiled c) {
-        return c.warnings().stream().map(Diagnostic::code).sorted().toList();
+        return c.warnings().stream().map(Located::diagnostic).map(Diagnostic::code).sorted().toList();
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/WarningReportingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WarningReportingTest.java
@@ -1,0 +1,219 @@
+package souther.compiler;
+
+import souther.compiler.diag.Located;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A warning reaches the command line the way an error does: the same header, the offending line and
+ * a caret under it, in the language and the format the flags asked for. A warning is the whole of
+ * what the invariant checker has to say about a construction it cannot prove, so one printed without
+ * its position cannot be attributed to the construction it is about.
+ */
+class WarningReportingTest {
+
+    /** One unproven construction, on line 8. */
+    private static final String UNPROVEN = """
+            data Eaches = Int
+                invariant value >= 0
+
+            behavior wrap : (n: Int) -> Eaches
+                constructs Eaches
+            let wrap (n) = {
+                let m = n
+                Eaches(m)
+            }
+            """;
+
+    @Test
+    void aWarningIsPrintedWithItsPositionAndSourceLine() throws Exception {
+        Path file = write("probe.sou", UNPROVEN);
+
+        String reported = compile(file, "--lang", "en");
+
+        assertTrue(reported.contains("probe.sou:8:5"), reported);      // which file, where in it
+        assertTrue(reported.contains("Eaches(m)"), reported);          // the offending line
+        assertTrue(reported.contains("^"), reported);                  // the caret under it
+        assertTrue(reported.contains("E2011"), reported);
+    }
+
+    @Test
+    void theHeaderSaysItIsAWarning() throws Exception {
+        Path file = write("probe.sou", UNPROVEN);
+
+        String reported = compile(file, "--lang", "en");
+
+        assertTrue(reported.contains("INVARIANT (WARNING)"),
+                "a warning that is titled by what it is about still says which severity it is: "
+                        + reported);
+        assertFalse(reported.contains("ERROR"), reported);
+    }
+
+    @Test
+    void theWarningFollowsTheChosenLanguage() throws Exception {
+        Path file = write("probe.sou", UNPROVEN);
+
+        String ja = compile(file, "--lang", "ja");
+
+        assertTrue(ja.contains("(警告)"), ja);
+        assertTrue(ja.contains("不変条件に違反する可能性があります"), ja);
+    }
+
+    @Test
+    void jsonRendersTheWarningAsOneObjectWithItsRegion() throws Exception {
+        Path file = write("probe.sou", UNPROVEN);
+
+        String reported = compile(file, "--format", "json", "--lang", "en").strip();
+
+        assertFalse(reported.contains("\n"), "one diagnostic is one line, not an array: " + reported);
+        assertTrue(reported.startsWith("{") && reported.endsWith("}"), reported);
+        assertTrue(reported.contains("\"severity\":\"warning\""), reported);
+        assertTrue(reported.contains("\"code\":\"E2011\""), reported);
+        assertTrue(reported.contains("\"file\":\"probe.sou\""), reported);
+        assertTrue(reported.contains("\"startLine\":8"), reported);
+    }
+
+    /**
+     * A compile of one file names no source — {@code Compilation.ofSource} drops the index, since the
+     * caller knows the file it handed over — so the position would be lost if the renderer read the
+     * index as "quote no line".
+     */
+    @Test
+    void aSingleFileWarningNamesNoSourceAndIsStillQuoted() throws Exception {
+        Path file = write("probe.sou", UNPROVEN);
+        List<Located> warnings = new ArrayList<>();
+
+        Main.compileToDir(List.of(file), Files.createTempDirectory("souther-warn-out"),
+                List.of(), warnings);
+
+        assertEquals(1, warnings.size(), warnings.toString());
+        assertEquals(Located.NO_SOURCE, warnings.get(0).sourceIndex(),
+                "a single-source compile tags nothing, and the renderer has to fall back to the "
+                        + "one file it was given");
+        assertTrue(compile(file, "--lang", "en").contains("probe.sou:8:5"));
+    }
+
+    @Test
+    void aWarningNamesTheFileOfTheModuleItIsIn() throws Exception {
+        Path dir = Files.createTempDirectory("souther-warn");
+        Path a = dir.resolve("a.sou");
+        Path b = dir.resolve("b.sou");
+        Files.writeString(a, """
+                module a exposing ( Eaches, wrap )
+
+                data Eaches = Int
+                    invariant value >= 0
+
+                behavior wrap : (n: Int) -> Eaches
+                    constructs Eaches
+                let wrap (n) = {
+                    let m = n
+                    Eaches(m)
+                }
+                """);
+        Files.writeString(b, """
+                module b
+
+                import a ( Eaches )
+
+                data Box = { it: Eaches }
+                """);
+
+        String reported = capture(() -> Main.main(new String[]{
+                "compile", "--lang", "en", a.toString(), b.toString(),
+                "-d", Files.createTempDirectory("souther-warn-out").toString()}));
+
+        assertTrue(reported.contains("a.sou:10:5"),
+                "the warning belongs to the module that declares the construction: " + reported);
+        assertFalse(reported.contains("b.sou"), reported);
+    }
+
+    @Test
+    void runWarnsOnStderrAndKeepsItsResultOnStdout() throws Exception {
+        Path file = write("probe.sou", UNPROVEN);
+
+        PrintStream outWas = System.out;
+        PrintStream errWas = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[]{"run", "--lang", "en", file.toString(), "--input", "5"});
+        } finally {
+            System.setOut(outWas);
+            System.setErr(errWas);
+        }
+
+        assertEquals("5", out.toString(StandardCharsets.UTF_8).strip(),
+                "a caller piping the result reads the behavior's output and nothing else");
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("probe.sou:8:5"),
+                err.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void runKeepsTheStreamsApartInJsonToo() throws Exception {
+        Path file = write("probe.sou", UNPROVEN);
+
+        PrintStream outWas = System.out;
+        PrintStream errWas = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[]{
+                    "run", "--format", "json", "--lang", "en", file.toString(), "--input", "5"});
+        } finally {
+            System.setOut(outWas);
+            System.setErr(errWas);
+        }
+
+        assertEquals("5", out.toString(StandardCharsets.UTF_8).strip());
+        assertTrue(err.toString(StandardCharsets.UTF_8).contains("\"severity\":\"warning\""),
+                err.toString(StandardCharsets.UTF_8));
+    }
+
+    /** What {@code souther compile} writes to stderr for {@code file}. */
+    private static String compile(Path file, String... flags) throws Exception {
+        List<String> args = new ArrayList<>(List.of("compile"));
+        args.addAll(List.of(flags));
+        args.add(file.toString());
+        args.add("-d");
+        args.add(Files.createTempDirectory("souther-warn-out").toString());
+        return capture(() -> Main.main(args.toArray(new String[0])));
+    }
+
+    private static String capture(Action action) throws Exception {
+        PrintStream original = System.err;
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+        try {
+            action.run();
+        } finally {
+            System.setErr(original);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
+    private static Path write(String name, String content) throws Exception {
+        Path file = Files.createTempDirectory("souther-warn").resolve(name);
+        Files.writeString(file, content);
+        return file;
+    }
+
+    private interface Action {
+        void run() throws Exception;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/WarningReportingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WarningReportingTest.java
@@ -132,7 +132,7 @@ class WarningReportingTest {
 
         String reported = capture(() -> Main.main(new String[]{
                 "compile", "--lang", "en", a.toString(), b.toString(),
-                "-d", Files.createTempDirectory("souther-warn-out").toString()}));
+                "-d", Files.createTempDirectory("souther-warn-out").toString()})).err();
 
         assertTrue(reported.contains("a.sou:10:5"),
                 "the warning belongs to the module that declares the construction: " + reported);
@@ -143,46 +143,23 @@ class WarningReportingTest {
     void runWarnsOnStderrAndKeepsItsResultOnStdout() throws Exception {
         Path file = write("probe.sou", UNPROVEN);
 
-        PrintStream outWas = System.out;
-        PrintStream errWas = System.err;
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
-        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
-        try {
-            Main.main(new String[]{"run", "--lang", "en", file.toString(), "--input", "5"});
-        } finally {
-            System.setOut(outWas);
-            System.setErr(errWas);
-        }
+        Captured ran = capture(() -> Main.main(
+                new String[]{"run", "--lang", "en", file.toString(), "--input", "5"}));
 
-        assertEquals("5", out.toString(StandardCharsets.UTF_8).strip(),
+        assertEquals("5", ran.out().strip(),
                 "a caller piping the result reads the behavior's output and nothing else");
-        assertTrue(err.toString(StandardCharsets.UTF_8).contains("probe.sou:8:5"),
-                err.toString(StandardCharsets.UTF_8));
+        assertTrue(ran.err().contains("probe.sou:8:5"), ran.err());
     }
 
     @Test
     void runKeepsTheStreamsApartInJsonToo() throws Exception {
         Path file = write("probe.sou", UNPROVEN);
 
-        PrintStream outWas = System.out;
-        PrintStream errWas = System.err;
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
-        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
-        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
-        try {
-            Main.main(new String[]{
-                    "run", "--format", "json", "--lang", "en", file.toString(), "--input", "5"});
-        } finally {
-            System.setOut(outWas);
-            System.setErr(errWas);
-        }
+        Captured ran = capture(() -> Main.main(new String[]{
+                "run", "--format", "json", "--lang", "en", file.toString(), "--input", "5"}));
 
-        assertEquals("5", out.toString(StandardCharsets.UTF_8).strip());
-        assertTrue(err.toString(StandardCharsets.UTF_8).contains("\"severity\":\"warning\""),
-                err.toString(StandardCharsets.UTF_8));
+        assertEquals("5", ran.out().strip());
+        assertTrue(ran.err().contains("\"severity\":\"warning\""), ran.err());
     }
 
     /** What {@code souther compile} writes to stderr for {@code file}. */
@@ -192,19 +169,28 @@ class WarningReportingTest {
         args.add(file.toString());
         args.add("-d");
         args.add(Files.createTempDirectory("souther-warn-out").toString());
-        return capture(() -> Main.main(args.toArray(new String[0])));
+        return capture(() -> Main.main(args.toArray(new String[0]))).err();
     }
 
-    private static String capture(Action action) throws Exception {
-        PrintStream original = System.err;
-        ByteArrayOutputStream captured = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(captured, true, StandardCharsets.UTF_8));
+    /** What an action wrote to each stream. Both are captured because the point of several of these
+     *  tests is that the two carry different things. */
+    private record Captured(String out, String err) {}
+
+    private static Captured capture(Action action) throws Exception {
+        PrintStream outWas = System.out;
+        PrintStream errWas = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
         try {
             action.run();
         } finally {
-            System.setErr(original);
+            System.setOut(outWas);
+            System.setErr(errWas);
         }
-        return captured.toString(StandardCharsets.UTF_8);
+        return new Captured(out.toString(StandardCharsets.UTF_8),
+                err.toString(StandardCharsets.UTF_8));
     }
 
     private static Path write(String name, String content) throws Exception {

--- a/souther-compiler/src/test/java/souther/compiler/WarningReportingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WarningReportingTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -149,6 +150,26 @@ class WarningReportingTest {
         assertEquals("5", ran.out().strip(),
                 "a caller piping the result reads the behavior's output and nothing else");
         assertTrue(ran.err().contains("probe.sou:8:5"), ran.err());
+    }
+
+    /**
+     * The run that aborts is the one the warning predicted, so it is the last one that should
+     * swallow it. The compile finishes before the run begins, so the warnings are already the whole
+     * set by the time the abort is raised, and {@code Main} renders them from its catch.
+     *
+     * <p>Driven through {@link Runner} rather than {@link Main#main}, because the failing path ends
+     * in {@code System.exit} and would take the test JVM with it.
+     */
+    @Test
+    void theWarningsSurviveARunThatAborts() throws Exception {
+        Path file = write("probe.sou", UNPROVEN);
+        List<Located> warnings = new ArrayList<>();
+
+        assertThrows(Runner.RunException.class, () -> Runner.runCli(
+                new String[]{file.toString(), "--input", "-1"}, warnings));
+
+        assertEquals(1, warnings.size(), warnings.toString());
+        assertEquals("E2011", warnings.get(0).diagnostic().code());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/apt/ProcessorRun.java
+++ b/souther-compiler/src/test/java/souther/compiler/apt/ProcessorRun.java
@@ -1,0 +1,69 @@
+package souther.compiler.apt;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+/**
+ * One javac run with {@link SoutherProcessor} pointed at a {@code .sou} file or directory, and what
+ * it reported, split by kind. The processor's whole surface to a build is what reaches the
+ * {@code Messager}, so a test asserts on that text rather than on anything the compiler returns.
+ *
+ * @param ok whether the compilation succeeded — false when the processor reported an error
+ * @param errors every {@code ERROR} message, one per line
+ * @param warnings every {@code WARNING} message, one per line
+ */
+record ProcessorRun(boolean ok, String errors, String warnings) {
+
+    /**
+     * Runs javac over one throwaway Java file with the processor reading {@code source}, rendering
+     * its diagnostics in {@code lang}. {@code dir} holds the scratch Java file and output classes.
+     */
+    static ProcessorRun of(Path dir, Path source, String lang) throws IOException {
+        Path java = write(dir, "Dummy.java", "public class Dummy {}\n");
+        Path classes = Files.createDirectories(dir.resolve("classes"));
+        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> collected = new DiagnosticCollector<>();
+        boolean ok;
+        try (StandardJavaFileManager files =
+                     javac.getStandardFileManager(collected, null, StandardCharsets.UTF_8)) {
+            List<String> options = new ArrayList<>(List.of(
+                    "-processor", SoutherProcessor.class.getName(),
+                    "-Asouther.source=" + source,
+                    "-Asouther.lang=" + lang,
+                    "-d", classes.toString(),
+                    "-classpath", System.getProperty("java.class.path")));
+            ok = javac.getTask(null, files, collected, options,
+                    null, files.getJavaFileObjects(java)).call();
+        }
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+        for (Diagnostic<? extends JavaFileObject> d : collected.getDiagnostics()) {
+            StringBuilder into = switch (d.getKind()) {
+                case ERROR -> errors;
+                case WARNING, MANDATORY_WARNING -> warnings;
+                default -> null;
+            };
+            if (into != null) {
+                into.append(d.getMessage(Locale.ENGLISH)).append('\n');
+            }
+        }
+        return new ProcessorRun(ok, errors.toString(), warnings.toString());
+    }
+
+    static Path write(Path dir, String name, String content) throws IOException {
+        Path file = dir.resolve(name);
+        Files.writeString(file, content);
+        return file;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorDiagnosticTest.java
@@ -3,19 +3,9 @@ package souther.compiler.apt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import javax.tools.Diagnostic;
-import javax.tools.DiagnosticCollector;
-import javax.tools.JavaCompiler;
-import javax.tools.JavaFileObject;
-import javax.tools.StandardJavaFileManager;
-import javax.tools.ToolProvider;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -119,38 +109,14 @@ class SoutherProcessorDiagnosticTest {
                 "a count does not stand in for the reason: " + reported);
     }
 
-    /** Runs javac over one throwaway Java file with the processor pointed at {@code source}, and
-     *  returns what the processor reported. The compilation must fail. */
+    /** What the processor reported as an error. The compilation must fail: these are all errors. */
     private static String compile(Path dir, Path source, String lang) throws IOException {
-        Path java = write(dir, "Dummy.java", "public class Dummy {}\n");
-        Path classes = Files.createDirectories(dir.resolve("classes"));
-        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
-        DiagnosticCollector<JavaFileObject> collected = new DiagnosticCollector<>();
-        boolean ok;
-        try (StandardJavaFileManager files =
-                     javac.getStandardFileManager(collected, null, StandardCharsets.UTF_8)) {
-            List<String> options = new ArrayList<>(List.of(
-                    "-processor", SoutherProcessor.class.getName(),
-                    "-Asouther.source=" + source,
-                    "-Asouther.lang=" + lang,
-                    "-d", classes.toString(),
-                    "-classpath", System.getProperty("java.class.path")));
-            ok = javac.getTask(null, files, collected, options,
-                    null, files.getJavaFileObjects(java)).call();
-        }
-        StringBuilder reported = new StringBuilder();
-        for (Diagnostic<? extends JavaFileObject> d : collected.getDiagnostics()) {
-            if (d.getKind() == Diagnostic.Kind.ERROR) {
-                reported.append(d.getMessage(Locale.ENGLISH)).append('\n');
-            }
-        }
-        assertFalse(ok, "the compilation should have failed: " + reported);
-        return reported.toString();
+        ProcessorRun run = ProcessorRun.of(dir, source, lang);
+        assertFalse(run.ok(), "the compilation should have failed: " + run.errors());
+        return run.errors();
     }
 
     private static Path write(Path dir, String name, String content) throws IOException {
-        Path file = dir.resolve(name);
-        Files.writeString(file, content);
-        return file;
+        return ProcessorRun.write(dir, name, content);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorWarningTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorWarningTest.java
@@ -1,0 +1,166 @@
+package souther.compiler.apt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A warning the invariant checker finds reaches the build log the way an error does. The build is
+ * what a project is actually verified by, so a warning it does not carry lets unproven constructions
+ * accumulate while everything stays green.
+ *
+ * <p>javac's {@code Messager} positions a message by {@code Element}, and the construction is inside
+ * a {@code .sou} file javac has no element for, so the rendered snippet is what carries the position
+ * across — as it already does for an error.
+ */
+class SoutherProcessorWarningTest {
+
+    /** One unproven construction, on line 9. */
+    private static final String UNPROVEN = """
+            module demo
+
+            data Eaches = Int
+                invariant value >= 0
+
+            behavior wrap : (n: Int) -> Eaches
+                constructs Eaches
+            let wrap (n) = {
+                let m = n
+                Eaches(m)
+            }
+            """;
+
+    @Test
+    void anUnprovenConstructionIsReportedAsAWarningWithItsPosition(@TempDir Path dir)
+            throws IOException {
+        Path source = write(dir, "probe.sou", UNPROVEN);
+
+        Reported reported = compile(dir, source, "en");
+
+        assertTrue(reported.ok(), "a warning does not fail the build: " + reported.errors());
+        assertTrue(reported.warnings().contains("probe.sou:10:5"), reported.warnings());
+        assertTrue(reported.warnings().contains("Eaches(m)"), reported.warnings());
+        assertTrue(reported.warnings().contains("^"), reported.warnings());
+        assertTrue(reported.warnings().contains("E2011"), reported.warnings());
+        assertTrue(reported.warnings().contains("INVARIANT (WARNING)"), reported.warnings());
+    }
+
+    @Test
+    void theWarningFollowsTheChosenLanguage(@TempDir Path dir) throws IOException {
+        Path source = write(dir, "probe.sou", UNPROVEN);
+
+        Reported reported = compile(dir, source, "ja");
+
+        assertTrue(reported.warnings().contains("(警告)"), reported.warnings());
+        assertTrue(reported.warnings().contains("不変条件に違反する可能性があります"),
+                reported.warnings());
+    }
+
+    @Test
+    void aWarningInAModuleSetNamesTheFileItIsIn(@TempDir Path dir) throws IOException {
+        Path sources = Files.createDirectories(dir.resolve("souther"));
+        write(sources, "a.sou", """
+                module a exposing ( Eaches, wrap )
+
+                data Eaches = Int
+                    invariant value >= 0
+
+                behavior wrap : (n: Int) -> Eaches
+                    constructs Eaches
+                let wrap (n) = {
+                    let m = n
+                    Eaches(m)
+                }
+                """);
+        write(sources, "b.sou", """
+                module b
+
+                import a ( Eaches )
+
+                data Box = { it: Eaches }
+                """);
+
+        Reported reported = compile(dir, sources, "en");
+
+        assertTrue(reported.ok(), reported.errors());
+        assertTrue(reported.warnings().contains("a.sou:10:5"), reported.warnings());
+        assertFalse(reported.warnings().contains("b.sou"), reported.warnings());
+    }
+
+    @Test
+    void aCleanSourceReportsNothing(@TempDir Path dir) throws IOException {
+        Path source = write(dir, "clean.sou", """
+                module demo
+
+                data Eaches = Int
+                    invariant value >= 0
+
+                behavior wrap : (n: Eaches) -> Eaches
+                    constructs Eaches
+                let wrap (n) = Eaches(n.value)
+                """);
+
+        Reported reported = compile(dir, source, "en");
+
+        assertTrue(reported.ok(), reported.errors());
+        assertTrue(reported.warnings().isBlank(), reported.warnings());
+    }
+
+    /** What javac reported, split by kind, and whether the compilation succeeded. */
+    private record Reported(boolean ok, String errors, String warnings) {}
+
+    /** Runs javac over one throwaway Java file with the processor pointed at {@code source}. */
+    private static Reported compile(Path dir, Path source, String lang) throws IOException {
+        Path java = write(dir, "Dummy.java", "public class Dummy {}\n");
+        Path classes = Files.createDirectories(dir.resolve("classes"));
+        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
+        DiagnosticCollector<JavaFileObject> collected = new DiagnosticCollector<>();
+        boolean ok;
+        try (StandardJavaFileManager files =
+                     javac.getStandardFileManager(collected, null, StandardCharsets.UTF_8)) {
+            List<String> options = new ArrayList<>(List.of(
+                    "-processor", SoutherProcessor.class.getName(),
+                    "-Asouther.source=" + source,
+                    "-Asouther.lang=" + lang,
+                    "-d", classes.toString(),
+                    "-classpath", System.getProperty("java.class.path")));
+            ok = javac.getTask(null, files, collected, options,
+                    null, files.getJavaFileObjects(java)).call();
+        }
+        StringBuilder errors = new StringBuilder();
+        StringBuilder warnings = new StringBuilder();
+        for (Diagnostic<? extends JavaFileObject> d : collected.getDiagnostics()) {
+            StringBuilder into = switch (d.getKind()) {
+                case ERROR -> errors;
+                case WARNING, MANDATORY_WARNING -> warnings;
+                default -> null;
+            };
+            if (into != null) {
+                into.append(d.getMessage(Locale.ENGLISH)).append('\n');
+            }
+        }
+        return new Reported(ok, errors.toString(), warnings.toString());
+    }
+
+    private static Path write(Path dir, String name, String content) throws IOException {
+        Path file = dir.resolve(name);
+        Files.writeString(file, content);
+        return file;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorWarningTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/apt/SoutherProcessorWarningTest.java
@@ -3,19 +3,9 @@ package souther.compiler.apt;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-import javax.tools.Diagnostic;
-import javax.tools.DiagnosticCollector;
-import javax.tools.JavaCompiler;
-import javax.tools.JavaFileObject;
-import javax.tools.StandardJavaFileManager;
-import javax.tools.ToolProvider;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -49,9 +39,9 @@ class SoutherProcessorWarningTest {
     @Test
     void anUnprovenConstructionIsReportedAsAWarningWithItsPosition(@TempDir Path dir)
             throws IOException {
-        Path source = write(dir, "probe.sou", UNPROVEN);
+        Path source = ProcessorRun.write(dir, "probe.sou", UNPROVEN);
 
-        Reported reported = compile(dir, source, "en");
+        ProcessorRun reported = ProcessorRun.of(dir, source, "en");
 
         assertTrue(reported.ok(), "a warning does not fail the build: " + reported.errors());
         assertTrue(reported.warnings().contains("probe.sou:10:5"), reported.warnings());
@@ -63,9 +53,9 @@ class SoutherProcessorWarningTest {
 
     @Test
     void theWarningFollowsTheChosenLanguage(@TempDir Path dir) throws IOException {
-        Path source = write(dir, "probe.sou", UNPROVEN);
+        Path source = ProcessorRun.write(dir, "probe.sou", UNPROVEN);
 
-        Reported reported = compile(dir, source, "ja");
+        ProcessorRun reported = ProcessorRun.of(dir, source, "ja");
 
         assertTrue(reported.warnings().contains("(警告)"), reported.warnings());
         assertTrue(reported.warnings().contains("不変条件に違反する可能性があります"),
@@ -75,7 +65,7 @@ class SoutherProcessorWarningTest {
     @Test
     void aWarningInAModuleSetNamesTheFileItIsIn(@TempDir Path dir) throws IOException {
         Path sources = Files.createDirectories(dir.resolve("souther"));
-        write(sources, "a.sou", """
+        ProcessorRun.write(sources, "a.sou", """
                 module a exposing ( Eaches, wrap )
 
                 data Eaches = Int
@@ -88,7 +78,7 @@ class SoutherProcessorWarningTest {
                     Eaches(m)
                 }
                 """);
-        write(sources, "b.sou", """
+        ProcessorRun.write(sources, "b.sou", """
                 module b
 
                 import a ( Eaches )
@@ -96,7 +86,7 @@ class SoutherProcessorWarningTest {
                 data Box = { it: Eaches }
                 """);
 
-        Reported reported = compile(dir, sources, "en");
+        ProcessorRun reported = ProcessorRun.of(dir, sources, "en");
 
         assertTrue(reported.ok(), reported.errors());
         assertTrue(reported.warnings().contains("a.sou:10:5"), reported.warnings());
@@ -105,7 +95,7 @@ class SoutherProcessorWarningTest {
 
     @Test
     void aCleanSourceReportsNothing(@TempDir Path dir) throws IOException {
-        Path source = write(dir, "clean.sou", """
+        Path source = ProcessorRun.write(dir, "clean.sou", """
                 module demo
 
                 data Eaches = Int
@@ -116,51 +106,10 @@ class SoutherProcessorWarningTest {
                 let wrap (n) = Eaches(n.value)
                 """);
 
-        Reported reported = compile(dir, source, "en");
+        ProcessorRun reported = ProcessorRun.of(dir, source, "en");
 
         assertTrue(reported.ok(), reported.errors());
         assertTrue(reported.warnings().isBlank(), reported.warnings());
     }
 
-    /** What javac reported, split by kind, and whether the compilation succeeded. */
-    private record Reported(boolean ok, String errors, String warnings) {}
-
-    /** Runs javac over one throwaway Java file with the processor pointed at {@code source}. */
-    private static Reported compile(Path dir, Path source, String lang) throws IOException {
-        Path java = write(dir, "Dummy.java", "public class Dummy {}\n");
-        Path classes = Files.createDirectories(dir.resolve("classes"));
-        JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
-        DiagnosticCollector<JavaFileObject> collected = new DiagnosticCollector<>();
-        boolean ok;
-        try (StandardJavaFileManager files =
-                     javac.getStandardFileManager(collected, null, StandardCharsets.UTF_8)) {
-            List<String> options = new ArrayList<>(List.of(
-                    "-processor", SoutherProcessor.class.getName(),
-                    "-Asouther.source=" + source,
-                    "-Asouther.lang=" + lang,
-                    "-d", classes.toString(),
-                    "-classpath", System.getProperty("java.class.path")));
-            ok = javac.getTask(null, files, collected, options,
-                    null, files.getJavaFileObjects(java)).call();
-        }
-        StringBuilder errors = new StringBuilder();
-        StringBuilder warnings = new StringBuilder();
-        for (Diagnostic<? extends JavaFileObject> d : collected.getDiagnostics()) {
-            StringBuilder into = switch (d.getKind()) {
-                case ERROR -> errors;
-                case WARNING, MANDATORY_WARNING -> warnings;
-                default -> null;
-            };
-            if (into != null) {
-                into.append(d.getMessage(Locale.ENGLISH)).append('\n');
-            }
-        }
-        return new Reported(ok, errors.toString(), warnings.toString());
-    }
-
-    private static Path write(Path dir, String name, String content) throws IOException {
-        Path file = dir.resolve(name);
-        Files.writeString(file, content);
-        return file;
-    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.Compiler;
 import souther.compiler.Prelude;
+import souther.compiler.diag.Located;
 import souther.compiler.diag.Severity;
 
 import org.junit.jupiter.api.Test;
@@ -247,7 +248,7 @@ class InvariantCombinatorRulesTest {
     void theElementCarriesItsInvariantIntoEachClosure() {
         for (Fires f : FIRES) {
             Compiler.Compiled c = Compiler.compileWithWarnings(PREAMBLE + f.body());
-            long warnings = c.warnings().stream()
+            long warnings = c.warnings().stream().map(Located::diagnostic)
                     .filter(d -> d.severity() == Severity.WARNING).count();
             assertEquals(0, warnings,
                     f.fn() + ": the construction in the closure should discharge from the element's"

--- a/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
@@ -248,7 +248,7 @@ class InvariantCombinatorRulesTest {
     void theElementCarriesItsInvariantIntoEachClosure() {
         for (Fires f : FIRES) {
             Compiler.Compiled c = Compiler.compileWithWarnings(PREAMBLE + f.body());
-            long warnings = c.warnings().stream().map(Located::diagnostic)
+            long warnings = c.warnings().stream()
                     .filter(d -> d.severity() == Severity.WARNING).count();
             assertEquals(0, warnings,
                     f.fn() + ": the construction in the closure should discharge from the element's"

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -17,6 +17,7 @@ import souther.compiler.cst.LineIndex;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.DiagnosticRenderer;
+import souther.compiler.diag.Located;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.cst.SyntaxElement;
@@ -92,7 +93,9 @@ public final class Analyzer {
             }
             // A self-contained module compiles fully here, so its inline `example`s are evaluated
             // on save and a failing one (E1805) surfaces as an editor diagnostic.
-            Compiler.compile(text, "Main");
+            for (Located w : Compiler.compileWithWarnings(text, "Main").warnings()) {
+                out.add(fromDiagnostic(lines, w.diagnostic()));
+            }
         } catch (CompileException e) {
             out.addAll(fromCompile(lines, e));
         } catch (RuntimeException | StackOverflowError e) {

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -93,7 +93,7 @@ public final class Analyzer {
             }
             // A self-contained module compiles fully here, so its inline `example`s are evaluated
             // on save and a failing one (E1805) surfaces as an editor diagnostic.
-            for (Located w : Compiler.compileWithWarnings(text, "Main").warnings()) {
+            for (Located w : Compiler.compileWithWarnings(text, "Main").locatedWarnings()) {
                 out.add(fromDiagnostic(lines, w.diagnostic()));
             }
         } catch (CompileException e) {

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -66,7 +66,7 @@ public final class Analyzer {
     private souther.compiler.meta.ModulePath compiledAgainst;
 
     /** All diagnostics for a document: every syntax error, or — when there are none — the first
-     * semantic error a compile turns up. */
+     * semantic error a compile turns up, or the warnings a clean compile found. */
     public List<LspDiagnostic> diagnostics(String text) {
         LineIndex lines = new LineIndex(text);
         List<LspDiagnostic> out = new ArrayList<>();

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -37,6 +37,33 @@ class AnalyzerTest {
         assertEquals(1, d.range().start().line(), "the error is on the second line (0-based line 1)");
     }
 
+    /** A warning is all the invariant checker has to say about a construction it cannot prove, so an
+     *  editor that shows none leaves the author with nothing to read. */
+    @Test
+    void anUnprovenConstructionIsReportedAsAWarningWhereItIsWritten() {
+        String src = """
+                module demo
+
+                data Eaches = Int
+                    invariant value >= 0
+
+                behavior wrap : (n: Int) -> Eaches
+                    constructs Eaches
+                let wrap (n) = {
+                    let m = n
+                    Eaches(m)
+                }
+                """;
+        List<LspDiagnostic> diags = analyzer.diagnostics(src);
+
+        assertEquals(1, diags.size(), diags.toString());
+        LspDiagnostic d = diags.get(0);
+        assertEquals(LspDiagnostic.WARNING, d.severity());
+        assertEquals("E2011", d.code());
+        assertEquals(9, d.range().start().line(), "the construction is on the tenth line");
+        assertEquals(4, d.range().start().character());
+    }
+
     @Test
     void aSemanticErrorIsReportedWhenSyntaxIsClean() {
         // a type variable in a user module is a semantic error the compiler raises

--- a/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
@@ -136,6 +136,17 @@ public class CompileException extends RuntimeException {
         return sources == null || i >= sources.size() ? NO_SOURCE : sources.get(i);
     }
 
+    /** Every diagnostic this error carries, each with the source it came from — what a renderer
+     *  walks, and the shape a warning arrives in too, so one loop renders both. */
+    public List<Located> locatedDiagnostics() {
+        List<Diagnostic> ds = diagnostics();
+        List<Located> located = new java.util.ArrayList<>(ds.size());
+        for (int i = 0; i < ds.size(); i++) {
+            located.add(new Located(ds.get(i), sourceIndexOf(i)));
+        }
+        return List.copyOf(located);
+    }
+
     /**
      * The same error, tagged with the source being compiled when it was thrown. The first tag wins:
      * an inner phase that already named its source keeps it, so a surrounding loop may tag freely.

--- a/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
@@ -21,7 +21,7 @@ public class CompileException extends RuntimeException {
 
     /** A position is a line and a column, so a compile that was handed several sources also has to
      *  say which one — otherwise there is nothing to quote the line from. */
-    private static final int NO_SOURCE = -1;
+    private static final int NO_SOURCE = Located.NO_SOURCE;
 
     private final transient List<Diagnostic> diagnostics;
     /** One entry per diagnostic: which source it came from, or {@link #NO_SOURCE}. A compile that

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
@@ -1,6 +1,9 @@
 package souther.compiler.diag;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Locale;
+import java.util.function.IntFunction;
 
 /** Turns a {@link Diagnostic} into text: {@link HumanRenderer} for people, {@link JsonRenderer} for
  * tools. The source snippet comes from {@code src}, which may be null when the source is unavailable
@@ -8,6 +11,26 @@ import java.util.Locale;
 public interface DiagnosticRenderer {
 
     String render(Diagnostic d, SourceContext src, Locale locale);
+
+    /**
+     * Renders each of {@code located}, one string per diagnostic — never one string for the list, so
+     * a JSON caller prints one object per line rather than an array.
+     *
+     * <p>Each diagnostic quotes its own file: a compile reporting several modules at once has one per
+     * module, and they do not share a source. {@code sourceAt} maps a
+     * {@link Located#sourceIndex()} to the text to quote, and is asked about
+     * {@link Located#NO_SOURCE} as well — what an unnamed source means is the caller's to say, since
+     * a single-source compile names none and yet has exactly one file to quote. Returning null there
+     * (or for a file that cannot be read) leaves the snippet out rather than quoting the wrong line.
+     */
+    static List<String> renderAll(List<Located> located, IntFunction<SourceContext> sourceAt,
+                                  DiagnosticRenderer renderer, Locale locale) {
+        List<String> rendered = new ArrayList<>(located.size());
+        for (Located one : located) {
+            rendered.add(renderer.render(one.diagnostic(), sourceAt.apply(one.sourceIndex()), locale));
+        }
+        return List.copyOf(rendered);
+    }
 
     /** The message body, from the catalog key or the compatibility literal. */
     static String body(Diagnostic d, Locale locale) {

--- a/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
@@ -15,6 +15,7 @@ public final class HumanRenderer implements DiagnosticRenderer {
     private static final String RESET = "[0m";
     private static final String CYAN = "[36m";
     private static final String RED = "[31m";
+    private static final String YELLOW = "[33m";
     private static final String DIM = "[2m";
 
     private final boolean useColor;
@@ -28,7 +29,7 @@ public final class HumanRenderer implements DiagnosticRenderer {
         StringBuilder out = new StringBuilder();
         header(out, d, src, locale);
         out.append('\n');
-        snippet(out, d.region(), src, RED);
+        snippet(out, d.region(), src, d.severity() == Severity.WARNING ? YELLOW : RED);
         for (LabeledRegion sec : d.secondary()) {
             out.append('\n');
             snippet(out, sec.region(), src, CYAN);
@@ -69,7 +70,24 @@ public final class HumanRenderer implements DiagnosticRenderer {
         out.append(color(CYAN, bar.toString())).append('\n');
     }
 
+    /**
+     * The header's title. A diagnostic that names what it is about keeps that name and says its
+     * severity beside it; one that names nothing is titled by its severity alone. A warning is
+     * marked either way, since the code and the message read the same for both and the bar is the
+     * only place the difference can be seen.
+     */
     private String title(Diagnostic d, Locale locale) {
+        String specific = specificTitle(d, locale);
+        if (d.severity() != Severity.WARNING) {
+            return specific != null ? specific : Messages.get("diag.error.title", locale);
+        }
+        String warning = Messages.get("diag.warning.title", locale);
+        return specific != null ? specific + " (" + warning + ")" : warning;
+    }
+
+    /** What this diagnostic is about — its own title, or the one its code carries — or null when it
+     *  names neither and only its severity is left to title it with. */
+    private String specificTitle(Diagnostic d, Locale locale) {
         if (d.titleKey() != null && Messages.has(d.titleKey(), locale)) {
             return Messages.get(d.titleKey(), locale);
         }
@@ -79,7 +97,7 @@ public final class HumanRenderer implements DiagnosticRenderer {
                 return Messages.get(key, locale);
             }
         }
-        return Messages.get("diag.error.title", locale);
+        return null;
     }
 
     private String location(SourcePos pos, SourceContext src) {

--- a/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
@@ -71,33 +71,26 @@ public final class HumanRenderer implements DiagnosticRenderer {
     }
 
     /**
-     * The header's title. A diagnostic that names what it is about keeps that name and says its
-     * severity beside it; one that names nothing is titled by its severity alone. A warning is
-     * marked either way, since the code and the message read the same for both and the bar is the
-     * only place the difference can be seen.
+     * The header's title: what the diagnostic is about — its own title, or the one its code carries
+     * — with its severity beside it, or the severity alone when it is about nothing in particular. A
+     * warning is marked either way, since the code and the message read the same for both and the
+     * bar is the only place the difference can be seen.
      */
     private String title(Diagnostic d, Locale locale) {
-        String specific = specificTitle(d, locale);
-        if (d.severity() != Severity.WARNING) {
-            return specific != null ? specific : Messages.get("diag.error.title", locale);
-        }
-        String warning = Messages.get("diag.warning.title", locale);
-        return specific != null ? specific + " (" + warning + ")" : warning;
-    }
-
-    /** What this diagnostic is about — its own title, or the one its code carries — or null when it
-     *  names neither and only its severity is left to title it with. */
-    private String specificTitle(Diagnostic d, Locale locale) {
+        String about = null;
         if (d.titleKey() != null && Messages.has(d.titleKey(), locale)) {
-            return Messages.get(d.titleKey(), locale);
-        }
-        if (d.code() != null) {
+            about = Messages.get(d.titleKey(), locale);
+        } else if (d.code() != null) {
             String key = d.code().toLowerCase(Locale.ROOT) + ".title";
             if (Messages.has(key, locale)) {
-                return Messages.get(key, locale);
+                about = Messages.get(key, locale);
             }
         }
-        return null;
+        if (d.severity() != Severity.WARNING) {
+            return about != null ? about : Messages.get("diag.error.title", locale);
+        }
+        String warning = Messages.get("diag.warning.title", locale);
+        return about != null ? about + " (" + warning + ")" : warning;
     }
 
     private String location(SourcePos pos, SourceContext src) {

--- a/souther-syntax/src/main/java/souther/compiler/diag/Located.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Located.java
@@ -1,0 +1,21 @@
+package souther.compiler.diag;
+
+/**
+ * A diagnostic and which of the sources a compile was handed it came from. A {@link Diagnostic}
+ * says where in a file it is; which file that is belongs to the compile, not to the diagnostic, so
+ * it is carried alongside.
+ *
+ * @param diagnostic what was found
+ * @param sourceIndex the source it belongs to, or {@code -1} when it names none — which covers a
+ *        single-source compile, where the caller knows the file it handed over
+ */
+public record Located(Diagnostic diagnostic, int sourceIndex) {
+
+    /** The index a diagnostic that names no source carries. */
+    public static final int NO_SOURCE = -1;
+
+    /** A diagnostic that names no source. */
+    public static Located of(Diagnostic diagnostic) {
+        return new Located(diagnostic, NO_SOURCE);
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/Located.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Located.java
@@ -1,5 +1,7 @@
 package souther.compiler.diag;
 
+import java.util.List;
+
 /**
  * A diagnostic and which of the sources a compile was handed it came from. A {@link Diagnostic}
  * says where in a file it is; which file that is belongs to the compile, not to the diagnostic, so
@@ -13,4 +15,19 @@ public record Located(Diagnostic diagnostic, int sourceIndex) {
 
     /** The index a diagnostic that names no source carries. */
     public static final int NO_SOURCE = -1;
+
+    /**
+     * The one of {@code sources} that {@code index} names, or null when it names none — so a caller
+     * quotes no line rather than the wrong one.
+     *
+     * <p>A compile of one source names none: it drops the index, since the caller knows the file it
+     * handed over. The single source it was given is the answer there however the diagnostic is
+     * tagged, which is why one item is not read as "index 0 or nothing".
+     */
+    public static <T> T in(List<T> sources, int index) {
+        if (sources.size() == 1) {
+            return sources.get(0);
+        }
+        return index >= 0 && index < sources.size() ? sources.get(index) : null;
+    }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Located.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Located.java
@@ -13,9 +13,4 @@ public record Located(Diagnostic diagnostic, int sourceIndex) {
 
     /** The index a diagnostic that names no source carries. */
     public static final int NO_SOURCE = -1;
-
-    /** A diagnostic that names no source. */
-    public static Located of(Diagnostic diagnostic) {
-        return new Located(diagnostic, NO_SOURCE);
-    }
 }


### PR DESCRIPTION
Closes #285.

The invariant checker's possible-violation warning (E2011) is built with the position of the construction, and was printed without it — the message body alone, in a hardcoded English, behind a `warning: ` prefix that no renderer, locale, or format flag ever reached. It was also never handed to the annotation processor, so the build every project is actually verified by showed none of them.

## What the repro actually does

Running the issue's source through the CLI produces **one** warning, not an ambiguous one of two. The diagnostic carries `pos=14:5` and names the `letForm` construction exactly. The inline `Eaches(Int.modBy(...))` draws no warning at all, which is a separate checker finding (F27 in `souther-lang/examples`), not a reporting problem. The position was there the whole time; only the printing dropped it.

The issue also reads the LSP as a third silent consumer. Its workspace path already published these — `Compilation.diagnostics()` does not filter by severity and `fromDiagnostic` maps `Severity.WARNING` to `LspDiagnostic.WARNING`. Only the single-document path was silent.

## The change

**A diagnostic's file is carried beside it.** A `Diagnostic` says where in a file it is; which file that is belongs to the compile. An error carried this as a source index on the exception and each consumer resolved it itself; a warning had nowhere to carry it. `Located` names the pair, `CompileException.locatedDiagnostics()` derives it in one place, and `DiagnosticRenderer.renderAll` renders a list of them — one string per diagnostic, so a JSON caller still prints one object per line rather than an array. `Compilation.warnings` tags each warning with `indexOf`, the same tag `firstError` puts on an error.

What an unnamed source means is left to each caller, because it differs: a compile of one file names none — `Compilation.ofSource` drops the index deliberately, since the caller knows the file it handed over — and yet has exactly one file to quote.

**The header says which severity it is.** It is titled by what the diagnostic is about, falling back to `ERROR` only when it is about nothing in particular, so a warning with a title of its own rendered the same bar as an error. A titled warning now keeps its title and says the severity beside it; an untitled one is titled by the severity alone. `ERROR (WARNING)` is not a form this can produce.

```
-- INVARIANT (WARNING)  E2011 ----------------probe.sou:14:5

14|     Eaches(leftover)
        ^

Constructing `Eaches` here may violate its invariant: the guards do not establish it. ...
Hint: If a relation between inputs guarantees this, declare it as an `invariant` on the input data ...
```

**Four consumers now agree.** `souther compile` renders through the renderer its flags chose, so `--lang`, `--color` and `--format json` all work. `souther run` compiles the same module and says the same thing on stderr, with the behavior's output left alone on stdout. `SoutherProcessor` prints each through the `Messager` as `Diagnostic.Kind.WARNING` — javac positions a message by `Element` and the construction is in a `.sou` file javac has no element for, so the rendered snippet carries the position across, as it already does for an error. The editor's single-document path publishes them at the construction's range — though `LspServer` only ever drives the workspace path, which already surfaced them, so that hunk closes a gap in a method reached today only by tests.

A compile that stops at an error still drops the warnings it had collected. Nothing is reported past the error, and where the collection would be cut off is not a line an author could reason about. A run that *aborts* is different: the compile finished, so those warnings are complete, and they are reported alongside the abort — the run that trips an invariant is the one the warning predicted.

## Verification

Full suite green: 2002 compiler tests, 99 LSP tests. Each of the three commits builds and tests green on its own.

Building `souther-lang/examples` surfaces 24 warnings across 10 files — `billing.sou` 4, `socialinsurance.sou` 4, `forecasting.sou` 3, `inventory.sou` 3, `payroll.sou` 3, `quoting.sou` 3, and one each in `employmentinsurance.sou`, `ledger.sou`, `pipeline.sou`, `returns.sou` — the same count and the same lines the CLI names. Neither pom sets `-Werror`, so the build still succeeds.

New tests cover the position and snippet, the header, `--lang ja`, `--format json` as one object with its region, a warning in a module set naming the file it is in, the `run` streams staying apart, the processor's `Kind.WARNING`, and the editor's range. One pins the single-file case where `Located.sourceIndex` is `-1` and the file is quoted anyway — a regression test against `Compilation.ofSource` clearing the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
