### PR TITLE
A fake whose table did not finish is not a fake that agrees

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -137,16 +137,16 @@ public final class ExampleVerifier {
      * itself dispatches with ({@link #standingIn}) — the same rule, not a second reading of it — and
      * the two answers are compared as the written values they are built into.
      */
-    public static List<Disagreement> disagreements(Ast.Module module, Symbols symbols,
-                                                   Map<String, Sig> sigs, Map<String, byte[]> classes,
-                                                   Map<String, List<BehaviorRequirement>> requirements,
-                                                   ClassLoader parent, Map<String, Ast.FnDef> values,
-                                                   List<String> exampleOrigins,
-                                                   List<String> fakeOrigins) {
+    public static Readings disagreements(Ast.Module module, Symbols symbols,
+                                         Map<String, Sig> sigs, Map<String, byte[]> classes,
+                                         Map<String, List<BehaviorRequirement>> requirements,
+                                         ClassLoader parent, Map<String, Ast.FnDef> values,
+                                         List<String> exampleOrigins,
+                                         List<String> fakeOrigins) {
         if (module.examples().isEmpty()
                 || exampleOrigins.size() != module.examples().size()
                 || fakeOrigins.size() != module.fakes().size()) {
-            return List.of();
+            return Readings.NONE;
         }
         // Which behaviors have both a stand-in and rows of their own, read off the text. Two written
         // statements are what this is about, and where there are not two there is nothing to build:
@@ -155,7 +155,7 @@ public final class ExampleVerifier {
         // loaded or a worker is started.
         Set<String> contested = contested(module, sigs);
         if (contested.isEmpty()) {
-            return List.of();
+            return Readings.NONE;
         }
         ExampleVerifier v = new ExampleVerifier(module, symbols, sigs, requirements,
                 new MemoryClassLoader(classes, parent), values);
@@ -163,7 +163,39 @@ public final class ExampleVerifier {
     }
 
     /**
-     * One statement, read within its own share of the budget; empty where it did not finish.
+     * What one reading came to: the statement, or the reason there is no statement.
+     *
+     * <p>The reason is answered rather than dropped because the two reasons are held against
+     * different things. A statement that did not finish is about this module, and where nothing else
+     * builds what it was reading it is this reading's to say; a host with no runtime is about the
+     * host, and says the same thing about every fake and every row in every module compiled on it.
+     * A reader that got only "nothing was read" would have to pick one of those, and each caller
+     * would pick for itself.
+     */
+    private sealed interface Read<T> {
+
+        /** What the reading answered. Null where the statement is written in a form that states
+         * nothing — an input that will not build, an expectation that cannot be read. */
+        record Got<T>(T value) implements Read<T> {}
+
+        /** The reading ran out of its budget, and the budget it ran out of: what a report has to
+         * name is what the wait was actually held to, not what a second reader of the setting
+         * makes of it later. */
+        record TimedOut<T>(long budgetMs) implements Read<T> {}
+
+        /** This host has no runtime to build a value against. */
+        record RuntimeAbsent<T>() implements Read<T> {}
+
+        /** What was read, or null — for a caller that has nothing of its own to say about why
+         * there is nothing. Both reasons come out the same here on purpose: the reading that did
+         * not happen is reported by whoever else reads the same statement. */
+        default T orNull() {
+            return this instanceof Got(T value) ? value : null;
+        }
+    }
+
+    /**
+     * One statement, read within its own share of the budget.
      *
      * <p>Per statement rather than per module. Building a fixture runs the helpers it applies
      * (ADR-0077), and a `partial` one may not stop — so a budget covering the whole reading is one a
@@ -172,11 +204,12 @@ public final class ExampleVerifier {
      * to do with. It is what {@link #checkRow} already does for a row it evaluates, and this reads
      * strictly fewer statements than that evaluates rows.
      *
-     * <p>What did not finish states nothing, and nothing is what it is held against. The row it
-     * belongs to reports it (E1910).
+     * <p>What did not finish states nothing. Who says so is the caller's, and differs: a row and a
+     * {@code with} written on one are evaluated elsewhere and report it there (E1910), while a fake
+     * table is built here and, where no row depends on the behavior it stands in for, nowhere else.
      */
-    private <T> java.util.Optional<T> within(java.util.function.Function<ExampleVerifier, T> read,
-                                             String what) {
+    private <T> Read<T> within(java.util.function.Function<ExampleVerifier, T> read,
+                               String what) {
         // On its own reader. A worker that runs out of budget is asked to stop and cannot be made to
         // — a fixture reaches no interrupt point — so it may still be inside `expandedValue`, holding
         // a binding or a half-walked expansion. Nothing it can still write to is read by the
@@ -190,18 +223,18 @@ public final class ExampleVerifier {
         worker.setDaemon(true);
         worker.start();
         try {
-            return java.util.Optional.ofNullable(
+            return new Read.Got<>(
                     task.get(EXAMPLE_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS));
         } catch (java.util.concurrent.TimeoutException _) {
             task.cancel(true);
-            return java.util.Optional.empty();
+            return new Read.TimedOut<>(EXAMPLE_TIMEOUT_MS);
         } catch (java.util.concurrent.ExecutionException ee) {
             task.cancel(true);
             Throwable cause = ee.getCause();
             // One thing ends a reading without the model or this code being at fault: a host with no
             // runtime to build a value against, since the runtime is `provided` (as it is for CTFE).
             if (runtimeAbsent(cause)) {
-                return java.util.Optional.empty();
+                return new Read.RuntimeAbsent<>();
             }
             // Anything else is this code being wrong. An empty reading says the statements agree, so
             // answering with one would leave a broken compiler reporting every model consistent, and
@@ -266,8 +299,8 @@ public final class ExampleVerifier {
      * ever shown. */
     private record RecordedRow(SourceRef at, Ast.Expr expected, Object[] arguments, Asserted answer) {}
 
-    private List<Disagreement> collectDisagreements(List<String> exampleOrigins,
-                                                    List<String> fakeOrigins, Set<String> contested) {
+    private Readings collectDisagreements(List<String> exampleOrigins,
+                                          List<String> fakeOrigins, Set<String> contested) {
         Map<String, List<RecordedRow>> recorded = new LinkedHashMap<>();
         for (int i = 0; i < module.examples().size(); i++) {
             Ast.Example ex = module.examples().get(i);
@@ -276,9 +309,10 @@ public final class ExampleVerifier {
             }
         }
         if (recorded.isEmpty()) {
-            return List.of();
+            return Readings.NONE;
         }
         List<Disagreement> found = new ArrayList<>();
+        List<TimedOutFake> timedOut = new ArrayList<>();
         // The first table for a dependency is the one that answers ({@link #resolveFake}); a second
         // one written for the same name never stands in for anything, so it states nothing to
         // disagree with. What that second table is, is its own question.
@@ -286,13 +320,13 @@ public final class ExampleVerifier {
         for (int j = 0; j < module.fakes().size(); j++) {
             Ast.Fake fk = module.fakes().get(j);
             if (answering.add(fk.target())) {
-                againstFake(fk, fakeOrigins.get(j), recorded, found);
+                againstFake(fk, fakeOrigins.get(j), recorded, found, timedOut);
             }
         }
         for (int i = 0; i < module.examples().size(); i++) {
             againstWiths(module.examples().get(i), exampleOrigins.get(i), recorded, found);
         }
-        return List.copyOf(found);
+        return new Readings(found, timedOut);
     }
 
     /**
@@ -314,7 +348,7 @@ public final class ExampleVerifier {
             if (row.inputs().size() != sig.ins().size()) {
                 continue;
             }
-            RecordedRow read = within(reader -> {
+            Read<RecordedRow> read = within(reader -> {
                 Object[] arguments = reader.builtOrNull(row.inputs(), sig.ins());
                 if (arguments == null) {
                     return null;
@@ -323,27 +357,57 @@ public final class ExampleVerifier {
                 return answer instanceof Asserted.Unreadable ? null
                         : new RecordedRow(new SourceRef(origin, row.expected().pos()),
                                 row.expected(), arguments, answer);
-            }, "a row of `" + ex.target() + "`").orElse(null);
-            if (read == null) {
+            }, "a row of `" + ex.target() + "`");
+            // A reading that did not finish is not said here, whichever reason ended it. The same row
+            // is evaluated where the example is checked, which builds these fixtures and then runs the
+            // behavior on top of them, so a fixture that overruns this overruns that too and is E1910
+            // there, at the row.
+            RecordedRow got = read.orNull();
+            if (got == null) {
                 continue;
             }
-            into.computeIfAbsent(ex.target(), _ -> new ArrayList<>()).add(read);
+            into.computeIfAbsent(ex.target(), _ -> new ArrayList<>()).add(got);
         }
     }
 
     /** One fake against the rows recorded for the behavior it stands in for. */
     private void againstFake(Ast.Fake fk, String origin, Map<String, List<RecordedRow>> recorded,
-                             List<Disagreement> found) {
+                             List<Disagreement> found, List<TimedOutFake> timedOut) {
         List<RecordedRow> rows = recorded.get(fk.target());
         Sig sig = sigs.get(fk.target());
         if (rows == null || sig == null) {
             return;
         }
-        // The whole table, built the one way the proxy builds it: a table with a row that will not
-        // build is one the fake cannot stand in with, and it answers nothing here either. What is
-        // wrong with it is reported where the fake is used.
-        Standins table = within(reader -> reader.standins(fk, sig.ins(), sig.out(), new ArrayList<>()),
-                "the `fake " + fk.target() + "` table").orElse(null);
+        // The whole table, built the one way the proxy builds it.
+        Read<Standins> read = within(
+                reader -> reader.standins(fk, sig.ins(), sig.out(), new ArrayList<>()),
+                "the `fake " + fk.target() + "` table");
+        // A switch, so that a fourth reason for a reading to end has to decide what a fake does about
+        // it rather than falling in with one of these.
+        switch (read) {
+            // Said here, because here is where it can be. The other place a table is built is
+            // `resolveFake`, which runs while a row of a behavior that *depends on* this one is
+            // evaluated — and a fake nothing depends on has no such row, so an overrun that went
+            // unsaid here would leave "the two agree" as the answer to a comparison never made.
+            // The caret goes on the target, which is what `fk.pos()` is.
+            case Read.TimedOut(long budgetMs) -> {
+                timedOut.add(new TimedOutFake(fk.target(), new SourceRef(origin, fk.pos()),
+                        fk.target().length(), budgetMs));
+                return;
+            }
+            // Not about this fake. The runtime is `provided`, so a host without it builds no value at
+            // all, and every fake and every row in the module would say the same thing; what was not
+            // read for that reason is recorded once, where the rows are evaluated. Defensive: with no
+            // runtime no recorded row builds either, and a reading with no rows read never reaches a
+            // fake — so nothing arrives here today.
+            case Read.RuntimeAbsent() -> {
+                return;
+            }
+            case Read.Got(Standins _) -> { }
+        }
+        // The whole table or nothing: a table with a row that will not build answers nothing here,
+        // and what is wrong with it is reported where the fake is used.
+        Standins table = read.orNull();
         if (table == null) {
             return;
         }
@@ -397,10 +461,13 @@ public final class ExampleVerifier {
                 if (rows == null || depSig == null || !depSig.ins().isEmpty()) {
                     continue;
                 }
+                // As with a recorded row: a `with` is written on a row, and that row is evaluated
+                // where the example is checked, installing this same value. What did not finish here
+                // did not finish there, and there is where it is said (E1910).
                 Asserted constant = within(
                         reader -> reader.readStandIn(w.value(), depSig.out(), outCases(depSig.out())),
-                        "a `with " + w.dep() + "`").orElse(new Asserted.Unreadable());
-                if (constant instanceof Asserted.Unreadable) {
+                        "a `with " + w.dep() + "`").orNull();
+                if (constant == null || constant instanceof Asserted.Unreadable) {
                     continue;
                 }
                 for (RecordedRow recordedRow : rows) {
@@ -536,6 +603,37 @@ public final class ExampleVerifier {
      */
     public record Disagreement(String behavior, Statement recorded, Statement standIn,
                                boolean viaWith) {}
+
+    /**
+     * A fake whose table did not finish being built within the budget, so what it states and what the
+     * rows recorded for the behavior state were never compared.
+     *
+     * <p>Carries what it takes to report it. The position and its width are measured here, where the
+     * text is, the way a {@link Statement}'s are; the budget is the one the wait was actually held to,
+     * rather than a second reading of the setting taken later, which a budget that stops being one
+     * number for the whole compile would make wrong with nothing to say so.
+     *
+     * @param at where the fake names the behavior it stands in for, which is what the report marks
+     */
+    public record TimedOutFake(String target, SourceRef at, int width, long budgetMs) {}
+
+    /**
+     * What reading a module's written statements against each other came to.
+     *
+     * <p>Both lists, because a reading that did not finish and a reading that found nothing are
+     * different answers and an empty list of disagreements is what the second one looks like. Which
+     * of the two a compile got can otherwise turn on machine load, between a build and the next
+     * keystroke in the editor.
+     */
+    public record Readings(List<Disagreement> disagreements, List<TimedOutFake> timedOut) {
+
+        public static final Readings NONE = new Readings(List.of(), List.of());
+
+        public Readings {
+            disagreements = List.copyOf(disagreements);
+            timedOut = List.copyOf(timedOut);
+        }
+    }
 
     /** The one-line form for a set of failures gathered across modules: the count, then the first
      * one's reason, matching what a single module's aggregate says. */
@@ -2387,10 +2485,18 @@ public final class ExampleVerifier {
 
     // --- invoke the behavior ------------------------------------------------------------------
 
-    /** Wall-clock budget for evaluating one example row. A total behavior finishes in well under this;
-     * a `partial` recursion that does not terminate hits it, so the compiler is bounded, never hung.
-     * Overridable with the `souther.example.timeout.ms` system property for an unusually slow example. */
+    /** Wall-clock budget for one thing built and run on a worker of its own: an example row evaluated
+     * ({@link #checkRow}), or one written statement read to compare it against another ({@link
+     * #within}). A total behavior finishes in well under this; a `partial` recursion that does not
+     * terminate hits it, so the compiler is bounded, never hung. Overridable with the
+     * `souther.example.timeout.ms` system property for an unusually slow example. */
     private static final long EXAMPLE_TIMEOUT_MS = readTimeoutMs();
+
+    /** The budget, for a test that has to say what a reading was held to. A report reads it off the
+     * reading that ran out of it ({@link TimedOutFake}), not off here. */
+    static long exampleTimeoutMs() {
+        return EXAMPLE_TIMEOUT_MS;
+    }
 
     private static long readTimeoutMs() {
         String override = System.getProperty("souther.example.timeout.ms");

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -440,9 +440,13 @@ public final class Output {
      * be in one file: a module's fakes are what its attached files' rows run against and the other way
      * round. Each source's key projects the ones written in it ({@link SaidDisagreements}), so one
      * disagreement is said at both of the places it is written and computed once.
+     *
+     * <p>The answer is what the check came to and not the disagreements alone: a statement that could
+     * not be read within its budget is a statement nothing was decided about, and a bare list of
+     * disagreements says that with the same empty list it says agreement with.
      */
     public record Disagreements(String name)
-            implements Key<List<souther.compiler.ExampleVerifier.Disagreement>> {
+            implements Key<souther.compiler.ExampleVerifier.Readings> {
 
         @Override
         public String module() {
@@ -450,7 +454,7 @@ public final class Output {
         }
 
         @Override
-        public Answer<List<souther.compiler.ExampleVerifier.Disagreement>> compute(Db db) {
+        public Answer<souther.compiler.ExampleVerifier.Readings> compute(Db db) {
             Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
             Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
             Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
@@ -458,7 +462,8 @@ public final class Output {
                 return Answer.absent();
             }
             if (db.ask(new Bodies.Checked(name)).value() == null) {
-                return Answer.of(List.of());   // a module that did not check states nothing yet
+                // a module that did not check states nothing yet
+                return Answer.of(souther.compiler.ExampleVerifier.Readings.NONE);
             }
             Map<String, byte[]> classes = db.ask(new Linked(name)).value();
             Map<String, List<BehaviorRequirement>> requirements =
@@ -499,6 +504,9 @@ public final class Output {
      * <p>A warning. The two contradict, and which of them the model is to be held to is not readable
      * from the text — that would be a claim about which side is derived from the other, and neither
      * is.
+     *
+     * <p>A fake whose table could not be read in time is a warning of its own (E1920): what it and
+     * the rows state was not compared, which is not what saying nothing means here.
      */
     public record SaidDisagreements(String name) implements Key<Boolean> {
 
@@ -509,17 +517,33 @@ public final class Output {
 
         @Override
         public Answer<Boolean> compute(Db db) {
-            List<souther.compiler.ExampleVerifier.Disagreement> found =
+            souther.compiler.ExampleVerifier.Readings read =
                     db.ask(new Disagreements(name)).value();
-            if (found == null) {
+            if (read == null) {
                 return Answer.of(true);
             }
             List<Report> reports = new ArrayList<>();
-            for (souther.compiler.ExampleVerifier.Disagreement d : found) {
+            for (souther.compiler.ExampleVerifier.Disagreement d : read.disagreements()) {
                 reports.add(Report.saidAt(said(d),
                         Report.Delivery.atEveryRegionOf(d.recorded().at().sourceId())));
             }
+            for (souther.compiler.ExampleVerifier.TimedOutFake f : read.timedOut()) {
+                reports.add(Report.saidAt(unread(f),
+                        Report.Delivery.atEveryRegionOf(f.at().sourceId())));
+            }
             return Answer.of(true, reports);
+        }
+
+        /** One fake that could not be read: the caret on the behavior it names, and what stopped. */
+        private static Diagnostic unread(souther.compiler.ExampleVerifier.TimedOutFake f) {
+            return Diagnostic.of("E1920", "check.example.disagreement.unread").warning()
+                    .title("check.example.title")
+                    .at(f.at().pos(), f.width())
+                    // As written, not as a number the locale groups: `2,000ms` is not a budget
+                    // anyone set, and the property that sets it takes the ungrouped form.
+                    .args(f.target(), Long.toString(f.budgetMs()))
+                    .hint("check.example.disagreement.unread.hint", f.target())
+                    .build();
         }
 
         /** One disagreement: the caret on the recorded row, a second region on the stand-in in

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -470,7 +470,7 @@ parse.fn.emptyparams=`let {0}` takes no parameters, so it is written without `()
 parse.example.row=An `example` needs at least one `|` row.
 parse.fake.row=A `fake` needs at least one `|` row.
 
-# --- examples (E1901-E1919) ---
+# --- examples (E1901-E1920) ---
 check.example.title=EXAMPLE
 check.example.unknown=`{0}` is not a behavior in this module, so this example has no target.
 check.example.notrunnable=`{0}` cannot be evaluated as an example.
@@ -521,6 +521,8 @@ check.example.disagreement.here=the `fake {0}` row
 check.example.disagreement.with=This row and the `with {0}` state different answers for the same input.
 check.example.disagreement.with.hint=The row says {0}; the `with` says {1}.
 check.example.disagreement.with.here=the `with {0}`
+check.example.disagreement.unread=Could not compare this fake with the rows recorded for `{0}` — building the table did not finish within {1}ms.
+check.example.disagreement.unread.hint=What the budget went on is not read here; a row applying a `partial` helper that may not stop is the usual one, and making it structural or reducing it ends this. A table that is only slow has `souther.example.timeout.ms`. Until one of those, whether this fake and the `example {0}` rows agree is unknown.
 
 # --- souther run (the command line drives one behavior; not compile errors) ---
 run.usage.line=usage: souther run <file.sou> [--behavior <name>] [--input <json>]

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -469,7 +469,7 @@ parse.fn.emptyparams=`let {0}` は引数を取らないので `()` は書きま�
 parse.example.row=example には `|` で始まる行が少なくとも1つ必要です。
 parse.fake.row=fake には `|` で始まる行が少なくとも1つ必要です。
 
-# --- examples (E1901-E1919) ---
+# --- examples (E1901-E1920) ---
 check.example.title=example
 check.example.unknown=`{0}` はこのモジュールの behavior ではないため、この example には対象がありません。
 check.example.notrunnable=`{0}` は example として評価できません。
@@ -520,6 +520,8 @@ check.example.disagreement.here=`fake {0}` の行
 check.example.disagreement.with=この行と `with {0}` が、同じ入力に対して違う答えを述べています。
 check.example.disagreement.with.hint=行は {0}、`with` は {1} と述べています。
 check.example.disagreement.with.here=`with {0}`
+check.example.disagreement.unread=この fake と `{0}` に記録された行を照合できませんでした。テーブルの構築が {1}ms 以内に終わりませんでした。
+check.example.disagreement.unread.hint=予算が何に使われたかはここでは読めません。よくあるのは、停止しないかもしれない `partial` ヘルパを適用している行で、それを構造的にするか小さくすれば終わります。遅いだけのテーブルには `souther.example.timeout.ms` があります。どちらかを行うまで、この fake と `example {0}` の行が一致するかは不明です。
 
 # --- souther run（コマンドラインが behavior を1つ駆動する。コンパイルエラーではない） ---
 run.usage.line=使い方: souther run <file.sou> [--behavior <名前>] [--input <json>]

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -4,11 +4,13 @@ import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.HumanRenderer;
 import souther.compiler.diag.Located;
 import souther.compiler.meta.ModulePath;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -52,19 +54,11 @@ class CompileFakeExampleDisagreementTest {
 
     /** The E1919s of a single-source compile, in the order they were said. */
     private static List<Located> disagreements(String model) {
-        List<Located> out = new ArrayList<>();
-        assertDoesNotThrow(() -> Compiler.compiled(model, "Main", out));
-        return onlyDisagreements(out);
+        return onlyDisagreements(warningsOf(model));
     }
 
     private static List<Located> onlyDisagreements(List<Located> warnings) {
-        List<Located> found = new ArrayList<>();
-        for (Located w : warnings) {
-            if ("E1919".equals(w.diagnostic().code())) {
-                found.add(w);
-            }
-        }
-        return found;
+        return only("E1919", warnings);
     }
 
     private static boolean anyDisagreement(String model) {
@@ -284,8 +278,207 @@ class CompileFakeExampleDisagreementTest {
         for (souther.compiler.diag.Diagnostic d : e.diagnostics()) {
             codes.add(d.code());
         }
-        assertTrue(codes.contains("E1910"), codes.toString());
-        assertFalse(codes.contains("E1919"), codes.toString());
+        assertTrue(codesOf(e).contains("E1910"), codesOf(e).toString());
+        assertFalse(codesOf(e).contains("E1919"), codesOf(e).toString());
+    }
+
+    // --- a table that did not finish ----------------------------------------------------------
+
+    private static final String UNUSED_FAKE = """
+            module example.table
+
+            data N = Int
+            data Found = { n: N }
+            data Missing = { why: String }
+
+            partial let spin (n: Int): Int = spin(n)
+
+            behavior find : (n: N) -> Found | Missing
+                constructs Found
+
+            let find (n) = Found { n = n }
+
+            example find
+                | "one" : (N(1)) -> Found { n = N(1) }
+            """;
+
+    /**
+     * A fake nobody depends on is built here and nowhere else, so here is where running out of budget
+     * has to be said.
+     *
+     * <p>The other place a table is built is {@code resolveFake}, which runs while a row of a behavior
+     * that depends on the faked one is evaluated. `find` has no such row — nothing depends on it — so
+     * the reading is the table's only reader, and a table that never finishes would otherwise leave
+     * "these two agree" as the answer to a question nobody got to ask.
+     *
+     * <p>Two rows that will not build, and one warning: the whole table is one reading held to one
+     * budget, so what is said is said about the fake and not about a row of it.
+     */
+    @Test
+    void aTableThatDidNotFinishIsSaidOnceAtTheFake() {
+        List<Located> said = only("E1920", warningsOf(UNUSED_FAKE + """
+
+                fake find
+                    | (N(spin(1))) -> Missing { why = "none" }
+                    | (N(spin(2))) -> Missing { why = "none" }
+                """));
+
+        assertEquals(1, said.size(), said.toString());
+        Diagnostic one = said.get(0).diagnostic();
+        assertEquals(17, one.pos().line(), "anchored where the fake names the behavior");
+        assertEquals(6, one.pos().column());
+        // What could not be done, then what stopped: the table is what did not finish, and the
+        // comparison is what that cost. The budget is read off the budget rather than written in —
+        // it is settable (`souther.example.timeout.ms`), and a literal here would fail every run that
+        // set it, which is the run a slow host most wants to make. It is still read as it is set and
+        // not as a locale would group it, which is what the number in this line is for.
+        assertTrue(rendered(one).contains("Could not compare this fake with the rows recorded for"
+                        + " `find` — building the table did not finish within "
+                        + ExampleVerifier.exampleTimeoutMs() + "ms."),
+                rendered(one));
+    }
+
+    /** And a table that finishes says nothing: the code is not one every fake gets. */
+    @Test
+    void aTableThatFinishesIsSaidNowhere() {
+        assertEquals(List.of(), only("E1920", warningsOf(UNUSED_FAKE + """
+
+                fake find
+                    | (N(1)) -> Found { n = N(1) }
+                """)));
+    }
+
+    /**
+     * A row that runs the table and the reading of the table are two attempts, and each says what it
+     * found: the row did not finish (E1910, at the row), and what the fake and the recorded rows state
+     * was never compared (E1920, at the fake). Neither stands for the other — a table can overrun the
+     * reading with no row that uses it, and a row can overrun for what its own behavior does.
+     */
+    @Test
+    void aRowThatRunsTheTableAndTheReadingBothSayWhatTheyFound() {
+        List<Located> warnings = new ArrayList<>();
+        CompileException e = org.junit.jupiter.api.Assertions.assertThrows(CompileException.class,
+                () -> Compiler.compiledModules(List.of("""
+                        module example.both
+
+                        data N = Int
+                        data Found = { n: N }
+                        data Missing = { why: String }
+                        data Ok = { n: N }
+
+                        partial let spin (n: Int): Int = spin(n)
+
+                        behavior find : (n: N) -> Found | Missing
+
+                        behavior use : (n: N) -> Ok | Missing
+                            depends on find
+                            constructs Ok, Missing
+
+                        let use (n, find) = match find(n) with
+                            | Found   -> Ok { n = n }
+                            | Missing -> Missing { why = "none" }
+
+                        example find
+                            | "one" : (N(1)) -> Found { n = N(1) }
+
+                        example use
+                            | "one" : (N(1)) -> Ok { n = N(1) }
+
+                        fake find
+                            | (N(spin(1))) -> Missing { why = "none" }
+                        """), ModulePath.EMPTY, warnings));
+
+        assertTrue(codesOf(e).contains("E1910"), codesOf(e).toString());
+        assertEquals(1, only("E1920", warnings).size(), warnings.toString());
+    }
+
+    /**
+     * A host with no runtime says nothing about any fake. That is a fact about the host — the runtime
+     * is `provided`, as it is for CTFE — so it is not turned into a warning per fake; where the rows
+     * are evaluated it is recorded once, as an {@code Incompleteness}, which is what a measure
+     * reading the rows needs.
+     *
+     * <p>The same model read with the runtime present says the two statements disagree, so what is
+     * being checked is a reading that reaches a value and not one that never started.
+     *
+     * <p>Where it stops is before a fake: with no runtime the recorded rows do not build either, and
+     * a reading with no rows read has nothing to hold a stand-in against. So this says what the
+     * module answers and not which arm answered it — {@code againstFake} is not reached, and its
+     * {@code RuntimeAbsent} arm is what a fake would meet if a row ever got past one.
+     */
+    @Test
+    void aHostWithNoRuntimeSaysNothingAboutAnyFake() {
+        String model = BASE + """
+
+                example findMember
+                    | "m-1 is a member" : (MemberId("m-1")) -> Found { id = MemberId("m-1") }
+
+                fake findMember
+                    | (MemberId("m-1")) -> Missing { why = "no such member" }
+                """;
+
+        assertEquals(1, readingOf(model, ExampleVerifier.class.getClassLoader()).disagreements().size(),
+                "with a runtime, the fake and the row are read and disagree");
+
+        ExampleVerifier.Readings withoutRuntime = readingOf(model, new ClassLoader(null) {
+            @Override
+            protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                if (name.startsWith("souther.runtime.")) {
+                    throw new NoClassDefFoundError(name);
+                }
+                return ExampleVerifier.class.getClassLoader().loadClass(name);
+            }
+        });
+
+        assertEquals(List.of(), withoutRuntime.disagreements());
+        assertEquals(List.of(), withoutRuntime.timedOut());
+    }
+
+    /** {@code disagreements} as the query asks it, but against a class loader the test chooses. */
+    private static ExampleVerifier.Readings readingOf(String model, ClassLoader parent) {
+        souther.compiler.query.Compilation c =
+                souther.compiler.query.Compilation.ofSource(model, "Main");
+        c.db().ask(new souther.compiler.query.Output.All());
+        String name = c.modules().get(0);
+        return ExampleVerifier.disagreements(
+                c.db().ask(new souther.compiler.query.Shapes.Prepared(name)).value(),
+                c.db().ask(new souther.compiler.query.Shapes.Scope(name)).value(),
+                c.db().ask(new souther.compiler.query.Bodies.Signatures(name)).value(),
+                c.db().ask(new souther.compiler.query.Output.Linked(name)).value(),
+                c.db().ask(new souther.compiler.query.Bodies.Requirements(name)).value(),
+                parent,
+                c.db().ask(new souther.compiler.query.Bodies.Helpers(name)).value(),
+                c.db().ask(new souther.compiler.query.Front.ExampleOrigins(name)).value(),
+                c.db().ask(new souther.compiler.query.Front.FakeOrigins(name)).value());
+    }
+
+    /** The warnings of a single-source compile that holds. */
+    private static List<Located> warningsOf(String model) {
+        List<Located> out = new ArrayList<>();
+        assertDoesNotThrow(() -> Compiler.compiled(model, "Main", out));
+        return out;
+    }
+
+    private static List<String> codesOf(CompileException e) {
+        List<String> codes = new ArrayList<>();
+        for (Diagnostic d : e.diagnostics()) {
+            codes.add(d.code());
+        }
+        return codes;
+    }
+
+    private static String rendered(Diagnostic d) {
+        return new HumanRenderer(false).render(d, null, Locale.ENGLISH);
+    }
+
+    private static List<Located> only(String code, List<Located> warnings) {
+        List<Located> found = new ArrayList<>();
+        for (Located w : warnings) {
+            if (code.equals(w.diagnostic().code())) {
+                found.add(w);
+            }
+        }
+        return found;
     }
 
     /**


### PR DESCRIPTION
Closes #315.

## What was left of the issue

Two of the three things #315 asks about were settled while it sat open. `62e89a5b`
gave the reading a budget per statement rather than one for the module, and
`72ab686c` stopped an exception from coming back as "these statements agree". What
remained was one call site.

`againstFake` builds a fake's whole table to read what it states. The comment
beside it rests on the table being read somewhere that reports what is wrong with
it — but the other path that builds a table, `resolveFake`, runs only while a row
of a behavior that *depends on* the faked one is evaluated, and `contested` does
not ask for such a row. It asks that the behavior have a stand-in and rows of its
own. So a module writing `fake B` and `example B` with nothing depending on `B`
builds that table exactly once, in the reading, and an overrun there answered with
an empty list — which is what agreement looks like.

## What this does

A warning at the fake, E1920, saying that the comparison was not made and that
building the table is what did not finish. It is said whether or not a row also
uses the fake: a row that runs the table and the reading of the table are two
attempts, and E1910 ("this row did not finish") and E1920 ("these two statements
were never compared") are about different things, at different positions.

`within` answers the reason rather than an empty `Optional`. A timeout and a host
with no runtime were the same answer before, and they are held against different
things — an overrun is about this module, an absent runtime is about the host and
says the same of every fake and every row compiled on it. Only the first becomes
a warning; the second stays as the `Incompleteness` the rows already record.

`Output.Disagreements` answers `Readings(disagreements, timedOut)` rather than a
bare list, so "found nothing" and "did not finish" stop being the same empty list.
`TimedOutFake` carries the position, the width and the budget, measured where the
reading was held rather than read back from the constant at the report.

`Incompleteness` is deliberately not the channel for this. Its readers —
`Adequacy`, `AdequacyReport`, `Coverages`, `PartitionEvidence`, `Partitions`,
`Generator` — all read a gap as "this measure could not see everything, so do not
count the absence as a gap in the model". A fake table that did not build is not
that: the rows of the faked behavior ran and were observed, and its coverage is
exactly as complete as it was.

## Tests

Four, in `CompileFakeExampleDisagreementTest`:

- a table nothing depends on that will not build — one E1920, no E1910, and the
  rendered message and its region;
- a table that finishes — no E1920, so the code is not one every fake gets;
- a row that runs the table and the reading of it — E1910 at the row and E1920 at
  the fake, from one compile;
- a host with no runtime — no E1920 and no disagreement, read against a class
  loader the test chooses, with the same model read against a real one to show the
  reading reaches a value.

The budget is settable (`souther.example.timeout.ms`), and the tests read it
rather than writing it in, so a run that lowers it still holds.

## Not this change

Diagnostics the table build produces for reasons other than the budget are still
dropped, which is the same hole through the same call. That is #322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
