### PR TITLE
Every position carries the source it was read from

### DIFF
--- a/docs/adr/0044-diagnostics-as-data-with-renderer-layer.md
+++ b/docs/adr/0044-diagnostics-as-data-with-renderer-layer.md
@@ -76,3 +76,25 @@ Two decisions bound the scope.
 - A multi-file build has no per-diagnostic file identity (SourcePos carries no file), so a snippet is
   quoted only for a single-file compile; a linked build renders the frame and message without the
   source line until a file handle is added to the position.
+
+## Amendment: the file handle is on the position (issue #309)
+
+The last consequence deferred a file handle on the position, and a compile worked out which file a
+report belonged to from the question that found it instead. That holds while each question is about
+one file and stops holding where it is not: a module's `example` rows, fake tables and values are
+written in the module's own source and in any number of attached `examples for` files, and once they
+are gathered under one name a question asked about the module can only answer with the module's own
+file. What the author was then shown was the right line number quoted out of the wrong file — an
+unrelated declaration with a caret in the middle of it.
+
+So `SourcePos` now carries the source it was read from. It is given once, where a position is made
+from a text (`LineIndex`), so no later pass has to reconstruct it, and it reaches every position a
+parse makes without an AST walker. A position read from no source of this compile — a synthesized
+node, the standard library, a module read back off the module path — names none, and a reader falls
+back as it did before.
+
+The source is part of what makes two positions the same position. Line 25 of two files is one
+coordinate and is not one place, and a value whose identity denied one of its components would leave
+"the same position" meaning something different in every container that held one — which is the
+original mistake, re-expressible. Where coordinates alone are wanted, they are compared as
+coordinates.

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -39,21 +39,24 @@ public final class AstBuilder {
     private int patternCounter = 0;
     private int spreadCounter = 0;
 
-    private AstBuilder(String source) {
-        this.lines = new LineIndex(source);
+    private AstBuilder(String source, String sourceId) {
+        this.lines = new LineIndex(source, sourceId);
     }
 
     /**
      * Builds a module from a parsed source file. A header-less source is named
-     * {@code defaultModuleName}; a {@code null} default makes the header required.
+     * {@code defaultModuleName}; a {@code null} default makes the header required. Every position
+     * the module carries names {@code sourceId}, which is null for a source the caller has no name
+     * for — a module read off the module path, which is in no source of the compile reading it.
      *
      * <p>Requires a CST the parser accepted: every node it reads has the children the grammar gives
      * it, and a missing one is dereferenced rather than reported. {@link CstFrontend#parse} is the
      * one caller and raises the parser's first error before building — which is why this is
      * package-private, and what a second caller would have to guarantee.
      */
-    static Ast.Module build(SyntaxNode sourceFile, String source, String defaultModuleName) {
-        return new AstBuilder(source).module(sourceFile, defaultModuleName);
+    static Ast.Module build(SyntaxNode sourceFile, String source, String defaultModuleName,
+                            String sourceId) {
+        return new AstBuilder(source, sourceId).module(sourceFile, defaultModuleName);
     }
 
     // --- module ---

--- a/souther-compiler/src/main/java/souther/compiler/frontend/CstFrontend.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/CstFrontend.java
@@ -26,13 +26,20 @@ public final class CstFrontend {
     }
 
     /** Parses one compilation unit, naming a header-less source {@code defaultModuleName} (a
-     * {@code null} default makes the {@code module} header required). */
+     * {@code null} default makes the {@code module} header required).
+     *
+     * <p>The positions it makes name no source. A caller that has a name for the text it is handing
+     * over — a compile reading one of its own sources — parses through
+     * {@link #parseWithSlices(String, String, String)} instead, so that what it gets back says which
+     * file each position was read from. A caller here has no such name: the standard library and a
+     * module read back off the module path are in no source of the compile that is reading them. */
     public static Ast.Module parse(String source, String defaultModuleName) {
         CstParser.Result result = CstParser.parse(source);
         if (!result.errors().isEmpty()) {
-            throw firstError(source, result.errors().get(0));
+            throw firstError(source, null, result.errors().get(0));
         }
-        return ImplicitUnits.expand(AstBuilder.build(result.root(), source, defaultModuleName));
+        return ImplicitUnits.expand(
+                AstBuilder.build(result.root(), source, defaultModuleName, null));
     }
 
     /** As {@link #parse(String, String)} with the default module name {@code Main}. */
@@ -53,12 +60,27 @@ public final class CstFrontend {
      * neighbour's name.
      */
     public static Parsed parseWithSlices(String source, String defaultModuleName) {
+        return parseWithSlices(source, defaultModuleName, null);
+    }
+
+    /**
+     * As {@link #parseWithSlices(String, String)}, with every position it makes naming
+     * {@code sourceId}.
+     *
+     * <p>A compile that holds several sources has a name for each of them, and this is where that
+     * name reaches the positions. It has to be here: a module's writings do not all stay in the file
+     * they were written in — an attached {@code examples for} file's rows, tables and values join the
+     * module they are for — and after that a line and a column no longer say which file they were
+     * read from. Read at the one place a position is made from a text, the answer never has to be
+     * worked out again.
+     */
+    public static Parsed parseWithSlices(String source, String defaultModuleName, String sourceId) {
         CstParser.Result result = CstParser.parse(source);
         if (!result.errors().isEmpty()) {
-            throw firstError(source, result.errors().get(0));
+            throw firstError(source, sourceId, result.errors().get(0));
         }
         Ast.Module module = ImplicitUnits.expand(
-                AstBuilder.build(result.root(), source, defaultModuleName));
+                AstBuilder.build(result.root(), source, defaultModuleName, sourceId));
         String header = "module " + module.name();   // a source with no header is named for its file
         List<String> imports = new ArrayList<>();
         Map<String, String> defs = new LinkedHashMap<>();
@@ -94,8 +116,12 @@ public final class CstFrontend {
     public record Slices(String header, List<String> imports, Map<String, String> defs,
                          Map<String, String> behaviors, Map<String, String> fns) {}
 
-    private static CompileException firstError(String source, CstError e) {
-        LineIndex lines = new LineIndex(source);
+    /** The parser's first error, positioned in {@code sourceId}. The index is built here rather than
+     * taken off the builder — the build never ran — so this is the one position of a source that
+     * would otherwise not say which file it is in, and a syntax error would be the single kind of
+     * mistake still reported against whatever file the reader guessed at. */
+    private static CompileException firstError(String source, String sourceId, CstError e) {
+        LineIndex lines = new LineIndex(source, sourceId);
         Diagnostic diag = Diagnostic.of(null, e.messageKey()).title("parse.title")
                 .at(lines.posOf(e.offset()), e.width()).args(e.args()).build();
         return CompileException.of(diag, e.legacyMessage());

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -315,7 +315,7 @@ public final class Compilation {
             byId.put(id, new ArrayList<>());
         }
         for (Db.Found found : db.allReports()) {
-            String primary = primarySourceIdOf(found);
+            String primary = locatedSourceIdOf(found);
             for (String id : publishSourceIdsOf(found)) {
                 List<Located> on = byId.get(id);
                 if (on != null) {
@@ -356,17 +356,24 @@ public final class Compilation {
     }
 
     /**
-     * Which source a report's primary region is in, as this compilation names its sources: the one
-     * the report named, or the one its key did, or the one that declares the module it was about.
+     * Which of the sources this compilation holds a report's primary region is in: the one the report
+     * claims ({@link Db.Found#claimedSourceId()}), or — where it claims none, or claims one this
+     * compile was not handed — the one that declares the module it was about.
+     *
+     * <p>The second half of that is a guard, and it guards availability as much as attribution. A
+     * position may have been read from a source this compile does not have: the prelude, or a module
+     * read back off the module path. Filing a report under a name {@link #diagnostics()} has no entry
+     * for would drop it silently, and a report the author never sees is worse than one on the wrong
+     * file.
      *
      * <p>Always answered, whatever the compile tells a caller about its sources. What a source is
      * called here is how a report is filed and how its regions are quoted; what a caller is told is
      * {@link #sourceIdOf(Db.Found)}, and the two are not the same question.
      */
-    private String primarySourceIdOf(Db.Found found) {
-        String said = found.primarySourceId();
-        if (said != null) {
-            return said;
+    private String locatedSourceIdOf(Db.Found found) {
+        String claimed = found.claimedSourceId();
+        if (claimed != null && sourceIds().contains(claimed)) {
+            return claimed;
         }
         return found.module() == null ? null : sourceIdOf(found.module());
     }
@@ -376,7 +383,7 @@ public final class Compilation {
      * told — none, for a compile of one source, where that caller knows the file it handed over.
      */
     public String sourceIdOf(Db.Found found) {
-        return namesSources ? primarySourceIdOf(found) : null;
+        return namesSources ? locatedSourceIdOf(found) : null;
     }
 
     /**
@@ -388,7 +395,7 @@ public final class Compilation {
      * report has something to show.
      */
     public List<String> publishSourceIdsOf(Db.Found found) {
-        String primary = primarySourceIdOf(found);
+        String primary = locatedSourceIdOf(found);
         List<String> saidAt = new ArrayList<>();
         if (primary != null) {
             saidAt.add(primary);
@@ -407,7 +414,7 @@ public final class Compilation {
     /** Where a report sits in the order the sources were given, or -1 when it names none. Only for
      * ordering: which file a reader is sent to is {@link #sourceIdOf(Db.Found)}. */
     private int indexOf(Db.Found found) {
-        String id = primarySourceIdOf(found);
+        String id = locatedSourceIdOf(found);
         if (id == null) {
             return -1;
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Db.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Db.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import java.util.ArrayDeque;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.SourcePos;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -229,7 +230,7 @@ public final class Db {
                 // into, and both are looking at the same line. The first to say it is the one that
                 // says it, so the order is the order the work happened in.
                 Found one = new Found(key.module(), key.sourceId(), report);
-                found.putIfAbsent(new Told(key.module(), one.primarySourceId(), report.problem()),
+                found.putIfAbsent(new Told(key.module(), one.claimedSourceId(), report.problem()),
                         one);
             }
         }
@@ -256,22 +257,36 @@ public final class Db {
      * may be null.
      *
      * <p>Where the report is said is read off this rather than stored beside it, so there is one
-     * answer and not two that can come apart: the report says where it goes when it knows
-     * ({@link Report.Delivery}), and the key answers when it does not. A module named but no source
-     * is the last fallback, and only a caller holding the module layout can apply it —
-     * {@link Compilation#publishSourceIdsOf(Found)} is where the whole
-     * answer is worked out.
+     * answer and not two that can come apart. A module named but no source is the last fallback, and
+     * only a caller holding the module layout can apply it —
+     * {@link Compilation#publishSourceIdsOf(Found)} is where the whole answer is worked out.
      */
     public record Found(String module, String sourceId, Report report) {
 
         /**
-         * The source the primary region is in: the one the report names, else the one the key does.
-         * Null when neither says, which leaves the module's own source as the last word — a fallback
-         * only a caller that knows the module layout can apply.
+         * The source this report claims, before a compile decides whether it has it: the one the
+         * report named, else the one its primary position was read from, else the one the key asked
+         * about. Null when none of the three says, which leaves the module's own source as the last
+         * word — a fallback only a caller that knows the module layout can apply.
+         *
+         * <p>The position comes before the key, and that ordering is the whole of what a reader
+         * needs. A key says which input was asked about; a position says where the caret sits, and
+         * the line under the caret is quoted out of the file this names. Where the two disagree,
+         * answering with the key's shows a reader a line they did not write — which is what a
+         * question asked about a module whose rows were written in an attached {@code examples for}
+         * file did (issue #309). A report that belongs somewhere other than where its caret sits says
+         * so itself, which is what {@link Report.Delivery} is for, and that is why it comes first.
          */
-        public String primarySourceId() {
+        public String claimedSourceId() {
             String said = report.delivery().primarySourceId();
-            return said != null ? said : sourceId;
+            if (said != null) {
+                return said;
+            }
+            SourcePos at = report.diagnostic().pos();
+            if (at != null && at.sourceId() != null) {
+                return at.sourceId();
+            }
+            return sourceId;
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -91,7 +91,9 @@ public final class Front {
      */
     public record ExampleBudget() implements Input<Long> {}
 
-    /** One source, parsed, with the text of each declaration kept for publishing. */
+    /** One source, parsed, with the text of each declaration kept for publishing. Every position in
+     * what comes back names this source, so a writing that later joins another file's module still
+     * says where it was written. */
     public record Parsed(String id) implements Key<CstFrontend.Parsed> {
         @Override
         public String sourceId() {
@@ -106,7 +108,7 @@ public final class Front {
             }
             try {
                 return Answer.of(CstFrontend.parseWithSlices(
-                        text.value(), db.ask(new DefaultName()).value()));
+                        text.value(), db.ask(new DefaultName()).value(), id));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -957,12 +957,31 @@ public final class Names {
         }
     }
 
-    /** Whether the name {@code written} starting at {@code start} covers {@code at}. A name is one
-     * line's worth of text, so a position on another line is not on it. */
+    /**
+     * Whether the name {@code written} starting at {@code start} covers {@code at}. A name is one
+     * line's worth of text, so a position on another line is not on it — and a name in another file
+     * is not on it either, however the line numbers happen to line up.
+     *
+     * <p>The file matters here for the reason it matters anywhere: what a module is made of is not
+     * all written in one file. An attached {@code examples for} file's rows, tables and values join
+     * the module they are for, and a question asked of the module reads all of them, so line 8
+     * column 14 is two places and an editor asking about one of them was answered about whichever
+     * came first. What was under the cursor and what the answer described were then two different
+     * names.
+     *
+     * <p>Where either position names no source — a caller with only a coordinate to give — the
+     * coordinates decide, which is what every such caller got before.
+     */
     static boolean spans(SourcePos start, String written, SourcePos at) {
         return start != null && at != null && start.line() == at.line()
+                && sameSource(start, at)
                 && at.column() >= start.column()
                 && at.column() <= start.column() + written.length();
+    }
+
+    private static boolean sameSource(SourcePos start, SourcePos at) {
+        return start.sourceId() == null || at.sourceId() == null
+                || start.sourceId().equals(at.sourceId());
     }
     public record DeclaredAt(TypeName denoted) implements Key<SourcePos> {
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -969,7 +969,7 @@ public final class Names {
      * came first. What was under the cursor and what the answer described were then two different
      * names.
      *
-     * <p>Where either position names no source — a caller with only a coordinate to give — the
+     * <p>Where the question names no source — a caller with only a coordinate to give — the
      * coordinates decide, which is what every such caller got before.
      */
     static boolean spans(SourcePos start, String written, SourcePos at) {
@@ -979,9 +979,17 @@ public final class Names {
                 && at.column() <= start.column() + written.length();
     }
 
+    /**
+     * Whether a name written at {@code start} is in the file the question at {@code at} is about.
+     *
+     * <p>The two absences are not the same absence, so this is not symmetric. A question that names
+     * no source is a caller with only a coordinate to give, and is answered by coordinate. A name
+     * that names none was read from no source of this compile, and is under nothing a reader has
+     * open — answering with it would be the thing this is here to stop, arrived at from the other
+     * side.
+     */
     private static boolean sameSource(SourcePos start, SourcePos at) {
-        return start.sourceId() == null || at.sourceId() == null
-                || start.sourceId().equals(at.sourceId());
+        return at.sourceId() == null || at.sourceId().equals(start.sourceId());
     }
     public record DeclaredAt(TypeName denoted) implements Key<SourcePos> {
         @Override

--- a/souther-compiler/src/main/java/souther/compiler/query/Report.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Report.java
@@ -32,13 +32,13 @@ public record Report(Diagnostic diagnostic, String legacyMessage, Delivery deliv
     /**
      * Where a report is said, for the reports that cannot be left to their key.
      *
-     * <p>A key names one source, and that is the answer for nearly everything: a problem is found
-     * while a file is being read and belongs to that file. Two cases are not like that. A comparison
-     * of two written statements is asked of the module, so its key names no source at all and the
-     * primary region's file has to be said here. And where neither of the two statements is the one
-     * in the wrong, the problem is said at both, so the author reading either file is told.
+     * <p>Nearly nothing needs this. A report's primary region was read from a file and says so, and
+     * that file is the one whose line is quoted under the caret — so leaving it alone is right
+     * whenever the problem is where it points. What this is for is the case where it is not: where
+     * neither of two written statements is the one in the wrong, the problem is said at both, so the
+     * author reading either file is told, and neither region can settle that on its own.
      *
-     * <p>{@code primarySourceId} is null for "the source the key names", which is what a report
+     * <p>{@code primarySourceId} is null for "wherever the report points", which is what a report
      * built any other way carries.
      *
      * <p>{@code saidAtEveryRegion} says the second case, and says it as a property of the report
@@ -53,7 +53,7 @@ public record Report(Diagnostic diagnostic, String legacyMessage, Delivery deliv
      * claim only the site that found it can make.
      *
      * <p>This is the declaration. What it resolves to against a particular key is
-     * {@link Db.Found#primarySourceId()} and {@link Compilation#publishSourceIdsOf(Db.Found)}.
+     * {@link Db.Found#claimedSourceId()} and {@link Compilation#publishSourceIdsOf(Db.Found)}.
      */
     public record Delivery(String primarySourceId, boolean saidAtEveryRegion) {
 

--- a/souther-compiler/src/test/java/souther/compiler/AMistakeInAnAttachedFileIsSaidOnThatFileTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMistakeInAnAttachedFileIsSaidOnThatFileTest.java
@@ -1,0 +1,193 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.HumanRenderer;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.SourceContext;
+import souther.compiler.diag.SourceContextResolver;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A module's rows, fake tables and values may be written beside it in an {@code examples for} file,
+ * and once they are gathered under the module's name a line and a column no longer say which file
+ * they came from. What was quoted then was the model file's line at that number — a line the author
+ * did not write, and, the two files being different lengths, usually a line about something else
+ * entirely (issue #309).
+ *
+ * <p>The rule these pin down: a report is said on the file the writing it is about was written in.
+ * So each of these reads the file back as well as the line — the id alone passed for the wrong
+ * reason in half the cases before the fix, since the two files' line numbers happened to agree.
+ *
+ * <p>The model is long and the attached file is short on purpose. A misattribution then lands on a
+ * line about something else, or past the end of the file, rather than on a coincidence.
+ */
+class AMistakeInAnAttachedFileIsSaidOnThatFileTest {
+
+    /** Long enough that a coordinate from the short file beside it lands on an unrelated line. */
+    private static final String MODEL = """
+            module shippingfee
+
+            data 都道府県 = { 名前: String }
+            data 数量     = { 個数: Int }
+            data 送料     = { 円: Int }
+
+            behavior 送料を求める : (県: 都道府県, 数: 数量) -> 送料
+                constructs 送料
+
+            let 送料を求める (県, 数) = 送料 { 円 = 数.個数 * 100 }
+
+            data 一般 = { 名前: String }
+            """;
+
+    private static final String ATTACHED_PREFIX = "examples for shippingfee\n\n";
+
+    private static CompileException raisedBy(String attached) {
+        return assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(MODEL, ATTACHED_PREFIX + attached)));
+    }
+
+    /** Where the compile says the problem is, as `sourceId line:column`. */
+    private static String saidAt(CompileException e) {
+        return e.sourceId() + " " + e.diagnostic().pos();
+    }
+
+    // --- one method per way of getting it wrong -------------------------------------------------
+
+    @Test
+    void anUnknownValueNamedByARowIsSaidInTheFileTheRowIsWrittenIn() {
+        CompileException e = raisedBy("""
+                example 送料を求める
+                    | "北海道" : (北海道沖縄, 数量 { 個数 = 1 }) -> 送料 { 円 = 100 }
+                """);
+
+        assertEquals("1 4:16", saidAt(e), "the row names it, and the row is in the attached file");
+    }
+
+    @Test
+    void anUnknownValueInAnAttachedFilesFixtureIsSaidInThatFile() {
+        CompileException e = raisedBy("""
+                let 県 = 都道府県 { 名前 = 北海道沖縄 }
+
+                example 送料を求める
+                    | "一つ" : (県, 数量 { 個数 = 1 }) -> 送料 { 円 = 100 }
+                """);
+
+        assertEquals("1 3:21", saidAt(e), "the value is declared in the attached file");
+    }
+
+    @Test
+    void anUnknownTypeInAnAttachedFilesFixtureIsSaidInThatFile() {
+        CompileException e = raisedBy("""
+                let 県 = 北海道沖縄 { 名前 = "北海道" }
+
+                example 送料を求める
+                    | "一つ" : (県, 数量 { 個数 = 1 }) -> 送料 { 円 = 100 }
+                """);
+
+        assertEquals("1 3:9", saidAt(e), "the type is written in the attached file");
+    }
+
+    @Test
+    void aTypeErrorInAnAttachedFilesFixtureIsSaidInThatFile() {
+        CompileException e = raisedBy("""
+                let 数 = 数量 { 個数 = "いくつか" }
+
+                example 送料を求める
+                    | "一つ" : (都道府県 { 名前 = "北海道" }, 数) -> 送料 { 円 = 100 }
+                """);
+
+        assertEquals("1", e.sourceId(), "the field is given its value in the attached file");
+        assertEquals(3, e.diagnostic().pos().line());
+    }
+
+    /**
+     * A syntax error never reaches the builder, so its position is made where the parser's first
+     * error is read rather than where the module is built. That is the one position of a known source
+     * that would otherwise say nothing about its file, which would leave a syntax error the single
+     * kind of mistake still reported against whatever file the reader guessed at.
+     */
+    @Test
+    void aSyntaxErrorInAnAttachedFileIsSaidInThatFile() {
+        CompileException e = raisedBy("""
+                example 送料を求める
+                    | "壊れている" : (
+                """);
+
+        assertEquals("1", e.sourceId());
+        assertEquals("1", e.diagnostic().pos().sourceId(),
+                "the position itself says which file, which is what the id is read off");
+    }
+
+    /**
+     * What the author actually sees. The id and the line agreeing is the mechanism; the line under
+     * the caret being the line they wrote is the point, and it is the only assertion here that would
+     * have caught the bug on its own.
+     */
+    @Test
+    void theQuotedLineIsTheLineTheAuthorWrote() {
+        String attached = ATTACHED_PREFIX + """
+                example 送料を求める
+                    | "北海道" : (北海道沖縄, 数量 { 個数 = 1 }) -> 送料 { 円 = 100 }
+                """;
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(MODEL, attached)));
+        SourceContextResolver sources = id -> switch (id) {
+            case "0" -> new SourceContext("shippingfee.sou", MODEL);
+            case "1" -> new SourceContext("shippingfee.examples.sou", attached);
+            default -> null;
+        };
+
+        String out = new HumanRenderer(false).render(
+                new Located(e.diagnostic(), e.sourceId()), sources, Locale.ENGLISH);
+
+        assertTrue(out.contains("shippingfee.examples.sou:4:"), out);
+        assertTrue(out.contains("北海道沖縄"), "the line quoted is the row that names it: " + out);
+        assertFalse(out.contains("data 一般"),
+                "the model's line 4 is not what this is about: " + out);
+    }
+
+    /** So the fix is not "always blame the attached file". */
+    @Test
+    void aMistakeInTheModelFileIsStillSaidThere() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileModules(List.of(MODEL + """
+
+                        let 壊れた = 都道府県 { 名前 = 見つからない }
+                        """, ATTACHED_PREFIX + """
+                        example 送料を求める
+                            | "一つ" : (都道府県 { 名前 = "北海道" }, 数量 { 個数 = 1 }) -> 送料 { 円 = 100 }
+                        """)));
+
+        assertEquals("0", e.sourceId(), "it is written in the model file, attached file or not");
+    }
+
+    /** One problem is one marker however many questions found it — a helper is checked on its own
+     *  and again wherever it is expanded, and both are looking at one line of one file. */
+    @Test
+    void oneProblemIsOneMarkerHoweverManyQuestionsFoundIt() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("shippingfee.sou", MODEL);
+        byId.put("shippingfee.examples.sou", ATTACHED_PREFIX + """
+                example 送料を求める
+                    | "北海道" : (北海道沖縄, 数量 { 個数 = 1 }) -> 送料 { 円 = 100 }
+                """);
+
+        Map<String, List<Located>> found = Compiler.diagnoseModules(byId);
+
+        assertEquals(List.of(), found.get("shippingfee.sou"),
+                "the model file is clean: " + found);
+        assertEquals(1, found.get("shippingfee.examples.sou").size(),
+                "one problem, one marker: " + found);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/diag/APositionKnowsItsFileTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/APositionKnowsItsFileTest.java
@@ -1,0 +1,117 @@
+package souther.compiler.diag;
+
+import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Front;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A position says which source it was read from.
+ *
+ * <p>A line and a column are enough while one file is being read. They stop being enough the moment
+ * writings from several files are gathered under one module — which is what an attached
+ * {@code examples for} file is for — because after that nothing about a coordinate says which file
+ * it came from, and what gets quoted is whatever happens to sit at those numbers in the file the
+ * reader guessed at (issue #309).
+ *
+ * <p>These are about the position alone, so that a failure here is not mistaken for a failure in
+ * what reads one. Where a report ends up being said is
+ * {@code AMistakeInAnAttachedFileIsSaidOnThatFileTest}.
+ */
+class APositionKnowsItsFileTest {
+
+    private static final String SOURCE = """
+            module m exposing ( N )
+            data N = { v: Int }
+            """;
+
+    private static Ast.Module parsedAs(String id, String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put(id, source);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), souther.compiler.meta.ModulePath.EMPTY);
+        return c.db().ask(new Front.Parsed(id)).value().module();
+    }
+
+    @Test
+    void aPositionParsedFromASourceNamesThatSource() {
+        Ast.Module m = parsedAs("m.sou", SOURCE);
+
+        assertEquals("m.sou", m.defs().get(0).pos().sourceId(),
+                "the `data` was read from m.sou, so that is what its position says");
+    }
+
+    @Test
+    void everyPositionOfAParsedModuleNamesIt() {
+        Ast.Module m = parsedAs("m.sou", SOURCE);
+
+        assertEquals("m.sou", m.pos().sourceId());
+        assertTrue(m.defs().stream().allMatch(d -> "m.sou".equals(d.pos().sourceId())),
+                "one index made every position, so there is no part of the module it missed");
+    }
+
+    @Test
+    void aPositionBuiltByHandNamesNoSource() {
+        assertNull(new SourcePos(4, 7).sourceId(),
+                "a caller with no source to name says so by naming none");
+    }
+
+    @Test
+    void aRegionsEndIsInTheSameFileAsItsStart() {
+        Region r = Region.ofWidth(new SourcePos(4, 7, "m.sou"), 5);
+
+        assertEquals("m.sou", r.end().sourceId(), "a region does not leave the source it began in");
+    }
+
+    /**
+     * Line 25 of two files is the same coordinate and is not the same place. The whole of issue #309
+     * is what follows from treating the two as one, so a position that dropped its source from what
+     * makes it itself would leave the bug expressible again — this time inside every set and map that
+     * holds one.
+     */
+    @Test
+    void theSameCoordinateInTwoFilesIsTwoPlaces() {
+        assertNotEquals(new SourcePos(25, 16, "shippingfee.sou"),
+                new SourcePos(25, 16, "shippingfee.examples.sou"));
+    }
+
+    @Test
+    void theSameCoordinateInOneFileIsOnePlace() {
+        assertEquals(new SourcePos(25, 16, "shippingfee.sou"),
+                new SourcePos(25, 16, "shippingfee.sou"));
+        assertEquals(new SourcePos(25, 16, "shippingfee.sou").hashCode(),
+                new SourcePos(25, 16, "shippingfee.sou").hashCode());
+    }
+
+    /**
+     * The standard library is not one of the sources a compile was handed, so a position in it has no
+     * file this compile could quote. Naming none is how it says so, and what reads a report then falls
+     * back to the module it is about.
+     */
+    @Test
+    void aModuleReadOffThePathCarriesNoFileOfThisCompiles() {
+        Ast.FnDef helper = Prelude.helpers().values().iterator().next();
+
+        assertNull(helper.pos().sourceId(),
+                "the prelude is in no source of the compile that reads it");
+    }
+
+    /** A source id names a source or is absent. An empty one is neither, and would be a file nothing
+     *  can be quoted from that nonetheless reads as an answer. */
+    @Test
+    void aBlankSourceIdIsRefused() {
+        assertThrows(IllegalArgumentException.class, () -> new SourcePos(1, 1, ""));
+        assertThrows(IllegalArgumentException.class, () -> new SourcePos(1, 1, "  "));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/diag/ASecondaryRegionNamesItsFileTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/ASecondaryRegionNamesItsFileTest.java
@@ -184,6 +184,39 @@ class ASecondaryRegionNamesItsFileTest {
         assertEquals(2, view.others().size());
     }
 
+    // --- a label and its region say one file, or one of them says nothing -----------------------
+
+    /**
+     * Two things here can say which file a secondary is in: what the label was given, and what its
+     * region's own position was read from. A reader takes the first, so if they can disagree the
+     * file a marker is put in and the file its line is quoted from come apart again — the shape of
+     * mistake this whole change is about. They are refused at construction instead.
+     */
+    @Test
+    void aLabelAndItsRegionCannotNameTwoFiles() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new LabeledRegion(Region.ofWidth(new SourcePos(3, 3, "rows"), 4),
+                        "fakes", "diag.hint.label", null));
+    }
+
+    /** A region built from a hand-made position knows no file, and a label that names one is how it
+     *  is told — which is what every site that points across files does. */
+    @Test
+    void aLabelMayNameTheFileWhenItsRegionDoesNot() {
+        assertEquals("fakes", new LabeledRegion(Region.ofWidth(new SourcePos(3, 3), 4),
+                "fakes", "diag.hint.label", null).sourceId());
+    }
+
+    /** A label that names nothing means the diagnostic's own file, whatever its region was read
+     *  from — that is what {@link LabeledRegion#sourceIdOr(String)} is for. */
+    @Test
+    void aLabelMayNameNothingWhileItsRegionKnowsItsFile() {
+        LabeledRegion label = new LabeledRegion(Region.ofWidth(new SourcePos(3, 3, "rows"), 4),
+                null, "diag.hint.label", null);
+
+        assertEquals("rows", label.sourceIdOr("rows"));
+    }
+
     private static int count(String text, String part) {
         int found = 0;
         for (int at = text.indexOf(part); at >= 0; at = text.indexOf(part, at + 1)) {

--- a/souther-compiler/src/test/java/souther/compiler/query/ACursorIsOnAPlaceNotACoordinateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ACursorIsOnAPlaceNotACoordinateTest.java
@@ -11,7 +11,9 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What a module is made of is not all written in one file. An attached {@code examples for} file's
@@ -105,5 +107,30 @@ class ACursorIsOnAPlaceNotACoordinateTest {
                 .ask(new Names.ValueDenotedAt("m", new SourcePos(8, 14))).value();
 
         assertNotNull(use, "nothing was taken away from a caller that names no source");
+    }
+
+    // --- the two absences are not the same absence ------------------------------------------------
+
+    /** A question with only a coordinate to give is answered by coordinate. */
+    @Test
+    void aQuestionThatNamesNoFileIsAnsweredByCoordinate() {
+        assertTrue(Names.spans(new SourcePos(8, 14, MODEL_ID), "name", new SourcePos(8, 14)));
+    }
+
+    /**
+     * A name that names no source was read from no source of this compile — a synthesized node, or
+     * a module read off the module path. It is under nothing a reader has open, so a question about
+     * an open file is not answered with it. This is the same misreading as the one above, arrived at
+     * from the other side, which is why the two absences cannot be treated alike.
+     */
+    @Test
+    void aQuestionAboutAFileIsNotAnsweredWithANameFromNoFile() {
+        assertFalse(Names.spans(new SourcePos(8, 14), "name", new SourcePos(8, 14, MODEL_ID)));
+    }
+
+    @Test
+    void aNameInAnotherFileIsNotUnderTheCursorHoweverTheLinesLineUp() {
+        assertFalse(Names.spans(new SourcePos(8, 14, ATTACHED_ID), "name",
+                new SourcePos(8, 14, MODEL_ID)));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ACursorIsOnAPlaceNotACoordinateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ACursorIsOnAPlaceNotACoordinateTest.java
@@ -1,0 +1,109 @@
+package souther.compiler.query;
+
+import souther.compiler.check.Resolve;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a module is made of is not all written in one file. An attached {@code examples for} file's
+ * rows, tables and values join the module they are for, and a question asked of the module reads all
+ * of them — so one line and column is two places, and an editor asking about one of them was
+ * answered about whichever the merge happened to reach first.
+ *
+ * <p>The consequence in an editor is that go-to-definition, hover and rename describe a name the
+ * cursor is not on. Same defect as issue #309, one layer over: a coordinate treated as a place.
+ *
+ * <p>The two files here are built so that line 8 column 14 is a name in each, and the two names
+ * denote different values — otherwise a wrong answer would still look right.
+ */
+class ACursorIsOnAPlaceNotACoordinateTest {
+
+    private static final String MODEL_ID = "m.sou";
+    private static final String ATTACHED_ID = "m.examples.sou";
+
+    /** `もと` is read by the row on line 8, at column 14. */
+    private static final String MODEL = """
+            module m
+
+            data D = { v: Int }
+            behavior f : (d: D) -> D
+            let f (d) = d
+
+            example f
+                | "a" : (もと) -> もと
+            """;
+
+    /** `べつ` is read on line 8, at column 14 — the same coordinate, another file, another value. */
+    private static final String ATTACHED = """
+            examples for m
+
+            let もと = D { v = 1 }
+            let べつ = D { v = 2 }
+
+            let ほか = D
+                {
+                     v = べつ.v
+                }
+            """;
+
+    private static Compilation compiled() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put(MODEL_ID, MODEL);
+        byId.put(ATTACHED_ID, ATTACHED);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        c.answerEverything();
+        return c;
+    }
+
+    /** What the compiler says is under a cursor at line 8 column 14 of {@code inFile}. */
+    private static Resolve.ValueUse under(String inFile) {
+        return compiled().db()
+                .ask(new Names.ValueDenotedAt("m", new SourcePos(8, 14, inFile))).value();
+    }
+
+    @Test
+    void bothFilesReallyDoWriteANameAtThatCoordinate() {
+        assertNotNull(under(MODEL_ID), "the model's row reads a name at 8:14");
+        assertNotNull(under(ATTACHED_ID), "and so does the attached file's value");
+    }
+
+    @Test
+    void aCursorInTheModelFileIsOnTheNameTheModelFileWrote() {
+        Resolve.ValueUse use = under(MODEL_ID);
+
+        assertEquals("もと", use.written());
+        assertEquals(MODEL_ID, use.pos().sourceId());
+    }
+
+    @Test
+    void aCursorInTheAttachedFileIsOnTheNameThatFileWrote() {
+        Resolve.ValueUse use = under(ATTACHED_ID);
+
+        assertEquals("べつ", use.written());
+        assertEquals(ATTACHED_ID, use.pos().sourceId());
+    }
+
+    @Test
+    void theTwoAnswersAreNotTheSameValue() {
+        assertEquals("m.もと", under(MODEL_ID).denotes().toString());
+        assertEquals("m.べつ", under(ATTACHED_ID).denotes().toString());
+    }
+
+    /** A caller with only a coordinate to give is answered by coordinate, as it always was. */
+    @Test
+    void aCursorThatNamesNoFileIsStillAnsweredByCoordinate() {
+        Resolve.ValueUse use = compiled().db()
+                .ask(new Names.ValueDenotedAt("m", new SourcePos(8, 14))).value();
+
+        assertNotNull(use, "nothing was taken away from a caller that names no source");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AFileThisCompileDoesNotHaveIsNotAFileToFileUnderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AFileThisCompileDoesNotHaveIsNotAFileToFileUnderTest.java
@@ -1,0 +1,98 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A position says which source it was read from, and that source is not always one this compile has.
+ * The prelude and a module read back off the module path are both read somewhere else, and a caller
+ * can hand over any set of files it likes.
+ *
+ * <p>What is guarded here is availability as much as attribution. A report filed under a name
+ * {@link Compilation#diagnostics()} has no entry for is dropped on the floor, and a problem the
+ * author never sees is worse than one shown against the wrong file. So a claim this compile cannot
+ * honour falls back to the module's own source rather than being taken at its word.
+ */
+class AFileThisCompileDoesNotHaveIsNotAFileToFileUnderTest {
+
+    private static final String M = """
+            module m
+            data N = { v: Int }
+            """;
+
+    /** A report about module {@code m} whose primary region was read from {@code positionsFile}. */
+    private static Db.Found about(String positionsFile) {
+        Diagnostic d = Diagnostic.of("E9001", "diag.hint.label")
+                .at(new SourcePos(2, 1, positionsFile), 4).build();
+        return new Db.Found("m", null, Report.of(d));
+    }
+
+    private static Compilation ofDocuments(Map<String, String> byId) {
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    @Test
+    void aKnownPositionalSourceIsUsed() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("m.sou", M);
+        Compilation c = ofDocuments(byId);
+
+        assertEquals("m.sou", c.sourceIdOf(about("m.sou")));
+    }
+
+    @Test
+    void anUnknownPositionalSourceFallsBackToTheModulesSource() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("m.sou", M);
+        Compilation c = ofDocuments(byId);
+
+        assertEquals("m.sou", c.sourceIdOf(about("somewhere-else.sou")),
+                "the position names a file this compile was never handed");
+    }
+
+    /** The failure this guards against is silent: {@code diagnostics()} keys its buckets by the
+     *  sources it was given, so a report filed under anything else is simply not there. */
+    @Test
+    void anUnknownPositionalSourceDoesNotMakeTheReportDisappear() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("m.sou", M);
+        Compilation c = ofDocuments(byId);
+
+        List<String> saidAt = c.publishSourceIdsOf(about("somewhere-else.sou"));
+
+        assertEquals(1, saidAt.size(), saidAt.toString());
+        assertTrue(c.sourceIds().contains(saidAt.get(0)),
+                "it is said at a source this compile has, or it is said nowhere: " + saidAt);
+    }
+
+    /** A workspace names its sources by document URI, and never fills the index a compile of a
+     *  plain list keeps — so reading the guard off that index would leave the editor unfixed. */
+    @Test
+    void aKnownSourceIsRecognisedThroughOfDocuments() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("file:///w/m.sou", M);
+        Compilation c = ofDocuments(byId);
+
+        assertEquals(List.of("file:///w/m.sou"), c.publishSourceIdsOf(about("file:///w/m.sou")));
+    }
+
+    /** A compile of one source tells its caller nothing about which file, since the caller knows —
+     *  but it still has one to quote from, and files its problems under it. */
+    @Test
+    void aKnownSourceIsRecognisedThroughOfSource() {
+        Compilation c = Compilation.ofSource(M, "Main");
+
+        assertEquals(List.of("0"), c.publishSourceIdsOf(about("0")));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -352,7 +352,7 @@ class ResolvedValueNamesTest {
      */
     @Test
     void aFieldAnInvariantReadsIsDeclaredWhereTheFieldIsWritten() {
-        assertEquals(new SourcePos(4, 7), declaredAt("""
+        assertEquals(new SourcePos(4, 7, "a.sou"), declaredAt("""
                 module m.a exposing ( Amount )
 
                 data Amount = {
@@ -366,7 +366,7 @@ class ResolvedValueNamesTest {
      * declared there and not where it was spread in. */
     @Test
     void aFieldAnIncludeBringsInIsDeclaredWhereItWasWritten() {
-        assertEquals(new SourcePos(4, 7), declaredAt("""
+        assertEquals(new SourcePos(4, 7, "a.sou"), declaredAt("""
                 module m.a exposing ( Priced )
 
                 data Money = {

--- a/souther-compiler/src/test/java/souther/compiler/query/WhereADiagnosticIsSaidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhereADiagnosticIsSaidTest.java
@@ -97,4 +97,76 @@ class WhereADiagnosticIsSaidTest {
         return found.report().diagnostic().secondary().stream()
                 .anyMatch(label -> id.equals(label.sourceIdOr(primary)));
     }
+
+    // --- one problem, one report; two problems, two ----------------------------------------------
+
+    /**
+     * A helper is checked on its own and again in each body it is expanded into, and both are looking
+     * at one line of one file. Neither is wrong to have found it and neither can see the other, so it
+     * is the reading of them that settles that it is one problem.
+     */
+    @Test
+    void theSameProblemFoundThroughTwoQuestionsIsOneReport() {
+        // `Bodies.ModuleCheck` finds this checking the helper on its own, and
+        // `Bodies.CheckedBehavior` finds it again in each body the helper is expanded into. Both
+        // report it; both name the same line of the same file, so the reading of them is one report.
+        Compilation c = Compilation.ofSources(List.of("""
+                module m
+                data N = { v: Int }
+                let joined (n: N) = n.v + "text"
+                behavior f : (n: N) -> Int
+                let f (n) = joined(n)
+                behavior g : (n: N) -> Int
+                let g (n) = joined(n)
+                """), souther.compiler.meta.ModulePath.EMPTY);
+
+        Map<String, List<Located>> found = c.diagnostics();
+
+        assertEquals(1, found.get("0").size(),
+                "the helper and the two bodies it is expanded into found one mistake: " + found);
+    }
+
+    /**
+     * Two checks of one expression against different expectations say the same thing at the same
+     * place with different arguments, and those are two problems. Nothing about filing a report by
+     * where it points may collapse them.
+     */
+    @Test
+    void twoDifferentProblemsAtOneCoordinateInOneFileAreTwoReports() {
+        Compilation c = Compilation.ofSources(List.of("""
+                module m
+                data N = { v: Int }
+                behavior f : (n: N) -> Int
+                let f (n) = bogusOne
+                behavior g : (n: N) -> Int
+                let g (n) = bogusTwo
+                """), souther.compiler.meta.ModulePath.EMPTY);
+
+        Map<String, List<Located>> found = c.diagnostics();
+
+        assertEquals(2, found.get("0").size(),
+                "two names denote nothing, so there are two things to say: " + found);
+    }
+
+    /**
+     * The same mistake written at the same line and column of two files is two mistakes. Before a
+     * position said which file it was read from, the coordinate was all there was to tell them apart
+     * by — so this is the reading that the earlier design could not have got right.
+     */
+    @Test
+    void oneCoordinateInTwoFilesIsTwoReports() {
+        String same = """
+                data N = { v: Int }
+                behavior f : (n: N) -> Int
+                let f (n) = bogus
+                """;
+        Compilation c = Compilation.ofSources(
+                List.of("module a\n" + same, "module b\n" + same),
+                souther.compiler.meta.ModulePath.EMPTY);
+
+        Map<String, List<Located>> found = c.diagnostics();
+
+        assertEquals(1, found.get("0").size(), "a's is said on a: " + found);
+        assertEquals(1, found.get("1").size(), "b's is said on b: " + found);
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/WhereAReportIsSaidIsReadOffWhereItPointsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhereAReportIsSaidIsReadOffWhereItPointsTest.java
@@ -1,0 +1,64 @@
+package souther.compiler.query;
+
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.SourcePos;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Three things can say which file a report is about, and they are asked in one order. This states
+ * that order, so it is a contract rather than whatever the implementation happens to do.
+ *
+ * <p>A key says which input was asked about. A position says where the caret sits — and the line
+ * under the caret is quoted out of the file the report is filed under, so where the two disagree,
+ * answering with the key's shows a reader a line they did not write. That is the whole of issue
+ * #309: a question asked about a module whose rows were written in an attached {@code examples for}
+ * file could only answer with the module's own file.
+ *
+ * <p>So the position comes first, and a report that belongs somewhere other than where its caret
+ * sits says so itself. That is what {@link Report.Delivery} is for, and why it comes before both.
+ */
+class WhereAReportIsSaidIsReadOffWhereItPointsTest {
+
+    /** A report pointing at line 3 of {@code positionsFile}, found by a key naming {@code keysFile}. */
+    private static Db.Found found(String positionsFile, String keysFile, Report.Delivery delivery) {
+        Diagnostic d = Diagnostic.of("E9001", "diag.hint.label")
+                .at(new SourcePos(3, 3, positionsFile), 4).build();
+        return new Db.Found("m", keysFile, Report.saidAt(d, delivery));
+    }
+
+    @Test
+    void anExplicitDeliverySourceOverridesThePrimaryPosition() {
+        Db.Found f = found("rows.sou", "model.sou", Report.Delivery.at("said.sou"));
+
+        assertEquals("said.sou", f.claimedSourceId(),
+                "a report that knows where it belongs is not overruled by where its caret sits");
+    }
+
+    @Test
+    void aPrimaryPositionOverridesTheSourceTheQuestionWasAskedAbout() {
+        Db.Found f = found("rows.sou", "model.sou", Report.Delivery.BY_KEY);
+
+        assertEquals("rows.sou", f.claimedSourceId(),
+                "the line under the caret is quoted from here, so this is the file");
+    }
+
+    @Test
+    void theQuestionsSourceAnswersWhenThePositionNamesNone() {
+        Db.Found f = found(null, "model.sou", Report.Delivery.BY_KEY);
+
+        assertEquals("model.sou", f.claimedSourceId(),
+                "a synthesized position says nothing, so what asked the question answers");
+    }
+
+    @Test
+    void nothingSaysWhenNeitherDoes() {
+        Db.Found f = found(null, null, Report.Delivery.BY_KEY);
+
+        assertEquals(null, f.claimedSourceId(),
+                "the module's own source is the last word, and only a caller holding the layout "
+                        + "can apply it");
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -280,7 +280,7 @@ public final class Analyzer {
         if (module == null) {
             return null;
         }
-        SourcePos at = new SourcePos(pos.line() + 1, pos.character() + 1);
+        SourcePos at = new SourcePos(pos.line() + 1, pos.character() + 1, uri);
         return compilation.db().ask(new Names.TypeAt(module, at)).value();
     }
 
@@ -671,7 +671,7 @@ public final class Analyzer {
         if (module == null) {
             return null;
         }
-        SourcePos at = new SourcePos(pos.line() + 1, pos.character() + 1);
+        SourcePos at = new SourcePos(pos.line() + 1, pos.character() + 1, uri);
         Resolve.ValueUse use = compilation.db().ask(new Names.ValueDenotedAt(module, at)).value();
         return use == null ? null : use.denotes();
     }
@@ -693,7 +693,10 @@ public final class Analyzer {
         if (at == null) {
             return Optional.empty();
         }
-        String targetUri = switch (target) {
+        // Where the declaration was written is what the declaration's position says. Reading it off
+        // the module instead is right only while a module is one file, and a value declared in an
+        // attached `examples for` file is one the module has and that file wrote.
+        String targetUri = at.sourceId() != null ? at.sourceId() : switch (target) {
             case ValueName.Local _ -> uri;   // bound in the body the cursor is in
             case ValueName.Helper h -> compilation.sourceIdOf(h.module());
             case ValueName.Behavior b -> compilation.sourceIdOf(b.module());

--- a/souther-lsp/src/test/java/souther/lsp/analysis/ACursorIsOnAPlaceNotACoordinateTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/ACursorIsOnAPlaceNotACoordinateTest.java
@@ -1,0 +1,73 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+import souther.lsp.protocol.Location;
+import souther.lsp.protocol.Position;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A value a row names may be declared beside the rows, in the attached {@code examples for} file.
+ * Where it is declared is what its declaration's position says; working it out from the module
+ * instead is right only while a module is one file, and this is the case where it is not.
+ *
+ * <p>Before, the cursor was sent to the module's own file at the coordinate the declaration has in
+ * the other one — which, here, is the cursor's own line. Go-to-definition landed back where it
+ * started.
+ */
+class ACursorIsOnAPlaceNotACoordinateTest {
+
+    private static final String MODEL_URI = "file:///m.sou";
+    private static final String ATTACHED_URI = "file:///m.examples.sou";
+
+    /** The row on line 8 names `もと`, which this file does not declare. */
+    private static final String MODEL = """
+            module m
+
+            data D = { v: Int }
+            behavior f : (d: D) -> D
+            let f (d) = d
+
+            example f
+                | "a" : (もと) -> D { v = 1 }
+            """;
+
+    private static final String ATTACHED = """
+            examples for m
+
+            let もと = D { v = 1 }
+            """;
+
+    private static Optional<Location> definitionFromTheRow() {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(MODEL_URI, MODEL);
+        sources.put(ATTACHED_URI, ATTACHED);
+        ModuleGraph graph = ModuleGraph.of(sources);
+        Analyzer analyzer = new Analyzer();
+        analyzer.diagnostics(graph);
+        // the `もと` of the row: line 8 column 14 as the compiler counts, zero-based here
+        return analyzer.definition(MODEL_URI, new Position(7, 13), graph);
+    }
+
+    @Test
+    void aValueTheRowNamesIsFoundInTheFileThatDeclaresIt() {
+        Location found = definitionFromTheRow().orElseThrow();
+
+        assertEquals(ATTACHED_URI, found.uri(), "the `let` is written beside the rows");
+    }
+
+    @Test
+    void theCursorLandsOnTheNameAndNotBackWhereItStarted() {
+        Location found = definitionFromTheRow().orElseThrow();
+
+        assertEquals(2, found.range().start().line(), "the third line of the attached file");
+        String declaration = ATTACHED.lines().toList().get(2);
+        assertTrue(declaration.substring(found.range().start().character()).startsWith("もと"),
+                "on the name it declares: " + found.range());
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AMarkerLandsInTheFileTheMistakeIsWrittenInTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AMarkerLandsInTheFileTheMistakeIsWrittenInTest.java
@@ -1,0 +1,112 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+import souther.lsp.protocol.LspDiagnostic;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An author renames a case in the model and leaves a row in the attached file still naming the old
+ * one. In the editor the marker used to land on the model file, at the line number the row happened
+ * to have — an unrelated declaration — while the file that actually holds the mistake was left
+ * without a squiggle at all (issue #309).
+ *
+ * <p>A marker goes in the file the writing it is about was written in, which for an
+ * {@code examples for} file's rows is that file.
+ */
+class AMarkerLandsInTheFileTheMistakeIsWrittenInTest {
+
+    private static final String MODEL_URI = "file:///shippingfee.sou";
+    private static final String ATTACHED_URI = "file:///shippingfee.examples.sou";
+    private static final String RENAMED_URI = "file:///rows/shippingfee.examples.sou";
+
+    /** Long enough that a coordinate from the short file beside it lands on an unrelated line. */
+    private static final String MODEL = """
+            module shippingfee
+
+            data 都道府県 = { 名前: String }
+            data 数量     = { 個数: Int }
+            data 送料     = { 円: Int }
+
+            behavior 送料を求める : (県: 都道府県, 数: 数量) -> 送料
+                constructs 送料
+
+            let 送料を求める (県, 数) = 送料 { 円 = 数.個数 * 100 }
+
+            data 一般 = { 名前: String }
+            """;
+
+    /** A row still naming `北海道沖縄`, which the model no longer has. */
+    private static final String ATTACHED = """
+            examples for shippingfee
+
+            example 送料を求める
+                | "北海道" : (北海道沖縄, 数量 { 個数 = 1 }) -> 送料 { 円 = 100 }
+            """;
+
+    private static Map<String, List<LspDiagnostic>> publishedBy(Analyzer analyzer,
+                                                                Map<String, String> sources) {
+        return analyzer.diagnostics(ModuleGraph.of(sources));
+    }
+
+    private static Map<String, List<LspDiagnostic>> asWritten() {
+        return publishedBy(new Analyzer(), Map.of(MODEL_URI, MODEL, ATTACHED_URI, ATTACHED));
+    }
+
+    private static List<LspDiagnostic> on(Map<String, List<LspDiagnostic>> byUri, String uri) {
+        return byUri.getOrDefault(uri, List.of());
+    }
+
+    @Test
+    void aWorkspaceMarksAnAttachedFilesMistakeInThatDocument() {
+        List<LspDiagnostic> here = on(asWritten(), ATTACHED_URI);
+
+        assertEquals(1, here.size(), "the row that names it is written here: " + here);
+        assertEquals(3, here.get(0).range().start().line(),
+                "on the row, which is the fourth line and so line 3 zero-based");
+    }
+
+    @Test
+    void theModelFilesDocumentIsLeftClean() {
+        assertEquals(List.of(), on(asWritten(), MODEL_URI),
+                "the model declares nothing wrong, so it gets no squiggle");
+    }
+
+    /**
+     * The file a position was read from is part of what makes it that position, so a document that
+     * moves takes its diagnostics with it. Renaming without editing is the case that would go wrong
+     * if provenance were carried alongside a position rather than in it: nothing about the text
+     * changes, so nothing downstream would be recomputed and the marker would be left on a URI the
+     * workspace no longer has.
+     */
+    @Test
+    void aMarkerMovesWhenAnAttachedFileIsRenamedWithoutChangingItsContents() {
+        // One analyzer across both, so the second reading goes through the workspace compile it
+        // already has — the incremental path, which is where this could go wrong.
+        Analyzer analyzer = new Analyzer();
+        Map<String, List<LspDiagnostic>> before =
+                publishedBy(analyzer, Map.of(MODEL_URI, MODEL, ATTACHED_URI, ATTACHED));
+        assertEquals(1, on(before, ATTACHED_URI).size(), "it starts on the first URI: " + before);
+
+        Map<String, List<LspDiagnostic>> after =
+                publishedBy(analyzer, Map.of(MODEL_URI, MODEL, RENAMED_URI, ATTACHED));
+
+        assertEquals(List.of(), on(after, ATTACHED_URI), "gone from the URI that no longer exists");
+        assertEquals(1, on(after, RENAMED_URI).size(), "and on the one that does: " + after);
+        assertEquals(List.of(), on(after, MODEL_URI), "and still not on the model file");
+    }
+
+    /** The marker is on the name the author has to change, not merely in the right file. */
+    @Test
+    void theMarkerSitsOnTheNameThatDenotesNothing() {
+        LspDiagnostic only = on(asWritten(), ATTACHED_URI).get(0);
+        String row = ATTACHED.lines().toList().get(3);
+
+        assertTrue(row.substring(only.range().start().character()).startsWith("北海道沖縄"),
+                "the squiggle starts at the name: " + only.range());
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/cst/LineIndex.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/LineIndex.java
@@ -13,15 +13,29 @@ import java.util.List;
  * <p>Lines and columns are 1-based for {@link SourcePos} (the compiler's convention); the LSP
  * accessors return 0-based positions. Columns count UTF-16 code units, which matches both Java
  * {@code char} offsets and the LSP's default position encoding.
+ *
+ * <p>An index made for a named source gives every {@link SourcePos} that source. This is the one
+ * place a position is made from a text, so it is the one place that has both halves to hand — which
+ * is why nothing downstream has to work the file out again from what it is looking at.
  */
 public final class LineIndex {
 
     private final String source;
+    /** Which source this is an index of, so that every position it makes says where it was read
+     * from. Null where the caller has no name for it — a document the compile does not hold, or a
+     * reader that only wants offsets converted. */
+    private final String sourceId;
     /** {@code lineStart[i]} is the offset at which line {@code i} (0-based) begins. */
     private final int[] lineStart;
 
+    /** An index of a source this caller has no name for. Its positions name no source. */
     public LineIndex(String source) {
+        this(source, null);
+    }
+
+    public LineIndex(String source, String sourceId) {
         this.source = source;
+        this.sourceId = sourceId;
         List<Integer> starts = new ArrayList<>();
         starts.add(0);
         for (int i = 0; i < source.length(); i++) {
@@ -48,7 +62,7 @@ public final class LineIndex {
     /** The compiler's 1-based line/column position for {@code offset}. */
     public SourcePos posOf(int offset) {
         int line = lineIndex(offset);
-        return new SourcePos(line + 1, offset - lineStart[line] + 1);
+        return new SourcePos(line + 1, offset - lineStart[line] + 1, sourceId);
     }
 
     /** The 0-based line of {@code offset} (LSP). */

--- a/souther-syntax/src/main/java/souther/compiler/diag/LabeledRegion.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/LabeledRegion.java
@@ -14,6 +14,21 @@ package souther.compiler.diag;
  */
 public record LabeledRegion(Region region, String sourceId, String labelKey, Object[] labelArgs) {
 
+    public LabeledRegion {
+        // Two things can say which file this is in — what the label was given, and what the region's
+        // own position was read from — and a reader takes the first. So they are allowed to differ
+        // only by one of them saying nothing: a region built from a hand-made position knows no
+        // file, and a label left null means the diagnostic's own. Saying two different files is a
+        // disagreement no reader can resolve, and is exactly the shape of mistake that put a
+        // diagnostic's coordinates and its file name in different files to begin with.
+        if (sourceId != null && region != null && region.start() != null
+                && region.start().sourceId() != null
+                && !sourceId.equals(region.start().sourceId())) {
+            throw new IllegalArgumentException("a label in " + sourceId
+                    + " points at a region read from " + region.start().sourceId());
+        }
+    }
+
     /** The source this region is in, inheriting {@code diagnosticSourceId} when it names none. */
     public String sourceIdOr(String diagnosticSourceId) {
         return sourceId == null ? diagnosticSourceId : sourceId;

--- a/souther-syntax/src/main/java/souther/compiler/diag/Region.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Region.java
@@ -13,10 +13,12 @@ public record Region(SourcePos start, SourcePos end) {
         return new Region(p, p);
     }
 
-    /** A region beginning at {@code start} and spanning {@code width} columns on the same line. */
+    /** A region beginning at {@code start} and spanning {@code width} columns on the same line. The
+     * end is in the file the start is in: a region does not leave the source it began in. */
     public static Region ofWidth(SourcePos start, int width) {
         int w = Math.max(0, width);
-        return new Region(start, new SourcePos(start.line(), start.column() + w));
+        return new Region(start,
+                new SourcePos(start.line(), start.column() + w, start.sourceId()));
     }
 
     /** The number of caret characters to draw on the start line: at least one. */

--- a/souther-syntax/src/main/java/souther/compiler/diag/SourcePos.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/SourcePos.java
@@ -1,10 +1,39 @@
 package souther.compiler.diag;
 
 /**
- * A 1-based source position (line and column). Every AST node and token carries one so
- * that compile errors can point at the source (spec section 28).
+ * A place in a source: a 1-based line and column, and the source they were read from. Every AST node
+ * and token carries one so that compile errors can point at the source (spec section 28).
+ *
+ * <p>A line and a column are enough while one file is being read and not enough afterwards. A
+ * module's {@code example} rows, fake tables and values are written in the module's own source and
+ * in any number of attached {@code examples for} files, and once they are gathered under one name a
+ * coordinate on its own no longer says which file it came from — so what is quoted is whatever
+ * happens to sit at those numbers in the file the reader guessed at.
+ *
+ * <p>Which is why the source is part of the position and part of what makes two positions the same
+ * one. Line 25 of two files is the same coordinate and is not the same place; a value whose identity
+ * denied one of its components would leave "the same position" meaning something different in every
+ * container that held one. Where a caller wants coordinates compared without a file — an editor
+ * asking what is under a cursor — it compares the coordinates, which is what
+ * {@code Names.spans} does.
+ *
+ * @param sourceId the source this was read from, or null for a position that was read from none: a
+ *        node the compiler synthesized, or a module read off the module path, which is in no source
+ *        of the compile that is reading it
  */
-public record SourcePos(int line, int column) {
+public record SourcePos(int line, int column, String sourceId) {
+
+    public SourcePos {
+        if (sourceId != null && sourceId.isBlank()) {
+            throw new IllegalArgumentException("a source id names a source or is absent, never blank");
+        }
+    }
+
+    /** A position read from no source. */
+    public SourcePos(int line, int column) {
+        this(line, column, null);
+    }
+
     @Override
     public String toString() {
         return line + ":" + column;


### PR DESCRIPTION
Closes #309.

## What was wrong

A line and a column are enough while one file is being read. They stop being enough
the moment a module's writings are not all in one file, which is what an attached
`examples for` file is for: its rows, fake tables and values join the module they
are written for, and after that nothing about a coordinate says which file it came
from.

Everything downstream then had to work the file out again from something else, and
each place that did so got it wrong in its own way:

- `Compilation.primarySourceIdOf` fell back to the module's own source, so a name a
  row could not resolve was reported against the model file at the row's line
  number — an unrelated declaration with a caret in the middle of it. Renaming a
  `data` case is exactly when this fires.
- A helper expanded from another module keeps that module's coordinates, so a
  problem found in one was reported on this module at a line number belonging to
  the other one's file.
- `Names.spans` matched an editor's cursor by coordinate alone over the merged
  module, so line 8 column 14 was two places and the question was answered about
  whichever the merge reached first. Go-to-definition, hover and rename described a
  name the cursor was not on.

## What this does

The fix is not to attribute these diagnostics better. It is to make a position
carry the source it was read from, and then to stop reconstructing that fact from
anything else. ADR-0044's last consequence deferred exactly this — *"until a file
handle is added to the position"* — and this adds it.

**A position carries its source.** `SourcePos` gains a `sourceId`, given where a
position is made from a text (`LineIndex`). That is the one place with both halves
to hand, so it reaches every position a parse makes without an AST walker and
nothing downstream has to work it out again. `CstFrontend.firstError` builds its own
index, so it is threaded too — otherwise a syntax error would be the single kind of
mistake still reported against whatever file the reader guessed at. A position read
from no source of this compile — a synthesized node, the prelude, a module read back
off the module path — names none, and says so.

The source is part of what makes two positions the same position. Line 25 of two
files is one coordinate and is not one place, and a value whose identity denied one
of its components would leave "the same position" meaning something different in
every container that held one — which is the original mistake, re-expressible. It
costs almost nothing to say so: no main-source change at all, and two assertions in
`ResolvedValueNamesTest` that now name the file they were already about.

**Where a report is said is read off where it points.** A key says which input was
asked about; a position says where the caret sits, and the line under the caret is
quoted out of the file the report is filed under. Where the two disagree, answering
with the key's shows a reader a line they did not write. So the order is now the
report's own claim (`Report.Delivery`, for a problem that belongs somewhere other
than where its caret sits), then the position, then the key, then the module.

The claim is honoured only if the compile has that source. A position may come from
the prelude or from a module off the path, and filing a report under a name
`diagnostics()` has no bucket for drops it in silence — a problem the author never
sees is worse than one on the wrong file. The guard reads `Front.Ids`, not the
index a compile of a plain list keeps, because a workspace never fills that one and
reading it there would have left the editor unfixed.

Read before the reports are collected, so one problem two questions found stays one
and two problems at one coordinate in two files stay two.

**A cursor is on a place, not a coordinate.** A name covers a cursor when it is on
the same line of the same file, and the editor says which file it is asking about. A
caller with only a coordinate to give is still answered by coordinate. Where a
declaration was written is read off its position too: working it out from the module
sent a row's `let` to the module's own file at the coordinate it has in the other
one — which, for a row naming a value declared beside it, is the cursor's own line,
so the cursor landed back where it started.

Three concepts that were one name are now three: what a report or key explicitly
named (`Report.Delivery.primarySourceId`), what a report claims
(`Db.Found.claimedSourceId`), and what this compile can actually show
(`Compilation.locatedSourceIdOf`).

Nothing changes in `HumanRenderer`, `JsonRenderer`, `DiagnosticView`, `Located` or
`LabeledRegion`. The renderer already took the file from `Located.primarySourceId()`
and the line from `Diagnostic.pos()`; the whole of this is making those two agree
upstream.

## Where it is asked

`APositionKnowsItsFileTest` is about the position alone, so a failure in the
parse-time plumbing is not mistaken for one in what reads a position — including
that two files' one coordinate is two places, which pins the identity decision.

`AMistakeInAnAttachedFileIsSaidOnThatFileTest` is the issue, one method per way of
getting it wrong: an unknown value named by a row, an unknown value and an unknown
type and a type error in the attached file's own fixture, a constant construction,
and a syntax error. Each asserts the file **and** the line, because either alone
passed for the wrong reason before — the two files' line numbers happened to agree,
which is what made the original report so confusing. The model file is long and the
attached file short on purpose, so a misattribution lands on a line about something
else. `theQuotedLineIsTheLineTheAuthorWrote` renders through `HumanRenderer` and
asserts the quoted text; it is the only one here that would have caught the bug on
its own.

`WhereAReportIsSaidIsReadOffWhereItPointsTest` fixes the order as a contract rather
than as whatever the implementation happens to do.
`AFileThisCompileDoesNotHaveIsNotAFileToFileUnderTest` takes the guard apart per
compile entry point, and includes the availability half — a report must not vanish.
`WhereADiagnosticIsSaidTest` gains dedup in both directions: one problem two
questions found is one, two problems at one coordinate are two, and one coordinate
in two files is two.

`AMarkerLandsInTheFileTheMistakeIsWrittenInTest` is the editor: the marker is on the
attached file, the model file is clean, and it moves when the attached file is
renamed without its contents changing. That last one runs on one `Analyzer`, so it
goes through the workspace compile's incremental path, which is where carrying
provenance beside a position rather than in it would have gone wrong.

`ACursorIsOnAPlaceNotACoordinateTest` — one at the query, one at the editor. The
query one is built so both files write a name at line 8 column 14 and the two names
denote different values, because otherwise a wrong answer still looks right.

## What this costs

`Compilation.sourceIds()` is a `List`, so the guard's membership test is linear in
the number of sources. Diagnostics times sources is small enough to leave alone.

`Compiler.compileModules` orders its first error by which source it is in, so a
report that crosses a file boundary moves in that order and a compile with two
errors can raise the other one. Nothing in the suite depended on it.

## Left out

Navigation from a cursor **inside** an attached file. `Compiler.moduleNameFromHeader`
answers nothing for `examples for m`, so the resolution-based path is skipped there
and navigation falls back to matching by spelling — which is why a local is out of
reach in a companion file. That is a gap of its own rather than this defect, and
wants its own issue.

## Specification

No rule changes. ADR-0044 gets an amendment: the file handle its last consequence
deferred is now on the position, and why the source counts towards a position's
identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
