### PR TITLE
A query answers in the order the module declares

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -147,7 +147,7 @@ public final class Adequacy {
                 out.put(behavior.name(), evidenceOf(sig, scope.value(),
                         byTarget.getOrDefault(behavior.name(), Observed.NONE)));
             }
-            return Answer.of(Map.copyOf(out));
+            return Answer.of(Ordered.map(out));
         }
 
     }
@@ -198,7 +198,7 @@ public final class Adequacy {
                 out.put(spec.name(), Coverages.of(spec, sig, scope.value(), bodies.get(spec.name()),
                         plan, seen, armsMeasured && !seen.armsUnseen()));
             }
-            return Answer.of(Map.copyOf(out));
+            return Answer.of(Ordered.map(out));
         }
 
         private static String sourceIdOf(Db db, String module) {
@@ -351,7 +351,7 @@ public final class Adequacy {
                 out.put(behavior.name(), new BranchEvidence(arms, covered,
                         partial ? MeasurementStatus.PARTIAL : MeasurementStatus.COMPLETE));
             }
-            return Answer.of(Map.copyOf(out));
+            return Answer.of(Ordered.map(out));
         }
     }
 
@@ -577,7 +577,9 @@ public final class Adequacy {
                             Incompleteness.Scope.BEHAVIOR, spec.name())));
                 }
             }
-            return Answer.of(Map.copyOf(out));
+            // In the order the module declares them, because the block printed from this is read
+            // against the one before it.
+            return Answer.of(Ordered.map(out));
         }
 
         /** A way to build values against this module's own classes, or nothing where there are none to

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -691,6 +691,64 @@ class CompileExampleGenerateTest {
         }
     }
 
+    /**
+     * The behaviors come out in the order the module declares them.
+     *
+     * <p>A block is read against the one before it, to see what the last change to the model added. So
+     * where a behavior's rows sit has to be a fact about the model and not about the run that printed
+     * them: rows that moved make every line look changed, and there is nothing left to read the block
+     * for. Declaration order is the order the module already has, and the one the report prints in.
+     */
+    @Test
+    void theBlockNamesTheBehaviorsInTheOrderTheyAreDeclared() {
+        List<String> declared = List.of("submit", "approve", "reject", "withdraw", "reopen", "close");
+        StringBuilder behaviors = new StringBuilder();
+        StringBuilder rows = new StringBuilder();
+        for (String name : declared) {
+            behaviors.append("""
+                    behavior %1$s : (r: Req) -> Ok
+                        constructs Ok
+
+                    let %1$s (r) = Ok { n = 0 }
+
+                    """.formatted(name));
+            rows.append("""
+                    example %s
+                        | (Req { flag = Yes }) -> Ok { n = 0 }
+
+                    """.formatted(name));
+        }
+        String model = """
+                module example.order
+
+                data Yes
+                data No
+                data Flag = Yes | No
+
+                data Req = { flag: Flag }
+                data Ok = { n: Int }
+
+                %s""".formatted(behaviors);
+        // The rows sit in a companion source, which is where a module with this many behaviors puts
+        // them, and which is the arrangement the block is read against.
+        String companion = """
+                examples for example.order
+
+                %s""".formatted(rows);
+
+        Compilation compilation = Compilation.ofSources(List.of(model, companion),
+                souther.compiler.meta.ModulePath.EMPTY);
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        String block = GeneratedRows.of(compilation, null, null, false);
+
+        assertEquals(declared, block.lines()
+                        .filter(line -> line.startsWith("// example "))
+                        .map(line -> line.substring("// example ".length()))
+                        .toList(),
+                block);
+    }
+
     /** Nothing to fill is nothing printed, rather than a header over an empty list. */
     @Test
     void aModelTheRowsCoverPrintsNothing() {


### PR DESCRIPTION
Closes #307.

`souther examples --generate` printed the same rows in a different order every run. What moved was where each behavior's rows and notes sat, and that is what the block is read for — against the block before it, to see what the last change to the model added. Rows that moved make every line look changed.

## What it was

`Adequacy.Generated` returned its answer through `Map.copyOf`. The JDK's immutable maps draw the index iteration starts at from a salt taken once per process, so the order holds within a run and differs in the next one. Which is why pinning the processor count settled nothing — the order rows finished being evaluated in was never the question.

Three sibling queries in the same file did the same thing and showed nothing. `AdequacyReport` and the editor's lens walk `module.behaviors()` and look each behavior up, so the map's order never reaches them. `GeneratedRows` iterates the map, and was the only reader that did.

## What changed

All four answers go through `Ordered.map`, which is what that helper is in this package for — its own comment says `Map.copyOf` does not keep order and that order is load-bearing here.

The two `covered` sets are left alone: `unreached()` and `uncovered()` filter ordered lists with them, so nothing iterates the sets themselves.

## Held to

A model with six behaviors and its rows in a companion file, asserting the block names them in the order the module declares. Two runs in one process would agree whatever the map did, so the test asks for declaration order: it failed in six consecutive processes before the change and holds in all of them after.

On the crm model in `souther-lang/examples`, six runs of `--generate` are now byte for byte identical, and the rows are the same rows as before — sorting the old output against the new one gives an empty diff. The report was already stable and still is.

`mvn test` is green across every module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
