### PR TITLE
A row that does not come back is a fact a test states, not a race it runs

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -126,7 +126,7 @@ public final class Compiler {
     /** As above, telling the compile how much of the rows' coverage to measure and warn about. */
     static Compilation compiled(String source, String defaultModuleName,
                                 List<Located> warningsOut, Adequacy.Asked measure) {
-        return compiled(source, defaultModuleName, warningsOut, measure, null);
+        return compiled(source, defaultModuleName, warningsOut, measure, null, null);
     }
 
     /**
@@ -140,9 +140,20 @@ public final class Compiler {
     static Compilation compiled(String source, String defaultModuleName,
                                 List<Located> warningsOut, Adequacy.Asked measure,
                                 java.time.Duration exampleBudget) {
+        return compiled(source, defaultModuleName, warningsOut, measure, exampleBudget, null);
+    }
+
+    /** As above, with what a row or a reading is given to finish within said outright — for a test
+     *  stating which work does not come back rather than timing it. */
+    static Compilation compiled(String source, String defaultModuleName,
+                                List<Located> warningsOut, Adequacy.Asked measure,
+                                java.time.Duration exampleBudget, Deadline deadline) {
         Compilation compilation = Compilation.ofSource(source, defaultModuleName);
         if (exampleBudget != null) {
             compilation.withExampleBudget(exampleBudget);
+        }
+        if (deadline != null) {
+            compilation.withDeadline(deadline);
         }
         compilation.measure(measure);
         Db db = compilation.db();
@@ -269,20 +280,36 @@ public final class Compiler {
     static Compilation compiledModules(List<String> sources, ModulePath path,
                                        List<Located> warningsOut, Adequacy.Asked measure,
                                        java.time.Duration exampleBudget) {
-        return linked(sources, path, warningsOut, measure, exampleBudget);
+        return linked(sources, path, warningsOut, measure, exampleBudget, null);
+    }
+
+    /** As above, with what a row or a reading is given to finish within said outright. */
+    static Compilation compiledModules(List<String> sources, ModulePath path,
+                                       List<Located> warningsOut, Adequacy.Asked measure,
+                                       java.time.Duration exampleBudget, Deadline deadline) {
+        return linked(sources, path, warningsOut, measure, exampleBudget, deadline);
     }
 
     private static Compilation linked(List<String> sources, ModulePath path,
                                       List<Located> warningsOut, Adequacy.Asked measure) {
-        return linked(sources, path, warningsOut, measure, null);
+        return linked(sources, path, warningsOut, measure, null, null);
     }
 
     private static Compilation linked(List<String> sources, ModulePath path,
                                       List<Located> warningsOut, Adequacy.Asked measure,
                                       java.time.Duration exampleBudget) {
+        return linked(sources, path, warningsOut, measure, exampleBudget, null);
+    }
+
+    private static Compilation linked(List<String> sources, ModulePath path,
+                                      List<Located> warningsOut, Adequacy.Asked measure,
+                                      java.time.Duration exampleBudget, Deadline deadline) {
         Compilation compilation = Compilation.ofSources(sources, path);
         if (exampleBudget != null) {
             compilation.withExampleBudget(exampleBudget);
+        }
+        if (deadline != null) {
+            compilation.withDeadline(deadline);
         }
         compilation.measure(measure);
         Db db = compilation.db();

--- a/souther-compiler/src/main/java/souther/compiler/Deadline.java
+++ b/souther-compiler/src/main/java/souther/compiler/Deadline.java
@@ -1,5 +1,7 @@
 package souther.compiler;
 
+import souther.compiler.diag.SourcePos;
+
 import java.util.concurrent.Callable;
 
 /**
@@ -12,20 +14,52 @@ import java.util.concurrent.Callable;
  * direction that matters: work that does finish is reported as work that did not.
  *
  * <p>So the limit is a seam. What a build uses is {@link #ofMillis}, which is what both sites did
- * before. What a test uses is a deadline that decides by what the work is, so "this row does not
+ * before. What a test uses is a deadline that decides by which work it is, so "this row does not
  * come back" is stated rather than raced for.
  */
 public interface Deadline {
 
+    /**
+     * One piece of work, said as what it is rather than as a sentence about it.
+     *
+     * <p>A deadline a test writes decides by reading this, so it is an identity and not a label:
+     * a description that read well would still have to be unique, and would break every test that
+     * matched on it the day the wording improved. What makes it unique is where the writing is —
+     * two rows of one behavior differ in nothing else, and a behavior can be exampled by more than
+     * one {@code example} block and by more than one file.
+     */
+    sealed interface Work {
+
+        /** The behavior this work is about. */
+        String target();
+
+        /** The source the writing this is about was written in. */
+        String sourceId();
+
+        /** Where in that source it starts. */
+        SourcePos pos();
+
+        /** A row of an {@code example}, evaluated: its fixtures built, the behavior applied, the
+         * result compared. {@code description} is what the row was written with, or null. */
+        record Row(String target, String sourceId, SourcePos pos, String description)
+                implements Work {}
+
+        /** The statements a row is read from, with no behavior applied. */
+        record Fixtures(String target, String sourceId, SourcePos pos, String description)
+                implements Work {}
+
+        /** A {@code fake} table, built. */
+        record Table(String target, String sourceId, SourcePos pos) implements Work {}
+
+        /** A {@code with} written on a row. */
+        record With(String target, String sourceId, SourcePos pos) implements Work {}
+    }
+
     /** How many milliseconds this allows. What a report about an overrun quotes. */
     long budgetMs();
 
-    /**
-     * {@code work}, run within what this allows.
-     *
-     * @param what the work, named as a report about it would name it
-     */
-    <T> Outcome<T> given(String what, Callable<T> work);
+    /** {@code work}, run within what this allows. */
+    <T> Outcome<T> given(Work work, Callable<T> work0);
 
     /** What became of work that was given a deadline. */
     sealed interface Outcome<T> {
@@ -57,8 +91,8 @@ public interface Deadline {
             }
 
             @Override
-            public <T> Outcome<T> given(String what, Callable<T> work) {
-                java.util.concurrent.FutureTask<T> task = new java.util.concurrent.FutureTask<>(work);
+            public <T> Outcome<T> given(Work work, Callable<T> body) {
+                java.util.concurrent.FutureTask<T> task = new java.util.concurrent.FutureTask<>(body);
                 // A daemon, because work that overran is asked to stop and cannot be made to: a
                 // fixture's helper reaches no interrupt point, so the thread may outlive the answer
                 // about it and must not outlive the JVM.
@@ -73,12 +107,12 @@ public interface Deadline {
                 } catch (java.util.concurrent.ExecutionException ee) {
                     task.cancel(true);
                     return new Outcome.Threw<>(ee.getCause());
-                } catch (InterruptedException ie) {
+                } catch (InterruptedException _) {
                     task.cancel(true);
                     Thread.currentThread().interrupt();
                     return new Outcome.Threw<>(
                             new java.util.concurrent.CancellationException(
-                                    "interrupted while reading " + what));
+                                    "interrupted while reading " + work.target()));
                 }
             }
         };

--- a/souther-compiler/src/main/java/souther/compiler/Deadline.java
+++ b/souther-compiler/src/main/java/souther/compiler/Deadline.java
@@ -1,0 +1,86 @@
+package souther.compiler;
+
+import java.util.concurrent.Callable;
+
+/**
+ * How long a piece of work gets, and what the caller is handed when it does not finish.
+ *
+ * <p>Two places give work a limit: a written statement being read ({@link ExampleStatements}) and a
+ * row being evaluated ({@link ExampleVerifier}). Both do it the same way — a worker of its own and a
+ * wall clock — and both did it inline, which left every test about what the compiler <em>says</em>
+ * about work that overran racing a clock to say it. On a loaded host the race is lost in the
+ * direction that matters: work that does finish is reported as work that did not.
+ *
+ * <p>So the limit is a seam. What a build uses is {@link #ofMillis}, which is what both sites did
+ * before. What a test uses is a deadline that decides by what the work is, so "this row does not
+ * come back" is stated rather than raced for.
+ */
+public interface Deadline {
+
+    /** How many milliseconds this allows. What a report about an overrun quotes. */
+    long budgetMs();
+
+    /**
+     * {@code work}, run within what this allows.
+     *
+     * @param what the work, named as a report about it would name it
+     */
+    <T> Outcome<T> given(String what, Callable<T> work);
+
+    /** What became of work that was given a deadline. */
+    sealed interface Outcome<T> {
+
+        /** It finished, and this is what it answered. */
+        record Finished<T>(T value) implements Outcome<T> {}
+
+        /**
+         * It did not finish.
+         *
+         * <p>{@code abandon} gives up on it, and is separate from this arriving because the two are
+         * ordered: work that overran may have published how far it got, and giving up interrupts it,
+         * so a caller that wants to know reads first and abandons after. A caller with nothing to
+         * read still has to call it — nothing else will.
+         */
+        record Overran<T>(Runnable abandon) implements Outcome<T> {}
+
+        /** It ended by throwing, and this is what came out. */
+        record Threw<T>(Throwable cause) implements Outcome<T> {}
+    }
+
+    /** The deadline a build runs on: a worker of its own, and {@code budgetMs} on the clock. */
+    static Deadline ofMillis(long budgetMs) {
+        return new Deadline() {
+
+            @Override
+            public long budgetMs() {
+                return budgetMs;
+            }
+
+            @Override
+            public <T> Outcome<T> given(String what, Callable<T> work) {
+                java.util.concurrent.FutureTask<T> task = new java.util.concurrent.FutureTask<>(work);
+                // A daemon, because work that overran is asked to stop and cannot be made to: a
+                // fixture's helper reaches no interrupt point, so the thread may outlive the answer
+                // about it and must not outlive the JVM.
+                Thread worker = new Thread(task, "souther-reading");
+                worker.setDaemon(true);
+                worker.start();
+                try {
+                    return new Outcome.Finished<>(
+                            task.get(budgetMs, java.util.concurrent.TimeUnit.MILLISECONDS));
+                } catch (java.util.concurrent.TimeoutException _) {
+                    return new Outcome.Overran<>(() -> task.cancel(true));
+                } catch (java.util.concurrent.ExecutionException ee) {
+                    task.cancel(true);
+                    return new Outcome.Threw<>(ee.getCause());
+                } catch (InterruptedException ie) {
+                    task.cancel(true);
+                    Thread.currentThread().interrupt();
+                    return new Outcome.Threw<>(
+                            new java.util.concurrent.CancellationException(
+                                    "interrupted while reading " + what));
+                }
+            }
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleStatements.java
@@ -55,19 +55,19 @@ public final class ExampleStatements {
      * force and no helper is run, so there is no reading here to isolate. What it is for is the
      * module's encoders and its loader. Every actual reading gets {@link #newFixtureReader()}. */
     private final FixtureReader rendering;
-    /** Wall-clock budget for one written statement read on a worker of its own ({@link #within}).
-     * Carried rather than looked up, so two compiles in one JVM need not agree on it. */
-    private final long budgetMs;
+    /** What one written statement gets to be read within ({@link #within}). Carried rather than
+     * looked up, so two compiles in one JVM need not agree on it. */
+    private final Deadline deadline;
 
     private ExampleStatements(Ast.Module module, Symbols symbols, Map<String, Sig> sigs,
                               MemoryClassLoader loader, Map<String, Ast.FnDef> values,
-                              long budgetMs) {
+                              Deadline deadline) {
         this.module = module;
         this.symbols = symbols;
         this.sigs = sigs;
         this.loader = loader;
         this.values = values;
-        this.budgetMs = budgetMs;
+        this.deadline = deadline;
         this.rendering = new FixtureReader(module, symbols, values, loader);
     }
 
@@ -105,7 +105,7 @@ public final class ExampleStatements {
                                          Map<String, Sig> sigs, Map<String, byte[]> classes,
                                          ClassLoader parent, Map<String, Ast.FnDef> values,
                                          List<String> exampleOrigins,
-                                         List<String> fakeOrigins, long budgetMs) {
+                                         List<String> fakeOrigins, Deadline deadline) {
         if (module.examples().isEmpty()
                 || exampleOrigins.size() != module.examples().size()
                 || fakeOrigins.size() != module.fakes().size()) {
@@ -121,7 +121,7 @@ public final class ExampleStatements {
             return Readings.NONE;
         }
         ExampleStatements v = new ExampleStatements(module, symbols, sigs,
-                new MemoryClassLoader(classes, parent), values, budgetMs);
+                new MemoryClassLoader(classes, parent), values, deadline);
         return v.collectDisagreements(exampleOrigins, fakeOrigins, contested);
     }
 
@@ -155,13 +155,13 @@ public final class ExampleStatements {
                                               Map<String, Sig> sigs, Map<String, byte[]> classes,
                                               ClassLoader parent, Map<String, Ast.FnDef> values,
                                               List<String> fakeOrigins, String sourceId,
-                                              long budgetMs) {
+                                              Deadline deadline) {
         if (module.fakes().isEmpty()) {
             return List.of();
         }
         boolean placed = fakeOrigins.size() == module.fakes().size();
         ExampleStatements v = new ExampleStatements(module, symbols, sigs,
-                new MemoryClassLoader(classes, parent), values, budgetMs);
+                new MemoryClassLoader(classes, parent), values, deadline);
         List<Diagnostic> said = new ArrayList<>();
         Set<String> answering = new LinkedHashSet<>();
         for (int i = 0; i < module.fakes().size(); i++) {
@@ -249,39 +249,33 @@ public final class ExampleStatements {
         // it may still be inside `expandedValue`, holding a binding or a half-walked expansion. What a
         // late worker can still write to is that reader, and the statement after it gets another.
         FixtureReader reader = newFixtureReader();
-        java.util.concurrent.FutureTask<T> task =
-                new java.util.concurrent.FutureTask<>(() -> read.apply(reader));
-        Thread worker = new Thread(task, "souther-reading");
-        worker.setDaemon(true);
-        worker.start();
-        try {
-            return new Read.Got<>(
-                    task.get(budgetMs, java.util.concurrent.TimeUnit.MILLISECONDS));
-        } catch (java.util.concurrent.TimeoutException _) {
-            task.cancel(true);
-            return new Read.TimedOut<>(budgetMs);
-        } catch (java.util.concurrent.ExecutionException ee) {
-            task.cancel(true);
-            Throwable cause = ee.getCause();
-            // One thing ends a reading without the model or this code being at fault: a host with no
-            // runtime to build a value against, since the runtime is `provided` (as it is for CTFE).
-            if (runtimeAbsent(cause)) {
-                return new Read.RuntimeAbsent<>();
+        switch (deadline.given(what, () -> read.apply(reader))) {
+            case Deadline.Outcome.Finished(T value) -> {
+                return new Read.Got<>(value);
             }
-            // Anything else is this code being wrong. An empty reading says the statements agree, so
-            // answering with one would leave a broken compiler reporting every model consistent, and
-            // only a test that reached the broken shape would ever say otherwise.
-            if (cause instanceof RuntimeException runtime) {
-                throw runtime;
+            case Deadline.Outcome.Overran(Runnable abandon) -> {
+                // Nothing here was going to read how far it got, so it is given up on at once.
+                abandon.run();
+                return new Read.TimedOut<>(deadline.budgetMs());
             }
-            if (cause instanceof Error error) {
-                throw error;
+            case Deadline.Outcome.Threw(Throwable cause) -> {
+                // One thing ends a reading without the model or this code being at fault: a host with
+                // no runtime to build a value against, since the runtime is `provided` (as it is for
+                // CTFE).
+                if (runtimeAbsent(cause)) {
+                    return new Read.RuntimeAbsent<>();
+                }
+                // Anything else is this code being wrong. An empty reading says the statements agree,
+                // so answering with one would leave a broken compiler reporting every model
+                // consistent, and only a test that reached the broken shape would ever say otherwise.
+                if (cause instanceof RuntimeException runtime) {
+                    throw runtime;
+                }
+                if (cause instanceof Error error) {
+                    throw error;
+                }
+                throw new IllegalStateException(cause);
             }
-            throw new IllegalStateException(cause);
-        } catch (InterruptedException _) {
-            task.cancel(true);
-            Thread.currentThread().interrupt();
-            throw new java.util.concurrent.CancellationException("interrupted while reading " + what);
         }
     }
 
@@ -377,10 +371,13 @@ public final class ExampleStatements {
             return;
         }
         Set<TypeName> cases = outCases(sig.out());
+        int nth = 0;
         for (Ast.ExampleRow row : ex.rows()) {
+            nth++;
             if (row.inputs().size() != sig.ins().size()) {
                 continue;
             }
+            int written = nth;   // which row this is, counted as the source wrote them
             Read<RecordedRow> read = within(reader -> {
                 Object[] arguments = builtOrNull(reader, row.inputs(), sig.ins());
                 if (arguments == null) {
@@ -390,7 +387,7 @@ public final class ExampleStatements {
                 return answer instanceof Answered.Unreadable ? null
                         : new RecordedRow(new SourceRef(origin, row.expected().pos()),
                                 row.expected(), arguments, answer);
-            }, "a row of `" + ex.target() + "`");
+            }, "the fixtures of row " + written + " of `" + ex.target() + "`");
             // A reading that did not finish is not said here, whichever reason ended it. The same row
             // is evaluated where the example is checked, which builds these fixtures and then runs the
             // behavior on top of them, so a fixture that overruns this overruns that too and is E1910

--- a/souther-compiler/src/main/java/souther/compiler/ExampleStatements.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleStatements.java
@@ -183,7 +183,7 @@ public final class ExampleStatements {
                 List<Diagnostic> wrong = new ArrayList<>();
                 standins(reader, fk, sig.ins(), sig.out(), wrong);
                 return wrong;
-            }, "the `fake " + fk.target() + "` table");
+            }, new Deadline.Work.Table(fk.target(), sourceId, fk.pos()));
             switch (read) {
                 case Read.Got(List<Diagnostic> wrong) -> said.addAll(wrong);
                 case Read.TimedOut(long ranOutOf) -> said.add(uncheckedFake(fk, ranOutOf));
@@ -243,7 +243,7 @@ public final class ExampleStatements {
      * table is built here and, where no row depends on the behavior it stands in for, nowhere else.
      */
     private <T> Read<T> within(java.util.function.Function<FixtureReader, T> read,
-                               String what) {
+                               Deadline.Work what) {
         // On a reader of its own, and that is all a reading needs to be given: a worker that runs out
         // of budget is asked to stop and cannot be made to — a fixture reaches no interrupt point — so
         // it may still be inside `expandedValue`, holding a binding or a half-walked expansion. What a
@@ -371,13 +371,10 @@ public final class ExampleStatements {
             return;
         }
         Set<TypeName> cases = outCases(sig.out());
-        int nth = 0;
         for (Ast.ExampleRow row : ex.rows()) {
-            nth++;
             if (row.inputs().size() != sig.ins().size()) {
                 continue;
             }
-            int written = nth;   // which row this is, counted as the source wrote them
             Read<RecordedRow> read = within(reader -> {
                 Object[] arguments = builtOrNull(reader, row.inputs(), sig.ins());
                 if (arguments == null) {
@@ -387,7 +384,8 @@ public final class ExampleStatements {
                 return answer instanceof Answered.Unreadable ? null
                         : new RecordedRow(new SourceRef(origin, row.expected().pos()),
                                 row.expected(), arguments, answer);
-            }, "the fixtures of row " + written + " of `" + ex.target() + "`");
+            }, new Deadline.Work.Fixtures(ex.target(), origin, row.pos(),
+                    row.description()));
             // A reading that did not finish is not said here, whichever reason ended it. The same row
             // is evaluated where the example is checked, which builds these fixtures and then runs the
             // behavior on top of them, so a fixture that overruns this overruns that too and is E1910
@@ -411,7 +409,7 @@ public final class ExampleStatements {
         // The whole table, built the one way the proxy builds it.
         Read<Standins> read = within(
                 reader -> standins(reader, fk, sig.ins(), sig.out(), new ArrayList<>()),
-                "the `fake " + fk.target() + "` table");
+                new Deadline.Work.Table(fk.target(), origin, fk.pos()));
         // A switch, so that a fourth reason for a reading to end has to decide what a fake does about
         // it rather than falling in with one of these.
         switch (read) {
@@ -497,7 +495,7 @@ public final class ExampleStatements {
                 // did not finish there, and there is where it is said (E1910).
                 Answered constant = within(
                         reader -> readStandIn(reader, w.value(), depSig.out(), outCases(depSig.out())),
-                        "a `with " + w.dep() + "`").orNull();
+                        new Deadline.Work.With(w.dep(), origin, w.value().pos())).orNull();
                 if (constant == null || constant instanceof Answered.Unreadable) {
                     continue;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -78,13 +78,13 @@ public final class ExampleVerifier {
                                      Map<String, byte[]> classes,
                                      Map<String, List<BehaviorRequirement>> requirements,
                                      ClassLoader parent, Map<String, Ast.FnDef> values,
-                                     String sourceId, long budgetMs) {
+                                     String sourceId, Deadline deadline) {
         if (module.examples().isEmpty()) {
             return Observations.NONE;
         }
         MemoryClassLoader loader = new MemoryClassLoader(classes, parent);
         ExampleVerifier v = new ExampleVerifier(module, symbols, sigs, requirements, loader, values,
-                budgetMs);
+                deadline);
         v.sourceId = sourceId;
         List<Diagnostic> failures = new ArrayList<>();
         List<RowOutcome> rows = new ArrayList<>();
@@ -172,22 +172,22 @@ public final class ExampleVerifier {
      * and from any number of attached {@code examples for} files, and a position alone stops saying
      * which once they are gathered under the module's name. */
     private String sourceId;
-    /** Wall-clock budget for one row evaluated on a worker of its own ({@link #checkRow}). Carried
-     * rather than looked up, so two compiles in one JVM need not agree on it. Reading a written
-     * statement is held to a budget of its own, which is {@link ExampleStatements}'. */
-    private final long budgetMs;
+    /** What one row gets to be evaluated within ({@link #checkRow}). Carried rather than looked up,
+     * so two compiles in one JVM need not agree on it. Reading a written statement is held to a
+     * deadline of its own, which is {@link ExampleStatements}'. */
+    private final Deadline deadline;
 
     private ExampleVerifier(Ast.Module module, Symbols symbols, Map<String, Sig> sigs,
                             Map<String, List<BehaviorRequirement>> requirements,
                             MemoryClassLoader loader, Map<String, Ast.FnDef> values,
-                            long budgetMs) {
+                            Deadline deadline) {
         this.module = module;
         this.symbols = symbols;
         this.sigs = sigs;
         this.requirements = requirements;
         this.loader = loader;
         this.values = values;
-        this.budgetMs = budgetMs;
+        this.deadline = deadline;
     }
 
     /**
@@ -216,8 +216,9 @@ public final class ExampleVerifier {
             throw new IllegalStateException("`" + target.name() + "` is evaluable but has no signature");
         }
         Set<TypeName> outCases = outCases(sig.out());
+        int nth = 0;
         for (Ast.ExampleRow row : ex.rows()) {
-            checkRow(target, sig, outCases, row, out, rows);
+            checkRow(target, sig, outCases, row, ++nth, out, rows);
         }
     }
 
@@ -438,52 +439,51 @@ public final class ExampleVerifier {
      * {@link RowEvaluation} for why the row's own worker must not.
      */
     private void checkRow(ExampleTarget target, Sig sig, Set<TypeName> outCases, Ast.ExampleRow row,
-                          List<Diagnostic> out, List<RowOutcome> rows) {
+                          int nth, List<Diagnostic> out, List<RowOutcome> rows) {
         RowEvaluation evaluation = new RowEvaluation(this, target, sig, outCases, row);
-        java.util.concurrent.FutureTask<List<Diagnostic>> task =
-                new java.util.concurrent.FutureTask<>(evaluation);
-        Thread worker = new Thread(task, "souther-example-eval");
-        worker.setDaemon(true);
-        worker.start();
-        try {
-            out.addAll(task.get(budgetMs, java.util.concurrent.TimeUnit.MILLISECONDS));
-            rows.add(outcomeOf(target, row, evaluation.state));
-        } catch (java.util.concurrent.TimeoutException _) {
-            // Read what the row was doing before cancelling: the interrupt may let the worker leave the
-            // helper it is in, and then the reason would depend on which thread got there first.
-            String helper = evaluation.helper();
-            // Only the stage, which the worker publishes: the rest of its state is still being written.
-            // How far it got is the difference between a fixture's helper that will not stop and a
-            // behavior that will not stop, which is what the author has to know.
-            Stage reached = evaluation.state.stage;
-            task.cancel(true);   // best-effort: marks the task cancelled and interrupts the worker
-            out.add(Diagnostic.of("E1910", "check.example.nonterminating").title("check.example.title")
-                    .at(row.pos()).args("did not finish within " + budgetMs + "ms"
-                            + (helper == null ? "" : " while calling `" + helper + "`")).build());
-            rows.add(new RowOutcome(new SourceRef(sourceId, row.pos()), target.name(),
-                    row.description(), reached, Disposition.INCOMPLETE, FailurePhase.TIMEOUT,
-                    null, null, List.of(), List.of(), Set.of()));
-        } catch (java.util.concurrent.ExecutionException ee) {
-            Throwable cause = ee.getCause();
-            if (cause instanceof NonTerminationException nt) {
-                out.add(Diagnostic.of("E1910", "check.example.nonterminating")
-                        .title("check.example.title").at(row.pos()).args(nt.getMessage()).build());
-                evaluation.state.incomplete(FailurePhase.TIMEOUT);
+        switch (deadline.given("row " + nth + " of `" + target.name() + "`", evaluation)) {
+            case Deadline.Outcome.Finished(List<Diagnostic> found) -> {
+                out.addAll(found);
                 rows.add(outcomeOf(target, row, evaluation.state));
-                return;
             }
-            if (cause instanceof RuntimeException re) {
-                throw re;
+            case Deadline.Outcome.Overran(Runnable abandon) -> {
+                // Read what the row was doing before abandoning it: giving up interrupts the worker,
+                // which may let it leave the helper it is in, and then the reason would depend on
+                // which thread got there first.
+                String helper = evaluation.helper();
+                // Only the stage, which the worker publishes: the rest of its state is still being
+                // written. How far it got is the difference between a fixture's helper that will not
+                // stop and a behavior that will not stop, which is what the author has to know.
+                Stage reached = evaluation.state.stage;
+                abandon.run();
+                out.add(Diagnostic.of("E1910", "check.example.nonterminating")
+                        .title("check.example.title")
+                        .at(row.pos()).args("did not finish within " + deadline.budgetMs() + "ms"
+                                + (helper == null ? "" : " while calling `" + helper + "`")).build());
+                rows.add(new RowOutcome(new SourceRef(sourceId, row.pos()), target.name(),
+                        row.description(), reached, Disposition.INCOMPLETE, FailurePhase.TIMEOUT,
+                        null, null, List.of(), List.of(), Set.of()));
             }
-            throw new IllegalStateException(cause);
-        } catch (InterruptedException e) {
-            // Whoever is compiling asked to stop. Nothing is known about this row — no result was
-            // produced and no comparison was made — so this is not a failing example, and reporting it
-            // as one would put a diagnostic on a model that may be correct.
-            task.cancel(true);
-            Thread.currentThread().interrupt();
-            throw new java.util.concurrent.CancellationException(
-                    "interrupted while evaluating an example of `" + target.name() + "`");
+            case Deadline.Outcome.Threw(Throwable cause) -> {
+                if (cause instanceof NonTerminationException nt) {
+                    out.add(Diagnostic.of("E1910", "check.example.nonterminating")
+                            .title("check.example.title").at(row.pos()).args(nt.getMessage()).build());
+                    evaluation.state.incomplete(FailurePhase.TIMEOUT);
+                    rows.add(outcomeOf(target, row, evaluation.state));
+                    return;
+                }
+                // Whoever is compiling asked to stop. Nothing is known about this row — no result was
+                // produced and no comparison was made — so this is not a failing example, and
+                // reporting it as one would put a diagnostic on a model that may be correct.
+                if (cause instanceof java.util.concurrent.CancellationException) {
+                    throw new java.util.concurrent.CancellationException(
+                            "interrupted while evaluating an example of `" + target.name() + "`");
+                }
+                if (cause instanceof RuntimeException re) {
+                    throw re;
+                }
+                throw new IllegalStateException(cause);
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -216,9 +216,8 @@ public final class ExampleVerifier {
             throw new IllegalStateException("`" + target.name() + "` is evaluable but has no signature");
         }
         Set<TypeName> outCases = outCases(sig.out());
-        int nth = 0;
         for (Ast.ExampleRow row : ex.rows()) {
-            checkRow(target, sig, outCases, row, ++nth, out, rows);
+            checkRow(target, sig, outCases, row, out, rows);
         }
     }
 
@@ -439,9 +438,11 @@ public final class ExampleVerifier {
      * {@link RowEvaluation} for why the row's own worker must not.
      */
     private void checkRow(ExampleTarget target, Sig sig, Set<TypeName> outCases, Ast.ExampleRow row,
-                          int nth, List<Diagnostic> out, List<RowOutcome> rows) {
+                          List<Diagnostic> out, List<RowOutcome> rows) {
         RowEvaluation evaluation = new RowEvaluation(this, target, sig, outCases, row);
-        switch (deadline.given("row " + nth + " of `" + target.name() + "`", evaluation)) {
+        switch (deadline.given(
+                new Deadline.Work.Row(target.name(), sourceId, row.pos(), row.description()),
+                evaluation)) {
             case Deadline.Outcome.Finished(List<Diagnostic> found) -> {
                 out.addAll(found);
                 rows.add(outcomeOf(target, row, evaluation.state));

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -252,6 +252,21 @@ public final class Compilation {
         return this;
     }
 
+    /**
+     * What this compilation gives one row or one reading to finish within, said outright. Returns
+     * this compilation, so it can be said where the sources are.
+     *
+     * <p>For a test that is asking what the compiler says about work that did not come back. Written
+     * with a budget, that test has to write a model that does not terminate and then race a clock to
+     * see it reported — and a loaded host loses the race in the direction that matters, reporting
+     * work that finished as work that did not. A deadline that decides by what the work is says the
+     * same thing as a fact. A build has no reason to set one; see {@link #withExampleBudget}.
+     */
+    public Compilation withDeadline(souther.compiler.Deadline deadline) {
+        db.set(new Front.ExampleDeadline(), deadline);
+        return this;
+    }
+
     /** How well one module's rows cover it. {@link #answerEverything()} need not have run: the
      * measures ask for what they read. */
     public Adequacy.Of adequacy(String module) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -91,6 +91,19 @@ public final class Front {
      */
     public record ExampleBudget() implements Input<Long> {}
 
+    /**
+     * What one row or one reading is given to finish within, set outright rather than as a number of
+     * milliseconds.
+     *
+     * <p>Only a test sets one. A wall clock answers "did this finish in time", which is not the
+     * question nearly every test about an overrun is asking — those ask what the compiler says about
+     * work that did not finish, and had to write a model that does not terminate and then race the
+     * clock to observe it. On a loaded host the race is lost in the direction that matters: work
+     * that does finish is reported as work that did not. A deadline that decides by what the work is
+     * lets the test state the fact instead.
+     */
+    public record ExampleDeadline() implements Input<souther.compiler.Deadline> {}
+
     /** One source, parsed, with the text of each declaration kept for publishing. Every position in
      * what comes back names this source, so a writing that later joins another file's module still
      * says where it was written. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -334,6 +334,18 @@ public final class Output {
     }
 
     /**
+     * What this compilation gives one row or one reading to finish within.
+     *
+     * <p>A deadline set outright wins over a budget in milliseconds, and only a test sets one: what
+     * it is for is stating that a particular row does not come back, rather than writing a model
+     * that does not come back and racing a clock to observe it.
+     */
+    static souther.compiler.Deadline deadlineOf(Db db) {
+        souther.compiler.Deadline said = db.ask(new Front.ExampleDeadline()).value();
+        return said != null ? said : souther.compiler.Deadline.ofMillis(exampleBudgetMs(db));
+    }
+
+    /**
      * Whether each constant newtype construction in a module satisfies its invariant, by running the
      * same bytecode a run-time construction would. A check that cannot be loaded or run here is left
      * to the run-time check.
@@ -489,7 +501,7 @@ public final class Output {
             return Answer.of(souther.compiler.ExampleStatements.disagreements(prepared.value(),
                     scope.value(), sigs.value(), classes, loader(db, Map.of()),
                     values == null ? Map.of() : values, exampleOrigins, fakeOrigins,
-                    exampleBudgetMs(db)));
+                    deadlineOf(db)));
         }
     }
 
@@ -676,7 +688,7 @@ public final class Output {
             return souther.compiler.ExampleStatements.fakeTables(prepared.value(), scope.value(),
                     sigs.value(), classes, loader(db, Map.of()),
                     values == null ? Map.of() : values, fakeOrigins, sourceId,
-                    exampleBudgetMs(db));
+                    deadlineOf(db));
         }
 
         /**
@@ -717,7 +729,7 @@ public final class Output {
             souther.compiler.ExampleVerifier.Observations observed =
                     souther.compiler.ExampleVerifier.check(rows, scope.value(), sigs.value(), classes,
                             requirements, loader(db, Map.of()),
-                            values == null ? Map.of() : values, sourceId, exampleBudgetMs(db));
+                            values == null ? Map.of() : values, sourceId, deadlineOf(db));
             for (Diagnostic failure : observed.failures()) {
                 reports.add(Report.of(failure));
             }

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -35,14 +35,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AdequacyNeverAssertsFromPartOfTheRowsTest {
 
     /**
-     * A model, with the budget the compile that reads it is given.
+     * A model, with the work the compile that reads it does not get back from.
      *
-     * <p>The two here want opposite budgets, which is why it is carried beside the source rather than
-     * set for the run: one is a row that never comes back, and waiting the default out reaches the
-     * same answer later, while the other walks four thousand nodes to spend the observation budget and
-     * would be reported as a row that does not terminate if it were held to the first one's.
+     * <p>Carried beside the source because the two here differ in it. One holds a row that never
+     * comes back, which is said here rather than timed; the other walks four thousand nodes to spend
+     * the observation budget and comes back from everything, so nothing about it overruns.
      */
-    private record Unreadable(String source, java.time.Duration budget) {}
+    private record Unreadable(String source, Deadline overrun) {}
 
     /** Models where something a measure would want to read was not read, each in a different way. */
     private static List<Unreadable> unreadableInSomeWay() {
@@ -74,7 +73,7 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
 
                 example take
                     | (Draft { flag = Yes, cost = Amount(500) }) -> Big { n = 0 }
-                """, DoesNotComeBack.BUDGET),
+                """, DoesNotComeBack.overrunningOn("row 1 of `take`")),
                 // a value past the observation's limits: the position is there and unreadable
                 new Unreadable(budgetSpent(), null));
     }
@@ -121,18 +120,18 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
     private static final Map<String, Compilation> COMPILED = new java.util.LinkedHashMap<>();
 
     private static Compilation measured(Unreadable model) {
-        return COMPILED.computeIfAbsent(model.budget() + ":" + model.source(),
-                _ -> measured(model.source(), model.budget()));
+        return COMPILED.computeIfAbsent(model.source(),
+                _ -> measured(model.source(), model.overrun()));
     }
 
     private static Compilation measured(String source) {
         return measured(source, null);
     }
 
-    private static Compilation measured(String source, java.time.Duration budget) {
+    private static Compilation measured(String source, Deadline overrun) {
         Compilation compilation = Compilation.ofSource(source, "Main");
-        if (budget != null) {
-            compilation.withExampleBudget(budget);
+        if (overrun != null) {
+            compilation.withDeadline(overrun);
         }
         compilation.measure(Adequacy.Asked.reportOnly());
         compilation.answerEverything();

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -73,7 +73,7 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
 
                 example take
                     | (Draft { flag = Yes, cost = Amount(500) }) -> Big { n = 0 }
-                """, DoesNotComeBack.overrunningOn("row 1 of `take`")),
+                """, DoesNotComeBack.overrunningOn(DoesNotComeBack.everyRowOf("take"))),
                 // a value past the observation's limits: the position is there and unreadable
                 new Unreadable(budgetSpent(), null));
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleCoverageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleCoverageTest.java
@@ -142,7 +142,7 @@ class CompileExampleCoverageTest {
                     | (Draft { n = 1 }) -> Done { n = 1 }
                 """;
         Compilation compilation = Compilation.ofSource(spinning, "Main")
-                .withDeadline(DoesNotComeBack.overrunningOn("row 1 of `go`"));
+                .withDeadline(DoesNotComeBack.overrunningOn(DoesNotComeBack.everyRowOf("go")));
         compilation.measure(Adequacy.Asked.reportOnly());
         compilation.answerEverything();
         String module = compilation.modules().get(0);

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleCoverageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleCoverageTest.java
@@ -142,7 +142,7 @@ class CompileExampleCoverageTest {
                     | (Draft { n = 1 }) -> Done { n = 1 }
                 """;
         Compilation compilation = Compilation.ofSource(spinning, "Main")
-                .withExampleBudget(DoesNotComeBack.BUDGET);
+                .withDeadline(DoesNotComeBack.overrunningOn("row 1 of `go`"));
         compilation.measure(Adequacy.Asked.reportOnly());
         compilation.answerEverything();
         String module = compilation.modules().get(0);

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -256,7 +256,7 @@ class CompileFakeExampleDisagreementTest {
     @Test
     void aRowWhoseFixtureWillNotFinishIsHeldAgainstNothing() {
         CompileException e = org.junit.jupiter.api.Assertions.assertThrows(CompileException.class,
-                () -> DoesNotComeBack.compile("""
+                () -> DoesNotComeBack.compileOverrunning("""
                         module example.spin
 
                         data N = Int
@@ -272,7 +272,7 @@ class CompileFakeExampleDisagreementTest {
 
                         fake find
                             | (N(1)) -> Missing { why = "none" }
-                        """));
+                        """, "the fixtures of row 1 of `find`", "row 1 of `find`"));
 
         List<String> codes = new ArrayList<>();
         for (souther.compiler.diag.Diagnostic d : e.diagnostics()) {
@@ -321,7 +321,7 @@ class CompileFakeExampleDisagreementTest {
                 fake find
                     | (N(spin(1))) -> Missing { why = "none" }
                     | (N(spin(2))) -> Missing { why = "none" }
-                """, DoesNotComeBack.BUDGET));
+                """, DoesNotComeBack.overrunningOn("the `fake find` table")));
 
         assertEquals(1, said.size(), said.toString());
         Diagnostic one = said.get(0).diagnostic();
@@ -357,7 +357,7 @@ class CompileFakeExampleDisagreementTest {
     void aRowThatRunsTheTableAndTheReadingBothSayWhatTheyFound() {
         List<Located> warnings = new ArrayList<>();
         CompileException e = org.junit.jupiter.api.Assertions.assertThrows(CompileException.class,
-                () -> DoesNotComeBack.compileModules(List.of("""
+                () -> DoesNotComeBack.compileModulesOverrunning(List.of("""
                         module example.both
 
                         data N = Int
@@ -385,7 +385,7 @@ class CompileFakeExampleDisagreementTest {
 
                         fake find
                             | (N(spin(1))) -> Missing { why = "none" }
-                        """), warnings));
+                        """), warnings, "the `fake find` table", "row 1 of `use`"));
 
         assertTrue(codesOf(e).contains("E1910"), codesOf(e).toString());
         assertEquals(1, only("E1920", warnings).size(), warnings.toString());
@@ -448,7 +448,7 @@ class CompileFakeExampleDisagreementTest {
                 c.db().ask(new souther.compiler.query.Bodies.Helpers(name)).value(),
                 c.db().ask(new souther.compiler.query.Front.ExampleOrigins(name)).value(),
                 c.db().ask(new souther.compiler.query.Front.FakeOrigins(name)).value(),
-                ExampleVerifier.defaultBudgetMs());
+                Deadline.ofMillis(ExampleVerifier.defaultBudgetMs()));
     }
 
     /** The warnings of a single-source compile that holds. */
@@ -458,12 +458,12 @@ class CompileFakeExampleDisagreementTest {
         return out;
     }
 
-    /** As {@link #warningsOf(String)}, for a model whose table does not finish being built: the
-     * answer is the same at the default budget, reached after a wait that decides nothing. */
-    private static List<Located> warningsOf(String model, java.time.Duration budget) {
+    /** As {@link #warningsOf(String)}, for a model whose table does not finish being built —
+     * which is said here rather than waited for. */
+    private static List<Located> warningsOf(String model, Deadline overrun) {
         List<Located> out = new ArrayList<>();
         assertDoesNotThrow(() -> Compiler.compiled(model, "Main", out,
-                souther.compiler.query.Adequacy.Asked.NOTHING, budget));
+                souther.compiler.query.Adequacy.Asked.NOTHING, null, overrun));
         return out;
     }
 
@@ -550,7 +550,7 @@ class CompileFakeExampleDisagreementTest {
 
                 fake other
                     | (N(1)) -> Missing { why = "none" }
-                """, DoesNotComeBack.BUDGET));
+                """, DoesNotComeBack.overrunningOn("the fixtures of row 1 of `other`", "row 1 of `other`")));
     }
 
     /**
@@ -620,11 +620,11 @@ class CompileFakeExampleDisagreementTest {
     }
 
     /** As {@link #allCodesOf(String)}, for a model with a row that does not come back. */
-    private static List<String> allCodesOf(String model, java.time.Duration budget) {
+    private static List<String> allCodesOf(String model, Deadline overrun) {
         souther.compiler.query.Compilation compilation =
                 souther.compiler.query.Compilation.ofSource(model, "Main");
-        if (budget != null) {
-            compilation.withExampleBudget(budget);
+        if (overrun != null) {
+            compilation.withDeadline(overrun);
         }
         compilation.answerEverything();
         List<String> codes = new ArrayList<>();

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -272,7 +272,7 @@ class CompileFakeExampleDisagreementTest {
 
                         fake find
                             | (N(1)) -> Missing { why = "none" }
-                        """, "the fixtures of row 1 of `find`", "row 1 of `find`"));
+                        """, DoesNotComeBack.everythingAboutRowsOf("find")));
 
         List<String> codes = new ArrayList<>();
         for (souther.compiler.diag.Diagnostic d : e.diagnostics()) {
@@ -321,7 +321,7 @@ class CompileFakeExampleDisagreementTest {
                 fake find
                     | (N(spin(1))) -> Missing { why = "none" }
                     | (N(spin(2))) -> Missing { why = "none" }
-                """, DoesNotComeBack.overrunningOn("the `fake find` table")));
+                """, DoesNotComeBack.overrunningOn(DoesNotComeBack.everyTableOf("find"))));
 
         assertEquals(1, said.size(), said.toString());
         Diagnostic one = said.get(0).diagnostic();
@@ -385,7 +385,7 @@ class CompileFakeExampleDisagreementTest {
 
                         fake find
                             | (N(spin(1))) -> Missing { why = "none" }
-                        """), warnings, "the `fake find` table", "row 1 of `use`"));
+                        """), warnings, DoesNotComeBack.everyTableOf("find").or(DoesNotComeBack.everyRowOf("use"))));
 
         assertTrue(codesOf(e).contains("E1910"), codesOf(e).toString());
         assertEquals(1, only("E1920", warnings).size(), warnings.toString());
@@ -550,7 +550,7 @@ class CompileFakeExampleDisagreementTest {
 
                 fake other
                     | (N(1)) -> Missing { why = "none" }
-                """, DoesNotComeBack.overrunningOn("the fixtures of row 1 of `other`", "row 1 of `other`")));
+                """, DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("other"))));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
@@ -215,7 +215,7 @@ class CompileFakeTableWhereWrittenTest {
                 fake find
                     | (N(spin(1))) -> Found { n = N(1) }
                 """, "Main", warnings, souther.compiler.query.Adequacy.Asked.NOTHING,
-                null, DoesNotComeBack.overrunningOn("the `fake find` table")));
+                null, DoesNotComeBack.overrunningOn(DoesNotComeBack.everyTableOf("find"))));
 
         List<Located> said = only("E1921", warnings);
         assertEquals(1, said.size(), warnings.toString());

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
@@ -215,7 +215,7 @@ class CompileFakeTableWhereWrittenTest {
                 fake find
                     | (N(spin(1))) -> Found { n = N(1) }
                 """, "Main", warnings, souther.compiler.query.Adequacy.Asked.NOTHING,
-                DoesNotComeBack.BUDGET));
+                null, DoesNotComeBack.overrunningOn("the `fake find` table")));
 
         List<Located> said = only("E1921", warnings);
         assertEquals(1, said.size(), warnings.toString());

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -109,7 +109,7 @@ class CompilePartialAdequacyTest {
     /** A model that comes back, on the default budget — including {@link #budgetSpent}, which walks
      * four thousand nodes and is the reason a short budget cannot be set for the whole suite. */
     private static Compilation measured(String source) {
-        return measured(source, null);
+        return measured(source, (Deadline) null);
     }
 
     /** As {@link #measured(String)}, for a model whose rows do not come back: waiting out the default
@@ -139,6 +139,42 @@ class CompilePartialAdequacyTest {
         });
     }
 
+    /** Measured, with {@code overrun} the work this model does not get back from — for a model
+     *  written out here, which is its own key. */
+    private static Compilation measured(String source, Deadline overrun) {
+        return measured("report:", source, overrun, Adequacy.Asked.reportOnly());
+    }
+
+    /** The same, for a model shared between tests, which needs a key of its own. */
+    private static Compilation measured(String key, String source, Deadline overrun) {
+        return measured("report:" + key, source, overrun, Adequacy.Asked.reportOnly());
+    }
+
+    /** The same, warned about at every level. */
+    private static Compilation warned(String key, String source, Deadline overrun) {
+        return measured("warn:" + key, source, overrun,
+                Adequacy.Asked.warningsAt(Adequacy.Level.ALL));
+    }
+
+    /**
+     * Measured, with {@code overrun} the work this model does not get back from.
+     *
+     * <p>Said rather than timed. What these tests are about is what a measure makes of a row that did
+     * not come back, and a model that loops plus a clock short enough to catch it also reports the
+     * rows that were supposed to finish as rows that did not, on any host loaded enough to make it
+     * so.
+     */
+    private static Compilation measured(String key, String source, Deadline overrun,
+                                        Adequacy.Asked asked) {
+        return COMPILED.computeIfAbsent(key + ":" + source, _ -> {
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.withDeadline(overrun);
+            compilation.measure(asked);
+            compilation.answerEverything();
+            return compilation;
+        });
+    }
+
     private static List<String> warningCodes(Compilation compilation) {
         List<String> codes = new ArrayList<>();
         for (Db.Found found : compilation.db().allReports()) {
@@ -159,7 +195,7 @@ class CompilePartialAdequacyTest {
      */
     @Test
     void aBranchMeasureOverAnUnfinishedRowIsUndecided() {
-        Compilation compilation = measured(TIMES_OUT, DoesNotComeBack.BUDGET);
+        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"));
         Adequacy.BranchEvidence branch = compilation.db()
                 .ask(new Adequacy.BranchCoverage(compilation.modules().get(0))).value().get("go");
 
@@ -171,7 +207,7 @@ class CompilePartialAdequacyTest {
     /** And nothing is warned about from it. */
     @Test
     void anUndecidedBranchMeasureWarnsAboutNoArm() {
-        assertFalse(warningCodes(warned(TIMES_OUT, DoesNotComeBack.BUDGET)).contains("E1918"),
+        assertFalse(warningCodes(warned("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"))).contains("E1918"),
                 "an arm a row might have gone through is not an arm nothing reaches");
     }
 
@@ -229,12 +265,12 @@ class CompilePartialAdequacyTest {
      */
     @Test
     void whatStoppedARowBeingSeenReachesTheMeasureThatReadsIt() {
-        Compilation compilation = measured(TIMES_OUT, DoesNotComeBack.BUDGET);
+        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"));
         Adequacy.SignatureEvidence signature = compilation.db()
                 .ask(new Adequacy.Witnesses(compilation.modules().get(0))).value().get("go");
 
         assertEquals(MeasurementStatus.PARTIAL, signature.status());
-        assertFalse(warningCodes(warned(TIMES_OUT, DoesNotComeBack.BUDGET)).contains("E1913"),
+        assertFalse(warningCodes(warned("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"))).contains("E1913"),
                 "a case the unfinished row might have produced is not a case nothing claims");
     }
 
@@ -271,7 +307,7 @@ class CompilePartialAdequacyTest {
 
                 example cancel
                     | (Draft { n = spin(1) }) -> Gone { why = "x" }
-                """, DoesNotComeBack.BUDGET);
+                """, DoesNotComeBack.overrunningOn("the fixtures of row 1 of `cancel`", "row 1 of `cancel`"));
         AdequacyReport whole = AdequacyReport.of(compilation);
 
         assertEquals(MeasurementStatus.PARTIAL, whole.status(), "`cancel` did not finish");
@@ -433,7 +469,7 @@ class CompilePartialAdequacyTest {
     @Test
     void theJsonNamesNoUnreachedArmUnderPartial() throws Exception {
         JsonNode branch = JsonMapper.builder().build().readTree(
-                AdequacyReport.of(measured(TIMES_OUT, DoesNotComeBack.BUDGET)).json())
+                AdequacyReport.of(measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"))).json())
                 .get("modules").get(0).get("behaviors").get(0).get("branch");
 
         assertEquals("partial", branch.get("status").asString());
@@ -467,7 +503,7 @@ class CompilePartialAdequacyTest {
 
                 example pick
                     | (Yes, Yes) -> Ok { n = 0 }
-                """, DoesNotComeBack.BUDGET);
+                """, DoesNotComeBack.overrunningOn("row 1 of `pick`"));
         PartitionEvidence partition = compilation.db()
                 .ask(new Adequacy.Coverage("example.pair")).value().get("pick");
 
@@ -506,7 +542,7 @@ class CompilePartialAdequacyTest {
 
                 example pick
                     | (Yes, Yes) -> Ok { n = 0 }
-                """, DoesNotComeBack.BUDGET);
+                """, DoesNotComeBack.overrunningOn("row 1 of `pick`"));
         PartitionEvidence partition = compilation.db()
                 .ask(new Adequacy.Coverage("example.agree")).value().get("pick");
 
@@ -525,7 +561,7 @@ class CompilePartialAdequacyTest {
      */
     @Test
     void aBoundaryARowDemonstrablyMetStaysMet() {
-        PartitionEvidence partition = measured("""
+        PartitionEvidence partition = measured("mix", """
                 module example.mix
 
                 data Amount = Int
@@ -552,7 +588,8 @@ class CompilePartialAdequacyTest {
                 example take
                     | (Draft { kind = Overseas, cost = Amount(100) }) -> Ok { n = 100 }
                     | (Draft { kind = Domestic, cost = Amount(500) }) -> Big { n = 0 }
-                """, DoesNotComeBack.BUDGET).db().ask(new Adequacy.Coverage("example.mix")).value().get("take");
+                """, DoesNotComeBack.overrunningOn("row 2 of `take`", "the fixtures of row 2 of `take`"), Adequacy.Asked.reportOnly())
+                .db().ask(new Adequacy.Coverage("example.mix")).value().get("take");
 
         PartitionEvidence.BoundaryCoverage line = partition.boundaries().stream()
                 .filter(b -> b.value().equals("100")).findFirst().orElseThrow();
@@ -622,7 +659,7 @@ class CompilePartialAdequacyTest {
     /** The row that did not finish is still there to be counted, and still says it did not. */
     @Test
     void theUnfinishedRowIsStillReported() {
-        Compilation compilation = measured(TIMES_OUT, DoesNotComeBack.BUDGET);
+        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"));
         String sourceId = compilation.exampleSourcesOf("example.loop").get(0);
 
         List<souther.compiler.observe.RowOutcome> rows = compilation.db()

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -195,7 +195,7 @@ class CompilePartialAdequacyTest {
      */
     @Test
     void aBranchMeasureOverAnUnfinishedRowIsUndecided() {
-        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"));
+        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("go")));
         Adequacy.BranchEvidence branch = compilation.db()
                 .ask(new Adequacy.BranchCoverage(compilation.modules().get(0))).value().get("go");
 
@@ -207,7 +207,7 @@ class CompilePartialAdequacyTest {
     /** And nothing is warned about from it. */
     @Test
     void anUndecidedBranchMeasureWarnsAboutNoArm() {
-        assertFalse(warningCodes(warned("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"))).contains("E1918"),
+        assertFalse(warningCodes(warned("loop", TIMES_OUT, DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("go")))).contains("E1918"),
                 "an arm a row might have gone through is not an arm nothing reaches");
     }
 
@@ -265,12 +265,12 @@ class CompilePartialAdequacyTest {
      */
     @Test
     void whatStoppedARowBeingSeenReachesTheMeasureThatReadsIt() {
-        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"));
+        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("go")));
         Adequacy.SignatureEvidence signature = compilation.db()
                 .ask(new Adequacy.Witnesses(compilation.modules().get(0))).value().get("go");
 
         assertEquals(MeasurementStatus.PARTIAL, signature.status());
-        assertFalse(warningCodes(warned("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"))).contains("E1913"),
+        assertFalse(warningCodes(warned("loop", TIMES_OUT, DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("go")))).contains("E1913"),
                 "a case the unfinished row might have produced is not a case nothing claims");
     }
 
@@ -307,7 +307,7 @@ class CompilePartialAdequacyTest {
 
                 example cancel
                     | (Draft { n = spin(1) }) -> Gone { why = "x" }
-                """, DoesNotComeBack.overrunningOn("the fixtures of row 1 of `cancel`", "row 1 of `cancel`"));
+                """, DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("cancel")));
         AdequacyReport whole = AdequacyReport.of(compilation);
 
         assertEquals(MeasurementStatus.PARTIAL, whole.status(), "`cancel` did not finish");
@@ -469,7 +469,7 @@ class CompilePartialAdequacyTest {
     @Test
     void theJsonNamesNoUnreachedArmUnderPartial() throws Exception {
         JsonNode branch = JsonMapper.builder().build().readTree(
-                AdequacyReport.of(measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"))).json())
+                AdequacyReport.of(measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("go")))).json())
                 .get("modules").get(0).get("behaviors").get(0).get("branch");
 
         assertEquals("partial", branch.get("status").asString());
@@ -503,7 +503,7 @@ class CompilePartialAdequacyTest {
 
                 example pick
                     | (Yes, Yes) -> Ok { n = 0 }
-                """, DoesNotComeBack.overrunningOn("row 1 of `pick`"));
+                """, DoesNotComeBack.overrunningOn(DoesNotComeBack.everyRowOf("pick")));
         PartitionEvidence partition = compilation.db()
                 .ask(new Adequacy.Coverage("example.pair")).value().get("pick");
 
@@ -542,7 +542,7 @@ class CompilePartialAdequacyTest {
 
                 example pick
                     | (Yes, Yes) -> Ok { n = 0 }
-                """, DoesNotComeBack.overrunningOn("row 1 of `pick`"));
+                """, DoesNotComeBack.overrunningOn(DoesNotComeBack.everyRowOf("pick")));
         PartitionEvidence partition = compilation.db()
                 .ask(new Adequacy.Coverage("example.agree")).value().get("pick");
 
@@ -586,9 +586,10 @@ class CompilePartialAdequacyTest {
                 }
 
                 example take
-                    | (Draft { kind = Overseas, cost = Amount(100) }) -> Ok { n = 100 }
-                    | (Draft { kind = Domestic, cost = Amount(500) }) -> Big { n = 0 }
-                """, DoesNotComeBack.overrunningOn("row 2 of `take`", "the fixtures of row 2 of `take`"), Adequacy.Asked.reportOnly())
+                    | "at the line" : (Draft { kind = Overseas, cost = Amount(100) }) -> Ok { n = 100 }
+                    | "over it"     : (Draft { kind = Domestic, cost = Amount(500) }) -> Big { n = 0 }
+                """, DoesNotComeBack.overrunningOn(
+                        DoesNotComeBack.everythingAboutTheRowDescribed("over it")), Adequacy.Asked.reportOnly())
                 .db().ask(new Adequacy.Coverage("example.mix")).value().get("take");
 
         PartitionEvidence.BoundaryCoverage line = partition.boundaries().stream()
@@ -600,6 +601,46 @@ class CompilePartialAdequacyTest {
                 .filter(b -> b.value().equals("101")).findFirst().orElseThrow();
         assertEquals(MeasurementStatus.PARTIAL, beyond.status(),
                 "and the one nothing was found at is undecided, not missed");
+    }
+
+    /**
+     * One row of two written under separate {@code example} blocks does not come back, and the other
+     * is evaluated as it would have been.
+     *
+     * <p>Here because a behavior can be exampled more than once — a second block beside the first, or
+     * an {@code examples for} file beside the model — and the first thing this was written with named
+     * a row by its number within its block. That made both first rows one name, so picking out either
+     * picked out both, and a model of this shape would have had its working rows reported as rows that
+     * did not come back.
+     */
+    @Test
+    void aRowIsPickedOutOfTheBlockItIsInAndNoOther() {
+        Compilation compilation = measured("""
+                module example.twice
+
+                data Draft = { n: Int }
+                data Ok = { n: Int }
+
+                behavior take : (request: Draft) -> Ok
+                    constructs Ok
+
+                let take (request) = Ok { n = request.n }
+
+                example take
+                    | "does not come back" : (Draft { n = 1 }) -> Ok { n = 1 }
+
+                example take
+                    | "comes back" : (Draft { n = 2 }) -> Ok { n = 2 }
+                """,
+                DoesNotComeBack.overrunningOn(
+                        DoesNotComeBack.everythingAboutTheRowDescribed("does not come back")));
+
+        List<String> codes = new ArrayList<>();
+        for (Db.Found found : compilation.db().allReports()) {
+            codes.add(String.valueOf(found.report().diagnostic().code()));
+        }
+        assertEquals(1, codes.stream().filter("E1910"::equals).count(),
+                "one row was picked out, so one row did not come back: " + codes);
     }
 
     // --- who a reason counts against ---------------------------------------------------------------
@@ -659,7 +700,7 @@ class CompilePartialAdequacyTest {
     /** The row that did not finish is still there to be counted, and still says it did not. */
     @Test
     void theUnfinishedRowIsStillReported() {
-        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn("row 1 of `go`", "the fixtures of row 1 of `go`"));
+        Compilation compilation = measured("loop", TIMES_OUT, DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("go")));
         String sourceId = compilation.exampleSourcesOf("example.loop").get(0);
 
         List<souther.compiler.observe.RowOutcome> rows = compilation.db()

--- a/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
+++ b/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
@@ -55,6 +55,65 @@ final class DoesNotComeBack {
                 souther.compiler.query.Adequacy.Asked.NOTHING, BUDGET);
     }
 
+    /** As {@link #compile(String)}, with the work this model does not get back from said rather
+     *  than timed. {@code what} is named as {@link #overrunningOn} names it. */
+    static void compileOverrunning(String model, String... what) {
+        Compiler.compiled(model, "Main", new java.util.ArrayList<>(),
+                souther.compiler.query.Adequacy.Asked.NOTHING, null, overrunningOn(what));
+    }
+
+    /** As {@link #compileModules(java.util.List, java.util.List)}, said rather than timed. */
+    static void compileModulesOverrunning(java.util.List<String> sources,
+                                          java.util.List<souther.compiler.diag.Located> warningsOut,
+                                          String... what) {
+        Compiler.compiledModules(sources, souther.compiler.meta.ModulePath.EMPTY, warningsOut,
+                souther.compiler.query.Adequacy.Asked.NOTHING, null, overrunningOn(what));
+    }
+
+    /**
+     * A deadline under which the work a test names does not come back, and everything else runs to
+     * completion.
+     *
+     * <p>What a test about an overrun is asking is what the compiler <em>says</em> about work that
+     * did not finish, and a clock is a poor way to ask it: the model has to be written so that
+     * something genuinely loops, and then the answer depends on whether the host was loaded enough
+     * to cut short the rows that were supposed to finish. Named work overruns here because the test
+     * said so, and the rest is run on the calling thread — no worker, no waiting, and no row that
+     * finishes reported as one that did not.
+     *
+     * <p>The names are the ones the two sites give their work, and each names the thing rather than
+     * the visit: {@code row 2 of `take`} for a row evaluated, {@code the fixtures of row 2 of
+     * `take`} for the statements it is read from, {@code the `fake find` table}, {@code a `with
+     * dep`}. Naming the thing is what makes this deterministic — one row is evaluated more than once
+     * over a compile, once to check it and again to measure what it covered, and anything counting
+     * visits would answer differently on the second pass.
+     *
+     * <p>Only the work named overruns, so whatever else the model does still has to finish: it is
+     * run inline, and a loop nobody named would not be cut short but would hang.
+     */
+    static Deadline overrunningOn(String... what) {
+        java.util.Set<String> named = java.util.Set.of(what);
+        return new Deadline() {
+
+            @Override
+            public long budgetMs() {
+                return BUDGET.toMillis();   // what a report about an overrun quotes
+            }
+
+            @Override
+            public <T> Outcome<T> given(String subject, java.util.concurrent.Callable<T> work) {
+                if (named.contains(subject)) {
+                    return new Outcome.Overran<>(() -> { });   // nothing was started to give up on
+                }
+                try {
+                    return new Outcome.Finished<>(work.call());
+                } catch (Exception e) {
+                    return new Outcome.Threw<>(e);
+                }
+            }
+        };
+    }
+
     private DoesNotComeBack() {
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
+++ b/souther-compiler/src/test/java/souther/compiler/DoesNotComeBack.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import java.time.Duration;
+import java.util.function.Predicate;
 
 /**
  * The budget a compile is given when the point of the model is a row that never finishes.
@@ -57,42 +58,38 @@ final class DoesNotComeBack {
 
     /** As {@link #compile(String)}, with the work this model does not get back from said rather
      *  than timed. {@code what} is named as {@link #overrunningOn} names it. */
-    static void compileOverrunning(String model, String... what) {
+    static void compileOverrunning(String model, Predicate<Deadline.Work> which) {
         Compiler.compiled(model, "Main", new java.util.ArrayList<>(),
-                souther.compiler.query.Adequacy.Asked.NOTHING, null, overrunningOn(what));
+                souther.compiler.query.Adequacy.Asked.NOTHING, null, overrunningOn(which));
     }
 
     /** As {@link #compileModules(java.util.List, java.util.List)}, said rather than timed. */
     static void compileModulesOverrunning(java.util.List<String> sources,
                                           java.util.List<souther.compiler.diag.Located> warningsOut,
-                                          String... what) {
+                                          Predicate<Deadline.Work> which) {
         Compiler.compiledModules(sources, souther.compiler.meta.ModulePath.EMPTY, warningsOut,
-                souther.compiler.query.Adequacy.Asked.NOTHING, null, overrunningOn(what));
+                souther.compiler.query.Adequacy.Asked.NOTHING, null, overrunningOn(which));
     }
 
     /**
-     * A deadline under which the work a test names does not come back, and everything else runs to
-     * completion.
+     * A deadline under which the work a test picks out does not come back, and everything else runs
+     * to completion.
      *
      * <p>What a test about an overrun is asking is what the compiler <em>says</em> about work that
      * did not finish, and a clock is a poor way to ask it: the model has to be written so that
      * something genuinely loops, and then the answer depends on whether the host was loaded enough
-     * to cut short the rows that were supposed to finish. Named work overruns here because the test
-     * said so, and the rest is run on the calling thread — no worker, no waiting, and no row that
+     * to cut short the rows that were supposed to finish. Work overruns here because the test picked
+     * it out, and the rest is run on the calling thread — no worker, no waiting, and no row that
      * finishes reported as one that did not.
      *
-     * <p>The names are the ones the two sites give their work, and each names the thing rather than
-     * the visit: {@code row 2 of `take`} for a row evaluated, {@code the fixtures of row 2 of
-     * `take`} for the statements it is read from, {@code the `fake find` table}, {@code a `with
-     * dep`}. Naming the thing is what makes this deterministic — one row is evaluated more than once
-     * over a compile, once to check it and again to measure what it covered, and anything counting
-     * visits would answer differently on the second pass.
+     * <p>Picked out by what the work is, never by how many times something has been asked. One row
+     * is worked on more than once over a compile — once to check it, again to measure what it
+     * covered — so anything counting visits answers differently on the second pass.
      *
-     * <p>Only the work named overruns, so whatever else the model does still has to finish: it is
-     * run inline, and a loop nobody named would not be cut short but would hang.
+     * <p>Only the work picked out overruns, so whatever else the model does still has to finish: it
+     * is run inline, and a loop nothing picked out would not be cut short but would hang.
      */
-    static Deadline overrunningOn(String... what) {
-        java.util.Set<String> named = java.util.Set.of(what);
+    static Deadline overrunningOn(Predicate<Deadline.Work> which) {
         return new Deadline() {
 
             @Override
@@ -101,17 +98,56 @@ final class DoesNotComeBack {
             }
 
             @Override
-            public <T> Outcome<T> given(String subject, java.util.concurrent.Callable<T> work) {
-                if (named.contains(subject)) {
+            public <T> Outcome<T> given(Work work, java.util.concurrent.Callable<T> body) {
+                if (which.test(work)) {
                     return new Outcome.Overran<>(() -> { });   // nothing was started to give up on
                 }
                 try {
-                    return new Outcome.Finished<>(work.call());
-                } catch (Exception e) {
-                    return new Outcome.Threw<>(e);
+                    return new Outcome.Finished<>(body.call());
+                } catch (Throwable cause) {
+                    // Everything the worker could have thrown, as the build's deadline hands it over:
+                    // `ExampleStatements` reads a `NoClassDefFoundError` as this host having no
+                    // runtime, and would never see one that came past this instead of through it.
+                    return new Outcome.Threw<>(cause);
                 }
             }
         };
+    }
+
+    /** Every row of {@code target}, evaluated — its fixtures built, the behavior applied. */
+    static Predicate<Deadline.Work> everyRowOf(String target) {
+        return w -> w instanceof Deadline.Work.Row row && row.target().equals(target);
+    }
+
+    /** The statements every row of {@code target} is read from, with nothing applied. */
+    static Predicate<Deadline.Work> theFixturesOfEveryRowOf(String target) {
+        return w -> w instanceof Deadline.Work.Fixtures f && f.target().equals(target);
+    }
+
+    /** Everything a row of {@code target} is worked on for: read, and evaluated. */
+    static Predicate<Deadline.Work> everythingAboutRowsOf(String target) {
+        return everyRowOf(target).or(theFixturesOfEveryRowOf(target));
+    }
+
+    /**
+     * The one row written with {@code description}, and the statements it is read from.
+     *
+     * <p>For a model with more than one row of a behavior, where only one of them is the one that
+     * does not come back. The description is written on the row, so it moves with it — a position
+     * would have to be counted out of a text block and re-counted whenever the model above it
+     * changed.
+     */
+    static Predicate<Deadline.Work> everythingAboutTheRowDescribed(String description) {
+        return w -> switch (w) {
+            case Deadline.Work.Row row -> description.equals(row.description());
+            case Deadline.Work.Fixtures f -> description.equals(f.description());
+            default -> false;
+        };
+    }
+
+    /** Every {@code fake} table of {@code target}, built. */
+    static Predicate<Deadline.Work> everyTableOf(String target) {
+        return w -> w instanceof Deadline.Work.Table t && t.target().equals(target);
     }
 
     private DoesNotComeBack() {


### PR DESCRIPTION
Closes #331.

`CompilePartialAdequacyTest.aBoundaryARowDemonstrablyMetStaysMet` failed on CI and passed on a re-run
of the same commit. Under two cores locally a *different* test of the same family failed instead.
Neither was a defect in what was being tested.

## Where it came from

Two places gave work a limit — a statement being read (`ExampleStatements`), a row being evaluated
(`ExampleVerifier`) — and both did it inline, with a worker of its own and `task.get(budgetMs, …)`.
`DoesNotComeBack.BUDGET` is 100ms, and on a loaded two-core runner a reading that *does* come back
takes longer than that and is reported as one that did not. That is exactly what CI saw: the row
`(Overseas, Amount(100))` terminates at once, and the boundary it demonstrably met was recorded as
unmet.

The two questions sharing that mechanism are not the same question:

| Question | What it needs |
|---|---|
| Does a reading that never returns take the compile down? | a real runaway thread |
| What does the compiler *say* about one that did not return? | the outcome, and nothing else |

Six test classes and twenty call sites were asking the second and paying for the first, in the
direction that makes them wrong rather than slow.

## The change

`Deadline` is the seam. `Deadline.ofMillis` is what both sites did before and what a build still runs
on — the production path is unchanged. `DoesNotComeBack.overrunningOn(…)` answers for the work a test
names and runs everything else on the calling thread: no worker, no waiting, and no row that finishes
reported as one that did not.

Work is named by what it is rather than by the visit — `` `row 2 of `take`` ``, not "the second time
something called itself a row of `take`". One row is worked on more than once over a compile, once to
check it and again to measure what it covered, so anything counting visits answers differently on the
second pass. I wrote the counting version first and it hung the suite; the note in
`DoesNotComeBack`'s javadoc is there because of it.

`Resolve.sumCases` is unrelated and came out of the same reading: it answered a name without
recording it, alone among the paths that answer names.

## Verification

- `mvn -o test` — 2,788 tests, 0 failures.
- **`taskset -c 0,1 mvn -o test`** — 2,665 tests, 0 failures. The same command on `develop` fails, and
  is how the CI failure was reproduced locally.
- `CompileFakeExampleDisagreementTest` runs in 1.3s where it took twelve times that.

Also visible while diagnosing this, and left alone: an overrun worker keeps running after
`cancel(true)` because a `partial` loop reaches no interrupt point, so abandoned spinners accumulate
across a suite and steal cores from everything after them. Two of them were pegging a core each
during a full run. The deterministic deadline starts no thread, so the tests moved here stop
contributing to that.

## Not done here

Counting steps rather than milliseconds would make the *product* deterministic too — today the same
model can compile clean on one machine and report E1910 on another. That needs the classes generated
for example evaluation to carry a fuel counter, and is a much larger change than this seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
