### PR TITLE
One expression, one answer, whether or not it was given a name

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
@@ -3,10 +3,12 @@ package souther.compiler.check;
 import souther.compiler.ast.Ast;
 
 import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import java.util.List;
-import java.util.Optional;
 
 /**
  * Folds a compile-time-constant expression to its value ({@code Long} / {@code BigDecimal} /
@@ -170,11 +172,16 @@ public final class ConstEval {
      */
     private static Optional<Object> matches(String pattern, String s) {
         try {
-            return Optional.of(Pattern.compile(pattern).matcher(new Budgeted(s)).matches());
+            return Optional.of(COMPILED.computeIfAbsent(pattern, Pattern::compile)
+                    .matcher(new Budgeted(s)).matches());
         } catch (PatternSyntaxException | Budgeted.Spent | StackOverflowError _) {
             return Optional.empty();   // a bad pattern is reported by the check that compiles it
         }
     }
+
+    /** Patterns already compiled. A declaration's pattern is asked about once per construction from
+     * it and once per reading of a branch, and compiling one is the only expensive thing here. */
+    private static final Map<String, Pattern> COMPILED = new ConcurrentHashMap<>();
 
     /** A subject the regex engine may only read so many times. */
     private static final class Budgeted implements CharSequence {

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
@@ -147,6 +147,20 @@ public final class ConstEval {
                     return Optional.of((long) s.length());
                 }
             }
+            // matches(pattern, s): the pattern is written first and the subject last (spec §pipe).
+            // The pattern of a declaration is already required to be a written constant, so a call
+            // over a written subject is one the compiler answers rather than the run time.
+            case "String.matches" -> {
+                if (args.size() == 2
+                        && eval(args.get(0)).orElse(null) instanceof String pattern
+                        && eval(args.get(1)).orElse(null) instanceof String s) {
+                    try {
+                        return Optional.of(java.util.regex.Pattern.matches(pattern, s));
+                    } catch (java.util.regex.PatternSyntaxException _) {
+                        return Optional.empty();   // the pattern check reports this on its own
+                    }
+                }
+            }
             case "String.contains" -> {
                 // contains(sub, s): the string being searched is the last argument (spec §pipe)
                 if (args.size() == 2

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
@@ -78,8 +78,8 @@ public final class ConstEval {
                     ? Optional.of(x && y) : Optional.empty();
             case OR -> a instanceof Boolean x && b instanceof Boolean y
                     ? Optional.of(x || y) : Optional.empty();
-            case EQ -> Optional.of(a.equals(b));
-            case NE -> Optional.of(!a.equals(b));
+            case EQ -> Optional.of(equal(a, b));
+            case NE -> Optional.of(!equal(a, b));
             case LT, LE, GT, GE -> compare(bin.op(), a, b);
             case ADD, SUB, MUL -> arith(bin.op(), a, b);
             // `++` appends two strings or two lists (spec 18.1); the string case folds, and a list is
@@ -137,6 +137,16 @@ public final class ConstEval {
             });
         }
         return Optional.empty();
+    }
+
+    /** Whether two folded values are the one value. A {@code Decimal} answers by amount and not by
+     * how it was written, as it does everywhere else: {@code 1.0m} and {@code 1.00m} are one number,
+     * and a comparison folding the other way would decide at compile time what the run time denies. */
+    private static boolean equal(Object a, Object b) {
+        if (a instanceof BigDecimal x && b instanceof BigDecimal y) {
+            return x.compareTo(y) == 0;
+        }
+        return a.equals(b);
     }
 
     private static Optional<Object> call(Ast.Apply call) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
@@ -3,6 +3,8 @@ package souther.compiler.check;
 import souther.compiler.ast.Ast;
 
 import java.math.BigDecimal;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.List;
 import java.util.Optional;
 
@@ -149,6 +151,78 @@ public final class ConstEval {
         return a.equals(b);
     }
 
+    /**
+     * Whether {@code s} matches {@code pattern}, or empty where answering it here would cost more
+     * than leaving it to the run time.
+     *
+     * <p>A backtracking engine can take exponential time on a pattern written to make it, and can
+     * exhaust the stack on one written to make that. Neither is this compiler's to survive by luck:
+     * the walk that asks fails open on a {@code RuntimeException} and a {@code StackOverflowError} is
+     * not one, so an unbounded attempt here ends the compilation rather than the fold. The subject is
+     * handed over through a reader that stops the engine past a budget, and what the engine spends
+     * before answering is what decides whether the answer is worth having.
+     */
+    private static Optional<Object> matches(String pattern, String s) {
+        try {
+            return Optional.of(Pattern.compile(pattern).matcher(new Budgeted(s)).matches());
+        } catch (PatternSyntaxException | Budgeted.Spent _) {
+            return Optional.empty();   // the pattern check reports a bad pattern on its own
+        } catch (StackOverflowError _) {
+            return Optional.empty();
+        }
+    }
+
+    /** A subject the regex engine may only read so many times. */
+    private static final class Budgeted implements CharSequence {
+
+        /** Enough for any pattern written to say what a value is, and far short of what one written
+         * to backtrack costs. */
+        private static final int READS = 200_000;
+
+        /** Raised where the engine has read past the budget. Not an error in the program: it says
+         * only that this is not answered here. */
+        static final class Spent extends RuntimeException {
+            Spent() {
+                super(null, null, false, false);
+            }
+        }
+
+        private final String of;
+        private final int[] read;
+
+        Budgeted(String of) {
+            this(of, new int[1]);
+        }
+
+        private Budgeted(String of, int[] read) {
+            this.of = of;
+            this.read = read;
+        }
+
+        @Override
+        public char charAt(int at) {
+            if (++read[0] > READS) {
+                throw new Spent();
+            }
+            return of.charAt(at);
+        }
+
+        @Override
+        public int length() {
+            return of.length();
+        }
+
+        @Override
+        public CharSequence subSequence(int from, int to) {
+            return new Budgeted(of.substring(from, to), read);
+        }
+
+        @Override
+        public String toString() {
+            return of;
+        }
+    }
+
     private static Optional<Object> call(Ast.Apply call) {
         List<Ast.Expr> args = call.args();
         switch (call.reaches()) {
@@ -164,11 +238,7 @@ public final class ConstEval {
                 if (args.size() == 2
                         && eval(args.get(0)).orElse(null) instanceof String pattern
                         && eval(args.get(1)).orElse(null) instanceof String s) {
-                    try {
-                        return Optional.of(java.util.regex.Pattern.matches(pattern, s));
-                    } catch (java.util.regex.PatternSyntaxException _) {
-                        return Optional.empty();   // the pattern check reports this on its own
-                    }
+                    return matches(pattern, s);
                 }
             }
             case "String.contains" -> {

--- a/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
@@ -123,12 +123,18 @@ public final class ConstEval {
 
     private static Optional<Object> arith(Ast.BinOp op, Object a, Object b) {
         if (a instanceof Long x && b instanceof Long y) {
-            return Optional.of(switch (op) {
-                case ADD -> x + y;
-                case SUB -> x - y;
-                case MUL -> x * y;
-                default -> throw new IllegalStateException();
-            });
+            // The same kernels the operators emit: an Int that overflows aborts rather than wrapping,
+            // so a fold that wrapped would answer what the run time refuses to compute.
+            try {
+                return Optional.of(switch (op) {
+                    case ADD -> Math.addExact(x, y);
+                    case SUB -> Math.subtractExact(x, y);
+                    case MUL -> Math.multiplyExact(x, y);
+                    default -> throw new IllegalStateException();
+                });
+            } catch (ArithmeticException _) {
+                return Optional.empty();
+            }
         }
         if (a instanceof BigDecimal x && b instanceof BigDecimal y) {
             return Optional.of(switch (op) {
@@ -165,10 +171,8 @@ public final class ConstEval {
     private static Optional<Object> matches(String pattern, String s) {
         try {
             return Optional.of(Pattern.compile(pattern).matcher(new Budgeted(s)).matches());
-        } catch (PatternSyntaxException | Budgeted.Spent _) {
-            return Optional.empty();   // the pattern check reports a bad pattern on its own
-        } catch (StackOverflowError _) {
-            return Optional.empty();
+        } catch (PatternSyntaxException | Budgeted.Spent | StackOverflowError _) {
+            return Optional.empty();   // a bad pattern is reported by the check that compiles it
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -260,7 +260,7 @@ public final class InvariantChecker {
             }
             Set<String> all = new HashSet<>(spoken);
             all.addAll(terms);
-            return new Known(numbers, facts, quantified, Set.copyOf(all));
+            return new Known(numbers, facts, quantified, all);
         }
 
         /** Whether an assumption on this path named {@code term}. */
@@ -286,12 +286,8 @@ public final class InvariantChecker {
                     kept.add(q);
                 }
             }
-            Set<String> said = new HashSet<>();
-            for (String term : spoken) {
-                if (!drop.test(term)) {
-                    said.add(term);
-                }
-            }
+            Set<String> said = new HashSet<>(spoken);
+            said.removeIf(drop);
             return new Known(numbers.forgetIf(drop), facts.forgetIf(drop), List.copyOf(kept),
                     Set.copyOf(said));
         }
@@ -334,6 +330,11 @@ public final class InvariantChecker {
          * denotation was rooted at {@code name} loses it: the name it was written as denotes something
          * else from here, so what it stood for can no longer be said.
          */
+        /** This scope with {@code name} bound to {@code type}, denoting the location it is. */
+        Scope binding(String name, Type type) {
+            return binding(name, type, new Denotes.Location(name));
+        }
+
         Scope binding(String name, Type type, Denotes what) {
             Map<String, Type> t = new HashMap<>(types);
             if (type == null) {
@@ -373,6 +374,13 @@ public final class InvariantChecker {
          * it.
          */
         record Term(String key, boolean readable) implements Denotes {}
+
+        /**
+         * A value written out, kept as what was written. There is no guard an author could add about
+         * it, so it is never named at a construction; what it is, though, still has to travel with
+         * the name, or the same text would fold where it is written and not where it is bound.
+         */
+        record Written(String key, Ast.Expr value) implements Denotes {}
 
         /** Nothing this check can name. */
         record Nothing() implements Denotes {
@@ -526,8 +534,7 @@ public final class InvariantChecker {
                 if (built != null) {
                     k2 = seedParam(ic.binderName(), built, k2);   // on this branch the invariant holds
                 }
-                walk(ic.then(), k2, scope.binding(ic.binderName(), built,
-                        new Denotes.Location(ic.binderName())), depth);
+                walk(ic.then(), k2, scope.binding(ic.binderName(), built), depth);
                 // Each departure stands where the invariant did not hold, and nothing was built
                 // there, so none of them is seeded with anything the attempt would have guaranteed.
                 ic.els().forEach(arm -> walk(arm.body(), k, scope, depth));
@@ -564,7 +571,7 @@ public final class InvariantChecker {
                                 ? MatchElaborator.caseBindType(c.caseTypes().get(0).denotes()) : null;
                         // A sum has no fields of its own, so the scrutinee is not a location any
                         // clause could have named — the case's value names only itself.
-                        s2 = scope.binding(c.bindingName(), bound, new Denotes.Location(c.bindingName()));
+                        s2 = scope.binding(c.bindingName(), bound);
                     }
                     walk(c.body(), k2, s2, depth);
                 }
@@ -592,7 +599,7 @@ public final class InvariantChecker {
                 List<Quantified> relations = elementRelations(container, k, scope);
                 String p = step.params().get(combo.elementParam()).name();
                 // an element of a container is not a location the body can otherwise name
-                Scope s2 = scope.binding(p, elem, new Denotes.Location(p));
+                Scope s2 = scope.binding(p, elem);
                 Known k2 = rebind(k, p);
                 if (elem != null) {
                     k2 = seedParam(p, elem, k2);   // the element carries its type's invariant
@@ -738,7 +745,7 @@ public final class InvariantChecker {
                         // an arithmetic result is a form, not a location, so it names no path
                         report(type, bin.pos(), attempted, verdictOf(r.name(), type,
                                 Bindings.ofPaths(name -> "value".equals(name) ? value : null, _ -> null,
-                                        TypeOps.fieldTypes(type, symbols)), k));
+                                        TypeOps.fieldTypes(type, symbols)), k, true));
                     }
                 }
             }
@@ -765,11 +772,14 @@ public final class InvariantChecker {
             if (p != null) {
                 paths.put(fi.name(), p);
             }
-            given.put(fi.name(), fi.value());
+            // A name given a value written out hands over that value: the clause folds over what
+            // was written, wherever the writing was done.
+            Ast.Expr written = writtenValue(fi.value(), scope);
+            given.put(fi.name(), written != null ? written : fi.value());
         }
         return verdictOf(nd.typeName().denotes(), type,
                 new Bindings(forms::get, paths::get, given::get, bodyKey,
-                        TypeOps.fieldTypes(type, symbols)), k);
+                        TypeOps.fieldTypes(type, symbols)), k, !constantlyBuilt(type, nd));
     }
 
     /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
@@ -825,39 +835,35 @@ public final class InvariantChecker {
         /** A clause is expressible and unproven: the construction may abort. */
         UNKNOWN,
         /** A clause is proven to fail on a path that is reached. */
-        REFUTED,
-        /** Nothing reaches here: the conditions along the way contradict. */
-        UNREACHABLE;
+        REFUTED;
 
         /**
          * What holds of a value that is one of two. It is discharged where both are, and it is proven
          * to fail only where both fail — a construction one branch satisfies does not definitely
          * violate, whichever branch is taken. Everything else is possible and unproven.
          *
-         * <p>A branch nothing reaches says nothing either way, so it is the one the other is read
-         * against: it is not a branch the value could have taken.
+         * <p>A branch nothing reaches finds nothing to combine: {@link #reading} answers it with no
+         * findings at all, and a position only one branch found is read as discharged on the other.
          */
         static Verdict of(Verdict a, Verdict b) {
-            if (a == UNREACHABLE) {
-                return b;
-            }
-            if (b == UNREACHABLE) {
-                return a;
-            }
             return a == b ? a : UNKNOWN;
         }
     }
 
     /** The discharge verdict for a construction of {@code type} whose field values resolve through
      * {@code binds}. */
-    private Verdict verdictOf(TypeName named, Ast.Data type, Bindings binds, Known k) {
+    private Verdict verdictOf(TypeName named, Ast.Data type, Bindings binds, Known k,
+                              boolean decidesFalse) {
         List<Ast.InvariantClause> invs = invariantsOf(named, type);
         if (invs.isEmpty()) {
             return Verdict.PROVED;
         }
         List<Clause> owed = new ArrayList<>();
         for (Ast.InvariantClause inv : invs) {
-            List<Clause> o = obligations(inv.expr(), binds, !type.newtype());
+            // A newtype construction from a value written out is the constant check's to report: it
+            // names the clause that failed. It reads the construction as written, so a name given the
+            // value is not one it sees, and this check says it instead.
+            List<Clause> o = obligations(inv.expr(), binds, decidesFalse);
             if (o != null) {
                 owed.addAll(o);
             }
@@ -884,20 +890,30 @@ public final class InvariantChecker {
         return out;
     }
 
+    /** Whether the constant check reads this construction: a newtype's, over a value written where
+     * it is built. That check names the clause that failed, so it is left to say it — and it reads
+     * the construction as written, so a name given the value is not one it sees. */
+    private static boolean constantlyBuilt(Ast.Data type, Ast.NewData nd) {
+        return type.newtype() && nd.inits().size() == 1 && isWritten(nd.inits().get(0).value());
+    }
+
     /** Says what {@code verdict} found. A definite violation is an error and an unproven one a
      * warning; a discharged or non-expressible invariant says nothing. An {@code attempted}
      * construction raises no warning: what the warning reports is a possible abort, and an attempt
      * takes its else branch instead. */
     private void report(Ast.Data type, SourcePos pos, boolean attempted, Verdict verdict) {
         if (capturing != null) {
-            capturing.merge(pos, new Reported(type, verdict, attempted),
-                    (was, now) -> new Reported(was.type(),
-                            Verdict.of(was.verdict(), now.verdict()), was.attempted()));
+            // Which construction this is, rather than where it is written or what it says. A helper
+            // expanded twice puts two constructions at the helper body's one position, so the
+            // position alone reads them as one; and the readings are of the same body with a
+            // conditional replaced, so what a construction says differs between them by design.
+            // The nth construction written at a position is the same one in both readings.
+            capturing.put(new Occurrence(pos, capturing.size()),
+                    new Reported(type, pos, verdict, attempted));
             return;
         }
         switch (verdict) {
             case REFUTED -> reportViolation(type, pos);
-            case UNREACHABLE -> { }
             case UNKNOWN -> {
                 if (!attempted) {
                     warnings.add(Diagnostic.of("E2011", "check.invariant.unproven")
@@ -910,7 +926,10 @@ public final class InvariantChecker {
     }
 
     /** What a construction came out as where it is being read on a branch rather than said. */
-    private record Reported(Ast.Data type, Verdict verdict, boolean attempted) {}
+    private record Reported(Ast.Data type, SourcePos pos, Verdict verdict, boolean attempted) {}
+
+    /** Which construction a reading found: where it is written, and how many were found before it. */
+    private record Occurrence(SourcePos pos, int nth) {}
 
     /**
      * Where a walk is reading one branch, what it finds is collected here rather than said. A body
@@ -918,15 +937,23 @@ public final class InvariantChecker {
      * construction is one answer: it is the branches together that decide, the same as for a
      * construction the conditional is written inside.
      */
-    private Map<SourcePos, Reported> capturing;
+    private Map<Occurrence, Reported> capturing;
 
     /** What reading {@code e} finds, or nothing where the conditions along the way contradict — a
      * branch nothing reaches finds nothing, and what is not there violates nothing. */
-    private Map<SourcePos, Reported> reading(Ast.Expr e, Known k, Scope scope, int depth) {
+    private Map<Occurrence, Reported> reading(Ast.Expr e, Known k, Scope scope, int depth) {
         if (k.numbers().isBottom()) {
             return Map.of();
         }
-        return found(() -> walk(e, k, scope, depth + 1));
+        Map<Occurrence, Reported> outer = capturing;
+        Map<Occurrence, Reported> mine = new LinkedHashMap<>();
+        capturing = mine;
+        try {
+            walk(e, k, scope, depth + 1);
+        } finally {
+            capturing = outer;
+        }
+        return mine;
     }
 
     /**
@@ -981,29 +1008,18 @@ public final class InvariantChecker {
         return Ast.mapChildren(e, child -> without(child, was, key, becomes, scope), name -> name);
     }
 
-    /** What {@code reading} finds, collected instead of said. */
-    private Map<SourcePos, Reported> found(Runnable reading) {
-        Map<SourcePos, Reported> outer = capturing;
-        Map<SourcePos, Reported> mine = new LinkedHashMap<>();
-        capturing = mine;
-        try {
-            reading.run();
-        } finally {
-            capturing = outer;
-        }
-        return mine;
-    }
-
     /** Says of each construction the two readings reached what the two of them together decide. One
      * that only one reading reached is discharged on the other: it is not there to violate anything. */
-    private void say(Map<SourcePos, Reported> a, Map<SourcePos, Reported> b) {
-        Set<SourcePos> at = new LinkedHashSet<>(a.keySet());
+    private void say(Map<Occurrence, Reported> a, Map<Occurrence, Reported> b) {
+        Set<Occurrence> at = new LinkedHashSet<>(a.keySet());
         at.addAll(b.keySet());
-        for (SourcePos pos : at) {
-            Reported one = a.containsKey(pos) ? a.get(pos) : b.get(pos);
-            report(one.type(), pos, one.attempted(), Verdict.of(
-                    a.containsKey(pos) ? a.get(pos).verdict() : Verdict.PROVED,
-                    b.containsKey(pos) ? b.get(pos).verdict() : Verdict.PROVED));
+        for (Occurrence one : at) {
+            Reported x = a.get(one);
+            Reported y = b.get(one);
+            Reported said = x != null ? x : y;
+            report(said.type(), said.pos(), said.attempted(),
+                    Verdict.of(x == null ? Verdict.PROVED : x.verdict(),
+                            y == null ? Verdict.PROVED : y.verdict()));
         }
     }
 
@@ -1196,8 +1212,9 @@ public final class InvariantChecker {
             }
             // What the comparison named, recorded as spoken about: a construction from one of these
             // is one the author has said something about, whichever route ends up carrying it.
-            out = out.speaking(spokenOf(b.left(), scope, la));
-            out = out.speaking(spokenOf(b.right(), scope, ra));
+            Set<String> named = new HashSet<>(spokenOf(b.left(), scope, la));
+            named.addAll(spokenOf(b.right(), scope, ra));
+            out = out.speaking(named);
         }
         List<Quantified> quantified = new ArrayList<>();
         quantifiedBy(cond, Bindings.ofScope(scope), positive, quantified);
@@ -1434,6 +1451,10 @@ public final class InvariantChecker {
                     && numericNewtype(Type.ref(nd.typeName().denotes()))) {
                 return affineOf(nd.inits().get(0).value(), scope, k);
             }
+            Ast.Expr written = writtenValue(n, scope);
+            if (written != null && written != n) {
+                return affineOf(written, scope, k);
+            }
             if (n instanceof Ast.LetIn li) {
                 // A binding an expansion introduced is read the way the walk reads one: the name is
                 // what it was given. Without that, a helper called on a record is opaque here while
@@ -1595,9 +1616,6 @@ public final class InvariantChecker {
         // state of `"xyz"` that the text does not already say. Where a clause reading it folds it is
         // decided before this is asked, and where it does not fold there is no guard that would
         // discharge it, so naming it here would only report what the author cannot answer.
-        if (isWritten(e)) {
-            return null;
-        }
         Denotes d = denotationOf(e, scope, k);
         return readable(d, k) ? d.key() : null;
     }
@@ -2046,6 +2064,10 @@ public final class InvariantChecker {
      * given a name first.
      */
     private Denotes denotationOf(Ast.Expr e, Scope scope, Known k) {
+        Ast.Expr written = writtenValue(e, scope);
+        if (written != null) {
+            return new Denotes.Written(bodyKey(written, scope), written);
+        }
         String located = locationKey(e, scope);
         if (located != null) {
             return new Denotes.Location(located);
@@ -2073,8 +2095,17 @@ public final class InvariantChecker {
         return switch (d) {
             case Denotes.Location _ -> true;
             case Denotes.Term term -> term.readable() || k.speaksOf(term.key());
-            case Denotes.Nothing _ -> false;
+            case Denotes.Written _, Denotes.Nothing _ -> false;
         };
+    }
+
+    /** What {@code e} is written as, where it is a written value or a name given one — and
+     * {@code null} where it is computed from anything. */
+    private Ast.Expr writtenValue(Ast.Expr e, Scope scope) {
+        if (e instanceof Ast.Var v) {
+            return scope.denotes(v.name()) instanceof Denotes.Written w ? w.value() : null;
+        }
+        return isWritten(e) ? e : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -38,7 +38,29 @@ import java.util.function.Function;
  */
 public final class InvariantChecker {
 
-    record Findings(List<CompileException> errors, List<Diagnostic> warnings) {}
+    record Findings(List<CompileException> errors, List<Diagnostic> warnings) {
+
+        /**
+         * The same, with a construction said of once. Reading a body on each branch of a conditional
+         * reads everything after it once per branch, so a construction the branches agree about is
+         * reached more than once. One construction is one position and one code, which is what makes
+         * the second reading of it the same finding rather than another one.
+         */
+        Findings said() {
+            return new Findings(distinct(errors, e -> key(e.diagnostic())),
+                    distinct(warnings, Findings::key));
+        }
+
+        private static String key(Diagnostic d) {
+            return d.code() + "@" + d.pos();
+        }
+
+        private static <T> List<T> distinct(List<T> all, Function<T, String> by) {
+            Map<String, T> first = new java.util.LinkedHashMap<>();
+            all.forEach(one -> first.putIfAbsent(by.apply(one), one));
+            return List.copyOf(first.values());
+        }
+    }
 
     /**
      * What this check reads: one behavior's body and the invariants of the types around it, both in
@@ -171,6 +193,11 @@ public final class InvariantChecker {
      * far the statement travels is what {@link #CARRIED} already answers of any predicate — so a
      * quantifier is the name and nothing else. {@code List.all} is the only one the library has. */
     private static final Set<String> QUANTIFIERS = Set.of("List.all");
+
+    /** How many conditionals a construction opens before the rest is left to the run-time check.
+     * Each one doubles the paths, and a value written over three of them is not what the bound is
+     * protecting against so much as what it declines to spend the time on. */
+    private static final int BRANCHES_OPENED = 3;
 
     /** Emptiness, by the size call it means. This is not a rule about what an operation does to a
      * property (spec §invariant-discharge-preservation) but about what a predicate <em>says</em>:
@@ -467,29 +494,29 @@ public final class InvariantChecker {
     static Findings analyze(Source source, Map<String, Type> params, Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols, source == null ? Map.of() : source.invariants());
         if (source == null) {
-            return new Findings(c.errors, c.warnings);
+            return new Findings(c.errors, c.warnings).said();
         }
         try {
             Known k = Known.top();
             for (Map.Entry<String, Type> p : params.entrySet()) {
                 k = c.seedParam(p.getKey(), p.getValue(), k);
             }
-            c.walk(source.body(), k, Scope.of(params));
+            c.walk(source.body(), k, Scope.of(params), 0);
         } catch (RuntimeException _) {
             // fail-open: the run-time invariant check remains the backstop
         }
-        return new Findings(c.errors, c.warnings);
+        return new Findings(c.errors, c.warnings).said();
     }
 
     // --- the walk ------------------------------------------------------------------------------
 
-    private void walk(Ast.Expr e, Known k, Scope scope) {
+    private void walk(Ast.Expr e, Known k, Scope scope, int depth) {
         checkIfConstruction(e, k, scope, false);
         switch (e) {
             case Ast.If iff -> {
-                walk(iff.cond(), k, scope);
-                walk(iff.then(), assumeCond(iff.cond(), k, scope, true), scope);
-                walk(iff.els(), assumeCond(iff.cond(), k, scope, false), scope);
+                walk(iff.cond(), k, scope, depth);
+                walk(iff.then(), assumeCond(iff.cond(), k, scope, true), scope, depth);
+                walk(iff.els(), assumeCond(iff.cond(), k, scope, false), scope, depth);
             }
             case Ast.IfConstructed ic -> {
                 // The attempt's own construction cannot abort — a failing invariant is the else
@@ -497,7 +524,7 @@ public final class InvariantChecker {
                 // possible one. Its field values are walked on their own so a construction nested
                 // inside an argument is still an ordinary, aborting one.
                 checkIfConstruction(ic.construct(), k, scope, true);
-                Ast.forEachChild(ic.construct(), child -> walk(child, k, scope));
+                Ast.forEachChild(ic.construct(), child -> walk(child, k, scope, depth));
                 Known k2 = rebind(k, ic.binderName());
                 Type built = typeExpr(ic.construct(), scope);
                 // The attempt built the value, so the binding is that construction and no location
@@ -505,13 +532,25 @@ public final class InvariantChecker {
                     k2 = seedParam(ic.binderName(), built, k2);   // on this branch the invariant holds
                 }
                 walk(ic.then(), k2, scope.binding(ic.binderName(), built,
-                        new Denotes.Location(ic.binderName())));
+                        new Denotes.Location(ic.binderName())), depth);
                 // Each departure stands where the invariant did not hold, and nothing was built
                 // there, so none of them is seeded with anything the attempt would have guaranteed.
-                ic.els().forEach(arm -> walk(arm.body(), k, scope));
+                ic.els().forEach(arm -> walk(arm.body(), k, scope, depth));
+            }
+            case Ast.LetIn li when li.value() instanceof Ast.If iff && depth < BRANCHES_OPENED -> {
+                // The name is given one of the two, and which one is decided by the condition, so the
+                // body is read once with each standing there. The same reading a construction written
+                // over a conditional gets, moved to where the conditional was given a name.
+                walk(iff.cond(), k, scope, depth);
+                walk(new Ast.LetIn(li.binder(), iff.then(), li.declaredType(), li.annotated(),
+                                li.opens(), li.body(), li.pos()),
+                        assumeCond(iff.cond(), k, scope, true), scope, depth + 1);
+                walk(new Ast.LetIn(li.binder(), iff.els(), li.declaredType(), li.annotated(),
+                                li.opens(), li.body(), li.pos()),
+                        assumeCond(iff.cond(), k, scope, false), scope, depth + 1);
             }
             case Ast.LetIn li -> {
-                walk(li.value(), k, scope);
+                walk(li.value(), k, scope, depth);
                 Type vt = typeExpr(li.value(), scope);
                 // The name is an alias for what its initializer denotes, so what is recorded about it
                 // is recorded under that denotation and not under the spelling. Recording it under the
@@ -520,13 +559,17 @@ public final class InvariantChecker {
                 Denotes what = denotationOf(li.value(), scope);
                 LinearForm vf = affineOf(li.value(), scope);
                 Known k2 = rebind(k, li.name());
-                if (isNumeric(vt) && vf != null && what.key() != null) {
-                    k2 = k2.with(k2.numbers().assign(what.key(), vf));
+                // A binding given a location is an alias and introduces no value, so there is nothing
+                // to record of it: what holds of the location already holds. Recording it anyway
+                // would be assigning the location its own form, and an assignment drops what was
+                // known of what it assigns to — the guard on it would be lost to the copy.
+                if (what instanceof Denotes.Term term && isNumeric(vt) && vf != null) {
+                    k2 = k2.with(k2.numbers().assign(term.key(), vf));
                 }
-                walk(li.body(), k2, scope.binding(li.name(), vt, what));
+                walk(li.body(), k2, scope.binding(li.name(), vt, what), depth);
             }
             case Ast.Match m -> {
-                walk(m.scrutinee(), k, scope);
+                walk(m.scrutinee(), k, scope, depth);
                 for (Ast.Case c : m.cases()) {
                     Scope s2 = scope;
                     Known k2 = k;
@@ -538,17 +581,17 @@ public final class InvariantChecker {
                         // clause could have named — the case's value names only itself.
                         s2 = scope.binding(c.bindingName(), bound, new Denotes.Location(c.bindingName()));
                     }
-                    walk(c.body(), k2, s2);
+                    walk(c.body(), k2, s2, depth);
                 }
             }
-            case Ast.Apply call -> walkCall(call, k, scope);
-            default -> Ast.forEachChild(e, child -> walk(child, k, scope));
+            case Ast.Apply call -> walkCall(call, k, scope, depth);
+            default -> Ast.forEachChild(e, child -> walk(child, k, scope, depth));
         }
     }
 
     /** Walks a call, binding a combinator closure's element parameter to the list's element type (and
      * seeding its invariant) so a construction inside the closure is analyzed rather than left opaque. */
-    private void walkCall(Ast.Apply call, Known k, Scope scope) {
+    private void walkCall(Ast.Apply call, Known k, Scope scope, int depth) {
         Combinator combo = COMBINATORS.get(call.reaches());
         for (int i = 0; i < call.args().size(); i++) {
             Ast.Expr arg = call.args().get(i);
@@ -577,9 +620,9 @@ public final class InvariantChecker {
                         k2 = instantiate(q, p, elem, k2);
                     }
                 }
-                walk(step.body(), k2, s2);
+                walk(step.body(), k2, s2, depth);
             } else {
-                walk(arg, k, scope);
+                walk(arg, k, scope, depth);
             }
         }
     }
@@ -699,25 +742,7 @@ public final class InvariantChecker {
         switch (e) {
             case Ast.NewData nd when nd.spreads().isEmpty() -> {
                 if (symbols.get(nd.typeName().denotes()) instanceof Ast.Data type) {
-                    Map<String, LinearForm> forms = new HashMap<>();
-                    Map<String, String> paths = new HashMap<>();
-                    Map<String, Ast.Expr> given = new HashMap<>();
-                    Function<Ast.Expr, String> bodyKey = value -> siteKey(value, scope, k);
-                    for (Ast.FieldInit fi : nd.inits()) {
-                        LinearForm f = affineOf(fi.value(), scope);
-                        if (f != null) {
-                            forms.put(fi.name(), f);
-                        }
-                        String p = bodyKey.apply(fi.value());
-                        if (p != null) {
-                            paths.put(fi.name(), p);
-                        }
-                        given.put(fi.name(), fi.value());
-                    }
-                    check(nd.typeName().denotes(), type,
-                            new Bindings(forms::get, paths::get, given::get, bodyKey,
-                                    TypeOps.fieldTypes(type, symbols)),
-                            k, nd.pos(), attempted);
+                    report(type, nd.pos(), attempted, verdictOf(nd, type, k, scope, 0));
                 }
             }
             case Ast.Binary bin when isArith(bin.op()) -> {
@@ -726,15 +751,65 @@ public final class InvariantChecker {
                     LinearForm value = affineOf(bin, scope);
                     if (value != null) {
                         // an arithmetic result is a form, not a location, so it names no path
-                        check(r.name(), type,
+                        report(type, bin.pos(), attempted, verdictOf(r.name(), type,
                                 Bindings.ofPaths(name -> "value".equals(name) ? value : null, _ -> null,
-                                        TypeOps.fieldTypes(type, symbols)),
-                                k, bin.pos(), attempted);
+                                        TypeOps.fieldTypes(type, symbols)), k));
                     }
                 }
             }
             default -> { }
         }
+    }
+
+    /**
+     * The verdict for one construction, read on each branch of a conditional it is given. A field
+     * given {@code if c then a else b} is given one of the two, and which one is decided by
+     * {@code c}, so the construction is checked with each standing there under its own condition and
+     * answered by whichever answer is worse. Reading the conditional as a term of its own instead
+     * would say only that it is that term, which reports every construction over one — including
+     * where both branches satisfy the clause.
+     *
+     * <p>{@code depth} bounds how many conditionals are opened, since each doubles the paths.
+     */
+    private Verdict verdictOf(Ast.NewData nd, Ast.Data type, Known k, Scope scope, int depth) {
+        if (depth < BRANCHES_OPENED) {
+            for (int i = 0; i < nd.inits().size(); i++) {
+                if (nd.inits().get(i).value() instanceof Ast.If iff) {
+                    return Verdict.worse(
+                            verdictOf(withFieldValue(nd, i, iff.then()), type,
+                                    assumeCond(iff.cond(), k, scope, true), scope, depth + 1),
+                            verdictOf(withFieldValue(nd, i, iff.els()), type,
+                                    assumeCond(iff.cond(), k, scope, false), scope, depth + 1));
+                }
+            }
+        }
+        Map<String, LinearForm> forms = new HashMap<>();
+        Map<String, String> paths = new HashMap<>();
+        Map<String, Ast.Expr> given = new HashMap<>();
+        Function<Ast.Expr, String> bodyKey = value -> siteKey(value, scope, k);
+        for (Ast.FieldInit fi : nd.inits()) {
+            LinearForm f = affineOf(fi.value(), scope);
+            if (f != null) {
+                forms.put(fi.name(), f);
+            }
+            String p = bodyKey.apply(fi.value());
+            if (p != null) {
+                paths.put(fi.name(), p);
+            }
+            given.put(fi.name(), fi.value());
+        }
+        return verdictOf(nd.typeName().denotes(), type,
+                new Bindings(forms::get, paths::get, given::get, bodyKey,
+                        TypeOps.fieldTypes(type, symbols)), k);
+    }
+
+    /** {@code nd} with the value at {@code at} replaced, everything else kept. */
+    private static Ast.NewData withFieldValue(Ast.NewData nd, int at, Ast.Expr value) {
+        List<Ast.FieldInit> inits = new ArrayList<>(nd.inits());
+        Ast.FieldInit was = inits.get(at);
+        inits.set(at, new Ast.FieldInit(was.name(), value, was.pos()));
+        return new Ast.NewData(nd.typeName(), List.copyOf(inits), nd.spreads(), nd.origin(),
+                nd.pos());
     }
 
     /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
@@ -779,15 +854,31 @@ public final class InvariantChecker {
         return e instanceof Ast.Var v ? binds.given().apply(v.name()) : null;
     }
 
-    /** Runs the discharge check for a construction of {@code type} whose field values resolve through
-     * {@code binds}. A definite violation is an error; an unproven one a warning; a fully-discharged
-     * or non-expressible invariant is silent. An {@code attempted} construction raises no warning:
-     * what the warning reports is a possible abort, and an attempt takes its else branch instead. */
-    private void check(TypeName named, Ast.Data type, Bindings binds, Known k, SourcePos pos,
-                       boolean attempted) {
+    /**
+     * How a construction came out. A construction is checked before it is reported so that one
+     * written over a conditional can be checked on each branch and answered once — which of the two
+     * values it is is not decided here, so what holds of the construction is what holds of both.
+     */
+    private enum Verdict {
+        /** Every clause is discharged, or none of them is expressible. */
+        PROVED,
+        /** A clause is expressible and unproven: the construction may abort. */
+        UNKNOWN,
+        /** A clause is proven to fail on a path that is reached. */
+        REFUTED;
+
+        /** The worse of two answers, which is what holds of a value that is one of two. */
+        static Verdict worse(Verdict a, Verdict b) {
+            return a.compareTo(b) >= 0 ? a : b;
+        }
+    }
+
+    /** The discharge verdict for a construction of {@code type} whose field values resolve through
+     * {@code binds}. */
+    private Verdict verdictOf(TypeName named, Ast.Data type, Bindings binds, Known k) {
         List<Ast.InvariantClause> invs = invariantsOf(named, type);
         if (invs.isEmpty()) {
-            return;
+            return Verdict.PROVED;
         }
         List<Clause> owed = new ArrayList<>();
         for (Ast.InvariantClause inv : invs) {
@@ -797,7 +888,7 @@ public final class InvariantChecker {
             }
         }
         if (owed.isEmpty()) {
-            return;   // nothing here is expressible — the run-time check stands for all of it
+            return Verdict.PROVED;   // nothing here is expressible — the run-time check stands for it
         }
         NumericDomain dom = k.numbers();
         for (Clause c : owed) {
@@ -805,22 +896,34 @@ public final class InvariantChecker {
                 dom = dom.assume(known.form(), known.rel());
             }
         }
-        boolean possible = false;
+        Verdict out = Verdict.PROVED;
         for (Clause c : owed) {
             if (c.dischargedBy(dom, k.facts())) {
                 continue;
             }
             if (c.refutedBy(dom, k.facts())) {
-                reportViolation(type, pos);
-                return;
+                return Verdict.REFUTED;
             }
-            possible = true;
+            out = Verdict.UNKNOWN;
         }
-        if (possible && !attempted) {
-            warnings.add(
-                    Diagnostic.of("E2011", "check.invariant.unproven").title("check.invariant.title")
-                            .at(pos).args(type.name()).hint("check.invariant.reify", type.name())
-                            .warning().build());
+        return out;
+    }
+
+    /** Says what {@code verdict} found. A definite violation is an error and an unproven one a
+     * warning; a discharged or non-expressible invariant says nothing. An {@code attempted}
+     * construction raises no warning: what the warning reports is a possible abort, and an attempt
+     * takes its else branch instead. */
+    private void report(Ast.Data type, SourcePos pos, boolean attempted, Verdict verdict) {
+        switch (verdict) {
+            case REFUTED -> reportViolation(type, pos);
+            case UNKNOWN -> {
+                if (!attempted) {
+                    warnings.add(Diagnostic.of("E2011", "check.invariant.unproven")
+                            .title("check.invariant.title").at(pos).args(type.name())
+                            .hint("check.invariant.reify", type.name()).warning().build());
+                }
+            }
+            case PROVED -> { }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -775,7 +775,7 @@ public final class InvariantChecker {
         if (depth < BRANCHES_OPENED) {
             for (int i = 0; i < nd.inits().size(); i++) {
                 if (nd.inits().get(i).value() instanceof Ast.If iff) {
-                    return Verdict.worse(
+                    return Verdict.of(
                             verdictOf(withFieldValue(nd, i, iff.then()), type,
                                     assumeCond(iff.cond(), k, scope, true), scope, depth + 1),
                             verdictOf(withFieldValue(nd, i, iff.els()), type,
@@ -867,9 +867,13 @@ public final class InvariantChecker {
         /** A clause is proven to fail on a path that is reached. */
         REFUTED;
 
-        /** The worse of two answers, which is what holds of a value that is one of two. */
-        static Verdict worse(Verdict a, Verdict b) {
-            return a.compareTo(b) >= 0 ? a : b;
+        /**
+         * What holds of a value that is one of two. It is discharged where both are, and it is proven
+         * to fail only where both fail — a construction one branch satisfies does not definitely
+         * violate, whichever branch is taken. Everything else is possible and unproven.
+         */
+        static Verdict of(Verdict a, Verdict b) {
+            return a == b ? a : UNKNOWN;
         }
     }
 
@@ -1930,10 +1934,37 @@ public final class InvariantChecker {
         return term == null ? new Denotes.Nothing() : new Denotes.Term(term, namedByRule(e, scope));
     }
 
-    /** Whether {@code e} is a value written out rather than computed from anything. */
+    /**
+     * Whether {@code e} is a value written out rather than computed from anything: a literal, and a
+     * list or a construction whose every part is one. A table written into the source is this — every
+     * row of it is there to read — and there is no guard an author could add about it, which is what
+     * naming it at a construction site would ask for.
+     */
     private static boolean isWritten(Ast.Expr e) {
-        return e instanceof Ast.IntLit || e instanceof Ast.DecimalLit || e instanceof Ast.StringLit
-                || e instanceof Ast.BoolLit;
+        return isWritten(e, Set.of());
+    }
+
+    /** The same, where {@code written} names the bindings an expansion introduced for values that
+     * were themselves written. A helper called on written arguments is a written value: what it
+     * expands to binds each argument and reads it back, which is the source's own text moved. */
+    private static boolean isWritten(Ast.Expr e, Set<String> written) {
+        return switch (e) {
+            case Ast.IntLit _, Ast.DecimalLit _, Ast.StringLit _, Ast.BoolLit _ -> true;
+            case Ast.Var v -> written.contains(v.name());
+            case Ast.ListLit list -> list.elements().stream().allMatch(x -> isWritten(x, written));
+            case Ast.Tuple t -> t.elements().stream().allMatch(x -> isWritten(x, written));
+            case Ast.NewData nd -> nd.spreads().isEmpty()
+                    && nd.inits().stream().allMatch(fi -> isWritten(fi.value(), written));
+            case Ast.LetIn li -> {
+                if (!isWritten(li.value(), written)) {
+                    yield false;
+                }
+                Set<String> inner = new HashSet<>(written);
+                inner.add(li.name());
+                yield isWritten(li.body(), inner);
+            }
+            default -> false;
+        };
     }
 
     /** Whether {@code e} is a container built by an operation the preservation table covers, over an

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -719,7 +720,7 @@ public final class InvariantChecker {
         switch (e) {
             case Ast.NewData nd when nd.spreads().isEmpty() -> {
                 if (symbols.get(nd.typeName().denotes()) instanceof Ast.Data type) {
-                    report(type, nd.pos(), attempted, verdictOf(nd, type, k, scope));
+                    report(nd, type, nd.pos(), attempted, verdictOf(nd, type, k, scope));
                 }
             }
             case Ast.Expr arith when asOperator(arith) instanceof Ast.Binary bin
@@ -729,7 +730,7 @@ public final class InvariantChecker {
                     LinearForm value = affineOf(bin, scope, k);
                     if (value != null) {
                         // an arithmetic result is a form, not a location, so it names no path
-                        report(type, bin.pos(), attempted, verdictOf(r.name(), type,
+                        report(bin, type, bin.pos(), attempted, verdictOf(r.name(), type,
                                 Bindings.ofPaths(name -> "value".equals(name) ? value : null, _ -> null,
                                         fieldsOf(type)), k, true));
                     }
@@ -887,14 +888,11 @@ public final class InvariantChecker {
      * warning; a discharged or non-expressible invariant says nothing. An {@code attempted}
      * construction raises no warning: what the warning reports is a possible abort, and an attempt
      * takes its else branch instead. */
-    private void report(Ast.Data type, SourcePos pos, boolean attempted, Verdict verdict) {
+    private void report(Ast.Expr at, Ast.Data type, SourcePos pos, boolean attempted,
+                        Verdict verdict) {
         if (capturing != null) {
-            // Which construction this is, rather than where it is written or what it says. A helper
-            // expanded twice puts two constructions at the helper body's one position, so the
-            // position alone reads them as one; and the readings are of the same body with a
-            // conditional replaced, so what a construction says differs between them by design.
-            // The nth construction written at a position is the same one in both readings.
-            capturing.put(pos, new Reported(type, pos, verdict, attempted));
+            capturing.found().put(new Occurrence(asWritten(at)),
+                    new Reported(type, pos, verdict, attempted));
             return;
         }
         switch (verdict) {
@@ -913,8 +911,38 @@ public final class InvariantChecker {
     /** What a construction came out as where it is being read on a branch rather than said. */
     private record Reported(Ast.Data type, SourcePos pos, Verdict verdict, boolean attempted) {}
 
-    /** Which construction a reading found: where it is written, and how many were found before it. */
-    private record Occurrence(SourcePos pos, int nth) {}
+    /**
+     * Which construction a reading found: the one in the body as it was written. A reading is that
+     * body with a conditional replaced, so the constructions along the way to the replacement are
+     * rebuilt — those are the same construction given a different value, and they answer together.
+     * One written inside the replacement is only in the reading that reached it, and one beside it
+     * is the very node, unchanged.
+     */
+    private record Occurrence(Ast.Expr of) {
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof Occurrence x && x.of == of;
+        }
+
+        @Override
+        public int hashCode() {
+            return System.identityHashCode(of);
+        }
+    }
+
+    /** What each node a rewrite built stands for, so a construction keeps its identity through one. */
+    private final Map<Ast.Expr, Ast.Expr> rebuilt = new IdentityHashMap<>();
+
+    /** The node {@code e} was built from, however many rewrites ago. */
+    private Ast.Expr asWritten(Ast.Expr e) {
+        Ast.Expr from = e;
+        Ast.Expr next;
+        while ((next = rebuilt.get(from)) != null) {
+            from = next;
+        }
+        return from;
+    }
 
     /**
      * Where a walk is reading one branch, what it finds is collected here rather than said. A body
@@ -928,16 +956,11 @@ public final class InvariantChecker {
      * building one walks the declaration's includes, so it is built once per declaration instead. */
     private final Map<Ast.Data, Map<String, Type>> fieldsOf = new HashMap<>();
 
-    /** What a reading has found so far, and how many it has found at each position. */
-    private record Capture(Map<Occurrence, Reported> found, Map<SourcePos, Integer> counted) {
+    /** What a reading has found so far. */
+    private record Capture(Map<Occurrence, Reported> found) {
 
         static Capture empty() {
-            return new Capture(new LinkedHashMap<>(), new HashMap<>());
-        }
-
-        void put(SourcePos pos, Reported what) {
-            int nth = counted.merge(pos, 1, Integer::sum) - 1;
-            found.put(new Occurrence(pos, nth), what);
+            return new Capture(new LinkedHashMap<>());
         }
     }
 
@@ -1008,7 +1031,12 @@ public final class InvariantChecker {
         if (e instanceof Ast.Block) {
             return e;
         }
-        return Ast.mapChildren(e, child -> without(child, was, key, becomes, scope), name -> name);
+        Ast.Expr made = Ast.mapChildren(e, child -> without(child, was, key, becomes, scope),
+                name -> name);
+        if (made != e) {
+            rebuilt.put(made, e);
+        }
+        return made;
     }
 
     /** Says of each construction the two readings reached what the two of them together decide. One
@@ -1023,10 +1051,11 @@ public final class InvariantChecker {
                 // Written inside one branch, so the other reading did not discharge it — it was not
                 // there to discharge. What the reading that reached it found is what it is.
                 Reported said = x != null ? x : y;
-                report(said.type(), said.pos(), said.attempted(), said.verdict());
+                report(one.of(), said.type(), said.pos(), said.attempted(), said.verdict());
                 continue;
             }
-            report(x.type(), x.pos(), x.attempted(), Verdict.of(x.verdict(), y.verdict()));
+            report(one.of(), x.type(), x.pos(), x.attempted(),
+                    Verdict.of(x.verdict(), y.verdict()));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -15,6 +15,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,29 +40,7 @@ import java.util.function.Function;
  */
 public final class InvariantChecker {
 
-    record Findings(List<CompileException> errors, List<Diagnostic> warnings) {
-
-        /**
-         * The same, with a construction said of once. Reading a body on each branch of a conditional
-         * reads everything after it once per branch, so a construction the branches agree about is
-         * reached more than once. One construction is one position and one code, which is what makes
-         * the second reading of it the same finding rather than another one.
-         */
-        Findings said() {
-            return new Findings(distinct(errors, e -> key(e.diagnostic())),
-                    distinct(warnings, Findings::key));
-        }
-
-        private static String key(Diagnostic d) {
-            return d.code() + "@" + d.pos();
-        }
-
-        private static <T> List<T> distinct(List<T> all, Function<T, String> by) {
-            Map<String, T> first = new java.util.LinkedHashMap<>();
-            all.forEach(one -> first.putIfAbsent(by.apply(one), one));
-            return List.copyOf(first.values());
-        }
-    }
+    record Findings(List<CompileException> errors, List<Diagnostic> warnings) {}
 
     /**
      * What this check reads: one behavior's body and the invariants of the types around it, both in
@@ -494,7 +474,7 @@ public final class InvariantChecker {
     static Findings analyze(Source source, Map<String, Type> params, Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols, source == null ? Map.of() : source.invariants());
         if (source == null) {
-            return new Findings(c.errors, c.warnings).said();
+            return new Findings(c.errors, c.warnings);
         }
         try {
             Known k = Known.top();
@@ -505,7 +485,7 @@ public final class InvariantChecker {
         } catch (RuntimeException _) {
             // fail-open: the run-time invariant check remains the backstop
         }
-        return new Findings(c.errors, c.warnings).said();
+        return new Findings(c.errors, c.warnings);
     }
 
     // --- the walk ------------------------------------------------------------------------------
@@ -542,12 +522,10 @@ public final class InvariantChecker {
                 // body is read once with each standing there. The same reading a construction written
                 // over a conditional gets, moved to where the conditional was given a name.
                 walk(iff.cond(), k, scope, depth);
-                walk(new Ast.LetIn(li.binder(), iff.then(), li.declaredType(), li.annotated(),
-                                li.opens(), li.body(), li.pos()),
-                        assumeCond(iff.cond(), k, scope, true), scope, depth + 1);
-                walk(new Ast.LetIn(li.binder(), iff.els(), li.declaredType(), li.annotated(),
-                                li.opens(), li.body(), li.pos()),
-                        assumeCond(iff.cond(), k, scope, false), scope, depth + 1);
+                Known taken = assumeCond(iff.cond(), k, scope, true);
+                Known otherwise = assumeCond(iff.cond(), k, scope, false);
+                say(reading(li, iff.then(), taken, scope, depth),
+                        reading(li, iff.els(), otherwise, scope, depth));
             }
             case Ast.LetIn li -> {
                 walk(li.value(), k, scope, depth);
@@ -559,11 +537,13 @@ public final class InvariantChecker {
                 Denotes what = denotationOf(li.value(), scope);
                 LinearForm vf = affineOf(li.value(), scope);
                 Known k2 = rebind(k, li.name());
-                // A binding given a location is an alias and introduces no value, so there is nothing
-                // to record of it: what holds of the location already holds. Recording it anyway
-                // would be assigning the location its own form, and an assignment drops what was
-                // known of what it assigns to — the guard on it would be lost to the copy.
-                if (what instanceof Denotes.Term term && isNumeric(vt) && vf != null) {
+                // A binding that denotes what it was given is an alias and introduces no value, so
+                // there is nothing to record of it: what holds of what it names already holds.
+                // Recording it anyway assigns that name its own form, and an assignment drops what
+                // was known of what it assigns to — the bound on it would be lost to the copy. A
+                // location is always this; a term is where the form is that term's own atom.
+                if (what instanceof Denotes.Term term && isNumeric(vt) && vf != null
+                        && !vf.equals(LinearForm.atom(term.key()))) {
                     k2 = k2.with(k2.numbers().assign(term.key(), vf));
                 }
                 walk(li.body(), k2, scope.binding(li.name(), vt, what), depth);
@@ -776,10 +756,10 @@ public final class InvariantChecker {
             for (int i = 0; i < nd.inits().size(); i++) {
                 if (nd.inits().get(i).value() instanceof Ast.If iff) {
                     return Verdict.of(
-                            verdictOf(withFieldValue(nd, i, iff.then()), type,
-                                    assumeCond(iff.cond(), k, scope, true), scope, depth + 1),
-                            verdictOf(withFieldValue(nd, i, iff.els()), type,
-                                    assumeCond(iff.cond(), k, scope, false), scope, depth + 1));
+                            onBranch(withFieldValue(nd, i, iff.then()), type,
+                                    assumeCond(iff.cond(), k, scope, true), scope, depth),
+                            onBranch(withFieldValue(nd, i, iff.els()), type,
+                                    assumeCond(iff.cond(), k, scope, false), scope, depth));
                 }
             }
         }
@@ -801,6 +781,12 @@ public final class InvariantChecker {
         return verdictOf(nd.typeName().denotes(), type,
                 new Bindings(forms::get, paths::get, given::get, bodyKey,
                         TypeOps.fieldTypes(type, symbols)), k);
+    }
+
+    /** The verdict on one branch, which is none where the conditions along the way contradict. */
+    private Verdict onBranch(Ast.NewData nd, Ast.Data type, Known k, Scope scope, int depth) {
+        return k.numbers().isBottom() ? Verdict.UNREACHABLE
+                : verdictOf(nd, type, k, scope, depth + 1);
     }
 
     /** {@code nd} with the value at {@code at} replaced, everything else kept. */
@@ -865,14 +851,25 @@ public final class InvariantChecker {
         /** A clause is expressible and unproven: the construction may abort. */
         UNKNOWN,
         /** A clause is proven to fail on a path that is reached. */
-        REFUTED;
+        REFUTED,
+        /** Nothing reaches here: the conditions along the way contradict. */
+        UNREACHABLE;
 
         /**
          * What holds of a value that is one of two. It is discharged where both are, and it is proven
          * to fail only where both fail — a construction one branch satisfies does not definitely
          * violate, whichever branch is taken. Everything else is possible and unproven.
+         *
+         * <p>A branch nothing reaches says nothing either way, so it is the one the other is read
+         * against: it is not a branch the value could have taken.
          */
         static Verdict of(Verdict a, Verdict b) {
+            if (a == UNREACHABLE) {
+                return b;
+            }
+            if (b == UNREACHABLE) {
+                return a;
+            }
             return a == b ? a : UNKNOWN;
         }
     }
@@ -886,7 +883,7 @@ public final class InvariantChecker {
         }
         List<Clause> owed = new ArrayList<>();
         for (Ast.InvariantClause inv : invs) {
-            List<Clause> o = obligations(inv.expr(), binds);
+            List<Clause> o = obligations(inv.expr(), binds, !type.newtype());
             if (o != null) {
                 owed.addAll(o);
             }
@@ -918,8 +915,15 @@ public final class InvariantChecker {
      * construction raises no warning: what the warning reports is a possible abort, and an attempt
      * takes its else branch instead. */
     private void report(Ast.Data type, SourcePos pos, boolean attempted, Verdict verdict) {
+        if (capturing != null) {
+            capturing.merge(pos, new Reported(type, verdict, attempted),
+                    (was, now) -> new Reported(was.type(),
+                            Verdict.of(was.verdict(), now.verdict()), was.attempted()));
+            return;
+        }
         switch (verdict) {
             case REFUTED -> reportViolation(type, pos);
+            case UNREACHABLE -> { }
             case UNKNOWN -> {
                 if (!attempted) {
                     warnings.add(Diagnostic.of("E2011", "check.invariant.unproven")
@@ -928,6 +932,54 @@ public final class InvariantChecker {
                 }
             }
             case PROVED -> { }
+        }
+    }
+
+    /** What a construction came out as where it is being read on a branch rather than said. */
+    private record Reported(Ast.Data type, Verdict verdict, boolean attempted) {}
+
+    /**
+     * Where a walk is reading one branch, what it finds is collected here rather than said. A body
+     * read on each branch of a conditional reads every construction after it once per branch, and one
+     * construction is one answer: it is the branches together that decide, the same as for a
+     * construction the conditional is written inside.
+     */
+    private Map<SourcePos, Reported> capturing;
+
+    /** What reading the body with {@code branch} bound to the name finds, or nothing where the
+     * conditions along the way contradict — a branch nothing reaches finds nothing. */
+    private Map<SourcePos, Reported> reading(Ast.LetIn li, Ast.Expr branch, Known k, Scope scope,
+                                             int depth) {
+        if (k.numbers().isBottom()) {
+            return Map.of();
+        }
+        return found(() -> walk(new Ast.LetIn(li.binder(), branch, li.declaredType(), li.annotated(),
+                li.opens(), li.body(), li.pos()), k, scope, depth + 1));
+    }
+
+    /** What {@code reading} finds, collected instead of said. */
+    private Map<SourcePos, Reported> found(Runnable reading) {
+        Map<SourcePos, Reported> outer = capturing;
+        Map<SourcePos, Reported> mine = new LinkedHashMap<>();
+        capturing = mine;
+        try {
+            reading.run();
+        } finally {
+            capturing = outer;
+        }
+        return mine;
+    }
+
+    /** Says of each construction the two readings reached what the two of them together decide. One
+     * that only one reading reached is discharged on the other: it is not there to violate anything. */
+    private void say(Map<SourcePos, Reported> a, Map<SourcePos, Reported> b) {
+        Set<SourcePos> at = new LinkedHashSet<>(a.keySet());
+        at.addAll(b.keySet());
+        for (SourcePos pos : at) {
+            Reported one = a.containsKey(pos) ? a.get(pos) : b.get(pos);
+            report(one.type(), pos, one.attempted(), Verdict.of(
+                    a.containsKey(pos) ? a.get(pos).verdict() : Verdict.PROVED,
+                    b.containsKey(pos) ? b.get(pos).verdict() : Verdict.PROVED));
         }
     }
 
@@ -989,16 +1041,24 @@ public final class InvariantChecker {
      * can express is owed to the domain; anything else is owed as a fact, which a guard stating the
      * same thing of the same term settles. */
     private List<Clause> obligations(Ast.Expr inv, Bindings binds) {
-        return obligations(inv, binds, true);
+        return obligations(inv, binds, true, false);
     }
 
-    private List<Clause> obligations(Ast.Expr rawInv, Bindings binds, boolean positive) {
+    /** The same, where a clause folding to the other answer than it is read with is this check's to
+     * report. A newtype's constant construction is checked elsewhere, and that check names the clause
+     * that failed rather than only saying one did, so it is left to say it. */
+    private List<Clause> obligations(Ast.Expr inv, Bindings binds, boolean decidesFalse) {
+        return obligations(inv, binds, true, decidesFalse);
+    }
+
+    private List<Clause> obligations(Ast.Expr rawInv, Bindings binds, boolean positive,
+                                     boolean decidesFalse) {
         Ast.Expr inv = asSizeComparison(rawInv);
         if (inv instanceof Ast.Binary b && b.op() == Ast.BinOp.AND && positive) {
             // Each conjunct on its own: an invariant is a set of things that hold, and one the check
             // cannot read leaves its own run-time check standing without costing the others theirs.
-            List<Clause> l = obligations(b.left(), binds, true);
-            List<Clause> r = obligations(b.right(), binds, true);
+            List<Clause> l = obligations(b.left(), binds, true, decidesFalse);
+            List<Clause> r = obligations(b.right(), binds, true, decidesFalse);
             if (l == null && r == null) {
                 return null;
             }
@@ -1008,9 +1068,16 @@ public final class InvariantChecker {
         }
         Ast.Expr under = negated(inv);
         if (under != null) {
-            return obligations(under, binds, !positive);
+            return obligations(under, binds, !positive, decidesFalse);
         }
         Boolean folded = decidedAt(inv, binds);
+        if (folded != null && folded != positive && decidesFalse) {
+            // It folds the other way than it is read: the construction violates, and saying so needs
+            // no term to be named — the answer is already computed.
+            return List.of(new Clause(
+                    new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE),
+                    null, List.of()));
+        }
         if (folded != null && folded == positive) {
             // The clause folds once the construction's own expressions stand where it wrote a field,
             // and it folds the way it is being read. There is nothing to owe. Read under a negation
@@ -1043,17 +1110,31 @@ public final class InvariantChecker {
      * names replaced by what the construction gives that field, folded. {@code null} where it does not
      * fold — which is every clause reading anything computed at run time. */
     private Boolean decidedAt(Ast.Expr inv, Bindings binds) {
-        Object folded = ConstEval.eval(substituted(inv, binds)).orElse(null);
+        Object folded = ConstEval.eval(substituted(inv, binds, Set.of())).orElse(null);
         return folded instanceof Boolean b ? b : null;
     }
 
-    /** {@code inv} with every name the construction fills replaced by the expression filling it. */
-    private static Ast.Expr substituted(Ast.Expr e, Bindings binds) {
+    /** {@code inv} with every name the construction fills replaced by the expression filling it. A
+     * name a binding inside the clause has taken over is that binding's and not a field's, so it is
+     * left alone: {@code List.all(x -> x > 0, x)} says two different things by one spelling. */
+    private static Ast.Expr substituted(Ast.Expr e, Bindings binds, Set<String> bound) {
+        if (e instanceof Ast.Var v && bound.contains(v.name())) {
+            return e;
+        }
         Ast.Expr given = atSite(e, binds);
         if (given != null) {
             return given;
         }
-        return Ast.mapChildren(e, child -> substituted(child, binds), name -> name);
+        Set<String> inner = bound;
+        if (e instanceof Ast.Block b && !b.params().isEmpty()) {
+            inner = new HashSet<>(bound);
+            inner.addAll(b.paramNames());
+        } else if (e instanceof Ast.LetIn li) {
+            inner = new HashSet<>(bound);
+            inner.add(li.name());
+        }
+        Set<String> taken = inner;
+        return Ast.mapChildren(e, child -> substituted(child, binds, taken), name -> name);
     }
 
     private static List<String> firstOnly(List<String> keys) {
@@ -1263,12 +1344,17 @@ public final class InvariantChecker {
      * {@code leaf} (which decides whether it is an atom, a resolved field, or opaque). */
     private LinearForm affine(Ast.Expr raw, Function<Ast.Expr, LinearForm> leaf) {
         Ast.Expr e = asOperator(raw);
-        return switch (e) {
+        if (e instanceof Ast.Apply) {
             // A call that folds is the number it folds to. `String.length("1A")` is 2, and a clause
             // about it is decided rather than owed — the run-time check is not what should answer a
-            // question the compiler has already computed.
-            case Ast.Apply call when constantNumber(call) != null ->
-                    LinearForm.constant(constantNumber(call));
+            // question the compiler has already computed. Asked once: folding walks the subtree, and
+            // a pattern in it is a regex to run.
+            BigDecimal folded = constantNumber(e);
+            if (folded != null) {
+                return LinearForm.constant(folded);
+            }
+        }
+        return switch (e) {
             case Ast.IntLit i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
             case Ast.DecimalLit dd -> LinearForm.constant(dd.value());
             case Ast.Neg n -> negate(affine(n.operand(), leaf));

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -353,11 +353,11 @@ public final class InvariantChecker {
     }
 
     /**
-     * What a name denotes. The three are not one thing with a missing case: a location is somewhere the
-     * seeding can have written about and a clause can have named, a term is a value known only by what
-     * computes it, and nothing is nothing. Collapsing the last two would put a computed value where a
-     * location is expected, which is the shape of {@code let} answering differently from the expression
-     * it was given.
+     * What a name denotes. A location is somewhere the seeding can have written about and a clause
+     * can have named; a term is a value known only by what computes it. Merging those two would put a
+     * computed value where a location is expected, which is the shape of a {@code let} answering
+     * differently from the expression it was given. A written value is apart from both because what
+     * it is has to travel with the name, and nothing is apart because only a term is assigned a form.
      */
     private sealed interface Denotes {
 
@@ -401,13 +401,13 @@ public final class InvariantChecker {
     public static ClauseDischarge capabilityOf(Ast.Expr clause, SourcePos at, Ast.Data data,
                                                Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols, Map.of());
-        Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
+        Map<String, Type> fields = c.fieldsOf(data);
         Bindings binds = Bindings.ofPaths(
                 name -> fields.containsKey(name) ? LinearForm.atom(name) : null,
                 name -> fields.containsKey(name) ? name : null, fields);
         List<Clause> owed;
         try {
-            owed = c.obligations(clause, binds);
+            owed = c.obligations(clause, binds, false);
         } catch (RuntimeException _) {
             owed = null;   // fail-open, as the walk is
         }
@@ -445,15 +445,7 @@ public final class InvariantChecker {
         if (e instanceof Ast.Var v) {
             return bound.contains(v.name()) || binds.path().apply(v.name()) != null ? null : v.name();
         }
-        Set<String> inner = bound;
-        if (e instanceof Ast.Block b && !b.params().isEmpty()) {
-            inner = new java.util.HashSet<>(bound);
-            inner.addAll(b.paramNames());
-        } else if (e instanceof Ast.LetIn li) {
-            inner = new java.util.HashSet<>(bound);
-            inner.add(li.name());
-        }
-        Set<String> scope = inner;
+        Set<String> scope = taken(e, bound);
         String[] found = {null};
         Ast.forEachChild(e, child -> {
             if (found[0] == null) {
@@ -547,16 +539,17 @@ public final class InvariantChecker {
                 // name is what made a named subexpression a term of its own, answering differently
                 // from the very expression it was given.
                 Denotes what = denotationOf(li.value(), scope, k);
-                LinearForm vf = affineOf(li.value(), scope, k);
                 Known k2 = rebind(k, li.name());
                 // A binding that denotes what it was given is an alias and introduces no value, so
                 // there is nothing to record of it: what holds of what it names already holds.
                 // Recording it anyway assigns that name its own form, and an assignment drops what
                 // was known of what it assigns to — the bound on it would be lost to the copy. A
                 // location is always this; a term is where the form is that term's own atom.
-                if (what instanceof Denotes.Term term && isNumeric(vt) && vf != null
-                        && !vf.equals(LinearForm.atom(term.key()))) {
-                    k2 = k2.with(k2.numbers().assign(term.key(), vf));
+                if (what instanceof Denotes.Term term && isNumeric(vt)) {
+                    LinearForm vf = affineOf(li.value(), scope, k);
+                    if (vf != null && !vf.equals(LinearForm.atom(term.key()))) {
+                        k2 = k2.with(k2.numbers().assign(term.key(), vf));
+                    }
                 }
                 walk(li.body(), k2, scope.binding(li.name(), vt, what), depth);
             }
@@ -664,7 +657,7 @@ public final class InvariantChecker {
                 q.binds().given(), q.binds().bodyKey(), fields);
         List<Quantified> nested = new ArrayList<>();
         quantifiedBy(q.predicate().body(), at, true, nested);
-        return assume(obligations(q.predicate().body(), at), k).and(nested);
+        return assume(obligations(q.predicate().body(), at, false), k).and(nested);
     }
 
     /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
@@ -715,15 +708,7 @@ public final class InvariantChecker {
             }
             return;
         }
-        Set<String> inner = bound;
-        if (e instanceof Ast.Block b && !b.params().isEmpty()) {
-            inner = new java.util.HashSet<>(bound);
-            inner.addAll(b.paramNames());
-        } else if (e instanceof Ast.LetIn li) {
-            inner = new java.util.HashSet<>(bound);
-            inner.add(li.name());
-        }
-        Set<String> scope = inner;
+        Set<String> scope = taken(e, bound);
         Ast.forEachChild(e, child -> reads(child, binds, scope, out));
     }
 
@@ -737,7 +722,8 @@ public final class InvariantChecker {
                     report(type, nd.pos(), attempted, verdictOf(nd, type, k, scope));
                 }
             }
-            case Ast.Binary bin when isArith(bin.op()) -> {
+            case Ast.Expr arith when asOperator(arith) instanceof Ast.Binary bin
+                    && isArith(bin.op()) -> {
                 if (typeExpr(bin, scope) instanceof Type.Ref r
                         && symbols.get(r.name()) instanceof Ast.Data type && type.newtype()) {
                     LinearForm value = affineOf(bin, scope, k);
@@ -745,7 +731,7 @@ public final class InvariantChecker {
                         // an arithmetic result is a form, not a location, so it names no path
                         report(type, bin.pos(), attempted, verdictOf(r.name(), type,
                                 Bindings.ofPaths(name -> "value".equals(name) ? value : null, _ -> null,
-                                        TypeOps.fieldTypes(type, symbols)), k, true));
+                                        fieldsOf(type)), k, true));
                     }
                 }
             }
@@ -779,7 +765,7 @@ public final class InvariantChecker {
         }
         return verdictOf(nd.typeName().denotes(), type,
                 new Bindings(forms::get, paths::get, given::get, bodyKey,
-                        TypeOps.fieldTypes(type, symbols)), k, !constantlyBuilt(type, nd));
+                        fieldsOf(type)), k, !constantlyBuilt(type, nd));
     }
 
     /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
@@ -908,8 +894,7 @@ public final class InvariantChecker {
             // position alone reads them as one; and the readings are of the same body with a
             // conditional replaced, so what a construction says differs between them by design.
             // The nth construction written at a position is the same one in both readings.
-            capturing.put(new Occurrence(pos, capturing.size()),
-                    new Reported(type, pos, verdict, attempted));
+            capturing.put(pos, new Reported(type, pos, verdict, attempted));
             return;
         }
         switch (verdict) {
@@ -937,7 +922,24 @@ public final class InvariantChecker {
      * construction is one answer: it is the branches together that decide, the same as for a
      * construction the conditional is written inside.
      */
-    private Map<Occurrence, Reported> capturing;
+    private Capture capturing;
+
+    /** What each declaration's fields are. Asked at every field read the local typer walks past, and
+     * building one walks the declaration's includes, so it is built once per declaration instead. */
+    private final Map<Ast.Data, Map<String, Type>> fieldsOf = new HashMap<>();
+
+    /** What a reading has found so far, and how many it has found at each position. */
+    private record Capture(Map<Occurrence, Reported> found, Map<SourcePos, Integer> counted) {
+
+        static Capture empty() {
+            return new Capture(new LinkedHashMap<>(), new HashMap<>());
+        }
+
+        void put(SourcePos pos, Reported what) {
+            int nth = counted.merge(pos, 1, Integer::sum) - 1;
+            found.put(new Occurrence(pos, nth), what);
+        }
+    }
 
     /** What reading {@code e} finds, or nothing where the conditions along the way contradict — a
      * branch nothing reaches finds nothing, and what is not there violates nothing. */
@@ -945,15 +947,15 @@ public final class InvariantChecker {
         if (k.numbers().isBottom()) {
             return Map.of();
         }
-        Map<Occurrence, Reported> outer = capturing;
-        Map<Occurrence, Reported> mine = new LinkedHashMap<>();
+        Capture outer = capturing;
+        Capture mine = Capture.empty();
         capturing = mine;
         try {
             walk(e, k, scope, depth + 1);
         } finally {
             capturing = outer;
         }
-        return mine;
+        return mine.found();
     }
 
     /**
@@ -967,6 +969,7 @@ public final class InvariantChecker {
             // Where the walk goes next is not a value it is handed: an `if`'s own branches, a `let`'s
             // body and a case's body are read after this, each with what is known there.
             case Ast.If iff -> conditionalIn(iff.cond());
+            case Ast.IfConstructed ic -> conditionalIn(ic.construct());
             case Ast.LetIn li -> conditionalIn(li.value());
             case Ast.Match m -> conditionalIn(m.scrutinee());
             default -> conditionalIn(e);
@@ -999,7 +1002,7 @@ public final class InvariantChecker {
      * make the guard say nothing about what is built.
      */
     private Ast.Expr without(Ast.Expr e, Ast.If was, String key, Ast.Expr becomes, Scope scope) {
-        if (e == was || (key != null && key.equals(bodyKey(e, scope)))) {
+        if (e == was || (key != null && e instanceof Ast.If && key.equals(bodyKey(e, scope)))) {
             return becomes;
         }
         if (e instanceof Ast.Block) {
@@ -1016,10 +1019,14 @@ public final class InvariantChecker {
         for (Occurrence one : at) {
             Reported x = a.get(one);
             Reported y = b.get(one);
-            Reported said = x != null ? x : y;
-            report(said.type(), said.pos(), said.attempted(),
-                    Verdict.of(x == null ? Verdict.PROVED : x.verdict(),
-                            y == null ? Verdict.PROVED : y.verdict()));
+            if (x == null || y == null) {
+                // Written inside one branch, so the other reading did not discharge it — it was not
+                // there to discharge. What the reading that reached it found is what it is.
+                Reported said = x != null ? x : y;
+                report(said.type(), said.pos(), said.attempted(), said.verdict());
+                continue;
+            }
+            report(x.type(), x.pos(), x.attempted(), Verdict.of(x.verdict(), y.verdict()));
         }
     }
 
@@ -1063,6 +1070,10 @@ public final class InvariantChecker {
      * present either one discharging the clause is enough — a guard is written one way and a clause
      * another, and which of the two routes carries it is not the author's concern.
      */
+    /** A clause that cannot hold, said in the language the domain reads: {@code -1 >= 0}. */
+    private static final Clause VIOLATED = new Clause(
+            new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE), null, List.of());
+
     private record Clause(Constraint numeric, Fact fact, List<Constraint> known) {
 
         boolean dischargedBy(NumericDomain d, PredicateFacts facts) {
@@ -1080,13 +1091,10 @@ public final class InvariantChecker {
      * being given), or {@code null} if it names nothing this check can carry. A comparison the domain
      * can express is owed to the domain; anything else is owed as a fact, which a guard stating the
      * same thing of the same term settles. */
-    private List<Clause> obligations(Ast.Expr inv, Bindings binds) {
-        return obligations(inv, binds, true, false);
-    }
-
-    /** The same, where a clause folding to the other answer than it is read with is this check's to
-     * report. A newtype's constant construction is checked elsewhere, and that check names the clause
-     * that failed rather than only saying one did, so it is left to say it. */
+    /** What {@code inv} owes, where {@code decidesFalse} says a clause folding to the other answer
+     * than it is read with is this check's to report. A newtype's constant construction is checked
+     * elsewhere, and that check names the clause that failed rather than only saying one did, so it
+     * is left to say it. */
     private List<Clause> obligations(Ast.Expr inv, Bindings binds, boolean decidesFalse) {
         return obligations(inv, binds, true, decidesFalse);
     }
@@ -1111,19 +1119,17 @@ public final class InvariantChecker {
             return obligations(under, binds, !positive, decidesFalse);
         }
         Boolean folded = decidedAt(inv, binds);
-        if (folded != null && folded != positive && decidesFalse) {
-            // It folds the other way than it is read: the construction violates, and saying so needs
-            // no term to be named — the answer is already computed.
-            return List.of(new Clause(
-                    new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE),
-                    null, List.of()));
-        }
-        if (folded != null && folded == positive) {
-            // The clause folds once the construction's own expressions stand where it wrote a field,
-            // and it folds the way it is being read. There is nothing to owe. Read under a negation
-            // it is the other answer that discharges, which is why the polarity is asked: folding to
-            // true under a denial is a violation and not a discharge.
-            return List.of();
+        if (folded != null) {
+            // The clause folds once the construction's own expressions stand where it wrote a field.
+            // Folding the way it is read owes nothing; folding the other way is a violation, and
+            // saying so needs no term to be named. Read under a denial it is the other answer that
+            // discharges, which is why the polarity is asked.
+            if (folded == positive) {
+                return List.of();
+            }
+            if (decidesFalse) {
+                return List.of(VIOLATED);
+            }
         }
         Constraint numeric = null;
         if (inv instanceof Ast.Binary b && relOf(b.op()) != null) {
@@ -1154,6 +1160,22 @@ public final class InvariantChecker {
         return folded instanceof Boolean b ? b : null;
     }
 
+    /** {@code bound} with whatever names {@code e} itself binds — a closure's parameters, a
+     * binding's name. A name a binding took over is that binding's and not a field's. */
+    private static Set<String> taken(Ast.Expr e, Set<String> bound) {
+        if (e instanceof Ast.Block b && !b.params().isEmpty()) {
+            Set<String> inner = new HashSet<>(bound);
+            inner.addAll(b.paramNames());
+            return inner;
+        }
+        if (e instanceof Ast.LetIn li) {
+            Set<String> inner = new HashSet<>(bound);
+            inner.add(li.name());
+            return inner;
+        }
+        return bound;
+    }
+
     /** {@code inv} with every name the construction fills replaced by the expression filling it. A
      * name a binding inside the clause has taken over is that binding's and not a field's, so it is
      * left alone: {@code List.all(x -> x > 0, x)} says two different things by one spelling. */
@@ -1165,15 +1187,15 @@ public final class InvariantChecker {
         if (given != null) {
             return given;
         }
-        Set<String> inner = bound;
-        if (e instanceof Ast.Block b && !b.params().isEmpty()) {
-            inner = new HashSet<>(bound);
-            inner.addAll(b.paramNames());
-        } else if (e instanceof Ast.LetIn li) {
-            inner = new HashSet<>(bound);
-            inner.add(li.name());
+        if (e instanceof Ast.LetIn li) {
+            // The initializer is read where the binding is not yet in scope, so a field the clause
+            // names keeps its meaning there even where the binding takes the same spelling over.
+            Set<String> inner = taken(e, bound);
+            return new Ast.LetIn(li.binder(), substituted(li.value(), binds, bound),
+                    li.declaredType(), li.annotated(), li.opens(),
+                    substituted(li.body(), binds, inner), li.pos());
         }
-        Set<String> taken = inner;
+        Set<String> taken = taken(e, bound);
         return Ast.mapChildren(e, child -> substituted(child, binds, taken), name -> name);
     }
 
@@ -1320,7 +1342,7 @@ public final class InvariantChecker {
         if (depth > 2 || !(t instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)) {
             return k;
         }
-        Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
+        Map<String, Type> fields = fieldsOf(data);
         Function<String, String> resolvePath = fieldName -> {
             if (data.newtype() && fieldName.equals("value")) {
                 return path;
@@ -1337,7 +1359,7 @@ public final class InvariantChecker {
         List<Quantified> quantified = new ArrayList<>();
         for (Ast.InvariantClause inv : invariantsOf(ref.name(), data)) {
             quantifiedBy(inv.expr(), binds, true, quantified);
-            out = assume(obligations(inv.expr(), binds), out);
+            out = assume(obligations(inv.expr(), binds, false), out);
         }
         out = out.and(quantified);
         if (data.newtype()) {
@@ -2043,18 +2065,8 @@ public final class InvariantChecker {
      * The same walk {@link #pathKey} makes, asking each name for a location instead of for whatever
      * key it has — so a chain read off a computed value is computed too. */
     private String locationKey(Ast.Expr e, Scope scope) {
-        return switch (e) {
-            case Ast.Var v -> scope.denotes(v.name()) instanceof Denotes.Location loc ? loc.key() : null;
-            case Ast.FieldAccess fa -> {
-                Type owner = typeExpr(fa.target(), scope);
-                if (fa.field().equals("value") && TypeOps.isSingleValueNewtype(owner, symbols)) {
-                    yield locationKey(fa.target(), scope);
-                }
-                String base = locationKey(fa.target(), scope);
-                yield base == null ? null : base + "." + fa.field();
-            }
-            default -> null;
-        };
+        return chainKey(e, scope,
+                name -> scope.denotes(name) instanceof Denotes.Location loc ? loc.key() : null);
     }
 
     /**
@@ -2123,7 +2135,7 @@ public final class InvariantChecker {
      * expands to binds each argument and reads it back, which is the source's own text moved. */
     private static boolean isWritten(Ast.Expr e, Set<String> written) {
         return switch (e) {
-            case Ast.IntLit _, Ast.DecimalLit _, Ast.StringLit _, Ast.BoolLit _ -> true;
+            case Ast.Expr lit when BinaryElaborator.isLiteralExpr(lit) -> true;
             case Ast.Var v -> written.contains(v.name());
             case Ast.ListLit list -> list.elements().stream().allMatch(x -> isWritten(x, written));
             case Ast.Tuple t -> t.elements().stream().allMatch(x -> isWritten(x, written));
@@ -2200,19 +2212,31 @@ public final class InvariantChecker {
     }
 
     private String pathKey(Ast.Expr e, Scope scope) {
+        // a name given a location is that location, as a newtype's `.value` is its own
+        return chainKey(e, scope, scope::keyOf);
+    }
+
+    /** The key of a {@code x}/{@code x.a.b} chain, with {@code ofName} saying what the name at its
+     * head is. A newtype's {@code .value} is the same location as the newtype, which is the one rule
+     * this walk carries and the reason there is one walk rather than one per caller. */
+    private String chainKey(Ast.Expr e, Scope scope, Function<String, String> ofName) {
         return switch (e) {
-            // a name given a location is that location, as a newtype's `.value` is its own
-            case Ast.Var v -> scope.keyOf(v.name());
+            case Ast.Var v -> ofName.apply(v.name());
             case Ast.FieldAccess fa -> {
                 Type owner = typeExpr(fa.target(), scope);
                 if (fa.field().equals("value") && TypeOps.isSingleValueNewtype(owner, symbols)) {
-                    yield pathKey(fa.target(), scope);   // a newtype's .value is the same location
+                    yield chainKey(fa.target(), scope, ofName);
                 }
-                String base = pathKey(fa.target(), scope);
+                String base = chainKey(fa.target(), scope, ofName);
                 yield base == null ? null : base + "." + fa.field();
             }
             default -> null;
         };
+    }
+
+    /** What {@code data}'s fields are, remembered. */
+    private Map<String, Type> fieldsOf(Ast.Data data) {
+        return fieldsOf.computeIfAbsent(data, d -> TypeOps.fieldTypes(d, symbols));
     }
 
     /** What is known after a binding takes over {@code name}: everything that mentioned it is dropped,
@@ -2247,7 +2271,7 @@ public final class InvariantChecker {
             case Ast.FieldAccess fa -> {
                 Type owner = typeExpr(fa.target(), scope);
                 yield owner instanceof Type.Ref r && symbols.get(r.name()) instanceof Ast.Data d
-                        ? TypeOps.fieldTypes(d, symbols).get(fa.field()) : null;
+                        ? fieldsOf(d).get(fa.field()) : null;
             }
             case Ast.NewData nd -> Type.ref(nd.typeName().denotes());
             case Ast.LetIn li -> {
@@ -2256,10 +2280,11 @@ public final class InvariantChecker {
                         scope.binding(li.name(), bound, denotationOf(li.value(), scope, Known.top())));
             }
             case Ast.Neg n -> typeExpr(n.operand(), scope);
-            // A size is a number whatever it counts, and this typer reads no signatures — without
-            // this a name bound to one has no type, and a name that has no type is not the atom the
-            // expression it was given is.
-            case Ast.Apply call when SIZE_CALLS.contains(call.reaches()) -> Type.INT;
+            // The library says what its own calls answer, so this typer asks it rather than listing
+            // the ones it has needed so far. Without a type a name bound to a call is not the atom
+            // the expression it was given is.
+            case Ast.Apply call when Prelude.entry(call.reaches()) != null ->
+                    Prelude.entry(call.reaches()).signature().result();
             case Ast.Binary b when isArith(b.op()) -> arithType(b, scope);
             default -> null;
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -12,7 +12,9 @@ import souther.compiler.types.TypeName;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -224,18 +226,39 @@ public final class InvariantChecker {
     /** What the guards have settled on the current path: numeric relations, predicates known to hold
      * or to fail, and relations known of every element of a container. Threaded functionally through
      * the walk, as the domain alone once was. */
-    private record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified) {
+    private record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified,
+                         Set<String> spoken) {
 
         static Known top() {
-            return new Known(NumericDomain.top(), PredicateFacts.none(), List.of());
+            return new Known(NumericDomain.top(), PredicateFacts.none(), List.of(), Set.of());
         }
 
         Known with(NumericDomain n) {
-            return new Known(n, facts, quantified);
+            return new Known(n, facts, quantified, spoken);
         }
 
         Known with(PredicateFacts f) {
-            return new Known(numbers, f, quantified);
+            return new Known(numbers, f, quantified, spoken);
+        }
+
+        /**
+         * This, with each of {@code terms} recorded as one an assumption on this path named. It is
+         * recorded where the assumption is made rather than searched for afterwards: what a guard
+         * spoke about is known exactly then, and reading it back out of a domain would mean matching
+         * key text, which is how a term that merely reads like another gets mistaken for it.
+         */
+        Known speaking(Collection<String> terms) {
+            if (terms.isEmpty()) {
+                return this;
+            }
+            Set<String> all = new HashSet<>(spoken);
+            all.addAll(terms);
+            return new Known(numbers, facts, quantified, Set.copyOf(all));
+        }
+
+        /** Whether an assumption on this path named {@code term}. */
+        boolean speaksOf(String term) {
+            return spoken.contains(term);
         }
 
         Known and(List<Quantified> more) {
@@ -244,7 +267,7 @@ public final class InvariantChecker {
             }
             List<Quantified> all = new ArrayList<>(quantified);
             all.addAll(more);
-            return new Known(numbers, facts, List.copyOf(all));
+            return new Known(numbers, facts, List.copyOf(all), spoken);
         }
 
         Known forgetIf(java.util.function.Predicate<String> drop) {
@@ -256,7 +279,14 @@ public final class InvariantChecker {
                     kept.add(q);
                 }
             }
-            return new Known(numbers.forgetIf(drop), facts.forgetIf(drop), List.copyOf(kept));
+            Set<String> said = new HashSet<>();
+            for (String term : spoken) {
+                if (!drop.test(term)) {
+                    said.add(term);
+                }
+            }
+            return new Known(numbers.forgetIf(drop), facts.forgetIf(drop), List.copyOf(kept),
+                    Set.copyOf(said));
         }
     }
 
@@ -271,7 +301,7 @@ public final class InvariantChecker {
      * a helper taking a record names locations the seeding never wrote, and everything an input's
      * type guarantees stops at the call.
      */
-    private record Scope(Map<String, Type> types, Map<String, String> locations) {
+    private record Scope(Map<String, Type> types, Map<String, Denotes> denotations) {
 
         static Scope of(Map<String, Type> types) {
             return new Scope(types, Map.of());
@@ -281,30 +311,68 @@ public final class InvariantChecker {
             return types.get(name);
         }
 
-        /** The location {@code name} reads, which is itself unless it was given another. */
-        String locationOf(String name) {
-            return locations.getOrDefault(name, name);
+        /** What {@code name} denotes, which is the location it is unless it was given something else. */
+        Denotes denotes(String name) {
+            return denotations.getOrDefault(name, new Denotes.Location(name));
+        }
+
+        /** The key {@code name} is known by, whichever kind of thing it denotes, or {@code null} where
+         * it denotes nothing. */
+        String keyOf(String name) {
+            return denotes(name).key();
         }
 
         /**
-         * This scope with {@code name} bound to {@code type}, reading {@code location} where it was
-         * given one. A binding that read a location rooted at {@code name} loses it: the name it was
-         * written as denotes something else from here, so what it stood for can no longer be said.
+         * This scope with {@code name} bound to {@code type} and to what it denotes. A binding whose
+         * denotation was rooted at {@code name} loses it: the name it was written as denotes something
+         * else from here, so what it stood for can no longer be said.
          */
-        Scope binding(String name, Type type, String location) {
+        Scope binding(String name, Type type, Denotes what) {
             Map<String, Type> t = new HashMap<>(types);
             if (type == null) {
                 t.remove(name);
             } else {
                 t.put(name, type);
             }
-            Map<String, String> at = new HashMap<>(locations);
-            at.values().removeIf(read -> mentions(read, name));
+            Map<String, Denotes> at = new HashMap<>(denotations);
+            at.values().removeIf(d -> d.key() != null && mentions(d.key(), name));
             at.remove(name);
-            if (location != null && !location.equals(name)) {
-                at.put(name, location);
+            if (!(what instanceof Denotes.Location loc && loc.key().equals(name))) {
+                at.put(name, what);
             }
             return new Scope(Map.copyOf(t), Map.copyOf(at));
+        }
+    }
+
+    /**
+     * What a name denotes. The three are not one thing with a missing case: a location is somewhere the
+     * seeding can have written about and a clause can have named, a term is a value known only by what
+     * computes it, and nothing is nothing. Collapsing the last two would put a computed value where a
+     * location is expected, which is the shape of {@code let} answering differently from the expression
+     * it was given.
+     */
+    private sealed interface Denotes {
+
+        /** The key this is known by, or {@code null} where it is known by none. */
+        String key();
+
+        /** A place: a parameter, a field chain, or another location a binding was given. */
+        record Location(String key) implements Denotes {}
+
+        /**
+         * A value named by the expression that computes it. {@code byRule} is true where the check has
+         * a rule about how it was built — a container the preservation table covers — and that rule is
+         * what names it however it is reached; false where only a guard naming it can.
+         */
+        record Term(String key, boolean byRule) implements Denotes {}
+
+        /** Nothing this check can name. */
+        record Nothing() implements Denotes {
+
+            @Override
+            public String key() {
+                return null;
+            }
         }
     }
 
@@ -436,7 +504,8 @@ public final class InvariantChecker {
                 if (built != null) {
                     k2 = seedParam(ic.binderName(), built, k2);   // on this branch the invariant holds
                 }
-                walk(ic.then(), k2, scope.binding(ic.binderName(), built, null));
+                walk(ic.then(), k2, scope.binding(ic.binderName(), built,
+                        new Denotes.Location(ic.binderName())));
                 // Each departure stands where the invariant did not hold, and nothing was built
                 // there, so none of them is seeded with anything the attempt would have guaranteed.
                 ic.els().forEach(arm -> walk(arm.body(), k, scope));
@@ -444,14 +513,17 @@ public final class InvariantChecker {
             case Ast.LetIn li -> {
                 walk(li.value(), k, scope);
                 Type vt = typeExpr(li.value(), scope);
-                // Given a location, the binding is that location; given anything else, it is a term
-                // of its own, and only a number can be related to what it was computed from.
+                // The name is an alias for what its initializer denotes, so what is recorded about it
+                // is recorded under that denotation and not under the spelling. Recording it under the
+                // name is what made a named subexpression a term of its own, answering differently
+                // from the very expression it was given.
+                Denotes what = denotationOf(li.value(), scope);
                 LinearForm vf = affineOf(li.value(), scope);
                 Known k2 = rebind(k, li.name());
-                if (isNumeric(vt) && vf != null) {
-                    k2 = k2.with(k2.numbers().assign(li.name(), vf));
+                if (isNumeric(vt) && vf != null && what.key() != null) {
+                    k2 = k2.with(k2.numbers().assign(what.key(), vf));
                 }
-                walk(li.body(), k2, scope.binding(li.name(), vt, pathKey(li.value(), scope)));
+                walk(li.body(), k2, scope.binding(li.name(), vt, what));
             }
             case Ast.Match m -> {
                 walk(m.scrutinee(), k, scope);
@@ -464,7 +536,7 @@ public final class InvariantChecker {
                                 ? MatchElaborator.caseBindType(c.caseTypes().get(0).denotes()) : null;
                         // A sum has no fields of its own, so the scrutinee is not a location any
                         // clause could have named — the case's value names only itself.
-                        s2 = scope.binding(c.bindingName(), bound, null);
+                        s2 = scope.binding(c.bindingName(), bound, new Denotes.Location(c.bindingName()));
                     }
                     walk(c.body(), k2, s2);
                 }
@@ -492,7 +564,7 @@ public final class InvariantChecker {
                 List<Quantified> relations = elementRelations(container, k, scope);
                 String p = step.params().get(combo.elementParam()).name();
                 // an element of a container is not a location the body can otherwise name
-                Scope s2 = scope.binding(p, elem, null);
+                Scope s2 = scope.binding(p, elem, new Denotes.Location(p));
                 Known k2 = rebind(k, p);
                 if (elem != null) {
                     k2 = seedParam(p, elem, k2);   // the element carries its type's invariant
@@ -630,7 +702,7 @@ public final class InvariantChecker {
                     Map<String, LinearForm> forms = new HashMap<>();
                     Map<String, String> paths = new HashMap<>();
                     Map<String, Ast.Expr> given = new HashMap<>();
-                    Function<Ast.Expr, String> bodyKey = value -> siteKey(value, scope);
+                    Function<Ast.Expr, String> bodyKey = value -> siteKey(value, scope, k);
                     for (Ast.FieldInit fi : nd.inits()) {
                         LinearForm f = affineOf(fi.value(), scope);
                         if (f != null) {
@@ -686,7 +758,8 @@ public final class InvariantChecker {
         /** A clause written in the body's own scope, where every name already stands for itself —
          * what a guard states, read by the rule a type's clause is read by. */
         static Bindings ofScope(Scope scope) {
-            return ofPaths(name -> LinearForm.atom(scope.locationOf(name)), scope::locationOf,
+            return ofPaths(name -> scope.keyOf(name) == null ? null : LinearForm.atom(scope.keyOf(name)),
+                    scope::keyOf,
                     scope.types());
         }
     }
@@ -830,6 +903,12 @@ public final class InvariantChecker {
         if (under != null) {
             return obligations(under, binds, !positive);
         }
+        if (Boolean.TRUE.equals(decidedAt(inv, binds))) {
+            // The clause folds to true once the construction's own expressions stand where it wrote a
+            // field, so there is nothing to owe. A clause that folds to false is left to the constant
+            // check, which says which clause failed rather than only that one did.
+            return List.of();
+        }
         Constraint numeric = null;
         if (inv instanceof Ast.Binary b && relOf(b.op()) != null) {
             Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
@@ -849,6 +928,23 @@ public final class InvariantChecker {
         List<Constraint> known = new ArrayList<>();
         sizeFacts(inv, binds, known);
         return List.of(new Clause(numeric, fact, known));
+    }
+
+    /** Whether {@code inv} is decided outright at this construction: the clause with each field it
+     * names replaced by what the construction gives that field, folded. {@code null} where it does not
+     * fold — which is every clause reading anything computed at run time. */
+    private Boolean decidedAt(Ast.Expr inv, Bindings binds) {
+        Object folded = ConstEval.eval(substituted(inv, binds)).orElse(null);
+        return folded instanceof Boolean b ? b : null;
+    }
+
+    /** {@code inv} with every name the construction fills replaced by the expression filling it. */
+    private static Ast.Expr substituted(Ast.Expr e, Bindings binds) {
+        Ast.Expr given = atSite(e, binds);
+        if (given != null) {
+            return given;
+        }
+        return Ast.mapChildren(e, child -> substituted(child, binds), name -> name);
     }
 
     private static List<String> firstOnly(List<String> keys) {
@@ -884,6 +980,10 @@ public final class InvariantChecker {
             if (la != null && ra != null) {
                 out = out.with(out.numbers().assume(la.minus(ra), eff));
             }
+            // What the comparison named, recorded as spoken about: a construction from one of these
+            // is one the author has said something about, whichever route ends up carrying it.
+            out = out.speaking(spokenOf(b.left(), scope, la));
+            out = out.speaking(spokenOf(b.right(), scope, ra));
         }
         List<Quantified> quantified = new ArrayList<>();
         quantifiedBy(cond, Bindings.ofScope(scope), positive, quantified);
@@ -893,6 +993,17 @@ public final class InvariantChecker {
         Polar polar = polar(cond, positive);
         String key = bodyKey(polar.expr(), scope);
         return key == null ? out : out.with(out.facts().assume(key, polar.positive()));
+    }
+
+    /** The terms one side of a compared pair names: the expression itself, and each atom of the form it
+     * reduced to — {@code leftover + 1} says something about {@code leftover}. */
+    private Collection<String> spokenOf(Ast.Expr side, Scope scope, LinearForm form) {
+        Set<String> terms = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
+        String written = bodyKey(side, scope);
+        if (written != null) {
+            terms.add(written);
+        }
+        return terms;
     }
 
     /** A predicate as one of {@code ==}/{@code <} states it, and whether it is being stated or denied. */
@@ -1012,10 +1123,43 @@ public final class InvariantChecker {
 
     // --- affine forms --------------------------------------------------------------------------
 
+    /**
+     * The library's function forms of the arithmetic operators, and the operator each one is. They
+     * reach the same kernel in the same argument order — {@code Int.add} is {@code IntMath.addExact},
+     * which is what {@code +} emits — so the two spellings compute one value and are read as one term.
+     * {@code divide} is absent: it answers a union rather than a number.
+     */
+    private static final Map<String, Ast.BinOp> OPERATOR_CALLS = Map.of(
+            "Int.add", Ast.BinOp.ADD,
+            "Int.subtract", Ast.BinOp.SUB,
+            "Int.multiply", Ast.BinOp.MUL,
+            "Decimal.add", Ast.BinOp.ADD,
+            "Decimal.subtract", Ast.BinOp.SUB,
+            "Decimal.multiply", Ast.BinOp.MUL);
+
+    /** The operator {@code e} is, where it is a library call written as a function, or {@code e}
+     * itself. Reading it as the operator is what puts it on the one path the operator already has,
+     * rather than on a second path that would have to be kept saying the same thing. */
+    private static Ast.Expr asOperator(Ast.Expr e) {
+        if (e instanceof Ast.Apply call && call.args().size() == 2) {
+            Ast.BinOp op = OPERATOR_CALLS.get(call.reaches());
+            if (op != null) {
+                return new Ast.Binary(op, call.args().get(0), call.args().get(1), call.pos());
+            }
+        }
+        return e;
+    }
+
     /** The shared affine walk: literals and {@code +}/{@code -} compose; every other node is handed to
      * {@code leaf} (which decides whether it is an atom, a resolved field, or opaque). */
-    private LinearForm affine(Ast.Expr e, Function<Ast.Expr, LinearForm> leaf) {
+    private LinearForm affine(Ast.Expr raw, Function<Ast.Expr, LinearForm> leaf) {
+        Ast.Expr e = asOperator(raw);
         return switch (e) {
+            // A call that folds is the number it folds to. `String.length("1A")` is 2, and a clause
+            // about it is decided rather than owed — the run-time check is not what should answer a
+            // question the compiler has already computed.
+            case Ast.Apply call when constantNumber(call) != null ->
+                    LinearForm.constant(constantNumber(call));
             case Ast.IntLit i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
             case Ast.DecimalLit dd -> LinearForm.constant(dd.value());
             case Ast.Neg n -> negate(affine(n.operand(), leaf));
@@ -1039,6 +1183,15 @@ public final class InvariantChecker {
             }
             default -> leaf.apply(e);
         };
+    }
+
+    /** The number {@code e} folds to at compile time, or {@code null} where it folds to none. */
+    private static BigDecimal constantNumber(Ast.Expr e) {
+        Object folded = ConstEval.eval(e).orElse(null);
+        if (folded instanceof Long n) {
+            return BigDecimal.valueOf(n);
+        }
+        return folded instanceof BigDecimal d ? d : null;
     }
 
     /** A linear form scaled by a constant, when one side is a bare constant (a scalar multiply); null
@@ -1073,6 +1226,10 @@ public final class InvariantChecker {
      * arithmetic result rather than a location; a chain read off it is a location either way. */
     private Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
         return n -> {
+            BigDecimal folded = clauseSizeConstant(n, binds);
+            if (folded != null) {
+                return LinearForm.constant(folded);
+            }
             String size = clauseSizeAtom(n, binds);
             if (size != null) {
                 return LinearForm.atom(size);
@@ -1102,6 +1259,25 @@ public final class InvariantChecker {
             return new Named(here, siteOf(binds));
         }
         return new Named(peel ? sizeSource(given) : given, binds.bodyKey());
+    }
+
+    /** The number a size call in a clause folds to once the construction's own expression stands where
+     * the clause wrote a field — {@code String.length(value)} over {@code Code("1A")} is 2 — or
+     * {@code null} where it folds to none. */
+    private BigDecimal clauseSizeConstant(Ast.Expr e, Bindings binds) {
+        if (!(e instanceof Ast.Apply call) || !SIZE_CALLS.contains(call.reaches())
+                || call.args().size() != 1) {
+            return null;
+        }
+        Ast.Expr arg = call.args().get(0);
+        Ast.Expr given = atSite(arg, binds);
+        Ast.Expr container = given == null ? arg : given;
+        // A list written out has as many elements as it is written with, whatever the elements are.
+        if (container instanceof Ast.ListLit list) {
+            return BigDecimal.valueOf(list.elements().size());
+        }
+        return constantNumber(new Ast.Apply(call.function(), List.of(container),
+                call.origin(), call.pos()));
     }
 
     /** The atom a size call in a clause names, or {@code null}. */
@@ -1152,6 +1328,12 @@ public final class InvariantChecker {
         if (size != null) {
             return size;
         }
+        // A conditional is a number this walk can name but cannot say a form for: which branch it
+        // takes is not decided here. It is that term and nothing is guaranteed of it, so a clause
+        // reading it is owed and a guard naming it settles it.
+        if (e instanceof Ast.If && isNumeric(typeExpr(e, scope))) {
+            return bodyKey(e, scope);
+        }
         return isNumeric(typeExpr(e, scope)) ? pathKey(e, scope) : null;
     }
 
@@ -1166,24 +1348,28 @@ public final class InvariantChecker {
      * itself, and a container built from one by an operation the table covers names that
      * construction. Anything else names nothing.
      *
-     * <p>The restriction is what ties the flagging to the rules. A value the check has no rule about
-     * — a string joined from parts, a number a helper returned — can be rendered, but nothing follows
-     * from rendering it, and reporting its construction would be reporting a possible violation the
-     * author has no reasonable guard for.
+     * <p>The restriction is what ties the flagging to what is said. A location is always named: the
+     * seeding writes about locations, so a clause reading one reads something. A container built by an
+     * operation the table covers is named, since the table is a rule about it. A computed value is
+     * named only where a guard on this path spoke about it — then, and only then, the author has
+     * stated something the clause can be read against, and leaving the construction unreported would
+     * be dropping what they said.
+     *
+     * <p>A computed value nothing has spoken about is named by nothing, and its construction is
+     * silent. That is this check's flagging policy and not a proof: the run-time check stands for the
+     * whole of such an invariant. Widening it is a matter of naming more values here, which is where
+     * a stated result type or a stdlib rule would enter.
      */
-    private String siteKey(Ast.Expr e, Scope scope) {
-        String path = pathKey(e, scope);
-        if (path != null) {
-            return path;
+    private String siteKey(Ast.Expr e, Scope scope, Known k) {
+        String located = locationKey(e, scope);
+        if (located != null) {
+            return located;
         }
-        if (e instanceof Ast.Apply call) {
-            Built built = BUILT_FROM.get(call.reaches());
-            if (built != null && built.from() < call.args().size()
-                    && siteKey(call.args().get(built.from()), scope) != null) {
-                return bodyKey(e, scope);
-            }
+        String term = bodyKey(e, scope);
+        if (term == null) {
+            return null;
         }
-        return null;
+        return namedByRule(e, scope) || k.speaksOf(term) ? term : null;
     }
 
     /** The atom key of {@code SIZE_CALL(container)} when {@code key} can name the container, else
@@ -1474,8 +1660,9 @@ public final class InvariantChecker {
      * through {@code site} and so is part of the term. Anything outside this grammar keys as
      * {@code null}, and the clause reading it is left opaque.
      */
-    private String termKey(Ast.Expr e, Function<Ast.Expr, String> site, Map<String, String> bound,
+    private String termKey(Ast.Expr raw, Function<Ast.Expr, String> site, Map<String, String> bound,
                            int depth) {
+        Ast.Expr e = asOperator(raw);
         String root = rootName(e);
         if (root != null) {
             String at = bound.get(root);
@@ -1604,10 +1791,94 @@ public final class InvariantChecker {
         return e instanceof Ast.FieldAccess fa ? chainOn(head, fa.target()) + "." + fa.field() : head;
     }
 
+    /** The location {@code e} is, or {@code null} where it is a computed value rather than a place.
+     * The same walk {@link #pathKey} makes, asking each name for a location instead of for whatever
+     * key it has — so a chain read off a computed value is computed too. */
+    private String locationKey(Ast.Expr e, Scope scope) {
+        return switch (e) {
+            case Ast.Var v -> scope.denotes(v.name()) instanceof Denotes.Location loc ? loc.key() : null;
+            case Ast.FieldAccess fa -> {
+                Type owner = typeExpr(fa.target(), scope);
+                if (fa.field().equals("value") && TypeOps.isSingleValueNewtype(owner, symbols)) {
+                    yield locationKey(fa.target(), scope);
+                }
+                String base = locationKey(fa.target(), scope);
+                yield base == null ? null : base + "." + fa.field();
+            }
+            default -> null;
+        };
+    }
+
+    /**
+     * What a binding's initializer denotes: the location it is where it is one, else the term it
+     * computes, else nothing. A name is an alias and never a value of its own — this is the one place
+     * that decides it, so an expression answers the same whether it was written where it is used or
+     * given a name first.
+     */
+    private Denotes denotationOf(Ast.Expr e, Scope scope) {
+        String located = locationKey(e, scope);
+        if (located != null) {
+            return new Denotes.Location(located);
+        }
+        String term = bodyKey(e, scope);
+        return term == null ? new Denotes.Nothing() : new Denotes.Term(term, namedByRule(e, scope));
+    }
+
+    /** Whether {@code e} is a container built by an operation the preservation table covers, over an
+     * argument that is itself named. */
+    private boolean builtByRule(Ast.Expr e, Scope scope) {
+        if (!(e instanceof Ast.Apply call)) {
+            return false;
+        }
+        Built built = BUILT_FROM.get(call.reaches());
+        return built != null && built.from() < call.args().size()
+                && namedByRule(call.args().get(built.from()), scope);
+    }
+
+    /**
+     * Whether {@code e} names something without a guard having to have spoken about it: it is read all
+     * the way down. A location is; so is a value composed of ones by a shape the term grammar reads —
+     * a concatenation, a conditional, arithmetic, a container the preservation table covers. A call
+     * the check has no rule about is not, and neither is anything built from one: nothing follows from
+     * naming it, and its construction is left to the run-time check.
+     */
+    private boolean namedByRule(Ast.Expr e, Scope scope) {
+        if (locationKey(e, scope) != null) {
+            return true;
+        }
+        if (e instanceof Ast.Var v) {
+            return scope.denotes(v.name()) instanceof Denotes.Term t && t.byRule();
+        }
+        Ast.Expr read = asOperator(e);
+        if (read instanceof Ast.Apply call && !readsAsATerm(call)) {
+            return builtByRule(read, scope);
+        }
+        // Arithmetic is the numeric domain's to name. Where the domain builds a form, that form is
+        // what a clause is read against; where it declines to — a variable product, an integer divide
+        // — declining is a decision about what this check reasons over, and reporting a construction
+        // it has decided not to reason over would be reporting the decision as the author's to fix.
+        if (read instanceof Ast.Binary bin && isArith(bin.op())) {
+            return false;
+        }
+        boolean[] all = {true};
+        // A closure is not part of what names the value: the tables are rules about how many elements
+        // there are and where they came from, and how each one is made has no bearing on either.
+        Ast.forEachChild(read, child -> all[0] = all[0]
+                && (child instanceof Ast.Block || namedByRule(child, scope)));
+        return all[0];
+    }
+
+    /** Whether the check has a rule about what a call answers, rather than only about how to render it. */
+    private static boolean readsAsATerm(Ast.Apply call) {
+        return SIZE_CALLS.contains(call.reaches()) || BUILT_FROM.containsKey(call.reaches())
+                || CARRIED.containsKey(call.reaches()) || QUANTIFIERS.contains(call.reaches())
+                || "Bool.not".equals(call.reaches());
+    }
+
     private String pathKey(Ast.Expr e, Scope scope) {
         return switch (e) {
             // a name given a location is that location, as a newtype's `.value` is its own
-            case Ast.Var v -> scope.locationOf(v.name());
+            case Ast.Var v -> scope.keyOf(v.name());
             case Ast.FieldAccess fa -> {
                 Type owner = typeExpr(fa.target(), scope);
                 if (fa.field().equals("value") && TypeOps.isSingleValueNewtype(owner, symbols)) {
@@ -1643,7 +1914,8 @@ public final class InvariantChecker {
 
     // --- a minimal local typer (enough for atom/affine detection) ------------------------------
 
-    private Type typeExpr(Ast.Expr e, Scope scope) {
+    private Type typeExpr(Ast.Expr raw, Scope scope) {
+        Ast.Expr e = asOperator(raw);
         return switch (e) {
             case Ast.IntLit _ -> Type.INT;
             case Ast.DecimalLit _ -> Type.DECIMAL;
@@ -1657,9 +1929,13 @@ public final class InvariantChecker {
             case Ast.LetIn li -> {
                 Type bound = typeExpr(li.value(), scope);
                 yield typeExpr(li.body(),
-                        scope.binding(li.name(), bound, pathKey(li.value(), scope)));
+                        scope.binding(li.name(), bound, denotationOf(li.value(), scope)));
             }
             case Ast.Neg n -> typeExpr(n.operand(), scope);
+            case Ast.If iff -> {
+                Type t = typeExpr(iff.then(), scope);
+                yield t != null ? t : typeExpr(iff.els(), scope);
+            }
             case Ast.Binary b when isArith(b.op()) -> arithType(b, scope);
             default -> null;
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -903,10 +903,12 @@ public final class InvariantChecker {
         if (under != null) {
             return obligations(under, binds, !positive);
         }
-        if (Boolean.TRUE.equals(decidedAt(inv, binds))) {
-            // The clause folds to true once the construction's own expressions stand where it wrote a
-            // field, so there is nothing to owe. A clause that folds to false is left to the constant
-            // check, which says which clause failed rather than only that one did.
+        Boolean folded = decidedAt(inv, binds);
+        if (folded != null && folded == positive) {
+            // The clause folds once the construction's own expressions stand where it wrote a field,
+            // and it folds the way it is being read. There is nothing to owe. Read under a negation
+            // it is the other answer that discharges, which is why the polarity is asked: folding to
+            // true under a denial is a violation and not a discharge.
             return List.of();
         }
         Constraint numeric = null;
@@ -1361,6 +1363,13 @@ public final class InvariantChecker {
      * a stated result type or a stdlib rule would enter.
      */
     private String siteKey(Ast.Expr e, Scope scope, Known k) {
+        // A value written out is not something a guard can be written about: there is nothing to
+        // state of `"xyz"` that the text does not already say. Where a clause reading it folds it is
+        // decided before this is asked, and where it does not fold there is no guard that would
+        // discharge it, so naming it here would only report what the author cannot answer.
+        if (isWritten(e)) {
+            return null;
+        }
         String located = locationKey(e, scope);
         if (located != null) {
             return located;
@@ -1822,6 +1831,12 @@ public final class InvariantChecker {
         }
         String term = bodyKey(e, scope);
         return term == null ? new Denotes.Nothing() : new Denotes.Term(term, namedByRule(e, scope));
+    }
+
+    /** Whether {@code e} is a value written out rather than computed from anything. */
+    private static boolean isWritten(Ast.Expr e) {
+        return e instanceof Ast.IntLit || e instanceof Ast.DecimalLit || e instanceof Ast.StringLit
+                || e instanceof Ast.BoolLit;
     }
 
     /** Whether {@code e} is a container built by an operation the preservation table covers, over an

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1330,12 +1330,6 @@ public final class InvariantChecker {
         if (size != null) {
             return size;
         }
-        // A conditional is a number this walk can name but cannot say a form for: which branch it
-        // takes is not decided here. It is that term and nothing is guaranteed of it, so a clause
-        // reading it is owed and a guard naming it settles it.
-        if (e instanceof Ast.If && isNumeric(typeExpr(e, scope))) {
-            return bodyKey(e, scope);
-        }
         return isNumeric(typeExpr(e, scope)) ? pathKey(e, scope) : null;
     }
 
@@ -1875,6 +1869,13 @@ public final class InvariantChecker {
         if (read instanceof Ast.Binary bin && isArith(bin.op())) {
             return false;
         }
+        // A conditional is one of its branches and which one is not decided here. Saying only that it
+        // is that term reports every construction over one, including where both branches satisfy the
+        // clause. Reading it is checking the construction on each branch under its own condition,
+        // which this walk does not do, so it is not named until it does.
+        if (read instanceof Ast.If) {
+            return false;
+        }
         boolean[] all = {true};
         // A closure is not part of what names the value: the tables are rules about how many elements
         // there are and where they came from, and how each one is made has no bearing on either.
@@ -1947,10 +1948,6 @@ public final class InvariantChecker {
                         scope.binding(li.name(), bound, denotationOf(li.value(), scope)));
             }
             case Ast.Neg n -> typeExpr(n.operand(), scope);
-            case Ast.If iff -> {
-                Type t = typeExpr(iff.then(), scope);
-                yield t != null ? t : typeExpr(iff.els(), scope);
-            }
             case Ast.Binary b when isArith(b.op()) -> arithType(b, scope);
             default -> null;
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -367,11 +367,12 @@ public final class InvariantChecker {
         record Location(String key) implements Denotes {}
 
         /**
-         * A value named by the expression that computes it. {@code byRule} is true where the check has
-         * a rule about how it was built — a container the preservation table covers — and that rule is
-         * what names it however it is reached; false where only a guard naming it can.
+         * A value named by the expression that computes it. {@code readable} is true where there is
+         * something to say of it however it is reached — a form the numeric domain built, or a rule
+         * about how it was made; false where only a guard naming it makes a clause readable against
+         * it.
          */
-        record Term(String key, boolean byRule) implements Denotes {}
+        record Term(String key, boolean readable) implements Denotes {}
 
         /** Nothing this check can name. */
         record Nothing() implements Denotes {
@@ -491,6 +492,20 @@ public final class InvariantChecker {
     // --- the walk ------------------------------------------------------------------------------
 
     private void walk(Ast.Expr e, Known k, Scope scope, int depth) {
+        Ast.If value = conditionalValueIn(e);
+        if (value != null && depth < BRANCHES_OPENED) {
+            // A conditional in a value position is one of its two branches, and which one is decided
+            // by its condition. So this is read once with each standing there, under that condition,
+            // and what the two readings find is said once. Every place a conditional can be given —
+            // to a field, to a name, to a guard — is this one place.
+            walk(value.cond(), k, scope, depth);
+            String same = bodyKey(value, scope);
+            say(reading(without(e, value, same, value.then(), scope),
+                            assumeCond(value.cond(), k, scope, true), scope, depth),
+                    reading(without(e, value, same, value.els(), scope),
+                            assumeCond(value.cond(), k, scope, false), scope, depth));
+            return;
+        }
         checkIfConstruction(e, k, scope, false);
         switch (e) {
             case Ast.If iff -> {
@@ -517,16 +532,6 @@ public final class InvariantChecker {
                 // there, so none of them is seeded with anything the attempt would have guaranteed.
                 ic.els().forEach(arm -> walk(arm.body(), k, scope, depth));
             }
-            case Ast.LetIn li when li.value() instanceof Ast.If iff && depth < BRANCHES_OPENED -> {
-                // The name is given one of the two, and which one is decided by the condition, so the
-                // body is read once with each standing there. The same reading a construction written
-                // over a conditional gets, moved to where the conditional was given a name.
-                walk(iff.cond(), k, scope, depth);
-                Known taken = assumeCond(iff.cond(), k, scope, true);
-                Known otherwise = assumeCond(iff.cond(), k, scope, false);
-                say(reading(li, iff.then(), taken, scope, depth),
-                        reading(li, iff.els(), otherwise, scope, depth));
-            }
             case Ast.LetIn li -> {
                 walk(li.value(), k, scope, depth);
                 Type vt = typeExpr(li.value(), scope);
@@ -534,8 +539,8 @@ public final class InvariantChecker {
                 // is recorded under that denotation and not under the spelling. Recording it under the
                 // name is what made a named subexpression a term of its own, answering differently
                 // from the very expression it was given.
-                Denotes what = denotationOf(li.value(), scope);
-                LinearForm vf = affineOf(li.value(), scope);
+                Denotes what = denotationOf(li.value(), scope, k);
+                LinearForm vf = affineOf(li.value(), scope, k);
                 Known k2 = rebind(k, li.name());
                 // A binding that denotes what it was given is an alias and introduces no value, so
                 // there is nothing to record of it: what holds of what it names already holds.
@@ -722,13 +727,13 @@ public final class InvariantChecker {
         switch (e) {
             case Ast.NewData nd when nd.spreads().isEmpty() -> {
                 if (symbols.get(nd.typeName().denotes()) instanceof Ast.Data type) {
-                    report(type, nd.pos(), attempted, verdictOf(nd, type, k, scope, 0));
+                    report(type, nd.pos(), attempted, verdictOf(nd, type, k, scope));
                 }
             }
             case Ast.Binary bin when isArith(bin.op()) -> {
                 if (typeExpr(bin, scope) instanceof Type.Ref r
                         && symbols.get(r.name()) instanceof Ast.Data type && type.newtype()) {
-                    LinearForm value = affineOf(bin, scope);
+                    LinearForm value = affineOf(bin, scope, k);
                     if (value != null) {
                         // an arithmetic result is a form, not a location, so it names no path
                         report(type, bin.pos(), attempted, verdictOf(r.name(), type,
@@ -742,33 +747,17 @@ public final class InvariantChecker {
     }
 
     /**
-     * The verdict for one construction, read on each branch of a conditional it is given. A field
-     * given {@code if c then a else b} is given one of the two, and which one is decided by
-     * {@code c}, so the construction is checked with each standing there under its own condition and
-     * answered by whichever answer is worse. Reading the conditional as a term of its own instead
-     * would say only that it is that term, which reports every construction over one — including
-     * where both branches satisfy the clause.
-     *
-     * <p>{@code depth} bounds how many conditionals are opened, since each doubles the paths.
+     * The verdict for one construction, over what each field is being given. A conditional never
+     * reaches here: the walk opens it before anything is checked, so what a field is given is a
+     * value and not a choice of two.
      */
-    private Verdict verdictOf(Ast.NewData nd, Ast.Data type, Known k, Scope scope, int depth) {
-        if (depth < BRANCHES_OPENED) {
-            for (int i = 0; i < nd.inits().size(); i++) {
-                if (nd.inits().get(i).value() instanceof Ast.If iff) {
-                    return Verdict.of(
-                            onBranch(withFieldValue(nd, i, iff.then()), type,
-                                    assumeCond(iff.cond(), k, scope, true), scope, depth),
-                            onBranch(withFieldValue(nd, i, iff.els()), type,
-                                    assumeCond(iff.cond(), k, scope, false), scope, depth));
-                }
-            }
-        }
+    private Verdict verdictOf(Ast.NewData nd, Ast.Data type, Known k, Scope scope) {
         Map<String, LinearForm> forms = new HashMap<>();
         Map<String, String> paths = new HashMap<>();
         Map<String, Ast.Expr> given = new HashMap<>();
         Function<Ast.Expr, String> bodyKey = value -> siteKey(value, scope, k);
         for (Ast.FieldInit fi : nd.inits()) {
-            LinearForm f = affineOf(fi.value(), scope);
+            LinearForm f = affineOf(fi.value(), scope, k);
             if (f != null) {
                 forms.put(fi.name(), f);
             }
@@ -781,21 +770,6 @@ public final class InvariantChecker {
         return verdictOf(nd.typeName().denotes(), type,
                 new Bindings(forms::get, paths::get, given::get, bodyKey,
                         TypeOps.fieldTypes(type, symbols)), k);
-    }
-
-    /** The verdict on one branch, which is none where the conditions along the way contradict. */
-    private Verdict onBranch(Ast.NewData nd, Ast.Data type, Known k, Scope scope, int depth) {
-        return k.numbers().isBottom() ? Verdict.UNREACHABLE
-                : verdictOf(nd, type, k, scope, depth + 1);
-    }
-
-    /** {@code nd} with the value at {@code at} replaced, everything else kept. */
-    private static Ast.NewData withFieldValue(Ast.NewData nd, int at, Ast.Expr value) {
-        List<Ast.FieldInit> inits = new ArrayList<>(nd.inits());
-        Ast.FieldInit was = inits.get(at);
-        inits.set(at, new Ast.FieldInit(was.name(), value, was.pos()));
-        return new Ast.NewData(nd.typeName(), List.copyOf(inits), nd.spreads(), nd.origin(),
-                nd.pos());
     }
 
     /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
@@ -946,15 +920,65 @@ public final class InvariantChecker {
      */
     private Map<SourcePos, Reported> capturing;
 
-    /** What reading the body with {@code branch} bound to the name finds, or nothing where the
-     * conditions along the way contradict — a branch nothing reaches finds nothing. */
-    private Map<SourcePos, Reported> reading(Ast.LetIn li, Ast.Expr branch, Known k, Scope scope,
-                                             int depth) {
+    /** What reading {@code e} finds, or nothing where the conditions along the way contradict — a
+     * branch nothing reaches finds nothing, and what is not there violates nothing. */
+    private Map<SourcePos, Reported> reading(Ast.Expr e, Known k, Scope scope, int depth) {
         if (k.numbers().isBottom()) {
             return Map.of();
         }
-        return found(() -> walk(new Ast.LetIn(li.binder(), branch, li.declaredType(), li.annotated(),
-                li.opens(), li.body(), li.pos()), k, scope, depth + 1));
+        return found(() -> walk(e, k, scope, depth + 1));
+    }
+
+    /**
+     * The first conditional {@code e} gives a value to, or {@code null} where it gives none. A
+     * conditional in tail position — an {@code if}'s own branches, a {@code let}'s body, a case's
+     * body — is where the walk goes next rather than a value it is handed, and a closure's body is
+     * read where the closure is applied.
+     */
+    private static Ast.If conditionalValueIn(Ast.Expr e) {
+        return switch (e) {
+            // Where the walk goes next is not a value it is handed: an `if`'s own branches, a `let`'s
+            // body and a case's body are read after this, each with what is known there.
+            case Ast.If iff -> conditionalIn(iff.cond());
+            case Ast.LetIn li -> conditionalIn(li.value());
+            case Ast.Match m -> conditionalIn(m.scrutinee());
+            default -> conditionalIn(e);
+        };
+    }
+
+    /** The first conditional inside a value. Everything under one is part of it, including the body
+     * of a binding an expansion introduced — {@code let $0 = r in if $0.a > b then ...} is a helper
+     * called on an argument, which is one value however many bindings writing it took. */
+    private static Ast.If conditionalIn(Ast.Expr e) {
+        if (e instanceof Ast.If iff) {
+            return iff;
+        }
+        if (e instanceof Ast.Block) {
+            return null;   // read where the closure is applied
+        }
+        Ast.If[] found = {null};
+        Ast.forEachChild(e, child -> {
+            if (found[0] == null) {
+                found[0] = conditionalIn(child);
+            }
+        });
+        return found[0];
+    }
+
+    /**
+     * {@code e} with every occurrence of {@code was} replaced by {@code becomes}. Occurrence is by
+     * what it computes and not by where it is written: an author who writes one conditional twice —
+     * once to guard on and once to build from — wrote one value, and reading the two as two would
+     * make the guard say nothing about what is built.
+     */
+    private Ast.Expr without(Ast.Expr e, Ast.If was, String key, Ast.Expr becomes, Scope scope) {
+        if (e == was || (key != null && key.equals(bodyKey(e, scope)))) {
+            return becomes;
+        }
+        if (e instanceof Ast.Block) {
+            return e;
+        }
+        return Ast.mapChildren(e, child -> without(child, was, key, becomes, scope), name -> name);
     }
 
     /** What {@code reading} finds, collected instead of said. */
@@ -1165,8 +1189,8 @@ public final class InvariantChecker {
         if (cond instanceof Ast.Binary b) {
             Rel rel = relOf(b.op());
             Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
-            LinearForm la = eff == null ? null : affineOf(b.left(), scope);
-            LinearForm ra = eff == null ? null : affineOf(b.right(), scope);
+            LinearForm la = eff == null ? null : affineOf(b.left(), scope, out);
+            LinearForm ra = eff == null ? null : affineOf(b.right(), scope, out);
             if (la != null && ra != null) {
                 out = out.with(out.numbers().assume(la.minus(ra), eff));
             }
@@ -1403,14 +1427,21 @@ public final class InvariantChecker {
 
     /** The affine form of a body expression: a numeric atom, a newtype construct's wrapped value, or
      * {@code null}. */
-    private LinearForm affineOf(Ast.Expr e, Scope scope) {
+    private LinearForm affineOf(Ast.Expr e, Scope scope, Known k) {
         return affine(e, n -> {
             if (n instanceof Ast.NewData nd && nd.spreads().isEmpty() && nd.inits().size() == 1
                     && nd.inits().get(0).name().equals("value")
                     && numericNewtype(Type.ref(nd.typeName().denotes()))) {
-                return affineOf(nd.inits().get(0).value(), scope);
+                return affineOf(nd.inits().get(0).value(), scope, k);
             }
-            String atom = atomOf(n, scope);
+            if (n instanceof Ast.LetIn li) {
+                // A binding an expansion introduced is read the way the walk reads one: the name is
+                // what it was given. Without that, a helper called on a record is opaque here while
+                // the body it expands to is not, and the call and its expansion disagree.
+                return affineOf(li.body(), scope.binding(li.name(),
+                        typeExpr(li.value(), scope), denotationOf(li.value(), scope, k)), k);
+            }
+            String atom = atomOf(n, scope, k);
             return atom == null ? null : LinearForm.atom(atom);
         });
     }
@@ -1518,12 +1549,22 @@ public final class InvariantChecker {
 
     /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value) or of
      * a size call over a nameable container, or {@code null} if {@code e} is neither. */
-    private String atomOf(Ast.Expr e, Scope scope) {
+    private String atomOf(Ast.Expr e, Scope scope, Known k) {
         String size = sizeAtom(e, arg -> bodyKey(arg, scope));
         if (size != null) {
             return size;
         }
-        return isNumeric(typeExpr(e, scope)) ? pathKey(e, scope) : null;
+        if (!isNumeric(typeExpr(e, scope))) {
+            return null;
+        }
+        // A path rooted at a name is the atom of what that name denotes, and only where a clause
+        // could be read against it — otherwise a name would be an atom where the expression it was
+        // given is not one, and the two spellings would answer differently.
+        String root = rootName(e);
+        if (root != null && !readable(scope.denotes(root), k)) {
+            return null;
+        }
+        return pathKey(e, scope);
     }
 
     /** A body expression's canonical key: a location names itself, and everything else is read
@@ -1557,15 +1598,8 @@ public final class InvariantChecker {
         if (isWritten(e)) {
             return null;
         }
-        String located = locationKey(e, scope);
-        if (located != null) {
-            return located;
-        }
-        String term = bodyKey(e, scope);
-        if (term == null) {
-            return null;
-        }
-        return namedByRule(e, scope) || k.speaksOf(term) ? term : null;
+        Denotes d = denotationOf(e, scope, k);
+        return readable(d, k) ? d.key() : null;
     }
 
     /** The atom key of {@code SIZE_CALL(container)} when {@code key} can name the container, else
@@ -2011,13 +2045,36 @@ public final class InvariantChecker {
      * that decides it, so an expression answers the same whether it was written where it is used or
      * given a name first.
      */
-    private Denotes denotationOf(Ast.Expr e, Scope scope) {
+    private Denotes denotationOf(Ast.Expr e, Scope scope, Known k) {
         String located = locationKey(e, scope);
         if (located != null) {
             return new Denotes.Location(located);
         }
         String term = bodyKey(e, scope);
-        return term == null ? new Denotes.Nothing() : new Denotes.Term(term, namedByRule(e, scope));
+        if (term == null) {
+            return new Denotes.Nothing();
+        }
+        // Readable where there is something to say of it: a form the numeric domain built, or a rule
+        // about how it was made. This is asked of the expression, so a name for it answers the same.
+        return new Denotes.Term(term,
+                affineOf(e, scope, k) != null || namedByRule(e, scope));
+    }
+
+    /**
+     * Whether a clause may be read against what {@code d} denotes. A location always may: the seeding
+     * writes about locations. A computed term may where something can be said of it, or where a guard
+     * on this path has said something. Nothing never may.
+     *
+     * <p>Every question of the form "is this value one a clause can be read against" asks this, and
+     * asking it of a name gives the same answer as asking it of the expression the name was bound to.
+     * That is what makes naming an expression not change what is known of it.
+     */
+    private static boolean readable(Denotes d, Known k) {
+        return switch (d) {
+            case Denotes.Location _ -> true;
+            case Denotes.Term term -> term.readable() || k.speaksOf(term.key());
+            case Denotes.Nothing _ -> false;
+        };
     }
 
     /**
@@ -2076,7 +2133,7 @@ public final class InvariantChecker {
             return true;
         }
         if (e instanceof Ast.Var v) {
-            return scope.denotes(v.name()) instanceof Denotes.Term t && t.byRule();
+            return scope.denotes(v.name()) instanceof Denotes.Term t && t.readable();
         }
         Ast.Expr read = asOperator(e);
         if (read instanceof Ast.Apply call && !readsAsATerm(call)) {
@@ -2165,9 +2222,13 @@ public final class InvariantChecker {
             case Ast.LetIn li -> {
                 Type bound = typeExpr(li.value(), scope);
                 yield typeExpr(li.body(),
-                        scope.binding(li.name(), bound, denotationOf(li.value(), scope)));
+                        scope.binding(li.name(), bound, denotationOf(li.value(), scope, Known.top())));
             }
             case Ast.Neg n -> typeExpr(n.operand(), scope);
+            // A size is a number whatever it counts, and this typer reads no signatures — without
+            // this a name bound to one has no type, and a name that has no type is not the atom the
+            // expression it was given is.
+            case Ast.Apply call when SIZE_CALLS.contains(call.reaches()) -> Type.INT;
             case Ast.Binary b when isArith(b.op()) -> arithType(b, scope);
             default -> null;
         };

--- a/souther-compiler/src/test/java/souther/compiler/CompileDischargeThroughAHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDischargeThroughAHelperTest.java
@@ -110,7 +110,7 @@ class CompileDischargeThroughAHelperTest {
     }
 
     @Test
-    void aBindingGivenSomethingThatIsNotALocationNamesItself() {
+    void aBindingGivenAConditionalIsThatConditional() {
         String m = """
                 module demo
                 data Qty = Int
@@ -125,7 +125,17 @@ class CompileDischargeThroughAHelperTest {
                     Qty(c)
                 }
                 """;
-        assertEquals(1, warnings(m), "a choice of two is neither of them");
+        // A conditional is one of its branches, and which one is not decided here. Naming it as a
+        // term of its own reported every construction over one, including where both branches satisfy
+        // the clause; leaving it unnamed reports none. Reading it is checking the construction on each
+        // branch under its own condition, which this walk does not do, so the run-time check stands
+        // for it. What is asked here is that the name answer as the expression does, either way.
+        assertEquals(warnings(m.replace("""
+                        {
+                    let c = if pick then cart.quantity else other.quantity
+                    Qty(c)
+                }""", "Qty(if pick then cart.quantity else other.quantity)")),
+                warnings(m), "the name answers as the conditional it was given does");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileDischargeThroughAHelperTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDischargeThroughAHelperTest.java
@@ -125,17 +125,18 @@ class CompileDischargeThroughAHelperTest {
                     Qty(c)
                 }
                 """;
-        // A conditional is one of its branches, and which one is not decided here. Naming it as a
-        // term of its own reported every construction over one, including where both branches satisfy
-        // the clause; leaving it unnamed reports none. Reading it is checking the construction on each
-        // branch under its own condition, which this walk does not do, so the run-time check stands
-        // for it. What is asked here is that the name answer as the expression does, either way.
-        assertEquals(warnings(m.replace("""
+        // A conditional is one of its branches, so the construction is read on each under its own
+        // condition: `cart.quantity` is at least one and `other.quantity` is not, so one branch
+        // leaves the clause unproven and that is the answer. What is asked here is that the name
+        // answer as the conditional it was given does.
+        String inline = m.replace("""
                         {
                     let c = if pick then cart.quantity else other.quantity
                     Qty(c)
-                }""", "Qty(if pick then cart.quantity else other.quantity)")),
-                warnings(m), "the name answers as the conditional it was given does");
+                }""", "Qty(if pick then cart.quantity else other.quantity)");
+        assertEquals(1, warnings(m), "one branch leaves the clause unproven");
+        assertEquals(warnings(inline), warnings(m),
+                "the name answers as the conditional it was given does");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -376,4 +376,40 @@ class CompileInvariantOneDenotationTest {
                         m.formatted("Count(if x > 0 then 0 - 1 else 5)"))),
                 warnings(c), "the name answers as the conditional does");
     }
+
+    @Test
+    void aConstructionWrittenInOneBranchIsNotDischargedByTheOther() {
+        // `Count(x)` is not in the other branch to be discharged there — it is not there at all
+        String m = """
+                module demo
+                data Count = Int
+                    invariant value >= 0
+                data Wrap = { c: Count }
+                behavior mk : (x: Int) -> Wrap
+                    constructs Wrap, Count
+                let mk (x) = Wrap { c = %s }
+                """;
+        assertEquals("E2010", assertThrows(CompileException.class,
+                        () -> Compiler.compile(m.formatted("if x < 0 then Count(x) else Count(5)")))
+                .diagnostic().code(), "the branch that reaches it decides it");
+    }
+
+    @Test
+    void aConstructionBesideAConditionalIsAnsweredOnItsOwn() {
+        // `R { v = 1 }` is outside the conditional, so how many values the branches build says
+        // nothing about it
+        String m = """
+                module demo
+                data Q = { v: Int }
+                    invariant v >= 10
+                data R = { v: Int }
+                    invariant v >= 10
+                data W = { a: Int, b: R }
+                behavior mk : (x: Int, y: Int) -> W
+                    constructs W, Q, R
+                let mk (x, y) = W { a = (if x > 0 then Q { v = y }.v else y), b = R { v = 1 } }
+                """;
+        assertEquals("E2010", assertThrows(CompileException.class, () -> Compiler.compile(m))
+                .diagnostic().code(), "1 is not 10 whichever branch is taken");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -6,6 +6,7 @@ import souther.compiler.diag.Severity;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -267,5 +268,39 @@ class CompileInvariantOneDenotationTest {
                                 Count(c)
                             } else Count(0)"""))),
                 "a name for a location is that location");
+    }
+
+    @Test
+    void aConstructionOneBranchSatisfiesIsNotRefuted() {
+        // the comprehension is one element or none, so the construction may violate and does not
+        // definitely violate — an error here would fail a build over a value that can be fine
+        String m = """
+                module demo
+                data Reasons = { why: List<Int> }
+                    invariant List.length(why) >= 1
+                behavior mk : (age: Int) -> Reasons
+                    constructs Reasons
+                let mk (age) = Reasons { why = [ 75 | age >= 75 ] }
+                """;
+        Compiler.Compiled c = Compiler.compileWithWarnings(m);
+        assertEquals(1, warnings(c), "possible, and not decided");
+        assertFalse(c.classes().isEmpty(), "a possible violation does not fail the build");
+    }
+
+    @Test
+    void aWrittenTableIsNotSomethingToGuard() {
+        // every row is there to read, and no guard an author could add says more about it
+        String m = """
+                module demo
+                data Row = { grade: Int }
+                data Table = List<Row>
+                    invariant List.allUniqueBy(.grade, value)
+                let row (n: Int) = Row { grade = n }
+                behavior mk : (x: Int) -> Table
+                    constructs Table, Row
+                let mk (x) = Table([ row(1), row(2), row(3) ])
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a table written into the source carries no guard");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -176,4 +176,49 @@ class CompileInvariantOneDenotationTest {
         assertEquals(1, warnings(Compiler.compileWithWarnings(named)), "stated, and still unproven");
         assertEquals(1, warnings(Compiler.compileWithWarnings(inline)), "the same written inline");
     }
+
+    @Test
+    void aClauseFoldsTheWayItIsRead() {
+        // read under a denial, folding to true is the violation and not the discharge
+        String m = """
+                module demo
+                data Pair = { lo: Int, hi: Int }
+                    invariant Bool.not(lo > hi)
+                behavior mk : (x: Int) -> Pair
+                    constructs Pair
+                let mk (x) = Pair { lo = 5, hi = 3 }
+                """;
+        assertEquals("E2010", assertThrows(CompileException.class, () -> Compiler.compile(m))
+                .diagnostic().code(), "5 > 3, and the clause denies it");
+    }
+
+    @Test
+    void aWrittenDecimalComparesByAmount() {
+        // 1.0m and 1.00m are one number, so `/=` of the two is false where it is constructed
+        String m = """
+                module demo
+                data Pair = { a: Decimal, b: Decimal }
+                    invariant a /= b
+                behavior mk : (x: Int) -> Pair
+                    constructs Pair
+                let mk (x) = Pair { a = 1.0m, b = 1.00m }
+                """;
+        assertEquals("E2010", assertThrows(CompileException.class, () -> Compiler.compile(m))
+                .diagnostic().code(), "scale is not part of what a decimal is");
+    }
+
+    @Test
+    void aWrittenValueIsNotSomethingToGuard() {
+        // nothing can be stated of `"xyz"` that the text does not say, so nothing is reported of it
+        String m = """
+                module demo
+                data Code = String
+                    invariant String.startsWith("x", value)
+                behavior mk : (x: Int) -> Code
+                    constructs Code
+                let mk (x) = Code("xyz")
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a written value carries no guard the author could add");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -412,4 +412,22 @@ class CompileInvariantOneDenotationTest {
         assertEquals("E2010", assertThrows(CompileException.class, () -> Compiler.compile(m))
                 .diagnostic().code(), "1 is not 10 whichever branch is taken");
     }
+
+    @Test
+    void oneBranchCallingAHelperMoreOftenDoesNotPairOffTheOthers() {
+        // both `Count`s are the helper body's one position, and only one branch reaches the first —
+        // which construction a reading found is the construction, not how many came before it
+        String m = """
+                module demo
+                data Count = Int
+                    invariant value >= 0
+                data Wrap = { a: Int, b: Count }
+                let count (n: Int) = Count(n)
+                behavior mk : (x: Int) -> Wrap
+                    constructs Wrap, Count
+                let mk (x) = Wrap { a = if x < 0 then count(x).value else x, b = count(1) }
+                """;
+        assertEquals("E2010", assertThrows(CompileException.class, () -> Compiler.compile(m))
+                .diagnostic().code(), "the negative branch decides the one it reaches");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -303,4 +303,77 @@ class CompileInvariantOneDenotationTest {
         assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
                 "a table written into the source carries no guard");
     }
+
+    @Test
+    void aClauseThatFoldsToFalseIsSaid() {
+        // the pattern and the value are both written, so whether it holds is computed, not owed
+        String m = """
+                module demo
+                data Zip = { code: String }
+                    invariant String.matches("[0-9][0-9]", code)
+                behavior bad : (x: Int) -> Zip
+                    constructs Zip
+                let bad (x) = Zip { code = "abc" }
+                """;
+        assertEquals("E2010", assertThrows(CompileException.class, () -> Compiler.compile(m))
+                .diagnostic().code(), "computed, and it does not hold");
+    }
+
+    @Test
+    void anAliasOfAComputedTermIsThatTerm() {
+        // `m` is `n` is `c.value + 1`, and copying a name must not drop what is known of it
+        String m = """
+                module demo
+                data Count = Int
+                    invariant value >= 0
+                data Positive = Int
+                    invariant value >= 1
+                behavior next : (c: Count) -> Positive
+                    constructs Positive
+                let next (c) = {
+                    let n = c.value + 1
+                    %s
+                }
+                """;
+        assertEquals(warnings(Compiler.compileWithWarnings(m.formatted("Positive(n)"))),
+                warnings(Compiler.compileWithWarnings(m.formatted("let m = n\n        Positive(m)"))),
+                "a name for a term is that term");
+    }
+
+    @Test
+    void aBranchNothingReachesSaysNothing() {
+        // under `x > 5` the inner test cannot hold, so what it would have built is not a value
+        String m = """
+                module demo
+                data Positive = Int
+                    invariant value >= 1
+                behavior mk : (x: Int) -> Positive
+                    constructs Positive
+                let mk (x) = if x > 5 then Positive(if x < 3 then 0 else 7) else Positive(9)
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a branch the conditions exclude is not one the value could have taken");
+    }
+
+    @Test
+    void aNamedConditionalOneBranchSatisfiesIsNotRefuted() {
+        // the two readings of the body are one construction, so they are answered together
+        String m = """
+                module demo
+                data Count = Int
+                    invariant value >= 0
+                behavior mk : (x: Int) -> Count
+                    constructs Count
+                let mk (x) = %s
+                """;
+        Compiler.Compiled c = Compiler.compileWithWarnings(m.formatted("""
+                {
+                        let n = if x > 0 then 0 - 1 else 5
+                        Count(n)
+                    }"""));
+        assertEquals(1, warnings(c), "possible, and not decided");
+        assertEquals(warnings(Compiler.compileWithWarnings(
+                        m.formatted("Count(if x > 0 then 0 - 1 else 5)"))),
+                warnings(c), "the name answers as the conditional does");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -221,4 +221,51 @@ class CompileInvariantOneDenotationTest {
         assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
                 "a written value carries no guard the author could add");
     }
+
+    private static final String CLAMP = """
+            module demo
+            data Count = Int
+                invariant value >= 0
+            behavior mk : (x: Int) -> Count
+                constructs Count
+            let mk (x) = %s
+            """;
+
+    @Test
+    void aConstructionOverAConditionalIsReadOnEachBranch() {
+        // x is at least one where the condition holds, and the other branch is zero, so both satisfy
+        assertEquals(0, warnings(Compiler.compileWithWarnings(
+                        CLAMP.formatted("Count(if x > 0 then x else 0)"))),
+                "each branch discharges under its own condition");
+    }
+
+    @Test
+    void namingAConditionalDoesNotChangeWhatIsKnownOfIt() {
+        assertEquals(warnings(Compiler.compileWithWarnings(
+                        CLAMP.formatted("Count(if x > 0 then x else 0)"))),
+                warnings(Compiler.compileWithWarnings(CLAMP.formatted("""
+                        {
+                                let c = if x > 0 then x else 0
+                                Count(c)
+                            }"""))),
+                "the name answers as the conditional does");
+    }
+
+    @Test
+    void aConstructionEveryBranchViolatesIsRefuted() {
+        assertEquals("E2010", assertThrows(CompileException.class,
+                        () -> Compiler.compile(CLAMP.formatted("Count(if x > 0 then 0 - 1 else 0 - 2)")))
+                .diagnostic().code(), "neither branch can satisfy it");
+    }
+
+    @Test
+    void anAliasKeepsWhatTheGuardSaidOfWhatItNames() {
+        // `c` is `x`, so the condition bounding x bounds it; copying it must not drop that
+        assertEquals(0, warnings(Compiler.compileWithWarnings(CLAMP.formatted("""
+                        if x > 0 then {
+                                let c = x
+                                Count(c)
+                            } else Count(0)"""))),
+                "a name for a location is that location");
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -1,0 +1,179 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * One expression, one answer, however it is written. The invariant-discharge check reads a value
+ * through what it denotes rather than through the shape it was typed in, so the function form of an
+ * operator is that operator, and naming a subexpression with a {@code let} does not change what is
+ * known about it.
+ */
+class CompileInvariantOneDenotationTest {
+
+    private static long warnings(Compiler.Compiled c) {
+        return c.warnings().stream().filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    @Test
+    void theFunctionFormOfAnOperatorIsRefutedWhereTheOperatorIs() {
+        // 0 - 1 is negative — the same definite violation the operator spelling is an error for
+        String m = """
+                module demo
+                data Money = Decimal
+                    invariant value >= 0m
+                behavior calc : (m: Money) -> Money
+                    constructs Money
+                let calc (m) = Money(Decimal.subtract(0m, 1m))
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(m));
+        assertEquals("E2010", e.diagnostic().code(),
+                "Decimal.subtract is `-`, so the violation is decided: " + e.getMessage());
+    }
+
+    @Test
+    void theFunctionFormOfAnOperatorDischargesWhereTheOperatorDoes() {
+        // b >= a, so b - a is non-negative and the re-wrap needs no guard
+        String m = """
+                module demo
+                data Money = Decimal
+                    invariant value >= 0m
+                data Pair = { a: Money, b: Money }
+                    invariant a <= b
+                behavior diff : (p: Pair) -> Money
+                    constructs Money
+                let diff (p) = Money(Decimal.subtract(p.b.value, p.a.value))
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "the reified relation discharges the function form as it does the operator");
+    }
+
+    @Test
+    void theFunctionFormOfAnAdditionIsThatAddition() {
+        String m = """
+                module demo
+                data Money = Decimal
+                    invariant value >= 0m
+                data Pair = { a: Money, b: Money }
+                behavior total : (p: Pair) -> Money
+                    constructs Money
+                let total (p) = Money(Decimal.add(p.a.value, p.b.value))
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "a sum of non-negatives is non-negative, written either way");
+    }
+
+    @Test
+    void aVariableProductIsNotRead() {
+        // `x * y` is not affine, and neither is its function form — nothing is proven either way
+        String m = """
+                module demo
+                data Count = Int
+                    invariant value >= 0
+                data Pair = { a: Count, b: Count }
+                behavior area : (p: Pair) -> Count
+                    constructs Count
+                let area (p) = Count(Int.multiply(p.a.value, p.b.value))
+                """;
+        assertEquals(warnings(Compiler.compileWithWarnings(m.replace(
+                        "Int.multiply(p.a.value, p.b.value)", "p.a.value * p.b.value"))),
+                warnings(Compiler.compileWithWarnings(m)),
+                "a variable product answers the same in both spellings");
+    }
+
+    @Test
+    void aScalarProductIsThatProduct() {
+        String m = """
+                module demo
+                data Count = Int
+                    invariant value >= 0
+                behavior twice : (c: Count) -> Count
+                    constructs Count
+                let twice (c) = Count(Int.multiply(2, c.value))
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "twice a non-negative is non-negative");
+    }
+
+    private static final String EACHES = """
+            module demo
+            data Eaches = Int
+                invariant value >= 0
+            data PackSize = Int
+                invariant value >= 1
+            behavior leftover : (eaches: Eaches, pack: PackSize) -> Eaches
+                constructs Eaches
+            let leftover (eaches, pack) = %s
+            """;
+
+    @Test
+    void namingACallDoesNotChangeWhatIsKnownOfIt() {
+        // the call is the same call either way, so the construction from it answers the same
+        assertEquals(warnings(Compiler.compileWithWarnings(
+                        EACHES.formatted("Eaches(Int.modBy(pack.value, eaches.value))"))),
+                warnings(Compiler.compileWithWarnings(EACHES.formatted("""
+                        {
+                                let n = Int.modBy(pack.value, eaches.value)
+                                Eaches(n)
+                            }"""))),
+                "inline and named answer alike");
+    }
+
+    @Test
+    void aCallNothingHasSpokenAboutIsSilent() {
+        assertEquals(0, warnings(Compiler.compileWithWarnings(
+                        EACHES.formatted("Eaches(Int.modBy(pack.value, eaches.value))"))),
+                "nothing is known of the call, so its construction is left to the run-time check");
+    }
+
+    private static final String GUARDED = """
+            module demo
+            data %s = Int
+                invariant value >= %d
+            data PackSize = Int
+                invariant value >= 1
+            data Odd = { why: Int }
+            behavior f : (n: Int, pack: PackSize) -> %s | Odd
+                constructs %s, Odd
+            let f (n, pack) = {
+                %s
+            }
+            """;
+
+    private static String guarded(String type, int bound, String body) {
+        return GUARDED.formatted(type, bound, type, type, body);
+    }
+
+    @Test
+    void aGuardOnACallDischargesWhatItEstablishes() {
+        String named = guarded("Eaches", 0, """
+                let n = Int.modBy(pack.value, n)
+                    guard n >= 0 else Odd { why = n }
+                    Eaches(n)""");
+        String inline = guarded("Eaches", 0, """
+                guard Int.modBy(pack.value, n) >= 0 else Odd { why = 0 }
+                    Eaches(Int.modBy(pack.value, n))""");
+        assertEquals(0, warnings(Compiler.compileWithWarnings(named)), "the guard establishes it");
+        assertEquals(0, warnings(Compiler.compileWithWarnings(inline)),
+                "and establishes it written inline too");
+    }
+
+    @Test
+    void aGuardOnACallLeavesWhatItDoesNotEstablishReported() {
+        // `>= 0` is stated and `>= 1` is owed — expressible, and unproven, in both spellings
+        String named = guarded("AtLeastOne", 1, """
+                let n = Int.modBy(pack.value, n)
+                    guard n >= 0 else Odd { why = n }
+                    AtLeastOne(n)""");
+        String inline = guarded("AtLeastOne", 1, """
+                guard Int.modBy(pack.value, n) >= 0 else Odd { why = 0 }
+                    AtLeastOne(Int.modBy(pack.value, n))""");
+        assertEquals(1, warnings(Compiler.compileWithWarnings(named)), "stated, and still unproven");
+        assertEquals(1, warnings(Compiler.compileWithWarnings(inline)), "the same written inline");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileNamingAnExpressionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNamingAnExpressionTest.java
@@ -57,11 +57,6 @@ class CompileNamingAnExpressionTest {
             let mk (c, p, n, xs) = %s
             """;
 
-    /** How the same expression is written: in place, given a name, and given a name for that name. */
-    private static String inline(String e) {
-        return e;
-    }
-
     private static String named(String e) {
         return "{\n        let v = " + e + "\n        %s\n    }";
     }
@@ -106,7 +101,7 @@ class CompileNamingAnExpressionTest {
     @MethodSource("rows")
     void namingAnExpressionDoesNotChangeWhatIsKnownOfIt(Row row) {
         String construct = row.target() + "(%s)";
-        String written = said(module(row.target(), construct.formatted(inline(row.expression()))));
+        String written = said(module(row.target(), construct.formatted(row.expression())));
         String bound = said(module(row.target(),
                 named(row.expression()).formatted(construct.formatted("v"))));
         assertEquals(written, bound, "a name for the expression is that expression");
@@ -116,7 +111,7 @@ class CompileNamingAnExpressionTest {
     @MethodSource("rows")
     void aChainOfNamesEndsAtTheExpression(Row row) {
         String construct = row.target() + "(%s)";
-        String written = said(module(row.target(), construct.formatted(inline(row.expression()))));
+        String written = said(module(row.target(), construct.formatted(row.expression())));
         String chained = said(module(row.target(), "{\n        let v = " + row.expression()
                 + "\n        let w = v\n        let y = w\n        " + construct.formatted("y")
                 + "\n    }"));
@@ -138,5 +133,54 @@ class CompileNamingAnExpressionTest {
                 .replace("constructs " + row.target(), "constructs " + row.target() + ", Small")
                 .replace("-> " + row.target(), "-> " + row.target() + " | Small"));
         assertEquals(written, bound, "one value, one guard, one answer");
+    }
+
+    /** Values written into the source rather than computed: what a name for one has to carry is not
+     * a key but the text, since what a clause reading it says is decided by folding that text. */
+    private static final List<String> WRITTEN = List.of(
+            "Code(%s)|\"12\"",
+            "Code(%s)|\"ab\"",
+            "Table(%s)|[ Row { grade = 1 }, Row { grade = 2 } ]",
+            "Table(%s)|[ ]",
+            "Wrapped(%s)|Row { grade = 1 }",
+            "Wrapped(%s)|row(1)");
+
+    private static final String WRITTEN_MODULE = """
+            module demo
+            data Code = String
+                invariant String.matches("[0-9][0-9]", value)
+            data Row = { grade: Int }
+            data Table = List<Row>
+                invariant List.length(value) >= 1
+            data Wrapped = { of: Row }
+                invariant of.grade >= 1
+            let row (n: Int) = Row { grade = n }
+            behavior mk : (x: Int) -> %s
+                constructs Code, Table, Wrapped, Row
+            let mk (x) = %s
+            """;
+
+    private static List<String> written() {
+        return WRITTEN;
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("written")
+    void namingAWrittenValueDoesNotChangeWhatIsKnownOfIt(String row) {
+        String construct = row.split("\\|")[0];
+        String value = row.split("\\|")[1];
+        String target = construct.substring(0, construct.indexOf('('));
+        String inline = WRITTEN_MODULE.formatted(target, construct.formatted(value));
+        String bound = WRITTEN_MODULE.formatted(target,
+                "{\n        let v = " + value + "\n        " + construct.formatted("v") + "\n    }");
+        assertEquals(kindOf(said(inline)), kindOf(said(bound)),
+                "a name for a written value carries what was written");
+    }
+
+    /** Whether it was an error or not. Which check named the error is not what is being fixed here:
+     * a construction from a value written where it is built is the constant check's to report, and
+     * one from a name for that value is this check's, and they word it differently. */
+    private static String kindOf(String said) {
+        return said.startsWith("warnings=") ? said : "error";
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileNamingAnExpressionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNamingAnExpressionTest.java
@@ -1,0 +1,142 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Naming an expression does not change what is known about it. This is the property the
+ * invariant-discharge check is built on rather than an example of it: whatever the check answers for
+ * a construction from an expression, it answers the same for a construction from a name bound to
+ * that expression, and from a name bound to that name.
+ *
+ * <p>Each expression is put through every shape against every target, and the shapes are required to
+ * agree with each other — not to give any particular answer. What the check can prove is free to
+ * change; that it proves the same thing of one value written two ways is not.
+ */
+class CompileNamingAnExpressionTest {
+
+    /** The expressions a construction is given, one per row, over the inputs {@link #MODULE} binds. */
+    private static final List<String> EXPRESSIONS = List.of(
+            "c.value",                              // a location
+            "c.value + 1",                          // affine over one
+            "c.value * 2",                          // a scalar product
+            "c.value * n",                          // a variable product, outside the fragment
+            "c.value / 2",                          // an integer divide, outside it too
+            "Int.add(c.value, 1)",                  // the function form of an operator
+            "Int.subtract(c.value, 1)",
+            "Int.modBy(p.value, c.value)",          // a call the check has no rule about
+            "Int.max(0, c.value)",
+            "Int.modBy(p.value, c.value) + 1",      // one inside arithmetic
+            "if n > 0 then c.value else 0",         // a conditional over locations
+            "if n > 0 then c.value else n",         // one branch bounded and one not
+            "5",                                    // written out
+            "List.length(xs)",                      // a size
+            "List.length(List.filter(x -> x > 0, xs))");
+
+    /** The types constructed from them: one every non-negative value satisfies, one that wants more. */
+    private static final List<String> TARGETS = List.of("Count", "Positive");
+
+    private static final String MODULE = """
+            module demo
+            data Count = Int
+                invariant value >= 0
+            data Positive = Int
+                invariant value >= 1
+            data Small = Int
+                invariant value >= 0
+            behavior mk : (c: Count, p: Positive, n: Int, xs: List<Int>) -> %s
+                constructs %s
+            let mk (c, p, n, xs) = %s
+            """;
+
+    /** How the same expression is written: in place, given a name, and given a name for that name. */
+    private static String inline(String e) {
+        return e;
+    }
+
+    private static String named(String e) {
+        return "{\n        let v = " + e + "\n        %s\n    }";
+    }
+
+    /** What the check says, as one string — the code of an error, or how many warnings. */
+    private static String said(String source) {
+        try {
+            Compiler.Compiled c = Compiler.compileWithWarnings(source);
+            return "warnings=" + c.warnings().stream()
+                    .filter(d -> d.severity() == Severity.WARNING).count();
+        } catch (CompileException e) {
+            String code = e.diagnostic().code();
+            return code == null ? "error: " + e.getMessage() : code;
+        } catch (RuntimeException e) {
+            return "raised: " + e.getMessage();
+        }
+    }
+
+    private static String module(String target, String body) {
+        return MODULE.formatted(target, target, body);
+    }
+
+    private record Row(String expression, String target) {
+
+        @Override
+        public String toString() {
+            return target + "(" + expression + ")";
+        }
+    }
+
+    private static List<Row> rows() {
+        List<Row> rows = new ArrayList<>();
+        for (String e : EXPRESSIONS) {
+            for (String target : TARGETS) {
+                rows.add(new Row(e, target));
+            }
+        }
+        return rows;
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("rows")
+    void namingAnExpressionDoesNotChangeWhatIsKnownOfIt(Row row) {
+        String construct = row.target() + "(%s)";
+        String written = said(module(row.target(), construct.formatted(inline(row.expression()))));
+        String bound = said(module(row.target(),
+                named(row.expression()).formatted(construct.formatted("v"))));
+        assertEquals(written, bound, "a name for the expression is that expression");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("rows")
+    void aChainOfNamesEndsAtTheExpression(Row row) {
+        String construct = row.target() + "(%s)";
+        String written = said(module(row.target(), construct.formatted(inline(row.expression()))));
+        String chained = said(module(row.target(), "{\n        let v = " + row.expression()
+                + "\n        let w = v\n        let y = w\n        " + construct.formatted("y")
+                + "\n    }"));
+        assertEquals(written, chained, "each name is what it was given, down the chain");
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("rows")
+    void aGuardOnTheExpressionReadsTheSameAsAGuardOnItsName(Row row) {
+        // The guard states the same thing of the same value either way, so it settles the same clause
+        String construct = row.target() + "(%s)";
+        String written = said(module(row.target(), "{\n        guard (" + row.expression()
+                + ") >= 1 else Small(0)\n        " + construct.formatted(row.expression()) + "\n    }")
+                .replace("constructs " + row.target(), "constructs " + row.target() + ", Small")
+                .replace("-> " + row.target(), "-> " + row.target() + " | Small"));
+        String bound = said(module(row.target(), "{\n        let v = " + row.expression()
+                + "\n        guard v >= 1 else Small(0)\n        " + construct.formatted("v")
+                + "\n    }")
+                .replace("constructs " + row.target(), "constructs " + row.target() + ", Small")
+                .replace("-> " + row.target(), "-> " + row.target() + " | Small"));
+        assertEquals(written, bound, "one value, one guard, one answer");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileNamingAnExpressionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNamingAnExpressionTest.java
@@ -75,6 +75,12 @@ class CompileNamingAnExpressionTest {
         }
     }
 
+    /** {@code source} with the guard's departure added to what the behavior answers and builds. */
+    private static String departing(String target, String source) {
+        return said(source.replace("constructs " + target, "constructs " + target + ", Small")
+                .replace("-> " + target, "-> " + target + " | Small"));
+    }
+
     private static String module(String target, String body) {
         return MODULE.formatted(target, target, body);
     }
@@ -123,15 +129,12 @@ class CompileNamingAnExpressionTest {
     void aGuardOnTheExpressionReadsTheSameAsAGuardOnItsName(Row row) {
         // The guard states the same thing of the same value either way, so it settles the same clause
         String construct = row.target() + "(%s)";
-        String written = said(module(row.target(), "{\n        guard (" + row.expression()
-                + ") >= 1 else Small(0)\n        " + construct.formatted(row.expression()) + "\n    }")
-                .replace("constructs " + row.target(), "constructs " + row.target() + ", Small")
-                .replace("-> " + row.target(), "-> " + row.target() + " | Small"));
-        String bound = said(module(row.target(), "{\n        let v = " + row.expression()
-                + "\n        guard v >= 1 else Small(0)\n        " + construct.formatted("v")
-                + "\n    }")
-                .replace("constructs " + row.target(), "constructs " + row.target() + ", Small")
-                .replace("-> " + row.target(), "-> " + row.target() + " | Small"));
+        String written = departing(row.target(), module(row.target(), "{\n        guard ("
+                + row.expression() + ") >= 1 else Small(0)\n        "
+                + construct.formatted(row.expression()) + "\n    }"));
+        String bound = departing(row.target(), module(row.target(), "{\n        let v = "
+                + row.expression() + "\n        guard v >= 1 else Small(0)\n        "
+                + construct.formatted("v") + "\n    }"));
         assertEquals(written, bound, "one value, one guard, one answer");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ConstEvalMatchBudgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ConstEvalMatchBudgetTest.java
@@ -1,0 +1,45 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.SourcePos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Folding {@code String.matches} answers where answering is cheap and declines where it is not. A
+ * backtracking engine recurses over its subject, and the walk that asks this fails open on a
+ * {@code RuntimeException} — which a {@code StackOverflowError} is not — so an unbounded attempt
+ * would end the compilation rather than the fold.
+ */
+class ConstEvalMatchBudgetTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static Optional<Object> fold(String pattern, String subject) {
+        return ConstEval.eval(new Ast.Apply("String.matches",
+                List.of(new Ast.StringLit(pattern, POS), new Ast.StringLit(subject, POS)), POS));
+    }
+
+    @Test
+    void aPatternOverAWrittenSubjectFolds() {
+        assertEquals(Optional.of(true), fold("[0-9][A-E]", "1A"));
+        assertEquals(Optional.of(false), fold("[0-9][A-E]", "zz"));
+    }
+
+    @Test
+    void aSubjectTheEngineWouldRecurseOverIsLeftToTheRunTime() {
+        String subject = "a".repeat(100_000);
+        assertThrows(StackOverflowError.class,
+                () -> java.util.regex.Pattern.matches("(a|b)*", subject),
+                "the engine recurses over its subject, which is what the budget is for");
+        assertTrue(fold("(a|b)*", subject).isEmpty(),
+                "declined rather than answered, and the compilation goes on");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ConstEvalMatchBudgetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ConstEvalMatchBudgetTest.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -34,12 +33,9 @@ class ConstEvalMatchBudgetTest {
     }
 
     @Test
-    void aSubjectTheEngineWouldRecurseOverIsLeftToTheRunTime() {
-        String subject = "a".repeat(100_000);
-        assertThrows(StackOverflowError.class,
-                () -> java.util.regex.Pattern.matches("(a|b)*", subject),
-                "the engine recurses over its subject, which is what the budget is for");
-        assertTrue(fold("(a|b)*", subject).isEmpty(),
+    void aSubjectPastTheBudgetIsLeftToTheRunTime() {
+        // Far past what the budget allows the engine to read, and far past what it can recurse over
+        assertTrue(fold("(a|b)*", "a".repeat(100_000)).isEmpty(),
                 "declined rather than answered, and the compilation goes on");
     }
 }


### PR DESCRIPTION
Closes #290 (needs closing by hand after merge, as this targets `develop`).

The discharge check read a value through the shape it was written in rather than
through what it denotes. The same construction from the same expression was
answered two ways: written inline it was silent, bound to a `let` and constructed
from afterwards it warned. The form that warned was the readable one, and the
silence on the other was not a proof.

## What changes

A name is an alias and never a value of its own. A scope binding says which of
four things a name denotes -- a location, a term named by what computes it, a
value written out, or nothing -- and one place decides which, so a `let` cannot
answer differently from the expression it was given. A binding that denotes what
it was given records nothing: what holds of it already holds, and recording it
anyway assigned that name its own form, which dropped what a guard had said.

Whether a clause may be read against a value is asked once. A location always
may; a computed term may where there is something to say of it, or where a guard
on this path has said something; a written value never does, and nothing never
does. Every question of that form -- what a construction is given, what a name
denotes, what a guard states, what atom the domain reasons over -- asks it, so
asking it of a name gives the same answer as asking it of the expression.

Rules follow, each about one thing:

- **A library call written as a function is the operator it is.** `Int.add`
  reaches the kernel `+` emits, in the same argument order, so the two spellings
  are one term and one form.
- **Arithmetic is the numeric domain's to name.** Where the domain declines to
  build a form -- a variable product, an integer divide -- declining is a decision
  about what this check reasons over, and reporting a construction it has decided
  not to reason over would be reporting that decision as the author's to fix.
- **A conditional in a value position is opened in one place.** The walk opens
  the first one it is handed before anything is checked, replacing every
  occurrence of it -- occurrence by what it computes, since an author who writes
  one conditional twice wrote one value -- and says of each construction what the
  two readings decide. A construction only one reading reached is what that
  reading found: a branch that did not build it did not discharge it.
- **A written value is not something to guard.** A literal, a written list, a
  construction from written parts, and a helper called on them: every part is
  there to read and no guard says more about it. What it is travels with a name
  for it, so a clause reading one folds over what was written wherever the
  writing was done.
- **A clause that folds at the construction is decided, not owed.** It folds the
  way it is being read: under a denial, folding to true is the violation and not
  the discharge.

`check` returns what it found rather than reporting it, so branches can be
answered together: discharged, unproven, or proven to fail on a path that is
reached. Which construction a reading found is carried by the rewrite that made
the reading, not worked out from where it is written.

`ConstEval` folds Int arithmetic with the kernels the operators emit -- an
overflow folds to nothing rather than wrapping -- compares decimals by amount
rather than by how they were written, gains `String.matches` over written
arguments, and hands the subject to the regex engine through a reader that stops
it past a budget.

## The property, as a test

`CompileNamingAnExpressionTest` puts sixteen expressions -- locations, arithmetic
inside and outside the linear fragment, operator-form calls, opaque calls,
conditionals, sizes -- and six written values through every shape: written in
place, given a name, given a name for that name, and guarded either way. It fixes
that the shapes agree, not what they agree on. It failed on twenty of ninety rows
when it was written.

## Effect

Measured against a clean checkout of `souther-lang/examples` at 8f02925, with
both builds succeeding: the reported invariants go from 19 to 13, none added.

2165/2165 compiler tests pass at 601641e0.

## Not in this change

Stating what a stdlib operation's result ranges over; it belongs with tightening
the library's own signatures rather than with a table in the checker. Folding a
record or a list element-wise. `NumericDomain` reading a seeded bound when it
decides whether a path is feasible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
