### PR TITLE
A format rule says what a value looks like, so one can be written

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -51,9 +51,27 @@ public record FixtureTemplate(String text, Ast.Expr value) {
                 value.signum() < 0 ? new Ast.Neg(literal, NOWHERE) : literal);
     }
 
+    /**
+     * A string, written the way the language reads one back.
+     *
+     * <p>Every escape a string literal has, because a row is offered as text to paste into a model and
+     * has to come back as the value it was made from. A tab or a newline written as itself would end
+     * the line the row is on as well.
+     */
     public static FixtureTemplate string(String value) {
-        return new FixtureTemplate("\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"",
-                new Ast.StringLit(value, NOWHERE));
+        StringBuilder written = new StringBuilder("\"");
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\' -> written.append("\\\\");
+                case '"' -> written.append("\\\"");
+                case '\n' -> written.append("\\n");
+                case '\t' -> written.append("\\t");
+                case '\r' -> written.append("\\r");
+                default -> written.append(c);
+            }
+        }
+        return new FixtureTemplate(written.append('"').toString(), new Ast.StringLit(value, NOWHERE));
     }
 
     public static FixtureTemplate bool(boolean value) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -60,6 +60,17 @@ public record FixtureTemplate(String text, Ast.Expr value) {
         return new FixtureTemplate(Boolean.toString(value), new Ast.BoolLit(value, NOWHERE));
     }
 
+    /** A date, written the way a row writes one: the constructor applied to an ISO 8601 string. */
+    public static FixtureTemplate date(String iso) {
+        return new FixtureTemplate("Date(\"" + iso + "\")",
+                new Ast.Apply("Date", List.of(new Ast.StringLit(iso, NOWHERE)), NOWHERE));
+    }
+
+    public static FixtureTemplate dateTime(String iso) {
+        return new FixtureTemplate("DateTime(\"" + iso + "\")",
+                new Ast.Apply("DateTime", List.of(new Ast.StringLit(iso, NOWHERE)), NOWHERE));
+    }
+
     /** The absent optional, which the language names rather than any module. */
     public static FixtureTemplate none() {
         return new FixtureTemplate("None",

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -9,9 +9,12 @@ import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;
 
 import java.math.BigDecimal;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -35,9 +38,10 @@ public final class Generator {
 
     /** How many rows one call will write. Past this the output stops being something a person reads
      * and pastes, and a model that wants more than this has axes it should be measured at fewer of. */
-    /** How many candidates one position is asked for. A rule can only put so many values in front of
-     * a position, and a model that put more there than this is one whose row nobody would read. */
-    private static final int MAX_CANDIDATES = 16;
+    /** How many assignments of values one row is tried at. The choices multiply, so this is a bound on
+     * the search and not on any one position — and reaching it is reported as the search having
+     * stopped, which is a different thing from every assignment having been refused. */
+    private static final int MAX_TUPLES = 256;
 
     static final int MAX_ROWS = 200;
 
@@ -247,15 +251,20 @@ public final class Generator {
                         UnresolvedCombination.Reason.NO_REPRESENTATIVE));
                 continue;
             }
-            Map<String, FixtureTemplate> byPath = new LinkedHashMap<>();
-            byPath.put(axis.path().toString(), at);
-            Composed composed = attempts(subject, check, 1, _ -> byPath);
-            if (composed.inputs() == null) {
-                unresolved.add(new UnresolvedCombination(List.of(label), composed.reason(),
-                        composed.detail()));
+            Choices choices = choicesOf(subject,
+                    Map.of(axis.path().toString(), List.of(at)));
+            if (choices.missingAt() != null) {
+                unresolved.add(new UnresolvedCombination(List.of(label),
+                        UnresolvedCombination.Reason.NO_REPRESENTATIVE, choices.missingAt()));
                 continue;
             }
-            rows.add(new GeneratedRow(List.of(label), composed.inputs()));
+            Outcome tried = walk(subject, choices, check);
+            if (tried.inputs() == null) {
+                unresolved.add(new UnresolvedCombination(List.of(label), tried.reason(),
+                        tried.detail()));
+                continue;
+            }
+            rows.add(new GeneratedRow(List.of(label), tried.inputs()));
         }
         return new GenerationResult(rows, unresolved, List.of());
     }
@@ -438,19 +447,22 @@ public final class Generator {
     /**
      * One assignment of classes, built into the values a row would carry.
      *
-     * <p>Each position offers more than one value, and they are tried in order: a value refused at
-     * construction says nothing about the position, only about that value, and the next one may well
-     * build. What is tried is the same index at every position at once, which keeps the attempts linear
-     * in the longest candidate list rather than multiplying them.
+     * <p>What a position offers is values, and what has to build is all of them together: the check is
+     * the model's own constructor over the whole input, so a field's value can be refused for what
+     * another field was given. The unit being tried is the tuple, not the value — walking one index
+     * across every position at once tries the diagonal of the choices and misses the rest, and two
+     * fields whose rules are the same but written in a different order then land on different indices
+     * and never meet.
      *
-     * <p>Every position, which includes the ones no axis divides. A field carrying a format rule is
-     * usually not an axis — a format has no classes to cover — and it is exactly the kind of position
-     * whose first candidate gets refused. How many candidates those have is not known before composing
-     * once, so the bound on the attempts is raised by what composing reports rather than being counted
-     * up front.
+     * <p>So the assignments are walked outward from the one where every position takes its first
+     * value: then the ones a single position has moved one step from, then two, and so on. Nearest
+     * first, because a position's first value is the one that stands for it, and a row that took a
+     * later one at every position is a row further from what the model says it is about. The walk
+     * stops at {@link #MAX_TUPLES}, and stopping is reported as having stopped rather than as
+     * everything having been refused.
      */
     private static Attempt build(Subject subject, List<Axis> axes, int[] where, CandidateCheck check) {
-        int deepest = 1;
+        Map<String, List<FixtureTemplate>> decided = new LinkedHashMap<>();
         for (int i = 0; i < axes.size(); i++) {
             List<FixtureTemplate> candidates =
                     axes.get(i).classes().get(where[i]).representatives().candidates();
@@ -458,124 +470,183 @@ public final class Generator {
                 return new Attempt(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
                         label(axes.get(i), where[i]));
             }
-            deepest = Math.max(deepest, candidates.size());
+            decided.put(axes.get(i).path().toString(), candidates);
         }
-        Composed composed = attempts(subject, check, deepest, attempt -> {
-            Map<String, FixtureTemplate> byPath = new LinkedHashMap<>();
-            for (int i = 0; i < axes.size(); i++) {
-                List<FixtureTemplate> candidates =
-                        axes.get(i).classes().get(where[i]).representatives().candidates();
-                byPath.put(axes.get(i).path().toString(),
-                        candidates.get(Math.min(attempt, candidates.size() - 1)));
-            }
-            return byPath;
-        });
-        return composed.inputs() != null
-                ? new Attempt(new GeneratedRow(labels(axes, where), composed.inputs()), null, null)
-                : new Attempt(null, composed.reason(), composed.detail());
+        Choices choices = choicesOf(subject, decided);
+        if (choices.missingAt() != null) {
+            return new Attempt(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
+                    choices.missingAt());
+        }
+        Outcome tried = walk(subject, choices, check);
+        return tried.inputs() != null
+                ? new Attempt(new GeneratedRow(labels(axes, where), tried.inputs()), null, null)
+                : new Attempt(null, tried.reason(), tried.detail());
     }
 
     /**
-     * The inputs for a row, asking each position for its next value until one set builds.
+     * Every position a row chooses a value at, in the order they are decided.
      *
-     * <p>The one place the candidates are walked. Both the rows that fill a combination and the rows
-     * that reach a boundary compose the same way and are refused the same way, and a walk written only
-     * where the combinations are is a boundary row that gives up on the first value a rule refuses.
-     *
-     * @param axisDeepest how many values the axes themselves offer, which is known before composing;
-     *                    what the positions no axis divides offer is not, and raises the bound as it
-     *                    is discovered
+     * @param at        the paths, so that an assignment can be read back as which value went where
+     * @param values    what each of those positions can take, never empty
+     * @param missingAt the position nothing at all can be written at, where there is one — which is
+     *                  not a choice to make but a reason there is no row
      */
-    private static Composed attempts(Subject subject, CandidateCheck check, int axisDeepest,
-                                     java.util.function.IntFunction<Map<String, FixtureTemplate>> fixed) {
-        int deepest = Math.max(1, axisDeepest);
-        Composed last = new Composed(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
-                null, 1);
-        for (int attempt = 0; attempt < deepest && attempt < MAX_CANDIDATES; attempt++) {
-            last = inputsOf(subject, fixed.apply(attempt), check, attempt);
-            if (last.inputs() != null
-                    || last.reason() == UnresolvedCombination.Reason.NO_REPRESENTATIVE) {
-                // Built, or a position with no values at all — where another candidate changes
-                // nothing.
-                return last;
-            }
-            deepest = Math.max(deepest, last.candidates());
+    private record Choices(List<String> at, List<List<FixtureTemplate>> values, String missingAt) {
+
+        static Choices missing(String at) {
+            return new Choices(List.of(), List.of(), at);
         }
-        return new Composed(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
-                last.detail(), last.candidates());
     }
 
-    /** One set of values for the parameters, with every position taking its {@code attempt}-th
-     * candidate. */
-    private static Composed inputsOf(Subject subject, Map<String, FixtureTemplate> byPath,
-                                     CandidateCheck check, int attempt) {
-        List<FixtureTemplate> inputs = new ArrayList<>();
-        int candidates = 1;
+    /**
+     * What the positions of one row can take: the axes at the classes this assignment fixes, and every
+     * other position at whatever stands for its type.
+     *
+     * <p>The same walk the values are composed by, which is what keeps the two agreeing about where the
+     * positions are. A record is not a position but the fields under it are, and a position the caller
+     * has already decided keeps what it was given.
+     *
+     * @param decided what the caller fixed: the classes of an axis, or the single value a boundary is
+     *                to be reached at
+     */
+    private static Choices choicesOf(Subject subject, Map<String, List<FixtureTemplate>> decided) {
+        List<String> at = new ArrayList<>(decided.keySet());
+        List<List<FixtureTemplate>> values = new ArrayList<>(decided.values());
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
-            TermPath at = TermPath.of(subject.parameters().get(p));
-            Composition built = compose(subject.types().get(p), at, byPath, subject.symbols(), 0,
-                    attempt);
-            candidates = Math.max(candidates, built.candidates());
-            if (built.value() == null) {
-                // Nothing could be written at all: a field of a type nothing stands for. Which is not
-                // the same as a value that was written and refused, and reporting it as one sends the
-                // author looking for a rule relating two inputs that has nothing to do with it.
-                return new Composed(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
-                        built.missingAt(), candidates);
+            String missing = choicesUnder(subject.types().get(p),
+                    TermPath.of(subject.parameters().get(p)), subject.symbols(), 0, at, values);
+            if (missing != null) {
+                return Choices.missing(missing);
             }
-            if (check.refuse(p, built.value()).isPresent()) {
-                return new Composed(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null,
-                        candidates);
-            }
-            inputs.add(built.value());
         }
-        return new Composed(inputs, null, null, candidates);
+        return new Choices(at, values, null);
     }
 
+    /** The positions under one parameter, appended in the order they are composed. Returns the path
+     * nothing can be written at, where there is one. */
+    private static String choicesUnder(Type type, TermPath at, Symbols symbols, int depth,
+                                       List<String> paths, List<List<FixtureTemplate>> values) {
+        if (paths.contains(at.toString())) {
+            return null;   // an axis decides here
+        }
+        if (depth < MAX_DEPTH && type instanceof Type.Ref ref
+                && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
+            Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
+            if (!fields.isEmpty()) {
+                for (Map.Entry<String, Type> field : fields.entrySet()) {
+                    String missing = choicesUnder(field.getValue(), at.then(field.getKey()), symbols,
+                            depth + 1, paths, values);
+                    if (missing != null) {
+                        return missing;
+                    }
+                }
+                return null;
+            }
+        }
+        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols);
+        if (stands.isEmpty()) {
+            // Nothing could be written at all: a position of a type nothing stands for. Which is not
+            // the same as a value that was written and refused, and reporting it as one sends the
+            // author looking for a rule relating two inputs that has nothing to do with it.
+            return at + ": " + Type.show(type);
+        }
+        paths.add(at.toString());
+        values.add(stands);
+        return null;
+    }
+
+    /** What came of trying the assignments: the values, or why there are none. */
+    private record Outcome(List<FixtureTemplate> inputs, UnresolvedCombination.Reason reason,
+                           String detail) {}
+
     /**
-     * One attempt at a row's inputs: the values, or why there are none.
+     * The assignments, nearest first, until one builds.
      *
-     * @param candidates the most any one position under here had to offer, which is how far the
-     *                   attempts have to go before the row can be called unbuildable
+     * <p>Breadth-first over the choices: the assignment where every position takes its first value,
+     * then every assignment one step from one already tried. Deterministic, because the order the
+     * positions were collected in is the order their steps are taken in, and a row is compared against
+     * the last run's to see what changed.
      */
-    private record Composed(List<FixtureTemplate> inputs, UnresolvedCombination.Reason reason,
-                            String detail, int candidates) {}
+    private static Outcome walk(Subject subject, Choices choices, CandidateCheck check) {
+        int positions = choices.at().size();
+        ArrayDeque<int[]> next = new ArrayDeque<>();
+        Set<String> seen = new LinkedHashSet<>();
+        int[] first = new int[positions];
+        next.add(first);
+        seen.add(Arrays.toString(first));
 
-    /** One position's value, or the position that had none, with what it had to offer. */
-    private record Composition(FixtureTemplate value, String missingAt, int candidates) {}
+        int tried = 0;
+        while (!next.isEmpty() && tried < MAX_TUPLES) {
+            int[] assignment = next.poll();
+            tried++;
+            List<FixtureTemplate> inputs = inputsOf(subject, choices, assignment, check);
+            if (inputs != null) {
+                return new Outcome(inputs, null, null);
+            }
+            for (int i = 0; i < positions; i++) {
+                if (assignment[i] + 1 >= choices.values().get(i).size()) {
+                    continue;
+                }
+                int[] stepped = assignment.clone();
+                stepped[i]++;
+                if (seen.add(Arrays.toString(stepped))) {
+                    next.add(stepped);
+                }
+            }
+        }
+        // Nothing left to try is every assignment refused; something left is the search having stopped,
+        // and the difference is what the reader is owed. Neither carries a detail: what these are
+        // about is the combination, and a detail is read as the position that is the fact behind
+        // several of them.
+        return next.isEmpty()
+                ? new Outcome(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null)
+                : new Outcome(null, UnresolvedCombination.Reason.SEARCH_LIMIT, null);
+    }
 
-    /** The value at one position: what an axis fixed there, or a record built out of its fields, or the
-     * {@code attempt}-th value that stands for the type. Null where nothing can be written. */
-    private static Composition compose(Type type, TermPath at, Map<String, FixtureTemplate> byPath,
-                                       Symbols symbols, int depth, int attempt) {
-        FixtureTemplate fixed = byPath.get(at.toString());
-        if (fixed != null) {
-            return new Composition(fixed, null, 1);   // an axis already chose, and this is its choice
+    /** One assignment built into the parameters, or null where the model refused it. */
+    private static List<FixtureTemplate> inputsOf(Subject subject, Choices choices, int[] assignment,
+                                                  CandidateCheck check) {
+        Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
+        for (int i = 0; i < choices.at().size(); i++) {
+            chosen.put(choices.at().get(i), choices.values().get(i).get(assignment[i]));
+        }
+        List<FixtureTemplate> inputs = new ArrayList<>();
+        for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
+            FixtureTemplate built = compose(subject.types().get(p),
+                    TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0);
+            if (built == null || check.refuse(p, built).isPresent()) {
+                return null;
+            }
+            inputs.add(built);
+        }
+        return inputs;
+    }
+
+    /** The value at one position: what the assignment chose there, or a record built out of its
+     * fields. Null only where the walk that collected the choices and this one disagree. */
+    private static FixtureTemplate compose(Type type, TermPath at, Map<String, FixtureTemplate> chosen,
+                                           Symbols symbols, int depth) {
+        FixtureTemplate here = chosen.get(at.toString());
+        if (here != null) {
+            return here;
         }
         if (depth < MAX_DEPTH && type instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
             Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
             if (!fields.isEmpty()) {
                 Map<String, FixtureTemplate> built = new LinkedHashMap<>();
-                int candidates = 1;
                 for (Map.Entry<String, Type> field : fields.entrySet()) {
-                    Composition value = compose(field.getValue(), at.then(field.getKey()), byPath,
-                            symbols, depth + 1, attempt);
-                    candidates = Math.max(candidates, value.candidates());
-                    if (value.value() == null) {
-                        // The field that had none, not the record that wanted it — but carrying what
-                        // the fields before it could have offered, so the attempts are not cut short.
-                        return new Composition(null, value.missingAt(), candidates);
+                    FixtureTemplate value = compose(field.getValue(), at.then(field.getKey()), chosen,
+                            symbols, depth + 1);
+                    if (value == null) {
+                        return null;
                     }
-                    built.put(field.getKey(), value.value());
+                    built.put(field.getKey(), value);
                 }
-                return new Composition(FixtureTemplate.record(ref.name(), built), null, candidates);
+                return FixtureTemplate.record(ref.name(), built);
             }
         }
-        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols);
-        return stands.isEmpty() ? new Composition(null, at + ": " + Type.show(type), 1)
-                : new Composition(stands.get(Math.min(attempt, stands.size() - 1)), null,
-                        stands.size());
+        return null;
     }
 
     /** A boundary value written the way the position takes it: bare where the position is a number,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -35,6 +35,10 @@ public final class Generator {
 
     /** How many rows one call will write. Past this the output stops being something a person reads
      * and pastes, and a model that wants more than this has axes it should be measured at fewer of. */
+    /** How many candidates one position is asked for. A rule can only put so many values in front of
+     * a position, and a model that put more there than this is one whose row nobody would read. */
+    private static final int MAX_CANDIDATES = 16;
+
     static final int MAX_ROWS = 200;
 
     /** How deep a record is built. Past this a value stops being anything an author recognises as one
@@ -245,7 +249,7 @@ public final class Generator {
             }
             Map<String, FixtureTemplate> byPath = new LinkedHashMap<>();
             byPath.put(axis.path().toString(), at);
-            Composed composed = inputsOf(subject, byPath, check);
+            Composed composed = attempts(subject, check, 1, _ -> byPath);
             if (composed.inputs() == null) {
                 unresolved.add(new UnresolvedCombination(List.of(label), composed.reason(),
                         composed.detail()));
@@ -434,13 +438,19 @@ public final class Generator {
     /**
      * One assignment of classes, built into the values a row would carry.
      *
-     * <p>Each class offers more than one value, and they are tried in order: a value refused at
-     * construction says nothing about the class, only about that value, and the next one may well
+     * <p>Each position offers more than one value, and they are tried in order: a value refused at
+     * construction says nothing about the position, only about that value, and the next one may well
      * build. What is tried is the same index at every position at once, which keeps the attempts linear
      * in the longest candidate list rather than multiplying them.
+     *
+     * <p>Every position, which includes the ones no axis divides. A field carrying a format rule is
+     * usually not an axis — a format has no classes to cover — and it is exactly the kind of position
+     * whose first candidate gets refused. How many candidates those have is not known before composing
+     * once, so the bound on the attempts is raised by what composing reports rather than being counted
+     * up front.
      */
     private static Attempt build(Subject subject, List<Axis> axes, int[] where, CandidateCheck check) {
-        int deepest = 0;
+        int deepest = 1;
         for (int i = 0; i < axes.size(); i++) {
             List<FixtureTemplate> candidates =
                     axes.get(i).classes().get(where[i]).representatives().candidates();
@@ -450,7 +460,7 @@ public final class Generator {
             }
             deepest = Math.max(deepest, candidates.size());
         }
-        for (int attempt = 0; attempt < deepest; attempt++) {
+        Composed composed = attempts(subject, check, deepest, attempt -> {
             Map<String, FixtureTemplate> byPath = new LinkedHashMap<>();
             for (int i = 0; i < axes.size(); i++) {
                 List<FixtureTemplate> candidates =
@@ -458,80 +468,114 @@ public final class Generator {
                 byPath.put(axes.get(i).path().toString(),
                         candidates.get(Math.min(attempt, candidates.size() - 1)));
             }
-            Composed composed = inputsOf(subject, byPath, check);
-            if (composed.inputs() != null) {
-                return new Attempt(new GeneratedRow(labels(axes, where), composed.inputs()), null,
-                        null);
-            }
-            if (composed.reason() == UnresolvedCombination.Reason.NO_REPRESENTATIVE) {
-                // Another candidate changes nothing: the position has no values at all.
-                return new Attempt(null, composed.reason(), composed.detail());
-            }
-        }
-        return new Attempt(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
+            return byPath;
+        });
+        return composed.inputs() != null
+                ? new Attempt(new GeneratedRow(labels(axes, where), composed.inputs()), null, null)
+                : new Attempt(null, composed.reason(), composed.detail());
     }
 
     /**
-     * One value per parameter, or null where one of them could not be produced or would not build.
+     * The inputs for a row, asking each position for its next value until one set builds.
      *
-     * <p>Several axes on one parameter are one value, not several: {@code request.kind} and
-     * {@code request.cost} are two positions of one {@code Request}, and a row writes one of those.
+     * <p>The one place the candidates are walked. Both the rows that fill a combination and the rows
+     * that reach a boundary compose the same way and are refused the same way, and a walk written only
+     * where the combinations are is a boundary row that gives up on the first value a rule refuses.
+     *
+     * @param axisDeepest how many values the axes themselves offer, which is known before composing;
+     *                    what the positions no axis divides offer is not, and raises the bound as it
+     *                    is discovered
      */
+    private static Composed attempts(Subject subject, CandidateCheck check, int axisDeepest,
+                                     java.util.function.IntFunction<Map<String, FixtureTemplate>> fixed) {
+        int deepest = Math.max(1, axisDeepest);
+        Composed last = new Composed(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
+                null, 1);
+        for (int attempt = 0; attempt < deepest && attempt < MAX_CANDIDATES; attempt++) {
+            last = inputsOf(subject, fixed.apply(attempt), check, attempt);
+            if (last.inputs() != null
+                    || last.reason() == UnresolvedCombination.Reason.NO_REPRESENTATIVE) {
+                // Built, or a position with no values at all — where another candidate changes
+                // nothing.
+                return last;
+            }
+            deepest = Math.max(deepest, last.candidates());
+        }
+        return new Composed(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
+                last.detail(), last.candidates());
+    }
+
+    /** One set of values for the parameters, with every position taking its {@code attempt}-th
+     * candidate. */
     private static Composed inputsOf(Subject subject, Map<String, FixtureTemplate> byPath,
-                                     CandidateCheck check) {
+                                     CandidateCheck check, int attempt) {
         List<FixtureTemplate> inputs = new ArrayList<>();
+        int candidates = 1;
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
             TermPath at = TermPath.of(subject.parameters().get(p));
-            Composition built = compose(subject.types().get(p), at, byPath, subject.symbols(), 0);
+            Composition built = compose(subject.types().get(p), at, byPath, subject.symbols(), 0,
+                    attempt);
+            candidates = Math.max(candidates, built.candidates());
             if (built.value() == null) {
                 // Nothing could be written at all: a field of a type nothing stands for. Which is not
                 // the same as a value that was written and refused, and reporting it as one sends the
                 // author looking for a rule relating two inputs that has nothing to do with it.
                 return new Composed(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
-                        built.missingAt());
+                        built.missingAt(), candidates);
             }
             if (check.refuse(p, built.value()).isPresent()) {
-                return new Composed(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
+                return new Composed(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null,
+                        candidates);
             }
             inputs.add(built.value());
         }
-        return new Composed(inputs, null, null);
+        return new Composed(inputs, null, null, candidates);
     }
 
-    /** One attempt at a row's inputs: the values, or why there are none. */
+    /**
+     * One attempt at a row's inputs: the values, or why there are none.
+     *
+     * @param candidates the most any one position under here had to offer, which is how far the
+     *                   attempts have to go before the row can be called unbuildable
+     */
     private record Composed(List<FixtureTemplate> inputs, UnresolvedCombination.Reason reason,
-                            String detail) {}
+                            String detail, int candidates) {}
 
-    /** One position's value, or the position that had none. */
-    private record Composition(FixtureTemplate value, String missingAt) {}
+    /** One position's value, or the position that had none, with what it had to offer. */
+    private record Composition(FixtureTemplate value, String missingAt, int candidates) {}
 
-    /** The value at one position: what an axis fixed there, or a record built out of its fields, or a
-     * value that stands for the type. Null where nothing can be written. */
+    /** The value at one position: what an axis fixed there, or a record built out of its fields, or the
+     * {@code attempt}-th value that stands for the type. Null where nothing can be written. */
     private static Composition compose(Type type, TermPath at, Map<String, FixtureTemplate> byPath,
-                                       Symbols symbols, int depth) {
+                                       Symbols symbols, int depth, int attempt) {
         FixtureTemplate fixed = byPath.get(at.toString());
         if (fixed != null) {
-            return new Composition(fixed, null);
+            return new Composition(fixed, null, 1);   // an axis already chose, and this is its choice
         }
         if (depth < MAX_DEPTH && type instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
             Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
             if (!fields.isEmpty()) {
                 Map<String, FixtureTemplate> built = new LinkedHashMap<>();
+                int candidates = 1;
                 for (Map.Entry<String, Type> field : fields.entrySet()) {
                     Composition value = compose(field.getValue(), at.then(field.getKey()), byPath,
-                            symbols, depth + 1);
+                            symbols, depth + 1, attempt);
+                    candidates = Math.max(candidates, value.candidates());
                     if (value.value() == null) {
-                        return value;   // the field that had none, not the record that wanted it
+                        // The field that had none, not the record that wanted it — but carrying what
+                        // the fields before it could have offered, so the attempts are not cut short.
+                        return new Composition(null, value.missingAt(), candidates);
                     }
                     built.put(field.getKey(), value.value());
                 }
-                return new Composition(FixtureTemplate.record(ref.name(), built), null);
+                return new Composition(FixtureTemplate.record(ref.name(), built), null, candidates);
             }
         }
         List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols);
-        return stands.isEmpty() ? new Composition(null, at + ": " + Type.show(type))
-                : new Composition(stands.get(0), null);
+        return stands.isEmpty() ? new Composition(null, at + ": " + Type.show(type), 1)
+                : new Composition(stands.get(Math.min(attempt, stands.size() - 1)), null,
+                        stands.size());
     }
 
     /** A boundary value written the way the position takes it: bare where the position is a number,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -38,12 +38,12 @@ public final class Generator {
 
     /** How many rows one call will write. Past this the output stops being something a person reads
      * and pastes, and a model that wants more than this has axes it should be measured at fewer of. */
-    /** How many assignments of values one row is tried at. The choices multiply, so this is a bound on
-     * the search and not on any one position — and reaching it is reported as the search having
-     * stopped, which is a different thing from every assignment having been refused. */
-    private static final int MAX_TUPLES = 256;
-
     static final int MAX_ROWS = 200;
+
+    /** How many assignments of values one parameter is tried at. The choices multiply, so this is a
+     * bound on the search and not on any one position — and reaching it is reported as the search
+     * having stopped, which is a different thing from every assignment having been refused. */
+    private static final int MAX_TUPLES = 256;
 
     /** How deep a record is built. Past this a value stops being anything an author recognises as one
      * input, and a type that refers to itself would not stop at all. */
@@ -251,20 +251,24 @@ public final class Generator {
                         UnresolvedCombination.Reason.NO_REPRESENTATIVE));
                 continue;
             }
-            Choices choices = choicesOf(subject,
-                    Map.of(axis.path().toString(), List.of(at)));
-            if (choices.missingAt() != null) {
-                unresolved.add(new UnresolvedCombination(List.of(label),
-                        UnresolvedCombination.Reason.NO_REPRESENTATIVE, choices.missingAt()));
+            List<FixtureTemplate> inputs = new ArrayList<>();
+            UnresolvedCombination left = null;
+            for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
+                Map<String, List<FixtureTemplate>> here =
+                        TermPath.of(subject.parameters().get(p)).head().equals(axis.path().head())
+                                ? Map.of(axis.path().toString(), List.of(at)) : Map.of();
+                Outcome tried = valueAt(subject, p, here, check);
+                if (tried.value() == null) {
+                    left = new UnresolvedCombination(List.of(label), tried.reason(), tried.detail());
+                    break;
+                }
+                inputs.add(tried.value());
+            }
+            if (left != null) {
+                unresolved.add(left);
                 continue;
             }
-            Outcome tried = walk(subject, choices, check);
-            if (tried.inputs() == null) {
-                unresolved.add(new UnresolvedCombination(List.of(label), tried.reason(),
-                        tried.detail()));
-                continue;
-            }
-            rows.add(new GeneratedRow(List.of(label), tried.inputs()));
+            rows.add(new GeneratedRow(List.of(label), inputs));
         }
         return new GenerationResult(rows, unresolved, List.of());
     }
@@ -472,15 +476,50 @@ public final class Generator {
             }
             decided.put(axes.get(i).path().toString(), candidates);
         }
-        Choices choices = choicesOf(subject, decided);
-        if (choices.missingAt() != null) {
-            return new Attempt(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
-                    choices.missingAt());
+        List<FixtureTemplate> inputs = new ArrayList<>();
+        for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
+            Outcome tried = valueFor(subject, p, axes, decided, check);
+            if (tried.value() == null) {
+                return new Attempt(null, tried.reason(), tried.detail());
+            }
+            inputs.add(tried.value());
         }
-        Outcome tried = walk(subject, choices, check);
-        return tried.inputs() != null
-                ? new Attempt(new GeneratedRow(labels(axes, where), tried.inputs()), null, null)
-                : new Attempt(null, tried.reason(), tried.detail());
+        return new Attempt(new GeneratedRow(labels(axes, where), inputs), null, null);
+    }
+
+    /**
+     * One parameter's value, searched for on its own.
+     *
+     * <p>Each parameter is built and refused on its own — the check is the model's constructor for that
+     * one type, and a rule relating two of them is not something a model can write. So the choices
+     * under one parameter and the choices under another do not multiply, and searching them together
+     * would spend the bound on assignments that differ only in a parameter already settled. Two
+     * parameters of eight either-or fields are two searches of 256, not one of 65,536.
+     */
+    private static Outcome valueFor(Subject subject, int p, List<Axis> axes,
+                                    Map<String, List<FixtureTemplate>> decided,
+                                    CandidateCheck check) {
+        TermPath at = TermPath.of(subject.parameters().get(p));
+        Map<String, List<FixtureTemplate>> here = new LinkedHashMap<>();
+        for (Axis axis : axes) {
+            if (axis.path().head().equals(at.head())
+                    && decided.containsKey(axis.path().toString())) {
+                here.put(axis.path().toString(), decided.get(axis.path().toString()));
+            }
+        }
+        return valueAt(subject, p, here, check);
+    }
+
+    /** One parameter's value, with the positions the caller fixed already decided. */
+    private static Outcome valueAt(Subject subject, int p,
+                                   Map<String, List<FixtureTemplate>> decided,
+                                   CandidateCheck check) {
+        Choices choices = choicesOf(subject.types().get(p),
+                TermPath.of(subject.parameters().get(p)), subject.symbols(), decided);
+        return choices.missingAt() != null
+                ? new Outcome(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
+                        choices.missingAt())
+                : walk(subject, p, choices, check);
     }
 
     /**
@@ -509,17 +548,12 @@ public final class Generator {
      * @param decided what the caller fixed: the classes of an axis, or the single value a boundary is
      *                to be reached at
      */
-    private static Choices choicesOf(Subject subject, Map<String, List<FixtureTemplate>> decided) {
-        List<String> at = new ArrayList<>(decided.keySet());
+    private static Choices choicesOf(Type type, TermPath at, Symbols symbols,
+                                     Map<String, List<FixtureTemplate>> decided) {
+        List<String> paths = new ArrayList<>(decided.keySet());
         List<List<FixtureTemplate>> values = new ArrayList<>(decided.values());
-        for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
-            String missing = choicesUnder(subject.types().get(p),
-                    TermPath.of(subject.parameters().get(p)), subject.symbols(), 0, at, values);
-            if (missing != null) {
-                return Choices.missing(missing);
-            }
-        }
-        return new Choices(at, values, null);
+        String missing = choicesUnder(type, at, symbols, 0, paths, values);
+        return missing != null ? Choices.missing(missing) : new Choices(paths, values, null);
     }
 
     /** The positions under one parameter, appended in the order they are composed. Returns the path
@@ -555,8 +589,8 @@ public final class Generator {
         return null;
     }
 
-    /** What came of trying the assignments: the values, or why there are none. */
-    private record Outcome(List<FixtureTemplate> inputs, UnresolvedCombination.Reason reason,
+    /** What came of trying the assignments for one parameter: its value, or why there is none. */
+    private record Outcome(FixtureTemplate value, UnresolvedCombination.Reason reason,
                            String detail) {}
 
     /**
@@ -567,7 +601,7 @@ public final class Generator {
      * positions were collected in is the order their steps are taken in, and a row is compared against
      * the last run's to see what changed.
      */
-    private static Outcome walk(Subject subject, Choices choices, CandidateCheck check) {
+    private static Outcome walk(Subject subject, int p, Choices choices, CandidateCheck check) {
         int positions = choices.at().size();
         ArrayDeque<int[]> next = new ArrayDeque<>();
         Set<String> seen = new LinkedHashSet<>();
@@ -579,9 +613,14 @@ public final class Generator {
         while (!next.isEmpty() && tried < MAX_TUPLES) {
             int[] assignment = next.poll();
             tried++;
-            List<FixtureTemplate> inputs = inputsOf(subject, choices, assignment, check);
-            if (inputs != null) {
-                return new Outcome(inputs, null, null);
+            Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
+            for (int i = 0; i < positions; i++) {
+                chosen.put(choices.at().get(i), choices.values().get(i).get(assignment[i]));
+            }
+            FixtureTemplate built = compose(subject.types().get(p),
+                    TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0);
+            if (built != null && check.refuse(p, built).isEmpty()) {
+                return new Outcome(built, null, null);
             }
             for (int i = 0; i < positions; i++) {
                 if (assignment[i] + 1 >= choices.values().get(i).size()) {
@@ -601,25 +640,6 @@ public final class Generator {
         return next.isEmpty()
                 ? new Outcome(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null)
                 : new Outcome(null, UnresolvedCombination.Reason.SEARCH_LIMIT, null);
-    }
-
-    /** One assignment built into the parameters, or null where the model refused it. */
-    private static List<FixtureTemplate> inputsOf(Subject subject, Choices choices, int[] assignment,
-                                                  CandidateCheck check) {
-        Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
-        for (int i = 0; i < choices.at().size(); i++) {
-            chosen.put(choices.at().get(i), choices.values().get(i).get(assignment[i]));
-        }
-        List<FixtureTemplate> inputs = new ArrayList<>();
-        for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
-            FixtureTemplate built = compose(subject.types().get(p),
-                    TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0);
-            if (built == null || check.refuse(p, built).isPresent()) {
-                return null;
-            }
-            inputs.add(built);
-        }
-        return inputs;
     }
 
     /** The value at one position: what the assignment chose there, or a record built out of its

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -354,6 +354,15 @@ public final class Partitions {
         if (type == Type.BOOL) {
             return List.of(FixtureTemplate.bool(true));
         }
+        // A date is built from its ISO 8601 form, which is how a row writes one. One fixed day rather
+        // than today's: a generated row is compared with the last one to see what changed, and a value
+        // that read the clock would change every time nothing had.
+        if (type == Type.DATE) {
+            return List.of(FixtureTemplate.date("2000-01-01"));
+        }
+        if (type == Type.DATETIME) {
+            return List.of(FixtureTemplate.dateTime("2000-01-01T00:00:00"));
+        }
         // The empty one, for every collection. It is the value that always builds — a rule about a
         // collection bounds its size or its elements, and neither can refuse having none — and a row
         // whose collection is not what it is about should say so by carrying nothing.
@@ -372,13 +381,41 @@ public final class Partitions {
                 && data.newtype()) {
             Bounds bounds = boundsOf(type, symbols);
             List<FixtureTemplate> inner = bounds == null || bounds.isEmpty()
-                    ? representativesOf(TypeOps.newtypeInner(ref.name(), symbols), symbols)
+                    ? insideTheFormat(ref.name(), symbols)
                     : List.of(bounds.decimal()
                             ? FixtureTemplate.decimal(inside(bounds))
                             : FixtureTemplate.integer(inside(bounds).longValueExact()));
             return inner.stream().map(t -> FixtureTemplate.newtype(ref.name(), t)).toList();
         }
         return List.of();
+    }
+
+    /**
+     * What a newtype wraps, written so that the rules on it hold.
+     *
+     * <p>A format rule is what an identifier usually says about itself, and a value that ignores it is
+     * refused at construction — so a record holding one could not be composed at all, and every
+     * combination that record took part in came back as one whose values the model refused. Reading
+     * the pattern is what turns those back into rows somebody can write.
+     *
+     * <p>Only the pattern is read. A rule this cannot produce a value for leaves the position with
+     * none, which is what it had before.
+     */
+    private static List<FixtureTemplate> insideTheFormat(TypeName newtype, Symbols symbols) {
+        Type base = TypeOps.newtypeInner(newtype, symbols);
+        if (base != Type.STRING || !(symbols.get(newtype) instanceof Ast.Data data)) {
+            return representativesOf(base, symbols);
+        }
+        for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
+            for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
+                if (InvariantConstraints.of(each, base).orElse(null)
+                        instanceof InvariantConstraints.Pattern format) {
+                    return PatternValues.shortestAccepted(format.regex())
+                            .map(FixtureTemplate::string).map(List::of).orElseGet(List::of);
+                }
+            }
+        }
+        return representativesOf(base, symbols);
     }
 
     /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -251,8 +251,7 @@ public final class Partitions {
                     RepresentativeSource.of(FixtureTemplate.unitCase(leaf)));   // naming it builds it
         }
         if (data.newtype()) {
-            List<FixtureTemplate> inner = representativesOf(TypeOps.newtypeInner(leaf, symbols),
-                    symbols);
+            List<FixtureTemplate> inner = insideTheNewtype(leaf, symbols);
             return inner.isEmpty()
                     ? PartitionClass.ungeneratable(leaf.name(), leaf.name(), is,
                             "no value of what `" + leaf.name() + "` wraps can be written")
@@ -379,43 +378,55 @@ public final class Partitions {
         // construction — but it does have values, and the edge of the bound is one that builds.
         if (type instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data
                 && data.newtype()) {
-            Bounds bounds = boundsOf(type, symbols);
-            List<FixtureTemplate> inner = bounds == null || bounds.isEmpty()
-                    ? insideTheFormat(ref.name(), symbols)
-                    : List.of(bounds.decimal()
-                            ? FixtureTemplate.decimal(inside(bounds))
-                            : FixtureTemplate.integer(inside(bounds).longValueExact()));
-            return inner.stream().map(t -> FixtureTemplate.newtype(ref.name(), t)).toList();
+            return insideTheNewtype(ref.name(), symbols).stream()
+                    .map(t -> FixtureTemplate.newtype(ref.name(), t)).toList();
         }
         return List.of();
     }
 
     /**
-     * What a newtype wraps, written so that the rules on it hold.
+     * What a newtype wraps: every value for it this can think of, in the order to try them.
      *
-     * <p>A format rule is what an identifier usually says about itself, and a value that ignores it is
-     * refused at construction — so a record holding one could not be composed at all, and every
-     * combination that record took part in came back as one whose values the model refused. Reading
-     * the pattern is what turns those back into rows somebody can write.
+     * <p>Candidates, not an answer. Whether a newtype accepts a value is decided by its own
+     * constructor, and this only proposes — so a rule it reads is a reason to offer another value
+     * rather than to withdraw the ones already there. A format rule that cannot be read leaves the
+     * position with what it had before this could read any of them, and a newtype carrying two rules
+     * gets a value from each, which is why the order they are declared in does not decide whether one
+     * builds.
      *
-     * <p>Only the pattern is read. A rule this cannot produce a value for leaves the position with
-     * none, which is what it had before.
+     * <p>Both the bound on a number and the format of a string, in one place, because a newtype is
+     * asked for a value from two: a field of a record, and a case of a sum. Reading the rules in only
+     * one of them is how a value that holds everywhere came to be written in one place and not the
+     * other.
      */
-    private static List<FixtureTemplate> insideTheFormat(TypeName newtype, Symbols symbols) {
+    private static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols) {
         Type base = TypeOps.newtypeInner(newtype, symbols);
-        if (base != Type.STRING || !(symbols.get(newtype) instanceof Ast.Data data)) {
-            return representativesOf(base, symbols);
+        List<FixtureTemplate> candidates = new ArrayList<>();
+
+        Bounds bounds = boundsOf(new Type.Ref(newtype), symbols);
+        if (bounds != null && !bounds.isEmpty()) {
+            candidates.add(bounds.decimal()
+                    ? FixtureTemplate.decimal(inside(bounds))
+                    : FixtureTemplate.integer(inside(bounds).longValueExact()));
         }
-        for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
-            for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
-                if (InvariantConstraints.of(each, base).orElse(null)
-                        instanceof InvariantConstraints.Pattern format) {
-                    return PatternValues.shortestAccepted(format.regex())
-                            .map(FixtureTemplate::string).map(List::of).orElseGet(List::of);
+        if (base == Type.STRING && symbols.get(newtype) instanceof Ast.Data data) {
+            for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
+                for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
+                    if (InvariantConstraints.of(each, base).orElse(null)
+                            instanceof InvariantConstraints.Pattern format) {
+                        PatternValues.shortestAccepted(format.regex())
+                                .map(FixtureTemplate::string).ifPresent(candidates::add);
+                    }
                 }
             }
         }
-        return representativesOf(base, symbols);
+        candidates.addAll(representativesOf(base, symbols));
+
+        Map<String, FixtureTemplate> once = new LinkedHashMap<>();
+        for (FixtureTemplate each : candidates) {
+            once.putIfAbsent(each.text(), each);
+        }
+        return List.copyOf(once.values());
     }
 
     /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge

--- a/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
@@ -37,6 +37,21 @@ final class PatternValues {
     private static final int LONGEST = 1024;
 
     /**
+     * How much backing up the answer is allowed to ask the engine for.
+     *
+     * <p>The answer is checked by putting it back through the pattern, and that check is the only
+     * unbounded thing here: the engine tries and backs up, and a repetition written over something of
+     * more than one length gives it somewhere to back up to for every copy in the string. Those
+     * multiply, so a pattern this reads perfectly well can take longer to check than anybody will wait
+     * — {@code (?:x?x){40}} is one, and the value it asks to have checked is forty characters long.
+     *
+     * <p>Twenty, because at twenty the check is under a millisecond and at thirty-three it is a fifth
+     * of a second and still doubling. What a real rule asks for is nothing like either: the most any
+     * of the format rules in the example models asks for is five.
+     */
+    private static final int MOST_BACKTRACKING = 20;
+
+    /**
      * Where a negated class takes its character from, in order.
      *
      * <p>A letter first, because a class that excludes something usually excludes punctuation, and a
@@ -94,7 +109,7 @@ final class PatternValues {
         PatternValues reader = new PatternValues(regex);
         String built;
         try {
-            built = reader.alternation();
+            built = reader.alternation().text();
             if (!reader.done()) {
                 return Optional.empty();   // stopped early — an unbalanced bracket, say
             }
@@ -107,9 +122,10 @@ final class PatternValues {
         try {
             return java.util.regex.Pattern.matches(regex, built)
                     ? Optional.of(built) : Optional.empty();
-        } catch (java.util.regex.PatternSyntaxException _) {
-            // Not a pattern at all. The compiler settles that where it is written, so nothing here
-            // reports it again; what it means for a value is that there is none.
+        } catch (java.util.regex.PatternSyntaxException | StackOverflowError _) {
+            // Not a pattern at all, or one the engine cannot walk to the end of. The compiler settles
+            // the first where it is written, so nothing here reports it again; what either means for a
+            // value is that there is none.
             return Optional.empty();
         }
     }
@@ -132,27 +148,54 @@ final class PatternValues {
 
     // --- the grammar ------------------------------------------------------------------------------
 
+    /**
+     * What one part of a pattern writes, and what putting it back through the engine will cost.
+     *
+     * <p>The second is the point. The engine matches by trying and backing up, and where a repetition
+     * is written over something that can itself match more than one length, every copy of it in the
+     * generated string is another place to back up to — which multiplies. {@code (?:x?x){40}} is
+     * forty of them over a forty-character string, and no part of it is a construct this cannot read.
+     *
+     * @param ambiguity how many places in {@code text} the engine may have to back up to, counted so
+     *                  that a repetition multiplies what is under it rather than adding to it
+     */
+    private record Piece(String text, int ambiguity) {
+
+        static final Piece NOTHING = new Piece("", 0);
+
+        static Piece plain(String text) {
+            return new Piece(text, 0);
+        }
+
+        Piece then(Piece next) {
+            return new Piece(text + next.text(), ambiguity + next.ambiguity());
+        }
+    }
+
     /** {@code a|b|c} — the first branch, always. The rest is still read, because a pattern this
-     * cannot read all of is one it will not offer a value for. */
-    private String alternation() {
-        String first = sequence();
+     * cannot read all of is one it will not offer a value for. A branch not taken is still somewhere
+     * the engine can back up to, so having more than one costs. */
+    private Piece alternation() {
+        Piece first = sequence();
+        int branches = 0;
         while (peek() == '|') {
             take();
             sequence();
+            branches++;
         }
-        return first;
+        return branches == 0 ? first : new Piece(first.text(), first.ambiguity() + branches);
     }
 
-    private String sequence() {
-        StringBuilder out = new StringBuilder();
+    private Piece sequence() {
+        Piece out = Piece.NOTHING;
         while (!done() && peek() != '|' && peek() != ')') {
-            out.append(quantified());
+            out = out.then(quantified());
         }
-        return out.toString();
+        return out;
     }
 
-    private String quantified() {
-        String one = atom();
+    private Piece quantified() {
+        Piece one = atom();
         int least = 1;
         int most = 1;
         switch (peek()) {
@@ -176,13 +219,25 @@ final class PatternValues {
             take();
         }
         int times = least + (most == least ? 0 : Math.min(BEYOND_MINIMUM, most - least));
-        if ((long) one.length() * times > LONGEST) {
+        if ((long) one.text().length() * times > LONGEST) {
             throw new Unreadable();   // longer than a row will carry, so there is no row to write
         }
-        return one.repeat(times);
+        // A repetition that can stop early is a place to back up to whatever it wrote — even where it
+        // wrote nothing, since the engine still has the choice. Each copy carries what is under it,
+        // which is how a repetition of a repetition becomes the product of the two.
+        boolean variable = most != least;
+        int copies = Math.max(times, 1);
+        long cost = (long) copies * one.ambiguity() + (variable ? copies : 0);
+        if (cost > MOST_BACKTRACKING) {
+            // Not a construct this cannot read — every part of it was read. What it cannot do is
+            // check the answer in the time anybody has, and an answer it did not check is not one it
+            // offers.
+            throw new Unreadable();
+        }
+        return new Piece(one.text().repeat(times), (int) cost);
     }
 
-    private String atom() {
+    private Piece atom() {
         char c = peek();
         switch (c) {
             case '(' -> {
@@ -196,31 +251,31 @@ final class PatternValues {
                     }
                     take();
                 }
-                String inside = alternation();
+                Piece inside = alternation();
                 expect(')');
                 return inside;
             }
             case '[' -> {
                 take();
-                return characterClass();
+                return Piece.plain(characterClass());
             }
             case '\\' -> {
                 take();
-                return escaped();
+                return Piece.plain(escaped());
             }
             case '.' -> {
                 take();
-                return "a";
+                return Piece.plain("a");
             }
             case '^', '$' -> {
                 // The whole string is matched anyway, so an anchor at either end says nothing extra.
                 take();
-                return "";
+                return Piece.NOTHING;
             }
             case 0 -> throw new Unreadable();
             default -> {
                 take();
-                return String.valueOf(c);
+                return Piece.plain(String.valueOf(c));
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
@@ -29,12 +29,20 @@ final class PatternValues {
     private static final int BEYOND_MINIMUM = 0;
 
     /**
+     * How long a value this will write. Past this the pattern is asking for something no row wants:
+     * an observation reads a string back to a bounded length, so a longer one could not be compared
+     * against what it produced anyway.
+     */
+    private static final int LONGEST = 1024;
+
+    /**
      * Where a negated class takes its character from, in order.
      *
      * <p>A letter first, because a class that excludes something usually excludes punctuation, and a
      * value made of letters is the one a reader recognises. Then the rest of printable ASCII, and then
-     * a character from each of the alphabets a model here is written in — a rule that excludes ASCII
-     * entirely is asking for one of those, and had nothing to give before.
+     * a character from each of the alphabets a model here is written in — a rule excluding ASCII
+     * entirely is asking for one of those. A tab or a newline last: they read as nothing at all in a
+     * row, so they are what is left when a rule excludes every character that reads as something.
      */
     private static final String PREFERRED = build();
 
@@ -44,8 +52,21 @@ final class PatternValues {
         for (char c = 0x20; c <= 0x7e; c++) {
             out.append(c);
         }
-        out.append('\n').append('\t');
-        return out.append("あアー一　ｦ").toString();
+        out.append("あアー一　ｦ");
+        return out.append('\t').append('\n').toString();
+    }
+
+    /**
+     * Whether a row can be written carrying this.
+     *
+     * <p>A value is offered to be pasted into a model as a string literal, and the literal reads five
+     * escapes. A character outside them and outside the printable ones cannot be written at all: what
+     * would go in is the character itself, which is not a value anybody can read, and for some of them
+     * not something a file holds. There is no value here, which is what the caller already handles.
+     */
+    private static boolean writable(String value) {
+        return value.length() <= LONGEST && value.chars().allMatch(c ->
+                c == '\n' || c == '\t' || c == '\r' || (c >= 0x20 && c != 0x7f));
     }
 
     /**
@@ -53,7 +74,8 @@ final class PatternValues {
      *
      * <p>Empty for a construct it does not read — a backreference, a lookaround, a unicode property —
      * and empty for anything it built that the pattern then refused, which is the same answer and the
-     * reason the second check is here.
+     * reason the second check is here. Empty too for a string the pattern accepts and a row cannot
+     * carry: what is wanted is a value somebody can paste into a model, not one that matches.
      */
     static Optional<String> shortestAccepted(String regex) {
         PatternValues reader = new PatternValues(regex);
@@ -64,6 +86,9 @@ final class PatternValues {
                 return Optional.empty();   // stopped early — an unbalanced bracket, say
             }
         } catch (Unreadable | StackOverflowError _) {
+            return Optional.empty();
+        }
+        if (!writable(built)) {
             return Optional.empty();
         }
         try {
@@ -138,6 +163,9 @@ final class PatternValues {
             take();
         }
         int times = least + (most == least ? 0 : Math.min(BEYOND_MINIMUM, most - least));
+        if ((long) one.length() * times > LONGEST) {
+            throw new Unreadable();   // longer than a row will carry, so there is no row to write
+        }
         return one.repeat(times);
     }
 
@@ -196,12 +224,19 @@ final class PatternValues {
         boolean first = true;
         while (!done() && (peek() != ']' || first)) {
             first = false;
-            char low = classMember();
-            if (peek() == '-' && at + 1 < regex.length() && regex.charAt(at + 1) != ']') {
+            List<char[]> member = classMember();
+            if (member.size() == 1 && peek() == '-'
+                    && at + 1 < regex.length() && regex.charAt(at + 1) != ']') {
                 take();
-                ranges.add(new char[] {low, classMember()});
+                // The far end of a range is one character. A shorthand cannot be one: `[\d-z]` is
+                // not a range this can read the ends of.
+                List<char[]> upper = classMember();
+                if (upper.size() != 1 || upper.get(0)[0] != upper.get(0)[1]) {
+                    throw new Unreadable();
+                }
+                ranges.add(new char[] {member.get(0)[0], upper.get(0)[0]});
             } else {
-                ranges.add(new char[] {low, low});
+                ranges.addAll(member);
             }
         }
         expect(']');
@@ -219,28 +254,38 @@ final class PatternValues {
         throw new Unreadable();
     }
 
-    /** One character of a class, which may be written as an escape. A shorthand inside a class covers
-     * several characters at once; the first of what it stands for is enough to be in the class, and to
-     * be out of a negated one it has to be excluded as a whole — which is why the shorthand's whole
-     * range is added. */
-    private char classMember() {
+    /**
+     * What one member of a class stands for — the characters it puts in, as ranges.
+     *
+     * <p>Ranges rather than a character, because the two questions a class is asked want different
+     * things from the same member. To pick a character the class accepts, one of them is enough. To
+     * pick one a negated class accepts, all of them are needed: a member standing for the letters and
+     * the digits excludes the letters and the digits, and a reader that recorded only the first of
+     * them would go on to pick the second and produce a value the pattern refuses.
+     */
+    private List<char[]> classMember() {
         char c = take();
         if (c != '\\') {
-            return c;
+            return one(c);
         }
         char kind = take();
         return switch (kind) {
-            case 'd' -> '0';
-            case 'w' -> 'a';
-            case 's' -> ' ';
-            case 'n' -> '\n';
-            case 't' -> '\t';
-            case 'r' -> '\r';
-            case 'x' -> hex(2);
-            case 'u' -> hex(4);
+            case 'd' -> List.of(new char[] {'0', '9'});
+            case 'w' -> List.of(new char[] {'a', 'z'}, new char[] {'A', 'Z'},
+                    new char[] {'0', '9'}, new char[] {'_', '_'});
+            case 's' -> List.of(new char[] {' ', ' '}, new char[] {'\t', '\r'});
+            case 'n' -> one('\n');
+            case 't' -> one('\t');
+            case 'r' -> one('\r');
+            case 'x' -> one(hex(2));
+            case 'u' -> one(hex(4));
             case 'D', 'W', 'S', 'p', 'P', 'b', 'B', 'c' -> throw new Unreadable();
-            default -> kind;   // an escaped literal: `\-`, `\.`, `\\`, `\+`
+            default -> one(kind);   // an escaped literal: `\-`, `\.`, `\\`, `\+`
         };
+    }
+
+    private static List<char[]> one(char c) {
+        return List.of(new char[] {c, c});
     }
 
     /** An escape outside a class. */
@@ -287,7 +332,13 @@ final class PatternValues {
         if (start == at) {
             throw new Unreadable();
         }
-        return Integer.parseInt(regex.substring(start, at));
+        try {
+            return Integer.parseInt(regex.substring(start, at));
+        } catch (NumberFormatException _) {
+            // A count past what an int holds. Whether the pattern engine reads it at all is its own
+            // business; what it is here is a bound this cannot answer with a value.
+            throw new Unreadable();
+        }
     }
 
     private boolean done() {

--- a/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
@@ -37,19 +37,19 @@ final class PatternValues {
     private static final int LONGEST = 1024;
 
     /**
-     * How much backing up the answer is allowed to ask the engine for.
+     * How many characters the engine may read while checking the answer.
      *
-     * <p>The answer is checked by putting it back through the pattern, and that check is the only
-     * unbounded thing here: the engine tries and backs up, and a repetition written over something of
-     * more than one length gives it somewhere to back up to for every copy in the string. Those
-     * multiply, so a pattern this reads perfectly well can take longer to check than anybody will wait
-     * — {@code (?:x?x){40}} is one, and the value it asks to have checked is forty characters long.
+     * <p>The check is the only unbounded thing here. The engine matches by trying and backing up, and
+     * how much of that a pattern asks for cannot be told from the pattern: it is not only a repetition
+     * written over something of more than one length, but any two variable-length parts competing for
+     * the same characters — {@code x*x*x*…x{16}} reads seventy-seven million characters of a sixteen
+     * character string, and nothing about its shape says so.
      *
-     * <p>Twenty, because at twenty the check is under a millisecond and at thirty-three it is a fifth
-     * of a second and still doubling. What a real rule asks for is nothing like either: the most any
-     * of the format rules in the example models asks for is five.
+     * <p>So what is bounded is the work itself, counted where the engine does it. The format rules in
+     * the example models read between one and fifteen characters; this is four orders of magnitude
+     * above the most demanding of them and is reached in well under a millisecond.
      */
-    private static final int MOST_BACKTRACKING = 20;
+    private static final int MOST_READS = 100_000;
 
     /**
      * Where a negated class takes its character from, in order.
@@ -109,7 +109,7 @@ final class PatternValues {
         PatternValues reader = new PatternValues(regex);
         String built;
         try {
-            built = reader.alternation().text();
+            built = reader.alternation();
             if (!reader.done()) {
                 return Optional.empty();   // stopped early — an unbalanced bracket, say
             }
@@ -120,13 +120,76 @@ final class PatternValues {
             return Optional.empty();
         }
         try {
-            return java.util.regex.Pattern.matches(regex, built)
+            return java.util.regex.Pattern.compile(regex)
+                    .matcher(new Budgeted(built, MOST_READS)).matches()
                     ? Optional.of(built) : Optional.empty();
-        } catch (java.util.regex.PatternSyntaxException | StackOverflowError _) {
-            // Not a pattern at all, or one the engine cannot walk to the end of. The compiler settles
-            // the first where it is written, so nothing here reports it again; what either means for a
-            // value is that there is none.
+        } catch (java.util.regex.PatternSyntaxException | OutOfBudget | StackOverflowError _) {
+            // Not a pattern at all, one that would take longer to check than anybody will wait, or
+            // one the engine cannot walk to the end of. The compiler settles the first where it is
+            // written, so nothing here reports it again; what any of them means for a value is that
+            // there is none.
             return Optional.empty();
+        }
+    }
+
+    /** The engine read more of the answer than it was given to read. */
+    private static final class OutOfBudget extends RuntimeException {
+        OutOfBudget() {
+            super(null, null, false, false);
+        }
+    }
+
+    /**
+     * The answer, handed to the engine a character at a time and counted.
+     *
+     * <p>Where the work is bounded. A matcher reads its input through {@code charAt} as it tries and
+     * backs up, so the reads are the work — no estimate of the pattern stands in for them, and one
+     * that runs away is stopped at the character that takes it past what it was given rather than
+     * after however long it takes.
+     *
+     * <p>The count is shared with every subsequence taken from it, because a matcher that took one
+     * would otherwise start again from nothing. Fresh for each answer checked, so that one pattern's
+     * reading is never charged to another's — the rows of a model are checked on more than one thread.
+     */
+    private static final class Budgeted implements CharSequence {
+
+        private final String value;
+        private final int[] left;
+
+        Budgeted(String value, int budget) {
+            this(value, new int[] {budget});
+        }
+
+        private Budgeted(String value, int[] left) {
+            this.value = value;
+            this.left = left;
+        }
+
+        @Override
+        public int length() {
+            return value.length();
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (--left[0] < 0) {
+                throw new OutOfBudget();
+            }
+            return value.charAt(index);
+        }
+
+        @Override
+        public CharSequence subSequence(int from, int to) {
+            return new Budgeted(value.substring(from, to), left);
+        }
+
+        /** Reading the whole of it at once is still reading the whole of it. */
+        @Override
+        public String toString() {
+            if ((left[0] -= value.length()) < 0) {
+                throw new OutOfBudget();
+            }
+            return value;
         }
     }
 
@@ -148,54 +211,27 @@ final class PatternValues {
 
     // --- the grammar ------------------------------------------------------------------------------
 
-    /**
-     * What one part of a pattern writes, and what putting it back through the engine will cost.
-     *
-     * <p>The second is the point. The engine matches by trying and backing up, and where a repetition
-     * is written over something that can itself match more than one length, every copy of it in the
-     * generated string is another place to back up to — which multiplies. {@code (?:x?x){40}} is
-     * forty of them over a forty-character string, and no part of it is a construct this cannot read.
-     *
-     * @param ambiguity how many places in {@code text} the engine may have to back up to, counted so
-     *                  that a repetition multiplies what is under it rather than adding to it
-     */
-    private record Piece(String text, int ambiguity) {
-
-        static final Piece NOTHING = new Piece("", 0);
-
-        static Piece plain(String text) {
-            return new Piece(text, 0);
-        }
-
-        Piece then(Piece next) {
-            return new Piece(text + next.text(), ambiguity + next.ambiguity());
-        }
-    }
-
     /** {@code a|b|c} — the first branch, always. The rest is still read, because a pattern this
-     * cannot read all of is one it will not offer a value for. A branch not taken is still somewhere
-     * the engine can back up to, so having more than one costs. */
-    private Piece alternation() {
-        Piece first = sequence();
-        int branches = 0;
+     * cannot read all of is one it will not offer a value for. */
+    private String alternation() {
+        String first = sequence();
         while (peek() == '|') {
             take();
             sequence();
-            branches++;
         }
-        return branches == 0 ? first : new Piece(first.text(), first.ambiguity() + branches);
+        return first;
     }
 
-    private Piece sequence() {
-        Piece out = Piece.NOTHING;
+    private String sequence() {
+        StringBuilder out = new StringBuilder();
         while (!done() && peek() != '|' && peek() != ')') {
-            out = out.then(quantified());
+            out.append(quantified());
         }
-        return out;
+        return out.toString();
     }
 
-    private Piece quantified() {
-        Piece one = atom();
+    private String quantified() {
+        String one = atom();
         int least = 1;
         int most = 1;
         switch (peek()) {
@@ -219,25 +255,13 @@ final class PatternValues {
             take();
         }
         int times = least + (most == least ? 0 : Math.min(BEYOND_MINIMUM, most - least));
-        if ((long) one.text().length() * times > LONGEST) {
+        if ((long) one.length() * times > LONGEST) {
             throw new Unreadable();   // longer than a row will carry, so there is no row to write
         }
-        // A repetition that can stop early is a place to back up to whatever it wrote — even where it
-        // wrote nothing, since the engine still has the choice. Each copy carries what is under it,
-        // which is how a repetition of a repetition becomes the product of the two.
-        boolean variable = most != least;
-        int copies = Math.max(times, 1);
-        long cost = (long) copies * one.ambiguity() + (variable ? copies : 0);
-        if (cost > MOST_BACKTRACKING) {
-            // Not a construct this cannot read — every part of it was read. What it cannot do is
-            // check the answer in the time anybody has, and an answer it did not check is not one it
-            // offers.
-            throw new Unreadable();
-        }
-        return new Piece(one.text().repeat(times), (int) cost);
+        return one.repeat(times);
     }
 
-    private Piece atom() {
+    private String atom() {
         char c = peek();
         switch (c) {
             case '(' -> {
@@ -251,31 +275,31 @@ final class PatternValues {
                     }
                     take();
                 }
-                Piece inside = alternation();
+                String inside = alternation();
                 expect(')');
                 return inside;
             }
             case '[' -> {
                 take();
-                return Piece.plain(characterClass());
+                return characterClass();
             }
             case '\\' -> {
                 take();
-                return Piece.plain(escaped());
+                return escaped();
             }
             case '.' -> {
                 take();
-                return Piece.plain("a");
+                return "a";
             }
             case '^', '$' -> {
                 // The whole string is matched anyway, so an anchor at either end says nothing extra.
                 take();
-                return Piece.NOTHING;
+                return "";
             }
             case 0 -> throw new Unreadable();
             default -> {
                 take();
-                return Piece.plain(String.valueOf(c));
+                return String.valueOf(c);
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
@@ -1,0 +1,279 @@
+package souther.compiler.partition;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * A string the pattern an invariant states would accept.
+ *
+ * <p>A format rule is the commonest thing an identifier says about itself — an office number is
+ * {@code [0-9]{2}-[0-9]{6}}, an invoice is {@code INV-[0-9]{4}-[0-9]{6}} — and until now nothing could
+ * write one. A record holding one could not be composed at all, so every combination it took part in
+ * came back as one whose values were refused, and a generator that could name the gaps could fill none
+ * of them. Twenty-seven of the patterns in the example models are of this kind.
+ *
+ * <p>What comes out is the shortest string the pattern accepts, chosen the same way every time: the
+ * first branch of an alternation, the first character of a class, the fewest repetitions a bound
+ * allows. Nothing here is random. A generated row is compared against the last one to see what changed,
+ * and a value that differed between two runs of the same model would make every row look changed.
+ *
+ * <p>What it does not understand, it does not guess at. The result is put back through the pattern
+ * before it is offered, so a construct this reads wrongly produces nothing rather than a value that
+ * does not match — the caller already knows what to do with nothing, which is to say so.
+ */
+final class PatternValues {
+
+    /** How many repetitions an unbounded quantifier is asked for beyond its minimum. None: the
+     * shortest string the pattern accepts is the one that says least about anything else. */
+    private static final int BEYOND_MINIMUM = 0;
+
+    /** Where a negated class takes its character from, in order. A letter first, because an
+     * identifier that excludes something usually excludes punctuation. */
+    private static final String PREFERRED = "abcdefghijklmnopqrstuvwxyz"
+            + "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    /**
+     * The shortest string {@code regex} accepts, or empty where this cannot say.
+     *
+     * <p>Empty for a construct it does not read — a backreference, a lookaround, a unicode property —
+     * and empty for anything it built that the pattern then refused, which is the same answer and the
+     * reason the second check is here.
+     */
+    static Optional<String> shortestAccepted(String regex) {
+        PatternValues reader = new PatternValues(regex);
+        String built;
+        try {
+            built = reader.alternation();
+            if (!reader.done()) {
+                return Optional.empty();   // stopped early — an unbalanced bracket, say
+            }
+        } catch (Unreadable | StackOverflowError _) {
+            return Optional.empty();
+        }
+        try {
+            return java.util.regex.Pattern.matches(regex, built)
+                    ? Optional.of(built) : Optional.empty();
+        } catch (java.util.regex.PatternSyntaxException _) {
+            // Not a pattern at all. The compiler settles that where it is written, so nothing here
+            // reports it again; what it means for a value is that there is none.
+            return Optional.empty();
+        }
+    }
+
+    /** A construct this does not read. Thrown rather than returned so that a nested one stops the
+     * whole walk: half of a pattern is not a value. */
+    private static final class Unreadable extends RuntimeException {
+        Unreadable() {
+            super(null, null, false, false);
+        }
+    }
+
+    private final String regex;
+    private int at;
+
+    private PatternValues(String regex) {
+        this.regex = regex;
+        this.at = 0;
+    }
+
+    // --- the grammar ------------------------------------------------------------------------------
+
+    /** {@code a|b|c} — the first branch, always. The rest is still read, because a pattern this
+     * cannot read all of is one it will not offer a value for. */
+    private String alternation() {
+        String first = sequence();
+        while (peek() == '|') {
+            take();
+            sequence();
+        }
+        return first;
+    }
+
+    private String sequence() {
+        StringBuilder out = new StringBuilder();
+        while (!done() && peek() != '|' && peek() != ')') {
+            out.append(quantified());
+        }
+        return out.toString();
+    }
+
+    private String quantified() {
+        String one = atom();
+        int least = 1;
+        int most = 1;
+        switch (peek()) {
+            case '?' -> { take(); least = 0; most = 1; }
+            case '*' -> { take(); least = 0; most = Integer.MAX_VALUE; }
+            case '+' -> { take(); least = 1; most = Integer.MAX_VALUE; }
+            case '{' -> {
+                take();
+                least = number();
+                most = least;
+                if (peek() == ',') {
+                    take();
+                    most = peek() == '}' ? Integer.MAX_VALUE : number();
+                }
+                expect('}');
+            }
+            default -> { }
+        }
+        // A reluctant or possessive marker changes what a matcher does, not what the language accepts.
+        if (peek() == '?' || peek() == '+') {
+            take();
+        }
+        int times = least + (most == least ? 0 : Math.min(BEYOND_MINIMUM, most - least));
+        return one.repeat(times);
+    }
+
+    private String atom() {
+        char c = peek();
+        switch (c) {
+            case '(' -> {
+                take();
+                if (peek() == '?') {
+                    take();
+                    // Only a plain non-capturing group. A lookaround or a named group says something
+                    // about the match that a value cannot be built from by reading left to right.
+                    if (peek() != ':') {
+                        throw new Unreadable();
+                    }
+                    take();
+                }
+                String inside = alternation();
+                expect(')');
+                return inside;
+            }
+            case '[' -> {
+                take();
+                return characterClass();
+            }
+            case '\\' -> {
+                take();
+                return escaped();
+            }
+            case '.' -> {
+                take();
+                return "a";
+            }
+            case '^', '$' -> {
+                // The whole string is matched anyway, so an anchor at either end says nothing extra.
+                take();
+                return "";
+            }
+            case 0 -> throw new Unreadable();
+            default -> {
+                take();
+                return String.valueOf(c);
+            }
+        }
+    }
+
+    // --- character classes -------------------------------------------------------------------------
+
+    /** {@code [a-z0-9_]} or {@code [^@\s]} — one character it accepts. */
+    private String characterClass() {
+        boolean negated = peek() == '^';
+        if (negated) {
+            take();
+        }
+        List<char[]> ranges = new ArrayList<>();
+        boolean first = true;
+        while (!done() && (peek() != ']' || first)) {
+            first = false;
+            char low = classMember();
+            if (peek() == '-' && at + 1 < regex.length() && regex.charAt(at + 1) != ']') {
+                take();
+                ranges.add(new char[] {low, classMember()});
+            } else {
+                ranges.add(new char[] {low, low});
+            }
+        }
+        expect(']');
+        if (ranges.isEmpty()) {
+            throw new Unreadable();
+        }
+        if (!negated) {
+            return String.valueOf(ranges.get(0)[0]);
+        }
+        for (char candidate : PREFERRED.toCharArray()) {
+            if (ranges.stream().noneMatch(r -> candidate >= r[0] && candidate <= r[1])) {
+                return String.valueOf(candidate);
+            }
+        }
+        throw new Unreadable();
+    }
+
+    /** One character of a class, which may be written as an escape. A shorthand inside a class covers
+     * several characters at once; the first of what it stands for is enough to be in the class, and to
+     * be out of a negated one it has to be excluded as a whole — which is why the shorthand's whole
+     * range is added. */
+    private char classMember() {
+        char c = take();
+        if (c != '\\') {
+            return c;
+        }
+        char kind = take();
+        return switch (kind) {
+            case 'd' -> '0';
+            case 'w' -> 'a';
+            case 's' -> ' ';
+            case 'n' -> '\n';
+            case 't' -> '\t';
+            case 'r' -> '\r';
+            case 'D', 'W', 'S', 'p', 'P', 'b', 'B' -> throw new Unreadable();
+            default -> kind;   // an escaped literal: `\-`, `\.`, `\\`, `\+`
+        };
+    }
+
+    /** An escape outside a class. */
+    private String escaped() {
+        char kind = take();
+        return switch (kind) {
+            case 'd' -> "0";
+            case 'w' -> "a";
+            case 's' -> " ";
+            case 'n' -> "\n";
+            case 't' -> "\t";
+            case 'r' -> "\r";
+            case 'D', 'W', 'S', 'p', 'P', 'b', 'B', 'k', 'Q', 'E', 'G', 'A', 'Z', 'z' ->
+                    throw new Unreadable();
+            case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> throw new Unreadable();   // a back reference
+            default -> String.valueOf(kind);
+        };
+    }
+
+    // --- reading ------------------------------------------------------------------------------------
+
+    private int number() {
+        int start = at;
+        while (!done() && Character.isDigit(peek())) {
+            take();
+        }
+        if (start == at) {
+            throw new Unreadable();
+        }
+        return Integer.parseInt(regex.substring(start, at));
+    }
+
+    private boolean done() {
+        return at >= regex.length();
+    }
+
+    private char peek() {
+        return done() ? 0 : regex.charAt(at);
+    }
+
+    private char take() {
+        if (done()) {
+            throw new Unreadable();
+        }
+        return regex.charAt(at++);
+    }
+
+    private void expect(char c) {
+        if (take() != c) {
+            throw new Unreadable();
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
@@ -28,10 +28,25 @@ final class PatternValues {
      * shortest string the pattern accepts is the one that says least about anything else. */
     private static final int BEYOND_MINIMUM = 0;
 
-    /** Where a negated class takes its character from, in order. A letter first, because an
-     * identifier that excludes something usually excludes punctuation. */
-    private static final String PREFERRED = "abcdefghijklmnopqrstuvwxyz"
-            + "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    /**
+     * Where a negated class takes its character from, in order.
+     *
+     * <p>A letter first, because a class that excludes something usually excludes punctuation, and a
+     * value made of letters is the one a reader recognises. Then the rest of printable ASCII, and then
+     * a character from each of the alphabets a model here is written in — a rule that excludes ASCII
+     * entirely is asking for one of those, and had nothing to give before.
+     */
+    private static final String PREFERRED = build();
+
+    private static String build() {
+        StringBuilder out = new StringBuilder("abcdefghijklmnopqrstuvwxyz"
+                + "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789");
+        for (char c = 0x20; c <= 0x7e; c++) {
+            out.append(c);
+        }
+        out.append('\n').append('\t');
+        return out.append("あアー一　ｦ").toString();
+    }
 
     /**
      * The shortest string {@code regex} accepts, or empty where this cannot say.
@@ -221,7 +236,9 @@ final class PatternValues {
             case 'n' -> '\n';
             case 't' -> '\t';
             case 'r' -> '\r';
-            case 'D', 'W', 'S', 'p', 'P', 'b', 'B' -> throw new Unreadable();
+            case 'x' -> hex(2);
+            case 'u' -> hex(4);
+            case 'D', 'W', 'S', 'p', 'P', 'b', 'B', 'c' -> throw new Unreadable();
             default -> kind;   // an escaped literal: `\-`, `\.`, `\\`, `\+`
         };
     }
@@ -236,11 +253,28 @@ final class PatternValues {
             case 'n' -> "\n";
             case 't' -> "\t";
             case 'r' -> "\r";
-            case 'D', 'W', 'S', 'p', 'P', 'b', 'B', 'k', 'Q', 'E', 'G', 'A', 'Z', 'z' ->
+            case 'x' -> String.valueOf(hex(2));
+            case 'u' -> String.valueOf(hex(4));
+            case 'D', 'W', 'S', 'p', 'P', 'b', 'B', 'c', 'k', 'Q', 'E', 'G', 'A', 'Z', 'z' ->
                     throw new Unreadable();
             case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9' -> throw new Unreadable();   // a back reference
             default -> String.valueOf(kind);
         };
+    }
+
+    /** A hex escape — two digits after {@code x}, four after {@code u} — as the character it names.
+     * Read rather than refused because a class written that way is usually one excluding ASCII, and
+     * what it is asking for is a character from one of the alphabets a model is written in. */
+    private char hex(int digits) {
+        int value = 0;
+        for (int i = 0; i < digits; i++) {
+            int digit = Character.digit(take(), 16);
+            if (digit < 0) {
+                throw new Unreadable();
+            }
+            value = value * 16 + digit;
+        }
+        return (char) value;
     }
 
     // --- reading ------------------------------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PatternValues.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -41,8 +42,9 @@ final class PatternValues {
      * <p>A letter first, because a class that excludes something usually excludes punctuation, and a
      * value made of letters is the one a reader recognises. Then the rest of printable ASCII, and then
      * a character from each of the alphabets a model here is written in — a rule excluding ASCII
-     * entirely is asking for one of those. A tab or a newline last: they read as nothing at all in a
-     * row, so they are what is left when a rule excludes every character that reads as something.
+     * entirely is asking for one of those. The three a literal spells but nobody sees last: they read
+     * as nothing at all in a row, so they are what is left when a rule excludes every character that
+     * reads as something.
      */
     private static final String PREFERRED = build();
 
@@ -53,20 +55,31 @@ final class PatternValues {
             out.append(c);
         }
         out.append("あアー一　ｦ");
-        return out.append('\t').append('\n').toString();
+        return out.append('\t').append('\n').append('\r').toString();
     }
 
     /**
      * Whether a row can be written carrying this.
      *
-     * <p>A value is offered to be pasted into a model as a string literal, and the literal reads five
-     * escapes. A character outside them and outside the printable ones cannot be written at all: what
-     * would go in is the character itself, which is not a value anybody can read, and for some of them
-     * not something a file holds. There is no value here, which is what the caller already handles.
+     * <p>Two things have to hold, and they are about different places. The literal reads five escapes,
+     * so a control character outside them would go into the row as itself — not a value anybody can
+     * read. And the row is a line of a source file, so the value has to survive being encoded into
+     * one: a lone surrogate is half of a character, which UTF-8 has nothing to write and replaces with
+     * a `?`, and the value somebody pastes is then not the value that was generated.
+     *
+     * <p>Either way there is no value here, which is what the caller already handles.
      */
     private static boolean writable(String value) {
-        return value.length() <= LONGEST && value.chars().allMatch(c ->
-                c == '\n' || c == '\t' || c == '\r' || (c >= 0x20 && c != 0x7f));
+        if (value.length() > LONGEST) {
+            return false;
+        }
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (c != '\n' && c != '\t' && c != '\r' && (c < 0x20 || c == 0x7f)) {
+                return false;
+            }
+        }
+        return StandardCharsets.UTF_8.newEncoder().canEncode(value);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -275,6 +275,59 @@ class CompileExampleGenerateTest {
                 inputs(generated(dated).get("take").pairs()));
     }
 
+    /**
+     * A value carrying a character a literal has to escape.
+     *
+     * <p>The row is text somebody pastes, so what it says has to read back as what it was made from.
+     * Written as itself, a tab is invisible in the row and a newline ends it — the rest of the row
+     * lands on a line that is not commented out, and what was pasted is not what was offered. So this
+     * asks the compiler rather than the text: the block goes back in, and the rows have to hold.
+     */
+    @Test
+    void aValueWithACharacterALiteralEscapesSurvivesBeingPasted() {
+        String tabbed = """
+                module example.tabbed
+
+                data Spaced = String
+                    invariant String.matches("a[\\\\t]b", value)
+
+                data Yes
+                data No
+                data Flag = Yes | No
+
+                data Note = { text: Spaced, flag: Flag }
+                data Ok = { n: Int }
+
+                behavior take : (note: Note) -> Ok
+                    constructs Ok
+
+                let take (note) = Ok { n = 0 }
+
+                example take
+                    | (Note { text = Spaced("a\\tb"), flag = Yes }) -> Ok { n = 0 }
+                """;
+
+        assertEquals(List.of("Note { text = Spaced(\"a\\tb\"), flag = No }"),
+                inputs(generated(tabbed).get("take").pairs()),
+                "the tab is written the way a literal spells one");
+
+        String block = GeneratedRows.of("example.tabbed", generated(tabbed), false);
+        String pasted = tabbed + block.lines()
+                .filter(line -> line.startsWith("//     ") || line.equals("// example take"))
+                .map(line -> line.substring("// ".length()).replace("<?>", "Ok { n = 0 }"))
+                .reduce("", (all, line) -> all + line + "\n");
+
+        Compilation compilation = Compilation.ofSource(pasted, "Main");
+        compilation.answerEverything();
+        List<souther.compiler.observe.RowOutcome> rows = outcomes(compilation);
+
+        assertEquals(2, rows.size(), "the row that was there, and the one generated");
+        for (souther.compiler.observe.RowOutcome row : rows) {
+            assertEquals(souther.compiler.observe.Disposition.HELD, row.disposition(),
+                    row.description() + " -> " + row.failurePhase());
+        }
+    }
+
     // --- the block, put back through the compiler ------------------------------------------------
 
     /** The rows of the block, with the placeholder answered the way an author answers it. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -205,6 +205,76 @@ class CompileExampleGenerateTest {
                 "the invariant's edge and both sides of the guard's line");
     }
 
+    /**
+     * A value a format rule accepts, and one the model then builds.
+     *
+     * <p>An identifier saying what it looks like is the commonest rule there is, and nothing could
+     * write one — so a record holding an id could not be composed at all, and every combination that
+     * record took part in came back as one whose values the model refused. What settles this is not
+     * that the string looks right but that the derived decoder takes it, which is what the check here
+     * is: the row is offered only if it built.
+     */
+    @Test
+    void anIdentifierWithAFormatRuleGetsAValueTheModelAccepts() {
+        String formatted = """
+                module example.office
+
+                data OfficeId = String
+                    invariant String.matches("[0-9]{2}-[0-9]{6}", value)
+
+                data Prefecture = String
+                    invariant String.matches("0[1-9]|[1-3][0-9]|4[0-7]", value)
+
+                data Domestic
+                data Overseas
+                data Kind = Domestic | Overseas
+
+                data Office = { id: OfficeId, prefecture: Prefecture, kind: Kind }
+                data Ok = { n: Int }
+
+                behavior register : (office: Office) -> Ok
+                    constructs Ok
+
+                let register (office) = Ok { n = 0 }
+
+                example register
+                    | (Office { id = OfficeId("12-345678"), prefecture = Prefecture("13"),
+                                kind = Domestic }) -> Ok { n = 0 }
+                """;
+
+        assertEquals(List.of(
+                        "Office { id = OfficeId(\"00-000000\"), prefecture = Prefecture(\"01\"),"
+                                + " kind = Overseas }"),
+                inputs(generated(formatted).get("register").pairs()),
+                "the class nothing covers, with an id and a prefecture the rules accept");
+    }
+
+    /** And a date, which a row writes as its ISO form. */
+    @Test
+    void aDateGetsAValueTheModelAccepts() {
+        String dated = """
+                module example.dated
+
+                data Yes
+                data No
+                data Flag = Yes | No
+
+                data Request = { on: Date, flag: Flag }
+                data Ok = { n: Int }
+
+                behavior take : (request: Request) -> Ok
+                    constructs Ok
+
+                let take (request) = Ok { n = 0 }
+
+                example take
+                    | (Request { on = Date("2026-08-03"), flag = Yes }) -> Ok { n = 0 }
+                """;
+
+        assertEquals(List.of("Request { on = Date(\"2000-01-01\"), flag = No }"),
+                inputs(generated(dated).get("take").pairs()));
+    }
+
     // --- the block, put back through the compiler ------------------------------------------------
 
     /** The rows of the block, with the placeholder answered the way an author answers it. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -449,6 +449,53 @@ class CompileExampleGenerateTest {
     }
 
     /**
+     * One parameter's choices do not multiply with another's.
+     *
+     * <p>Each parameter is built and refused on its own, so searching them together spends the bound
+     * on assignments differing only in a parameter already settled. Here every field's value is the
+     * second of the two it was offered, which is four steps out in each of two parameters — reachable
+     * on its own and, taken together, eight steps into a space of two hundred and fifty-six.
+     */
+    @Test
+    void eachParameterIsSearchedOnItsOwn() {
+        StringBuilder declarations = new StringBuilder();
+        for (char c = 'a'; c <= 'h'; c++) {
+            declarations.append("""
+                    data V%1$s = String
+                        invariant String.matches("[a-z]+", value)
+                        invariant String.matches("x+", value)
+
+                    """.formatted(Character.toUpperCase(c)));
+        }
+        String source = """
+                module example.two
+
+                %sdata Yes
+                data No
+                data Flag = Yes | No
+
+                data One = { a: VA, b: VB, c: VC, d: VD }
+                data Two = { e: VE, f: VF, g: VG, h: VH, flag: Flag }
+                data Ok = { n: Int }
+
+                behavior take : (one: One, two: Two) -> Ok
+                    constructs Ok
+
+                let take (one, two) = Ok { n = 0 }
+                """.formatted(declarations);
+
+        List<String> rows = inputs(generated(source).get("take").pairs());
+
+        assertEquals(2, rows.size(), "one row per class of the only axis: " + rows);
+        for (String row : rows) {
+            for (char c = 'a'; c <= 'h'; c++) {
+                assertTrue(row.contains("V%1$s(\"x\")".formatted(Character.toUpperCase(c))),
+                        "every field at the value its rules allow: " + row);
+            }
+        }
+    }
+
+    /**
      * A search that stopped says so, rather than saying everything was refused.
      *
      * <p>The choices multiply, so a row is tried at a bounded number of assignments. Past that bound

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -396,6 +396,109 @@ class CompileExampleGenerateTest {
     }
 
     /**
+     * Two positions, each needing a different one of the values it was offered.
+     *
+     * <p>What has to build is the whole input at once — the check is the model's own constructor — so
+     * what is being tried is the tuple, not a value. Here the two positions carry the same two rules
+     * written the other way round, so their values come out in opposite orders and the assignment that
+     * builds is the first value of one with the second of the other. Trying one index across every
+     * position walks the diagonal of the choices and never reaches it.
+     */
+    @Test
+    void candidatesAtDifferentPositionsAreNotWalkedInLockstep() {
+        String source = """
+                module example.lock
+
+                data Left = String
+                    invariant String.matches("[a-z]+", value)
+                    invariant String.matches("x+", value)
+
+                data Right = String
+                    invariant String.matches("x+", value)
+                    invariant String.matches("[a-z]+", value)
+
+                data Yes
+                data No
+                data Flag = Yes | No
+
+                data Req = { left: Left, right: Right, flag: Flag }
+                data Ok = { n: Int }
+
+                behavior take : (request: Req) -> Ok
+                    constructs Ok
+
+                let take (request) = Ok { n = 0 }
+
+                example take
+                    | (Req { left = Left("x"), right = Right("x"), flag = Yes }) -> Ok { n = 0 }
+                """;
+
+        assertEquals(List.of("Req { left = Left(\"x\"), right = Right(\"x\"), flag = No }"),
+                inputs(generated(source).get("take").pairs()));
+        // And the same model with one of the two rewritten to declare its rules in the other order,
+        // which is the same model. Order decided this before the assignments were walked as tuples.
+        assertEquals(inputs(generated(source).get("take").pairs()),
+                inputs(generated(source.replace("module example.lock", "module example.lock2")
+                        .replace("""
+                                data Right = String
+                                    invariant String.matches("x+", value)
+                                    invariant String.matches("[a-z]+", value)""", """
+                                data Right = String
+                                    invariant String.matches("[a-z]+", value)
+                                    invariant String.matches("x+", value)""")).get("take").pairs()));
+    }
+
+    /**
+     * A search that stopped says so, rather than saying everything was refused.
+     *
+     * <p>The choices multiply, so a row is tried at a bounded number of assignments. Past that bound
+     * the ones not reached were not refused — nothing was written and nothing built — and calling them
+     * refused tells an author their model rules out a combination it does not.
+     */
+    @Test
+    void whatTheSearchDidNotReachIsNotReportedAsRefused() {
+        StringBuilder declarations = new StringBuilder();
+        StringBuilder fields = new StringBuilder();
+        for (char c = 'a'; c <= 'i'; c++) {
+            declarations.append("""
+                    data V%1$s = String
+                        invariant String.matches("[a-z]+", value)
+                        invariant String.matches("x+", value)
+
+                    """.formatted(Character.toUpperCase(c)));
+            fields.append(c).append(": V").append(Character.toUpperCase(c)).append(", ");
+        }
+        String source = """
+                module example.wide
+
+                %sdata Yes
+                data No
+                data Flag = Yes | No
+
+                data Req = { %sflag: Flag }
+                    invariant String.length(a.value) > 1000
+
+                data Ok = { n: Int }
+
+                behavior take : (request: Req) -> Ok
+                    constructs Ok
+
+                let take (request) = Ok { n = 0 }
+                """.formatted(declarations, fields);
+
+        List<Generator.UnresolvedCombination> left = generated(source).get("take").pairs()
+                .unresolved();
+
+        assertFalse(left.isEmpty(), "nothing builds, so something is left");
+        for (Generator.UnresolvedCombination each : left) {
+            assertEquals(Generator.UnresolvedCombination.Reason.SEARCH_LIMIT, each.reason(),
+                    each.toString());
+            assertTrue(each.subject().startsWith("request.flag="),
+                    "and it is still about the combination: " + each.subject());
+        }
+    }
+
+    /**
      * A newtype's rules are read wherever it is asked for a value.
      *
      * <p>A newtype is asked for one from two places — a field of a record, and a case of a sum — and

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -328,6 +328,117 @@ class CompileExampleGenerateTest {
         }
     }
 
+    /** A model where the position under test is a field of the input and one flag divides the rows. */
+    private static String withField(String declarations, String field) {
+        return """
+                module example.candidates
+
+                %s
+
+                data Yes
+                data No
+                data Flag = Yes | No
+
+                data Req = { v: %s, f: Flag }
+                data Ok = { n: Int }
+
+                behavior take : (r: Req) -> Ok
+                    constructs Ok
+
+                let take (r) = Ok { n = 0 }
+
+                example take
+                    | (Req { v = %s, f = Yes }) -> Ok { n = 0 }
+                """.formatted(declarations, field, "%s");
+    }
+
+    /**
+     * A rule this cannot read leaves the position what it had.
+     *
+     * <p>Reading a format rule is a way to offer a value, not a way to decide there is none. A lookahead
+     * is past what the reader understands, and the plain representative for the position — which built
+     * before any of this existed, and which this rule happens to accept — is still offered.
+     */
+    @Test
+    void unsupportedPatternThatAcceptsTheDefaultCandidateStillGenerates() {
+        String source = withField("""
+                data V = String
+                    invariant String.matches("(?=x)x", value)""", "V").formatted("V(\"x\")");
+
+        assertEquals(List.of("Req { v = V(\"x\"), f = No }"),
+                inputs(generated(source).get("take").pairs()));
+    }
+
+    /**
+     * Two rules on one position, in either order.
+     *
+     * <p>Every clause of an invariant has to hold, so the order they are written in cannot decide
+     * whether a value can be found. Each readable rule contributes a candidate and the constructor
+     * settles which of them stands — reading only the first would make `[a-z]+` before `x+` produce
+     * `"a"` and stop, and the same two rules the other way round produce a value.
+     */
+    @Test
+    void conjoinedPatternsDoNotDependOnDeclarationOrder() {
+        String forwards = withField("""
+                data V = String
+                    invariant String.matches("[a-z]+", value)
+                    invariant String.matches("x+", value)""", "V").formatted("V(\"x\")");
+        String backwards = withField("""
+                data V = String
+                    invariant String.matches("x+", value)
+                    invariant String.matches("[a-z]+", value)""", "V").formatted("V(\"x\")");
+
+        assertEquals(List.of("Req { v = V(\"x\"), f = No }"),
+                inputs(generated(forwards).get("take").pairs()));
+        assertEquals(inputs(generated(forwards).get("take").pairs()),
+                inputs(generated(backwards).get("take").pairs()),
+                "the same two rules, written the other way round");
+    }
+
+    /**
+     * A newtype's rules are read wherever it is asked for a value.
+     *
+     * <p>A newtype is asked for one from two places — a field of a record, and a case of a sum — and
+     * the rules on it are the same rules in both. Read in only one of them, a formatted identifier
+     * composes as a field and is refused as a case, which is the same model reporting a position as
+     * unfillable depending on where it was written.
+     */
+    @Test
+    void aFormattedNewtypeUsedAsASumCaseGetsARepresentative() {
+        String source = """
+                module example.cases
+
+                data Email = String
+                    invariant String.matches("[a-z]+@[a-z]+", value)
+
+                data Amount = Int
+                    invariant value >= 100
+
+                data NoContact
+                data Contact = Email | NoContact
+                data NoAmount
+                data Wallet = NoAmount | Amount
+
+                data Req = { contact: Contact, w: Wallet }
+                data Ok = { n: Int }
+
+                behavior take : (r: Req) -> Ok
+                    constructs Ok
+
+                let take (r) = Ok { n = 0 }
+
+                example take
+                    | (Req { contact = NoContact, w = NoAmount }) -> Ok { n = 0 }
+                """;
+
+        List<String> rows = inputs(generated(source).get("take").pairs());
+
+        assertTrue(rows.stream().anyMatch(r -> r.contains("Email(\"a@a\")")),
+                "a case whose rule states a format: " + rows);
+        assertTrue(rows.stream().anyMatch(r -> r.contains("Amount(100)")),
+                "and one whose rule states a bound: " + rows);
+    }
+
     // --- the block, put back through the compiler ------------------------------------------------
 
     /** The rows of the block, with the placeholder answered the way an author answers it. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
@@ -3,12 +3,14 @@ package souther.compiler.partition;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -217,6 +219,44 @@ class PatternValuesTest {
         for (String regex : beyondIt) {
             assertEquals(Optional.empty(), PatternValues.shortestAccepted(regex), regex);
         }
+    }
+
+    /**
+     * A pattern whose answer would take longer to check than anyone will wait.
+     *
+     * <p>Every part of {@code (?:x?x){40}} is a construct this reads. What it cannot do is check the
+     * answer: the value it would offer is forty characters, and the engine matching it has forty
+     * places to back up to, which multiply. Measured on this machine before the bound went in, thirty
+     * took 40ms, thirty-three took 172ms, and each further one doubled — so a valid model was enough
+     * to stop the compiler.
+     *
+     * <p>The check runs preemptively because the failure being guarded against is not a wrong answer
+     * but no answer at all.
+     */
+    @Test
+    void aPatternWithNestedVariableRepetitionIsNotEvaluated() {
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            for (String regex : List.of("(?:x?x){30}", "(?:x?x){40}", "(?:x?x){200}",
+                    "(?:(?:x?x){8}){8}", "(?:(a|aa)x){30}")) {
+                assertEquals(Optional.empty(), PatternValues.shortestAccepted(regex), regex);
+            }
+        });
+    }
+
+    /**
+     * And what that bound must not cost.
+     *
+     * <p>A repetition over something of more than one length is not by itself expensive — what costs
+     * is how many copies of it end up in the answer, and a `+` or a `*` writes as few as it can. The
+     * rule for a domain name nests them three deep and is answered in under a millisecond, so a bound
+     * drawn at the shape rather than at what the answer asks for would refuse it for nothing.
+     */
+    @Test
+    void aNestedRepetitionWhoseAnswerIsShortIsStillRead() {
+        assertEquals(Optional.of("a.a"), PatternValues.shortestAccepted(
+                "[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)+"));
+        assertEquals(Optional.of("b"), PatternValues.shortestAccepted("(a|aa)*b"));
+        assertEquals(Optional.of("x".repeat(20)), PatternValues.shortestAccepted("(?:x?x){20}"));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
@@ -1,0 +1,135 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A string the pattern an invariant states would accept.
+ *
+ * <p>Two things are being held to. What comes out has to match — which is checked here the way the
+ * code checks it, by putting it back through the pattern, because a value that does not match is
+ * refused at construction and reported as a combination the model rules out. And what comes out has to
+ * be the same string every time: a generated block is read against the last one to see what changed,
+ * and a value that varied between runs would make every row look changed.
+ */
+class PatternValuesTest {
+
+    /** Every format rule written in `souther-lang/examples`, which is what this was built for. */
+    private static final List<String> IN_THE_EXAMPLES = List.of(
+            "[0-9]{6}",
+            "[0-9]{2}-[0-9]{6}",
+            "[0-9]{3}-[0-9]{4}",
+            "[0-9]{12}",
+            "[0-9]{13}",
+            "[0-9]{16}",
+            "[0-9]{4}",
+            "[0-9][A-E]",
+            "0[1-9]|[1-3][0-9]|4[0-7]",
+            "[A-Z]{2}-[0-9]{4}",
+            "[A-Z]{3}",
+            "[A-Z]-[0-9]{2}-[0-9]{2}",
+            "SH-[0-9]{6}",
+            "RMA-[0-9]{8}",
+            "INV-[0-9]{4}-[0-9]{6}",
+            "FY[0-9]{2}-Q[1-4]",
+            "T[0-9]{13}",
+            "001",
+            "003",
+            "00Q",
+            "006[0-9A-Za-z]{12}([0-9A-Z]{3})?",
+            "00T[0-9A-Za-z]{12}([0-9A-Z]{3})?",
+            "0Q0[0-9A-Za-z]{12}([0-9A-Z]{3})?",
+            "[ｦ-ﾟァ-ヴー 　]+",
+            "\\+?[0-9][0-9 \\-()]{6,19}",
+            "[^@\\s]+@[^@\\s]+\\.[^@\\s]+",
+            "[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)+");
+
+    @Test
+    void everyFormatRuleInTheExamplesGetsAValueThatMatches() {
+        List<String> without = IN_THE_EXAMPLES.stream()
+                .filter(regex -> PatternValues.shortestAccepted(regex).isEmpty()).toList();
+
+        assertEquals(List.of(), without, "a format rule nothing can write a value for");
+        for (String regex : IN_THE_EXAMPLES) {
+            String value = PatternValues.shortestAccepted(regex).orElseThrow();
+            assertTrue(Pattern.matches(regex, value), regex + " -> \"" + value + "\"");
+        }
+    }
+
+    /** What it writes, so that a change to any of it is a change somebody decided on. */
+    @Test
+    void theValueIsTheShortestOneAndTheSameEveryTime() {
+        assertEquals(Optional.of("00-000000"), PatternValues.shortestAccepted("[0-9]{2}-[0-9]{6}"));
+        assertEquals(Optional.of("01"), PatternValues.shortestAccepted("0[1-9]|[1-3][0-9]|4[0-7]"),
+                "the first branch of an alternation");
+        assertEquals(Optional.of("006000000000000"),
+                PatternValues.shortestAccepted("006[0-9A-Za-z]{12}([0-9A-Z]{3})?"),
+                "an optional group is left out");
+        assertEquals(Optional.of("0000000"),
+                PatternValues.shortestAccepted("\\+?[0-9][0-9 \\-()]{6,19}"),
+                "a bounded repetition takes its lower bound");
+        assertEquals(Optional.of("a@a.a"),
+                PatternValues.shortestAccepted("[^@\\s]+@[^@\\s]+\\.[^@\\s]+"),
+                "a negated class takes a letter that is not excluded");
+        assertEquals(Optional.of("ｦ"), PatternValues.shortestAccepted("[ｦ-ﾟァ-ヴー 　]+"),
+                "a range is a range whatever alphabet it is in");
+    }
+
+    @Test
+    void twoRunsOfOneRuleWriteTheSameValue() {
+        for (String regex : IN_THE_EXAMPLES) {
+            assertEquals(PatternValues.shortestAccepted(regex),
+                    PatternValues.shortestAccepted(regex), regex);
+        }
+    }
+
+    /**
+     * What it does not read, it does not guess at.
+     *
+     * <p>The alternative is a value that does not match, which is refused at construction and reported
+     * as a combination the model rules out — a wrong answer where there was a missing one.
+     */
+    @Test
+    void aRuleItCannotReadGetsNoValue() {
+        List<String> beyondIt = List.of(
+                "(a)\\1",            // a back reference
+                "(?=x)y",            // a lookahead
+                "(?<x>[0-9])",       // a named group
+                "\\p{Alpha}+",       // a unicode property
+                "[0-9",              // not a pattern at all
+                "(a",
+                "a{2,1}");           // a bound that admits nothing
+
+        for (String regex : beyondIt) {
+            assertEquals(Optional.empty(), PatternValues.shortestAccepted(regex), regex);
+        }
+    }
+
+    /**
+     * And the check that makes the rest of it safe.
+     *
+     * <p>Everything above is a construct someone thought about. What protects the ones nobody did is
+     * that the answer goes back through the pattern before it is offered — so being wrong about a
+     * construct produces nothing, which is what being unable to read it produces.
+     */
+    @Test
+    void anythingItGetsWrongComesBackAsNothing() {
+        // A quantifier this reads as "at least two" and the regex engine reads some other way would
+        // still have to survive the pattern. Rather than a construct nobody has thought of, the case
+        // is made with one whose meaning is genuinely elsewhere: possessive matching.
+        for (String regex : List.of("a{2}+b", "[0-9]++", "(?:ab)*+c")) {
+            Optional<String> value = PatternValues.shortestAccepted(regex);
+            assertTrue(value.isEmpty() || Pattern.matches(regex, value.get()),
+                    regex + " -> " + value);
+        }
+        assertFalse(PatternValues.shortestAccepted("[0-9]{2}").isEmpty(),
+                "and an ordinary rule is still answered");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
@@ -125,6 +125,49 @@ class PatternValuesTest {
         }
         assertEquals(Optional.of("あ"), PatternValues.shortestAccepted("[^\\x00-\\x7F]"),
                 "a rule excluding ASCII is asking for a character from somewhere else");
+        assertEquals(Optional.of("あ"), PatternValues.shortestAccepted("[^ -~]+"),
+                "and so is one excluding everything that prints in ASCII");
+    }
+
+    /**
+     * A shorthand excludes everything it stands for.
+     *
+     * <p>What a member of a class puts in is a set, and the two questions a class is asked want
+     * different amounts of it. One character is enough to be <em>in</em> the class. To be out of a
+     * negated one, every character the member stands for has to be excluded — a reader that took only
+     * the first of them excluded {@code a} and went on to offer {@code b}, which {@code [^\w]} refuses.
+     */
+    @Test
+    void aShorthandInANegatedClassExcludesAllOfWhatItMeans() {
+        for (String regex : List.of("[^\\w]+", "[^\\w\\s]", "[^\\d]", "[^\\s]", "[^0-9\\s]")) {
+            String value = PatternValues.shortestAccepted(regex)
+                    .orElseThrow(() -> new AssertionError("nothing written for " + regex));
+            assertTrue(Pattern.matches(regex, value), regex + " -> \"" + value + "\"");
+        }
+        assertEquals(Optional.of("a"), PatternValues.shortestAccepted("[\\w]"),
+                "and one character is still enough to be in the class");
+        assertEquals(Optional.of("000"), PatternValues.shortestAccepted("[\\d]{3}"));
+    }
+
+    /**
+     * A value a row could not carry is not a value.
+     *
+     * <p>What comes out is offered as text to paste into a model, as a string literal, on the line the
+     * row is on. A character the literal cannot spell would go in as itself; a long enough one would go
+     * in as a screenful. Both match the pattern and neither is something to hand anybody, so the answer
+     * is the one for a pattern nothing can be written for.
+     */
+    @Test
+    void aValueNoRowCanCarryIsNotOffered() {
+        assertEquals(Optional.empty(), PatternValues.shortestAccepted("[^\\x00-\\uFFFF]"),
+                "a rule leaving only characters a literal cannot spell");
+        assertEquals(Optional.empty(), PatternValues.shortestAccepted("[0-9]{2000000}"),
+                "a length nobody would read");
+        assertEquals(Optional.empty(), PatternValues.shortestAccepted("a{2147483648}"),
+                "a count past what a bound holds");
+
+        assertEquals(Optional.of("\n"), PatternValues.shortestAccepted("\\n"),
+                "and the ones a literal does spell are written");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
@@ -91,6 +91,43 @@ class PatternValuesTest {
     }
 
     /**
+     * An alphabet other than ASCII, on either side of a class.
+     *
+     * <p>A model here is as likely to state a rule in kana as in letters, and a rule that excludes
+     * something is as likely to exclude ASCII as to exclude punctuation. Neither is a special case for
+     * a reader that works in characters; what needed saying was where a negated class looks for one it
+     * is allowed, which was letters and digits and nothing else.
+     */
+    @Test
+    void aClassWrittenInAnotherAlphabetIsRead() {
+        assertEquals(Optional.of("ぁ"), PatternValues.shortestAccepted("[ぁ-ん]+"));
+        assertEquals(Optional.of("一一"), PatternValues.shortestAccepted("[一-龯]{2}"));
+        assertEquals(Optional.of("ｦ"), PatternValues.shortestAccepted("[ｦ-ﾟ]"));
+
+        assertEquals(Optional.of("a"), PatternValues.shortestAccepted("[^あいう]"),
+                "a letter is not one of the three, so it is what a negated class takes");
+        assertEquals(Optional.of("aaa"), PatternValues.shortestAccepted("[^あいう]{3}"));
+    }
+
+    /**
+     * A negated class that leaves no letter or digit.
+     *
+     * <p>It had nothing to give: the characters it looked through were the alphanumerics, and a rule
+     * excluding all of them is a rule asking for something else — punctuation, or a character outside
+     * ASCII altogether. What it looks through now goes on past those.
+     */
+    @Test
+    void aNegatedClassWithNoLetterLeftLooksFurther() {
+        for (String regex : List.of("[^a-zA-Z0-9]", "[^a-zA-Z0-9 ]+", "[^ -~]", "[^\\x00-\\x7F]")) {
+            String value = PatternValues.shortestAccepted(regex)
+                    .orElseThrow(() -> new AssertionError("nothing written for " + regex));
+            assertTrue(Pattern.matches(regex, value), regex + " -> \"" + value + "\"");
+        }
+        assertEquals(Optional.of("あ"), PatternValues.shortestAccepted("[^\\x00-\\x7F]"),
+                "a rule excluding ASCII is asking for a character from somewhere else");
+    }
+
+    /**
      * What it does not read, it does not guess at.
      *
      * <p>The alternative is a value that does not match, which is refused at construction and reported

--- a/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
@@ -2,6 +2,7 @@ package souther.compiler.partition;
 
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
@@ -168,6 +169,32 @@ class PatternValuesTest {
 
         assertEquals(Optional.of("\n"), PatternValues.shortestAccepted("\\n"),
                 "and the ones a literal does spell are written");
+    }
+
+    /**
+     * Half of a character is not a value.
+     *
+     * <p>A row is a line of a source file. A lone surrogate is one half of a pair, which UTF-8 has
+     * nothing to write for and replaces with a `?` — so the value that reaches the file is not the
+     * value that was generated, and the row somebody pastes back means something else. A whole pair
+     * is a character like any other and is written.
+     */
+    @Test
+    void anUnpairedSurrogateIsNotWritable() {
+        assertEquals(Optional.empty(), PatternValues.shortestAccepted("\\uD800"));
+        assertEquals(Optional.empty(), PatternValues.shortestAccepted("[\\uD800-\\uD801]"));
+
+        String pair = PatternValues.shortestAccepted("\\uD83D\\uDE00")
+                .orElseThrow(() -> new AssertionError("a whole character is still written"));
+        assertEquals(2, pair.length());
+        assertTrue(StandardCharsets.UTF_8.newEncoder().canEncode(pair));
+    }
+
+    /** And the one a negated class had nothing left but. */
+    @Test
+    void aRuleLeavingOnlyACarriageReturnGetsOne() {
+        assertEquals(Optional.of("\r"),
+                PatternValues.shortestAccepted("[^\\x00-\\x0C\\x0E-\\uFFFF]"));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PatternValuesTest.java
@@ -224,39 +224,58 @@ class PatternValuesTest {
     /**
      * A pattern whose answer would take longer to check than anyone will wait.
      *
-     * <p>Every part of {@code (?:x?x){40}} is a construct this reads. What it cannot do is check the
-     * answer: the value it would offer is forty characters, and the engine matching it has forty
-     * places to back up to, which multiply. Measured on this machine before the bound went in, thirty
-     * took 40ms, thirty-three took 172ms, and each further one doubled — so a valid model was enough
-     * to stop the compiler.
+     * <p>Every part of these is a construct the reader understands; what it cannot do is check the
+     * answer. A repetition written over something of more than one length gives the engine somewhere
+     * to back up to for every copy in the string — {@code (?:x?x){40}} took 22 seconds before the
+     * check was bounded — and so does any pair of variable-length parts competing for the same
+     * characters, which no shape gives away: {@code x*x*…x{16}} reads seventy-seven million characters
+     * of a sixteen-character string.
      *
-     * <p>The check runs preemptively because the failure being guarded against is not a wrong answer
-     * but no answer at all.
+     * <p>Which is why nothing here estimates. What is bounded is the reading itself, so a pattern that
+     * runs away is stopped whatever made it run away. The check runs preemptively because the failure
+     * being guarded against is not a wrong answer but no answer at all.
      */
     @Test
-    void aPatternWithNestedVariableRepetitionIsNotEvaluated() {
+    void aPatternWhoseAnswerCannotBeCheckedInTimeIsNotOffered() {
         assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
             for (String regex : List.of("(?:x?x){30}", "(?:x?x){40}", "(?:x?x){200}",
-                    "(?:(?:x?x){8}){8}", "(?:(a|aa)x){30}")) {
+                    "(?:(?:x?x){8}){8}")) {
+                assertEquals(Optional.empty(), PatternValues.shortestAccepted(regex), regex);
+            }
+        });
+    }
+
+    /** The same, where what runs away is two neighbours rather than a nesting. */
+    @Test
+    void adjacentVariableQuantifiersCannotExhaustTheMatcher() {
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            for (int repeats : List.of(12, 16, 20, 32)) {
+                String regex = "x*".repeat(repeats) + "x{" + repeats + "}";
                 assertEquals(Optional.empty(), PatternValues.shortestAccepted(regex), regex);
             }
         });
     }
 
     /**
-     * And what that bound must not cost.
+     * And what the bound must not cost.
      *
      * <p>A repetition over something of more than one length is not by itself expensive — what costs
-     * is how many copies of it end up in the answer, and a `+` or a `*` writes as few as it can. The
-     * rule for a domain name nests them three deep and is answered in under a millisecond, so a bound
-     * drawn at the shape rather than at what the answer asks for would refuse it for nothing.
+     * is how much of the answer the engine ends up reading, and a `+` or a `*` writes as few copies as
+     * it can. The rule for a domain name nests them three deep and is checked in five reads, so a
+     * bound drawn at the shape rather than at the reading would refuse it for nothing.
      */
     @Test
     void aNestedRepetitionWhoseAnswerIsShortIsStillRead() {
         assertEquals(Optional.of("a.a"), PatternValues.shortestAccepted(
                 "[a-z0-9]([a-z0-9\\-]*[a-z0-9])?(\\.[a-z0-9]([a-z0-9\\-]*[a-z0-9])?)+"));
         assertEquals(Optional.of("b"), PatternValues.shortestAccepted("(a|aa)*b"));
-        assertEquals(Optional.of("x".repeat(20)), PatternValues.shortestAccepted("(?:x?x){20}"));
+        assertEquals(Optional.of("x".repeat(20)), PatternValues.shortestAccepted("(?:x?x){20}"),
+                "and one that does back up, within what it is given to");
+        // Thirty repetitions of a two-branch group, which an estimate of the shape refused and which
+        // the engine checks in sixty reads: the branches are separated, so there is nothing to
+        // back up over.
+        assertEquals(Optional.of("ax".repeat(30)),
+                PatternValues.shortestAccepted("(?:(a|aa)x){30}"));
     }
 
     /**


### PR DESCRIPTION
A format rule is the commonest thing an identifier says about itself — an office number is `[0-9]{2}-[0-9]{6}`, an invoice is `INV-[0-9]{4}-[0-9]{6}` — and nothing could write one. A record holding such a field could not be composed at all, so every combination it took part in came back as one whose values the model refused, and the generator that names the gaps could fill none of them. Twenty-seven of the format rules in `souther-lang/examples` are of this kind.

This reads the pattern and writes the shortest string it accepts. Also `Date` and `DateTime`, which had no representative either.

## What comes out

The same string every time: the first branch of an alternation, the first character of a class, the fewest repetitions a bound allows. Nothing random. A generated block is read against the previous one to see what changed, and a value that differed between two runs would make every row look changed.

```
[0-9]{2}-[0-9]{6}          -> "00-000000"
0[1-9]|[1-3][0-9]|4[0-7]   -> "01"
006[0-9A-Za-z]{12}([0-9A-Z]{3})?  -> "006000000000000"
[^@\s]+@[^@\s]+\.[^@\s]+   -> "a@a.a"
[ｦ-ﾟァ-ヴー 　]+             -> "ｦ"
[^ -~]+                    -> "あ"
```

## What it does not read, it does not guess at

A backreference, a lookaround, a named group, a unicode property: no value, which is the answer the caller already handles. What protects the constructs nobody thought about is that the result goes back through the pattern before it is offered, so reading one wrongly produces nothing rather than a value that does not match. Verified against possessive quantifiers, whose meaning is genuinely elsewhere.

And a value the pattern accepts is still refused unless a row can carry it. A string literal reads five escapes; a character outside them would go into the row as itself, and a newline would end the line the row is commented out on. A value holding one of those, or longer than an observation reads back, gets the same answer as a pattern nothing can be written for.

## Effect on the corpus

Measured against the same base, over every model in `souther-lang/examples`:

| | before | after |
|---|---|---|
| generated rows | 103 | 516 |
| combinations where every candidate was refused | 96 | 26 |

The report's own measurements are unchanged: this fills rows, it does not move what counts as covered.

## Notes

- `[^\w]` and friends: a member of a class stands for a set, and the two questions a class is asked want different amounts of it. One character is enough to be *in* the class; to be out of a negated one, all of them have to be excluded.
- The block's ordering varies between runs of the same model. That is not from this branch — it reproduces on `develop` — and is filed as #307.