### PR TITLE
One node for an application, and a qualified name answered once

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -986,8 +986,14 @@ public interface Ast {
      * carries what it denotes — a helper, a library function, an injected behavior, a function-typed
      * binding, or the type a newtype construction wraps — answered once during resolution.
      */
-    record Apply(Expr function, List<Expr> args, ConstructionOrigin origin, SourcePos pos)
-            implements Expr {
+    record Apply(Expr function, List<Expr> args, ConstructionOrigin origin, String appliedAs,
+                 SourcePos pos) implements Expr {
+
+        /** Applying whatever {@code function} is, with nothing standing in for what the source
+         * wrote — every application but one a lowering rewrote. */
+        public Apply(Expr function, List<Expr> args, ConstructionOrigin origin, SourcePos pos) {
+            this(function, args, origin, null, pos);
+        }
 
         /** Applying a name, as the parser read it, before resolution has said what the name denotes. */
         public Apply(String fn, List<Expr> args, SourcePos pos) {
@@ -1013,11 +1019,15 @@ public interface Ast {
          * <p><b>Never a lookup key.</b> An import lets a library name be written without its
          * qualifier, so a table keyed by a declaration's name misses on the spelling — silently,
          * because a miss is what a table keyed by names does with one it has not got. Every
-         * question of the form "which declaration is this" asks {@link #reaches()}, whose answer is
-         * this spelling for every name an import cannot have renamed.
+         * question of the form "which declaration is this" asks {@link #reaches()}.
+         *
+         * <p>{@link #appliedAs} answers where a lowering replaced what was written with a binding
+         * it introduced: applying something other than a name binds it first, and the binding is
+         * named nothing an author could have typed. The two are separate for that reason — this
+         * one is read by reports and nothing else.
          */
         public String written() {
-            return function instanceof Var v ? v.name() : "";
+            return appliedAs != null ? appliedAs : nameApplied();
         }
 
         /**
@@ -1028,9 +1038,19 @@ public interface Ast {
          * bare, so that is what it answers; every other name is filed as it is written. The empty
          * answer is not a convention: it is what applying something that is not a name leaves, and
          * no declaration is named the empty spelling.
+         *
+         * <p>Never {@link #written()}: a spelling a report quotes is not what this application
+         * reaches, and a lowering that put one there would otherwise have every table in the
+         * compiler looked up with it.
          */
         public String reaches() {
-            return denotes() instanceof ValueName.Stdlib lib ? lib.qualified() : written();
+            return denotes() instanceof ValueName.Stdlib lib ? lib.qualified() : nameApplied();
+        }
+
+        /** The name in the callee position, or the empty spelling where what is applied is not a
+         *  name. What both spellings above are built from, and what neither may skip past. */
+        private String nameApplied() {
+            return function instanceof Var v ? v.name() : "";
         }
 
         /** What the name this applies denotes, or null where what it applies is not a name. */
@@ -1044,7 +1064,14 @@ public interface Ast {
          * where its constructions would otherwise stand, and it is what has to say where it came
          * from. */
         public Apply carriedByValue() {
-            return new Apply(function, args, origin.carriedByValue(), pos);
+            return new Apply(function, args, origin.carriedByValue(), appliedAs, pos);
+        }
+
+        /** The same application over rewritten arguments — a pass that touches only the arguments
+         *  says so here rather than listing the slots it is not changing, which is how
+         *  {@link #appliedAs} would be dropped by a rewrite that has no opinion about it. */
+        public Apply withArgs(List<Expr> args) {
+            return new Apply(function, args, origin, appliedAs, pos);
         }
     }
 
@@ -1095,7 +1122,7 @@ public interface Ast {
                 Expr function = atExpr.apply(a.function());
                 List<Expr> args = each(a.args(), atExpr);
                 yield function == a.function() && args == a.args() ? a
-                        : new Apply(function, args, a.origin(), a.pos());
+                        : new Apply(function, args, a.origin(), a.appliedAs(), a.pos());
             }
             case If iff -> {
                 Expr cond = atExpr.apply(iff.cond());

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -452,12 +452,11 @@ public final class CallElaborator {
                     yield applySignature(call, fn, ca, expected, env, ctx).result();
                 }
                 // A library qualifier that matched no builtin or intrinsic above is a wrong stdlib
-                // call (spec §stdlib) — report it as such, not as a missing behavior. A dotted
-                // spelling alone does not make one: a field read applied — `deps.count(x)` — is a
-                // binding in force, and what is wrong with it is that it is not a function, which
-                // is what the report below says.
-                if (library || (!(call.denotes() instanceof ValueName.Local)
-                        && call.written().indexOf('.') >= 0)) {
+                // call (spec §stdlib) — report it as such, not as a missing behavior. Asked of what
+                // this reaches rather than of what a report would quote: a field read applied
+                // (`deps.count(x)`) reaches a binding and is quoted with a dot in it, and what is
+                // wrong with it is that it is not a function, which is what the report below says.
+                if (library || call.reaches().indexOf('.') >= 0) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.stdlib.notfunction").title("check.unknown.title")
                                     .at(call.pos(), call.written().length()).args(call.written()).build(),

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -451,9 +451,13 @@ public final class CallElaborator {
                     }
                     yield applySignature(call, fn, ca, expected, env, ctx).result();
                 }
-                // a library qualifier that matched no builtin or intrinsic above is a wrong stdlib
-                // call (spec §stdlib) — report it as such, not as a missing behavior.
-                if (library || call.written().indexOf('.') >= 0) {
+                // A library qualifier that matched no builtin or intrinsic above is a wrong stdlib
+                // call (spec §stdlib) — report it as such, not as a missing behavior. A dotted
+                // spelling alone does not make one: a field read applied — `deps.count(x)` — is a
+                // binding in force, and what is wrong with it is that it is not a function, which
+                // is what the report below says.
+                if (library || (!(call.denotes() instanceof ValueName.Local)
+                        && call.written().indexOf('.') >= 0)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.stdlib.notfunction").title("check.unknown.title")
                                     .at(call.pos(), call.written().length()).args(call.written()).build(),

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1020,6 +1020,19 @@ public final class HelperInliner {
         }
     }
 
+    /** How the source wrote an expression that is a name or a chain of field reads off one, or null
+     *  where it wrote something with no spelling of its own — a call's result, a lambda. */
+    private static String spelling(Ast.Expr e) {
+        return switch (e) {
+            case Ast.Var v -> v.name();
+            case Ast.FieldAccess fa -> {
+                String target = spelling(fa.target());
+                yield target == null ? null : target + "." + fa.field();
+            }
+            default -> null;
+        };
+    }
+
     /** Rewrites every helper call in {@code e} to its inlined body, into the body already named. */
     public Ast.Expr inline(Ast.Expr e) {
         if (binders == null) {
@@ -1032,8 +1045,14 @@ public final class HelperInliner {
             // any argument, and the binding is what is applied.
             case Ast.Apply raw when !raw.appliesAName() -> {
                 Ast.Binder f = binders.binder("$fn" + counter++, raw.function().pos());
+                // The application reads the binding, and quotes what the author wrote. A field read
+                // applied — `deps.transform(x)` — has a spelling, and a report that quoted the
+                // binding instead would name `$fn0`, which is nowhere in the source. The spelling
+                // is what a report says; the binding is what the application means.
+                String written = spelling(raw.function());
                 yield inline(new Ast.LetIn(f, raw.function(), null, false, null,
-                        new Ast.Apply(f.name(), new ValueName.Local(f.name(), f.id()), raw.args(),
+                        new Ast.Apply(written != null ? written : f.name(),
+                                new ValueName.Local(f.name(), f.id()), raw.args(),
                                 raw.origin(), raw.pos()),
                         raw.pos()));
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1045,15 +1045,14 @@ public final class HelperInliner {
             // any argument, and the binding is what is applied.
             case Ast.Apply raw when !raw.appliesAName() -> {
                 Ast.Binder f = binders.binder("$fn" + counter++, raw.function().pos());
-                // The application reads the binding, and quotes what the author wrote. A field read
-                // applied — `deps.transform(x)` — has a spelling, and a report that quoted the
-                // binding instead would name `$fn0`, which is nowhere in the source. The spelling
-                // is what a report says; the binding is what the application means.
-                String written = spelling(raw.function());
+                // What the application reaches is the binding, and what a report about it quotes is
+                // what the author wrote — a field read applied (`deps.count(x)`) has a spelling, and
+                // quoting the binding would name `$fn0`, which is nowhere in the source. The two are
+                // separate slots: the binding is in the callee position, the spelling beside it.
                 yield inline(new Ast.LetIn(f, raw.function(), null, false, null,
-                        new Ast.Apply(written != null ? written : f.name(),
-                                new ValueName.Local(f.name(), f.id()), raw.args(),
-                                raw.origin(), raw.pos()),
+                        new Ast.Apply(new Ast.Var(f.name(), new ValueName.Local(f.name(), f.id()),
+                                raw.pos()),
+                                raw.args(), raw.origin(), spelling(raw.function()), raw.pos()),
                         raw.pos()));
             }
             case Ast.Apply rawCall -> {
@@ -1072,8 +1071,7 @@ public final class HelperInliner {
                     // builtin, injected behavior, a function-typed parameter, or a recursive helper —
                     // a recursive helper is lowered to a method, so its call stays a Call (spec 13.1);
                     // only its args inline.
-                    yield new Ast.Apply(call.function(), forwardDependencies(helper, args),
-                            call.origin(), call.pos());
+                    yield call.withArgs(forwardDependencies(helper, args));
                 }
                 // A declaration written with no parameter list is a value ([#fn-declaration]), so
                 // applying it applies whatever function that value is — not the declaration, which
@@ -1430,7 +1428,7 @@ public final class HelperInliner {
         Ast.Block block = etaExpand(v, helper.params().size(), i -> "$b" + k + "_" + i);
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.set(idx, block);
-        return new Ast.Apply(call.function(), args, call.origin(), call.pos());
+        return call.withArgs(args);
     }
 
     /**
@@ -1529,7 +1527,7 @@ public final class HelperInliner {
             case Ast.Apply call -> new Ast.Apply(
                     rename(call.function(), subst, substDenotes, at, copy),
                     renameList(call.args(), subst, substDenotes, at, copy),
-                    call.origin(), at(at, call.pos()));
+                    call.origin(), call.appliedAs(), at(at, call.pos()));
             case Ast.Binary bin -> new Ast.Binary(bin.op(), rename(bin.left(), subst, substDenotes, at, copy), rename(bin.right(), subst, substDenotes, at, copy), at(at, bin.pos()));
             case Ast.Neg neg -> new Ast.Neg(rename(neg.operand(), subst, substDenotes, at, copy), at(at, neg.pos()));
             case Ast.NewData nd -> {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1203,7 +1203,7 @@ public final class InvariantChecker {
     private static Ast.Apply withArg(Ast.Apply call, int at, Ast.Expr arg) {
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.set(at, arg);
-        return new Ast.Apply(call.function(), args, call.origin(), call.pos());
+        return call.withArgs(args);
     }
 
     /** An emptiness check as the comparison it means, or {@code e} unchanged. */

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -86,7 +86,7 @@ public final class NewtypeDesugar {
                             List.of(new Ast.FieldInit("value", args.get(0), call.pos())),
                             List.of(), ConstructionOrigin.own(), call.pos());
                 }
-                yield new Ast.Apply(call.function(), args, call.origin(), call.pos());
+                yield call.withArgs(args);
             }
             case Ast.NewData nd -> {
                 List<Ast.FieldInit> inits = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -559,14 +559,14 @@ public final class Resolve {
             case Ast.Apply call when call.appliesAName() -> new Ast.Apply(call.written(),
                     answered(call.written(), call.pos(), calledName(call, bound)),
                     exprs(call.args(), bound), call.origin(), call.pos());
-            case Ast.Apply call -> new Ast.Apply(expr(call.function(), bound),
+            case Ast.Apply call -> new Ast.Apply(callee(call.function(), bound),
                     exprs(call.args(), bound), call.origin(), call.pos());
-            // `Map.empty`, `String.isEmpty` — a namespace and a member of it, which the parser read
-            // as a field taken off a name because no `(` followed. Folded here and nowhere earlier:
-            // Souther reads no case, so `Map` may be a parameter, and a binding in force wins over
+            // `Map.empty`, `String.isEmpty`, `up.Amount` — a namespace and a member of it, which
+            // the parser read as a field taken off a name because it reads no case at all. Folded
+            // here and nowhere earlier: `Map` may be a parameter, and a binding in force wins over
             // everything else — which is a fact the parser and the AST builder do not have.
             case Ast.FieldAccess fa -> {
-                Ast.Var member = memberOfNamespace(fa, bound);
+                Ast.Var member = qualifiedName(fa, false, bound);
                 yield member != null ? member
                         : new Ast.FieldAccess(expr(fa.target(), bound), fa.field(), fa.pos());
             }
@@ -701,25 +701,102 @@ public final class Resolve {
     }
 
     /**
-     * {@code Q.m} read as a member of the namespace {@code Q}, or null where it is an ordinary field
-     * read.
+     * The callee of an application that does not apply a bare name.
      *
-     * <p>Only where {@code Q} is unbound. A parameter or a {@code let} named {@code Map} makes
-     * {@code Map.empty} that binding's {@code empty} field, resolved the ordinary way, and no
-     * namespace member is produced. Whether the namespace has a member {@code m} is not asked here —
-     * see {@link #lookup}.
-     *
-     * <p>The reference is written {@code Q.m} and positioned at {@code Q}, so what a reader asks
-     * about covers both tokens exactly as an applied qualified name already does.
+     * <p>A field read in this position may be a qualified name — {@code Map.empty(k)},
+     * {@code up.Amount(n)} — and it is answered here rather than as a value, because applied is
+     * what the position says: a type written as a value is a unit data's construction, and applied
+     * it is a newtype taking what it wraps. Anything else is the expression it is, and what may be
+     * applied is the check's to say.
      */
-    private Ast.Var memberOfNamespace(Ast.FieldAccess fa, Bindings bound) {
-        if (!(fa.target() instanceof Ast.Var base) || base.denotes() != null
-                || bound.binderOf(base.name()) != null || !Prelude.isQualifier(base.name())) {
+    private Ast.Expr callee(Ast.Expr function, Bindings bound) {
+        if (function instanceof Ast.FieldAccess fa) {
+            Ast.Var name = qualifiedName(fa, true, bound);
+            if (name != null) {
+                return name;
+            }
+        }
+        return expr(function, bound);
+    }
+
+    /**
+     * A chain of names read as one qualified name — {@code Map.empty}, {@code up.Amount},
+     * {@code probe.a.Amount}, where the module's own name is dotted — or null where it is an
+     * ordinary field read.
+     *
+     * <p>Only where the chain's root is unbound. A parameter or a {@code let} named {@code Map}
+     * makes {@code Map.empty} that binding's {@code empty} field, resolved the ordinary way, and no
+     * qualified name is produced.
+     *
+     * <p>The whole chain is asked first, and a chain that answers nothing is left for the caller to
+     * take apart — so {@code probe.a.defaultAmount.value} folds {@code probe.a.defaultAmount} and
+     * reads {@code .value} off it. What is reported, and where, is
+     * {@link #unknownMember}'s to say: a member of a namespace that has no such member is named in
+     * full, and a chain rooted at a name nothing declares is reported at that name.
+     *
+     * <p>Positioned at the root, so what a reader asks about covers every token of the name.
+     */
+    private Ast.Var qualifiedName(Ast.FieldAccess fa, boolean applied, Bindings bound) {
+        Ast.Var root = rootName(fa);
+        if (root == null || root.denotes() != null || bound.binderOf(root.name()) != null) {
             return null;
         }
-        String written = base.name() + "." + fa.field();
-        return new Ast.Var(written,
-                answered(written, base.pos(), new ValueName.Stdlib(written)), base.pos());
+        String written = dottedName(fa);
+        ValueName denotes = lookup(written, applied, bound);
+        if (denotes != null) {
+            return new Ast.Var(written, answered(written, root.pos(), denotes), root.pos());
+        }
+        return unknownMember(fa, written, applied, root.pos(), bound);
+    }
+
+    /**
+     * The report for a chain whose spelling denotes nothing, or null where there is nothing to say
+     * here and the chain is taken apart instead.
+     *
+     * <p>Something is said only where the part in front is a namespace: {@code probe.a.NoSuch}
+     * names a module that exists and a member it has not got, and reporting the root {@code probe}
+     * as an unknown identifier would send the author after a module name that is right. Where the
+     * front is not a namespace — {@code unknown.member} — nothing is said, and the root is reported
+     * as the unknown identifier it is once the chain is read as the field access it turned out to
+     * be.
+     */
+    private Ast.Var unknownMember(Ast.FieldAccess fa, String written, boolean applied,
+                                  SourcePos pos, Bindings bound) {
+        String qualifier = dottedName(fa.target());
+        if (qualifier == null || !isNamespace(qualifier)) {
+            return null;
+        }
+        CompileException why = applied ? notCallable(written, pos, bound)
+                : unknownIdentifier(written, pos, bound);
+        return new Ast.Var(written, answered(written, pos, nothing(written, pos, why)), pos);
+    }
+
+    /** Whether {@code qualifier} names a namespace a member may be reached through: a
+     *  standard-library one, or a module of this compilation (or an alias for one). */
+    private boolean isNamespace(String qualifier) {
+        return Prelude.isQualifier(qualifier) || symbols.moduleOfQualifier(qualifier) != null;
+    }
+
+    /** The name a chain of field reads is rooted at, or null where it is rooted at anything else —
+     *  a call's result, a parenthesised expression — which no qualified name can be. */
+    private static Ast.Var rootName(Ast.Expr e) {
+        return switch (e) {
+            case Ast.Var v -> v;
+            case Ast.FieldAccess fa -> rootName(fa.target());
+            default -> null;
+        };
+    }
+
+    /** The dotted spelling of a chain of names, or null where it is not one. */
+    private static String dottedName(Ast.Expr e) {
+        return switch (e) {
+            case Ast.Var v -> v.name();
+            case Ast.FieldAccess fa -> {
+                String target = dottedName(fa.target());
+                yield target == null ? null : target + "." + fa.field();
+            }
+            default -> null;
+        };
     }
 
     /** What a name used as a value denotes, and the report for one that denotes nothing. */

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -622,7 +622,6 @@ public final class AstBuilder {
             case LITERAL_EXPR -> literal(n);
             case VAR_EXPR -> new Ast.Var(firstIdentText(n), pos(n));
             case FIELD_ACCESS -> fieldAccess(n);
-            case CALL_EXPR -> call(n);
             case APPLY_EXPR -> apply(n);
             case BINARY_EXPR -> binary(n);
             case UNARY_EXPR -> new Ast.Neg(expr(onlyExpr(n)), pos(n));
@@ -670,41 +669,23 @@ public final class AstBuilder {
         return new Ast.FieldAccess(target, field.text(), posOf(field));
     }
 
-    private Ast.Expr call(SyntaxNode n) {
-        StringBuilder fn = new StringBuilder();
-        SyntaxToken first = null;
-        for (SyntaxElement e : meaningful(n)) {
-            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
-                if (fn.length() > 0) {
-                    fn.append('.');
-                }
-                fn.append(t.text());
-                if (first == null) {
-                    first = t;
-                }
-            }
-        }
-        List<Ast.Expr> args = new ArrayList<>();
-        n.child(SyntaxKind.ARG_LIST).ifPresent(list -> {
-            for (SyntaxNode a : exprChildren(list)) {
-                args.add(expr(a));
-            }
-        });
-        return new Ast.Apply(fn.toString(), args, posOf(first));
-    }
-
-    /** An argument list written after any expression. What is applied is the expression before it,
-     * so this is where a call whose callee is not a name is read. */
+    /**
+     * An argument list written after any expression — every application, whatever is applied.
+     *
+     * <p>Positioned where the callee starts, not where the callee node says it is: a field read
+     * positions itself at the field, so an application of {@code Map.empty} taken from
+     * {@code function.pos()} would report at {@code empty} and underline {@code Map.empty}'s
+     * length from there, running past the end of what was written.
+     */
     private Ast.Expr apply(SyntaxNode n) {
-        List<SyntaxNode> children = exprChildren(n);
-        Ast.Expr function = expr(children.get(0));
+        SyntaxNode callee = exprChildren(n).get(0);
         List<Ast.Expr> args = new ArrayList<>();
         n.child(SyntaxKind.ARG_LIST).ifPresent(list -> {
             for (SyntaxNode arg : exprChildren(list)) {
                 args.add(expr(arg));
             }
         });
-        return new Ast.Apply(function, args, ConstructionOrigin.own(), function.pos());
+        return new Ast.Apply(expr(callee), args, ConstructionOrigin.own(), pos(callee));
     }
 
     private Ast.Expr binary(SyntaxNode n) {
@@ -746,8 +727,12 @@ public final class AstBuilder {
         if (right instanceof Ast.Var v) {
             return new Ast.Apply(v.name(), List.of(left), v.pos());
         }
-        if (right instanceof Ast.FieldAccess fa && fa.target() instanceof Ast.Var base) {
-            return new Ast.Apply(base.name() + "." + fa.field(), List.of(left), fa.pos());
+        // `e |> Mod.name`: the read is handed over as the callee it is, rather than reassembled
+        // into a name here. Whether it is a namespace member or a field taken off a binding is
+        // resolution's to say, and it says it once, for this and for `Mod.name(e)` alike.
+        if (right instanceof Ast.FieldAccess fa) {
+            return new Ast.Apply(fa, List.of(left), ConstructionOrigin.own(),
+                    pos(operands.get(1)));
         }
         throw CompileException.of(
                 Diagnostic.of(null, "parse.vpipe.right").title("parse.title").at(right.pos()).build(),
@@ -1241,7 +1226,7 @@ public final class AstBuilder {
 
     private static boolean isExprKind(SyntaxKind k) {
         return switch (k) {
-            case LITERAL_EXPR, VAR_EXPR, FIELD_ACCESS, CALL_EXPR, APPLY_EXPR, BINARY_EXPR,
+            case LITERAL_EXPR, VAR_EXPR, FIELD_ACCESS, APPLY_EXPR, BINARY_EXPR,
                  UNARY_EXPR, PIPE_EXPR,
                  PAREN_EXPR, TUPLE_EXPR, LIST_EXPR, LIST_COMP, IF_EXPR, MATCH_EXPR, LAMBDA_EXPR,
                  FIELD_GETTER, NEW_DATA_EXPR, BLOCK_EXPR, UNREACHABLE_EXPR -> true;

--- a/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
@@ -2,6 +2,9 @@ package souther.compiler;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
 
@@ -315,5 +318,23 @@ class CompilePostfixApplicationTest {
         assertFalse(nameless.appliesAName());
         assertEquals("", nameless.written(), "there is no spelling to quote");
         assertEquals("", nameless.reaches(), "and no declaration to look up");
+    }
+
+    /**
+     * What a lowering put in the callee position and what a report quotes are separate slots. An
+     * application of something other than a name binds it first, so what this reaches is that
+     * binding — and every table in the compiler is keyed by declarations, so a spelling reaching one
+     * would be a miss that looked like a hit for whatever happened to be filed under it.
+     */
+    @Test
+    void whatAnApplicationReachesIsNeverTheSpellingAReportQuotes() {
+        SourcePos at = new SourcePos(1, 1);
+        BindingId id = new BindingId(new BindingOwner.OfValue("demo", "go"), 0);
+        Ast.Apply lowered = new Ast.Apply(
+                new Ast.Var("$fn0", new ValueName.Local("$fn0", id), at),
+                java.util.List.of(), souther.compiler.types.ConstructionOrigin.own(), "d.count", at);
+
+        assertEquals("d.count", lowered.written(), "a report quotes what the author wrote");
+        assertEquals("$fn0", lowered.reaches(), "a table is looked up with the binding");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileQualifiedCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQualifiedCalleeTest.java
@@ -1,0 +1,214 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.diag.CompileException;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An application is an argument list written after an expression, whatever the expression is, so a
+ * qualified callee reaches resolution as the field read the parser made of it (issue #274). What a
+ * chain of names means — a member of a namespace, or a field taken off a binding — is decided here,
+ * once, whether or not an argument list follows.
+ */
+class CompileQualifiedCalleeTest {
+
+    private static final String UP = """
+            module up exposing ( Amount, Defaults, defaults )
+
+            data Amount = Int invariant value >= 0
+            data Defaults = { limit: Int }
+
+            let defaults : Defaults = Defaults { limit = 7 }
+            """;
+
+    private static final String DOTTED = """
+            module probe.a exposing ( Amount )
+
+            data Amount = Int invariant value >= 0
+            """;
+
+    private static Map<String, byte[]> compile(String... srcs) {
+        return Compiler.compileModules(List.of(srcs));
+    }
+
+    private static CompileException refused(String... srcs) {
+        return assertThrows(CompileException.class, () -> compile(srcs));
+    }
+
+    /** A module-qualified construction, which reached the library ladder only because the parser
+     *  flattened `up.Amount(` into one name. */
+    @Test
+    void aQualifiedConstructionIsStillReached() {
+        compile(UP, """
+                module down exposing ( In, Out, run )
+                data In = { n: Int }
+                data Out = { m: Int }
+                behavior run : (i: In) -> Out constructs Out, up.Amount
+                let run (i) = Out { m = up.Amount(i.n).value }
+                """);
+    }
+
+    /**
+     * A module whose own name is dotted, in a value position. The parser looked three tokens ahead
+     * for a `(` and so read only one dot as part of a callee, which left this spelling working in a
+     * type position and refused in a value one.
+     */
+    @Test
+    void aModuleWhoseNameIsDottedIsReachedInAValuePositionToo() {
+        compile(DOTTED, """
+                module down exposing ( In, Out, run )
+                data In = { n: Int }
+                data Out = { m: Int }
+                behavior run : (i: In) -> Out constructs Out, probe.a.Amount
+                let run (i) = Out { m = probe.a.Amount(i.n).value }
+                """);
+    }
+
+    /**
+     * A chain that answers nothing as a whole is taken apart, and what is reported is the member of
+     * the namespace rather than the whole chain: {@code up.defaults} is where the answer runs out —
+     * a module reaches another module's values through an import, not through a qualifier — and
+     * {@code .limit} would have been an ordinary read off whatever it answered.
+     */
+    @Test
+    void aChainThatAnswersNothingIsReportedWhereTheAnswerRanOut() {
+        CompileException e = refused(UP, """
+                module down exposing ( In, Out, run )
+                data In = { n: Int }
+                data Out = { m: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = Out { m = i.n + up.defaults.limit }
+                """);
+
+        assertTrue(e.getMessage().contains("`up.defaults`"), e.getMessage());
+        assertEquals("up.defaults".length(),
+                e.diagnostic().region().end().column() - e.diagnostic().region().start().column());
+    }
+
+    /** A chain rooted at a binding is field reads all the way down, however long it is: the root is
+     *  bound, so nothing in it is a namespace and no fold is attempted. */
+    @Test
+    void aChainRootedAtABindingIsReadsAllTheWayDown() throws Exception {
+        Map<String, byte[]> classes = compile("""
+                module demo exposing ( In, Out, go )
+                data Inner = { n: Int }
+                data Mid = { inner: Inner }
+                data In = { n: Int }
+                data Out = { m: Int }
+                behavior go : (i: In) -> Out constructs Out, Mid, Inner
+                let go (i) = {
+                    let d = Mid { inner = Inner { n = i.n } }
+                    Out { m = d.inner.n }
+                }
+                """);
+
+        BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
+        Object b = loader.loadClass("demo.Go$Impl").getConstructor().newInstance();
+        Object out = Codecs.apply(b, Codecs.decoded(loader, "demo.In", Map.of("n", 5L)));
+        assertEquals(5L, out.getClass().getMethod("m").invoke(out));
+    }
+
+    /** A binding in force wins over a namespace of the same name, applied or not. */
+    @Test
+    void aBindingWinsOverANamespaceOfTheSameName() {
+        compile("""
+                module demo
+                data Out = { m: Int }
+                behavior go : (n: Int) -> Out constructs Out
+                let go (n) = {
+                    let Map = Out { m = n }
+                    Out { m = Map.m }
+                }
+                """);
+    }
+
+    /**
+     * A member a namespace has not got is named in full. Reporting the root would send the author
+     * after a module name that is right, and the root is what a chain rooted at an unknown name is
+     * reported at — see below.
+     */
+    @Test
+    void aMemberAKnownNamespaceHasNotGotIsNamedInFull() {
+        CompileException e = refused(DOTTED, """
+                module down exposing ( In, Out, run )
+                data In = { n: Int }
+                data Out = { m: Int }
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = Out { m = probe.a.NoSuch(i.n).value }
+                """);
+
+        assertTrue(e.getMessage().contains("probe.a.NoSuch"), e.getMessage());
+        assertEquals("probe.a.NoSuch".length(),
+                e.diagnostic().region().end().column() - e.diagnostic().region().start().column(),
+                "the report underlines exactly the name that was written");
+    }
+
+    /** A chain rooted at a name nothing declares is reported at that name: nothing in front of the
+     *  dot is a namespace, so there is no qualified name here to name. */
+    @Test
+    void aChainRootedAtAnUnknownNameIsReportedAtTheRoot() {
+        CompileException e = refused("""
+                module demo
+                data In = { n: Int }
+                data Out = { m: Int }
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { m = unknown.member(i.n) }
+                """);
+
+        assertEquals("check.unknown.name.msg", e.diagnostic().messageKey());
+        assertTrue(e.getMessage().contains("`unknown`"), e.getMessage());
+        assertEquals("unknown".length(),
+                e.diagnostic().region().end().column() - e.diagnostic().region().start().column());
+    }
+
+    /**
+     * A field read applied, where the field is not a function. The application is lowered to a
+     * binding that is applied, and the report quotes what the author wrote rather than the binding
+     * the compiler made — which is nowhere in the source.
+     */
+    @Test
+    void aFieldThatIsNotAFunctionIsReportedByTheSpellingTheAuthorWrote() {
+        CompileException e = refused("""
+                module demo
+                data Deps = { count: Int }
+                data In = { n: Int }
+                data Out = { m: Int }
+                behavior go : (i: In) -> Out constructs Out, Deps
+                let go (i) = {
+                    let d = Deps { count = 1 }
+                    Out { m = d.count(i.n) }
+                }
+                """);
+
+        assertEquals("check.apply.notfunction", e.diagnostic().messageKey());
+        assertTrue(e.getMessage().contains("`d.count`"), e.getMessage());
+        assertEquals("d.count".length(),
+                e.diagnostic().region().end().column() - e.diagnostic().region().start().column(),
+                "the report underlines the read, not the binding the lowering introduced");
+    }
+
+    /** `e |> Mod.name` hands the read over as the callee it is rather than reassembling a name from
+     *  its parts, so the pipe and the call reach the same answer for the same spelling. */
+    @Test
+    void aPipeToAQualifiedNameIsTheSameCallAsWritingIt() throws Exception {
+        Map<String, byte[]> classes = compile("""
+                module demo exposing ( In, Out, go )
+                data In = { s: String }
+                data Out = { t: String, u: String }
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { t = i.s |> String.trim, u = String.trim(i.s) }
+                """);
+
+        BytesClassLoader loader = new BytesClassLoader(classes, getClass().getClassLoader());
+        Object b = loader.loadClass("demo.Go$Impl").getConstructor().newInstance();
+        Object out = Codecs.apply(b, Codecs.decoded(loader, "demo.In", Map.of("s", "  a  ")));
+        assertEquals("a", out.getClass().getMethod("t").invoke(out));
+        assertEquals("a", out.getClass().getMethod("u").invoke(out));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/SyntaxDiagnosticTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/SyntaxDiagnosticTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,35 +46,42 @@ class SyntaxDiagnosticTest {
 
     @Test
     void aBlockOfOnlyStatementsIsASyntaxError() {
-        Diagnostic d = diagnosticOf("""
-                module demo
-                let run (i) = {
-                    let a = i
-                }
-                """);
-        assertEquals("parse.title", d.titleKey());
-        assertEquals("parse.block.noresult", d.messageKey());
-    }
-
-    // Issue #75: `i` and the following line's `(a)` read as one call, so the block is left with no
-    // result. It used to reach the AST builder and die with a NullPointerException; the message says
-    // what happened, in both locales.
-    @Test
-    void aResultAbsorbedByTheLineAboveIsReportedRatherThanCrashing() {
         String source = """
                 module demo
                 let run (i) = {
                     let a = i
-                    (a)
                 }
                 """;
         Diagnostic d = diagnosticOf(source);
+        assertEquals("parse.title", d.titleKey());
         assertEquals("parse.block.noresult", d.messageKey());
         SourceContext src = new SourceContext("m.sou", source);
         String en = new HumanRenderer(false).render(d, src, Locale.ENGLISH);
         String ja = new HumanRenderer(false).render(d, src, Locale.JAPANESE);
         assertTrue(en.contains("A block ends in one expression, which is its value"), en);
         assertTrue(ja.contains("ブロックは最後に値となる式を1つ置きます"), ja);
+    }
+
+    /**
+     * A result written under a statement that ends in a name is that result. An argument list must
+     * begin on the line its callee ends on, and that rule is now the only one: {@code i} and the
+     * following line's {@code (a)} were read as one call while an applied name was a shape of its
+     * own, which left the block with no result (issue #75) — and made a name applied across a line
+     * break mean something a name applied to the result of an expression never did (issue #274).
+     */
+    @Test
+    void aResultUnderAStatementIsNotAppliedToTheNameAboveIt() {
+        String source = """
+                module demo
+                data Out = { n: Int }
+                let run (i: Int) = {
+                    let a = i
+                    (a)
+                }
+                behavior go : (n: Int) -> Out constructs Out
+                let go (n) = Out { n = run(n) }
+                """;
+        assertDoesNotThrow(() -> Compiler.compile(source));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/cst/CstCallResultFieldAccessTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/cst/CstCallResultFieldAccessTest.java
@@ -1,6 +1,8 @@
 package souther.compiler.cst;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -82,5 +84,30 @@ class CstCallResultFieldAccessTest {
         assertEquals("personOf(i).address.city", outer.text().strip());
         assertEquals(SyntaxKind.FIELD_ACCESS, outer.childNodes().get(0).kind());
         assertEquals("personOf(i).address", outer.childNodes().get(0).text().strip());
+    }
+
+    /**
+     * An argument list begins on the line its callee ends on. The specification says so of every
+     * application; before this it held only where the callee was not a bare or qualified name, so
+     * the same two lines meant one thing written one way and another written the other. The block
+     * these are written in has a result of its own, so what a next-line `(` opens is a parenthesised
+     * expression that stands as a statement's value rather than an argument list.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "amountOf",                 // a bare name
+            "up.amountOf",              // a qualified name
+            "amountOf // a comment",    // a comment between the two
+            "amountOf(i)",              // the result of an application
+    })
+    void aLineBreakEndsThePostfixChainWhateverTheCalleeIs(String callee) {
+        SyntaxNode root = parsed("{\n    let a = " + callee + "\n    (i)\n}");
+
+        assertEquals(0, allOf(root, SyntaxKind.APPLY_EXPR).stream()
+                        .filter(n -> n.text().strip().endsWith("(i)")
+                                && n.text().contains("\n")).count(),
+                () -> "the next line's `(i)` was applied to `" + callee + "`");
+        assertEquals(1, allOf(root, SyntaxKind.PAREN_EXPR).size(),
+                () -> "`(i)` is a parenthesised expression after `" + callee + "`");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/cst/CstCallResultFieldAccessTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/cst/CstCallResultFieldAccessTest.java
@@ -47,17 +47,24 @@ class CstCallResultFieldAccessTest {
     void aCallResultCarriesTheFieldAccess() {
         SyntaxNode access = onlyOf(parsed("amountOf(i).value"), SyntaxKind.FIELD_ACCESS);
 
-        assertEquals(SyntaxKind.CALL_EXPR, access.childNodes().get(0).kind());
+        assertEquals(SyntaxKind.APPLY_EXPR, access.childNodes().get(0).kind());
         assertEquals("amountOf(i).value", access.text().strip());
     }
 
+    /**
+     * A qualified callee is a read like any other, and the argument list is written after it. The
+     * outermost read is the one the call's result carries; the inner one is how the name was
+     * written. Which of the two {@code up.amountOf} is — a member of a namespace or a field taken
+     * off a binding named {@code up} — is not a question the parser answers (issue #274).
+     */
     @Test
-    void aQualifiedCallIsTheCallAndNotAFieldReadOnTheModule() {
-        SyntaxNode access = onlyOf(parsed("up.amountOf(i).value"), SyntaxKind.FIELD_ACCESS);
+    void aQualifiedCallIsAnArgumentListAfterAReadAndTheResultCarriesAnother() {
+        List<SyntaxNode> reads = allOf(parsed("up.amountOf(i).value"), SyntaxKind.FIELD_ACCESS);
 
-        // one FIELD_ACCESS only: `up.amountOf` is the call's name, so `.value` is the sole read
-        assertEquals(SyntaxKind.CALL_EXPR, access.childNodes().get(0).kind());
-        assertEquals("up.amountOf(i)", access.childNodes().get(0).text().strip());
+        assertEquals(2, reads.size(), () -> "expected the callee's read and the result's, found " + reads);
+        assertEquals("up.amountOf(i).value", reads.get(0).text().strip());
+        assertEquals(SyntaxKind.APPLY_EXPR, reads.get(0).childNodes().get(0).kind());
+        assertEquals("up.amountOf", reads.get(1).text().strip());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -129,6 +129,28 @@ class FormatterTest {
     }
 
     /**
+     * A qualified callee is a field read the argument list is written after, so the formatter prints
+     * the callee as the expression it is. Nothing reassembles a name from the identifier tokens
+     * under the node — there is no node left that holds them (issue #274).
+     */
+    @Test
+    void aQualifiedCalleeSurvivesFormatting() {
+        String src = """
+                module demo
+                data In = { s: String, ns: List<Int> }
+                data Out = { t: String, m: Int }
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out {
+                    t = String.trim(i.s),
+                    m = List.length(List.map((n) -> n + 1, i.ns))
+                }
+                """;
+        String formatted = Formatter.format(src);
+        assertEquals(code(src), code(formatted), "the qualified callee was lost:\n" + formatted);
+        assertEquals(formatted, Formatter.format(formatted), "formatting is not idempotent here");
+    }
+
+    /**
      * The formatter never puts an argument list at the start of a line: there it would be a
      * parenthesised expression, and a block's tuple result would be read as applying the line above.
      */

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -538,7 +538,6 @@ public final class Formatter {
             case VAR_EXPR -> text(firstIdent(n));
             case FIELD_ACCESS -> concat(expr(firstExprChild(n)), text("."), text(lastIdent(n)));
             case FIELD_GETTER -> concat(text("."), text(lastIdent(n)));
-            case CALL_EXPR -> call(n);
             case APPLY_EXPR -> apply(n);
             case BINARY_EXPR -> binary(n);
             case UNARY_EXPR -> concat(text("-"), expr(onlyExpr(n)));
@@ -557,19 +556,10 @@ public final class Formatter {
         };
     }
 
-    private Doc call(SyntaxNode n) {
-        StringBuilder fn = new StringBuilder();
-        for (SyntaxToken t : idents(n)) {
-            if (fn.length() > 0) {
-                fn.append('.');
-            }
-            fn.append(t.text());
-        }
-        return concat(text(fn.toString()), arguments(n));
-    }
-
     /**
-     * An argument list applied to the expression before it.
+     * An argument list applied to the expression before it — every application, whatever is
+     * applied. The callee is printed as the expression it is, so a qualified name reaches here as
+     * the field read it was parsed as and no name is reassembled from the tokens under the node.
      *
      * <p>Printed on the line its callee ends on: an argument list that began the next line would be
      * a parenthesised expression rather than an application.
@@ -1011,7 +1001,7 @@ public final class Formatter {
 
     private static boolean isExprKind(SyntaxKind k) {
         return switch (k) {
-            case LITERAL_EXPR, VAR_EXPR, FIELD_ACCESS, CALL_EXPR, APPLY_EXPR, BINARY_EXPR,
+            case LITERAL_EXPR, VAR_EXPR, FIELD_ACCESS, APPLY_EXPR, BINARY_EXPR,
                  UNARY_EXPR, PIPE_EXPR, PAREN_EXPR, TUPLE_EXPR, LIST_EXPR, LIST_COMP, IF_EXPR,
                  MATCH_EXPR, LAMBDA_EXPR, FIELD_GETTER, NEW_DATA_EXPR, BLOCK_EXPR,
                  UNREACHABLE_EXPR -> true;

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -1098,24 +1098,33 @@ public final class Analyzer {
     /** Pre-order walk, appending {@code {line, startChar, length, tokenType}} for each classifiable
      * token in source order. */
     private void collectTokens(SyntaxNode node, LineIndex lines, List<int[]> out) {
-        collectTokens(node, lines, out, node.kind());
+        collectTokens(node, lines, out, node.kind(), false);
     }
 
     /**
      * {@code enclosing} is the nearest ancestor that is not a pattern. A pattern says what a value is
      * made of, not what its names are for: the same {@code (a, b)} binds parameters in a lambda's
      * head and locals in a {@code let}, so classification has to see past it.
+     *
+     * <p>{@code callee} says this node is what an application applies. It cannot be worked out from
+     * the parent alone: a qualified callee is a field read, and only its last name is the function —
+     * {@code Map.map(f, xs)} names a namespace and then a function in it. So it is carried down, to
+     * the field a read takes and not to what the read is taken off.
      */
     private void collectTokens(SyntaxNode node, LineIndex lines, List<int[]> out,
-                               SyntaxKind enclosing) {
+                               SyntaxKind enclosing, boolean callee) {
         SyntaxKind outer = isPatternNode(node.kind()) ? enclosing : node.kind();
         boolean seenIdent = false;
+        boolean seenChildNode = false;
         for (SyntaxElement e : node.children()) {
             if (e instanceof SyntaxNode child) {
-                collectTokens(child, lines, out, outer);
+                boolean applied = node.kind() == SyntaxKind.APPLY_EXPR ? !seenChildNode
+                        : callee && node.kind() == SyntaxKind.PAREN_EXPR;
+                seenChildNode = true;
+                collectTokens(child, lines, out, outer, applied);
             } else {
                 SyntaxToken token = (SyntaxToken) e;
-                int type = classify(token, node.kind(), outer, seenIdent);
+                int type = classify(token, node.kind(), outer, seenIdent, callee);
                 if (token.kind() == SyntaxKind.IDENT) {
                     seenIdent = true;
                 }
@@ -1140,7 +1149,7 @@ public final class Analyzer {
     }
 
     private int classify(SyntaxToken token, SyntaxKind parent, SyntaxKind enclosing,
-                         boolean afterFirstIdent) {
+                         boolean afterFirstIdent, boolean callee) {
         SyntaxKind k = token.kind();
         if (k == SyntaxKind.LINE_COMMENT) {
             return T_COMMENT;
@@ -1161,12 +1170,18 @@ public final class Analyzer {
             return T_OPERATOR;
         }
         if (k == SyntaxKind.IDENT) {
-            return classifyIdent(parent, enclosing, afterFirstIdent);
+            return classifyIdent(parent, enclosing, afterFirstIdent, callee);
         }
         return -1;   // braces, parens, commas, colons, dots
     }
 
-    private int classifyIdent(SyntaxKind parent, SyntaxKind enclosing, boolean afterFirstIdent) {
+    private int classifyIdent(SyntaxKind parent, SyntaxKind enclosing, boolean afterFirstIdent,
+                              boolean callee) {
+        // what an application applies: the bare name, or the last name of a qualified one. The
+        // qualifier in front of it is not the function and is classified as what it is written as.
+        if (callee && (parent == SyntaxKind.VAR_EXPR || parent == SyntaxKind.FIELD_ACCESS)) {
+            return T_FUNCTION;
+        }
         // a name a pattern binds is a parameter where the pattern is one, and a local otherwise
         if (parent == SyntaxKind.PATTERN_NAME) {
             return enclosing == SyntaxKind.LAMBDA_EXPR || enclosing == SyntaxKind.FN_PARAM
@@ -1183,7 +1198,7 @@ public final class Analyzer {
         return switch (parent) {
             case TYPE_REF, TYPE_ARGS, SUM_BODY, NEWTYPE_BODY, CONSTRUCTS_CLAUSE, DEPENDS_CLAUSE,
                  DATA_DEF, NEW_DATA_EXPR, PATTERN_CTOR -> T_TYPE;
-            case BEHAVIOR_DEF, FN_DEF, STAGE, CALL_EXPR -> T_FUNCTION;
+            case BEHAVIOR_DEF, FN_DEF, STAGE -> T_FUNCTION;
             case PARAM, FN_PARAM, LAMBDA_EXPR -> T_PARAMETER;
             case FIELD, FIELD_INIT, FIELD_ACCESS, FIELD_GETTER -> T_PROPERTY;
             case MODULE_HEADER, QUALIFIED_NAME, IMPORT_DECL -> T_NAMESPACE;

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -154,6 +154,40 @@ class AnalyzerTest {
         assertEquals(4, typeAt(tokens, 3, 10), "`n` is the name it binds, a variable (index 4)");
     }
 
+    /**
+     * What an application applies is the function, and a qualified callee is a read whose last name
+     * is the one. Every application is now an argument list written after an expression (issue
+     * #274), so a call is no longer a node of its own to classify by — the callee position is
+     * carried down instead, to the field a read takes and not to what it is taken off.
+     */
+    @Test
+    void whatAnApplicationAppliesIsTheFunctionAndTheQualifierInFrontOfItIsNot() {
+        //                     0         1         2         3         4
+        //                     0123456789012345678901234567890123456789012345
+        String body = "let g (d: D, xs: List<Int>) = List.map(f, xs)\n";
+        int[] data = analyzer.semanticTokens(
+                "module demo\ndata D = { n: Int }\nlet f (x: Int) = x\n" + body);
+        List<int[]> tokens = decodeSemanticTokens(data);
+
+        assertEquals(6, typeAt(tokens, 3, 35), "`map` is what is applied, so it is a function (index 6)");
+        assertEquals(4, typeAt(tokens, 3, 30), "`List` is the qualifier, not the function");
+        assertEquals(4, typeAt(tokens, 3, 39), "`f` is an argument, not what is applied");
+    }
+
+    @Test
+    void aBareCalleeIsAFunctionAndAFieldReadThatIsNotAppliedIsAProperty() {
+        //                     0         1         2         3
+        //                     012345678901234567890123456789012345
+        String body = "let g (d: D) = f(d.n)\n";
+        int[] data = analyzer.semanticTokens(
+                "module demo\ndata D = { n: Int }\nlet f (x: Int) = x\n" + body);
+        List<int[]> tokens = decodeSemanticTokens(data);
+
+        assertEquals(6, typeAt(tokens, 3, 15), "`f` is what is applied (index 6)");
+        assertEquals(4, typeAt(tokens, 3, 17), "`d` is what the read is taken off, a variable here");
+        assertEquals(5, typeAt(tokens, 3, 19), "`n` is a field read, not a function (index 5)");
+    }
+
     /** Reverses the LSP delta encoding into absolute {@code {line, char, length, type}} tokens. */
     private static List<int[]> decodeSemanticTokens(int[] data) {
         List<int[]> out = new java.util.ArrayList<>();

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -1289,24 +1289,18 @@ public final class CstParser {
         expect(SyntaxKind.RPAREN);
     }
 
-    /** An identifier-led primary: a call, a qualified call, a construction, or a bare variable —
-     * each of which a field-access chain may follow. */
+    /**
+     * An identifier-led primary: a construction or a bare variable, each of which a field-access
+     * chain or an argument list may follow.
+     *
+     * <p>A name that is applied is not read here. {@code name(args)} is the variable and the
+     * argument list {@link #postfixExpr} writes after it, and {@code Mod.name(args)} is that
+     * argument list after a field read — so what is applied is a subexpression whichever way it is
+     * written, and whether {@code Mod.name} is a namespace member or an ordinary field read is
+     * left to resolution, which knows the bindings in force.
+     */
     private void identExpr() {
-        if (nth(1) == SyntaxKind.DOT && nth(2) == SyntaxKind.IDENT && nth(3) == SyntaxKind.LPAREN) {
-            // qualified call `Mod.name(args)`
-            start(SyntaxKind.CALL_EXPR);
-            bump();   // Mod
-            bump();   // .
-            bump();   // name
-            argList();
-            finish();
-        } else if (nth(1) == SyntaxKind.LPAREN) {
-            // plain call `name(args)`
-            start(SyntaxKind.CALL_EXPR);
-            bump();   // name
-            argList();
-            finish();
-        } else if (!noConstruct && nth(1) == SyntaxKind.LBRACE) {
+        if (!noConstruct && nth(1) == SyntaxKind.LBRACE) {
             // construction `Type { ... }` (unless suppressed, as in a match scrutinee)
             newDataExpr();
         } else {

--- a/souther-syntax/src/main/java/souther/compiler/cst/SyntaxKind.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/SyntaxKind.java
@@ -111,7 +111,6 @@ public enum SyntaxKind {
     PIPE_EXPR,          // a |> b
     BINARY_EXPR,        // a <op> b (all precedence levels)
     UNARY_EXPR,         // -a
-    CALL_EXPR,          // f(args) — an identifier applied, which the AST builder folds into APPLY_EXPR
     APPLY_EXPR,         // <expr>(args) — what is applied is any expression
     ARG_LIST,
     FIELD_ACCESS,       // a.b


### PR DESCRIPTION
Closes #274 once merged (`gh issue close 274` — a PR into `develop` does not close it).

The CST had two nodes for one operation. `name(args)` and `Mod.name(args)` were a call; anything else applied was an application; the parser chose between them by looking three tokens ahead for a `(`. That left the callee of a call as a name reassembled from the identifier tokens under the node — in the AST builder, in the formatter, and in the `|>` desugaring — while the AST has held one node with a callee expression since #273.

`CALL_EXPR` is gone. A name is a variable, an argument list after it is an application, and a qualified callee is the field read it follows.

## What carried the weight

Resolution. `Q.m` was folded into one name only where `Q` was a standard-library qualifier and only where the chain was two segments long; everything else reachable through a qualifier got there because the parser had flattened it. The fold now asks the whole chain, and a chain that answers nothing is taken apart so the part that is a name is asked in turn — `probe.a.defaultAmount.value` folds `probe.a.defaultAmount` and reads `.value` off it.

A report names the member of the namespace where the answer ran out (`probe.a.NoSuch`, `up.defaults`). A chain rooted at a name nothing declares is reported at the root (`unknown`), because nothing in front of the dot is a namespace to have a member of.

## What this fixes

**A module whose own name is dotted, in a value position.** The lookahead read a single dot, so `probe.a.Amount(n)` was already the field-read shape and had no path to the module — while the same spelling worked in a type position. It works in both now.

**A report that quoted a name nobody wrote.** Applying something other than a name binds it first and applies the binding, so `deps.count(x)` reported `` `$fn0` is not a function here `` and underlined four characters from the right place. The callee's spelling now travels with the application: the written form is what a report says, the binding is what the application means.

## What changes for a program

**An argument list must begin on the line its callee ends on.** That was already the rule for an applied expression and is now the only rule: a `(` that opens a line is a parenthesised expression, so a result written under a statement is that result rather than an application of the name above it. No `.sou` in this repository or in `souther-lang/examples` writes an argument list across a line break. The case #75 reported — a block's result absorbed by the line above — cannot arise, and its test now pins the result being the result.

**Editor colours.** The callee of an application is the function, and for a qualified callee that is its last name: `Map.map(f, xs)` colours `map` as a function and `Map` as what it is written as. Before, both were the function.

## What did not fall out

A function cannot be stored in a data field — codec derivation runs on every declared data and refuses it — nor be a newtype's base. So a field read never answers a function, and applying one is never a working program: what this changes there is the report, not what compiles.

Reaching another module's values through a qualifier is still not a thing; only its types are. `up.someHelper` was refused before and is refused now, with the full spelling named.

## Measurement

- Full suite green: 2013 / 101 / 73 / 1.
- `souther-lang/examples` builds and its tests pass.
- Formatter output is byte-identical to `develop` over all 52 `.sou` in both repositories.
- `souther-bench warm phase`, same JDK and settings, is within noise: crm warm median 117.4 ms against 117.7 ms; phase `parse` 4.71 ms against 4.47 ms; `resolve names` 1.10 ms against 1.09 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
