### PR TITLE
Read a relation over a list at the element a closure is handed

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -163,19 +163,12 @@ public final class InvariantChecker {
             "Set.contains", new Carried(1, Set.of(Shape.PERMUTES)),
             "Map.containsKey", new Carried(1, Set.of(Shape.PERMUTES)));
 
-    /** A stdlib call that states a predicate ({@code predicate}) of every element of a container
-     * ({@code container}). Stating one is stating the predicate of each element, so the elements a
-     * combinator's closure is handed carry it — which is the other direction of {@link #CARRIED},
-     * where a predicate travels from a container to one built from it. {@code List.all} is the only
-     * such call the library has. */
-    private record Quantifier(int predicate, int container) {}
-
-    private static final Map<String, Quantifier> QUANTIFIERS =
-            Map.of("List.all", new Quantifier(0, 1));
-
-    /** The constructions every element of whose result is an element of what it was built from, so a
-     * relation stated of the source is a relation of each element here. */
-    private static final Set<Shape> KEEPS_ELEMENTS = Set.of(Shape.PERMUTES, Shape.SUBSET);
+    /** The calls that state their predicate of <em>every</em> element, so what they say of a
+     * container is what holds of each element a closure is handed. Which argument is the predicate
+     * and which the container is what {@link #COMBINATORS} already answers of any combinator, and how
+     * far the statement travels is what {@link #CARRIED} already answers of any predicate — so a
+     * quantifier is the name and nothing else. {@code List.all} is the only one the library has. */
+    private static final Set<String> QUANTIFIERS = Set.of("List.all");
 
     /** Emptiness, by the size call it means. This is not a rule about what an operation does to a
      * property (spec §invariant-discharge-preservation) but about what a predicate <em>says</em>:
@@ -211,12 +204,14 @@ public final class InvariantChecker {
      * relation as the clause it was written as, together with the rule that names its free leaves, so
      * it can be read again at the element a combinator's closure is handed.
      *
-     * <p>{@code reads} is every term the clause names from outside itself, {@code container}
+     * <p>{@code through} is how far it travels: a construction of one of those shapes holds only
+     * elements of what it was built from, so what was stated of the source still holds of each of
+     * them. {@code reads} is every term the clause names from outside itself, {@code container}
      * included. A binding that takes over one of those names leaves the clause saying something else,
      * so the relation is dropped there.
      */
-    private record Quantified(String container, Ast.Block predicate, Bindings binds,
-                              List<String> reads) {}
+    private record Quantified(String container, Set<Shape> through, Ast.Block predicate,
+                              Bindings binds, List<String> reads) {}
 
     /** What the guards have settled on the current path: numeric relations, predicates known to hold
      * or to fail, and relations known of every element of a container. Threaded functionally through
@@ -454,34 +449,30 @@ public final class InvariantChecker {
     }
 
     /** The relations known of every element of {@code container}: those stated of it as written, and
-     * those stated of each container it was built from by an operation that only drops or reorders
-     * elements — every element here is an element there. */
+     * those stated of a container it was built from that travel every construction in between. */
     private List<Quantified> elementRelations(Ast.Expr container, Known k, Map<String, Type> types) {
         List<Quantified> found = new ArrayList<>();
+        Set<Shape> crossed = java.util.EnumSet.noneOf(Shape.class);
         Ast.Expr source = container;
-        while (source != null) {
+        while (true) {
             String key = bodyKey(source, types);
             if (key != null) {
                 for (Quantified q : k.quantified()) {
-                    if (key.equals(q.container())) {
+                    if (key.equals(q.container()) && q.through().containsAll(crossed)) {
                         found.add(q);
                     }
                 }
             }
-            source = builtFromKeepingElements(source);
+            if (!(source instanceof Ast.Apply call)) {
+                return found;
+            }
+            Built built = BUILT_FROM.get(call.reaches());
+            if (built == null || built.from() >= call.args().size()) {
+                return found;
+            }
+            crossed.add(built.shape());
+            source = call.args().get(built.from());
         }
-        return found;
-    }
-
-    /** What {@code e} was built from where every element of {@code e} is one of that container's, or
-     * {@code null} where it was not built that way. */
-    private static Ast.Expr builtFromKeepingElements(Ast.Expr e) {
-        if (!(e instanceof Ast.Apply call)) {
-            return null;
-        }
-        Built built = BUILT_FROM.get(call.reaches());
-        return built != null && KEEPS_ELEMENTS.contains(built.shape())
-                && built.from() < call.args().size() ? call.args().get(built.from()) : null;
     }
 
     /** What {@code q} says of the element bound to {@code element}, taken into {@code k}. The clause
@@ -521,24 +512,25 @@ public final class InvariantChecker {
             quantifiedBy(under, binds, !positive, out);
             return;
         }
-        if (!positive || !(e instanceof Ast.Apply call)) {
+        if (!positive || !(e instanceof Ast.Apply call) || !QUANTIFIERS.contains(call.reaches())) {
             return;
         }
-        Quantifier over = QUANTIFIERS.get(call.reaches());
-        if (over == null || over.predicate() >= call.args().size()
-                || over.container() >= call.args().size()
-                || !(call.args().get(over.predicate()) instanceof Ast.Block p)
+        Combinator over = COMBINATORS.get(call.reaches());
+        Carried carried = CARRIED.get(call.reaches());
+        if (over == null || carried == null || over.closureArg() >= call.args().size()
+                || over.listArg() >= call.args().size()
+                || !(call.args().get(over.closureArg()) instanceof Ast.Block p)
                 || p.params().size() != 1) {
             return;
         }
-        String container = siteOf(binds).apply(call.args().get(over.container()));
+        String container = siteOf(binds).apply(call.args().get(over.listArg()));
         if (container == null) {
             return;
         }
         List<String> named = new ArrayList<>();
         named.add(container);
         reads(e, binds, Set.of(), named);
-        out.add(new Quantified(container, p, binds, List.copyOf(named)));
+        out.add(new Quantified(container, carried.through(), p, binds, List.copyOf(named)));
     }
 
     /** Every term {@code e} names from outside itself, as the clause's own rule names it. A name the

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -206,12 +206,20 @@ public final class InvariantChecker {
      *
      * <p>{@code through} is how far it travels: a construction of one of those shapes holds only
      * elements of what it was built from, so what was stated of the source still holds of each of
-     * them. {@code reads} is every term the clause names from outside itself, {@code container}
-     * included. A binding that takes over one of those names leaves the clause saying something else,
-     * so the relation is dropped there.
+     * them. {@code reads} is every term the <em>predicate</em> names from outside itself; a binding
+     * that takes over one of those names leaves the predicate saying something else. The container is
+     * kept apart from them because it is read where the call is written rather than inside the
+     * closure, so a closure parameter spelling its root does not reach it.
      */
     private record Quantified(String container, Set<Shape> through, Ast.Block predicate,
-                              Bindings binds, List<String> reads) {}
+                              Bindings binds, List<String> reads) {
+
+        /** Whether a binding that drops what {@code drop} matches leaves the predicate intact. The
+         * container is not asked: it is read outside the closure this is instantiated in. */
+        boolean survives(java.util.function.Predicate<String> drop) {
+            return reads.stream().noneMatch(drop);
+        }
+    }
 
     /** What the guards have settled on the current path: numeric relations, predicates known to hold
      * or to fail, and relations known of every element of a container. Threaded functionally through
@@ -242,7 +250,9 @@ public final class InvariantChecker {
         Known forgetIf(java.util.function.Predicate<String> drop) {
             List<Quantified> kept = new ArrayList<>();
             for (Quantified q : quantified) {
-                if (q.reads().stream().noneMatch(drop)) {
+                // Here the container is asked too: a relation this walk carries past the binding is
+                // one it may look up anywhere after it, where the name means what the binding gave.
+                if (!drop.test(q.container()) && q.survives(drop)) {
                     kept.add(q);
                 }
             }
@@ -431,6 +441,11 @@ public final class InvariantChecker {
                     && combo.listArg() < call.args().size()) {
                 Ast.Expr container = call.args().get(combo.listArg());
                 Type elem = elementType(typeExpr(container, types));
+                // The container is read where the call is written, so what is known of its elements
+                // is looked up before the closure's parameter takes any name over. Reading it after
+                // would make an argument spelling that name — `List.map(cart -> ..., cart.items)` —
+                // answer differently from one spelling any other, which is nothing the program says.
+                List<Quantified> relations = elementRelations(container, k, types);
                 Map<String, Type> t2 = new HashMap<>(types);
                 String p = step.params().get(combo.elementParam()).name();
                 Known k2 = rebind(k, p);
@@ -438,8 +453,13 @@ public final class InvariantChecker {
                     t2.put(p, elem);
                     k2 = seedParam(p, elem, k2);   // the element carries its type's invariant
                 }
-                for (Quantified q : elementRelations(container, k2, types)) {
-                    k2 = instantiate(q, p, elem, k2);
+                for (Quantified q : relations) {
+                    // What the predicate reads besides the element is still read inside the closure,
+                    // so a parameter that takes one of those names over does leave it saying
+                    // something else.
+                    if (q.survives(key -> mentions(key, p))) {
+                        k2 = instantiate(q, p, elem, k2);
+                    }
                 }
                 walk(step.body(), k2, t2);
             } else {
@@ -528,8 +548,7 @@ public final class InvariantChecker {
             return;
         }
         List<String> named = new ArrayList<>();
-        named.add(container);
-        reads(e, binds, Set.of(), named);
+        reads(p, binds, Set.of(), named);   // the predicate's own parameter is its own, and left out
         out.add(new Quantified(container, carried.through(), p, binds, List.copyOf(named)));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -163,6 +163,20 @@ public final class InvariantChecker {
             "Set.contains", new Carried(1, Set.of(Shape.PERMUTES)),
             "Map.containsKey", new Carried(1, Set.of(Shape.PERMUTES)));
 
+    /** A stdlib call that states a predicate ({@code predicate}) of every element of a container
+     * ({@code container}). Stating one is stating the predicate of each element, so the elements a
+     * combinator's closure is handed carry it — which is the other direction of {@link #CARRIED},
+     * where a predicate travels from a container to one built from it. {@code List.all} is the only
+     * such call the library has. */
+    private record Quantifier(int predicate, int container) {}
+
+    private static final Map<String, Quantifier> QUANTIFIERS =
+            Map.of("List.all", new Quantifier(0, 1));
+
+    /** The constructions every element of whose result is an element of what it was built from, so a
+     * relation stated of the source is a relation of each element here. */
+    private static final Set<Shape> KEEPS_ELEMENTS = Set.of(Shape.PERMUTES, Shape.SUBSET);
+
     /** Emptiness, by the size call it means. This is not a rule about what an operation does to a
      * property (spec §invariant-discharge-preservation) but about what a predicate <em>says</em>:
      * {@code List.isEmpty(xs)} and {@code List.length(xs) == 0} are one statement, so a guard writing
@@ -191,24 +205,53 @@ public final class InvariantChecker {
         return TypeOps.effectiveInvariants(named, data, symbols, dischargeInvariants::get);
     }
 
-    /** What the guards have settled on the current path: numeric relations, and predicates known to
-     * hold or to fail. Threaded functionally through the walk, as the domain alone once was. */
-    private record Known(NumericDomain numbers, PredicateFacts facts) {
+    /**
+     * A relation known of every element of a container. A fact settles the container as a whole and
+     * is keyed by the call that states it, which relates it to nothing inside; this keeps the
+     * relation as the clause it was written as, together with the rule that names its free leaves, so
+     * it can be read again at the element a combinator's closure is handed.
+     *
+     * <p>{@code reads} is every term the clause names from outside itself, {@code container}
+     * included. A binding that takes over one of those names leaves the clause saying something else,
+     * so the relation is dropped there.
+     */
+    private record Quantified(String container, Ast.Block predicate, Bindings binds,
+                              List<String> reads) {}
+
+    /** What the guards have settled on the current path: numeric relations, predicates known to hold
+     * or to fail, and relations known of every element of a container. Threaded functionally through
+     * the walk, as the domain alone once was. */
+    private record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified) {
 
         static Known top() {
-            return new Known(NumericDomain.top(), PredicateFacts.none());
+            return new Known(NumericDomain.top(), PredicateFacts.none(), List.of());
         }
 
         Known with(NumericDomain n) {
-            return new Known(n, facts);
+            return new Known(n, facts, quantified);
         }
 
         Known with(PredicateFacts f) {
-            return new Known(numbers, f);
+            return new Known(numbers, f, quantified);
+        }
+
+        Known and(List<Quantified> more) {
+            if (more.isEmpty()) {
+                return this;
+            }
+            List<Quantified> all = new ArrayList<>(quantified);
+            all.addAll(more);
+            return new Known(numbers, facts, List.copyOf(all));
         }
 
         Known forgetIf(java.util.function.Predicate<String> drop) {
-            return new Known(numbers.forgetIf(drop), facts.forgetIf(drop));
+            List<Quantified> kept = new ArrayList<>();
+            for (Quantified q : quantified) {
+                if (q.reads().stream().noneMatch(drop)) {
+                    kept.add(q);
+                }
+            }
+            return new Known(numbers.forgetIf(drop), facts.forgetIf(drop), List.copyOf(kept));
         }
     }
 
@@ -391,7 +434,8 @@ public final class InvariantChecker {
             if (combo != null && i == combo.closureArg() && arg instanceof Ast.Block step
                     && combo.elementParam() < step.params().size()
                     && combo.listArg() < call.args().size()) {
-                Type elem = elementType(typeExpr(call.args().get(combo.listArg()), types));
+                Ast.Expr container = call.args().get(combo.listArg());
+                Type elem = elementType(typeExpr(container, types));
                 Map<String, Type> t2 = new HashMap<>(types);
                 String p = step.params().get(combo.elementParam()).name();
                 Known k2 = rebind(k, p);
@@ -399,11 +443,126 @@ public final class InvariantChecker {
                     t2.put(p, elem);
                     k2 = seedParam(p, elem, k2);   // the element carries its type's invariant
                 }
+                for (Quantified q : elementRelations(container, k2, types)) {
+                    k2 = instantiate(q, p, elem, k2);
+                }
                 walk(step.body(), k2, t2);
             } else {
                 walk(arg, k, types);
             }
         }
+    }
+
+    /** The relations known of every element of {@code container}: those stated of it as written, and
+     * those stated of each container it was built from by an operation that only drops or reorders
+     * elements — every element here is an element there. */
+    private List<Quantified> elementRelations(Ast.Expr container, Known k, Map<String, Type> types) {
+        List<Quantified> found = new ArrayList<>();
+        Ast.Expr source = container;
+        while (source != null) {
+            String key = bodyKey(source, types);
+            if (key != null) {
+                for (Quantified q : k.quantified()) {
+                    if (key.equals(q.container())) {
+                        found.add(q);
+                    }
+                }
+            }
+            source = builtFromKeepingElements(source);
+        }
+        return found;
+    }
+
+    /** What {@code e} was built from where every element of {@code e} is one of that container's, or
+     * {@code null} where it was not built that way. */
+    private static Ast.Expr builtFromKeepingElements(Ast.Expr e) {
+        if (!(e instanceof Ast.Apply call)) {
+            return null;
+        }
+        Built built = BUILT_FROM.get(call.reaches());
+        return built != null && KEEPS_ELEMENTS.contains(built.shape())
+                && built.from() < call.args().size() ? call.args().get(built.from()) : null;
+    }
+
+    /** What {@code q} says of the element bound to {@code element}, taken into {@code k}. The clause
+     * is read again with the quantifier's own parameter standing for that element — the same reading
+     * {@link #seedAt} does of a type's invariant, over the clause a quantifier holds. A relation the
+     * clause in turn states of a container is recorded, so a container of containers reaches its
+     * innermost element. */
+    private Known instantiate(Quantified q, String element, Type elementType, Known k) {
+        Ast.Binder param = q.predicate().params().get(0);
+        Map<String, Type> fields = new HashMap<>(q.binds().fields());
+        if (elementType != null) {
+            fields.put(param.name(), elementType);
+        }
+        Bindings at = new Bindings(
+                name -> param.name().equals(name)
+                        ? LinearForm.atom(element) : q.binds().form().apply(name),
+                name -> param.name().equals(name) ? element : q.binds().path().apply(name),
+                q.binds().given(), q.binds().bodyKey(), fields);
+        List<Quantified> nested = new ArrayList<>();
+        quantifiedBy(q.predicate().body(), at, true, nested);
+        return assume(obligations(q.predicate().body(), at), k).and(nested);
+    }
+
+    /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
+     * Mirrors {@link #obligations}: a conjunction states each of its sides, and a negation flips the
+     * polarity. Only a stated quantifier is recorded — denying one says some element fails the
+     * predicate, and which one is not something this check can name. */
+    private void quantifiedBy(Ast.Expr raw, Bindings binds, boolean positive, List<Quantified> out) {
+        Ast.Expr e = asSizeComparison(raw);
+        if (e instanceof Ast.Binary b && b.op() == Ast.BinOp.AND && positive) {
+            quantifiedBy(b.left(), binds, true, out);
+            quantifiedBy(b.right(), binds, true, out);
+            return;
+        }
+        Ast.Expr under = negated(e);
+        if (under != null) {
+            quantifiedBy(under, binds, !positive, out);
+            return;
+        }
+        if (!positive || !(e instanceof Ast.Apply call)) {
+            return;
+        }
+        Quantifier over = QUANTIFIERS.get(call.reaches());
+        if (over == null || over.predicate() >= call.args().size()
+                || over.container() >= call.args().size()
+                || !(call.args().get(over.predicate()) instanceof Ast.Block p)
+                || p.params().size() != 1) {
+            return;
+        }
+        String container = siteOf(binds).apply(call.args().get(over.container()));
+        if (container == null) {
+            return;
+        }
+        List<String> named = new ArrayList<>();
+        named.add(container);
+        reads(e, binds, Set.of(), named);
+        out.add(new Quantified(container, p, binds, List.copyOf(named)));
+    }
+
+    /** Every term {@code e} names from outside itself, as the clause's own rule names it. A name the
+     * clause binds is its own and is left out; anything else the rule cannot name is kept as written,
+     * which can only drop the relation sooner. */
+    private void reads(Ast.Expr e, Bindings binds, Set<String> bound, List<String> out) {
+        String root = rootName(e);
+        if (root != null) {
+            if (!bound.contains(root)) {
+                String path = invPath(e, binds);
+                out.add(path == null ? root : path);
+            }
+            return;
+        }
+        Set<String> inner = bound;
+        if (e instanceof Ast.Block b && !b.params().isEmpty()) {
+            inner = new java.util.HashSet<>(bound);
+            inner.addAll(b.paramNames());
+        } else if (e instanceof Ast.LetIn li) {
+            inner = new java.util.HashSet<>(bound);
+            inner.add(li.name());
+        }
+        Set<String> scope = inner;
+        Ast.forEachChild(e, child -> reads(child, binds, scope, out));
     }
 
     // --- construction detection & discharge check ----------------------------------------------
@@ -467,6 +626,12 @@ public final class InvariantChecker {
         /** Nothing to substitute: what the body's own expressions are read with. */
         static Bindings ofBody(Function<Ast.Expr, String> bodyKey) {
             return new Bindings(_ -> null, _ -> null, _ -> null, bodyKey, Map.of());
+        }
+
+        /** A clause written in the body's own scope, where every name already stands for itself —
+         * what a guard states, read by the rule a type's clause is read by. */
+        static Bindings ofScope(Map<String, Type> types) {
+            return ofPaths(LinearForm::atom, name -> name, types);
         }
     }
 
@@ -664,6 +829,9 @@ public final class InvariantChecker {
                 out = out.with(out.numbers().assume(la.minus(ra), eff));
             }
         }
+        List<Quantified> quantified = new ArrayList<>();
+        quantifiedBy(cond, Bindings.ofScope(types), positive, quantified);
+        out = out.and(quantified);
         // Both routes, always: which one carries a clause is decided where the clause is read, and a
         // guard does not know which that will be.
         Polar polar = polar(cond, positive);
@@ -726,6 +894,30 @@ public final class InvariantChecker {
         return seedAt(name, t, k, 0);
     }
 
+    /** {@code k} with everything {@code owed} states taken as holding. What a clause owes at a
+     * construction is what it guarantees where it is already established, so the two read the same
+     * clauses through the same rule and differ only in direction. */
+    private Known assume(List<Clause> owed, Known k) {
+        if (owed == null) {
+            return k;
+        }
+        Known out = k;
+        for (Clause c : owed) {
+            for (Constraint known : c.known()) {
+                out = out.with(out.numbers().assume(known.form(), known.rel()));
+            }
+            if (c.numeric() != null) {
+                out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
+            }
+            if (c.fact() != null) {
+                // What is guaranteed is guaranteed of the term as written; a container built from it
+                // is another term, and reads the rules where it is constructed rather than here.
+                out = out.with(out.facts().assume(c.fact().keys().get(0), c.fact().positive()));
+            }
+        }
+        return out;
+    }
+
     private Known seedAt(String path, Type t, Known k, int depth) {
         if (depth > 2 || !(t instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)) {
             return k;
@@ -744,26 +936,12 @@ public final class InvariantChecker {
                 },
                 resolvePath, fields);
         Known out = k;
+        List<Quantified> quantified = new ArrayList<>();
         for (Ast.InvariantClause inv : invariantsOf(ref.name(), data)) {
-            List<Clause> o = obligations(inv.expr(), binds);
-            if (o == null) {
-                continue;
-            }
-            for (Clause c : o) {
-                for (Constraint known : c.known()) {
-                    out = out.with(out.numbers().assume(known.form(), known.rel()));
-                }
-                if (c.numeric() != null) {
-                    out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
-                }
-                if (c.fact() != null) {
-                    // What an input's type guarantees is guaranteed of the term as written; a
-                    // container built from it is another term, and reads the rules where it is
-                    // constructed rather than here.
-                    out = out.with(out.facts().assume(c.fact().keys().get(0), c.fact().positive()));
-                }
-            }
+            quantifiedBy(inv.expr(), binds, true, quantified);
+            out = assume(obligations(inv.expr(), binds), out);
         }
+        out = out.and(quantified);
         if (data.newtype()) {
             // A newtype's `.value` is the same location as the newtype, so what its base guarantees is
             // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
@@ -833,15 +1011,24 @@ public final class InvariantChecker {
         });
     }
 
-    /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}, and
-     * a size call over one to that container's size atom. */
+    /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}, a
+     * chain read off one to that location, and a size call over one to that container's size atom.
+     * A bare name goes through the form because what a construction gives a field may be an
+     * arithmetic result rather than a location; a chain read off it is a location either way. */
     private Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
         return n -> {
             String size = clauseSizeAtom(n, binds);
             if (size != null) {
                 return LinearForm.atom(size);
             }
-            return n instanceof Ast.Var v ? binds.form().apply(v.name()) : null;
+            if (n instanceof Ast.Var v) {
+                return binds.form().apply(v.name());
+            }
+            if (n instanceof Ast.FieldAccess) {
+                String path = invPath(n, binds);
+                return path == null ? null : LinearForm.atom(path);
+            }
+            return null;
         };
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -742,6 +742,25 @@ class CompileInvariantDischargeTest {
     }
 
     @Test
+    void aClauseOverAFieldChainIsARelationAndNotOnlyAFact() {
+        // `bounds.floor >= 1` bounds a term the domain names, so a sum built on it is derived from
+        // it rather than having to be restated
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Bounds = { floor: Int }
+                data Cart = { bounds: Bounds }
+                    invariant bounds.floor >= 1
+                behavior toQty : (cart: Cart) -> Qty
+                    constructs Qty
+                let toQty (cart) = Qty(cart.bounds.floor + 1)
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "floor >= 1 gives floor + 1 >= 1");
+    }
+
+    @Test
     void aFreeNameInsideTheClosureIsPartOfTheTerm() {
         // the clause's `floor` is the field being given, so the guard has to bound by the same value
         String m = """

--- a/souther-compiler/src/test/java/souther/compiler/CompileQuantifiedRelationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQuantifiedRelationTest.java
@@ -1,0 +1,265 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A relation stated of every element of a container, assumed of the element a combinator's closure is
+ * handed (spec §invariant-discharge). {@code List.all(p, xs)} known — as an input type's invariant
+ * clause or as a guard the path has asserted — is {@code p} of each element of {@code xs}, so a
+ * construction inside a {@code List.map} over {@code xs} reads it and discharges.
+ *
+ * <p>The counterpart of the rules that carry a property from a container to one built from it: this
+ * is the same seam read in the other direction, from the container to the element.
+ */
+class CompileQuantifiedRelationTest {
+
+    private static long warnings(String module) {
+        return Compiler.compileWithWarnings(module).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    @Test
+    void aRelationOverEveryElementIsAssumedInsideAMapping() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = List.map(i -> Qty(i.quantity), cart.items)
+                """;
+        assertEquals(0, warnings(m),
+                "the cart's relation holds of every item, so the element the closure is handed has it");
+    }
+
+    @Test
+    void aGuardStatingTheSameRelationIsAssumedInsideTheMapping() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) =
+                    if List.all(i -> i.quantity >= 1, cart.items) then
+                        List.map(i -> Qty(i.quantity), cart.items)
+                    else
+                        []
+                """;
+        assertEquals(0, warnings(m), "a guard states the relation the same way an invariant does");
+    }
+
+    @Test
+    void theClosuresOwnNameForTheElementDoesNotMatter() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = List.map(line -> Qty(line.quantity), cart.items)
+                """;
+        assertEquals(0, warnings(m), "the relation is read at the element, whatever it is called");
+    }
+
+    @Test
+    void theUnqualifiedSpellingStatesTheSameRelation() {
+        String m = """
+                module demo
+                import List ( all, map )
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                    invariant all(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = map(i -> Qty(i.quantity), cart.items)
+                """;
+        assertEquals(0, warnings(m), "an import drops the qualifier and nothing else");
+    }
+
+    @Test
+    void aRelationOverBareValuesIsAssumedAtTheElement() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Cart = { quantities: List<Int> }
+                    invariant List.all(q -> q >= 1, quantities)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = List.map(q -> Qty(q), cart.quantities)
+                """;
+        assertEquals(0, warnings(m), "an element with no type of its own carries the relation too");
+    }
+
+    @Test
+    void aHelperExpandedIntoTheClosureReadsTheRelation() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                let toOne (q: Int): Qty = Qty(q)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = List.map(i -> toOne(i.quantity), cart.items)
+                """;
+        assertEquals(0, warnings(m),
+                "a helper stands where it was called, which is inside the closure");
+    }
+
+    @Test
+    void anElementOfASelectionCarriesTheRelation() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int, taxable: Bool }
+                data Cart = { items: List<Line> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) =
+                    List.map(i -> Qty(i.quantity), List.filter(i -> i.taxable, cart.items))
+                """;
+        assertEquals(0, warnings(m), "a selection holds only elements the relation was stated of");
+    }
+
+    @Test
+    void anElementOfAFoldCarriesTheRelation() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                behavior first : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let first (cart) = List.fold((acc, i) -> acc ++ [Qty(i.quantity)], [], cart.items)
+                """;
+        assertEquals(0, warnings(m), "a fold is handed the elements a mapping is handed");
+    }
+
+    @Test
+    void aRelationOverNestedContainersReachesTheInnerElement() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Group = { lines: List<Line> }
+                data Cart = { groups: List<Group> }
+                    invariant List.all(g -> List.all(i -> i.quantity >= 1, g.lines), groups)
+                behavior toQty : (cart: Cart) -> List<List<Qty>>
+                    constructs Qty
+                let toQty (cart) =
+                    List.map(g -> List.map(i -> Qty(i.quantity), g.lines), cart.groups)
+                """;
+        assertEquals(0, warnings(m),
+                "the relation the outer element carries is itself stated of every inner element");
+    }
+
+    @Test
+    void aRelationOverAnotherContainerIsNotAssumed() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line>, spares: List<Line> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = List.map(i -> Qty(i.quantity), cart.spares)
+                """;
+        assertEquals(1, warnings(m), "nothing was stated of the spares");
+    }
+
+    @Test
+    void aRelationOfSomeElementIsNotAssumedOfEach() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                    invariant List.any(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = List.map(i -> Qty(i.quantity), cart.items)
+                """;
+        assertEquals(1, warnings(m), "one element having it says nothing about the rest");
+    }
+
+    @Test
+    void aRelationDeniedIsNotAssumed() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) =
+                    if List.all(i -> i.quantity >= 1, cart.items) then
+                        []
+                    else
+                        List.map(i -> Qty(i.quantity), cart.items)
+                """;
+        assertEquals(1, warnings(m), "some element failing it leaves every element unsettled");
+    }
+
+    @Test
+    void aMappedElementDoesNotCarryTheRelationOfWhatWasMapped() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty, Line
+                let toQty (cart) =
+                    List.map(i -> Qty(i.quantity), List.map(i -> Line { quantity = 0 }, cart.items))
+                """;
+        assertEquals(1, warnings(m), "what a mapping makes is not what the relation was stated of");
+    }
+
+    @Test
+    void aRelationIsDroppedWhereItsContainerIsRebound() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Group = { items: List<Line> }
+                data Cart = { items: List<Line>, groups: List<Group> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<List<Qty>>
+                    constructs Qty
+                let toQty (cart) =
+                    List.map(cart -> List.map(i -> Qty(i.quantity), cart.items), cart.groups)
+                """;
+        assertEquals(1, warnings(m),
+                "inside the closure `cart.items` is the group's, and nothing was stated of that");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileQuantifiedRelationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileQuantifiedRelationTest.java
@@ -245,6 +245,42 @@ class CompileQuantifiedRelationTest {
     }
 
     @Test
+    void aClosureParameterMayShadowTheContainersRootName() {
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int }
+                data Cart = { items: List<Line> }
+                    invariant List.all(i -> i.quantity >= 1, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = List.map(cart -> Qty(cart.quantity), cart.items)
+                """;
+        assertEquals(0, warnings(m),
+                "the container is read before the parameter takes the name, so what it is called"
+                        + " does not decide the answer");
+    }
+
+    @Test
+    void aParameterTakingOverWhatThePredicateReadsDropsTheRelation() {
+        // the clause's `floor` is the cart's; inside the closure the name is the element's, and the
+        // two are not the same value
+        String m = """
+                module demo
+                data Qty = Int
+                    invariant value >= 1
+                data Line = { quantity: Int, floor: Int }
+                data Cart = { items: List<Line>, floor: Int }
+                    invariant List.all(i -> i.quantity >= floor, items)
+                behavior toQty : (cart: Cart) -> List<Qty>
+                    constructs Qty
+                let toQty (cart) = List.map(cart -> Qty(cart.quantity - cart.floor + 1), cart.items)
+                """;
+        assertEquals(1, warnings(m), "the relation reads a name the parameter took over");
+    }
+
+    @Test
     void aRelationIsDroppedWhereItsContainerIsRebound() {
         String m = """
                 module demo

--- a/specification.adoc
+++ b/specification.adoc
@@ -1118,6 +1118,29 @@ The field the closure copied need not be the one the clause names: when the clos
 
 This is bounded to a field *copied*. A field the closure computes from others — `+code = String.concat([r.sku, r.name])+` — is not this: two rows that differ can land on one value, and nothing about the result follows.
 
+[#invariant-discharge-quantified]
+==== A relation over every element, read at the element
+
+`+List.all(p, xs)+` states `+p+` of each element of `+xs+`. Where a standard-library combinator hands its closure an element of `+xs+`, the check reads the relation again there, with the quantifier's own parameter standing for the element the closure was handed.
+
+[,text]
+----
+data Qty = Int invariant value >= 1
+data Line = { quantity: Int }
+data Cart = { items: List<Line> } invariant List.all(i -> i.quantity >= 1, items)
+
+behavior toQty : (cart: Cart) -> List<Qty> constructs Qty
+let toQty (cart) = List.map(i -> Qty(i.quantity), cart.items)   // discharged
+----
+
+Both sources of a relation read alike: an input type's invariant clause, and a `+guard+` or `+if+` on the path stating the relation of the same container.
+
+The container the closure walks need not be the one the relation was stated of. Where every element of it is an element of the one that was — a *permutes* or a *subset* construction (<<invariant-discharge-preservation>>) — the relation is read there too, so `+List.map(f, List.filter(q, xs))+` carries what was stated of `+xs+`. A *maps* or *collapses* construction makes elements the relation says nothing about.
+
+A relation the clause in turn states of a container is read at that container's elements as well, so a clause over a container of containers reaches the innermost element.
+
+`+List.any+` is not this: one element having a property says nothing about the rest. Neither is a `+List.all+` the path has *denied*, which says some element fails the predicate without naming which.
+
 [#invariant-discharge-facts]
 ==== A clause that states no relation is settled, not derived
 


### PR DESCRIPTION
`List.all(p, xs)` settled a fact keyed on the call, which relates it to nothing inside. A construction inside a `List.map` over `xs` read only what the element's own type says, so neither remedy E2011 names was available for a relation quantified over a list: stating it as the input's invariant changed nothing, and guarding the same `List.all` before the map warned identically.

```souther
data Qty = Int invariant value >= 1
data Line = { quantity: Int }
data Cart = { items: List<Line> } invariant List.all(i -> i.quantity >= 1, items)

behavior toQty : (cart: Cart) -> List<Qty> constructs Qty
let toQty (cart) = List.map(i -> Qty(i.quantity), cart.items)   // warned; now discharged
```

## What changed

A relation is kept as the clause it was written as, together with the rule that names its free leaves, so it can be read again at the element. `walkCall` already binds that element; where the container it walks is one a relation was stated of, the clause is read with the quantifier's own parameter standing for the element. That reading is `obligations` over a `Bindings` — the same reading seeding a type's invariant is, differing in direction and not in what it reads.

- An input type's invariant clause and a `guard` or `if` on the path record the same way.
- The container the closure walks need not be the one stated of. A *permutes* or a *subset* construction holds only elements of what it was built from, so `List.map(f, List.filter(q, xs))` carries what was stated of `xs`. A *maps* or *collapses* one does not.
- A relation the clause in turn states of a container is recorded as one, so a container of containers reaches its innermost element.
- A relation is dropped where a binding takes over a name it reads, the container included: inside `List.map(cart -> ..., cart.groups)` the term `cart.items` is the group's.
- `List.any` records nothing, and neither does a `List.all` the path has denied.

A clause comparing a field chain now bounds a term the numeric domain names, rather than only settling a fact a guard has to restate. The spec has read a chain as a term since it was written; the clause side had not.

## Verified

- `CompileQuantifiedRelationTest` — 14 rows: both repros from the issue, the bare-`Int` list, the unqualified `import List ( all, map )` spelling, a helper expanded into the closure, a selection, a fold, nesting, and the five that must still warn.
- `CompileInvariantDischargeTest` — one row for the chain leaf.
- Full suite green (2033 compiler, 101 lsp), and `souther-lang/examples` builds against it.

Fixes #288