### PR TITLE
A name that denotes nothing costs one definition, not the whole compilation

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -159,8 +159,22 @@ final class HelperParams {
         } catch (CompileException _) {
             return null;   // a written type or a call that does not resolve; the check reports it
         }
-        Map<Integer, Type> found =
-                determine(h, open, env, body, symbols, reqSigs, recursiveHelperFns, new HashMap<>());
+        Map<Integer, Type> found;
+        try {
+            found = determine(h, open, env, body, symbols, reqSigs, recursiveHelperFns, new HashMap<>());
+        } catch (Unanswerable _) {
+            // A body resting on a name that denotes nothing gives no type, which is an answer this
+            // reading is allowed to have: settling reports nothing, and the name was reported where
+            // it was written. One helper, so the helpers beside it are still settled — the same
+            // granularity `PipelineSigs.signatures` keeps for one composition.
+            //
+            // Caught at the call rather than inside the reading, because the check reads this same
+            // body through `determine` and needs the signal to reach it. There, a parameter left
+            // open is `check.helper.infer` — annotate it — and a parameter this body never named
+            // because the name beside it denotes nothing is that one mistake seen from another
+            // angle, not a type the author has to supply.
+            return null;
+        }
         if (found.isEmpty()) {
             return null;
         }

--- a/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingCostsOneDefinitionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingCostsOneDefinitionTest.java
@@ -1,0 +1,115 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Located;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name that denotes nothing costs the definition it was written in, and nothing else (issue #335).
+ *
+ * <p>The compiler abandons such a definition rather than reporting it twice, which is what
+ * {@code Unanswerable} says. That signal belongs to the check: it is raised where a body is read for
+ * meaning and caught where one definition's check ends. A reading done for a different reason — the
+ * best-effort settling of a helper's unwritten parameter types, which runs before the check and
+ * reports nothing — must answer "no type" instead of letting the signal past, because there is no
+ * check boundary above it to catch it. Left alone it reached the author as a bare stack trace, and
+ * took the language server's answer for the file with it.
+ *
+ * <p>The settling asks {@code HelperParams.determine} for the types a body gives, and so does the
+ * check. They want opposite things of the signal, which is why it is answered at the settling's call
+ * and not inside the reading the two of them share: suppressed inside, a helper whose body rests on
+ * a broken name would be reported as a parameter the author must annotate, which is that one mistake
+ * seen from another angle rather than anything new to fix.
+ */
+class ANameThatDenotesNothingCostsOneDefinitionTest {
+
+    /** The reduced case from the issue: the name stands in an arm beside the parameter's own use. */
+    private static final String IN_AN_ARM = """
+            module demo
+            let f (a) = if a == 1 then a else Nope
+            """;
+
+    /** The shape the specification itself is written in, which is where this was found. */
+    private static final String AS_THE_SPEC_WRITES_IT = """
+            module demo
+            let preApprove (request, approverId) = {
+                guard approverId == request.applicant.managerId
+                    else NotAuthorized
+
+                PreApproved { ...request, preApprovedAt = now(), preApprover = approverId }
+            }
+            """;
+
+    private static List<Located> diagnosed(String source) {
+        return Compiler.diagnoseModules(Map.of("demo", source)).getOrDefault("demo", List.of());
+    }
+
+    private static List<String> messageKeys(String source) {
+        return diagnosed(source).stream().map(l -> l.diagnostic().messageKey()).toList();
+    }
+
+    @Test
+    void everyEntryPointAnswersWithTheNameRatherThanTheAbandonSignal() {
+        // The signal carries no diagnostic and no frames, so a caller that meets it has nothing to
+        // render and nothing to read. Each of these is someone's only way in.
+        for (String source : List.of(IN_AN_ARM, AS_THE_SPEC_WRITES_IT)) {
+            assertThrows(CompileException.class, () -> Compiler.compile(source),
+                    "`compile` rejects it as the unknown name it is");
+            assertThrows(CompileException.class, () -> Compiler.compileWithWarnings(source),
+                    "`compileWithWarnings` rejects it as the unknown name it is");
+            assertThrows(CompileException.class, () -> Compiler.compiled(source, "demo"),
+                    "`compiled` rejects it as the unknown name it is");
+        }
+    }
+
+    @Test
+    void theLanguageServerIsAnsweredWithDiagnosticsForAFileBeingTyped() {
+        // `diagnoseModules` is the server's path. A throw here is not a diagnostic it can show, and
+        // it takes the dispatch loop with it.
+        assertEquals(List.of("check.unknown.name.msg"), messageKeys(IN_AN_ARM),
+                "the file being typed answers with the name that denotes nothing");
+        assertTrue(messageKeys(AS_THE_SPEC_WRITES_IT).contains("check.unknown.name.msg"),
+                "and so does the shape the specification is written in");
+    }
+
+    @Test
+    void theNameIsSaidOnceAndNothingIsAskedOfTheParameterBesideIt() {
+        // Everything that follows from the broken name is that one mistake seen from another angle.
+        // Telling the author to annotate `a` as well sends them at a parameter that is not the
+        // problem: fixing `Nope` is what settles it.
+        assertEquals(List.of("check.unknown.name.msg"), messageKeys(IN_AN_ARM),
+                "the parameter beside the name is not reported as undetermined");
+    }
+
+    @Test
+    void everyOtherDefinitionInTheModuleIsStillChecked() {
+        // The point of abandoning one definition: an author fixing one name is still told the rest.
+        assertEquals(List.of("check.unknown.name.msg", "check.unknown.name.msg"), messageKeys("""
+                module demo
+                let f (a) = if a == 1 then a else Nope
+                let h (b) = b + Missing
+                """), "both names are reported, one per definition");
+    }
+
+    @Test
+    void aParameterTheBodyGenuinelyLeavesOpenIsStillReported() {
+        // The signal is answered where it is raised for a broken name, not suppressed wholesale: a
+        // body that names no type for its parameter is a different thing, and still says so.
+        assertEquals(List.of("check.helper.infer"), messageKeys("""
+                module demo
+                let id (v) = v
+                """), "nothing in the body names a type for `v`, so the annotation is asked for");
+        assertEquals(List.of("check.helper.infer.field"), messageKeys("""
+                module demo
+                let g (r) = r.x
+                """), "a parameter only ever read through a field still says which it was");
+    }
+}


### PR DESCRIPTION
Fixes #335. Analysis and the rejected alternative are written up in
https://github.com/souther-lang/souther/issues/335#issuecomment-5185375977.

## What was wrong

`Unanswerable` abandons one definition. The settling of a helper's unwritten parameter types
(`HelperParams.settle`) called `determine(...)` outside every guard, so a helper whose body rests on
a name that denotes nothing threw it out of `Shapes.Derived` — a shape-derivation query node, three
layers above `Bodies.Settled` and well before the check phase. `TypeChecker.checkModule`'s recovery
boundary is not on that path, so nothing caught it, and every public entry point handed the author a
throw carrying no diagnostic and no frames:

```souther
module fuzz.probe
let f (a) = if a == 1 then a else Nope
```

`diagnoseModules` is the language server's path, so a file being typed answered with that instead of
the diagnostics it asked for.

## The change

One guard, at the call that does the reading:

```java
try {
    found = determine(h, open, env, body, symbols, reqSigs, recursiveHelperFns, new HashMap<>());
} catch (Unanswerable _) {
    return null;
}
```

The reading is one helper's, done best-effort and reporting nothing, so a body resting on a broken
name giving no type is an answer it is allowed to have. One helper, so the helpers beside it are
still settled — the granularity `PipelineSigs.signatures` already keeps for one composition. All
three entry points into the settling (`Shapes.Derived`, `Bodies.Settled` via `Lower.settle`,
`invariantsForDischarge`) funnel through this method, so one guard covers them.

## Why the guard is not inside the reading

`HelperParams.determine` is read by two callers that want opposite things from the signal:

| caller | phase | wants `Unanswerable` to |
|---|---|---|
| `HelperParams.settle` | pre-check, best-effort | be caught — it reports nothing |
| `HelperTyping.typeFromBody` | check | propagate — `collect()` abandons the definition |

Guarding `BodyTyping.typed()` instead — the obvious companion change, matching its sibling
`readFromBody` — was built as a separate variant and regresses:

| source | this PR | with `typed()` guarded too |
|---|---|---|
| `let f (a) = a + Nope` | `check.unknown.name.msg` @ `Nope` | `check.unknown.name.msg` @ `Nope`<br>**`check.helper.infer` @ `a`** |

The extra report tells the author to annotate `a`, when their only mistake is `Nope` and fixing it
settles `a`. `typed()`'s asymmetry is deliberate; the guard belongs at the call.

## Verification

- spec code blocks (209 extracted): non-`CompileException` escapes **2 → 0**, the two being exactly
  the `preApprove` blocks named in the issue.
- New `ANameThatDenotesNothingCostsOneDefinitionTest`: 5 tests, of which 4 fail without the change.
  The fifth is the control — `check.helper.infer` and `check.helper.infer.field` must still fire for
  a parameter the body genuinely leaves open, so the signal is answered where it is raised rather
  than suppressed wholesale.
- Full test suite green across all modules.

## Not done here

No `catch (Unanswerable)` added to the query adapters. Audited: with this guard there is no live
route left by which the signal reaches a query node, those handlers could not fire, and `Db.ask`
deliberately treats a throw out of `Key.compute` as an internal fault. Centralising the conversion in
`Db.ask` is a query-engine contract change — `Unanswerable` has per-definition granularity while a
key may be a whole module — and belongs in its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
