### PR TITLE
Which module a cursor is in is the file's to say, not the header's

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -396,9 +396,16 @@ public final class Compiler {
                                                              ModulePath path) {
         return Compilation.ofDocuments(sourcesById, brokenModuleNames, path).diagnostics();
     }
-    /** The module name from a source's {@code module <name>} header, for identifying a source that will
-     * not parse (so its importers can be skipped, and the LSP can map a broken file to its module).
-     * {@code null} if no header token is found. */
+    /**
+     * The module name from a source's {@code module <name>} header, for identifying a source that
+     * will not parse (so its importers can be skipped, and the LSP can map a broken file to its
+     * module). {@code null} if no header token is found.
+     *
+     * <p>Only for a source a compilation does not have. Which module a source is part of is
+     * {@link souther.compiler.query.Front.ModuleOf}'s to answer, and this cannot answer it: an
+     * {@code examples for} file writes no header and is part of a module all the same, so what
+     * comes back here is nothing rather than the module its rows are for.
+     */
     public static String moduleNameFromHeader(String source) {
         java.util.regex.Matcher mt = java.util.regex.Pattern
                 .compile("(?m)^\\s*module\\s+([\\p{L}\\p{N}_.]+)").matcher(source);

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -56,9 +56,19 @@ public interface Ast {
          */
         SourcePos namePos();
 
-        /** A binder as the parser read it from a name the author wrote at {@code pos}. */
-        static Binder written(String name, SourcePos pos) {
-            return new Written(name, pos, pos);
+        /**
+         * A binder read off a name the author wrote, taken from the name itself so its spelling and
+         * its place cannot come from two different things.
+         *
+         * <p>There is no form here that takes the two apart. A caller holding a spelling and a
+         * position separately is a caller nothing can stop from pairing a name with somewhere it is
+         * not written, and this branch shipped that mistake three times: the parameter {@code .v}
+         * desugars to, anchored at the {@code .}; a lambda's parameters, all anchored at the
+         * lambda; a {@code match} arm's binding, anchored at the {@code |}. The parser reads a
+         * binder off its token; a pass that needs a name of its own says {@link #desugared}.
+         */
+        static Binder of(Name written) {
+            return new Written(written.written(), written.pos(), written.pos());
         }
 
         /**
@@ -356,11 +366,6 @@ public interface Ast {
         /** A parameter whose type, if any, the author wrote (the common case). */
         public FnParam(Binder binder, RetType type) {
             this(binder, type, false);
-        }
-
-        /** A parameter as the parser read it. */
-        public FnParam(String name, RetType type, SourcePos pos) {
-            this(Binder.written(name, pos), type, false);
         }
 
         public String name() {

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -374,6 +374,15 @@ public interface Ast {
     sealed interface Def extends Ast permits Data, SumData, UnitData {
         String name();
 
+        /**
+         * Where the name is written, which is not where the declaration starts — {@code data} comes
+         * first. A reader asking what a cursor is on has only the name to compare against, and a
+         * declaration that answers from its keyword answers about the keyword.
+         *
+         * <p>Null for a declaration nobody wrote: a unit data a construction implied.
+         */
+        SourcePos namePos();
+
         SourcePos pos();
     }
 
@@ -393,6 +402,7 @@ public interface Ast {
                 List<InvariantClause> invariants,
                 Optional<DecoderDef> decoder,
                 Optional<EncoderDef> encoder,
+                SourcePos namePos,
                 SourcePos pos) implements Def {}
 
     /**
@@ -424,6 +434,7 @@ public interface Ast {
                    List<Name> cases,
                    Optional<Discriminate> decoder,
                    Optional<SumEncoder> encoder,
+                   SourcePos namePos,
                    SourcePos pos) implements Def {}
 
     /** {@code encoder discriminate on "key" { Case -> "tag" ... }} — the inverse of discriminate. */
@@ -432,7 +443,7 @@ public interface Ast {
     record EncVariant(Name caseType, String tag, SourcePos pos) implements Ast {}
 
     /** A unit data definition {@code data U} with no fields. */
-    record UnitData(String name, SourcePos pos) implements Def {}
+    record UnitData(String name, SourcePos namePos, SourcePos pos) implements Def {}
 
     /** {@code decoder from Object discriminate on "key" { "tag" -> Case.decoder ... }} */
     record Discriminate(String key, List<Variant> variants, SourcePos pos) implements Ast {}

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -728,7 +728,10 @@ public interface Ast {
             this(binder, value, null, false, null, body, pos);
         }
 
-        /** The same, as the parser read it. */
+        /** The same, as the parser read it, where the name is written at {@code pos} too — a
+         * binding a pass minted rather than read off a source. A binding the source wrote is built
+         * from a binder of its own, because a {@code let} statement starts at its keyword and the
+         * name it binds is somewhere after it. */
         public LetIn(String name, Expr value, Expr body, SourcePos pos) {
             this(Binder.written(name, pos), value, null, false, null, body, pos);
         }
@@ -739,8 +742,9 @@ public interface Ast {
         }
 
         /** {@code let x: T = value} — a binding the source annotated. */
-        public static LetIn annotated(String name, Expr value, RetType type, Expr body, SourcePos pos) {
-            return new LetIn(Binder.written(name, pos), value, type, true, null, body, pos);
+        public static LetIn annotated(Binder binder, Expr value, RetType type, Expr body,
+                                      SourcePos pos) {
+            return new LetIn(binder, value, type, true, null, body, pos);
         }
 
         public String name() {

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -42,9 +42,32 @@ public interface Ast {
          * after it; nothing decides identity by it. */
         String name();
 
-        /** A binder as the parser read it, before resolution has said which binding it is. */
+        /**
+         * Where the author wrote this name, or null where the author wrote no name at all.
+         *
+         * <p>Not the same as {@link #pos()}, which is the form the binding came from: a {@code let}
+         * statement starts at its keyword, a lambda's parameters share the lambda's start, and a
+         * name a desugaring invented — the parameter {@code .field} becomes, the value a
+         * {@code match} is held in — is written nowhere and only anchored somewhere.
+         *
+         * <p>A reader asking what is under a cursor has this and nothing else to compare against.
+         * Anchoring one of those invented names at a form the author did write would put it under a
+         * cursor on that form, and rename would then rewrite the source with a name no one can see.
+         */
+        SourcePos namePos();
+
+        /** A binder as the parser read it from a name the author wrote at {@code pos}. */
         static Binder written(String name, SourcePos pos) {
-            return new Written(name, pos);
+            return new Written(name, pos, pos);
+        }
+
+        /**
+         * A binder for a name no one wrote: what a desugaring binds a value to so that the form it
+         * is rewriting keeps taking plain names. {@code anchor} is the form it came from, which is
+         * where a complaint about it belongs and is not where its name is.
+         */
+        static Binder desugared(String name, SourcePos anchor) {
+            return new Written(name, null, anchor);
         }
 
         /**
@@ -63,7 +86,7 @@ public interface Ast {
         }
 
         /** A binder as the parser read it. */
-        record Written(String name, SourcePos pos) implements Binder {
+        record Written(String name, SourcePos namePos, SourcePos pos) implements Binder {
 
             @Override
             public String toString() {
@@ -72,7 +95,8 @@ public interface Ast {
         }
 
         /** A binder resolution answered, and the binding it introduces. */
-        record Bound(String name, BindingId binding, SourcePos pos) implements Binder {
+        record Bound(String name, BindingId binding, SourcePos namePos,
+                     SourcePos pos) implements Binder {
 
             public Bound {
                 if (binding == null) {
@@ -104,9 +128,10 @@ public interface Ast {
             this.owner = owner;
         }
 
-        /** A binding nothing else has, under this pass's owner. */
+        /** A binding nothing else has, under this pass's owner. A pass writes its own names, so
+         * none of them is a name the author wrote. */
         public Binder binder(String name, SourcePos pos) {
-            return new Binder.Bound(name, new BindingId(owner, next++), pos);
+            return new Binder.Bound(name, new BindingId(owner, next++), null, pos);
         }
     }
 
@@ -690,11 +715,13 @@ public interface Ast {
      */
     record Block(List<Binder> params, Expr body, SourcePos pos) implements Expr {
 
-        /** A block as the parser read it. */
-        public static Block written(List<String> params, Expr body, SourcePos pos) {
+        /** A block whose parameters are names no one wrote — what a desugaring builds. A block the
+         * author wrote is built from binders of its own, because its parameters are written one by
+         * one and the block's own position is where the first of them starts at best. */
+        public static Block desugared(List<String> params, Expr body, SourcePos pos) {
             List<Binder> binders = new ArrayList<>();
             for (String p : params) {
-                binders.add(Binder.written(p, pos));
+                binders.add(Binder.desugared(p, pos));
             }
             return new Block(binders, body, pos);
         }
@@ -728,12 +755,11 @@ public interface Ast {
             this(binder, value, null, false, null, body, pos);
         }
 
-        /** The same, as the parser read it, where the name is written at {@code pos} too — a
-         * binding a pass minted rather than read off a source. A binding the source wrote is built
-         * from a binder of its own, because a {@code let} statement starts at its keyword and the
-         * name it binds is somewhere after it. */
+        /** A binding for a name no one wrote: what a desugaring holds a value in. A binding the
+         * source wrote is built from a binder of its own, because a {@code let} statement starts at
+         * its keyword and the name it binds is somewhere after it. */
         public LetIn(String name, Expr value, Expr body, SourcePos pos) {
-            this(Binder.written(name, pos), value, null, false, null, body, pos);
+            this(Binder.desugared(name, pos), value, null, false, null, body, pos);
         }
 
         /** A binding carrying an inlined helper parameter's declared type. */
@@ -758,7 +784,7 @@ public interface Ast {
          * behind it, so the name is carried here for the checker to hold against the value's type.
          */
         public static LetIn opening(String name, Expr value, Name opens, Expr body, SourcePos pos) {
-            return new LetIn(Binder.written(name, pos), value, null, false, opens, body, pos);
+            return new LetIn(Binder.desugared(name, pos), value, null, false, opens, body, pos);
         }
 
         /** The type the source wrote on this binding, or null when it wrote none. An annotation is an
@@ -887,9 +913,6 @@ public interface Ast {
         }
 
         /** The same, as the parser read it. */
-        public IfConstructed(Expr construct, String binder, Expr then, Expr els, SourcePos pos) {
-            this(construct, Binder.written(binder, pos), then, List.of(ElseArm.any(els)), pos);
-        }
 
         /** How the binding was written. */
         public String binderName() {
@@ -944,13 +967,6 @@ public interface Ast {
                 SourcePos pos) implements Ast {
         public Case(List<Name> caseTypes, Binder binding, Expr body, SourcePos pos) {
             this(caseTypes, binding, body, null, pos);
-        }
-
-        /** An arm as the parser read it; {@code binding} is null where the arm binds nothing. */
-        public static Case written(List<Name> caseTypes, String binding, Expr body,
-                                   List<Name> unwrapAsserts, SourcePos pos) {
-            return new Case(caseTypes, binding == null ? null : Binder.written(binding, pos), body,
-                    unwrapAsserts, pos);
         }
 
         /** How the binding was written, or null where the arm binds nothing. */

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1559,9 +1559,11 @@ public final class HelperInliner {
                     mine.put(binder.id(), binders.binder(binder.name(), binder.pos()).id()));
         }
 
-        /** This copy's binder for one the body has. */
+        /** This copy's binder for one the body has. The copy is this pass's writing, however much
+         * it reads like the body it was taken from, so it claims no name position: the place the
+         * author wrote that name is the original binding's and stays with it. */
         Ast.Binder of(Ast.Binder binder) {
-            return new Ast.Binder.Bound(binder.name(), mine.get(binder.id()), binder.pos());
+            return new Ast.Binder.Bound(binder.name(), mine.get(binder.id()), null, binder.pos());
         }
 
         /** The same, for a name that reads one. A name bound outside the body — a parameter, which

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -546,7 +546,7 @@ public final class HelperInliner {
             defs.add(def instanceof Ast.Data d && !d.invariants().isEmpty()
                     ? new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(),
                             Ast.mapClauses(d.invariants(), inv -> qualifyForeign(inv, m.name())),
-                            d.decoder(), d.encoder(), d.pos())
+                            d.decoder(), d.encoder(), d.namePos(), d.pos())
                     : def);
         }
         return defs;
@@ -702,7 +702,7 @@ public final class HelperInliner {
                 BindingOwner declared = new BindingOwner.OfData(new TypeName(m.name(), d.name()));
                 defs.add(new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(),
                         Ast.mapClauses(d.invariants(), clause -> inline(clause, declared)),
-                        d.decoder(), d.encoder(), d.pos()));
+                        d.decoder(), d.encoder(), d.namePos(), d.pos()));
             } else {
                 defs.add(def);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -96,7 +96,7 @@ public final class Lower {
             if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
                 defs.add(new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(),
                         Ast.mapClauses(d.invariants(), Lower::desugar),
-                        d.decoder(), d.encoder(), d.pos()));
+                        d.decoder(), d.encoder(), d.namePos(), d.pos()));
             } else {
                 defs.add(def);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -54,7 +54,7 @@ public final class NewtypeDesugar {
             if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
                 defs.add(new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(),
                         Ast.mapClauses(d.invariants(), inv -> go(inv, symbols)),
-                        d.decoder(), d.encoder(), d.pos()));
+                        d.decoder(), d.encoder(), d.namePos(), d.pos()));
             } else {
                 defs.add(def);
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -350,10 +350,11 @@ public final class Resolve {
                 declareFields(d);
                 yield new Ast.Data(d.name(), d.newtype(), names(d.includes()), fields(d.fields()),
                         Ast.mapClauses(d.invariants(), inv -> expr(inv, boundFields(d))),
-                        d.decoder().map(this::decoder), d.encoder().map(this::encoder), d.pos());
+                        d.decoder().map(this::decoder), d.encoder().map(this::encoder),
+                        d.namePos(), d.pos());
             }
             case Ast.SumData s -> new Ast.SumData(s.name(), sumCases(s), s.decoder().map(this::discriminate),
-                    s.encoder().map(this::sumEncoder), s.pos());
+                    s.encoder().map(this::sumEncoder), s.namePos(), s.pos());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -78,8 +78,14 @@ public final class Resolve {
     private Answered bind(Bindings bound, Ast.Binder binder) {
         int ordinal = counts.merge(owner, 1, Integer::sum) - 1;
         BindingId id = new BindingId(owner, ordinal);
-        binders.put(id, new BoundName(binder.name(), binder.pos()));
-        return new Answered(new Ast.Binder.Bound(binder.name(), id, binder.pos()),
+        if (binder.namePos() != null) {
+            // Only a name the author wrote is a place a reader can be sent to or asked about. A
+            // desugaring's binding is anchored on the form it came from, which is a place holding
+            // something the author did write.
+            binders.put(id, new BoundName(binder.name(), binder.namePos()));
+        }
+        return new Answered(
+                new Ast.Binder.Bound(binder.name(), id, binder.namePos(), binder.pos()),
                 bound.and(binder.name(), new ValueName.Local(binder.name(), id)));
     }
 
@@ -162,11 +168,17 @@ public final class Resolve {
      * resolved as if the mistake were not there — so an author is told about every unknown name at
      * once instead of one per compile, and an editor can still say what the names around it mean.
      *
-     * <p>{@code binders} says what each binding is called and where that was written. A binding is
-     * not its position — a pass that expands a helper stamps the call site over the positions in the
-     * copy — so the two are kept apart, and a reader asking about the source rather than about the
-     * program reads this. The spelling comes with it because a reader asking what a cursor is on has
-     * to know how far the name reaches, and a position alone does not say.
+     * <p>{@code binders} says what each binding is called and where the author wrote that name. A
+     * binding is not its position — a pass that expands a helper stamps the call site over the
+     * positions in the copy — so the two are kept apart, and a reader asking about the source rather
+     * than about the program reads this. The spelling comes with it because a reader asking what a
+     * cursor is on has to know how far the name reaches, and a position alone does not say.
+     *
+     * <p>Only the bindings whose names the author wrote are in it. A desugaring binds a value to a
+     * name of its own — the parameter {@code .field} becomes, the value a {@code match} is held in —
+     * and anchors it on the form it was rewriting. That anchor is a place in the source holding
+     * something else, so a reader answered with one of these would be answered about a name that is
+     * not there, at a width that is not its.
      */
     public record Resolved(Ast.Module module, List<Denotation> denotations, List<ValueUse> values,
                            List<CompileException> unresolved, Map<BindingId, BoundName> binders) {}
@@ -405,7 +417,7 @@ public final class Resolve {
         for (Ast.Field field : d.fields()) {
             BindingId binding = bindings.get(field.name());
             if (binding != null) {
-                binders.put(binding, new BoundName(field.name(), field.pos()));
+                binders.put(binding, new BoundName(field.name(), field.pos()));   // OfFields
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -48,8 +48,8 @@ public final class Resolve {
     private final List<ValueUse> values0 = new ArrayList<>();
     /** Every name it could not answer, as the error it would once have thrown. */
     private final List<CompileException> unresolved = new ArrayList<>();
-    /** Where each binding this pass gave an identity to is written. */
-    private final Map<BindingId, SourcePos> binders = new LinkedHashMap<>();
+    /** What each binding this pass gave an identity to is called, and where that is written. */
+    private final Map<BindingId, BoundName> binders = new LinkedHashMap<>();
     /** How many bindings each definition has been given, so the next one gets the next number. */
     private final Map<BindingOwner, Integer> counts = new HashMap<>();
     /** The definition whose text is being read. Every binding met belongs to it. */
@@ -78,7 +78,7 @@ public final class Resolve {
     private Answered bind(Bindings bound, Ast.Binder binder) {
         int ordinal = counts.merge(owner, 1, Integer::sum) - 1;
         BindingId id = new BindingId(owner, ordinal);
-        binders.put(id, binder.pos());
+        binders.put(id, new BoundName(binder.name(), binder.pos()));
         return new Answered(new Ast.Binder.Bound(binder.name(), id, binder.pos()),
                 bound.and(binder.name(), new ValueName.Local(binder.name(), id)));
     }
@@ -162,12 +162,17 @@ public final class Resolve {
      * resolved as if the mistake were not there — so an author is told about every unknown name at
      * once instead of one per compile, and an editor can still say what the names around it mean.
      *
-     * <p>{@code binders} says where each binding was written. A binding is not its position — a pass
-     * that expands a helper stamps the call site over the positions in the copy — so the two are kept
-     * apart, and a reader asking about the source rather than about the program reads this.
+     * <p>{@code binders} says what each binding is called and where that was written. A binding is
+     * not its position — a pass that expands a helper stamps the call site over the positions in the
+     * copy — so the two are kept apart, and a reader asking about the source rather than about the
+     * program reads this. The spelling comes with it because a reader asking what a cursor is on has
+     * to know how far the name reaches, and a position alone does not say.
      */
     public record Resolved(Ast.Module module, List<Denotation> denotations, List<ValueUse> values,
-                           List<CompileException> unresolved, Map<BindingId, SourcePos> binders) {}
+                           List<CompileException> unresolved, Map<BindingId, BoundName> binders) {}
+
+    /** What a binding is called, and where that name is written. */
+    public record BoundName(String written, SourcePos pos) {}
 
     /** {@code m} with every name it writes resolved against its own definitions — a module compiled
      * with nothing else in sight. */
@@ -400,7 +405,7 @@ public final class Resolve {
         for (Ast.Field field : d.fields()) {
             BindingId binding = bindings.get(field.name());
             if (binding != null) {
-                binders.put(binding, field.pos());
+                binders.put(binding, new BoundName(field.name(), field.pos()));
             }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -77,7 +77,7 @@ public final class Deriver {
                         new Ast.Binders(new BindingOwner.Synthesized(declared,
                                 BindingOwner.Pass.DERIVER, 1))));
         return new Ast.Data(d.name(), d.newtype(), d.includes(), d.fields(), d.invariants(),
-                decoder, encoder, d.pos());
+                decoder, encoder, d.namePos(), d.pos());
     }
 
     // --- decoder derivation ---
@@ -375,7 +375,7 @@ public final class Deriver {
         Optional<Ast.SumEncoder> encoder = s.encoder().isPresent()
                 ? s.encoder()
                 : Optional.of(new Ast.SumEncoder("type", encVariants(s, leaves), s.pos()));
-        return new Ast.SumData(s.name(), s.cases(), decoder, encoder, s.pos());
+        return new Ast.SumData(s.name(), s.cases(), decoder, encoder, s.namePos(), s.pos());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -242,6 +242,7 @@ public final class AstBuilder {
 
     private Ast.Def dataDef(SyntaxNode n) {
         String name = firstIdentText(n);
+        SourcePos namePos = posOf(firstIdentToken(n));
         SourcePos pos = pos(n);
         List<Ast.InvariantClause> clauses = invariants(n, name);
 
@@ -268,7 +269,7 @@ public final class AstBuilder {
                         "data `" + name + "` has an empty body");
             }
             return new Ast.Data(name, false, includes, fields, clauses,
-                    Optional.empty(), Optional.empty(), pos);
+                    Optional.empty(), Optional.empty(), namePos, pos);
         }
         Optional<SyntaxNode> sum = n.child(SyntaxKind.SUM_BODY);
         if (sum.isPresent()) {
@@ -276,7 +277,7 @@ public final class AstBuilder {
             for (SyntaxToken t : identTokens(sum.get())) {
                 cases.add(Ast.Name.written(t.text(), posOf(t)));
             }
-            return new Ast.SumData(name, cases, Optional.empty(), Optional.empty(), pos);
+            return new Ast.SumData(name, cases, Optional.empty(), Optional.empty(), namePos, pos);
         }
         Optional<SyntaxNode> newtype = n.child(SyntaxKind.NEWTYPE_BODY);
         if (newtype.isPresent()) {
@@ -287,7 +288,7 @@ public final class AstBuilder {
             }
             List<Ast.Field> fields = List.of(new Ast.Field("value", innerType, pos(inner)));
             return new Ast.Data(name, true, List.of(), fields, clauses,
-                    Optional.empty(), Optional.empty(), pos);
+                    Optional.empty(), Optional.empty(), namePos, pos);
         }
         // No body of any kind: a unit data, which has no fields for an invariant to observe (spec
         // §unit-data). The parser takes an `invariant` clause after any data, so this is where a
@@ -299,7 +300,7 @@ public final class AstBuilder {
                             .at(pos(clause)).args(name).build(),
                     "unit data `" + name + "` cannot carry an invariant");
         }
-        return new Ast.UnitData(name, pos);
+        return new Ast.UnitData(name, namePos, pos);
     }
 
     /**
@@ -1262,9 +1263,14 @@ public final class AstBuilder {
      * builder names a {@code data}, a {@code behavior} and a {@code let}, and how the declaration's
      * source is filed under the same name when a module publishes what it declares. */
     static String firstIdentText(SyntaxNode n) {
+        return firstIdentToken(n).text();
+    }
+
+    /** The token that spells what a top-level declaration declares. */
+    static SyntaxToken firstIdentToken(SyntaxNode n) {
         for (SyntaxElement e : n.children()) {
             if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
-                return t.text();
+                return t;
             }
         }
         throw new IllegalStateException("no identifier in " + n.kind());

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -1090,9 +1090,12 @@ public final class AstBuilder {
                 Ast.RetType annotation = s.child(SyntaxKind.RET_TYPE).map(this::retType).orElse(null);
                 Ast.Expr value = expr(onlyExpr(s));
                 Ast.Expr rest = foldStatements(stmts, index + 1, result);
+                // The statement starts at its keyword and the binding is written after it. A reader
+                // asking what a cursor is on has only the name to compare against.
+                Ast.Binder bound = binderOf(s);
                 yield annotation == null
-                        ? new Ast.LetIn(firstIdentText(s), value, rest, pos)
-                        : Ast.LetIn.annotated(firstIdentText(s), value, annotation, rest, pos);
+                        ? new Ast.LetIn(bound, value, rest, pos)
+                        : Ast.LetIn.annotated(bound, value, annotation, rest, pos);
             }
             case GUARD_STMT -> {
                 List<SyntaxNode> exprs = exprChildren(s);
@@ -1125,7 +1128,7 @@ public final class AstBuilder {
      */
     private Ast.Expr bindPattern(SyntaxNode pat, Ast.Expr value, Ast.Expr rest, SourcePos pos) {
         return switch (pat.kind()) {
-            case PATTERN_NAME -> new Ast.LetIn(firstIdentText(pat), value, rest, pos);
+            case PATTERN_NAME -> new Ast.LetIn(binderOf(pat), value, rest, pos);
             case PATTERN_TUPLE -> {
                 List<SyntaxNode> elems = patternChildren(pat);
                 if (elems.size() == 1) {
@@ -1376,6 +1379,12 @@ public final class AstBuilder {
 
     private SourcePos posOf(SyntaxToken t) {
         return lines.posOf(t.start());
+    }
+
+    /** The name {@code n} binds, written where the source writes it. */
+    private Ast.Binder binderOf(SyntaxNode n) {
+        SyntaxToken name = firstIdentToken(n);
+        return Ast.Binder.written(name.text(), posOf(name));
     }
 
     /** The whole `{ ... }` of a body, so an error about the body underlines both braces. */

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -465,7 +465,12 @@ public final class AstBuilder {
     }
 
     private Ast.FnParam fnParam(SyntaxNode p, SyntaxNode pat) {
-        String name = pat == null ? firstIdentText(p) : "$p" + (patternCounter++);
+        // A parameter the author named binds that name where it is written. One that is a pattern
+        // takes a carrier the author never wrote; the pattern opens itself at the top of the body,
+        // and the names it binds are written there.
+        Ast.Binder bound = pat == null
+                ? binderOf(p)
+                : Ast.Binder.desugared("$p" + (patternCounter++), pos(p));
         Ast.RetType type = null;
         Optional<SyntaxNode> rt = p.child(SyntaxKind.RET_TYPE);
         if (rt.isPresent()) {
@@ -476,9 +481,9 @@ public final class AstBuilder {
             // only repeat what the pattern already named
             SourcePos at = pos(pat);
             type = new Ast.RetType(List.of(new Ast.TypeRef(qualifiedNameText(pat), null, at)), at);
-            return new Ast.FnParam(Ast.Binder.written(name, pos(p)), type, true);
+            return new Ast.FnParam(bound, type, true);
         }
-        return new Ast.FnParam(name, type, pos(p));
+        return new Ast.FnParam(bound, type, false);
     }
 
     private SyntaxNode optionalPatternChild(SyntaxNode n) {
@@ -760,12 +765,12 @@ public final class AstBuilder {
         List<Ast.ElseArm> arms = elseArms(n, binder);
         if (arms != null) {
             return new Ast.IfConstructed(expr(exprs.get(0)),
-                    Ast.Binder.written(binder, posOf(as)), expr(exprs.get(1)), arms, pos(n));
+                    binderOf(as), expr(exprs.get(1)), arms, pos(n));
         }
         return binder == null
                 ? new Ast.If(expr(exprs.get(0)), expr(exprs.get(1)), expr(exprs.get(2)), pos(n))
                 : new Ast.IfConstructed(expr(exprs.get(0)),
-                        Ast.Binder.written(binder, posOf(as)), expr(exprs.get(1)),
+                        binderOf(as), expr(exprs.get(1)),
                         List.of(Ast.ElseArm.any(expr(exprs.get(2)))), pos(n));
     }
 
@@ -982,7 +987,7 @@ public final class AstBuilder {
         // Option is the one case with a payload to reach, so every other case binds its value with
         // `as` and a bare identifier beside its name binds nothing.
         String someBinding = null;
-        SourcePos bindingPos = null;   // where the author wrote the name the arm binds, if they did
+        SyntaxToken bindingToken = null;   // the name the author wrote for the arm, if they did
         if (unwrapNames.isEmpty() && i < es.size() && isToken(es.get(i), SyntaxKind.IDENT)) {
             String ident = tokenText(es.get(i));
             // A qualified name is not a case this advice fits: `Some` is the one case with a payload
@@ -996,23 +1001,25 @@ public final class AstBuilder {
                         caseTypes.get(caseTypes.size() - 1).written(), ident);
             }
             someBinding = ident;
-            bindingPos = posOf((SyntaxToken) es.get(i));
+            bindingToken = (SyntaxToken) es.get(i);
             i++;
         }
         // field destructuring `{ field [= var], ... }`
         List<String> fieldNames = new ArrayList<>();
-        List<String> fieldVars = new ArrayList<>();
+        List<Ast.Binder> fieldVars = new ArrayList<>();
         if (i < es.size() && isToken(es.get(i), SyntaxKind.LBRACE)) {
             i++;   // {
             while (i < es.size() && !isToken(es.get(i), SyntaxKind.RBRACE)) {
-                String field = tokenText(es.get(i++));
-                String var = field;
+                SyntaxToken fieldToken = (SyntaxToken) es.get(i++);
+                // `{ v }` binds the field's own name; `{ v = x }` binds the name after the `=`.
+                // Either way the binding is written where its token is.
+                SyntaxToken varToken = fieldToken;
                 if (i < es.size() && isToken(es.get(i), SyntaxKind.ASSIGN)) {
                     i++;
-                    var = tokenText(es.get(i++));
+                    varToken = (SyntaxToken) es.get(i++);
                 }
-                fieldNames.add(field);
-                fieldVars.add(var);
+                fieldNames.add(fieldToken.text());
+                fieldVars.add(binderOf(varToken));
                 if (i < es.size() && isToken(es.get(i), SyntaxKind.COMMA)) {
                     i++;
                 }
@@ -1026,7 +1033,7 @@ public final class AstBuilder {
         if (i < es.size() && isToken(es.get(i), SyntaxKind.AS_KW)) {
             i++;
             asBinding = tokenText(es.get(i));
-            bindingPos = posOf((SyntaxToken) es.get(i++));
+            bindingToken = (SyntaxToken) es.get(i++);
         }
         if (isSome && asBinding != null) {
             throw error(casePos, "parse.option.positional",
@@ -1045,7 +1052,7 @@ public final class AstBuilder {
         if (!fieldNames.isEmpty()) {
             String whole = binding != null ? binding : "$m" + (matchWholeCounter++);
             if (binding == null) {
-                bindingPos = null;   // the arm binds a name nobody wrote
+                bindingToken = null;   // the arm holds the value in a name nobody wrote
             }
             for (int k = fieldNames.size() - 1; k >= 0; k--) {
                 body = new Ast.LetIn(fieldVars.get(k),
@@ -1056,7 +1063,7 @@ public final class AstBuilder {
         } else if (!unwrapNames.isEmpty()) {
             String whole = binding != null ? binding : "$m" + (matchWholeCounter++);
             if (binding == null) {
-                bindingPos = null;   // the arm binds a name nobody wrote
+                bindingToken = null;   // the arm holds the value in a name nobody wrote
             }
             // open the case's newtype (whole.value), then peel one layer per earlier name; the last
             // name binds the value reached — `アクティベート済み(メールアドレス(s))` binds s to whole.value.value.
@@ -1068,7 +1075,8 @@ public final class AstBuilder {
             for (int k = 0; k < unwrapNames.size() - 1; k++) {
                 target = new Ast.FieldAccess(target, "value", casePos);
             }
-            body = new Ast.LetIn(unwrapNames.get(unwrapNames.size() - 1).written(), target, body, casePos);
+            Ast.Name innermost = unwrapNames.get(unwrapNames.size() - 1);
+            body = new Ast.LetIn(Ast.Binder.of(innermost), target, body, casePos);
             binding = whole;
         }
         // null = no constructor destructure; otherwise the inner names (before the bound variable),
@@ -1076,8 +1084,10 @@ public final class AstBuilder {
         List<Ast.Name> unwrapAsserts = unwrapNames.isEmpty()
                 ? null
                 : new ArrayList<>(unwrapNames.subList(0, unwrapNames.size() - 1));
-        return new Ast.Case(caseTypes, binderFor(binding, bindingPos, casePos), body,
-                unwrapAsserts, casePos);
+        Ast.Binder bound = binding == null ? null
+                : bindingToken != null ? binderOf(bindingToken)
+                : Ast.Binder.desugared(binding, casePos);
+        return new Ast.Case(caseTypes, bound, body, unwrapAsserts, casePos);
     }
 
     /** A brace block: its {@code let}/{@code guard} statements folded into the result expression. */
@@ -1119,12 +1129,12 @@ public final class AstBuilder {
                 List<Ast.ElseArm> arms = elseArms(s, binder);
                 if (arms != null) {
                     yield new Ast.IfConstructed(expr(exprs.get(0)),
-                            Ast.Binder.written(binder, posOf(as)), rest, arms, pos);
+                            binderOf(as), rest, arms, pos);
                 }
                 yield binder == null
                         ? new Ast.If(expr(exprs.get(0)), rest, expr(exprs.get(1)), pos)
                         : new Ast.IfConstructed(expr(exprs.get(0)),
-                                Ast.Binder.written(binder, posOf(as)), rest,
+                                binderOf(as), rest,
                                 List.of(Ast.ElseArm.any(expr(exprs.get(1)))), pos);
             }
             case LET_DESTRUCTURE -> {
@@ -1172,8 +1182,8 @@ public final class AstBuilder {
                 for (int k = fields.size() - 1; k >= 0; k--) {
                     List<SyntaxToken> names = identTokens(fields.get(k));
                     String field = names.get(0).text();
-                    String var = names.size() > 1 ? names.get(1).text() : field;
-                    body = new Ast.LetIn(var,
+                    SyntaxToken var = names.size() > 1 ? names.get(1) : names.get(0);
+                    body = new Ast.LetIn(binderOf(var),
                             new Ast.FieldAccess(new Ast.Var(whole, pos), field, pos), body, pos);
                 }
                 yield new Ast.LetIn(whole, value, body, pos);
@@ -1399,19 +1409,16 @@ public final class AstBuilder {
 
     /** The name {@code n} binds, written where the source writes it. */
     private Ast.Binder binderOf(SyntaxNode n) {
-        SyntaxToken name = firstIdentToken(n);
-        return Ast.Binder.written(name.text(), posOf(name));
+        return binderOf(firstIdentToken(n));
     }
 
-    /** A binding of {@code name}, written at {@code namePos} where the author wrote it and anchored
-     * at {@code anchor} where the name is one a desugaring needed. Null where nothing is bound. */
-    private static Ast.Binder binderFor(String name, SourcePos namePos, SourcePos anchor) {
-        if (name == null) {
-            return null;
-        }
-        return namePos == null
-                ? Ast.Binder.desugared(name, anchor) : Ast.Binder.written(name, namePos);
+    /** The name {@code token} spells, bound where it is written. The one way this builder makes a
+     * binding out of something the author wrote: the token carries both halves, so they cannot be
+     * paired wrongly. */
+    private Ast.Binder binderOf(SyntaxToken token) {
+        return Ast.Binder.of(Ast.Name.written(token.text(), posOf(token)));
     }
+
 
     /** The whole `{ ... }` of a body, so an error about the body underlines both braces. */
     private Region bodyRegion(SyntaxNode body) {

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -755,16 +755,18 @@ public final class AstBuilder {
 
     private Ast.Expr ifExpr(SyntaxNode n) {
         List<SyntaxNode> exprs = exprChildren(n);
-        String binder = attemptBinder(n);
+        SyntaxToken as = attemptBinder(n);
+        String binder = as == null ? null : as.text();
         List<Ast.ElseArm> arms = elseArms(n, binder);
         if (arms != null) {
-            return new Ast.IfConstructed(expr(exprs.get(0)), Ast.Binder.written(binder, pos(n)),
-                    expr(exprs.get(1)), arms, pos(n));
+            return new Ast.IfConstructed(expr(exprs.get(0)),
+                    Ast.Binder.written(binder, posOf(as)), expr(exprs.get(1)), arms, pos(n));
         }
         return binder == null
                 ? new Ast.If(expr(exprs.get(0)), expr(exprs.get(1)), expr(exprs.get(2)), pos(n))
-                : new Ast.IfConstructed(expr(exprs.get(0)), binder,
-                        expr(exprs.get(1)), expr(exprs.get(2)), pos(n));
+                : new Ast.IfConstructed(expr(exprs.get(0)),
+                        Ast.Binder.written(binder, posOf(as)), expr(exprs.get(1)),
+                        List.of(Ast.ElseArm.any(expr(exprs.get(2)))), pos(n));
     }
 
     /**
@@ -806,14 +808,14 @@ public final class AstBuilder {
     /** The {@code x} of an attempted construction's {@code as x}, or {@code null} where none was
      * written. The binder is the identifier following {@code as} among the form's own tokens; the
      * condition is a child node, so its identifiers are not among them. */
-    private static String attemptBinder(SyntaxNode n) {
+    private static SyntaxToken attemptBinder(SyntaxNode n) {
         boolean afterAs = false;
         for (SyntaxElement e : n.children()) {
             if (!(e instanceof SyntaxToken t)) continue;
             if (t.kind() == SyntaxKind.AS_KW) {
                 afterAs = true;
             } else if (afterAs && t.kind() == SyntaxKind.IDENT) {
-                return t.text();
+                return t;
             }
         }
         return null;
@@ -825,20 +827,22 @@ public final class AstBuilder {
     private Ast.Expr lambda(SyntaxNode n) {
         SourcePos pos = pos(n);
         List<SyntaxNode> pats = patternChildren(n);
-        List<String> params = new ArrayList<>();
+        List<Ast.Binder> params = new ArrayList<>();
         for (SyntaxNode p : pats) {
+            // A parameter the author named is a name written where it is written; one that is a
+            // pattern takes a fresh name nobody wrote, anchored on the pattern it stands for.
             params.add(p.kind() == SyntaxKind.PATTERN_NAME
-                    ? firstIdentText(p)
-                    : "$p" + (patternCounter++));
+                    ? binderOf(p)
+                    : Ast.Binder.desugared("$p" + (patternCounter++), pos(p)));
         }
         Ast.Expr body = expr(lastExprChild(n));
         for (int i = pats.size() - 1; i >= 0; i--) {
             if (pats.get(i).kind() != SyntaxKind.PATTERN_NAME) {
                 SourcePos at = pos(pats.get(i));
-                body = bindPattern(pats.get(i), new Ast.Var(params.get(i), at), body, at);
+                body = bindPattern(pats.get(i), new Ast.Var(params.get(i).name(), at), body, at);
             }
         }
-        return Ast.Block.written(params, body, pos);
+        return new Ast.Block(List.copyOf(params), body, pos);
     }
 
     private Ast.Expr fieldGetter(SyntaxNode n) {
@@ -850,7 +854,7 @@ public final class AstBuilder {
         SourcePos pos = pos(n);
         String param = "$g" + (getterCounter++);
         Ast.Expr body = new Ast.FieldAccess(new Ast.Var(param, pos), field.text(), posOf(field));
-        return Ast.Block.written(List.of(param), body, pos);
+        return Ast.Block.desugared(List.of(param), body, pos);
     }
 
     private Ast.Expr newData(SyntaxNode n) {
@@ -978,6 +982,7 @@ public final class AstBuilder {
         // Option is the one case with a payload to reach, so every other case binds its value with
         // `as` and a bare identifier beside its name binds nothing.
         String someBinding = null;
+        SourcePos bindingPos = null;   // where the author wrote the name the arm binds, if they did
         if (unwrapNames.isEmpty() && i < es.size() && isToken(es.get(i), SyntaxKind.IDENT)) {
             String ident = tokenText(es.get(i));
             // A qualified name is not a case this advice fits: `Some` is the one case with a payload
@@ -991,6 +996,7 @@ public final class AstBuilder {
                         caseTypes.get(caseTypes.size() - 1).written(), ident);
             }
             someBinding = ident;
+            bindingPos = posOf((SyntaxToken) es.get(i));
             i++;
         }
         // field destructuring `{ field [= var], ... }`
@@ -1019,7 +1025,8 @@ public final class AstBuilder {
         String asBinding = null;
         if (i < es.size() && isToken(es.get(i), SyntaxKind.AS_KW)) {
             i++;
-            asBinding = tokenText(es.get(i++));
+            asBinding = tokenText(es.get(i));
+            bindingPos = posOf((SyntaxToken) es.get(i++));
         }
         if (isSome && asBinding != null) {
             throw error(casePos, "parse.option.positional",
@@ -1037,6 +1044,9 @@ public final class AstBuilder {
         String binding = someBinding != null ? someBinding : asBinding;
         if (!fieldNames.isEmpty()) {
             String whole = binding != null ? binding : "$m" + (matchWholeCounter++);
+            if (binding == null) {
+                bindingPos = null;   // the arm binds a name nobody wrote
+            }
             for (int k = fieldNames.size() - 1; k >= 0; k--) {
                 body = new Ast.LetIn(fieldVars.get(k),
                         new Ast.FieldAccess(new Ast.Var(whole, casePos), fieldNames.get(k), casePos),
@@ -1045,6 +1055,9 @@ public final class AstBuilder {
             binding = whole;
         } else if (!unwrapNames.isEmpty()) {
             String whole = binding != null ? binding : "$m" + (matchWholeCounter++);
+            if (binding == null) {
+                bindingPos = null;   // the arm binds a name nobody wrote
+            }
             // open the case's newtype (whole.value), then peel one layer per earlier name; the last
             // name binds the value reached — `アクティベート済み(メールアドレス(s))` binds s to whole.value.value.
             // Option's `Some` binds the unwrapped element already (codegen strips the wrapper), so its
@@ -1063,7 +1076,8 @@ public final class AstBuilder {
         List<Ast.Name> unwrapAsserts = unwrapNames.isEmpty()
                 ? null
                 : new ArrayList<>(unwrapNames.subList(0, unwrapNames.size() - 1));
-        return Ast.Case.written(caseTypes, binding, body, unwrapAsserts, casePos);
+        return new Ast.Case(caseTypes, binderFor(binding, bindingPos, casePos), body,
+                unwrapAsserts, casePos);
     }
 
     /** A brace block: its {@code let}/{@code guard} statements folded into the result expression. */
@@ -1099,17 +1113,19 @@ public final class AstBuilder {
             }
             case GUARD_STMT -> {
                 List<SyntaxNode> exprs = exprChildren(s);
-                String binder = attemptBinder(s);
+                SyntaxToken as = attemptBinder(s);
+                String binder = as == null ? null : as.text();
                 Ast.Expr rest = foldStatements(stmts, index + 1, result);
                 List<Ast.ElseArm> arms = elseArms(s, binder);
                 if (arms != null) {
-                    yield new Ast.IfConstructed(expr(exprs.get(0)), Ast.Binder.written(binder, pos),
-                            rest, arms, pos);
+                    yield new Ast.IfConstructed(expr(exprs.get(0)),
+                            Ast.Binder.written(binder, posOf(as)), rest, arms, pos);
                 }
                 yield binder == null
                         ? new Ast.If(expr(exprs.get(0)), rest, expr(exprs.get(1)), pos)
-                        : new Ast.IfConstructed(expr(exprs.get(0)), binder, rest,
-                                expr(exprs.get(1)), pos);
+                        : new Ast.IfConstructed(expr(exprs.get(0)),
+                                Ast.Binder.written(binder, posOf(as)), rest,
+                                List.of(Ast.ElseArm.any(expr(exprs.get(1)))), pos);
             }
             case LET_DESTRUCTURE -> {
                 SyntaxNode pat = patternChild(s);
@@ -1385,6 +1401,16 @@ public final class AstBuilder {
     private Ast.Binder binderOf(SyntaxNode n) {
         SyntaxToken name = firstIdentToken(n);
         return Ast.Binder.written(name.text(), posOf(name));
+    }
+
+    /** A binding of {@code name}, written at {@code namePos} where the author wrote it and anchored
+     * at {@code anchor} where the name is one a desugaring needed. Null where nothing is bound. */
+    private static Ast.Binder binderFor(String name, SourcePos namePos, SourcePos anchor) {
+        if (name == null) {
+            return null;
+        }
+        return namePos == null
+                ? Ast.Binder.desugared(name, anchor) : Ast.Binder.written(name, namePos);
     }
 
     /** The whole `{ ... }` of a body, so an error about the body underlines both braces. */

--- a/souther-compiler/src/main/java/souther/compiler/frontend/ImplicitUnits.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/ImplicitUnits.java
@@ -108,6 +108,9 @@ public final class ImplicitUnits {
                 || BUILT_IN.contains(name)) {
             return;
         }
-        added.put(name, new Ast.UnitData(name, pos));
+        // No name position: nobody wrote this declaration. The place `pos` names is the reference
+        // that implied it, and reading a use as a declaration's name would answer a cursor there
+        // about a declaration that is not in the file.
+        added.put(name, new Ast.UnitData(name, null, pos));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -292,6 +292,17 @@ public final class Compilation {
     }
 
     /**
+     * The module {@code sourceId} is part of — the one it declares, or the one its rows are for —
+     * or null when this compilation does not have the source.
+     *
+     * <p>The other direction of {@link #sourceIdOf}, and not its inverse: a module is declared in
+     * one source, and several sources may be part of it.
+     */
+    public String moduleOf(String sourceId) {
+        return db.ask(new Front.ModuleOf(sourceId)).value();
+    }
+
+    /**
      * The problems that stop this compilation before any module is looked at: a source that names a
      * module twice, one that shadows a module already on the path, and a cycle among them.
      *

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -603,6 +603,45 @@ public final class Front {
     }
 
     /**
+     * The module a source is part of: the one it declares, or — for an {@code examples for} file —
+     * the one its rows are for.
+     *
+     * <p>One question, because a reader that has a file and wants to ask about the names in it needs
+     * both answers and has no way to tell in advance which it will get. Asking it of the header
+     * instead gives the first only, and a file that declares no module of its own then belongs to
+     * nothing and is asked nothing.
+     *
+     * <p>No reports of its own: what is wrong with the source is already said by {@link Declares}
+     * and {@link AttachedTo}, and saying it a second time here would put two markers on one line.
+     */
+    public record ModuleOf(String id) implements Key<String> {
+        @Override
+        public String sourceId() {
+            return id;
+        }
+
+        @Override
+        public Answer<String> compute(Db db) {
+            Layout.Of layout = db.ask(new Layout()).value();
+            if (layout == null) {
+                return Answer.absent();
+            }
+            String attached = layout.exampleFileTargets().get(id);
+            if (attached != null) {
+                return layout.idOfModule().containsKey(attached)
+                        ? Answer.of(attached)
+                        : Answer.absent();   // names a module this compilation does not have
+            }
+            for (Map.Entry<String, String> declared : layout.idOfModule().entrySet()) {
+                if (declared.getValue().equals(id)) {
+                    return Answer.of(declared.getKey());
+                }
+            }
+            return Answer.absent();
+        }
+    }
+
+    /**
      * A source module that also exists on the path. Which one an import means would be decided by
      * nothing the author wrote, and the two would be different types under one name — the same
      * reason two sources may not share a name.

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -13,6 +13,7 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
 
@@ -1134,16 +1135,39 @@ public final class Names {
             if (!resolution.present()) {
                 return Answer.absent();
             }
-            for (Map.Entry<BindingId, Resolve.BoundName> bound
-                    : resolution.value().binders().entrySet()) {
+            Map<BindingId, Resolve.BoundName> binders = resolution.value().binders();
+            for (Map.Entry<BindingId, Resolve.BoundName> bound : binders.entrySet()) {
                 Resolve.BoundName written = bound.getValue();
-                if (spans(written.pos(), written.written(), at)) {
+                if (answerable(bound.getKey(), binders)
+                        && spans(written.pos(), written.written(), at)) {
                     ValueName local = new ValueName.Local(written.written(), bound.getKey());
                     return Answer.of(local);
                 }
             }
             Resolve.ValueUse use = db.ask(new ValueDenotedAt(at)).value();
-            return use == null ? Answer.absent() : Answer.of(use.denotes());
+            if (use == null) {
+                return Answer.absent();
+            }
+            if (use.denotes() instanceof ValueName.Local local
+                    && !answerable(local.id(), binders)) {
+                return Answer.absent();
+            }
+            return Answer.of(use.denotes());
+        }
+
+        /**
+         * Whether a reader can be told about this binding at all.
+         *
+         * <p>Two things have to hold, and both are about what the resolve pass read rather than
+         * about what an editor would like. The binding's name has to be one the author wrote —
+         * absent from {@code binders} means a desugaring invented it, and a name nobody wrote is
+         * under no cursor and cannot be renamed. And it has to be a binding whose uses this pass
+         * records: a field's are not names in scope but reads resolved by the type of what they are
+         * read from, and only the ones inside an {@code invariant} come through here. A field
+         * answered from what is written here would be renamed at its declaration and nowhere else.
+         */
+        private static boolean answerable(BindingId id, Map<BindingId, Resolve.BoundName> binders) {
+            return binders.containsKey(id) && !(id.owner() instanceof BindingOwner.OfFields);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -12,6 +12,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
 
@@ -1109,10 +1110,52 @@ public final class Names {
     }
 
     /**
-     * Where what {@code denoted} names is written: the {@code let} or {@code behavior} that declares
-     * it, or the binding that introduced a local.
+     * The value the cursor is on at {@code at}: the one a name there denotes, or — when the cursor
+     * is on a binding — the binding itself.
+     *
+     * <p>{@link TypeAt} for the value namespace, and for the same reason: a reader asking about a
+     * binding is asking from one end or the other, and the two ends are one question. Answering
+     * only where a name is read would put a local within reach from its uses and out of reach from
+     * the {@code let} that binds it.
      */
-    public record ValueDeclaredAt(ValueName denoted) implements Key<SourcePos> {
+    public record ValueAt(SourcePos at) implements Key<ValueName> {
+        @Override
+        public String sourceId() {
+            return at == null ? null : at.sourceId();
+        }
+
+        @Override
+        public Answer<ValueName> compute(Db db) {
+            String name = moduleAt(db, at);
+            if (name == null) {
+                return Answer.absent();
+            }
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            if (!resolution.present()) {
+                return Answer.absent();
+            }
+            for (Map.Entry<BindingId, Resolve.BoundName> bound
+                    : resolution.value().binders().entrySet()) {
+                Resolve.BoundName written = bound.getValue();
+                if (spans(written.pos(), written.written(), at)) {
+                    ValueName local = new ValueName.Local(written.written(), bound.getKey());
+                    return Answer.of(local);
+                }
+            }
+            Resolve.ValueUse use = db.ask(new ValueDenotedAt(at)).value();
+            return use == null ? Answer.absent() : Answer.of(use.denotes());
+        }
+    }
+
+    /**
+     * Every place the name of what {@code denoted} names is written as a declaration.
+     *
+     * <p>More than one, because a behavior is declared twice: the {@code behavior} line says what it
+     * is and the {@code let} line says what it does, and both write the name. A reader sent to the
+     * declaration wants the first of them; a rename has to rewrite all of them, or the module goes
+     * on naming something that is no longer there.
+     */
+    public record ValueDeclarationsOf(ValueName denoted) implements Key<List<SourcePos>> {
         @Override
         public String module() {
             return switch (denoted) {
@@ -1125,16 +1168,17 @@ public final class Names {
         }
 
         @Override
-        public Answer<SourcePos> compute(Db db) {
+        public Answer<List<SourcePos>> compute(Db db) {
             // a binding is not a position, so where it was written is asked of the pass that
             // answered it rather than read off the name
             if (denoted instanceof ValueName.Local local) {
-                Answer<Resolve.Resolved> resolution = db.ask(new Resolution(local.id().owner().module()));
+                Answer<Resolve.Resolved> resolution =
+                        db.ask(new Resolution(local.id().owner().module()));
                 if (!resolution.present()) {
                     return Answer.absent();
                 }
-                SourcePos binder = resolution.value().binders().get(local.id());
-                return binder == null ? Answer.absent() : Answer.of(binder);
+                Resolve.BoundName binder = resolution.value().binders().get(local.id());
+                return binder == null ? Answer.absent() : Answer.of(List.of(binder.pos()));
             }
             String in = module();
             if (in == null) {
@@ -1144,17 +1188,38 @@ public final class Names {
             if (m == null) {
                 return Answer.absent();
             }
+            List<SourcePos> written = new ArrayList<>();
             for (Ast.BehaviorDef b : m.behaviors()) {
                 if (b.name().equals(denoted.name())) {
-                    return Answer.of(b.pos());
+                    written.add(b.pos());
                 }
             }
             for (Ast.FnDef fn : m.fns()) {
                 if (fn.name().equals(denoted.name())) {
-                    return Answer.of(fn.pos());
+                    written.add(fn.pos());
                 }
             }
-            return Answer.absent();
+            return written.isEmpty() ? Answer.absent() : Answer.of(List.copyOf(written));
+        }
+    }
+
+    /**
+     * Where what {@code denoted} names is written: the {@code behavior} that declares it, the
+     * {@code let} where it has no signature, or the binding that introduced a local.
+     *
+     * <p>The first of {@link ValueDeclarationsOf}, which is the one to send a reader to. A behavior
+     * has two, and its signature says more about it than its body does.
+     */
+    public record ValueDeclaredAt(ValueName denoted) implements Key<SourcePos> {
+        @Override
+        public String module() {
+            return new ValueDeclarationsOf(denoted).module();
+        }
+
+        @Override
+        public Answer<SourcePos> compute(Db db) {
+            Answer<List<SourcePos>> written = db.ask(new ValueDeclarationsOf(denoted));
+            return written.present() ? Answer.of(written.value().get(0)) : Answer.absent();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -22,6 +22,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -939,21 +940,39 @@ public final class Names {
     }
 
     /**
-     * What the name written at {@code offset} in a module's source denotes, or absent when nothing
-     * there is a name of a declared type.
+     * The module a question about a place is a question about, or null when this compilation does
+     * not have the file — including a question that names no file at all, which names no place and
+     * so has no module to be asked of.
+     */
+    private static String moduleAt(Db db, SourcePos at) {
+        return at == null || at.sourceId() == null
+                ? null : db.ask(new Front.ModuleOf(at.sourceId())).value();
+    }
+
+    /**
+     * What the name written at {@code at} denotes, or absent when nothing there is a name of a
+     * declared type.
      *
      * <p>This is what an editor is asking when the cursor is on an identifier. It reads the answers
      * the resolve pass already gave, so a qualified reference names the module it names and not
      * whatever this module happens to declare by the same spelling.
+     *
+     * <p>Asked about a place, not about a module and a place. Which module answers is the file's to
+     * settle — an attached {@code examples for} file declares none and is part of one all the same,
+     * and a caller that had to name the module first was a caller that could name the wrong one.
      */
-    public record DenotedAt(String name, SourcePos at) implements Key<Resolve.Denotation> {
+    public record DenotedAt(SourcePos at) implements Key<Resolve.Denotation> {
         @Override
-        public String module() {
-            return name;
+        public String sourceId() {
+            return at == null ? null : at.sourceId();
         }
 
         @Override
         public Answer<Resolve.Denotation> compute(Db db) {
+            String name = moduleAt(db, at);
+            if (name == null) {
+                return Answer.absent();
+            }
             Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
             if (!resolution.present()) {
                 return Answer.absent();
@@ -974,29 +993,33 @@ public final class Names {
     }
 
     /**
-     * The type the cursor is on at {@code offset}: the one a name there denotes, or — when the
-     * cursor is on a declaration's own name — that declaration.
+     * The type the cursor is on at {@code at}: the one a name there denotes, or — when the cursor is
+     * on a declaration's own name — that declaration.
      *
      * <p>One question, so an editor's go-to-definition, find-references and rename all agree about
      * what the cursor is on. They used to each decide for themselves, by spelling.
      */
-    public record TypeAt(String name, SourcePos at) implements Key<TypeName> {
+    public record TypeAt(SourcePos at) implements Key<TypeName> {
         @Override
-        public String module() {
-            return name;
+        public String sourceId() {
+            return at == null ? null : at.sourceId();
         }
 
         @Override
         public Answer<TypeName> compute(Db db) {
+            String name = moduleAt(db, at);
+            if (name == null) {
+                return Answer.absent();
+            }
             Answer<Map<String, Ast.Def>> defs = db.ask(new Declarations(name));
             if (defs.present()) {
                 for (Ast.Def def : defs.value().values()) {
-                    if (spans(def.pos(), def.name(), at)) {
+                    if (spans(def.namePos(), def.name(), at)) {
                         return Answer.of(new TypeName(name, def.name()));
                     }
                 }
             }
-            Resolve.Denotation denoted = db.ask(new DenotedAt(name, at)).value();
+            Resolve.Denotation denoted = db.ask(new DenotedAt(at)).value();
             return denoted == null ? Answer.absent() : Answer.of(denoted.denotes());
         }
     }
@@ -1031,14 +1054,18 @@ public final class Names {
      * the answer resolution already gave, so a binding is the binding it is and not whatever else
      * in the module happens to be spelled the same.
      */
-    public record ValueDenotedAt(String name, SourcePos at) implements Key<Resolve.ValueUse> {
+    public record ValueDenotedAt(SourcePos at) implements Key<Resolve.ValueUse> {
         @Override
-        public String module() {
-            return name;
+        public String sourceId() {
+            return at == null ? null : at.sourceId();
         }
 
         @Override
         public Answer<Resolve.ValueUse> compute(Db db) {
+            String name = moduleAt(db, at);
+            if (name == null) {
+                return Answer.absent();
+            }
             Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
             if (!resolution.present()) {
                 return Answer.absent();
@@ -1049,6 +1076,35 @@ public final class Names {
                 }
             }
             return Answer.absent();
+        }
+    }
+
+    /**
+     * Every place a module names {@code denoted} as a value, wherever it was declared.
+     *
+     * <p>{@link UsesOf} for the value namespace. A local is answered here as readily as a top-level
+     * name: what a use denotes is a binding and not a spelling, so the uses of one {@code let}'s
+     * {@code x} are not the uses of another's.
+     */
+    public record ValueUsesOf(String name, ValueName denoted) implements Key<List<Resolve.ValueUse>> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<List<Resolve.ValueUse>> compute(Db db) {
+            Answer<Resolve.Resolved> resolution = db.ask(new Resolution(name));
+            if (!resolution.present()) {
+                return Answer.of(List.of());
+            }
+            List<Resolve.ValueUse> uses = new ArrayList<>();
+            for (Resolve.ValueUse use : resolution.value().values()) {
+                if (denoted.equals(use.denotes())) {
+                    uses.add(use);
+                }
+            }
+            return Answer.of(List.copyOf(uses));
         }
     }
 
@@ -1114,27 +1170,15 @@ public final class Names {
      * came first. What was under the cursor and what the answer described were then two different
      * names.
      *
-     * <p>Where the question names no source — a caller with only a coordinate to give — the
-     * coordinates decide, which is what every such caller got before.
+     * <p>A question that names no file names no place either. Every question about a cursor now
+     * arrives as one, because the module it is answered about is read off the file it names, so
+     * there is no longer a caller with only a line and a column to give.
      */
     static boolean spans(SourcePos start, String written, SourcePos at) {
         return start != null && at != null && start.line() == at.line()
-                && sameSource(start, at)
+                && Objects.equals(at.sourceId(), start.sourceId())
                 && at.column() >= start.column()
                 && at.column() <= start.column() + written.length();
-    }
-
-    /**
-     * Whether a name written at {@code start} is in the file the question at {@code at} is about.
-     *
-     * <p>The two absences are not the same absence, so this is not symmetric. A question that names
-     * no source is a caller with only a coordinate to give, and is answered by coordinate. A name
-     * that names none was read from no source of this compile, and is under nothing a reader has
-     * open — answering with it would be the thing this is here to stop, arrived at from the other
-     * side.
-     */
-    private static boolean sameSource(SourcePos start, SourcePos at) {
-        return at.sourceId() == null || at.sourceId().equals(start.sourceId());
     }
     public record DeclaredAt(TypeName denoted) implements Key<SourcePos> {
         @Override
@@ -1148,8 +1192,12 @@ public final class Names {
             if (!defs.present()) {
                 return Answer.absent();
             }
+            // Where the name is written, not where the declaration starts: a reader sent to a
+            // declaration is being sent to the name it declares, and the keyword in front of it is
+            // not what they asked about.
             Ast.Def def = defs.value().get(denoted.name());
-            return def == null || def.pos() == null ? Answer.absent() : Answer.of(def.pos());
+            return def == null || def.namePos() == null
+                    ? Answer.absent() : Answer.of(def.namePos());
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/core/EverySlotIsAChildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/core/EverySlotIsAChildTest.java
@@ -83,7 +83,7 @@ class EverySlotIsAChildTest {
     @Test
     void anAttemptsConstructionIsAChild() {
         Core.IfConstructed attempt = new Core.IfConstructed(construction(),
-                Ast.Binder.written("p", POS), new Core.Int(0, Type.INT, POS),
+                Ast.Binder.desugared("p", POS), new Core.Int(0, Type.INT, POS),
                 List.of(new Core.ElseArm(Optional.empty(), new Core.Int(1, Type.INT, POS))),
                 Type.INT, POS);
 
@@ -94,7 +94,7 @@ class EverySlotIsAChildTest {
     @Test
     void eachSlotGoesThroughTheOperatorForItsKind() {
         Core.IfConstructed attempt = new Core.IfConstructed(construction(),
-                Ast.Binder.written("p", POS),
+                Ast.Binder.desugared("p", POS),
                 new Core.Apply(read("f", 1), List.of(), Type.INT, POS),
                 List.of(), Type.INT, POS);
 

--- a/souther-compiler/src/test/java/souther/compiler/frontend/ANameIsWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/frontend/ANameIsWhereItIsWrittenTest.java
@@ -1,0 +1,185 @@
+package souther.compiler.frontend;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.ast.Ast;
+import souther.compiler.cst.CstParser;
+import souther.compiler.cst.LineIndex;
+import souther.compiler.cst.SyntaxElement;
+import souther.compiler.cst.SyntaxKind;
+import souther.compiler.cst.SyntaxNode;
+import souther.compiler.cst.SyntaxToken;
+import souther.compiler.diag.SourcePos;
+
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A binder that says where its name is written is claiming a place in the source, and this reads the
+ * claim back against the source it was parsed from.
+ *
+ * <p>The claim is two halves handed over separately — a spelling and a position — and nothing in the
+ * tree can check they came from the same token, because the tree has no text. So it is checked here,
+ * over every binding form the language has, rather than by each of the twenty-odd places that build
+ * a binder remembering to be careful.
+ *
+ * <p>Both ways of being wrong have been shipped on this branch. A desugaring binds what it is
+ * rewriting to a name of its own and anchors it on the form it came from — {@code .v} becomes a
+ * parameter called {@code $g0} anchored at the {@code .} — and a reader answered with one of those is
+ * answered about a name that is not in the file, at a width that is not its: renaming from it wrote
+ * {@code .v,} over. The other way round, a lowering that drops the token it had leaves a name the
+ * author did write with no place to be found at, and go-to-definition on it answers nothing.
+ */
+class ANameIsWhereItIsWrittenTest {
+
+    /** Every form that binds a name, in one module: parameters written and patterned, a lambda's
+     * parameters, a block `let`, a destructuring `let`, an attempted construction's `as`, and a
+     * `match` arm's `as`, field destructuring and constructor destructuring. */
+    private static final String EVERY_BINDING_FORM = """
+            module a exposing ( Amount, Pair, Shape, Round, Flat, sum, pick, tag, take, held )
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Pair = { left: Int, right: Int }
+            data Round = { r: Int }
+            data Flat = { f: Int }
+            data Shape = Round | Flat
+
+            behavior sum : (ps: List<Pair>) -> Int
+            let sum (ps) = List.fold((acc, p) -> acc + p.left + p.right, 0, ps)
+
+            behavior pick : (p: Pair) -> Int
+            let pick ({ left = l, right }) = l + right
+
+            behavior tag : (s: Shape) -> Int
+            let tag (s) = match s with
+                | Round as w -> w.r
+                | Flat { f } -> f
+
+            behavior take : (n: Int) -> Amount
+            let take (n) = {
+                let doubled = n * 2
+                if Amount(doubled) as ok then ok.value else 0
+            }
+
+            behavior held : (a: Amount) -> Int
+            let held (Amount(inner)) = inner
+            """;
+
+    private static Ast.Module parsed() {
+        return CstFrontend.parseWithSlices(EVERY_BINDING_FORM, "a", "a.sou").module();
+    }
+
+    private static SyntaxNode tree() {
+        return CstParser.parse(EVERY_BINDING_FORM).root();
+    }
+
+    /** Every binder anywhere in the tree, found by walking the records rather than by a visitor each
+     * new node kind would have to be added to. */
+    private static List<Ast.Binder> everyBinder(Object node) {
+        List<Ast.Binder> out = new ArrayList<>();
+        collect(node, out, new IdentityHashMap<>());
+        return out;
+    }
+
+    private static void collect(Object node, List<Ast.Binder> out, Map<Object, Boolean> seen) {
+        if (node == null || seen.put(node, Boolean.TRUE) != null) {
+            return;
+        }
+        if (node instanceof Ast.Binder binder) {
+            out.add(binder);
+        }
+        switch (node) {
+            case List<?> list -> list.forEach(e -> collect(e, out, seen));
+            case Optional<?> maybe -> maybe.ifPresent(e -> collect(e, out, seen));
+            // every record, not only the ones that are `Ast`: a body is held in an `FnBody`, an
+            // example's rows in their own records, and a walk that stopped at `Ast` would report a
+            // module full of bindings as a module with five
+            case Record record -> {
+                for (RecordComponent c : record.getClass().getRecordComponents()) {
+                    try {
+                        collect(c.getAccessor().invoke(record), out, seen);
+                    } catch (ReflectiveOperationException e) {
+                        throw new AssertionError("could not read " + c.getName(), e);
+                    }
+                }
+            }
+            default -> { /* a spelling, a number, a flag: nothing that holds a binder */ }
+        }
+    }
+
+    /** The identifier written at {@code at}, or null where no identifier starts there. */
+    private static SyntaxToken identAt(SyntaxNode node, LineIndex lines, SourcePos at) {
+        int offset = lines.offsetOf(at.line() - 1, at.column() - 1);
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxNode child) {
+                if (child.start() <= offset && offset < child.end()) {
+                    SyntaxToken found = identAt(child, lines, at);
+                    if (found != null) {
+                        return found;
+                    }
+                }
+            } else if (e instanceof SyntaxToken t
+                    && t.kind() == SyntaxKind.IDENT && t.start() == offset) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    void theModuleReallyHasEveryFormInIt() {
+        assertTrue(everyBinder(parsed()).size() >= 14,
+                "a fixture that binds little checks little: " + everyBinder(parsed()));
+    }
+
+    @Test
+    void everyBinderThatNamesAPlaceIsOnAnIdentifierSpelledThatWay() {
+        LineIndex lines = new LineIndex(EVERY_BINDING_FORM);
+        SyntaxNode root = tree();
+        List<String> wrong = new ArrayList<>();
+        for (Ast.Binder binder : everyBinder(parsed())) {
+            if (binder.namePos() == null) {
+                continue;   // says it is written nowhere, and claims no place to be wrong about
+            }
+            SyntaxToken written = identAt(root, lines, binder.namePos());
+            if (written == null || !written.text().equals(binder.name())) {
+                wrong.add("`" + binder.name() + "` claims " + binder.namePos() + ", which holds "
+                        + (written == null ? "no identifier" : "`" + written.text() + "`"));
+            }
+        }
+        assertEquals(List.of(), wrong,
+                "a binding that names a place has to be the name written there");
+    }
+
+    @Test
+    void aNameNoOneWroteSaysSo() {
+        List<String> claiming = new ArrayList<>();
+        for (Ast.Binder binder : everyBinder(parsed())) {
+            if (binder.name().startsWith("$") && binder.namePos() != null) {
+                claiming.add(binder.name() + " at " + binder.namePos());
+            }
+        }
+        assertEquals(List.of(), claiming,
+                "the names a desugaring makes for itself are written nowhere");
+    }
+
+    @Test
+    void andEveryNameTheAuthorDidWriteSaysWhere() {
+        List<String> silent = new ArrayList<>();
+        for (Ast.Binder binder : everyBinder(parsed())) {
+            if (!binder.name().startsWith("$") && binder.namePos() == null) {
+                silent.add(binder.name() + " anchored at " + binder.pos());
+            }
+        }
+        assertEquals(List.of(), silent,
+                "a name the author wrote is somewhere, and a reader has to be able to be sent there");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ACursorIsOnAPlaceNotACoordinateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ACursorIsOnAPlaceNotACoordinateTest.java
@@ -13,7 +13,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * What a module is made of is not all written in one file. An attached {@code examples for} file's
@@ -69,7 +69,7 @@ class ACursorIsOnAPlaceNotACoordinateTest {
     /** What the compiler says is under a cursor at line 8 column 14 of {@code inFile}. */
     private static Resolve.ValueUse under(String inFile) {
         return compiled().db()
-                .ask(new Names.ValueDenotedAt("m", new SourcePos(8, 14, inFile))).value();
+                .ask(new Names.ValueDenotedAt(new SourcePos(8, 14, inFile))).value();
     }
 
     @Test
@@ -100,28 +100,30 @@ class ACursorIsOnAPlaceNotACoordinateTest {
         assertEquals("m.べつ", under(ATTACHED_ID).denotes().toString());
     }
 
-    /** A caller with only a coordinate to give is answered by coordinate, as it always was. */
+    /**
+     * A question that names no file names no place. It used to be answered by line and column
+     * alone, for callers that had only those to give; the module a question is answered about is
+     * now read off the file it names, so a question without one names no module either.
+     */
     @Test
-    void aCursorThatNamesNoFileIsStillAnsweredByCoordinate() {
+    void aCursorThatNamesNoFileIsOnNothing() {
         Resolve.ValueUse use = compiled().db()
-                .ask(new Names.ValueDenotedAt("m", new SourcePos(8, 14))).value();
+                .ask(new Names.ValueDenotedAt(new SourcePos(8, 14))).value();
 
-        assertNotNull(use, "nothing was taken away from a caller that names no source");
+        assertNull(use, "a line and a column are not a place");
     }
 
-    // --- the two absences are not the same absence ------------------------------------------------
+    // --- a name is somewhere, and a question is about somewhere ------------------------------------
 
-    /** A question with only a coordinate to give is answered by coordinate. */
     @Test
-    void aQuestionThatNamesNoFileIsAnsweredByCoordinate() {
-        assertTrue(Names.spans(new SourcePos(8, 14, MODEL_ID), "name", new SourcePos(8, 14)));
+    void aQuestionThatNamesNoFileIsNotAnsweredWithANameFromOne() {
+        assertFalse(Names.spans(new SourcePos(8, 14, MODEL_ID), "name", new SourcePos(8, 14)));
     }
 
     /**
      * A name that names no source was read from no source of this compile — a synthesized node, or
      * a module read off the module path. It is under nothing a reader has open, so a question about
-     * an open file is not answered with it. This is the same misreading as the one above, arrived at
-     * from the other side, which is why the two absences cannot be treated alike.
+     * an open file is not answered with it.
      */
     @Test
     void aQuestionAboutAFileIsNotAnsweredWithANameFromNoFile() {

--- a/souther-compiler/src/test/java/souther/compiler/query/ADeclarationIsNamedWhereItsNameIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ADeclarationIsNamedWhereItsNameIsWrittenTest.java
@@ -1,0 +1,64 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.TypeName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A cursor on a declaration's own name is on that declaration. The question was answered by
+ * comparing the cursor against where the declaration starts — its {@code data} keyword — which is
+ * not where its name is written, so the answer was there for a cursor on the keyword and absent for
+ * one on the name.
+ *
+ * <p>What that cost is not visible from here: an editor asking this and getting nothing falls back
+ * to matching by spelling, which answers, and answers about whatever else in the workspace is
+ * spelled the same.
+ */
+class ADeclarationIsNamedWhereItsNameIsWrittenTest {
+
+    private static final String ID = "m.sou";
+
+    /** `data` starts at column 1 and `D` is written at column 6. */
+    private static final String SOURCE = """
+            module m
+
+            data D = { v: Int }
+            behavior f : (d: D) -> D
+            let f (d) = d
+            """;
+
+    private static TypeName under(int line, int column) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put(ID, SOURCE);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY).db()
+                .ask(new Names.TypeAt(new SourcePos(line, column, ID))).value();
+    }
+
+    @Test
+    void aCursorOnTheNameIsOnTheDeclaration() {
+        assertEquals(new TypeName("m", "D"), under(3, 6));
+    }
+
+    @Test
+    void aCursorJustPastTheNameIsStillOnIt() {
+        assertEquals(new TypeName("m", "D"), under(3, 7));
+    }
+
+    @Test
+    void aCursorOnTheKeywordIsNotOnTheName() {
+        assertNull(under(3, 1), "`data` is not what the declaration is called");
+    }
+
+    @Test
+    void aCursorOnAUseIsStillOnWhatTheUseDenotes() {
+        assertEquals(new TypeName("m", "D"), under(4, 18));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AnEditorIsOnlyToldAboutNamesTheAuthorWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AnEditorIsOnlyToldAboutNamesTheAuthorWroteTest.java
@@ -1,0 +1,141 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.ValueName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The resolve pass gives a binding to more than the names an author wrote. A desugaring binds what
+ * it is rewriting to a name of its own — the parameter {@code .field} becomes, the value a
+ * {@code match} is held in — and anchors it on the form it came from, which is a place in the source
+ * holding something the author did write.
+ *
+ * <p>Answering a cursor there with one of those would name a binding that is not in the file, at a
+ * width that is not its. Renaming from it would then write over whatever is at that place: the
+ * getter {@code .v} is three characters wide as `$g0`, and the three characters at its position are
+ * `.v,`.
+ *
+ * <p>The other half is a binding whose name the author did write but whose uses this pass does not
+ * record. A field is one: {@code d.v} and {@code D { v = ... }} are resolved by the type of what
+ * they are read from, not by what is in scope, and only the ones inside an {@code invariant} come
+ * through here. A rename answered from those would rewrite the declaration and leave every read.
+ */
+class AnEditorIsOnlyToldAboutNamesTheAuthorWroteTest {
+
+    private static final String ID = "a.sou";
+
+    /**
+     * Line 3 declares the field `v` at column 12, line 4 reads it in the invariant at column 15,
+     * and line 7 writes the getter `.v` at column 36. Line 10 reads `d.v` at column 27.
+     */
+    private static final String DESUGARED = """
+            module a exposing ( D, total )
+
+            data D = { v: Int }
+                invariant v >= 0
+
+            behavior total : (ds: List<D>) -> Int
+            let total (ds) = List.sum(List.map(.v, ds))
+
+            behavior copy : (d: D) -> D
+            let copy (d) = D { v = d.v }
+            """;
+
+    /**
+     * Line 10 binds the lambda parameters `acc` at column 29 and `d` at column 34; the lambda itself
+     * opens at column 28. Lines 14 and 15 bind `w` at column 16 and `z` at column 15.
+     */
+    private static final String WRITTEN = """
+            module a exposing ( D, Shape, total, tag )
+
+            data D = { v: Int }
+
+            data Round = { r: Int }
+            data Flat = { f: Int }
+            data Shape = Round | Flat
+
+            behavior total : (ds: List<D>) -> Int
+            let total (ds) = List.fold((acc, d) -> acc + d.v, 0, ds)
+
+            behavior tag : (s: Shape) -> Int
+            let tag (s) = match s with
+                | Round as w -> w.r
+                | Flat as z -> z.f
+            """;
+
+    private static ValueName under(String source, int line, int column) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put(ID, source);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY).db()
+                .ask(new Names.ValueAt(new SourcePos(line, column, ID))).value();
+    }
+
+    /** What the cursor is on across a whole span, as one string: `X` where something is, `.` where
+     * nothing is. */
+    private static String across(String source, int line, int from, int to) {
+        StringBuilder out = new StringBuilder();
+        for (int column = from; column <= to; column++) {
+            out.append(under(source, line, column) == null ? '.' : 'X');
+        }
+        return out.toString();
+    }
+
+    // --- a name no one wrote ----------------------------------------------------------------------
+
+    @Test
+    void aGetterIsNotABindingAnyoneCanBeSentTo() {
+        assertEquals("....", across(DESUGARED, 7, 36, 39),
+                "`.v, ` is not a name; the parameter it desugars to is written nowhere");
+    }
+
+    @Test
+    void theNamesAroundItAreStillAnswered() {
+        assertNotNull(under(DESUGARED, 7, 40), "`ds`, the argument beside the getter");
+        assertNotNull(under(DESUGARED, 7, 12), "`ds`, where it is bound");
+    }
+
+    // --- a name the author wrote whose uses are not names ------------------------------------------
+
+    @Test
+    void aFieldDeclarationIsNotOfferedAsALocal() {
+        assertNull(under(DESUGARED, 3, 12),
+                "renaming `v` here would leave every `d.v` and `D { v = ... }` behind");
+    }
+
+    @Test
+    void norIsTheOneUseOfItThisPassDoesRecord() {
+        assertNull(under(DESUGARED, 4, 15), "the invariant's `v` is the same field, and no more"
+                + " renameable for being the one read that resolution sees");
+    }
+
+    // --- a name the author wrote, wherever the form it is written in starts ------------------------
+
+    @Test
+    void aLambdaParameterIsWhereItIsWrittenAndNotWhereTheLambdaStarts() {
+        assertNull(under(WRITTEN, 10, 28), "the lambda opens here and binds no name here");
+        assertEquals("acc", under(WRITTEN, 10, 29).name(), "which is where `acc` is written");
+    }
+
+    @Test
+    void andSoIsTheSecondOne() {
+        assertEquals("d", under(WRITTEN, 10, 34).name(),
+                "a second parameter is its own name, not the first one's");
+        assertEquals("d", under(WRITTEN, 10, 46).name(), "the `d` of `d.v` is that parameter");
+    }
+
+    @Test
+    void aMatchArmBindsItsNameWhereItIsWritten() {
+        assertEquals("w", under(WRITTEN, 14, 16).name(), "`| Round as w`");
+        assertEquals("z", under(WRITTEN, 15, 15).name(), "`| Flat as z`");
+        assertNull(under(WRITTEN, 14, 7), "the arm starts at the case name, which binds nothing");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/EverySourceKnowsWhichModuleItIsPartOfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EverySourceKnowsWhichModuleItIsPartOfTest.java
@@ -1,0 +1,67 @@
+package souther.compiler.query;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.meta.ModulePath;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Which module a source is part of is one question with two answers behind it: the module a file
+ * declares, and the module an {@code examples for} file contributes to. A reader that has a file and
+ * wants to ask about the names in it needs the second as much as the first, and reading the header
+ * only ever gives the first.
+ */
+class EverySourceKnowsWhichModuleItIsPartOfTest {
+
+    private static final String MODEL_ID = "m.sou";
+    private static final String ATTACHED_ID = "m.examples.sou";
+
+    private static final String MODEL = """
+            module m
+
+            data D = { v: Int }
+            behavior f : (d: D) -> D
+            let f (d) = d
+            """;
+
+    private static final String ATTACHED = """
+            examples for m
+
+            let base = D { v = 1 }
+            """;
+
+    private static Compilation compiled() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put(MODEL_ID, MODEL);
+        byId.put(ATTACHED_ID, ATTACHED);
+        return Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+    }
+
+    @Test
+    void aSourceThatDeclaresAModuleIsPartOfIt() {
+        assertEquals("m", compiled().db().ask(new Front.ModuleOf(MODEL_ID)).value());
+    }
+
+    @Test
+    void anAttachedFileIsPartOfTheModuleItsRowsAreFor() {
+        assertEquals("m", compiled().db().ask(new Front.ModuleOf(ATTACHED_ID)).value());
+    }
+
+    @Test
+    void aSourceThisCompilationDoesNotHaveIsPartOfNothing() {
+        assertNull(compiled().db().ask(new Front.ModuleOf("elsewhere.sou")).value());
+    }
+
+    @Test
+    void theCompilationAnswersItTheWayItAnswersTheOtherDirection() {
+        Compilation c = compiled();
+
+        assertEquals("m", c.moduleOf(ATTACHED_ID));
+        assertEquals(MODEL_ID, c.sourceIdOf("m"));
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -382,15 +382,18 @@ public final class LspServer {
             return null;
         }
         ModuleGraph graph = workspace.snapshot(documents.openDocuments());
-        Map<String, List<Range>> edits = analyzer.renameEdits(p.uri(), p.position(), graph);
+        Map<String, List<souther.lsp.protocol.TextEdit>> edits =
+                analyzer.renameEdits(p.uri(), p.position(), graph, p.newName());
         if (edits.isEmpty()) {
             return null;
         }
         Map<String, Object> changes = new LinkedHashMap<>();
-        for (Map.Entry<String, List<Range>> e : edits.entrySet()) {
+        for (Map.Entry<String, List<souther.lsp.protocol.TextEdit>> e : edits.entrySet()) {
             List<Object> textEdits = new ArrayList<>();
-            for (Range r : e.getValue()) {
-                textEdits.add(textEdit(r, p.newName()));
+            for (souther.lsp.protocol.TextEdit edit : e.getValue()) {
+                // what to write comes with the place: a binding written as a field's own name is
+                // renamed by naming the field it reads, not by writing over it
+                textEdits.add(textEdit(edit.range(), edit.newText()));
             }
             changes.put(e.getKey(), textEdits);
         }

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -373,7 +373,7 @@ public final class LspServer {
 
     // --- rename ---
 
-    /** A {@code WorkspaceEdit} renaming the top-level symbol under the cursor everywhere it is used,
+    /** A {@code WorkspaceEdit} renaming the name under the cursor everywhere it is used,
      * or {@code null} when the new name is not a legal identifier or the cursor is not on a
      * renameable symbol — the client then reports the rename as unavailable. */
     private Object rename(JsonNode params) {

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -39,6 +39,7 @@ import souther.lsp.protocol.Location;
 import souther.lsp.protocol.LspDiagnostic;
 import souther.lsp.protocol.Position;
 import souther.lsp.protocol.Range;
+import souther.lsp.protocol.TextEdit;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -698,13 +699,98 @@ public final class Analyzer {
     }
 
     /**
-     * The edit ranges for renaming the name under the cursor, grouped by document uri: every
-     * reference to it plus every line that declares it. Empty when the cursor is not on a name.
+     * The edits for renaming the name under the cursor to {@code newName}, grouped by document uri:
+     * every reference to it plus every line that declares it. Empty when the cursor is not on a
+     * name.
      *
      * <p>A local is renameable, from its binding as much as from a use of it — the same reach
      * find-references has, for the same reason.
+     *
+     * <p>Each edit says what to write as well as where, because those differ. A record pattern's
+     * {@code { right }} names the field it reads and binds the value under that same spelling, and
+     * once the two are no longer spelled alike the field has to be named: what goes there is
+     * {@code right = r}. Answering with places alone left the caller to write one name over all of
+     * them, which is right everywhere else and silently produced a module reading a field that does
+     * not exist here.
      */
-    public Map<String, List<Range>> renameEdits(String uri, Position pos, ModuleGraph graph) {
+    public Map<String, List<TextEdit>> renameEdits(String uri, Position pos, ModuleGraph graph,
+                                                   String newName) {
+        Map<String, List<TextEdit>> out = new LinkedHashMap<>();
+        for (Map.Entry<String, List<Range>> e : renameRanges(uri, pos, graph).entrySet()) {
+            List<TextEdit> edits = new ArrayList<>();
+            SyntaxNode root = CstParser.parse(graph.text(e.getKey())).root();
+            LineIndex lines = new LineIndex(graph.text(e.getKey()));
+            for (Range range : e.getValue()) {
+                String field = fieldTakenAsName(root,
+                        lines.offsetOf(range.start().line(), range.start().character()));
+                edits.add(new TextEdit(range,
+                        field == null ? newName : field + " = " + newName));
+            }
+            out.put(e.getKey(), edits);
+        }
+        return out;
+    }
+
+    /**
+     * The field a binding takes its name from, or null where the binding is written as a name of
+     * its own.
+     *
+     * <p>Which characters are there is the syntax tree's question, being what knows about
+     * characters, and this is the one place where what a rename writes is not the name it was given.
+     */
+    private String fieldTakenAsName(SyntaxNode root, int offset) {
+        SyntaxToken token = identAt(root, offset);
+        SyntaxNode parent = token == null ? null : token.parent();
+        if (parent == null || token.start() != offset) {
+            return null;
+        }
+        if (parent.kind() == SyntaxKind.PATTERN_FIELD) {
+            // `{ f }` writes one name for both jobs; `{ f = x }` writes the binding's own
+            return onlyIdent(parent) ? token.text() : null;
+        }
+        if (parent.kind() == SyntaxKind.MATCH_CASE) {
+            // an arm's fields are the case's own tokens: `Flat { f }` against `Flat { f = x }`
+            return standsAlone(parent, token) ? token.text() : null;
+        }
+        return null;
+    }
+
+    /** Whether {@code node} holds one identifier and no other. */
+    private boolean onlyIdent(SyntaxNode node) {
+        int found = 0;
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
+                found++;
+            }
+        }
+        return found == 1;
+    }
+
+    /** Whether {@code token} is a field written with nothing beside it — the previous and next
+     * tokens that are not trivia open or separate the list rather than assign to it. */
+    private boolean standsAlone(SyntaxNode node, SyntaxToken token) {
+        SyntaxToken before = null;
+        boolean past = false;
+        for (SyntaxElement e : node.children()) {
+            if (!(e instanceof SyntaxToken t) || t.isTrivia()) {
+                continue;
+            }
+            if (past) {
+                return (t.kind() == SyntaxKind.COMMA || t.kind() == SyntaxKind.RBRACE)
+                        && before != null
+                        && (before.kind() == SyntaxKind.LBRACE || before.kind() == SyntaxKind.COMMA);
+            }
+            if (t == token) {
+                past = true;
+                continue;
+            }
+            before = t;
+        }
+        return false;
+    }
+
+    /** Where renaming touches, before what to write there is decided. */
+    private Map<String, List<Range>> renameRanges(String uri, Position pos, ModuleGraph graph) {
         Map<String, List<Range>> byUri = new LinkedHashMap<>();
         for (Location loc : references(uri, pos, graph, true)) {
             byUri.computeIfAbsent(loc.uri(), k -> new ArrayList<>()).add(loc.range());

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -270,27 +270,63 @@ public final class Analyzer {
                 : compiledAgainst, clean, broken);
     }
 
+    /** Where the cursor is, in the terms the compiler answers about: a place in a file, not a line
+     * and a column that any file might have. */
+    private static SourcePos cursor(String uri, Position pos) {
+        return new SourcePos(pos.line() + 1, pos.character() + 1, uri);
+    }
+
     /** What the cursor is on, as the compiler answers it: the type a name at {@code pos} denotes,
-     * or the declaration whose own name is there. Null when the compiler cannot say — a file that
-     * does not compile, or a name in the value namespace, which is still matched by spelling. */
-    private TypeName typeUnderCursor(Compilation compilation, String uri, ModuleGraph graph,
-                                     Position pos) {
-        String text = graph.text(uri);
-        String module = text == null ? null : Compiler.moduleNameFromHeader(text);
-        if (module == null) {
-            return null;
-        }
-        SourcePos at = new SourcePos(pos.line() + 1, pos.character() + 1, uri);
-        return compilation.db().ask(new Names.TypeAt(module, at)).value();
+     * or the declaration whose own name is there. Null when the compiler cannot say — a file it
+     * could not read, or a name in the value namespace. */
+    private TypeName typeUnderCursor(Compilation compilation, String uri, Position pos) {
+        return compilation.db().ask(new Names.TypeAt(cursor(uri, pos))).value();
     }
 
     /** The range of one written name, counting only its last segment: renaming a type rewrites the
      * {@code Amount} of {@code up.Amount}, never the {@code up}. */
-    private Range writtenRange(Resolve.Denotation denotation) {
-        int line = denotation.pos().line() - 1;
-        int start = denotation.pos().column() - 1 + denotation.written().lastIndexOf('.') + 1;
+    private Range writtenRange(SourcePos pos, String written) {
+        int line = pos.line() - 1;
+        int start = pos.column() - 1 + written.lastIndexOf('.') + 1;
         return new Range(new Position(line, start),
-                new Position(line, denotation.pos().column() - 1 + denotation.written().length()));
+                new Position(line, pos.column() - 1 + written.length()));
+    }
+
+    /**
+     * The document a compiler answer is about: the file its position names, or — for a position
+     * that names none — the file of the module it was asked of. Null when neither is a document
+     * this editor has open.
+     *
+     * <p>Every answer that carries a position carries the file it was written in, and what a module
+     * is made of is not all written in one file: its own source and every attached {@code examples
+     * for} file beside it. Filing an answer under the module's own source is right exactly while a
+     * module is one file, and nothing checks that it is.
+     */
+    private String documentOf(SourcePos written, String moduleUri, ModuleGraph graph) {
+        String uri = written != null && written.sourceId() != null ? written.sourceId() : moduleUri;
+        return uri != null && graph.text(uri) != null ? uri : null;
+    }
+
+    /**
+     * Where a name the compiler answered about is written, as a place an editor can open.
+     *
+     * <p>Which file and which name is the compiler's answer; which characters spell it there is the
+     * syntax tree's, being what knows about characters. The position is the start of the form that
+     * writes the name — a binding's is the pattern that binds it — so the token is looked for from
+     * there rather than assumed to be at it.
+     */
+    private Optional<Location> nameAt(SourcePos written, String name, String moduleUri,
+                                      ModuleGraph graph) {
+        String uri = documentOf(written, moduleUri, graph);
+        if (uri == null || written == null) {
+            return Optional.empty();
+        }
+        String text = graph.text(uri);
+        LineIndex lines = new LineIndex(text);
+        SyntaxToken token = identFrom(CstParser.parse(text).root(),
+                lines.offsetOf(written.line() - 1, written.column() - 1), name);
+        return token == null ? Optional.empty()
+                : Optional.of(new Location(uri, tokenRange(lines, token)));
     }
 
     /**
@@ -310,7 +346,7 @@ public final class Analyzer {
             return List.of();
         }
         Compilation compilation = compileOf(graph);
-        String module = moduleOf(compilation, uri);
+        String module = moduleOf(compilation, graph, uri);
         if (module == null) {
             return List.of();
         }
@@ -322,23 +358,35 @@ public final class Analyzer {
         LineIndex lines = new LineIndex(graph.text(uri));
         List<CodeLens> out = new ArrayList<>();
         for (Ast.BehaviorDef behavior : written.behaviors()) {
+            // A module's declarations need not all be in this document, and a line number from
+            // another file read against this one's index points somewhere arbitrary.
+            if (!uri.equals(documentOf(behavior.pos(), null, graph))) {
+                continue;
+            }
             String title = lensTitle(compilation, module, behavior.name(), adequacy);
-            if (title != null && behavior.pos() != null) {
+            if (title != null) {
                 out.add(new CodeLens(pointRange(lines, behavior.pos()), title));
             }
         }
         return out;
     }
 
-    /** Which module this document declares, or null where it declares none — a file held out for its
-     * syntax errors, or one the compile never reached. */
-    private static String moduleOf(Compilation compilation, String uri) {
-        for (String module : compilation.modules()) {
-            if (uri.equals(compilation.sourceIdOf(module))) {
-                return module;
-            }
+    /**
+     * The module this document is part of — the one it declares, or the one an attached
+     * {@code examples for} file's rows are for.
+     *
+     * <p>The compile's answer, with the header read only for a file the compile does not have: one
+     * held out for its syntax errors, which is the one case where there is nothing to ask. Reading
+     * the header first is what left a cursor in an attached file belonging to no module and being
+     * asked nothing.
+     */
+    private String moduleOf(Compilation compilation, ModuleGraph graph, String uri) {
+        String known = compilation.moduleOf(uri);
+        if (known != null) {
+            return known;
         }
-        return null;
+        String text = graph.text(uri);
+        return text == null ? null : Compiler.moduleNameFromHeader(text);
     }
 
     /**
@@ -465,7 +513,7 @@ public final class Analyzer {
             return List.of();
         }
         Compilation compilation = compileOf(graph);
-        String module = moduleOf(compilation, uri);
+        String module = moduleOf(compilation, graph, uri);
         if (module == null) {
             return List.of();
         }
@@ -475,7 +523,9 @@ public final class Analyzer {
         }
         LineIndex lines = new LineIndex(text);
         for (Ast.BehaviorDef behavior : written.behaviors()) {
-            if (behavior.pos() == null
+            // The cursor is in this document, so a declaration written in another one is not what
+            // it is on, however the lines happen to line up.
+            if (!uri.equals(documentOf(behavior.pos(), null, graph))
                     || !overlaps(pointRange(lines, behavior.pos()), requested)) {
                 continue;
             }
@@ -546,13 +596,16 @@ public final class Analyzer {
         if (text == null) {
             return Optional.empty();
         }
-        Optional<Location> answered = declarationOf(uri, pos, graph);
-        if (answered.isPresent()) {
-            return answered;
-        }
-        Optional<Location> value = valueDeclarationOf(uri, pos, graph);
-        if (value.isPresent()) {
-            return value;
+        Compilation compilation = compileOf(graph);
+        if (resolves(compilation, uri)) {
+            TypeName type = typeUnderCursor(compilation, uri, pos);
+            if (type != null) {
+                return declarationOf(compilation, type, graph);
+            }
+            Optional<Location> value = valueDeclarationOf(compilation, uri, pos, graph);
+            if (value.isPresent()) {
+                return value;
+            }
         }
         LineIndex lines = new LineIndex(text);
         SyntaxNode root = CstParser.parse(text).root();
@@ -569,7 +622,7 @@ public final class Analyzer {
         if (targetModule == null) {
             return Optional.empty();
         }
-        String targetUri = uriOfModule(graph, targetModule);
+        String targetUri = uriOfModule(compilation, graph, targetModule);
         if (targetUri == null) {
             return Optional.empty();
         }
@@ -595,9 +648,19 @@ public final class Analyzer {
         if (text == null) {
             return List.of();
         }
-        List<Location> answered = usesOf(uri, pos, graph, includeDeclaration);
-        if (answered != null) {
-            return answered;
+        Compilation compilation = compileOf(graph);
+        if (resolves(compilation, uri)) {
+            List<Location> uses = usesOf(compilation, uri, pos, graph, includeDeclaration);
+            if (uses != null) {
+                return uses;
+            }
+            List<Location> values = valueUsesOf(compilation, uri, pos, graph, includeDeclaration);
+            if (!values.isEmpty()) {
+                return values;
+            }
+            // Nothing found is not nothing here: the resolve pass records the value names written
+            // in a body, and a composition's stages and a declaration's own name are not those, so
+            // the cursor may be on a name it never saw. Matching the spelling still answers those.
         }
         SyntaxNode root = CstParser.parse(text).root();
         SyntaxToken ident = identAt(root, new LineIndex(text).offsetOf(pos.line(), pos.character()));
@@ -606,11 +669,11 @@ public final class Analyzer {
         }
         String name = ident.text();
         String definingModule = declaringDef(root, name) != null
-                ? Compiler.moduleNameFromHeader(text) : importedFrom(text, name);
+                ? moduleOf(compilation, graph, uri) : importedFrom(text, name);
         if (definingModule == null) {
             return List.of();
         }
-        String definingUri = uriOfModule(graph, definingModule);
+        String definingUri = uriOfModule(compilation, graph, definingModule);
         if (definingUri == null) {
             return List.of();
         }
@@ -619,7 +682,7 @@ public final class Analyzer {
         List<Location> out = new ArrayList<>();
         for (String u : graph.uris()) {
             String t = graph.text(u);
-            boolean owns = definingModule.equals(Compiler.moduleNameFromHeader(t));
+            boolean owns = definingModule.equals(moduleOf(compilation, graph, u));
             if (!owns && !definingModule.equals(importedFrom(t, name))) {
                 continue;   // this file neither defines nor imports the symbol
             }
@@ -650,9 +713,25 @@ public final class Analyzer {
         // to be answered the same way: renaming from a qualified use renames the module the
         // reference names, and matching the spelling here would edit this module's own `exposing`
         // instead — leaving both modules uncompilable.
-        TypeName target = typeUnderCursor(compileOf(graph), uri, graph, pos);
-        if (target != null) {
-            addExposingAndImportSites(target.name(), target.module(), graph, byUri);
+        Compilation compilation = compileOf(graph);
+        TypeName type = typeUnderCursor(compilation, uri, pos);
+        if (type != null) {
+            addExposingAndImportSites(compilation, type.name(), type.module(), graph, byUri);
+            return byUri;
+        }
+        ValueName value = valueUnderCursor(compilation, uri, pos);
+        if (value != null) {
+            String declaring = switch (value) {
+                case ValueName.Helper h -> h.module();
+                case ValueName.Behavior b -> b.module();
+                // a local is named where it is bound and nowhere else; the library and the language
+                // are not this workspace's to rename
+                case ValueName.Local _, ValueName.Stdlib _, ValueName.OfType _,
+                        ValueName.Builtin _, ValueName.Unresolved _ -> null;
+            };
+            if (declaring != null) {
+                addExposingAndImportSites(compilation, value.name(), declaring, graph, byUri);
+            }
             return byUri;
         }
         String text = graph.text(uri);
@@ -661,9 +740,9 @@ public final class Analyzer {
         if (ident != null) {
             String name = ident.text();
             String definingModule = declaringDef(root, name) != null
-                    ? Compiler.moduleNameFromHeader(text) : importedFrom(text, name);
+                    ? moduleOf(compilation, graph, uri) : importedFrom(text, name);
             if (definingModule != null) {
-                addExposingAndImportSites(name, definingModule, graph, byUri);
+                addExposingAndImportSites(compilation, name, definingModule, graph, byUri);
             }
         }
         return byUri;
@@ -671,15 +750,9 @@ public final class Analyzer {
 
     /** What the cursor is on in the value namespace, as the compiler answers it, or null when
      * nothing there is a name used as a value. */
-    private ValueName valueUnderCursor(Compilation compilation, String uri, ModuleGraph graph,
-                                       Position pos) {
-        String text = graph.text(uri);
-        String module = text == null ? null : Compiler.moduleNameFromHeader(text);
-        if (module == null) {
-            return null;
-        }
-        SourcePos at = new SourcePos(pos.line() + 1, pos.character() + 1, uri);
-        Resolve.ValueUse use = compilation.db().ask(new Names.ValueDenotedAt(module, at)).value();
+    private ValueName valueUnderCursor(Compilation compilation, String uri, Position pos) {
+        Resolve.ValueUse use =
+                compilation.db().ask(new Names.ValueDenotedAt(cursor(uri, pos))).value();
         return use == null ? null : use.denotes();
     }
 
@@ -690,38 +763,25 @@ public final class Analyzer {
      * <p>A local was out of reach while this was matched by spelling — one spelling may be bound in
      * several bodies, and nothing said which binding a use belonged to. Resolution says.
      */
-    private Optional<Location> valueDeclarationOf(String uri, Position pos, ModuleGraph graph) {
-        Compilation compilation = compileOf(graph);
-        ValueName target = valueUnderCursor(compilation, uri, graph, pos);
+    private Optional<Location> valueDeclarationOf(Compilation compilation, String uri, Position pos,
+                                                  ModuleGraph graph) {
+        ValueName target = valueUnderCursor(compilation, uri, pos);
         if (target == null) {
             return Optional.empty();
         }
+        return valueDeclarationOf(compilation, target, uri, graph);
+    }
+
+    private Optional<Location> valueDeclarationOf(Compilation compilation, ValueName target,
+                                                  String uri, ModuleGraph graph) {
         SourcePos at = compilation.db().ask(new Names.ValueDeclaredAt(target)).value();
-        if (at == null) {
-            return Optional.empty();
-        }
-        // Where the declaration was written is what the declaration's position says. Reading it off
-        // the module instead is right only while a module is one file, and a value declared in an
-        // attached `examples for` file is one the module has and that file wrote.
-        String targetUri = at.sourceId() != null ? at.sourceId() : switch (target) {
+        return nameAt(at, target.name(), switch (target) {
             case ValueName.Local _ -> uri;   // bound in the body the cursor is in
             case ValueName.Helper h -> compilation.sourceIdOf(h.module());
             case ValueName.Behavior b -> compilation.sourceIdOf(b.module());
             case ValueName.Stdlib _, ValueName.OfType _, ValueName.Builtin _,
                     ValueName.Unresolved _ -> null;
-        };
-        String targetText = targetUri == null ? null : graph.text(targetUri);
-        if (targetText == null) {
-            return Optional.empty();
-        }
-        // Which name, and where it was written, is the compiler's; which characters spell it there
-        // is the syntax tree's — the declaration's position is its first keyword, and a binding's is
-        // the form that binds it.
-        LineIndex lines = new LineIndex(targetText);
-        SyntaxToken name = identFrom(CstParser.parse(targetText).root(),
-                lines.offsetOf(at.line() - 1, at.column() - 1), target.name());
-        return name == null ? Optional.empty()
-                : Optional.of(new Location(targetUri, tokenRange(lines, name)));
+        }, graph);
     }
 
     /** The first identifier spelled {@code name} at or after {@code offset} — the name token of the
@@ -745,56 +805,85 @@ public final class Analyzer {
     }
 
     /**
-     * Where the type under the cursor is declared, as the compiler answers it. Empty when it cannot
-     * say: the workspace does not compile, or the cursor is on a name in the value namespace, which
-     * is still matched by spelling below.
+     * Whether the compile read this document and answered about the names in it.
+     *
+     * <p>This is what decides whether an unanswered question is a question with no answer or a
+     * question nothing could be asked of. Where the compile read the file, its silence is the
+     * answer: nothing is named under the cursor. Where it could not — a file with a syntax error is
+     * held out of the module set, and a module whose names would not resolve has no answers to give
+     * — matching the spelling is all there is, and it goes on being what an author gets while a file
+     * is half-typed.
      */
-    private Optional<Location> declarationOf(String uri, Position pos, ModuleGraph graph) {
-        Compilation compilation = compileOf(graph);
-        TypeName target = typeUnderCursor(compilation, uri, graph, pos);
-        if (target == null) {
-            return Optional.empty();
-        }
-        String targetUri = compilation.sourceIdOf(target.module());
-        String targetText = targetUri == null ? null : graph.text(targetUri);
-        if (targetText == null) {
-            return Optional.empty();
-        }
-        // Which module and which name is the compiler's answer — the part a spelling match gets
-        // wrong. Where in that file the name is written is the syntax tree's, which is what knows
-        // about characters; a module declares a name once, so there is nothing to choose between.
-        SyntaxNode def = declaringDef(CstParser.parse(targetText).root(), target.name());
-        SyntaxToken name = def == null ? null : nameToken(def);
-        return name == null ? Optional.empty()
-                : Optional.of(new Location(targetUri,
-                        tokenRange(new LineIndex(targetText), name)));
+    private boolean resolves(Compilation compilation, String uri) {
+        String module = compilation.moduleOf(uri);
+        return module != null && compilation.db().ask(new Names.Resolution(module)).present();
+    }
+
+    /** Where a type is declared, as the compiler answers it. */
+    private Optional<Location> declarationOf(Compilation compilation, TypeName target,
+                                             ModuleGraph graph) {
+        // Which module, which name and where it was written is the compiler's answer — the part a
+        // spelling match gets wrong.
+        SourcePos at = compilation.db().ask(new Names.DeclaredAt(target)).value();
+        return nameAt(at, target.name(), compilation.sourceIdOf(target.module()), graph);
     }
 
     /**
-     * Every place the type under the cursor is named, as the compiler answers it, or null when it
-     * cannot say. A name resolves to one declaration wherever it is written, so a module that
-     * declares its own type of the same spelling is not swept up, and a qualified reference to
-     * another module's is.
+     * Every place the type under the cursor is named, as the compiler answers it, or null when the
+     * cursor is not on a type. A name resolves to one declaration wherever it is written, so a
+     * module that declares its own type of the same spelling is not swept up, and a qualified
+     * reference to another module's is.
      */
-    private List<Location> usesOf(String uri, Position pos, ModuleGraph graph,
-                                  boolean includeDeclaration) {
-        Compilation compilation = compileOf(graph);
-        TypeName target = typeUnderCursor(compilation, uri, graph, pos);
+    private List<Location> usesOf(Compilation compilation, String uri, Position pos,
+                                  ModuleGraph graph, boolean includeDeclaration) {
+        TypeName target = typeUnderCursor(compilation, uri, pos);
         if (target == null) {
             return null;
         }
         List<Location> out = new ArrayList<>();
         if (includeDeclaration) {
-            declarationOf(uri, pos, graph).ifPresent(out::add);
+            declarationOf(compilation, target, graph).ifPresent(out::add);
         }
         for (String module : compilation.modules()) {
             String moduleUri = compilation.sourceIdOf(module);
-            if (moduleUri == null || graph.text(moduleUri) == null) {
-                continue;
-            }
             for (Resolve.Denotation use
                     : compilation.db().ask(new Names.UsesOf(module, target)).value()) {
-                out.add(new Location(moduleUri, writtenRange(use)));
+                String at = documentOf(use.pos(), moduleUri, graph);
+                if (at != null) {
+                    out.add(new Location(at, writtenRange(use.pos(), use.written())));
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * Every place the value under the cursor is named, as the compiler answers it. Empty when the
+     * cursor is not on one.
+     *
+     * <p>{@link #usesOf} for the value namespace, and the reason a local can be asked about at all:
+     * a use denotes a binding, so the uses of one body's {@code x} are not another's. Matching the
+     * spelling could only ever answer about top-level names, and answered about the wrong one where
+     * two modules spelled a name alike.
+     */
+    private List<Location> valueUsesOf(Compilation compilation, String uri, Position pos,
+                                       ModuleGraph graph, boolean includeDeclaration) {
+        ValueName target = valueUnderCursor(compilation, uri, pos);
+        if (target == null) {
+            return List.of();
+        }
+        List<Location> out = new ArrayList<>();
+        if (includeDeclaration) {
+            valueDeclarationOf(compilation, target, uri, graph).ifPresent(out::add);
+        }
+        for (String module : compilation.modules()) {
+            String moduleUri = compilation.sourceIdOf(module);
+            for (Resolve.ValueUse use
+                    : compilation.db().ask(new Names.ValueUsesOf(module, target)).value()) {
+                String at = documentOf(use.pos(), moduleUri, graph);
+                if (at != null) {
+                    out.add(new Location(at, writtenRange(use.pos(), use.written())));
+                }
             }
         }
         return out;
@@ -803,13 +892,14 @@ public final class Analyzer {
     /** Adds the {@code exposing ( name )} occurrence in the module that defines {@code name}, and each
      * {@code import <definingModule> ( name )} occurrence in the modules that import it — the binding
      * sites find-references skips but rename must carry along. */
-    private void addExposingAndImportSites(String name, String definingModule, ModuleGraph graph,
+    private void addExposingAndImportSites(Compilation compilation, String name,
+                                           String definingModule, ModuleGraph graph,
                                            Map<String, List<Range>> byUri) {
         for (String u : graph.uris()) {
             String t = graph.text(u);
             SyntaxNode root = CstParser.parse(t).root();
             LineIndex lines = new LineIndex(t);
-            boolean owns = definingModule.equals(Compiler.moduleNameFromHeader(t));
+            boolean owns = definingModule.equals(moduleOf(compilation, graph, u));
             for (SyntaxNode top : root.childNodes()) {
                 if (top.kind() == SyntaxKind.MODULE_HEADER && owns) {
                     top.child(SyntaxKind.EXPOSING_CLAUSE).ifPresent(clause -> {
@@ -1074,8 +1164,14 @@ public final class Analyzer {
         return null;
     }
 
-    /** The document URI of the module declared with {@code moduleName}, or {@code null} if none. */
-    private String uriOfModule(ModuleGraph graph, String moduleName) {
+    /** The document the module {@code moduleName} is declared in, or {@code null} if none — the
+     * compile's answer, with the headers read only for a module whose file the compile could not
+     * read. */
+    private String uriOfModule(Compilation compilation, ModuleGraph graph, String moduleName) {
+        String declared = compilation.sourceIdOf(moduleName);
+        if (declared != null && graph.text(declared) != null) {
+            return declared;
+        }
         for (String uri : graph.uris()) {
             if (moduleName.equals(Compiler.moduleNameFromHeader(graph.text(uri)))) {
                 return uri;
@@ -1129,11 +1225,11 @@ public final class Analyzer {
         }
         SyntaxNode data = enclosing(root, offset, SyntaxKind.DATA_DEF);
         SyntaxToken name = data == null ? null : nameToken(data);
-        String module = Compiler.moduleNameFromHeader(text);
+        Compilation compilation = compileOf(graph);
+        String module = moduleOf(compilation, graph, uri);
         if (name == null || module == null) {
             return Optional.empty();
         }
-        Compilation compilation = compileOf(graph);
         Map<TypeName, List<ClauseDischarge>> byType =
                 compilation.db().ask(new Shapes.InvariantCapabilities(module)).value();
         List<ClauseDischarge> clauses = byType == null

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -637,11 +637,16 @@ public final class Analyzer {
     }
 
     /**
-     * Find-references across the workspace: every use of the top-level symbol the cursor names, in the
-     * defining module and in every module that imports it. Resolution respects namespaces — a type
-     * mention and a value of the same spelling are different symbols — and scope: a use inside a
-     * definition that binds the name locally (a param or a {@code let}) is that local, not the symbol,
-     * and is excluded. The declaration itself is included only when {@code includeDeclaration} is set.
+     * Find-references across the workspace: every use of the name the cursor is on, in the module
+     * that declares it and in every module that names it. Namespaces are respected — a type mention
+     * and a value of the same spelling are different names — and so is scope: a local is the binding
+     * it is, so the uses of one body's {@code x} are not another's. The declaration itself is
+     * included only when {@code includeDeclaration} is set, and a behavior has two of them.
+     *
+     * <p>A local is in reach, which it was not while this matched by spelling: a scan of top-level
+     * declarations cannot see a name bound inside one. Where resolution has nothing to say — a
+     * pipeline's stages and a behavior's own declaration lines are written outside any body, so it
+     * never read them — the spelling is still what answers.
      */
     public List<Location> references(String uri, Position pos, ModuleGraph graph, boolean includeDeclaration) {
         String text = graph.text(uri);
@@ -693,9 +698,11 @@ public final class Analyzer {
     }
 
     /**
-     * The edit ranges for renaming the top-level symbol under the cursor, grouped by document uri:
-     * every reference to it plus its declaration. Empty when the cursor is not on a renameable
-     * top-level symbol (a local param or {@code let} is out of scope, as it is for find-references).
+     * The edit ranges for renaming the name under the cursor, grouped by document uri: every
+     * reference to it plus every line that declares it. Empty when the cursor is not on a name.
+     *
+     * <p>A local is renameable, from its binding as much as from a use of it — the same reach
+     * find-references has, for the same reason.
      */
     public Map<String, List<Range>> renameEdits(String uri, Position pos, ModuleGraph graph) {
         Map<String, List<Range>> byUri = new LinkedHashMap<>();
@@ -703,7 +710,7 @@ public final class Analyzer {
             byUri.computeIfAbsent(loc.uri(), k -> new ArrayList<>()).add(loc.range());
         }
         if (byUri.isEmpty()) {
-            return byUri;   // not a renameable top-level symbol
+            return byUri;   // nothing under the cursor to rename
         }
         // references() treats a name in an `exposing`/`import` list as a binding site, not a use, and
         // skips it. Rename must still update those, or the module stops exposing (and importers stop
@@ -749,11 +756,9 @@ public final class Analyzer {
     }
 
     /** What the cursor is on in the value namespace, as the compiler answers it, or null when
-     * nothing there is a name used as a value. */
+     * nothing there is a name in it. */
     private ValueName valueUnderCursor(Compilation compilation, String uri, Position pos) {
-        Resolve.ValueUse use =
-                compilation.db().ask(new Names.ValueDenotedAt(cursor(uri, pos))).value();
-        return use == null ? null : use.denotes();
+        return compilation.db().ask(new Names.ValueAt(cursor(uri, pos))).value();
     }
 
     /**
@@ -775,13 +780,41 @@ public final class Analyzer {
     private Optional<Location> valueDeclarationOf(Compilation compilation, ValueName target,
                                                   String uri, ModuleGraph graph) {
         SourcePos at = compilation.db().ask(new Names.ValueDeclaredAt(target)).value();
-        return nameAt(at, target.name(), switch (target) {
+        return nameAt(at, target.name(), declaringFile(compilation, target, uri), graph);
+    }
+
+    /**
+     * Every place the value's own name is written as a declaration.
+     *
+     * <p>More than one where a behavior is what it names: the {@code behavior} line and the
+     * {@code let} line both write it. Renaming from a use has to reach both, or the module goes on
+     * naming something that is no longer there — and matching the spelling, which is what answered
+     * this before, saw both because it saw every line the name was on.
+     */
+    private List<Location> valueDeclarationsOf(Compilation compilation, ValueName target,
+                                               String uri, ModuleGraph graph) {
+        List<SourcePos> written =
+                compilation.db().ask(new Names.ValueDeclarationsOf(target)).value();
+        if (written == null) {
+            return List.of();
+        }
+        List<Location> out = new ArrayList<>();
+        for (SourcePos at : written) {
+            nameAt(at, target.name(), declaringFile(compilation, target, uri), graph)
+                    .ifPresent(out::add);
+        }
+        return out;
+    }
+
+    /** The file a value's declaration is in where its position does not name one. */
+    private String declaringFile(Compilation compilation, ValueName target, String uri) {
+        return switch (target) {
             case ValueName.Local _ -> uri;   // bound in the body the cursor is in
             case ValueName.Helper h -> compilation.sourceIdOf(h.module());
             case ValueName.Behavior b -> compilation.sourceIdOf(b.module());
             case ValueName.Stdlib _, ValueName.OfType _, ValueName.Builtin _,
                     ValueName.Unresolved _ -> null;
-        }, graph);
+        };
     }
 
     /** The first identifier spelled {@code name} at or after {@code offset} — the name token of the
@@ -874,7 +907,7 @@ public final class Analyzer {
         }
         List<Location> out = new ArrayList<>();
         if (includeDeclaration) {
-            valueDeclarationOf(compilation, target, uri, graph).ifPresent(out::add);
+            out.addAll(valueDeclarationsOf(compilation, target, uri, graph));
         }
         for (String module : compilation.modules()) {
             String moduleUri = compilation.sourceIdOf(module);

--- a/souther-lsp/src/main/java/souther/lsp/protocol/TextEdit.java
+++ b/souther-lsp/src/main/java/souther/lsp/protocol/TextEdit.java
@@ -1,0 +1,12 @@
+package souther.lsp.protocol;
+
+/**
+ * One replacement: the characters to write, and where.
+ *
+ * <p>Both halves, because what to write is not always the same at every place a rename touches. A
+ * record pattern's {@code { right }} names the field it reads and binds the value under that same
+ * spelling, so renaming the binding to {@code r} has to leave the field named: what goes there is
+ * {@code right = r}, not {@code r}. A rename that answered with places alone left the caller to
+ * write one name over all of them, which is right everywhere else and wrong here.
+ */
+public record TextEdit(Range range, String newText) {}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AUseIsFoundInTheFileItIsWrittenInTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AUseIsFoundInTheFileItIsWrittenInTest.java
@@ -1,0 +1,96 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+import souther.lsp.protocol.Location;
+import souther.lsp.protocol.Position;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Find-references asked the module for every place it names a type and then filed all of them under
+ * the module's own file. A module's names are not all written in one file, so a use written in an
+ * attached {@code examples for} file was published in the model file at the line and column it has in
+ * the other one — a place in a file it is not in, and one that may well hold something else.
+ *
+ * <p>Where a use is written is what the answer already says; only the reading of it was module-wide.
+ */
+class AUseIsFoundInTheFileItIsWrittenInTest {
+
+    private static final String MODEL_URI = "file:///m.sou";
+    private static final String ATTACHED_URI = "file:///m.examples.sou";
+
+    /** Names `D` on line 3, twice on line 4 and twice on line 8. */
+    private static final String MODEL = """
+            module m
+
+            data D = { v: Int }
+            behavior f : (d: D) -> D
+            let f (d) = d
+
+            example f
+                | "a" : (D { v = 1 }) -> D { v = 1 }
+            """;
+
+    /** Names `D` on line 3 and line 6 — both past the end of what the model file writes. */
+    private static final String ATTACHED = """
+            examples for m
+
+            let base = D { v = 2 }
+
+            example f
+                | "b" : (base) -> D { v = 2 }
+            """;
+
+    private static ModuleGraph graph() {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(MODEL_URI, MODEL);
+        sources.put(ATTACHED_URI, ATTACHED);
+        return ModuleGraph.of(sources);
+    }
+
+    /** Every use of `D`, asked from the one the model file's `behavior` line writes. */
+    private static List<Location> usesOfD() {
+        ModuleGraph graph = graph();
+        Analyzer analyzer = new Analyzer();
+        analyzer.diagnostics(graph);
+        return analyzer.references(MODEL_URI, new Position(3, 17), graph, false);
+    }
+
+    @Test
+    void theUsesTheAttachedFileWritesAreFoundThere() {
+        List<Location> found = usesOfD();
+
+        assertEquals(2, found.stream().filter(l -> l.uri().equals(ATTACHED_URI)).count(),
+                "the attached file names `D` twice: " + found);
+    }
+
+    @Test
+    void andAreNotAlsoReportedInTheModelFile() {
+        List<Location> found = usesOfD();
+
+        assertEquals(4, found.stream().filter(l -> l.uri().equals(MODEL_URI)).count(),
+                "the model file names `D` four times besides declaring it: " + found);
+    }
+
+    @Test
+    void everyPlaceFoundReallySpellsTheNameThere() {
+        Map<String, String> text = new LinkedHashMap<>();
+        text.put(MODEL_URI, MODEL);
+        text.put(ATTACHED_URI, ATTACHED);
+
+        for (Location found : usesOfD()) {
+            List<String> lines = text.get(found.uri()).lines().toList();
+            assertTrue(found.range().start().line() < lines.size(),
+                    "line " + found.range().start().line() + " is past the end of " + found.uri());
+            String line = lines.get(found.range().start().line());
+            assertEquals("D", line.substring(found.range().start().character(),
+                            found.range().end().character()),
+                    "at " + found.uri() + " " + found.range());
+        }
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/AnalyzerTest.java
@@ -455,8 +455,8 @@ class AnalyzerTest {
         ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
 
         // cursor on the `data N` declaration in a (line 1, char 5)
-        java.util.Map<String, List<Range>> edits =
-                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph);
+        java.util.Map<String, List<souther.lsp.protocol.TextEdit>> edits =
+                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph, "Renamed");
 
         assertEquals(java.util.Set.of("file:///a.sou", "file:///b.sou"), edits.keySet(), edits.toString());
         // a: the `exposing ( N )` entry (line 0) and the `data N` declaration (line 1)
@@ -479,12 +479,12 @@ class AnalyzerTest {
         ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a));
 
         // cursor on the `data N` declaration (line 1, char 5)
-        java.util.Map<String, List<Range>> edits =
-                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph);
+        java.util.Map<String, List<souther.lsp.protocol.TextEdit>> edits =
+                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph, "Renamed");
 
         java.util.Set<Integer> lines = new java.util.HashSet<>();
-        for (Range r : edits.get("file:///a.sou")) {
-            lines.add(r.start().line());
+        for (souther.lsp.protocol.TextEdit e : edits.get("file:///a.sou")) {
+            lines.add(e.range().start().line());
         }
         assertTrue(lines.contains(4), "the annotation on line 4 is renamed: " + lines);
     }
@@ -501,12 +501,12 @@ class AnalyzerTest {
         ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a));
 
         // cursor on the `data Tag` declaration (line 1, char 5)
-        java.util.Map<String, List<Range>> edits =
-                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph);
+        java.util.Map<String, List<souther.lsp.protocol.TextEdit>> edits =
+                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph, "Renamed");
 
         java.util.Set<Integer> lines = new java.util.HashSet<>();
-        for (Range r : edits.get("file:///a.sou")) {
-            lines.add(r.start().line());
+        for (souther.lsp.protocol.TextEdit e : edits.get("file:///a.sou")) {
+            lines.add(e.range().start().line());
         }
         assertTrue(lines.contains(2), "the element inside `List<Tag>` on line 2 is renamed: " + lines);
     }
@@ -524,12 +524,12 @@ class AnalyzerTest {
                 + "}\n";
         ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a));
 
-        java.util.Map<String, List<Range>> edits =
-                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph);
+        java.util.Map<String, List<souther.lsp.protocol.TextEdit>> edits =
+                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph, "Renamed");
 
         java.util.Set<Integer> lines = new java.util.HashSet<>();
-        for (Range r : edits.get("file:///a.sou")) {
-            lines.add(r.start().line());
+        for (souther.lsp.protocol.TextEdit e : edits.get("file:///a.sou")) {
+            lines.add(e.range().start().line());
         }
         assertTrue(lines.contains(4), "the pattern on line 4 is renamed: " + lines);
     }
@@ -562,18 +562,18 @@ class AnalyzerTest {
         String b = "module b\nimport a ( N )\nbehavior f : (n: N) -> N\nlet f (n) = n\n";
         ModuleGraph graph = ModuleGraph.of(java.util.Map.of("file:///a.sou", a, "file:///b.sou", b));
 
-        java.util.Map<String, List<Range>> edits =
-                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph);
+        java.util.Map<String, List<souther.lsp.protocol.TextEdit>> edits =
+                analyzer.renameEdits("file:///a.sou", new Position(1, 5), graph, "Renamed");
 
         java.util.Set<Integer> aLines = new java.util.HashSet<>();
-        for (Range r : edits.get("file:///a.sou")) {
-            aLines.add(r.start().line());
+        for (souther.lsp.protocol.TextEdit e : edits.get("file:///a.sou")) {
+            aLines.add(e.range().start().line());
         }
         assertTrue(aLines.contains(0), "the exposing clause on line 0 is renamed: " + aLines);
 
         java.util.Set<Integer> bLines = new java.util.HashSet<>();
-        for (Range r : edits.get("file:///b.sou")) {
-            bLines.add(r.start().line());
+        for (souther.lsp.protocol.TextEdit e : edits.get("file:///b.sou")) {
+            bLines.add(e.range().start().line());
         }
         assertTrue(bLines.contains(1), "the import list on line 1 is renamed: " + bLines);
     }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationInsideAnAttachedFileTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationInsideAnAttachedFileTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import souther.lsp.protocol.Location;
 import souther.lsp.protocol.Position;
 import souther.lsp.protocol.Range;
+import souther.lsp.protocol.TextEdit;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -147,8 +148,8 @@ class NavigationInsideAnAttachedFileTest {
     void renamingFromTheAttachedFileReachesTheDeclaringFile() {
         ModuleGraph graph = graph();
 
-        Map<String, List<Range>> edits =
-                warmed(graph).renameEdits(ATTACHED_URI, new Position(4, 4), graph);
+        Map<String, List<TextEdit>> edits =
+                warmed(graph).renameEdits(ATTACHED_URI, new Position(4, 4), graph, "Renamed");
 
         assertTrue(edits.containsKey(MODEL_URI),
                 "renaming `D` from here rewrites where it is declared: " + edits);

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationInsideAnAttachedFileTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationInsideAnAttachedFileTest.java
@@ -1,0 +1,158 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+import souther.lsp.protocol.Location;
+import souther.lsp.protocol.Position;
+import souther.lsp.protocol.Range;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An attached {@code examples for} file declares no module of its own, and the editor used to work
+ * out which module a document was about by reading its header. So a cursor inside one reached no
+ * compile at all: the names it is on are the module's names, and nothing asked the module about
+ * them.
+ *
+ * <p>What the attached file writes is out of reach of a spelling match from either side. It declares
+ * no {@code data} and writes no imports, so a type it names is found nowhere; and a local it binds is
+ * under a top-level name, which a scan of top-level declarations does not see.
+ */
+class NavigationInsideAnAttachedFileTest {
+
+    private static final String MODEL_URI = "file:///m.sou";
+    private static final String ATTACHED_URI = "file:///m.examples.sou";
+
+    /** `D` is declared on line 3, at column 6. */
+    private static final String MODEL = """
+            module m
+
+            data D = { v: Int }
+            behavior f : (d: D) -> D
+            let f (d) = d
+
+            example f
+                | "a" : (D { v = 1 }) -> D { v = 1 }
+            """;
+
+    /**
+     * Line 3 declares `base` at column 5, line 4 binds the local `one` at column 9, line 5 names `D`
+     * at column 5 and reads `one` at column 13, and the row on line 9 reads `base` at column 14 and
+     * names `D` at column 23.
+     */
+    private static final String ATTACHED = """
+            examples for m
+
+            let base = {
+                let one = 2
+                D { v = one }
+            }
+
+            example f
+                | "b" : (base) -> D { v = 2 }
+            """;
+
+    private static ModuleGraph graph() {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(MODEL_URI, MODEL);
+        sources.put(ATTACHED_URI, ATTACHED);
+        return ModuleGraph.of(sources);
+    }
+
+    private static Analyzer warmed(ModuleGraph graph) {
+        Analyzer analyzer = new Analyzer();
+        analyzer.diagnostics(graph);
+        return analyzer;
+    }
+
+    /** The line of {@code text} the location points into, with its range marked by {@code [ ]}. */
+    private static String marked(String text, Range range) {
+        String line = text.lines().toList().get(range.start().line());
+        return line.substring(0, range.start().character()) + "["
+                + line.substring(range.start().character(), range.end().character()) + "]"
+                + line.substring(range.end().character());
+    }
+
+    @Test
+    void bothFilesAreCleanSoNothingBelowIsAboutAFileThatDoesNotCompile() {
+        Map<String, List<souther.lsp.protocol.LspDiagnostic>> found = new Analyzer()
+                .diagnostics(graph());
+
+        assertEquals(List.of(), found.get(MODEL_URI));
+        assertEquals(List.of(), found.get(ATTACHED_URI));
+    }
+
+    @Test
+    void aTypeTheAttachedFileNamesGoesToTheModuleThatDeclaresIt() {
+        ModuleGraph graph = graph();
+
+        Location found = warmed(graph)
+                .definition(ATTACHED_URI, new Position(4, 4), graph).orElseThrow();
+
+        assertEquals(MODEL_URI, found.uri(), "`D` is declared in the module's own file");
+        assertEquals("data [D] = { v: Int }", marked(MODEL, found.range()));
+    }
+
+    @Test
+    void aTypeNamedByARowInTheAttachedFileGoesThereToo() {
+        ModuleGraph graph = graph();
+
+        Location found = warmed(graph)
+                .definition(ATTACHED_URI, new Position(8, 22), graph).orElseThrow();
+
+        assertEquals(MODEL_URI, found.uri());
+        assertEquals("data [D] = { v: Int }", marked(MODEL, found.range()));
+    }
+
+    @Test
+    void aValueTheAttachedFileDeclaresIsFoundBesideTheRowThatReadsIt() {
+        ModuleGraph graph = graph();
+
+        Location found = warmed(graph)
+                .definition(ATTACHED_URI, new Position(8, 13), graph).orElseThrow();
+
+        assertEquals(ATTACHED_URI, found.uri());
+        assertEquals("let [base] = {", marked(ATTACHED, found.range()));
+    }
+
+    @Test
+    void aLocalBoundInTheAttachedFileIsTheBindingAndNotSomeTopLevelName() {
+        ModuleGraph graph = graph();
+
+        Location found = warmed(graph)
+                .definition(ATTACHED_URI, new Position(4, 12), graph).orElseThrow();
+
+        assertEquals(ATTACHED_URI, found.uri());
+        assertEquals("    let [one] = 2", marked(ATTACHED, found.range()));
+    }
+
+    @Test
+    void findingReferencesFromTheAttachedFileFindsBothFiles() {
+        ModuleGraph graph = graph();
+
+        List<Location> found =
+                warmed(graph).references(ATTACHED_URI, new Position(4, 4), graph, false);
+
+        assertTrue(found.stream().anyMatch(l -> l.uri().equals(MODEL_URI)),
+                "the module's own file names `D` four times: " + found);
+        assertTrue(found.stream().anyMatch(l -> l.uri().equals(ATTACHED_URI)),
+                "and the attached file twice: " + found);
+    }
+
+    @Test
+    void renamingFromTheAttachedFileReachesTheDeclaringFile() {
+        ModuleGraph graph = graph();
+
+        Map<String, List<Range>> edits =
+                warmed(graph).renameEdits(ATTACHED_URI, new Position(4, 4), graph);
+
+        assertTrue(edits.containsKey(MODEL_URI),
+                "renaming `D` from here rewrites where it is declared: " + edits);
+        assertTrue(edits.containsKey(ATTACHED_URI),
+                "and where this file names it: " + edits);
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesNamesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesNamesTest.java
@@ -3,6 +3,7 @@ package souther.lsp.analysis;
 import souther.lsp.protocol.Location;
 import souther.lsp.protocol.Position;
 import souther.lsp.protocol.Range;
+import souther.lsp.protocol.TextEdit;
 
 import org.junit.jupiter.api.Test;
 
@@ -53,12 +54,12 @@ class NavigationResolvesNamesTest {
 
     @Test
     void renamingOneModulesTypeLeavesTheOtherModulesAlone() {
-        Map<String, List<Range>> edits =
-                new Analyzer().renameEdits("file:///here.sou", HERES_AMOUNT, graph());
+        Map<String, List<TextEdit>> edits = new Analyzer()
+                .renameEdits("file:///here.sou", HERES_AMOUNT, graph(), "Renamed");
 
         assertTrue(edits.getOrDefault("file:///up.sou", List.of()).isEmpty(),
                 "up declares an Amount of its own, which this rename is not about");
-        List<Range> here = edits.getOrDefault("file:///here.sou", List.of());
+        List<Range> here = ranges(edits.get("file:///here.sou"));
         assertEquals(3, here.size(),
                 "the declaration, the `exposing` entry, and the one bare use — not the tail of"
                         + " `up.Amount`");
@@ -75,12 +76,12 @@ class NavigationResolvesNamesTest {
      */
     @Test
     void renamingFromAQualifiedUseCarriesTheRightModulesExposing() {
-        Map<String, List<Range>> edits =
-                new Analyzer().renameEdits("file:///here.sou", THE_QUALIFIED_USE, graph());
+        Map<String, List<TextEdit>> edits = new Analyzer()
+                .renameEdits("file:///here.sou", THE_QUALIFIED_USE, graph(), "Renamed");
 
         assertEquals(2, edits.getOrDefault("file:///up.sou", List.of()).size(),
                 "up's declaration and up's `exposing` entry");
-        List<Range> here = edits.getOrDefault("file:///here.sou", List.of());
+        List<Range> here = ranges(edits.get("file:///here.sou"));
         assertEquals(1, here.size(), "only the tail of `up.Amount`");
         assertEquals(4, here.get(0).start().line());
         assertEquals(21, here.get(0).start().character(),
@@ -95,5 +96,11 @@ class NavigationResolvesNamesTest {
         assertTrue(found.isPresent(), "up.Amount denotes up's declaration");
         assertEquals("file:///up.sou", found.get().uri(),
                 "a spelling match would have stopped at this module's own Amount");
+    }
+
+    /** The places a set of edits touches; these tests are about where a rename reaches. What each
+     * edit writes is {@code RenamedSourceStillCompilesTest}'s. */
+    private static List<Range> ranges(List<TextEdit> edits) {
+        return edits == null ? List.of() : edits.stream().map(TextEdit::range).toList();
     }
 }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesValuesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationResolvesValuesTest.java
@@ -3,6 +3,7 @@ package souther.lsp.analysis;
 import souther.lsp.protocol.Location;
 import souther.lsp.protocol.Position;
 import souther.lsp.protocol.Range;
+import souther.lsp.protocol.TextEdit;
 
 import org.junit.jupiter.api.Test;
 
@@ -117,14 +118,20 @@ class NavigationResolvesValuesTest {
      */
     @Test
     void renamingATypeRewritesTheConstructionsOfItInBodies() {
-        Map<String, List<Range>> edits =
-                new Analyzer().renameEdits("file:///up.sou", new Position(2, 5), twoModules());
+        Map<String, List<TextEdit>> edits = new Analyzer()
+                .renameEdits("file:///up.sou", new Position(2, 5), twoModules(), "Renamed");
 
-        List<Range> here = edits.getOrDefault("file:///here.sou", List.of());
+        List<Range> here = ranges(edits.get("file:///here.sou"));
         assertTrue(here.stream().anyMatch(r -> r.start().line() == 8 && r.start().character() == 14),
                 "the `Amount` of `B.Amount(n)` on the last line: " + here);
         assertEquals(3, here.size(),
                 "the output, the `constructs`, and the construction — not this module's own Amount: "
                         + here);
+    }
+
+    /** The places a set of edits touches; these tests are about where a rename reaches. What each
+     * edit writes is {@code RenamedSourceStillCompilesTest}'s. */
+    private static List<Range> ranges(List<TextEdit> edits) {
+        return edits == null ? List.of() : edits.stream().map(TextEdit::range).toList();
     }
 }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationSurvivesABadImportTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationSurvivesABadImportTest.java
@@ -69,8 +69,8 @@ class NavigationSurvivesABadImportTest {
 
     @Test
     void renamingIsStillAboutWhatNamesDenote() {
-        Map<String, java.util.List<souther.lsp.protocol.Range>> edits =
-                new Analyzer().renameEdits("file:///here.sou", new Position(4, 5), graph());
+        Map<String, java.util.List<souther.lsp.protocol.TextEdit>> edits = new Analyzer()
+                .renameEdits("file:///here.sou", new Position(4, 5), graph(), "Renamed");
 
         assertTrue(edits.getOrDefault("file:///up.sou", java.util.List.of()).isEmpty(),
                 "up declares an Amount of its own, which this rename is not about");

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationSurvivesAMistakeTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationSurvivesAMistakeTest.java
@@ -2,6 +2,7 @@ package souther.lsp.analysis;
 
 import souther.lsp.protocol.Position;
 import souther.lsp.protocol.Range;
+import souther.lsp.protocol.TextEdit;
 
 import org.junit.jupiter.api.Test;
 
@@ -56,8 +57,8 @@ class NavigationSurvivesAMistakeTest {
 
     @Test
     void renamingIsStillAboutWhatNamesDenote() {
-        Map<String, List<Range>> edits =
-                new Analyzer().renameEdits("file:///here.sou", HERES_AMOUNT, graph());
+        Map<String, List<TextEdit>> edits = new Analyzer()
+                .renameEdits("file:///here.sou", HERES_AMOUNT, graph(), "Renamed");
 
         assertTrue(edits.getOrDefault("file:///up.sou", List.of()).isEmpty(),
                 "up declares an Amount of its own, which this rename is not about");

--- a/souther-lsp/src/test/java/souther/lsp/analysis/RenamedSourceStillCompilesTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/RenamedSourceStillCompilesTest.java
@@ -1,0 +1,152 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.lsp.protocol.Position;
+import souther.lsp.protocol.Range;
+import souther.lsp.protocol.TextEdit;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rename is right when the source it produces means what the source it replaced meant. Checking
+ * the places an edit set touches does not say that: it says the editor found the occurrences it was
+ * looking for, which is a claim about the search and not about the result.
+ *
+ * <p>The difference is a form where one token has two jobs. A record pattern's {@code { right }}
+ * both names the field to read and binds the value to a name of the same spelling. Renaming the
+ * binding to {@code r} by writing {@code r} over that token gives {@code { r }}, which reads a field
+ * called {@code r} — and there is none. The edit set was right about where; only what to write there
+ * was wrong, and a check that reads positions cannot see it.
+ */
+class RenamedSourceStillCompilesTest {
+
+    private static final String URI = "file:///a.sou";
+
+    /**
+     * Line 9 destructures a parameter, naming one field and taking the other's own name. Line 14
+     * does the same in a {@code match} arm, and line 19 opens a newtype.
+     */
+    private static final String SOURCE = """
+            module a exposing ( Pair, Round, Flat, Shape, Amount, pick, tag, held )
+
+            data Pair = { left: Int, right: Int }
+            data Round = { r: Int }
+            data Flat = { f: Int }
+            data Shape = Round | Flat
+
+            behavior pick : (p: Pair) -> Int
+            let pick ({ left = l, right }) = l + right
+
+            behavior tag : (s: Shape) -> Int
+            let tag (s) = match s with
+                | Round as w -> w.r
+                | Flat { f } -> f
+
+            data Amount = Int
+
+            behavior held : (a: Amount) -> Int
+            let held (Amount(inner)) = inner
+            """;
+
+    private static ModuleGraph graph() {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(URI, SOURCE);
+        return ModuleGraph.of(sources);
+    }
+
+    /** The source as it stands after the rename an editor would carry out. */
+    private static String renamed(Position at, String newName) {
+        ModuleGraph graph = graph();
+        Analyzer analyzer = new Analyzer();
+        analyzer.diagnostics(graph);
+        List<TextEdit> edits = analyzer.renameEdits(URI, at, graph, newName).get(URI);
+        assertFalse(edits == null || edits.isEmpty(), "nothing to rename at " + at);
+        return applied(SOURCE, edits);
+    }
+
+    /** {@code edits} written into {@code text}, back to front so earlier ranges keep their places. */
+    private static String applied(String text, List<TextEdit> edits) {
+        List<String> lines = new ArrayList<>(text.lines().toList());
+        List<TextEdit> ordered = new ArrayList<>(edits);
+        ordered.sort(Comparator
+                .comparingInt((TextEdit e) -> e.range().start().line())
+                .thenComparingInt(e -> e.range().start().character())
+                .reversed());
+        for (TextEdit edit : ordered) {
+            Range r = edit.range();
+            assertEquals(r.start().line(), r.end().line(), "an edit spanning lines: " + r);
+            String line = lines.get(r.start().line());
+            lines.set(r.start().line(), line.substring(0, r.start().character())
+                    + edit.newText() + line.substring(r.end().character()));
+        }
+        return String.join("\n", lines) + "\n";
+    }
+
+    /** Whether a source compiles on its own with nothing said about it. */
+    private static List<String> problemsIn(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put(URI, source);
+        List<String> out = new ArrayList<>();
+        Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY).diagnostics()
+                .forEach((id, found) -> found.forEach(d -> out.add(d.toString())));
+        return out;
+    }
+
+    @Test
+    void theSourceItStartsFromCompiles() {
+        assertEquals(List.of(), problemsIn(SOURCE));
+    }
+
+    @Test
+    void renamingANameWrittenBesideItsFieldLeavesTheFieldAlone() {
+        String after = renamed(new Position(8, 19), "amount");   // the `l` of `{ left = l }`
+
+        assertTrue(after.contains("{ left = amount, right }"), after);
+        assertEquals(List.of(), problemsIn(after));
+    }
+
+    @Test
+    void renamingANameTakenFromItsFieldWritesTheFieldBackIn() {
+        String after = renamed(new Position(8, 22), "howMany");   // the `right` of `{ right }`
+
+        assertTrue(after.contains("{ left = l, right = howMany }"),
+                "`{ right }` binds by taking the field's own name; a rename has to say which"
+                        + " field it is reading now that the two differ:\n" + after);
+        assertEquals(List.of(), problemsIn(after));
+    }
+
+    @Test
+    void andTheSameInAMatchArm() {
+        String after = renamed(new Position(13, 13), "value");   // the `f` of `| Flat { f }`
+
+        assertTrue(after.contains("| Flat { f = value } -> value"), after);
+        assertEquals(List.of(), problemsIn(after));
+    }
+
+    @Test
+    void aNameANewtypePatternOpensIsRenamedAsItIs() {
+        String after = renamed(new Position(18, 17), "amount");   // the `inner` of `Amount(inner)`
+
+        assertTrue(after.contains("let held (Amount(amount)) = amount"), after);
+        assertEquals(List.of(), problemsIn(after));
+    }
+
+    @Test
+    void andSoIsAnOrdinaryParameter() {
+        String after = renamed(new Position(11, 9), "shape");   // the `s` of `let tag (s)`
+
+        assertTrue(after.contains("let tag (shape) = match shape with"), after);
+        assertEquals(List.of(), problemsIn(after));
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
@@ -3,6 +3,7 @@ package souther.lsp.analysis;
 import org.junit.jupiter.api.Test;
 import souther.lsp.protocol.Position;
 import souther.lsp.protocol.Range;
+import souther.lsp.protocol.TextEdit;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -49,20 +50,20 @@ class RenamingAValueAgreesWhereverItIsAskedTest {
             data N = { v: Int }
             """;
 
-    private static Map<String, List<Range>> renameFrom(Position pos) {
+    private static Map<String, List<TextEdit>> renameFrom(Position pos) {
         Map<String, String> sources = new LinkedHashMap<>();
         sources.put(URI, SOURCE);
         ModuleGraph graph = ModuleGraph.of(sources);
         Analyzer analyzer = new Analyzer();
         analyzer.diagnostics(graph);
-        return analyzer.renameEdits(URI, pos, graph);
+        return analyzer.renameEdits(URI, pos, graph, "renamed");
     }
 
     /** The lines an edit set touches, as `line:character`, sorted. */
-    private static Set<String> places(Map<String, List<Range>> edits) {
+    private static Set<String> places(Map<String, List<TextEdit>> edits) {
         Set<String> out = new TreeSet<>();
-        edits.forEach((uri, ranges) -> ranges.forEach(r ->
-                out.add(r.start().line() + ":" + r.start().character())));
+        edits.forEach((uri, made) -> made.forEach(e ->
+                out.add(e.range().start().line() + ":" + e.range().start().character())));
         return out;
     }
 
@@ -115,13 +116,13 @@ class RenamingAValueAgreesWhereverItIsAskedTest {
             let total (ds) = List.sum(List.map(.v, ds))
             """;
 
-    private static Map<String, List<Range>> renameInGetter(Position pos) {
+    private static Map<String, List<TextEdit>> renameInGetter(Position pos) {
         Map<String, String> sources = new LinkedHashMap<>();
         sources.put("file:///b.sou", GETTER);
         ModuleGraph graph = ModuleGraph.of(sources);
         Analyzer analyzer = new Analyzer();
         analyzer.diagnostics(graph);
-        return analyzer.renameEdits("file:///b.sou", pos, graph);
+        return analyzer.renameEdits("file:///b.sou", pos, graph, "renamed");
     }
 
     @Test
@@ -171,7 +172,7 @@ class RenamingAValueAgreesWhereverItIsAskedTest {
         ModuleGraph graph = ModuleGraph.of(sources);
         Analyzer analyzer = new Analyzer();
         analyzer.diagnostics(graph);
-        return places(analyzer.renameEdits("file:///c.sou", pos, graph));
+        return places(analyzer.renameEdits("file:///c.sou", pos, graph, "renamed"));
     }
 
     @Test

--- a/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
@@ -11,6 +11,8 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * What renaming edits does not depend on where the cursor was when it was asked.
@@ -133,5 +135,84 @@ class RenamingAValueAgreesWhereverItIsAskedTest {
     void aFieldIsNotSomethingToRenameEither() {
         assertEquals(Map.of(), renameInGetter(new Position(2, 11)),
                 "renaming `v` here would rewrite the declaration and leave every read of it");
+    }
+
+    /**
+     * The three forms where a pattern is lowered away: a parameter destructured into fields, a
+     * {@code match} arm's fields, and a newtype opened by name. Each binds a name the author wrote
+     * and holds the value in one nobody did.
+     *
+     * <p>Line 6 binds `l` at column 20 and `right` at column 23, and reads them at 32 and 36. Line 9
+     * binds `f` at column 14 and reads it at 21. Line 16 binds `inner` at column 18 and reads it at
+     * 28.
+     */
+    private static final String PATTERNS = """
+            module c exposing ( Pair, Flat, Amount, pick, tag, held )
+
+            data Pair = { left: Int, right: Int }
+            data Flat = { f: Int }
+
+            behavior pick : (p: Pair) -> Int
+            let pick ({ left = l, right }) = l + right
+
+            behavior tag : (x: Flat) -> Int
+            let tag (x) = match x with
+                | Flat { f } -> f
+
+            data Amount = Int
+
+            behavior held : (a: Amount) -> Int
+            let held (Amount(inner)) = inner
+            """;
+
+    private static Set<String> renameInPatterns(Position pos) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put("file:///c.sou", PATTERNS);
+        ModuleGraph graph = ModuleGraph.of(sources);
+        Analyzer analyzer = new Analyzer();
+        analyzer.diagnostics(graph);
+        return places(analyzer.renameEdits("file:///c.sou", pos, graph));
+    }
+
+    @Test
+    void aNameBoundByARecordPatternIsRenameableFromEitherEnd() {
+        assertEquals(Set.of("6:19", "6:33"), renameInPatterns(new Position(6, 19)),
+                "`{ left = l }` binds `l`, and the body reads it");
+        assertEquals(Set.of("6:19", "6:33"), renameInPatterns(new Position(6, 33)));
+    }
+
+    @Test
+    void andSoIsTheShorthandThatBindsTheFieldsOwnName() {
+        assertEquals(Set.of("6:22", "6:37"), renameInPatterns(new Position(6, 22)),
+                "`{ right }` binds `right` at the field's own token");
+        assertEquals(Set.of("6:22", "6:37"), renameInPatterns(new Position(6, 37)));
+    }
+
+    @Test
+    void aMatchArmsFieldDestructuringIsRenameableFromEitherEnd() {
+        assertEquals(Set.of("10:13", "10:20"), renameInPatterns(new Position(10, 13)),
+                "`| Flat { f } -> f`");
+        assertEquals(Set.of("10:13", "10:20"), renameInPatterns(new Position(10, 20)));
+    }
+
+    @Test
+    void soIsANameANewtypePatternOpens() {
+        assertEquals(Set.of("15:17", "15:27"), renameInPatterns(new Position(15, 17)),
+                "`let held (Amount(inner)) = inner`");
+        assertEquals(Set.of("15:17", "15:27"), renameInPatterns(new Position(15, 27)));
+    }
+
+    @Test
+    void andThePatternItselfCarriesNothingToRename() {
+        assertEquals(Set.of(), renameInPatterns(new Position(6, 10)),
+                "the `{` of the destructured parameter holds a name nobody wrote");
+    }
+
+    @Test
+    void thePatternsTypeNameIsThatTypeAndNotWhateverTheParameterIsCalled() {
+        Set<String> found = renameInPatterns(new Position(15, 10));
+
+        assertTrue(found.contains("12:5"), "`Amount(...)` names the type declared there: " + found);
+        assertFalse(found.contains("15:17"), "and not the name the pattern binds: " + found);
     }
 }

--- a/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
@@ -1,0 +1,104 @@
+package souther.lsp.analysis;
+
+import org.junit.jupiter.api.Test;
+import souther.lsp.protocol.Position;
+import souther.lsp.protocol.Range;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What renaming edits does not depend on where the cursor was when it was asked.
+ *
+ * <p>A behavior is declared twice — the {@code behavior} line says what it is, the {@code let} line
+ * says what it does — and both write its name. A value's binding is one place, and a use of it is
+ * another; asking from either is asking about the same binding.
+ *
+ * <p>Both directions used to go through matching the spelling, which is blind to which binding a
+ * name belongs to but does at least see every line the name is written on. Answering from
+ * resolution has to keep that: an answer that rewrites one of a behavior's two declaration lines
+ * leaves the module naming something that is no longer there.
+ */
+class RenamingAValueAgreesWhereverItIsAskedTest {
+
+    private static final String URI = "file:///a.sou";
+
+    /**
+     * `g` is declared on line 3 at column 10 and on line 4 at column 5, and used on line 7 at
+     * column 13. `x` is bound on line 8 at column 9 and used on line 9 at column 5.
+     */
+    private static final String SOURCE = """
+            module a exposing ( N, g )
+
+            behavior g : (n: N) -> N
+            let g (n) = n
+
+            behavior h : (n: N) -> N
+            let h (n) = g({
+                let x = n
+                x
+            })
+
+            data N = { v: Int }
+            """;
+
+    private static Map<String, List<Range>> renameFrom(Position pos) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put(URI, SOURCE);
+        ModuleGraph graph = ModuleGraph.of(sources);
+        Analyzer analyzer = new Analyzer();
+        analyzer.diagnostics(graph);
+        return analyzer.renameEdits(URI, pos, graph);
+    }
+
+    /** The lines an edit set touches, as `line:character`, sorted. */
+    private static Set<String> places(Map<String, List<Range>> edits) {
+        Set<String> out = new TreeSet<>();
+        edits.forEach((uri, ranges) -> ranges.forEach(r ->
+                out.add(r.start().line() + ":" + r.start().character())));
+        return out;
+    }
+
+    @Test
+    void renamingABehaviorFromItsSignatureRewritesBothOfItsDeclarations() {
+        Set<String> found = places(renameFrom(new Position(2, 9)));
+
+        assertEquals(Set.of("0:23", "2:9", "3:4", "6:12"), found,
+                "the `exposing` entry, both declaration lines and the one use");
+    }
+
+    @Test
+    void renamingABehaviorFromItsBodyRewritesTheSameLines() {
+        Set<String> found = places(renameFrom(new Position(3, 4)));
+
+        assertEquals(Set.of("0:23", "2:9", "3:4", "6:12"), found);
+    }
+
+    @Test
+    void renamingABehaviorFromAUseRewritesTheSameLines() {
+        Set<String> found = places(renameFrom(new Position(6, 12)));
+
+        assertEquals(Set.of("0:23", "2:9", "3:4", "6:12"), found,
+                "a use is a use of both declarations, not of the signature alone");
+    }
+
+    @Test
+    void renamingALocalFromItsUseRewritesTheBindingToo() {
+        Set<String> found = places(renameFrom(new Position(8, 4)));
+
+        assertEquals(Set.of("7:8", "8:4"), found, "the `let x` and the `x` that reads it");
+    }
+
+    @Test
+    void renamingALocalFromItsBindingRewritesTheSameLines() {
+        Set<String> found = places(renameFrom(new Position(7, 8)));
+
+        assertEquals(Set.of("7:8", "8:4"), found,
+                "a binding is what its uses denote, whichever end the question comes from");
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
@@ -101,4 +101,37 @@ class RenamingAValueAgreesWhereverItIsAskedTest {
         assertEquals(Set.of("7:8", "8:4"), found,
                 "a binding is what its uses denote, whichever end the question comes from");
     }
+
+    /** Line 3 writes the getter `.v` at column 36; a field getter desugars to a parameter nobody
+     * wrote, three characters wide, anchored there. */
+    private static final String GETTER = """
+            module b exposing ( D, total )
+
+            data D = { v: Int }
+
+            behavior total : (ds: List<D>) -> Int
+            let total (ds) = List.sum(List.map(.v, ds))
+            """;
+
+    private static Map<String, List<Range>> renameInGetter(Position pos) {
+        Map<String, String> sources = new LinkedHashMap<>();
+        sources.put("file:///b.sou", GETTER);
+        ModuleGraph graph = ModuleGraph.of(sources);
+        Analyzer analyzer = new Analyzer();
+        analyzer.diagnostics(graph);
+        return analyzer.renameEdits("file:///b.sou", pos, graph);
+    }
+
+    @Test
+    void aGetterIsNotSomethingToRename() {
+        assertEquals(Map.of(), renameInGetter(new Position(5, 35)),
+                "the `.` of `.v` names nothing an author can rename");
+        assertEquals(Map.of(), renameInGetter(new Position(5, 36)), "nor its field");
+    }
+
+    @Test
+    void aFieldIsNotSomethingToRenameEither() {
+        assertEquals(Map.of(), renameInGetter(new Position(2, 11)),
+                "renaming `v` here would rewrite the declaration and leave every read of it");
+    }
 }


### PR DESCRIPTION
Issue #326.

## What was wrong

A cursor inside an attached `examples for` file reached no compile. The editor
worked out which module a document was about with a regex over its text —
`Compiler.moduleNameFromHeader`, matching `^\s*module\s+X` — and an attached
file writes no such header. Every navigation entry point that starts from a
document fell out before asking the compiler anything.

The issue says navigation then falls back to matching by spelling. For a type it
does not: an attached file declares no `data` and writes no imports, so the
fallback finds nothing either. Go-to-definition and find-references answered
empty. For a value the fallback can land right by accident, when the name
happens to be declared in the same attached file.

The compiler side needed nothing. Asked with the module the file contributes to,
`Names.TypeAt`, `Names.ValueDenotedAt` and `Names.ValueDeclaredAt` all answer for
cursors in the attached file, and the positions carry that file's source id.

## What changed

**A question about a cursor is asked of a place.** `Front.ModuleOf(id)` answers
which module a source is part of — the one it declares, or the one an
`examples for` file's rows are for. `Names.TypeAt`, `DenotedAt` and
`ValueDenotedAt` now take only a position and read the module off the file it
names. A caller that had to name the module first was a caller that could name
the wrong one; there is no longer one to name.

`Compiler.moduleNameFromHeader` keeps one job, now stated on it: naming a module
whose file a compilation could not parse. Both remaining uses in the analyzer are
that case.

**An answer is filed where it was written.** Find-references asked each module
for every place it names a type and put all of them under the module's own
source. A use written in an attached file was published in the model file at the
line and column it has in the other one. In the fixture here that lands on the
`v` of `data D = { v: Int }` — a place in a file the use is not in, holding
something else. The reading of an answer's file is now one function that the
declaration, the type uses and the value uses go through. The same reading fixes
a code lens and the `write the rows` offer, which read another file's declaration
position against this document's line index.

**A declaration is named where its name is written.** `Names.TypeAt` compared the
cursor against the declaration's start — its `data` keyword — so it answered for
a cursor on the first columns of `data` and never for one on the name. That is
not specific to attached files: go-to-definition, find-references and rename from
a type's own declaration name fell back to spelling everywhere. `Ast.Def` now
carries where its name is written.

**What the fallback still does.** With the compile answering about types wherever
they are written, matching the spelling is no longer reached for one. It is still
what answers in the value namespace: the resolve pass records the value names
written in a body, and a composition's `>->` stages and a declaration's own name
are not among them, so nothing found there is not evidence of nothing. That is
written where the decision is made. `Names.ValueUsesOf` is new, which is what
lets find-references answer about a local at all — a spelling match could only
ever answer about top-level names.

**One removal.** `Names.spans` no longer answers a question that names no file.
That leniency was added in #309 for callers with only a line and a column to
give, and place-keyed queries leave none. The half that matters is kept: a name
that names no source is still not under a cursor in an open file.

## Tests

- `NavigationInsideAnAttachedFileTest` — a type, a row's type, a value and a
  local, from a cursor in the attached file, plus find-references and rename.
- `AUseIsFoundInTheFileItIsWrittenInTest` — every place found really spells the
  name there.
- `EverySourceKnowsWhichModuleItIsPartOfTest`, `ADeclarationIsNamedWhereItsNameIsWrittenTest`.

Against the unchanged code, 8 of the 10 new LSP assertions fail; the two that
pass are the fixture check and the value case that spelling gets right by
accident.

Full build green: runtime 109, compiler 2644, lsp 132, cli 1. The examples
repository builds and runs green against this compiler.

## Left out

Making find-references in the value namespace fully resolution-based needs the
resolve pass to record a composition's stages and a declaration's own name, which
is compiler work of its own. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
