### PR TITLE
One application of a signature decides its variables once

### DIFF
--- a/docs/adr/0092-a-helper-carries-the-variables-its-body-leaves-open.md
+++ b/docs/adr/0092-a-helper-carries-the-variables-its-body-leaves-open.md
@@ -90,15 +90,12 @@ each expansion. A bare unconstrained variable is not a body-determined parameter
   the position of the disagreement — which is what ADR-0066 already says happens to a settled type the
   rest of the body will not take. A mistake standing beside an open element is reported as the mistake
   it is: `let bad (xs, s: String) = List.length(xs) + (s * 2)` names the arithmetic, not `xs`.
-- **The variables are the helper's own, and a variable carries where it came from.** A library
-  signature is resolved once and shared by every call site, so two unrelated calls hand back one
-  spelling — `List.length` and `Set.size` both wrote `'a`. Variables are therefore minted where a
-  declaration is read, from the variables that declaration wrote and that call did not solve, and a
-  minted variable names the parameter it was minted for. That origin is what the rules ask, rather
-  than the spelling: a variable the core wrote is attached to nothing, one minted for the parameter
-  being settled is what is being worked out, and one minted for another parameter says this one holds
-  whatever that one holds. What links two parameters is a position that reads them together, not a
-  spelling two libraries share.
+- **The variables are the helper's own.** A library signature is resolved once and shared by every
+  call site, so two unrelated calls hand back one spelling — `List.length` and `Set.size` both wrote
+  `'a`. The instantiation that never happened is done where a callee is applied, and what a variable
+  carries is whether the compiler made it: an inferred one is shown as `_`, since its spelling is
+  internal and says nothing to a reader. What links two parameters is a position that reads them
+  together, not a spelling two libraries share.
 - **Two readings hold what a variable stands for while they are read, in both directions.** A
   variable says one thing everywhere it appears, so `('a, 'a)` read against `(Int, String)` is two
   answers rather than one left open. Holding one direction only would make the answer depend on which

--- a/souther-compiler/src/main/java/souther/compiler/check/Freshening.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Freshening.java
@@ -1,84 +1,65 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BindingId;
+import souther.compiler.ast.Ast;
 import souther.compiler.types.Type;
 
+import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * The variables one helper parameter carries, minted where a declaration is read.
+ * What each call standing in one body decides for the variables its callee's signature left open.
  *
- * <p>A library signature is resolved once, when the library is loaded, and every call site reads
- * that one value; nothing instantiates it. A call builds its own bindings and substitutes, so a
- * variable the call solves becomes what it was solved to and one it does not solve comes back out as
- * the variable the library wrote. Two unrelated calls therefore hand back one name —
- * {@code List.length} and {@code Set.size} both wrote {@code 'a} — and a parameter that took its
- * answer from each of them would claim the two hold the same thing.
+ * <p>A library signature is resolved once, when the library is loaded, and every call site reads that
+ * one value; nothing instantiates it. A call builds its own bindings and substitutes, so a variable
+ * the call solves becomes what it was solved to and one it does not solve comes back out as the
+ * variable the library wrote. Two unrelated calls therefore hand back one name — {@code List.length}
+ * and {@code Set.size} both wrote {@code 'a} — and a parameter that took its answer from each of them
+ * would claim the two hold the same thing.
  *
- * <p>So the instantiation that never happened is done here, at the one place where the two can be
- * told apart: reading a declaration, with that call's bindings in hand. A variable the declaration
- * wrote and the call did not solve is the declaration's own, and is minted afresh. A variable that
- * arrived through what the position asked for was minted already — by an earlier parameter of this
- * helper, or at an outer call — and is carried through untouched. The question is where the variable
- * came from, not what it is spelled.
+ * <p>So the instantiation that never happened is done here, and it belongs to <em>the call</em>. One
+ * application of a signature decides its variables once, and every parameter of the helper that reads
+ * that call reads the same decision: {@code Set.contains(v, s)} says {@code v} is what {@code s}
+ * holds, whichever of the two the walk is settling. Deciding afresh for each parameter would say that
+ * of neither.
  *
- * <p>One declaration is instantiated once, over everything it declares at that call: a signature
- * that writes {@code 'a} in two of its parameters wrote one variable, and {@code Set.union(a, b)}
- * says the two sets hold the same thing.
- *
- * <p>A minted name is stable for a given source: it names the binding the parameter is
- * and counts the declarations read for it in the order they are read, both of which the same source
- * gives the same way twice. It carries a {@code .}, which no written type variable can — the lexer
- * takes only identifier characters after the apostrophe — so it is never a name an author or the
- * core could have written.
+ * <p>An expansion follows the same rule where it inlines a call, instantiating the callee's signature
+ * once over the bindings its arguments become. Whether a call stands or is expanded is then not
+ * something the answer depends on.
  */
 final class Freshening {
 
-    private String parameter = "";
-    private int declarations;
-
-    /** Starts again for {@code target}: another parameter's variables are not this one's. */
-    void forParameter(BindingId target) {
-        declarations = 0;
-        parameter = target.toString();
-    }
-
-    /** {@code declared} with the variables it wrote replaced by this parameter's own. */
-    Type instantiate(Type declared) {
-        Map<String, Type> rename = renaming(List.of(declared), Map.of());
-        return rename.isEmpty() ? declared : TypeOps.substitute(declared, rename);
-    }
+    /** What each call has decided, by the call it is. Two calls written the same way are two
+     * applications, so they are told apart by which node they are and not by how they read. */
+    private final Map<Ast.Apply, Map<String, Type>> decided = new IdentityHashMap<>();
 
     /**
-     * What to rename the variables {@code declared} wrote and {@code solved} did not solve to.
-     *
-     * <p>Asked of the declaration as it was written, before {@code solved} is substituted into it: a
-     * variable that came in as one of {@code solved}'s answers was minted somewhere already, and
-     * asking after the substitution would see it standing in the declaration and mint it again. The
-     * caller substitutes both at once.
+     * What {@code call} decides for the variables {@code declared} left open — one fresh variable
+     * each, and the same ones every time this call is asked. Empty where the declaration left none
+     * open, which is most calls.
      */
-    Map<String, Type> renaming(List<Type> declared, Map<String, Type> solved) {
-        Map<String, Type> rename = new LinkedHashMap<>();
+    Map<String, Type> of(Ast.Apply call, List<Type> declared) {
+        Map<String, Type> already = decided.get(call);
+        if (already != null) {
+            return already;
+        }
+        Map<String, Type> theirs = new LinkedHashMap<>();
+        String at = "c" + decided.size();
         for (Type t : declared) {
-            collect(t, solved, rename);
+            collect(t, at, theirs);
         }
-        if (!rename.isEmpty()) {
-            declarations++;
-        }
-        return rename;
+        decided.put(call, theirs);
+        return theirs;
     }
 
-    private void collect(Type t, Map<String, Type> solved, Map<String, Type> rename) {
+    private static void collect(Type t, String at, Map<String, Type> theirs) {
         if (t == null) {
             return;
         }
         Type.mentions(t, x -> {
-            if (x instanceof Type.Var v && !solved.containsKey(v.name())
-                    && !rename.containsKey(v.name())) {
-                rename.put(v.name(),
-                        Type.inferredVar(v.name() + "." + parameter + "." + declarations));
+            if (x instanceof Type.Var v && !theirs.containsKey(v.name())) {
+                theirs.put(v.name(), Type.inferredVar(v.name() + "." + at));
             }
             return false;   // a collector, not a test: every position is visited
         });

--- a/souther-compiler/src/main/java/souther/compiler/check/Freshening.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Freshening.java
@@ -36,14 +36,12 @@ import java.util.Map;
  */
 final class Freshening {
 
-    private BindingId owner;
     private String parameter = "";
     private int declarations;
 
     /** Starts again for {@code target}: another parameter's variables are not this one's. */
     void forParameter(BindingId target) {
         declarations = 0;
-        owner = target;
         parameter = target.toString();
     }
 
@@ -80,7 +78,7 @@ final class Freshening {
             if (x instanceof Type.Var v && !solved.containsKey(v.name())
                     && !rename.containsKey(v.name())) {
                 rename.put(v.name(),
-                        Type.mintedVar(v.name() + "." + parameter + "." + declarations, owner));
+                        Type.inferredVar(v.name() + "." + parameter + "." + declarations));
             }
             return false;   // a collector, not a test: every position is visited
         });

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -797,6 +797,49 @@ public final class HelperInliner {
         return new Ast.LetIn(bound, body, declared, true, null, Ast.Var.local(bound, pos), pos);
     }
 
+    /**
+     * What this application decides for the variables {@code helper}'s signature left open — one
+     * fresh variable per variable it wrote, over its parameters and its declared return together.
+     * Empty where it wrote none, which is every call of a helper that names its types outright.
+     *
+     * <p>Every unsolved variable in a helper's declared types is that helper's own: a variable enters
+     * a type only where the core writes one in a signature or where a helper's own settling mints one
+     * for its parameters, and a reference to a declared type carries none. So renaming by name over
+     * the whole signature at once binds nothing it should not.
+     */
+    private static Map<String, Type> instantiation(Ast.FnDef helper, BindingOwner mine) {
+        Map<String, Type> applied = new LinkedHashMap<>();
+        for (Ast.FnParam p : helper.params()) {
+            collectVariables(p.type(), mine, applied);
+        }
+        collectVariables(helper.declaredReturn(), mine, applied);
+        return applied;
+    }
+
+    private static void collectVariables(Ast.RetType declared, BindingOwner mine,
+                                         Map<String, Type> applied) {
+        if (declared == null || !mentionsRetTypeVar(declared)) {
+            return;
+        }
+        Type.mentions(TypeOps.resolveParamType(declared, null), t -> {
+            if (t instanceof Type.Var v) {
+                applied.computeIfAbsent(v.name(), name -> Type.inferredVar(name + "." + mine));
+            }
+            return false;   // a collector, not a test: every position is visited
+        });
+    }
+
+    /** {@code declared} with what this application decided written into it, or as it stands where it
+     * left nothing open. The type is written as a reference with no surface text: what it denotes is
+     * decided, and no source stands for it. */
+    private static Ast.RetType instantiated(Ast.RetType declared, Map<String, Type> applied) {
+        if (declared == null || applied.isEmpty() || !mentionsRetTypeVar(declared)) {
+            return declared;
+        }
+        Type at = TypeOps.substitute(TypeOps.resolveParamType(declared, null), applied);
+        return new Ast.RetType(List.of(Ast.TypeRef.of(at, declared.pos())), declared.pos());
+    }
+
     /** Whether a declared type has a collection anywhere inside it — the types whose element/value
      * type an empty literal leaves open until something declares it. */
     static boolean carriesCollection(Ast.TypeTerm term) {
@@ -1120,8 +1163,15 @@ public final class HelperInliner {
                 // declared return is carried on, and every binding copied out of the callee's body.
                 // One minter, so no two of them are the same binding, and a reader can ask of any of
                 // them which call it came from.
-                Ast.Binders ours = new Ast.Binders(
-                        new BindingOwner.Expansion(into, call.denotes(), counter++));
+                BindingOwner mine = new BindingOwner.Expansion(into, call.denotes(), counter++);
+                Ast.Binders ours = new Ast.Binders(mine);
+                // What the callee's signature leaves open, this call decides. Its variables are
+                // instantiated once, here, over the whole signature at once — so a variable it wrote
+                // in two of its parameters is one variable in what this expansion writes, and two
+                // calls of it decide separately. Splitting the signature into a binding per parameter
+                // is what would otherwise lose that: each binding's type would be read on its own,
+                // and nothing left afterwards says the two came from one application.
+                Map<String, Type> applied = instantiation(helper, mine);
                 Map<BindingId, String> subst = new HashMap<>();
                 // what each substituted callee resolved to at the call site, so the expansion carries
                 // the argument's own answer rather than deciding one for it
@@ -1188,7 +1238,7 @@ public final class HelperInliner {
                         // carry the parameter's declared type onto the binding, so a value known to
                         // be a sum (an annotated `s: S`) is not narrowed to the argument's specific
                         // case when the body is re-checked inline — a `match s` inside still sees S.
-                        letTypes.add(p.type());
+                        letTypes.add(instantiated(p.type(), applied));
                     }
                 }
                 // a prelude helper's body is stamped with the call site, so errors inside it point at

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -68,7 +68,11 @@ public final class HelperInliner {
      */
     private Map<String, Integer> callableBehaviors = Map.of();
     private final Set<String> recursive = new HashSet<>();   // own helpers on a call cycle (spec 13.1)
-    private final Map<String, LambdaOrigin> lambdaOrigins = new HashMap<>();   // $k_p -> where it was written
+    /** Where a lambda given to a function parameter was written, by the binding it was registered
+     * under. Asked by the binding and not by the spelling: two combinators nested one inside the
+     * other give their function parameters the same name as often as not, and a report that found
+     * the outer one's lambda would point at another author's line. */
+    private final Map<BindingId, LambdaOrigin> lambdaOrigins = new HashMap<>();
     private int counter = 0;
     /** The body being expanded, and the bindings this expansion introduces into it. An expansion
      * writes bindings no source wrote, so they belong to it rather than to the definition whose text
@@ -1137,7 +1141,8 @@ public final class HelperInliner {
                     yield inline(new Ast.Apply(valueOf(named), args, call.origin(), call.pos()));
                 }
                 if (args.size() != helper.params().size()) {
-                    LambdaOrigin origin = lambdaOrigins.get(helper.name());
+                    LambdaOrigin origin = call.denotes() instanceof ValueName.Local applied
+                            ? lambdaOrigins.get(applied.id()) : null;
                     if (origin != null) {
                         // the callee is a lambda the caller wrote, applied by the combinator it was
                         // given to: report the parameter count against the lambda, not the synthetic
@@ -1205,7 +1210,7 @@ public final class HelperInliner {
                             scopedLambdas.put(f.id(),
                                     new Ast.FnDef(f.name(), lparams, null,
                                             new Ast.FnBody.Written(lambda.body()), lambda.pos()));
-                            lambdaOrigins.put(f.name(), new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
+                            lambdaOrigins.put(f.id(), new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
                         } else {
                             // Neither a name nor a lambda: a value written where the function goes —
                             // the argument-order mistake made with a named helper rather than a
@@ -1247,6 +1252,7 @@ public final class HelperInliner {
                 Copy copy = new Copy(helper.written(), ours);
                 Ast.Expr body = inline(rename(helper.written(), subst, substDenotes, at, copy));   // expand nested helpers too
                 given.forEach(scopedLambdas::remove);
+                given.forEach(lambdaOrigins::remove);
                 body = keepDeclaredReturn(helper, body, call.pos(), ours);
                 // wrap innermost-first so the value parameters bind in declared order
                 for (int i = letBinders.size() - 1; i >= 0; i--) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -83,7 +83,7 @@ public final class HelperInliner {
 
     /** Where a lambda given to a function parameter was written: the parameter it fills, the helper
      * that declares that parameter, and the lambda's own position. The lambda is inlined under a
-     * synthetic {@code $k_p} name, which must never reach a diagnostic — an error about it is
+     * synthetic name, which is a spelling and must never reach a diagnostic — an error about it is
      * reported against these instead. */
     private record LambdaOrigin(String param, String owner, SourcePos pos) {}
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -785,14 +785,15 @@ public final class HelperInliner {
      * leaving those bodies bare keeps a constant-foldable expression ({@code 金額(税込(100))}) a plain
      * expression for the compile-time invariant check. A union return is left alone too: the binding
      * would name one type where the body may produce several. */
-    private Ast.Expr keepDeclaredReturn(Ast.FnDef helper, Ast.Expr body, SourcePos pos, int k) {
+    private Ast.Expr keepDeclaredReturn(Ast.FnDef helper, Ast.Expr body, SourcePos pos,
+                                        Ast.Binders ours) {
         Ast.RetType declared = helper.declaredReturn();
         if (declared == null || declared.cases().size() != 1
                 || !carriesCollection(declared.cases().get(0))
                 || mentionsTypeVar(declared.cases().get(0))) {
             return body;
         }
-        Ast.Binder bound = binders.binder("$r" + k, pos);
+        Ast.Binder bound = ours.binder("$r", pos);
         return new Ast.LetIn(bound, body, declared, true, null, Ast.Var.local(bound, pos), pos);
     }
 
@@ -1114,7 +1115,13 @@ public final class HelperInliner {
                             "helper `let " + helper.name() + "` takes " + helper.params().size()
                                     + " argument(s) but is called with " + args.size());
                 }
-                int k = counter++;
+                // Everything this expansion writes belongs to it: the bindings its arguments become,
+                // the one a lambda given to a function parameter is registered under, the one its
+                // declared return is carried on, and every binding copied out of the callee's body.
+                // One minter, so no two of them are the same binding, and a reader can ask of any of
+                // them which call it came from.
+                Ast.Binders ours = new Ast.Binders(
+                        new BindingOwner.Expansion(into, call.denotes(), counter++));
                 Map<BindingId, String> subst = new HashMap<>();
                 // what each substituted callee resolved to at the call site, so the expansion carries
                 // the argument's own answer rather than deciding one for it
@@ -1135,7 +1142,7 @@ public final class HelperInliner {
                             subst.put(p.binder().id(), fnName.name());
                             substDenotes.put(p.binder().id(), fnName.denotes());
                         } else if (arg instanceof Ast.Block lambda) {
-                            Ast.Binder f = binders.binder("$" + k + "_" + p.name(), lambda.pos());
+                            Ast.Binder f = ours.binder("$" + p.name(), lambda.pos());
                             subst.put(p.binder().id(), f.name());
                             substDenotes.put(p.binder().id(), new ValueName.Local(f.name(), f.id()));
                             given.add(f.id());
@@ -1173,7 +1180,7 @@ public final class HelperInliner {
                         // the binding the argument is bound to; the reads of the parameter inside the
                         // body are answered with it, so a read says which binding it is rather than
                         // where it happens to be written
-                        Ast.Binder f = binders.binder(p.name(), call.pos());
+                        Ast.Binder f = ours.binder(p.name(), call.pos());
                         subst.put(p.binder().id(), f.name());
                         substDenotes.put(p.binder().id(), new ValueName.Local(f.name(), f.id()));
                         letBinders.add(f);
@@ -1187,11 +1194,10 @@ public final class HelperInliner {
                 // a prelude helper's body is stamped with the call site, so errors inside it point at
                 // the user's call, not at the shipped source of souther.*
                 SourcePos at = keepsItsPositions(call) ? null : call.pos();
-                Copy copy = new Copy(helper.written(),
-                        new BindingOwner.Expansion(into, call.denotes(), k));
+                Copy copy = new Copy(helper.written(), ours);
                 Ast.Expr body = inline(rename(helper.written(), subst, substDenotes, at, copy));   // expand nested helpers too
                 given.forEach(scopedLambdas::remove);
-                body = keepDeclaredReturn(helper, body, call.pos(), k);
+                body = keepDeclaredReturn(helper, body, call.pos(), ours);
                 // wrap innermost-first so the value parameters bind in declared order
                 for (int i = letBinders.size() - 1; i >= 0; i--) {
                     body = new Ast.LetIn(letBinders.get(i), letValues.get(i), letTypes.get(i), body, call.pos());
@@ -1462,8 +1468,7 @@ public final class HelperInliner {
          * whatever order the copy is written in: a read met before its binder would otherwise be
          * left on the original while the binder moved, and the two would no longer be one binding.
          */
-        private Copy(Ast.Expr body, BindingOwner owner) {
-            Ast.Binders binders = new Ast.Binders(owner);
+        private Copy(Ast.Expr body, Ast.Binders binders) {
             eachBinder(body, binder ->
                     mine.put(binder.id(), binders.binder(binder.name(), binder.pos()).id()));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -192,7 +192,7 @@ final class HelperParams {
                 if (env.holds(param.id())) {
                     continue;
                 }
-                Type t = typing.typeOf(param, body, env, answers);
+                Type t = typing.typeOf(param, body, env, answers, othersOf(h, idx, env));
                 if (t == null) {
                     openUses.put(idx, typing.openUse());
                 } else {
@@ -203,6 +203,25 @@ final class HelperParams {
             }
         }
         return found;
+    }
+
+    /**
+     * What every parameter of {@code h} other than {@code idx} is known to be — written beside it or
+     * settled in an earlier round. A variable standing in one of these is one the body has tied to a
+     * value this walk is not working out, which is what makes it evidence rather than the question.
+     */
+    private static List<Type> othersOf(Ast.FnDef h, int idx, Scope env) {
+        List<Type> others = new ArrayList<>();
+        for (int i = 0; i < h.params().size(); i++) {
+            if (i == idx) {
+                continue;
+            }
+            Type t = env.typeOf(h.params().get(i).binder().id());
+            if (t != null) {
+                others.add(t);
+            }
+        }
+        return others;
     }
 
     /**
@@ -290,8 +309,10 @@ final class HelperParams {
         private Type pinned;
         /** Whether the position now being read is a field read off its child. */
         private boolean readingAField;
-        /** The parameter being settled: a variable minted for it is what is being worked out. */
+        /** The parameter being settled: a variable standing for it is what is being worked out. */
         private BindingId target;
+        /** What every other parameter of this helper is known to be, for {@link #saysWhatAnotherHolds}. */
+        private List<Type> otherParameters = List.of();
         /** Every reading of the parameter that leaves what it holds open, and what they settle. */
         private Readings readings = new Readings();
         private OpenUse openUse;
@@ -314,6 +335,11 @@ final class HelperParams {
          * was — the body asked for two different things and neither is what it is.
          */
         Type typeOf(Ast.Binder target, Ast.Expr body, Scope env, Type answers) {
+            return typeOf(target, body, env, answers, List.of());
+        }
+
+        Type typeOf(Ast.Binder target, Ast.Expr body, Scope env, Type answers, List<Type> others) {
+            this.otherParameters = others;
             this.target = target.id();
             this.pinned = null;
             this.readings = new Readings();
@@ -867,7 +893,7 @@ final class HelperParams {
                 return false;
             }
             boolean outer = switch (t) {
-                case Type.Var v -> attachedElsewhere(v);
+                case Type.Var v -> saysWhatAnotherHolds(v);
                 case Type.FnOf _, Type.Nothing _, Type.Never _, Type.Erroneous _ -> false;
                 case Type.Prim _, Type.Ref _, Type.Union _, Type.ListOf _, Type.SetOf _,
                         Type.MapOf _, Type.OptionOf _, Type.TupleOf _ -> true;
@@ -876,17 +902,26 @@ final class HelperParams {
         }
 
         /**
-         * Whether {@code v} is a variable this walk has already attached to another of the helper's
-         * parameters. Standing alone it then says something after all — that this parameter holds
-         * whatever that one holds — which is a relation the body made and not a value nothing states.
-         * An arm beside an arm holding another parameter is where it arrives.
+         * Whether {@code v} standing alone says what this parameter holds: it stands in what another
+         * parameter of this helper is known to be. That parameter's type was settled without reading
+         * this one — a parameter is settled on its own, and an argument holding the parameter being
+         * settled is not read — so it is evidence rather than the question asked back.
          *
-         * <p>A variable the core wrote is attached to nothing, and one minted for the parameter being
-         * settled is what is being worked out, so neither says anything: {@code let id (v) = v} is
-         * open however the walk reached it.
+         * <p>Where the variable stands is not enough on its own. A binding the body made from this
+         * parameter carries it too, and taking that for evidence would let a parameter be settled by
+         * what was built out of it: {@code let f (v) = let xs = [v] in List.member(v, xs)} says
+         * nothing about {@code v} that {@code v} did not say first. Only the other parameters count.
+         *
+         * <p>A variable the core wrote, and one standing only where this parameter is being worked
+         * out, say nothing: {@code let id (v) = v} is open however the walk reached it.
          */
-        private boolean attachedElsewhere(Type.Var v) {
-            return v.mintedFor() != null && !v.mintedFor().equals(target);
+        private boolean saysWhatAnotherHolds(Type.Var v) {
+            for (Type other : otherParameters) {
+                if (Type.mentions(other, x -> x.equals(v))) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         /** The type of a neighbouring expression, or null where this scope cannot type it. */

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -202,7 +202,15 @@ final class HelperParams {
                 }
             }
         }
-        return found;
+        // What the readings settled about a variable may be settled while a later parameter is read,
+        // so what each of them is, is asked for once every parameter is in. `bothContain (xs, ys, y)`
+        // learns that the two calls' elements are one thing only while `y` is being read, and `xs`
+        // was answered before that.
+        Map<Integer, Type> settled = new LinkedHashMap<>();
+        for (Map.Entry<Integer, Type> e : found.entrySet()) {
+            settled.put(e.getKey(), typing.asSettled(e.getValue()));
+        }
+        return settled;
     }
 
     /**
@@ -302,9 +310,8 @@ final class HelperParams {
         private final CheckContext ctx;
         private final Map<String, ReqSig> reqSigs;
         private final Map<String, Type> recursiveHelperFns;
-        /** What this walk has minted for the parameter it is reading. A second position that asks
-         * the same signature is a second reading, and mints its own; the two are taken together
-         * where they answer one value. */
+        /** What each call in this body has decided for the variables its callee left open. One
+         * decision per call, read by every parameter that reaches it. */
         private final Freshening freshening = new Freshening();
         private Type pinned;
         /** Whether the position now being read is a field read off its child. */
@@ -313,8 +320,10 @@ final class HelperParams {
         private BindingId target;
         /** What every other parameter of this helper is known to be, for {@link #saysWhatAnotherHolds}. */
         private List<Type> otherParameters = List.of();
-        /** Every reading of the parameter that leaves what it holds open, and what they settle. */
-        private Readings readings = new Readings();
+        /** Every reading of a parameter that leaves what it holds open, and what they settle. One
+         * for the body: the shape is one parameter's, and what it settles about a variable is every
+         * parameter's, because they are read in one body. */
+        private final Readings readings = new Readings();
         private OpenUse openUse;
 
         BodyTyping(Symbols symbols, Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns) {
@@ -342,9 +351,8 @@ final class HelperParams {
             this.otherParameters = others;
             this.target = target.id();
             this.pinned = null;
-            this.readings = new Readings();
+            this.readings.forParameter();
             this.openUse = null;
-            this.freshening.forParameter(target.id());
             // A recursive helper's call is left standing rather than expanded, so the neighbouring
             // expression a parameter takes its type from can be one — `x + count(t)` reads `count(t)`
             // to type `x`. Its signature goes in here, once, and every inner scope is derived from
@@ -365,6 +373,11 @@ final class HelperParams {
          */
         private void offer(Type t) {
             readings.add(t);
+        }
+
+        /** {@code t} with what the readings of this body have settled written through it. */
+        Type asSettled(Type t) {
+            return readings.asSettled(t);
         }
 
         /** A use of the parameter that named no type, from the last {@link #typeOf} that found none. */
@@ -777,14 +790,14 @@ final class HelperParams {
             } catch (CompileException _) {
                 return sig.params();   // the call does not fit its signature; the check reports it
             }
-            // What the call solved and what it left for this parameter to carry, substituted at once:
-            // a variable that arrived as one of the call's answers was minted somewhere already, and
-            // renaming after the substitution would mint it a second time.
-            Map<String, Type> minted = freshening.renaming(sig.params(), bind);
+            // What this call decided for the variables it left open, and over it what this walk
+            // solved. The decision belongs to the call, so every parameter reading it reads the same
+            // one, and what the call solved outright wins over what it only named.
+            Map<String, Type> decided = freshening.of(call, sig.params());
             Map<String, Type> settled = bind;
-            if (!minted.isEmpty()) {
-                settled = new HashMap<>(bind);
-                settled.putAll(minted);
+            if (!decided.isEmpty()) {
+                settled = new HashMap<>(decided);
+                settled.putAll(bind);
             }
             List<Type> out = new ArrayList<>();
             for (Type param : sig.params()) {
@@ -917,8 +930,9 @@ final class HelperParams {
          * out, say nothing: {@code let id (v) = v} is open however the walk reached it.
          */
         private boolean saysWhatAnotherHolds(Type.Var v) {
+            Type is = readings.asSettled(v);
             for (Type other : otherParameters) {
-                if (Type.mentions(other, x -> x.equals(v))) {
+                if (Type.mentions(readings.asSettled(other), x -> x.equals(is))) {
                     return true;
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -311,8 +311,9 @@ final class HelperParams {
         private final Map<String, ReqSig> reqSigs;
         private final Map<String, Type> recursiveHelperFns;
         /** What each call in this body has decided for the variables its callee left open. One
-         * decision per call, read by every parameter that reaches it. */
-        private final Freshening freshening = new Freshening();
+         * decision per call, read by every parameter that reaches it — and by the walk one step
+         * inside a closure, which reads calls of the same body. */
+        private final Freshening freshening;
         private Type pinned;
         /** Whether the position now being read is a field read off its child. */
         private boolean readingAField;
@@ -327,6 +328,16 @@ final class HelperParams {
         private OpenUse openUse;
 
         BodyTyping(Symbols symbols, Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns) {
+            this(symbols, reqSigs, recursiveHelperFns, new Freshening());
+        }
+
+        /** The walk one step inside a closure reads the calls of the same body, so what those calls
+         * decided is the same decision. Deciding again would name two applications alike — the count
+         * a name carries starts over with the reader — and unifying them would say the two hold one
+         * thing. */
+        BodyTyping(Symbols symbols, Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns,
+                   Freshening freshening) {
+            this.freshening = freshening;
             this.symbols = symbols;
             this.ctx = new CheckContext(symbols, null, reqSigs);
             this.reqSigs = reqSigs;
@@ -717,7 +728,7 @@ final class HelperParams {
             Type.FnOf known = TypeOps.substitute(step, bind) instanceof Type.FnOf f ? f : step;
             Scope inner = walking(env, lambda, known);
             for (int i = 0; i < lambda.params().size(); i++) {
-                Type t = new BodyTyping(symbols, reqSigs, recursiveHelperFns)
+                Type t = new BodyTyping(symbols, reqSigs, recursiveHelperFns, freshening)
                         .typeOf(lambda.params().get(i), lambda.body(), inner, known.result());
                 if (t != null) {
                     // only a position the closure's body settled: unifying an undetermined one

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -581,13 +581,14 @@ final class HelperParams {
          * {@code x} through {@code y}, which is the shape a call to another body-typed helper inlines
          * to. A binding spelled like the parameter is another binding, and reads as one.
          *
-         * <p>What the binding demands is a declaration like any other, so the variables it wrote are
-         * minted as this parameter's own before they are read ({@link Freshening}): the type on the
-         * binding a helper's expansion writes is the callee's, and two callees spell theirs the same.
+         * <p>What the binding demands is read as it stands. The type on a binding a helper's
+         * expansion writes is the callee's signature with what that application decided already
+         * written into it, so two bindings of one expansion demand one variable and two expansions
+         * demand two.
          */
         private void visitLet(Ast.LetIn li, Scope env, BindingId target, Type expected) {
             Type demanded = li.declaredType() == null ? null
-                    : freshening.instantiate(TypeOps.resolveParamType(li.declaredType(), symbols));
+                    : TypeOps.resolveParamType(li.declaredType(), symbols);
             if (isParam(li.value(), target)) {
                 pin(demanded);
                 if (pinned != null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Readings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Readings.java
@@ -33,6 +33,9 @@ final class Readings {
     private final Map<Type.Var, Type> settled = new HashMap<>();
     private Type shape;
     private boolean refused;
+    /** What was settled before this parameter began, for a parameter that turns out to settle
+     * nothing. */
+    private Map<Type.Var, Type> held = Map.of();
 
     /**
      * Starts on another parameter. What the readings have settled about a variable is kept: two
@@ -44,6 +47,7 @@ final class Readings {
     void forParameter() {
         shape = null;
         refused = false;
+        held = Map.copyOf(settled);
     }
 
     /** {@code t} with what the readings have settled written through it. */
@@ -57,7 +61,16 @@ final class Readings {
             return;
         }
         shape = shape == null ? reading : unify(shape, reading);
-        refused = shape == null;
+        if (shape == null) {
+            // Readings that cannot be one value settle nothing. A constructor is taken apart one
+            // position at a time, so what the positions before the disagreement settled is written
+            // while it is still open whether they are one value at all — and this parameter having
+            // no answer is not evidence for the next one. What was settled before this parameter
+            // began is what stands.
+            refused = true;
+            settled.clear();
+            settled.putAll(held);
+        }
     }
 
     /** Every reading given, as one type, or null where they cannot be one value. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Readings.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Readings.java
@@ -34,6 +34,23 @@ final class Readings {
     private Type shape;
     private boolean refused;
 
+    /**
+     * Starts on another parameter. What the readings have settled about a variable is kept: two
+     * parameters of one helper are read in one body, and a variable one of them settled to another is
+     * settled for both — {@code let has (xs, y) = List.member(y, xs)} learns while reading {@code xs}
+     * that what the expansion left open and what the call inside it left open are one thing, and
+     * {@code y} is the parameter that needs to know.
+     */
+    void forParameter() {
+        shape = null;
+        refused = false;
+    }
+
+    /** {@code t} with what the readings have settled written through it. */
+    Type asSettled(Type t) {
+        return settledSoFar(t);
+    }
+
     /** Takes one more reading of the value. */
     void add(Type reading) {
         if (refused) {

--- a/souther-compiler/src/main/java/souther/compiler/types/Type.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/Type.java
@@ -56,14 +56,12 @@ public sealed interface Type
      * monomorphised by inline expansion, so the variable is resolved to the concrete argument type at
      * each call site.
      *
-     * <p>{@code mintedFor} is where the variable came from, which is not the same question as what it
-     * is spelled. A variable the shipped core wrote has none: it stands for anything and nothing has
-     * attached it to a value yet. One a helper's own settling minted names the parameter it was minted
-     * for, so a reader can ask whether a variable standing somewhere is one the body has already
-     * attached to another position — which is the difference between a value nothing says anything
-     * about and one the body said is whatever that other parameter holds.
+     * <p>{@code inferred} is whether the compiler made it. A variable the shipped core wrote is not:
+     * its spelling is what an author of core reads. One the compiler minted is: it stands for a value
+     * a use decides, and its spelling is an internal name that says nothing to anyone, so nothing
+     * shows it.
      */
-    record Var(String name, BindingId mintedFor) implements Type {}
+    record Var(String name, boolean inferred) implements Type {}
 
     /** A reference to a named data type (product or sum). */
     record Ref(TypeName name) implements Type {
@@ -160,14 +158,14 @@ public sealed interface Type
         return new TupleOf(elements);
     }
 
-    /** A variable as the core wrote it: it stands for anything, and nothing has attached it. */
+    /** A variable as the core wrote it. */
     static Type var(String name) {
-        return new Var(name, null);
+        return new Var(name, false);
     }
 
-    /** A variable minted while settling {@code mintedFor}, which is what it is attached to. */
-    static Type mintedVar(String name, BindingId mintedFor) {
-        return new Var(name, mintedFor);
+    /** A variable the compiler minted, standing for a value each use of the declaration decides. */
+    static Type inferredVar(String name) {
+        return new Var(name, true);
     }
 
     /** A user-facing rendering of {@code t} in surface syntax: {@code Int}, {@code List<Int>},
@@ -249,10 +247,10 @@ public sealed interface Type
             };
             case Ref r -> showName(r.name(), qualify);
             // A variable the core wrote is shown as the core wrote it; the name carries the `'`
-            // (`'a`), so it is not added twice. A minted one is shown as `_`: it names something an
-            // author never wrote and could not write, so its spelling says nothing to the reader,
-            // while what is open about the type is what they need.
-            case Var v -> v.mintedFor() != null ? "_"
+            // (`'a`), so it is not added twice. One the compiler minted is shown as `_`: its spelling
+            // is an internal name an author never wrote and could not write, so it says nothing to
+            // the reader, while what is open about the type is what they need.
+            case Var v -> v.inferred() ? "_"
                     : v.name().startsWith("'") ? v.name() : "'" + v.name();
             case Nothing _ -> "_";
             case Never _ -> "Never";

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperCarriesItsVariablesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperCarriesItsVariablesTest.java
@@ -244,6 +244,34 @@ class CompileHelperCarriesItsVariablesTest {
                 "and so does the self-hosted one");
     }
 
+    /**
+     * What a signature says between its arguments and its result reaches the caller too.
+     * {@code Map.upsert} declares {@code Map<'k, 'a>} for its map and for what it answers, so what
+     * the result holds is what the argument held.
+     *
+     * <p>Not through the declaration: an expansion drops a declared return that carries a variable,
+     * and it is right to — the reason a declared return is carried at all is to fix an
+     * empty-collection seed the body cannot type, and a type that names a variable fixes nothing.
+     * The relation reaches the caller through what the body builds, which is built from the
+     * arguments.
+     */
+    @Test
+    void whatASignatureSaysBetweenItsArgumentsAndItsResultReachesTheCaller() throws Exception {
+        Map<?, ?> out = run("""
+                module demo
+                data In = { counts: Map<String, Int> }
+                data Out = { n: Int }
+                behavior go : (i: In) -> Out constructs Out
+                let bump (k, m) = Map.upsert(k, 0, (v) -> v + 1, m)
+                let go (i) = Out { n = List.sum(Map.values(bump("a", i.counts))) }
+                """, Map.of("counts", Map.of("a", 1L, "b", 5L)));
+        assertEquals(7L, out.get("n"), "the result holds Ints because the argument did");
+        assertFalse(compiles("""
+                let bump (k, m) = Map.upsert(k, 0, (v) -> v + 1, m)
+                let use (t: Map<String, Bool>, n: Int) = Map.size(bump("a", t)) + n"""),
+                "a map of Bools does not take the Int the call decided");
+    }
+
     // --- what a position states reaches the arms, and what an arm states wins ---
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperCarriesItsVariablesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperCarriesItsVariablesTest.java
@@ -146,6 +146,22 @@ class CompileHelperCarriesItsVariablesTest {
                 "writing what the list holds says it");
     }
 
+    /**
+     * A bare variable says what this parameter holds only where another <em>parameter</em> is known
+     * to hold it. A binding the body made out of the parameter carries the same variable, and taking
+     * that for evidence would settle a parameter by what was built from it.
+     */
+    @Test
+    void whatWasBuiltFromTheParameterIsNotEvidenceAboutIt() {
+        assertFalse(compiles("""
+                let f (v) = {
+                    let xs = [ v ]
+                    List.member(v, xs)
+                }
+                let use (b: Bool) = f(1) && b"""),
+                "`xs` is made from `v`, so it says nothing about `v` that `v` did not say first");
+    }
+
     // --- what a position states reaches the arms, and what an arm states wins ---
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperCarriesItsVariablesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperCarriesItsVariablesTest.java
@@ -122,28 +122,34 @@ class CompileHelperCarriesItsVariablesTest {
     }
 
     /**
-     * A relation one signature makes is not carried across the bindings its expansion becomes.
-     * {@code List.member} writes one variable for its element and for its list, but it is
-     * self-hosted, so the call expands to a binding per parameter and each binding's declared type is
-     * read on its own. {@code y} is the element of {@code xs}, and nothing left after the expansion
-     * says so; the annotation states it instead.
-     *
-     * <p>Pinned as what happens rather than as what should: which side of the intrinsic /
-     * self-hosted line the library put a function on is not something an author can see, and
-     * {@code Set.union} — an intrinsic of the same shape — does link its two. Tracked as issue #313.
-     * Before a helper could carry a variable at all both of these parameters were annotated, so this
-     * widens that to one of them rather than narrowing anything.
+     * A relation a signature makes across its own parameters survives the expansion of the call.
+     * {@code List.member} writes one variable for its element and for its list, so {@code y} is the
+     * element of {@code xs} — and it says so whether the callee is expanded or stands, which is what
+     * makes the answer the language's and not the library's implementation choice.
      */
     @Test
-    void aRelationInsideAnExpansionIsNotCarriedAcrossTheBindingsItBecomes() {
-        assertFalse(compiles("""
+    void aRelationASignatureMakesSurvivesTheExpansionOfTheCall() {
+        assertTrue(compiles("""
                 let has (xs, y) = List.member(y, xs)
                 let use (b: Bool) = has([ 1 ], 2) && b"""),
-                "`y` is the element of `xs`, and what the expansion leaves does not say so");
+                "`y` is the element of `xs`, and two Ints fit");
+        assertFalse(compiles("""
+                let has (xs, y) = List.member(y, xs)
+                let use (b: Bool) = has([ 1 ], "a") && b"""),
+                "a List of Ints and a String do not");
+    }
+
+    /** And it does not depend on which of the two the helper declares first. */
+    @Test
+    void whichParameterIsWrittenFirstDecidesNothing() {
         assertTrue(compiles("""
-                let has (xs: List<Int>, y) = List.member(y, xs)
-                let use (b: Bool) = has([ 1 ], 2) && b"""),
-                "writing what the list holds says it");
+                let has (y, xs) = List.member(y, xs)
+                let use (b: Bool) = has(2, [ 1 ]) && b"""),
+                "the same relation, read the other way round");
+        assertFalse(compiles("""
+                let has (y, xs) = List.member(y, xs)
+                let use (b: Bool) = has("a", [ 1 ]) && b"""),
+                "and refused the same way");
     }
 
     /**
@@ -160,6 +166,82 @@ class CompileHelperCarriesItsVariablesTest {
                 }
                 let use (b: Bool) = f(1) && b"""),
                 "`xs` is made from `v`, so it says nothing about `v` that `v` did not say first");
+    }
+
+    @Test
+    void twoApplicationsOfOneHelperDecideSeparately() {
+        // Nothing here ties the two calls together, so one deciding Int does not make the other one.
+        assertTrue(compiles("""
+                let use (b: Bool) = List.member(1, [ 1 ]) && List.member("a", [ "a" ]) && b"""),
+                "two applications of `List.member`, at two element types");
+    }
+
+    @Test
+    void twoApplicationsTiedByOneParameterHoldOneThing() {
+        // The caller's own `y` is what ties them, and it is one value.
+        assertTrue(compiles("""
+                let bothContain (xs, ys, y) = List.member(y, xs) && List.member(y, ys)
+                let use (b: Bool) = bothContain([ 1 ], [ 2 ], 3) && b"""),
+                "three parameters, one element type");
+        assertFalse(compiles("""
+                let bothContain (xs, ys, y) = List.member(y, xs) && List.member(y, ys)
+                let use (b: Bool) = bothContain([ 1 ], [ "a" ], 3) && b"""),
+                "and the two lists hold the same thing");
+    }
+
+    @Test
+    void aSignatureVariableStandingInThreePositionsHoldsOneThing() {
+        // `Map.insert (key: 'k, value: 'a, m: Map<'k, 'a>)` writes `'k` twice and `'a` twice, so
+        // three of this helper's parameters are tied by one call.
+        assertTrue(compiles("""
+                let put (k, v, m) = Map.insert(k, v, m)
+                let use (n: Int) = Map.size(put("a", 1, Map.empty)) + n"""),
+                "the key, the value and what the map holds are one call's");
+        assertFalse(compiles("""
+                let put (k, v, m) = Map.insert(k, v, m)
+                let use (m: Map<String, Bool>, n: Int) = Map.size(put("a", 1, m)) + n"""),
+                "a map of Bools does not take an Int value");
+    }
+
+    @Test
+    void anExpansionInsideAnExpansionDecidesOnItsOwn() {
+        // `outer` expands into the body, and the `List.member` inside it expands again. The two are
+        // two applications, and the inner one's element is the outer one's — through the body, not
+        // through a name two signatures happen to share.
+        assertTrue(compiles("""
+                let outer (xs, y) = List.member(y, xs)
+                let go (zs, z) = outer(zs, z)
+                let use (b: Bool) = go([ 1 ], 2) && b"""),
+                "the relation reaches through two expansions");
+        assertFalse(compiles("""
+                let outer (xs, y) = List.member(y, xs)
+                let go (zs, z) = outer(zs, z)
+                let use (b: Bool) = go([ 1 ], "a") && b"""),
+                "and refuses through them");
+    }
+
+    /**
+     * A signature variable standing twice is one identity whether the callee is an intrinsic or is
+     * written in Souther. {@code Set.union} is an intrinsic and {@code List.member} is self-hosted;
+     * which side of that line a function is on is not something an author can read, so it decides
+     * nothing here.
+     */
+    @Test
+    void aRepeatedSignatureVariableIsOneIdentityWhicheverWayTheCalleeIsWritten() {
+        assertTrue(compiles("""
+                let viaIntrinsic (a, b) = Set.union(a, b)
+                let viaSouther (xs, y) = List.member(y, xs)
+                let use (p: Set<Int>, q: Set<Int>) = Set.size(viaIntrinsic(p, q))
+                    + (if viaSouther([ 1 ], 2) then 1 else 0)"""),
+                "both hold their repeated variable to one type");
+        assertFalse(compiles("""
+                let viaIntrinsic (a, b) = Set.union(a, b)
+                let use (p: Set<Int>, q: Set<String>) = Set.size(viaIntrinsic(p, q))"""),
+                "the intrinsic refuses two element types");
+        assertFalse(compiles("""
+                let viaSouther (xs, y) = List.member(y, xs)
+                let use (b: Bool) = viaSouther([ 1 ], "a") && b"""),
+                "and so does the self-hosted one");
     }
 
     // --- what a position states reaches the arms, and what an arm states wins ---

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
@@ -109,6 +109,32 @@ class AnExpansionOwnsWhatItWritesTest {
         assertEquals(2, expansionsOf(binders(body)).size(), "the inner call is its own expansion");
     }
 
+    /**
+     * A report about a lambda given to a function parameter names the lambda it is about. The lambda
+     * is registered under a synthetic name, and two combinators nested one inside the other name
+     * their function parameters the same as often as not — so which one a report finds is asked by
+     * the binding it was registered under and not by that name.
+     */
+    @Test
+    void aReportAboutALambdaNamesTheLambdaItIsAbout() {
+        // `Map.map` takes a two-argument step and `List.map` a one-argument one, and both call the
+        // parameter `f`. The inner one is written with one, and the report is about the inner one.
+        souther.compiler.diag.CompileException e = org.junit.jupiter.api.Assertions.assertThrows(
+                souther.compiler.diag.CompileException.class,
+                () -> souther.compiler.Compiler.compile("""
+                        module demo
+                        data X = Int
+                        behavior go : (x: X) -> X
+                        let go (x) = x
+                        let counts (ms: List<Map<String, Int>>) =
+                            List.map((m) -> Map.size(Map.map((k) -> k, m)), ms)
+                        """));
+        assertTrue(e.getMessage().contains("takes 2 argument(s) but is written with 1"),
+                e.getMessage());
+        assertEquals(6, e.diagnostic().region().start().line(),
+                "the inner lambda's line, not the outer one's: " + e.getMessage());
+    }
+
     /** Two bindings of one expansion are two bindings: one minter, so the ordinals do not repeat. */
     @Test
     void noTwoBindingsOfOneExpansionAreTheSameBinding() {

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
@@ -1,0 +1,128 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every binding an expansion writes belongs to that expansion.
+ *
+ * <p>Expanding a call writes several bindings: one per argument, one for a lambda given to a function
+ * parameter, one carrying the declared return, and one for every binding copied out of the callee's
+ * body. They are one call's, and a reader that has to answer something about the call — which
+ * signature they came from, what one variable of it stands for — can only do that if it can tell
+ * which of them are the same call's. Owning them is what says so; before this, only the copied body's
+ * were owned by the expansion and the rest belonged to the pass.
+ */
+class AnExpansionOwnsWhatItWritesTest {
+
+    private static Ast.Module resolved(String source) {
+        Ast.Module parsed = CstFrontend.parse(source);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    /** Every binding in {@code e}, in the order they are written. */
+    private static List<Ast.Binder> binders(Ast.Expr e) {
+        List<Ast.Binder> out = new ArrayList<>();
+        collect(e, out);
+        return out;
+    }
+
+    private static void collect(Ast.Expr e, List<Ast.Binder> out) {
+        if (e instanceof Ast.LetIn li) {
+            out.add(li.binder());
+        }
+        if (e instanceof Ast.Block b) {
+            out.addAll(b.params());
+        }
+        TypeChecker.forEachChild(e, c -> collect(c, out));
+    }
+
+    /** The expansion each of {@code binders} belongs to, or null where it belongs to something else. */
+    private static Set<BindingOwner.Expansion> expansionsOf(List<Ast.Binder> binders) {
+        Set<BindingOwner.Expansion> out = new LinkedHashSet<>();
+        for (Ast.Binder b : binders) {
+            if (b.id().owner() instanceof BindingOwner.Expansion x) {
+                out.add(x);
+            }
+        }
+        return out;
+    }
+
+    private static Ast.Expr expanded(String defs, String of) {
+        Ast.Module m = resolved("""
+                module demo
+                data X = Int
+                behavior f : (x: X) -> X
+                %s
+                let f (x) = x
+                """.formatted(defs));
+        HelperInliner inliner = HelperInliner.forModule(m);
+        return inliner.inline(inliner.helpers().get(of).written(), inliner.bodyOf(of));
+    }
+
+    @Test
+    void everyBindingOneExpansionWritesIsThatExpansionsOwn() {
+        // `taxed` takes two arguments and its body binds one of its own, so the expansion writes
+        // three bindings. All three are this call's.
+        Ast.Expr body = expanded("""
+                let taxed (n: Int, rate: Int) = {
+                    let scaled = n * rate
+                    scaled / 100
+                }
+                let go (m: Int) = taxed(m, 11)""", "go");
+        List<Ast.Binder> written = binders(body);
+        assertFalse(written.isEmpty(), "the expansion writes bindings");
+        assertEquals(1, expansionsOf(written).size(), "they are one call's");
+        for (Ast.Binder b : written) {
+            assertTrue(b.id().owner() instanceof BindingOwner.Expansion,
+                    "`" + b.name() + "` belongs to " + b.id().owner());
+        }
+    }
+
+    @Test
+    void twoCallsOfOneHelperAreTwoExpansions() {
+        Ast.Expr body = expanded("""
+                let twice (n: Int) = n * 2
+                let go (m: Int) = twice(m) + twice(m + 1)""", "go");
+        assertEquals(2, expansionsOf(binders(body)).size(), "two calls, two expansions");
+    }
+
+    @Test
+    void anExpansionInsideAnExpansionIsAnotherExpansion() {
+        Ast.Expr body = expanded("""
+                let inner (n: Int) = n * 2
+                let outer (n: Int) = inner(n) + 1
+                let go (m: Int) = outer(m)""", "go");
+        assertEquals(2, expansionsOf(binders(body)).size(), "the inner call is its own expansion");
+    }
+
+    /** Two bindings of one expansion are two bindings: one minter, so the ordinals do not repeat. */
+    @Test
+    void noTwoBindingsOfOneExpansionAreTheSameBinding() {
+        Ast.Expr body = expanded("""
+                let taxed (n: Int, rate: Int) = {
+                    let scaled = n * rate
+                    scaled / 100
+                }
+                let go (m: Int) = taxed(m, 11) + taxed(m, 12)""", "go");
+        List<Ast.Binder> written = binders(body);
+        Set<BindingId> distinct = new LinkedHashSet<>();
+        for (Ast.Binder b : written) {
+            assertTrue(distinct.add(b.id()), "`" + b.name() + "` repeats " + b.id());
+        }
+        assertEquals(written.size(), distinct.size());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ReadingsHoldTheirContractTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ReadingsHoldTheirContractTest.java
@@ -1,9 +1,6 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BindingId;
-import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
-import souther.compiler.types.TypeName;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,11 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 class ReadingsHoldTheirContractTest {
 
-    private static final BindingId OWNER =
-            new BindingId(new BindingOwner.OfData(new TypeName("demo", "X")), 0);
-
     private static Type v(String name) {
-        return Type.mintedVar(name, OWNER);
+        return Type.inferredVar(name);
     }
 
     /** Two variables and two primitives — enough for one variable to stand twice and for two

--- a/souther-compiler/src/test/java/souther/compiler/check/TwoReadingsOfOneValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TwoReadingsOfOneValueTest.java
@@ -115,6 +115,24 @@ class TwoReadingsOfOneValueTest {
         assertNull(Readings.of(listBAndB, aa));
     }
 
+    /**
+     * A parameter whose readings cannot be one value settles nothing for the parameters after it.
+     * A constructor is taken apart one position at a time, so what the positions before a
+     * disagreement settled is written while it is still open whether the readings agree at all.
+     */
+    @Test
+    void aParameterThatSettlesNothingLeavesNothingSettled() {
+        Type a = v("a");
+        Readings all = new Readings();
+        all.add(pair(a, Type.INT));
+        all.add(pair(Type.STRING, Type.BOOL));
+        assertNull(all.answer(), "an Int and a Bool are not one value");
+
+        all.forParameter();
+        all.add(a);
+        assertEquals(a, all.answer(), "`a` is what it was; the refused reading is not evidence");
+    }
+
     /** Neither reading is the one being checked, so which is given first decides nothing. */
     @Test
     void theAnswerIsTheSameWhicheverReadingIsGivenFirst() {

--- a/souther-compiler/src/test/java/souther/compiler/check/TwoReadingsOfOneValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TwoReadingsOfOneValueTest.java
@@ -1,9 +1,6 @@
 package souther.compiler.check;
 
-import souther.compiler.types.BindingId;
-import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
-import souther.compiler.types.TypeName;
 
 import org.junit.jupiter.api.Test;
 
@@ -20,11 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
  */
 class TwoReadingsOfOneValueTest {
 
-    private static final BindingId OWNER =
-            new BindingId(new BindingOwner.OfData(new TypeName("demo", "X")), 0);
-
     private static Type v(String name) {
-        return Type.mintedVar(name, OWNER);
+        return Type.inferredVar(name);
     }
 
     private static Type pair(Type a, Type b) {

--- a/specification.adoc
+++ b/specification.adoc
@@ -2681,7 +2681,7 @@ Only core in the reserved namespace may write a type variable; a user module wri
 
 Writing one and carrying one are different things. A user module's non-recursive helper may *carry* a variable its body left unsettled and is monomorphized the same way (<<fn-rules>>); what it may not do is write one. The variable is inferred, never spelled, and appears in no declaration a reader of the module sees.
 
-A single application of a function instantiates each variable its declared signature wrote once, and every occurrence of that variable — in its parameter types and in its return type — denotes that one instantiated type. Two applications of one function instantiate separately. This holds however the application is compiled: a call to a `+core+` primitive stands and a call to a Souther-bodied function is expanded, and neither decides anything the other does not. So `+let has (xs, y) = List.member(y, xs)+` types `+y+` as what `+xs+` holds, because `+List.member+` wrote one variable for its element and its list.
+A single application of a function instantiates each variable its declared signature wrote once, and every occurrence of that variable — in its parameter types and in its result — denotes that one instantiated type. Two applications of one function instantiate separately. This holds however the application is compiled: a call to a `+core+` primitive stands and a call to a Souther-bodied function is expanded, and neither decides anything the other does not. So `+let has (xs, y) = List.member(y, xs)+` types `+y+` as what `+xs+` holds, because `+List.member+` wrote one variable for its element and its list.
 
 [#intrinsics]
 ==== intrinsics

--- a/specification.adoc
+++ b/specification.adoc
@@ -2681,6 +2681,8 @@ Only core in the reserved namespace may write a type variable; a user module wri
 
 Writing one and carrying one are different things. A user module's non-recursive helper may *carry* a variable its body left unsettled and is monomorphized the same way (<<fn-rules>>); what it may not do is write one. The variable is inferred, never spelled, and appears in no declaration a reader of the module sees.
 
+A single application of a function instantiates each variable its declared signature wrote once, and every occurrence of that variable — in its parameter types and in its return type — denotes that one instantiated type. Two applications of one function instantiate separately. This holds however the application is compiled: a call to a `+core+` primitive stands and a call to a Souther-bodied function is expanded, and neither decides anything the other does not. So `+let has (xs, y) = List.member(y, xs)+` types `+y+` as what `+xs+` holds, because `+List.member+` wrote one variable for its element and its list.
+
 [#intrinsics]
 ==== intrinsics
 


### PR DESCRIPTION
Closes #313.

`let has (xs, y) = List.member(y, xs)` asked for an annotation on `y`, although the body says what `y`
is: `List.member` declares `(e: 'a, xs: List<'a>)` — one variable written twice, so `y` is the element
of `xs`.

`let both (a, b) = Set.union(a, b)` — the same shape — settled. What told them apart was `Set.union`
being an intrinsic and `List.member` being written in Souther: an intrinsic is called, a
Souther-bodied helper is expanded. Which side of that line the library put a function on decided the
surface type inference, and nothing an author can read says where that line is.

## The root cause

**A type variable's identity had a shorter lifetime than the scope over which it means something.**

The same fault in four places, each found by measuring rather than by reading:

| where | what it did |
|---|---|
| an expansion | decided nothing — it split the signature into one declared type per binding and each was read on its own |
| a standing call | decided afresh for **each parameter being settled**, so one application said different things depending on which parameter asked |
| the readings of a parameter | settled that one variable is another, then dropped it before the next parameter was read |
| the answer | was written back before a later parameter settled something about it |

`Set.union` settled anyway, but not because the minting agreed — the second parameter's walk reads the
first one's type back out of the scope and unifies through it. The agreement was accidental.

The fix is the same move each time: give the identity the lifetime of the thing it is about. An
application, and a body.

Audited afterwards: `Type.Var` identity is now created in exactly two places, both application-scoped
(`HelperInliner` per expansion, `Freshening` per call). Everything else only tests whether something
is a variable or erases it; `TypeOps.unify` and `CallElaborator.applySignature` bind into a map built
per call. There is no fifth place.

## What changed

**Every binding an expansion writes belongs to that expansion** (`edd12f56`). Only the copied callee
body's did; the argument bindings, the lambda binder and the return carrier were minted under the
inlining pass's own owner, which is one owner for every expansion in a definition. The `k` those
carried in their names was standing in for the owner they did not have. One minter per expansion —
two minters under one owner would each start their ordinals at zero. Changes no inference result.

**A bare variable says something on grounds other than the parameter itself** (`b7ad2ad4`). "Who
minted it" was a proxy that holds only while every variable is minted for a parameter. The question is
whether the body tied the variable on grounds independent of the parameter being settled, and that is:
it stands in what **another parameter** is known to be. Not "occurs anywhere in scope" — a binding the
body made out of the parameter carries it too, and `let f (v) = let xs = [v] in List.member(v, xs)`
says nothing about `v` that `v` did not say first.

**One application of a signature decides its variables once** (`dccaa2ef`). The expansion instantiates
the callee's signature over its parameters and return together before splitting it. Renaming by name
is safe because every unsolved variable in a helper's declared types is that helper's own: a variable
enters a type only where the core writes one in a signature or where a helper's own settling decides
one, and `Type.Ref` carries no type argument. `Type.Var` stopped naming the parameter it was minted
for — that was the proxy above — and carries whether the compiler made it, which is what `Type.show`
needs to render `_`.

**What a call decides is the call's, and what the readings settle is the body's** (`9f50c7a5`). A
standing call's decision is keyed by the call, so every parameter reaching it reads the same one. What
two readings settle about a variable is kept for the body. And each parameter's type is asked for once
every parameter is in — `let bothContain (xs, ys, y)` learns its two calls' elements are one thing
only while `y` is being read.

## What I did not do, and why

**`walking` is untouched.** The plan had a phase for widening what a closure parameter may be bound
to. Measuring after the above showed `has` settles without it: what was blocking was not constraint
propagation but the same root cause left in two more places.

**Two signature positions leave no carrier behind, and are filed rather than fixed.** An expansion
writes a binding per value argument, and what the signature said about those survives on them. A
declared return (**#318**) and a function parameter the callee never applies (**#320**) leave none.

Both are the same rule failing the same way, not a different rule: the instantiation is distributed
into the fragments an expansion leaves, and those positions leave no fragment. What separates them
from this PR is the frontier, not the principle — closing #318 puts an open type through
`Elaborator`'s annotation path for the first time (measured: 17 failures across 8 classes), and #320
needs a core helper that does not apply its function parameter, which none does.

Neither is reachable today. Every self-hosted helper in core that names a variable in its result
builds that result out of its arguments, and every combinator applies its function parameter, so both
relations are reproduced by the body. `whatASignatureSaysBetweenItsArgumentsAndItsResultReachesTheCaller`
pins one of them.

I first argued that a variable-carrying declared return says nothing worth carrying, on the grounds
that it cannot fix an empty-collection seed. That was wrong: `List<'a>` says the outer is a `List`
*and* that the element is the argument's. It is recorded in #318 for whoever picks it up.

**No ADR.** I wrote one and deleted it. Against `docs/adr/README.md`'s own criterion it fails: five of
its six decision bullets were implementation mechanics — "an implementation caught up with a rule
already stated" — and the rule itself is ordinary polymorphic application semantics, which belongs in
the specification. The one part that reads as a constraint on later passes (a rewriting must preserve
what it rewrites) is not a decision anyone would make the other way. #313 is a defect, not a design
choice. `[#type-variables]` gains the rule instead:

> A single application of a function instantiates each variable its declared signature wrote once, and
> every occurrence of that variable — in its parameter types and in its result — denotes that one
> instantiated type. Two applications of one function instantiate separately. This holds however the
> application is compiled.

ADR-0092's bullet about where variables come from is brought up to date.

## Scope

This fixes the violations a program can reach and separates the ones it cannot. It does not claim the
stated rule is fully implemented: #318 and #320 are the two signature positions that leave no carrier
after an expansion, and closing the class means keeping an application's instantiation as something
the expansion carries rather than something distributed into what it splits into. Worth weighing that
before doing either by hand.

## Tests

Type-variable scope was settled first, because the expected values depend on it: the binder is the
signature, a lambda parameter carries no type, and no core body annotates with a variable — so
shadowing cannot arise, and two unrelated variables in one expansion can only come from two
signatures.

- two applications of one helper decide separately, at two element types
- two tied by one parameter hold one thing, and refuse two
- a signature variable in three positions (`Map.insert`) ties three parameters
- an expansion inside an expansion decides on its own
- a repeated signature variable is one identity whichever way the callee is written — `Set.union`
  (intrinsic) and `List.member` (self-hosted) side by side
- what was built from the parameter is not evidence about it
- which parameter is written first decides nothing
- every binding one expansion writes is that expansion's, two calls are two expansions, a nested one
  is another, and no two bindings of one expansion are the same binding
- a parameter whose readings cannot be one value settles nothing for the parameters after it
- a report about a lambda given to a function parameter names that lambda, where two nested
  combinators call theirs the same

## Verification

2440 compiler tests, all modules, and every module of souther-lang/examples pass, with no existing
annotation moved. `souther-bench` warm, measured against the base on the same machine and read on
`min` because the medians swing 140–180ms: crm 116.1ms vs 115.9ms, issuetracker 14.6ms vs 14.4ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
