### PR TITLE
A fake's table is built because it is written

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -163,6 +163,77 @@ public final class ExampleVerifier {
     }
 
     /**
+     * What building this module's fake tables says about the ones {@code sourceId} wrote, each built
+     * once.
+     *
+     * <p>Because they are written, not because something reads them. A table is built to stand in for
+     * a behavior ({@link #resolveFake}) and to be read against the rows recorded for it ({@link
+     * #againstFake}), and a module can write one that neither of those reaches: nothing in it depends
+     * on the faked behavior, and no row records what that behavior owes. The table still states what
+     * it states, and what is wrong with it is wrong wherever it is read from.
+     *
+     * <p>The one place it is said, so a build and a row cannot come to two answers about one table.
+     * A row that applies a fake it could not build says nothing about the table any more — it does not
+     * run, and the error at the fake is what the compile fails on — which also ends the same table
+     * being reported once per row that reaches it.
+     *
+     * <p>The tables that answer, which is what the other two readers build: the first one written for
+     * a dependency. A second written for the same name stands in for nothing and is read by nobody,
+     * so building it here would hold a table to something no reader of it would ever ask.
+     *
+     * <p>{@code fakeOrigins} says which source wrote each of {@code module.fakes()}, in that order —
+     * every fake, since which one answers for a dependency is a fact about the module and not about
+     * one of its files. Where it does not line up with them, every table that answers is built here:
+     * a report in the wrong file is a report, and the reason to know the file is to place it, while
+     * nothing else would say what is wrong with the table at all.
+     */
+    public static List<Diagnostic> fakeTables(Ast.Module module, Symbols symbols,
+                                              Map<String, Sig> sigs, Map<String, byte[]> classes,
+                                              Map<String, List<BehaviorRequirement>> requirements,
+                                              ClassLoader parent, Map<String, Ast.FnDef> values,
+                                              List<String> fakeOrigins, String sourceId) {
+        if (module.fakes().isEmpty()) {
+            return List.of();
+        }
+        boolean placed = fakeOrigins.size() == module.fakes().size();
+        ExampleVerifier v = new ExampleVerifier(module, symbols, sigs, requirements,
+                new MemoryClassLoader(classes, parent), values);
+        v.sourceId = sourceId;
+        List<Diagnostic> said = new ArrayList<>();
+        Set<String> answering = new LinkedHashSet<>();
+        for (int i = 0; i < module.fakes().size(); i++) {
+            Ast.Fake fk = module.fakes().get(i);
+            if (!answering.add(fk.target())) {
+                continue;   // a second table for one dependency answers nothing, here as anywhere
+            }
+            if (placed && !fakeOrigins.get(i).equals(sourceId)) {
+                continue;   // written in another source, and built by that source's own reading
+            }
+            Sig sig = sigs.get(fk.target());
+            if (sig == null) {
+                continue;   // a fake for no behavior of this module; its target is its own question
+            }
+            // Within a budget of its own, for the reason a row and a reading each have one: a row of
+            // the table applies helpers, and a `partial` one may not stop. Nothing before this change
+            // built the table of a fake nothing reads, so this is the first thing that would run it.
+            Read<List<Diagnostic>> read = v.within(reader -> {
+                List<Diagnostic> wrong = new ArrayList<>();
+                reader.standins(fk, sig.ins(), sig.out(), wrong);
+                return wrong;
+            }, "the `fake " + fk.target() + "` table");
+            switch (read) {
+                case Read.Got(List<Diagnostic> wrong) -> said.addAll(wrong);
+                case Read.TimedOut(long budgetMs) -> said.add(uncheckedFake(fk, budgetMs));
+                // Not about this fake: the runtime is `provided`, so a host without it builds no value
+                // at all and every fake in every module would say the same thing. Where the rows are
+                // evaluated that is recorded once, as an incompleteness.
+                case Read.RuntimeAbsent() -> { }
+            }
+        }
+        return List.copyOf(said);
+    }
+
+    /**
      * What one reading came to: the statement, or the reason there is no statement.
      *
      * <p>The reason is answered rather than dropped because the two reasons are held against
@@ -406,7 +477,7 @@ public final class ExampleVerifier {
             case Read.Got(Standins _) -> { }
         }
         // The whole table or nothing: a table with a row that will not build answers nothing here,
-        // and what is wrong with it is reported where the fake is used.
+        // and what is wrong with it is reported where the fake is written ({@link #fakeTables}).
         Standins table = read.orNull();
         if (table == null) {
             return;
@@ -1203,7 +1274,10 @@ public final class ExampleVerifier {
         for (Ast.Param p : dep.params()) {
             paramTypes.add(TypeOps.successType(p.type(), symbols));
         }
-        Standins table = standins(fk, paramTypes, outType, out);
+        // What is wrong with the table is said where the fake is written ({@link #fakeTables}), and
+        // said once. Here it is a row that cannot run: this row and every other row reaching the same
+        // fake would each repeat the one thing wrong with the one table they all read.
+        Standins table = standins(fk, paramTypes, outType, new ArrayList<>());
         if (table == null) {
             return null;
         }
@@ -1360,6 +1434,21 @@ public final class ExampleVerifier {
     private static Diagnostic unbuildableFake(SourcePos pos, String dependency, String reason) {
         return Diagnostic.of("E1908", "check.fake.unbuildable").title("check.example.title")
                 .at(pos).args(dependency, reason).build();
+    }
+
+    /**
+     * A fake whose table did not finish being built, so nothing it states was checked.
+     *
+     * <p>A warning, where a table that will not build is an error: waiting says that this table was
+     * not read, not that it is wrong, and which of the two it is cannot be told from having waited.
+     * The budget is the one this wait was held to rather than the setting read back later, and it is
+     * written out rather than passed as a number, which a locale would group into a budget nobody set.
+     */
+    private static Diagnostic uncheckedFake(Ast.Fake fk, long budgetMs) {
+        return Diagnostic.of("E1921", "check.fake.unchecked").warning().title("check.example.title")
+                .at(fk.pos(), fk.target().length())
+                .args(fk.target(), Long.toString(budgetMs))
+                .hint("check.fake.unchecked.hint", fk.target()).build();
     }
 
     private byte[] fakeSubclassBytes(String fakeName, Class<?> base, java.lang.reflect.Method apply) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -607,9 +607,62 @@ public final class Output {
             return sourceId;
         }
 
+        /**
+         * The rows this source wrote, run — and the fakes it wrote, built.
+         *
+         * <p>The fakes here rather than in {@link #evaluate}, which a measurement runs a second time
+         * against instrumented classes ({@link Adequacy.ProbedExamples}). Whether a table can be built
+         * is not a question a measurement asks, and asking it twice would have one table answered for
+         * by two builds.
+         */
         @Override
         public Answer<Of> compute(Db db) {
-            return evaluate(db, name, sourceId, db.ask(new Linked(name)).value());
+            Answer<Of> ran = evaluate(db, name, sourceId, db.ask(new Linked(name)).value());
+            List<Diagnostic> wrong = fakeTables(db, name, sourceId);
+            if (wrong.isEmpty()) {
+                return ran;
+            }
+            List<Report> reports = new ArrayList<>(ran.reports());
+            for (Diagnostic d : wrong) {
+                reports.add(Report.of(d));
+            }
+            return new Answer<>(ran.value(), reports);
+        }
+
+        /**
+         * What building the fakes written in this source says about them.
+         *
+         * <p>Every fake it wrote, whether or not a row reaches one. A fake is a statement about the
+         * behavior it stands in for the way a row is, and the two other places a table is built each
+         * need something else to be there — a row of a behavior that depends on the faked one
+         * ({@code resolveFake}), or a row recorded for the faked one itself (the reading behind
+         * {@link Disagreements}) — so a module that writes neither had its table built nowhere.
+         *
+         * <p>Which source wrote which fake is passed rather than used here: which of two tables
+         * written for one dependency answers is a fact about the module, so the reading that knows
+         * that is the one that picks what this source's share of them is.
+         */
+        private static List<Diagnostic> fakeTables(Db db, String name, String sourceId) {
+            Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
+            if (!prepared.present() || !scope.present() || !sigs.present()) {
+                return List.of();
+            }
+            if (db.ask(new Bodies.Checked(name)).value() == null) {
+                return List.of();   // a module that did not check has nothing to build a value with
+            }
+            Map<String, byte[]> classes = db.ask(new Linked(name)).value();
+            Map<String, List<BehaviorRequirement>> requirements =
+                    db.ask(new Bodies.Requirements(name)).value();
+            List<String> fakeOrigins = db.ask(new Front.FakeOrigins(name)).value();
+            if (classes == null || requirements == null || fakeOrigins == null) {
+                return List.of();
+            }
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.Helpers(name)).value();
+            return souther.compiler.ExampleVerifier.fakeTables(prepared.value(), scope.value(),
+                    sigs.value(), classes, requirements, loader(db, Map.of()),
+                    values == null ? Map.of() : values, fakeOrigins, sourceId);
         }
 
         /**

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -508,13 +508,15 @@ check.invariant.violation=Constructing `{0}` here violates its invariant on a re
 check.invariant.unproven=Constructing `{0}` here may violate its invariant: the guards do not establish it. Guard it with `guard`, or reify the relation into `{0}`''s (or an input''s) invariant so it is assumed here.
 check.invariant.reify=If a relation between inputs guarantees this, declare it as an `invariant` on the input data so it is checked once at its boundary and assumed here.
 
-# --- fake (E1908-E1909, test doubles for injected dependencies) ---
+# --- fake (E1908-E1909, E1921, test doubles for injected dependencies) ---
 check.fake.missing=`{0}` depends on `{1}`, but no fake was supplied for it.
 check.fake.missing.through=`{0}` depends on `{1}` through {2}, but no fake was supplied for it.
 check.fake.missing.hint={0}
 check.fake.value=The fake value supplied for dependency `{0}` could not be built: {1}
 check.fake.unbuildable=The fake supplied for dependency `{0}` could not be built: {1}
 check.fake.miss=A fake had no output for an input: {0}
+check.fake.unchecked=Building the `fake {0}` table did not finish within {1}ms, so nothing it states was checked.
+check.fake.unchecked.hint=What the budget went on is not read here; a row applying a `partial` helper that may not stop is the usual one, and making it structural or reducing it ends this. A table that is only slow has `souther.example.timeout.ms`. Until one of those, whether the `fake {0}` table can be built at all is unknown.
 check.example.disagreement=This row and the `fake {0}` row state different answers for the same input.
 check.example.disagreement.hint=The row says {0}; the fake says {1}.
 check.example.disagreement.here=the `fake {0}` row

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -507,13 +507,15 @@ check.invariant.violation=ここでの `{0}` の構築は、到達可能な経�
 check.invariant.unproven=ここでの `{0}` の構築は不変条件に違反する可能性があります。ガードが不変条件を確立していません。`guard` でガードするか、関係を `{0}`（または入力）の `invariant` に宣言してここで仮定させてください。
 check.invariant.reify=入力間の関係がこれを保証するなら、入力データの `invariant` として宣言してください。境界で一度検査され、ここでは仮定されます。
 
-# --- fake (E1908-E1909, 注入依存のテストダブル) ---
+# --- fake (E1908-E1909, E1921, 注入依存のテストダブル) ---
 check.fake.missing=`{0}` は `{1}` に依存しますが、その fake が与えられていません。
 check.fake.missing.through=`{0}` は {2} を通じて `{1}` に依存しますが、その fake が与えられていません。
 check.fake.missing.hint={0}
 check.fake.value=依存 `{0}` に与えた fake の値を構築できませんでした: {1}
 check.fake.unbuildable=依存 `{0}` に与えた fake を構築できませんでした: {1}
 check.fake.miss=fake が入力に対する出力を持っていません: {0}
+check.fake.unchecked=`fake {0}` のテーブルの構築が {1}ms 以内に終わらなかったので、これが述べていることは何も検査されていません。
+check.fake.unchecked.hint=予算が何に使われたかはここでは読めません。よくあるのは、停止しないかもしれない `partial` ヘルパを適用している行で、それを構造的にするか小さくすれば終わります。遅いだけのテーブルには `souther.example.timeout.ms` があります。どちらかを行うまで、`fake {0}` のテーブルが構築できるかどうかは不明です。
 check.example.disagreement=この行と `fake {0}` の行が、同じ入力に対して違う答えを述べています。
 check.example.disagreement.hint=行は {0}、fake は {1} と述べています。
 check.example.disagreement.here=`fake {0}` の行

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
@@ -1,0 +1,263 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.Located;
+import souther.compiler.meta.ModulePath;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code fake}'s table is built because it is written, not because something reads it.
+ *
+ * <p>A table is read to stand in for a behavior while a row of something that depends on it runs, and
+ * read again against the rows recorded for the behavior itself. A module can write one that neither
+ * of those reaches — nothing depends on the faked behavior, and no row records what it owes — and
+ * what is wrong with such a table was said nowhere: the reading built it into a list nobody read, and
+ * nothing else built it at all.
+ */
+class CompileFakeTableWhereWrittenTest {
+
+    /** A behavior nothing depends on, with rows of its own: the reading is the only other place its
+     * table is built, and it does not report. */
+    private static final String UNREAD = """
+            module example.written
+
+            data N = Int
+            data Found = { n: N }
+            data Missing = { why: String }
+
+            behavior find : (n: N) -> Found | Missing
+                constructs Found
+
+            let find (n) = Found { n = n }
+
+            example find
+                | "one" : (N(1)) -> Found { n = N(1) }
+            """;
+
+    /** An injected dependency and a behavior whose rows run against a stand-in for it. */
+    private static final String INJECTED = """
+            module example.used
+
+            data N = Int
+            data Found = { n: N }
+            data Missing = { why: String }
+            data Ok = { n: N }
+
+            behavior find : (n: N) -> Found | Missing
+
+            behavior use : (n: N) -> Ok | Missing
+                depends on find
+                constructs Ok, Missing
+
+            let use (n, find) = match find(n) with
+                | Found   -> Ok { n = n }
+                | Missing -> Missing { why = "none" }
+            """;
+
+    @Test
+    void aTableNoRowReadsIsStillBuilt() {
+        // `N` is a newtype over Int, so `N("x")` is a row that will not build. Nothing depends on
+        // `find`, so no row ever stands in with this table; it says what it says all the same.
+        Diagnostic one = only(UNREAD + """
+
+                fake find
+                    | (N("x")) -> Found { n = N(1) }
+                """);
+
+        assertEquals("E1908", one.code());
+        assertEquals("check.fake.unbuildable", one.messageKey());
+        assertEquals("find", one.args()[0], "the behavior the table stands in for");
+        assertEquals(15, one.pos().line(), "at the fake, which is where the table is written");
+    }
+
+    @Test
+    void aTableNothingAtAllReadsIsStillBuilt() {
+        // No rows recorded for `find` either, so not even the reading builds this one.
+        Diagnostic one = only("""
+                module example.alone
+
+                data N = Int
+                data Found = { n: N }
+                data Missing = { why: String }
+
+                behavior find : (n: N) -> Found | Missing
+                    constructs Found
+
+                let find (n) = Found { n = n }
+
+                fake find
+                    | (N("x")) -> Found { n = N(1) }
+                """);
+
+        assertEquals("E1908", one.code());
+        assertEquals("check.fake.unbuildable", one.messageKey());
+    }
+
+    @Test
+    void aRowOfTheWrongArityIsSaidWithoutARowReadingTheTable() {
+        Diagnostic one = only(UNREAD + """
+
+                fake find
+                    | (N(1), N(2)) -> Found { n = N(1) }
+                """);
+
+        assertEquals("E1908", one.code());
+        assertEquals("check.fake.unbuildable", one.messageKey());
+        assertEquals(16, one.pos().line(), "at the row whose input count is wrong");
+    }
+
+    /**
+     * A second table written for one dependency is not built here either.
+     *
+     * <p>The first is the one that answers — it is what stands in ({@code resolveFake}) and what the
+     * rows are read against — so a second states nothing anywhere. Building it here would hold a
+     * table to something no reader of it would ever ask.
+     */
+    @Test
+    void aSecondTableForOneDependencyIsNotBuilt() {
+        assertDoesNotThrow(() -> Compiler.compile(UNREAD + """
+
+                fake find
+                    | (N(1)) -> Found { n = N(1) }
+
+                fake find
+                    | (N("x")) -> Found { n = N(1) }
+                """));
+    }
+
+    /** And a table that builds is said nowhere: the check is not one every fake fails. */
+    @Test
+    void aTableThatBuildsIsSaidNowhere() {
+        assertDoesNotThrow(() -> Compiler.compile(UNREAD + """
+
+                fake find
+                    | (N(1)) -> Found { n = N(1) }
+                """));
+    }
+
+    /**
+     * One table, one report, however many rows read it.
+     *
+     * <p>A row that applies a fake it could not build does not run, and what is wrong with the table
+     * is not the row's to say: each row reaching it would otherwise repeat the one thing wrong with
+     * the one table they all read.
+     */
+    @Test
+    void oneTableIsSaidOnceHoweverManyRowsReadIt() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(INJECTED + """
+
+                example use
+                    | "one" : (N(1)) -> Ok { n = N(1) }
+                    | "two" : (N(2)) -> Ok { n = N(2) }
+
+                fake find
+                    | (N("x")) -> Found { n = N(1) }
+                """));
+
+        assertEquals(List.of("E1908"), codesOf(e), e.getMessage());
+        assertEquals("check.fake.unbuildable", e.diagnostics().get(0).messageKey());
+    }
+
+    /** A fake written in an attached file is built for that file, and said in it. */
+    @Test
+    void aFakeInAnAttachedFileIsSaidInThatFile() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(INJECTED + """
+
+                        example use
+                            | "one" : (N(1)) -> Ok { n = N(1) }
+                        """, """
+                        examples for example.used
+
+                        fake find
+                            | (N("x")) -> Found { n = N(1) }
+                        """)));
+
+        assertEquals(List.of("E1908"), codesOf(e), e.getMessage());
+        assertEquals("1", e.sourceIdOf(0), "the file that wrote the fake is the file it is said in");
+    }
+
+    /**
+     * A table that did not finish being built says so, and says nothing about being wrong: waiting
+     * tells the two apart in neither direction. Nothing reads this one — no row depends on `find` and
+     * none is recorded for it — so the comparison the reading would report on (E1920) never arises,
+     * and this is the only thing said about the table.
+     */
+    @Test
+    void aTableThatDidNotFinishBuildingSaysSoAtTheFake() {
+        List<Located> warnings = new ArrayList<>();
+        assertDoesNotThrow(() -> Compiler.compiled("""
+                module example.slow
+
+                data N = Int
+                data Found = { n: N }
+                data Missing = { why: String }
+
+                partial let spin (n: Int): Int = spin(n)
+
+                behavior find : (n: N) -> Found | Missing
+                    constructs Found
+
+                let find (n) = Found { n = n }
+
+                fake find
+                    | (N(spin(1))) -> Found { n = N(1) }
+                """, "Main", warnings));
+
+        List<Located> said = only("E1921", warnings);
+        assertEquals(1, said.size(), warnings.toString());
+        assertEquals(List.of(), only("E1920", warnings),
+                "nothing records what `find` owes, so no comparison was missed");
+        Diagnostic one = said.get(0).diagnostic();
+        assertEquals(14, one.pos().line(), "at the fake");
+        assertEquals(6, one.pos().column(), "on the behavior it names");
+        // The budget is read off the budget: it is settable (`souther.example.timeout.ms`), and a
+        // literal here would fail the run that set it. Ungrouped, which is how it is set.
+        assertTrue(rendered(one).contains("Building the `fake find` table did not finish within "
+                        + ExampleVerifier.exampleTimeoutMs() + "ms"),
+                rendered(one));
+        assertTrue(rendered(one).contains("whether the `fake find` table can be built at all"),
+                "the hint names the table it is about: " + rendered(one));
+    }
+
+    /** The one diagnostic of a compile that has one. */
+    private static Diagnostic only(String model) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(model));
+        assertEquals(1, e.diagnostics().size(), "one table, one diagnostic: " + e.getMessage());
+        return e.diagnostics().get(0);
+    }
+
+    private static List<String> codesOf(CompileException e) {
+        List<String> codes = new ArrayList<>();
+        for (Diagnostic d : e.diagnostics()) {
+            codes.add(d.code());
+        }
+        return codes;
+    }
+
+    private static List<Located> only(String code, List<Located> warnings) {
+        List<Located> found = new ArrayList<>();
+        for (Located w : warnings) {
+            if (code.equals(w.diagnostic().code())) {
+                found.add(w);
+            }
+        }
+        return found;
+    }
+
+    private static String rendered(Diagnostic d) {
+        return new HumanRenderer(false).render(d, null, Locale.ENGLISH);
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -2270,6 +2270,8 @@ fake findManager
 
 Each dependency of the target must have a fake — a `+with+` on the row or a `+fake+` table — or it is a compile error (<<e1908>>). A fake, like an example, is written inline or in an attached `+examples for+` file, and is local to its module. `+fake+` is a contextual keyword.
 
+A `+fake+` table is built because it is written. Each table that answers for a dependency — the first one written for it (<<example-pending>>) — is built once, where it is written, whether or not any row reads it: a module may write a table nothing depends on and no row records an answer for, and what is wrong with such a table is wrong wherever it is read from. A table with a row that will not build is an error at the fake (<<e1908>>), said once however many rows would have read it; a table that does not finish being built is a warning there (<<e1921>>). A row that would have stood in with a table that will not build does not run, and says nothing of its own about the table.
+
 A composition's dependencies are its stages' (<<composition-with-requirements>>), so a row exampling one supplies a fake for each of those. That holds whichever path the row takes: an input that departs the main line at the first stage never reaches the second, and the second stage's dependency is faked all the same. What a row has to supply is a property of the composition, not of the input this row happens to use. One dependency two stages share is one fake — the composition holds one of it (<<composition-with-requirements>>) — and the diagnostic names the stage that wants it (<<e1908>>).
 
 [#example-pending]
@@ -3600,6 +3602,8 @@ Hint: Add `with now = ...` on the row, or a `fake now` table.
 
 Emitted when an example targets a behavior whose `+depends on+` dependency has neither a `+with+` on the row nor a `+fake+` declaration (<<example-fakes>>). A dependency that *is* faked but whose fake cannot be built — a `+with+` value, or a row of its `+fake+` table — is reported under the same code and says that instead, naming the dependency once: the fake is supplied, and what failed is the fixture.
 
+The two are quoted where each is written. A `+with+` is written on a row, so the row it is written on is where its value not building is said; a `+fake+` table is written on its own, so that is where a row of it not building is said — once for the table, whether or not any row reads it (<<example-fakes>>).
+
 [#e1909]
 === A fake has no output for an input
 
@@ -3696,6 +3700,28 @@ Where a recorded row names a case and nothing under it (<<example-expected>>), t
 A row whose fixture does not finish is read within its own budget and states nothing; the rows beside it are unaffected, and what happened is said where that row is evaluated (<<e1910>>).
 
 A row whose arity is wrong, whose inputs or expectation will not build, or whose expectation is not a case the behavior answers with, states nothing to compare, and each is said as the error it is (<<e1903>>, <<e1904>>).
+
+[#e1920]
+=== A fake and the rows recorded for one behavior were not compared
+
+[,text]
+----
+Could not compare this fake with the rows recorded for `find` — building the table
+did not finish within 2000ms.
+----
+
+A warning, quoted where the `+fake+` names the behavior it stands in for. Emitted when reading a `+fake+` table against the rows recorded for that behavior (<<example-pending>>) does not finish within the budget the reading is held to, so what the two state was never compared. Being told nothing was found and being told nothing was compared are different answers, and an empty list of disagreements is what the first one looks like.
+
+[#e1921]
+=== A fake's table was not built in time
+
+[,text]
+----
+Building the `fake find` table did not finish within 2000ms, so nothing it states
+was checked.
+----
+
+A warning, quoted where the `+fake+` names the behavior it stands in for. Emitted when building the table where it is written (<<example-fakes>>) does not finish within the budget that build is held to. A warning rather than an error: waiting says the table was not read, not that it is wrong, and which of the two it is cannot be told from having waited.
 
 [#e2001]
 === A recursive helper is not proven total


### PR DESCRIPTION
Closes #322.

## What was wrong

`againstFake` builds a fake's whole table into `new ArrayList<>()`, and the comment
beside it rested on the table being read somewhere that reports what is wrong with
it. The other path that builds one is `resolveFake`, which runs while a row of a
behavior that *depends on* the faked one is evaluated. `contested` does not ask for
such a row — it asks that the behavior have a stand-in and rows of its own — so a
module writing `fake B` and `example B` with nothing depending on `B` had the table
built once, in the reading, and whatever was wrong with it said nowhere. A module
writing `fake B` with neither a dependent row nor rows of its own had it built
nowhere at all.

## What this does

The issue asks whether the reading should report what it finds, or whether the
table should be read somewhere that already reports. This is the second, with the
place made: a table is built because it is written.

Each table that answers for a dependency is built once, from the source that wrote
it, whether or not any row reads it. E1908 is unchanged and lands at the fake,
which is where it was already positioned; what changed is who says it.

`resolveFake` no longer reports it. A row applying a fake that will not build is a
row that does not run, and the error at the fake is what the compile fails on. That
also ends the same table being reported once per row that reached it: two rows
reading one broken table said the one thing wrong with it twice.

The table that answers is the first written for a dependency, which is what
`resolveFake` and the reading each already take. A second written for the same name
stands in for nothing and is read by nobody, so building it would hold a table to
something no reader of it would ever ask. Which of two answers is a fact about the
module and not about one of its files, so `ExampleVerifier` picks this source's
share of the fakes rather than being handed it.

The build is held to a budget of its own, for the reason a row and a reading each
have one: a row of the table applies helpers, and a `partial` one may not stop. A
build that did not finish is a warning at the fake, **E1921** — nothing the table
states was checked, which is what having waited says, and not that the table is
wrong.

E1920 stays where it is. The reading builds the table again on a loader of its own,
so a build that finishes and a reading that does not is a thing that can happen,
and "these two were never compared" is what that has to say.

## Where it is asked

`Output.Examples(module, sourceId)`. Its errors already fail a compile on every
path that drives one — the single-source compile, the linking compile and
`answerEverything` all read that key — and `exampleSourcesOf` already includes the
sources that wrote only a fake. The other candidate, `SaidDisagreements`, carries
E1919 and E1920 and can carry only warnings: no driver reads its errors.

On the key rather than in the shared `evaluate`, which `Adequacy.ProbedExamples`
runs a second time against instrumented classes. Whether a table can be built is
not a question a measurement asks, and asking it there would have one table
answered for by two builds.

## Tests

Eight, in `CompileFakeTableWhereWrittenTest`. Six of them fail with the tests kept
and the change reverted, and the way they fail is the defect:

- a table nothing reads, and a table nothing at all reads — `Expected
  CompileException to be thrown, but nothing was thrown`;
- a wrong-arity row in a table nothing reads — likewise;
- two rows reading one broken table — `expected: <[E1908]> but was: <[E1908,
  E1908]>`;
- a fake in an attached file — said in the module's file, not the one that wrote it;
- a table that does not finish — no E1921 at all.

The two that hold either way are the controls: a table that builds is said nowhere,
and a second table for one dependency is not built.

## What this costs

A table that does not finish building now costs its budget in the check as well as
in the reading, where the fake has recorded rows. The worker that overran cannot be
stopped — a fixture reaches no interrupt point — so a module whose fake applies a
non-terminating `partial` helper leaves a spinning daemon thread behind, as a row
doing the same already does. Both are the price of building a table nothing else
builds, which is what the issue asks for.

## Specification

The rule is in the `fake` section and the E1908 entry. E1921 gets a catalogue entry,
and so does E1920, which #315 added without one — the gap between e1919 and e1921
is what made it visible.
