### PR TITLE
A type says in its own declaration whether it holds a type

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Substitution.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Substitution.java
@@ -6,7 +6,6 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
 
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -142,10 +141,10 @@ final class Substitution {
                     && f.params().size() == a.params().size()
                     && allFit(a.params(), f.params(), symbols)
                     && fits(a.result(), f.result(), symbols);
-            // Not a shape with anything inside it to weigh position by position, so what is left is
-            // the ordinary question. It answers a variable the declaration wrote too, which is not
-            // this application's to decide and stands for whatever each use of it makes it.
-            default -> TypeOps.assignable(actual, want, symbols);
+            // Nothing inside it to weigh position by position, so what is left is the ordinary
+            // question. It answers a variable the declaration wrote too, which is not this
+            // application's to decide and stands for whatever each use of it makes it.
+            case Type.Leaf _ -> TypeOps.assignable(actual, want, symbols);
         };
     }
 
@@ -170,68 +169,69 @@ final class Substitution {
         // bottom needs. What it was decided to is {@link #bind}'s to weigh.
         Type left = declared;
         Type right = actual;
+        if (left instanceof Type.MetaVar m) {
+            bind(m, right, symbols, pos, what);
+            return;
+        }
+        // The other side carries what this one left open: a declared `List<Int>` read against a
+        // result still standing at a variable says what that variable is.
+        if (right instanceof Type.MetaVar m) {
+            bind(m, left, symbols, pos, what);
+            return;
+        }
+        // Position by position where the two shapes line up. Where they do not there is no variable
+        // here to decide, and whether they agree is {@link #fits}'s question.
         switch (left) {
-            case Type.MetaVar m -> bind(m, right, symbols, pos, what);
-            case Type.ListOf l when right instanceof Type.ListOf a ->
+            case Type.ListOf l -> {
+                if (right instanceof Type.ListOf a) {
                     decide(l.element(), a.element(), symbols, pos, what);
-            case Type.SetOf s when right instanceof Type.SetOf a ->
+                }
+            }
+            case Type.SetOf s -> {
+                if (right instanceof Type.SetOf a) {
                     decide(s.element(), a.element(), symbols, pos, what);
-            case Type.OptionOf o when right instanceof Type.OptionOf a ->
+                }
+            }
+            case Type.OptionOf o -> {
+                if (right instanceof Type.OptionOf a) {
                     decide(o.element(), a.element(), symbols, pos, what);
-            case Type.MapOf m when right instanceof Type.MapOf a -> {
-                decide(m.key(), a.key(), symbols, pos, what);
-                decide(m.value(), a.value(), symbols, pos, what);
-            }
-            case Type.TupleOf t when right instanceof Type.TupleOf a
-                    && t.elements().size() == a.elements().size() -> {
-                for (int i = 0; i < t.elements().size(); i++) {
-                    decide(t.elements().get(i), a.elements().get(i), symbols, pos, what);
                 }
             }
-            case Type.FnOf f when right instanceof Type.FnOf a
-                    && f.params().size() == a.params().size() -> {
-                for (int i = 0; i < f.params().size(); i++) {
-                    decide(f.params().get(i), a.params().get(i), symbols, pos, what);
+            case Type.MapOf m -> {
+                if (right instanceof Type.MapOf a) {
+                    decide(m.key(), a.key(), symbols, pos, what);
+                    decide(m.value(), a.value(), symbols, pos, what);
                 }
-                decide(f.result(), a.result(), symbols, pos, what);
             }
-            // The other side carries what this one left open: a declared `List<Int>` read against a
-            // result still standing at a variable says what that variable is.
-            case Type _ when right instanceof Type.MetaVar m -> bind(m, left, symbols, pos, what);
-            // Neither side is open, or the shapes do not line up. Either way there is no variable
-            // here to decide; whether they agree is {@link #fits}'s question.
-            default -> { }
+            case Type.TupleOf t -> {
+                if (right instanceof Type.TupleOf a
+                        && t.elements().size() == a.elements().size()) {
+                    for (int i = 0; i < t.elements().size(); i++) {
+                        decide(t.elements().get(i), a.elements().get(i), symbols, pos, what);
+                    }
+                }
+            }
+            case Type.FnOf f -> {
+                if (right instanceof Type.FnOf a && f.params().size() == a.params().size()) {
+                    for (int i = 0; i < f.params().size(); i++) {
+                        decide(f.params().get(i), a.params().get(i), symbols, pos, what);
+                    }
+                    decide(f.result(), a.result(), symbols, pos, what);
+                }
+            }
+            // Nothing inside it to descend into, so nothing here decides a variable.
+            case Type.Leaf _ -> { }
         }
     }
 
     /** {@code t} with every variable this has decided written into it. One still open is left
      * standing: it is not yet wrong, only not yet answered. */
     Type zonk(Type t) {
-        return switch (t) {
-            case Type.MetaVar m -> {
-                Type at = at(m);
-                yield at == null ? m : zonk(at);
-            }
-            case Type.ListOf l -> Type.list(zonk(l.element()));
-            case Type.SetOf s -> Type.set(zonk(s.element()));
-            case Type.OptionOf o -> Type.option(zonk(o.element()));
-            case Type.MapOf m -> Type.map(zonk(m.key()), zonk(m.value()));
-            case Type.TupleOf tu -> {
-                List<Type> es = new ArrayList<>();
-                for (Type e : tu.elements()) {
-                    es.add(zonk(e));
-                }
-                yield Type.tuple(es);
-            }
-            case Type.FnOf f -> {
-                List<Type> ps = new ArrayList<>();
-                for (Type p : f.params()) {
-                    ps.add(zonk(p));
-                }
-                yield Type.fn(ps, zonk(f.result()));
-            }
-            default -> t;
-        };
+        if (t instanceof Type.MetaVar m) {
+            Type at = at(m);
+            return at == null ? m : zonk(at);
+        }
+        return Type.mapChildren(t, this::zonk);
     }
 
     /**
@@ -301,27 +301,6 @@ final class Substitution {
 
     /** Every variable still open read as the bottom, at every depth. */
     private Type toBottom(Type t) {
-        return switch (t) {
-            case Type.MetaVar _ -> Type.NOTHING;
-            case Type.ListOf l -> Type.list(toBottom(l.element()));
-            case Type.SetOf s -> Type.set(toBottom(s.element()));
-            case Type.OptionOf o -> Type.option(toBottom(o.element()));
-            case Type.MapOf m -> Type.map(toBottom(m.key()), toBottom(m.value()));
-            case Type.TupleOf tu -> {
-                List<Type> es = new ArrayList<>();
-                for (Type e : tu.elements()) {
-                    es.add(toBottom(e));
-                }
-                yield Type.tuple(es);
-            }
-            case Type.FnOf f -> {
-                List<Type> ps = new ArrayList<>();
-                for (Type p : f.params()) {
-                    ps.add(toBottom(p));
-                }
-                yield Type.fn(ps, toBottom(f.result()));
-            }
-            default -> t;
-        };
+        return t instanceof Type.MetaVar ? Type.NOTHING : Type.mapChildren(t, this::toBottom);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/types/Type.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/Type.java
@@ -346,14 +346,20 @@ public sealed interface Type permits Type.Leaf, Type.Compound {
 
     /** Every name {@code t} mentions, by the simple name it would be written under. A simple name
      * that covers two different types in one type is already ambiguous within it, and is recorded
-     * under whichever came first — the pair rendering only has to tell the two sides apart. */
+     * under whichever came first — the pair rendering only has to tell the two sides apart.
+     *
+     * <p>Every constructor is named here rather than answered by {@link Leaf} and {@link Compound},
+     * because what this asks is not what those divide types by. They say whether one holds a type;
+     * this asks whether one holds a name, and {@link Ref} and {@link Union} are leaves that do. A
+     * constructor added later has to answer for itself, so it stops the build here. Only the descent
+     * is delegated: which positions a compound holds is still {@link #atChildren}'s to say. */
     private static void collectNames(Type t, java.util.Map<String, TypeName> out) {
         switch (t) {
-            // the two that hold a name: what this is after, and neither of them holds a type
             case Ref r -> out.putIfAbsent(r.name().name(), r.name());
             case Union u -> u.members().forEach(m -> out.putIfAbsent(m.name(), m));
-            case Leaf _ -> { }
-            case Compound c -> forEachChild(c, held -> collectNames(held, out));
+            case ListOf _, SetOf _, OptionOf _, MapOf _, TupleOf _, FnOf _ ->
+                    forEachChild(t, held -> collectNames(held, out));
+            case Prim _, Var _, MetaVar _, Nothing _, Never _, Erroneous _ -> { }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/types/Type.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/Type.java
@@ -4,9 +4,31 @@ package souther.compiler.types;
  * The Souther value types. Either a primitive ({@code Int}/{@code String}/{@code Bool})
  * or a reference to a named data type. {@code Type.INT} etc. remain usable as constants.
  */
-public sealed interface Type
-        permits Type.Prim, Type.Ref, Type.ListOf, Type.MapOf, Type.SetOf, Type.OptionOf, Type.Union,
-                Type.FnOf, Type.Open, Type.Nothing, Type.Never, Type.TupleOf, Type.Erroneous {
+public sealed interface Type permits Type.Leaf, Type.Compound {
+
+    /**
+     * A type that holds no type inside it, where a walk over the tree of types ends. A {@link Ref}
+     * and a {@link Union} hold names rather than types, so a reader after names still has something
+     * to read at one; a reader after types has not.
+     *
+     * <p>Written here rather than as a {@code default} arm in each walk. What "there is nothing
+     * inside this one" means is a fact about the constructor, and stating it once is what lets a
+     * constructor added later be accounted for at its declaration instead of at every walk that
+     * would have swallowed it.
+     */
+    sealed interface Leaf extends Type
+            permits Prim, Ref, Open, Nothing, Never, Erroneous, Union {}
+
+    /**
+     * A type built out of other types: what a collection holds, what a map keys and holds, what a
+     * tuple carries, what a function takes and answers.
+     *
+     * <p>{@link #mapChildren} and {@link #forEachChild} are exhaustive over this and carry no
+     * {@code default}, so a constructor added here stops the build at the one place that says which
+     * positions it holds.
+     */
+    sealed interface Compound extends Type
+            permits ListOf, SetOf, OptionOf, MapOf, TupleOf, FnOf {}
 
     /**
      * A type that stands for another rather than being one. There are two, and they differ in who
@@ -15,16 +37,16 @@ public sealed interface Type
      * decides it. Wherever the question is only "does this stand for something else", both answer
      * yes, and a reader asking it says so by naming this.
      */
-    sealed interface Open extends Type permits Var, MetaVar {}
+    sealed interface Open extends Leaf permits Var, MetaVar {}
 
-    enum Prim implements Type { INT, STRING, BOOL, DECIMAL, DATE, DATETIME, RAW }
+    enum Prim implements Leaf { INT, STRING, BOOL, DECIMAL, DATE, DATETIME, RAW }
 
     /** The element type of the empty-list literal {@code []} (ADR-0028): a bottom that unifies with
      * any element type. It only ever appears as {@code ListOf(NOTHING)} — the empty list — whose type
      * is fixed by context ({@code ++}, an {@code if}/{@code match} case, a {@code fold} seed, or the
      * {@code List<T>} a position expects). It never reaches codegen: an empty list is element-agnostic
      * at runtime. */
-    record Nothing() implements Type {}
+    record Nothing() implements Leaf {}
 
     /**
      * The type of an expression that answers no value: {@code unreachable "reason"}, and nothing
@@ -39,7 +61,7 @@ public sealed interface Type
      * reads a shape, so where this survives to codegen — the position stated no type and no branch
      * beside it supplied one — that position is refused rather than emitted.
      */
-    record Never() implements Type {}
+    record Never() implements Leaf {}
 
     /**
      * A type the compiler could not work out, and has already said so about.
@@ -58,7 +80,7 @@ public sealed interface Type
      * <p>It never reaches codegen. There is no bytecode for a type nobody could name, so the one
      * place that gates emitting a module refuses a tree that holds one.
      */
-    record Erroneous() implements Type {}
+    record Erroneous() implements Leaf {}
 
     /**
      * A type variable ({@code 'a}). It stands for any type; a non-recursive helper carrying one is
@@ -105,7 +127,7 @@ public sealed interface Type
     }
 
     /** A reference to a named data type (product or sum). */
-    record Ref(TypeName name) implements Type {
+    record Ref(TypeName name) implements Leaf {
         public Ref {
             if (name == null) {
                 throw new IllegalArgumentException("a type reference needs a resolved name");
@@ -114,32 +136,32 @@ public sealed interface Type
     }
 
     /** A homogeneous list of {@code element}. */
-    record ListOf(Type element) implements Type {}
+    record ListOf(Type element) implements Compound {}
 
     /** A {@code Map<key, value>}. The key is {@code String} or a String-backed newtype (ADR-0040);
      * at runtime the map is keyed by that value (value equality, ADR-0009) and its external
      * representation is a JSON object whose string keys are the key's bare form. */
-    record MapOf(Type key, Type value) implements Type {}
+    record MapOf(Type key, Type value) implements Compound {}
 
     /** A {@code Set<element>} — an unordered collection with no duplicate elements, compared by value
      * equality (ADR-0009). Its external representation is a JSON array, deduplicated on decode. */
-    record SetOf(Type element) implements Type {}
+    record SetOf(Type element) implements Compound {}
 
     /** An optional value {@code Option<element>} — the desugaring of a {@code T?} field (spec 7.4). */
-    record OptionOf(Type element) implements Type {}
+    record OptionOf(Type element) implements Compound {}
 
     /** An anonymous union of data types (a behavior's multi-success output). */
-    record Union(java.util.Set<TypeName> members) implements Type {}
+    record Union(java.util.Set<TypeName> members) implements Leaf {}
 
     /** A function type {@code (params...) -> result}. Written only on a helper {@code fn}'s
      * parameter (spec §fn-declaration); a value of this type is never stored in a data field, so it
      * never crosses a codec boundary. */
-    record FnOf(java.util.List<Type> params, Type result) implements Type {}
+    record FnOf(java.util.List<Type> params, Type result) implements Compound {}
 
     /** A tuple {@code (A, B, ...)} of two or more element types (ADR-0036). Expression-level only —
      * like {@link FnOf}, a tuple is never stored in a data field or a behavior's I/O, so it never
      * crosses a codec boundary; it only carries several values through a computation. */
-    record TupleOf(java.util.List<Type> elements) implements Type {}
+    record TupleOf(java.util.List<Type> elements) implements Compound {}
 
     /** The one {@link Erroneous}: it carries nothing, so there is nothing to tell two apart. */
     Type ERRONEOUS = new Erroneous();
@@ -209,6 +231,92 @@ public sealed interface Type
         return new Var(name, true);
     }
 
+    /**
+     * {@code c} with each position that holds a type replaced by what {@code at} answers for it, or
+     * {@code c} itself where every position answered what it was given, so a walk that only reads
+     * allocates nothing.
+     *
+     * <p>This is the one place that says which positions a compound holds. Both {@link #mapChildren}
+     * and {@link #forEachChild} are derived from it, so a position a constructor gains later is
+     * written once and neither walk can be left behind. Being exhaustive over {@link Compound}, a
+     * constructor added later stops the build here, which is the one place it has to be accounted
+     * for.
+     */
+    private static Type atChildren(Compound c, java.util.function.UnaryOperator<Type> at) {
+        return switch (c) {
+            case ListOf l -> {
+                Type element = at.apply(l.element());
+                yield element == l.element() ? l : new ListOf(element);
+            }
+            case SetOf s -> {
+                Type element = at.apply(s.element());
+                yield element == s.element() ? s : new SetOf(element);
+            }
+            case OptionOf o -> {
+                Type element = at.apply(o.element());
+                yield element == o.element() ? o : new OptionOf(element);
+            }
+            case MapOf m -> {
+                Type key = at.apply(m.key());
+                Type value = at.apply(m.value());
+                yield key == m.key() && value == m.value() ? m : new MapOf(key, value);
+            }
+            case TupleOf tu -> {
+                java.util.List<Type> elements = each(tu.elements(), at);
+                yield elements == tu.elements() ? tu : new TupleOf(elements);
+            }
+            case FnOf f -> {
+                java.util.List<Type> params = each(f.params(), at);
+                Type result = at.apply(f.result());
+                yield params == f.params() && result == f.result() ? f : new FnOf(params, result);
+            }
+        };
+    }
+
+    /** {@code xs} with {@code at} applied to each, or {@code xs} itself where none of them changed. */
+    private static java.util.List<Type> each(java.util.List<Type> xs,
+            java.util.function.UnaryOperator<Type> at) {
+        java.util.List<Type> out = null;
+        for (int i = 0; i < xs.size(); i++) {
+            Type before = xs.get(i);
+            Type after = at.apply(before);
+            if (out == null && after != before) {
+                out = new java.util.ArrayList<>(xs.subList(0, i));
+            }
+            if (out != null) {
+                out.add(after);
+            }
+        }
+        return out == null ? xs : out;
+    }
+
+    /**
+     * {@code t} with each type it holds replaced by what {@code at} answers for it; a {@link Leaf}
+     * is answered as it was given. The single authoritative rewrite over the tree of types, so a
+     * pass that rewrites types — a substitution writing back what an application decided, a reading
+     * of what it did not — writes only the position it is about and delegates the descent here.
+     *
+     * <p>It rewrites the direct children only. A pass that means every depth says so by passing
+     * itself, which is what makes the recursion the caller's to state rather than this one's to
+     * assume.
+     */
+    static Type mapChildren(Type t, java.util.function.UnaryOperator<Type> at) {
+        return t instanceof Compound c ? atChildren(c, at) : t;
+    }
+
+    /**
+     * Applies {@code f} to each type {@code t} directly holds (a {@link Leaf} holds none) — the
+     * read-only counterpart of {@link #mapChildren}.
+     */
+    static void forEachChild(Type t, java.util.function.Consumer<Type> f) {
+        if (t instanceof Compound c) {
+            atChildren(c, child -> {
+                f.accept(child);
+                return child;
+            });
+        }
+    }
+
     /** A user-facing rendering of {@code t} in surface syntax: {@code Int}, {@code List<Int>},
      * {@code A | B}, {@code (A, B)}, {@code T?}. Used by diagnostics; unlike the record {@code toString}
      * it reads the way the source is written. */
@@ -241,21 +349,11 @@ public sealed interface Type
      * under whichever came first — the pair rendering only has to tell the two sides apart. */
     private static void collectNames(Type t, java.util.Map<String, TypeName> out) {
         switch (t) {
+            // the two that hold a name: what this is after, and neither of them holds a type
             case Ref r -> out.putIfAbsent(r.name().name(), r.name());
             case Union u -> u.members().forEach(m -> out.putIfAbsent(m.name(), m));
-            case ListOf l -> collectNames(l.element(), out);
-            case SetOf s -> collectNames(s.element(), out);
-            case OptionOf o -> collectNames(o.element(), out);
-            case MapOf m -> {
-                collectNames(m.key(), out);
-                collectNames(m.value(), out);
-            }
-            case TupleOf tu -> tu.elements().forEach(e -> collectNames(e, out));
-            case FnOf f -> {
-                f.params().forEach(p -> collectNames(p, out));
-                collectNames(f.result(), out);
-            }
-            case Prim _, Var _, MetaVar _, Nothing _, Never _, Erroneous _ -> { }
+            case Leaf _ -> { }
+            case Compound c -> forEachChild(c, held -> collectNames(held, out));
         }
     }
 
@@ -318,24 +416,20 @@ public sealed interface Type
     }
 
     /** Whether {@code t}, or any type nested inside it, satisfies {@code p}. Tests {@code t} itself
-     * first, then recurses through every position that holds a type: a collection's element,
-     * a {@code Map}'s key and value, a {@code Tuple}'s members, a function type's parameters and
-     * result. A {@code Union} ends the walk: its members are names, not nested types. The single
-     * tree walk both "contains a tuple" and "still carries the empty-collection bottom" are
-     * expressed over. */
+     * first, then descends through {@link #forEachChild}, so it reaches every position a rewrite
+     * would write and no other. A {@link Leaf} ends the walk — a {@code Union}'s members are names,
+     * not nested types. The single tree walk both "contains a tuple" and "still carries the
+     * empty-collection bottom" are expressed over. */
     static boolean mentions(Type t, java.util.function.Predicate<Type> p) {
         if (p.test(t)) {
             return true;
         }
-        return switch (t) {
-            case ListOf l -> mentions(l.element(), p);
-            case SetOf s -> mentions(s.element(), p);
-            case OptionOf o -> mentions(o.element(), p);
-            case MapOf m -> mentions(m.key(), p) || mentions(m.value(), p);
-            case TupleOf tu -> tu.elements().stream().anyMatch(e -> mentions(e, p));
-            case FnOf f -> f.params().stream().anyMatch(a -> mentions(a, p))
-                    || mentions(f.result(), p);
-            case Prim _, Ref _, Var _, MetaVar _, Nothing _, Never _, Erroneous _, Union _ -> false;
-        };
+        boolean[] found = { false };
+        forEachChild(t, held -> {
+            if (!found[0] && mentions(held, p)) {
+                found[0] = true;
+            }
+        });
+        return found[0];
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/types/EveryPositionOfATypeIsRewrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/EveryPositionOfATypeIsRewrittenTest.java
@@ -1,0 +1,158 @@
+package souther.compiler.types;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.RecordComponent;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A type says in its own declaration whether it holds a type: a {@link Type.Compound} does and a
+ * {@link Type.Leaf} does not. {@link Type#mapChildren} is the one place that says which positions a
+ * compound holds, so a constructor added later is written there and every walk expressed over it
+ * follows.
+ *
+ * <p>The samples are read back by reflection rather than by naming each position again here. A
+ * position added to a constructor is rewritten or it is not, and asking the record what it holds is
+ * how this notices without being told.
+ */
+class EveryPositionOfATypeIsRewrittenTest {
+
+    /** What a rewrite put there. No sample holds it, so finding it means the position was written. */
+    private static final Type REWRITTEN = Type.ref(new TypeName("m", "Rewritten"));
+
+    private static final TypeName A = new TypeName("m", "A");
+    private static final BindingOwner CALL = new BindingOwner.OfValue("m", "f");
+
+    private static List<Type> compounds() {
+        return List.of(
+                Type.list(Type.INT),
+                Type.set(Type.INT),
+                Type.option(Type.INT),
+                Type.map(Type.STRING, Type.INT),
+                Type.tuple(List.of(Type.INT, Type.STRING)),
+                Type.fn(List.of(Type.INT, Type.STRING), Type.BOOL));
+    }
+
+    private static List<Type> leaves() {
+        return List.of(
+                Type.INT,
+                Type.ref(A),
+                Type.var("'a"),
+                new Type.MetaVar(CALL, "'a"),
+                Type.NOTHING,
+                Type.NEVER,
+                Type.ERRONEOUS,
+                Type.union(Set.of(A)));
+    }
+
+    @Test
+    void everyCompoundConstructorHasASample() {
+        assertEquals(constructorsOf(Type.Compound.class), classesOf(compounds()));
+    }
+
+    @Test
+    void everyLeafConstructorHasASample() {
+        assertEquals(constructorsOf(Type.Leaf.class), classesOf(leaves()));
+    }
+
+    @Test
+    void everyPositionThatHoldsATypeIsRewritten() {
+        for (Type before : compounds()) {
+            Type after = Type.mapChildren(before, t -> REWRITTEN);
+            int positions = 0;
+            for (RecordComponent slot : after.getClass().getRecordComponents()) {
+                for (Type held : typesAt(slot, after)) {
+                    positions++;
+                    assertSame(REWRITTEN, held, after.getClass().getSimpleName() + "."
+                            + slot.getName() + " was not rewritten");
+                }
+            }
+            assertTrue(positions > 0, before.getClass().getSimpleName() + " holds no type");
+        }
+    }
+
+    @Test
+    void aLeafIsAnsweredAsItWasGiven() {
+        for (Type leaf : leaves()) {
+            assertSame(leaf, Type.mapChildren(leaf, t -> REWRITTEN));
+        }
+    }
+
+    @Test
+    void aRewriteThatChangesNothingAnswersTheTypeItWasGiven() {
+        for (Type before : compounds()) {
+            assertSame(before, Type.mapChildren(before, t -> t));
+        }
+    }
+
+    @Test
+    void aChildIsVisitedOnceAndInTheOrderItIsWritten() {
+        assertEquals(List.of(Type.STRING, Type.INT), childrenOf(Type.map(Type.STRING, Type.INT)));
+        assertEquals(List.of(Type.INT, Type.STRING, Type.BOOL),
+                childrenOf(Type.fn(List.of(Type.INT, Type.STRING), Type.BOOL)));
+        assertEquals(List.of(Type.INT), childrenOf(Type.list(Type.INT)));
+    }
+
+    @Test
+    void aLeafHasNoChildren() {
+        for (Type leaf : leaves()) {
+            assertEquals(List.of(), childrenOf(leaf), leaf + " holds no type");
+        }
+    }
+
+    private static List<Type> childrenOf(Type t) {
+        List<Type> seen = new ArrayList<>();
+        Type.forEachChild(t, seen::add);
+        return seen;
+    }
+
+    /** Every constructor under {@code sealed}, descending through the interfaces between. */
+    private static Set<Class<?>> constructorsOf(Class<?> sealed) {
+        Class<?>[] permitted = sealed.getPermittedSubclasses();
+        if (permitted == null) {
+            return Set.of(sealed);
+        }
+        Set<Class<?>> out = new LinkedHashSet<>();
+        for (Class<?> under : permitted) {
+            out.addAll(constructorsOf(under));
+        }
+        return out;
+    }
+
+    private static Set<Class<?>> classesOf(List<Type> samples) {
+        Set<Class<?>> out = new LinkedHashSet<>();
+        for (Type sample : samples) {
+            out.add(sample.getClass());
+        }
+        return out;
+    }
+
+    /** Whatever types {@code slot} holds on {@code of}: the type itself, or each type in a list. */
+    private static List<Type> typesAt(RecordComponent slot, Type of) {
+        Object value;
+        try {
+            value = slot.getAccessor().invoke(of);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("cannot read " + slot, e);
+        }
+        if (value instanceof Type t) {
+            return List.of(t);
+        }
+        List<Type> held = new ArrayList<>();
+        if (value instanceof List<?> xs) {
+            for (Object x : xs) {
+                if (x instanceof Type t) {
+                    held.add(t);
+                }
+            }
+        }
+        return held;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/types/EveryPositionOfATypeIsRewrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/types/EveryPositionOfATypeIsRewrittenTest.java
@@ -62,19 +62,56 @@ class EveryPositionOfATypeIsRewrittenTest {
         assertEquals(constructorsOf(Type.Leaf.class), classesOf(leaves()));
     }
 
+    /**
+     * Each position is given a mark of its own, so what comes back says more than that something
+     * was written: a position left alone holds no mark, one written twice holds a mark another
+     * position was given, and a rebuild that puts an answer in the wrong slot holds them out of
+     * order. The result is read back through the record rather than through the walk under test, so
+     * a position the walk never knew about is still counted.
+     */
     @Test
-    void everyPositionThatHoldsATypeIsRewritten() {
+    void everyPositionThatHoldsATypeIsRewrittenOnceAndInTheOrderItIsWritten() {
         for (Type before : compounds()) {
-            Type after = Type.mapChildren(before, t -> REWRITTEN);
-            int positions = 0;
-            for (RecordComponent slot : after.getClass().getRecordComponents()) {
-                for (Type held : typesAt(slot, after)) {
-                    positions++;
-                    assertSame(REWRITTEN, held, after.getClass().getSimpleName() + "."
-                            + slot.getName() + " was not rewritten");
+            List<Type> marks = new ArrayList<>();
+            Type after = Type.mapChildren(before, held -> {
+                Type mark = Type.ref(new TypeName("m", "Mark" + marks.size()));
+                marks.add(mark);
+                return mark;
+            });
+            assertTrue(marks.size() > 0, before.getClass().getSimpleName() + " holds no type");
+            assertEquals(marks, typesHeldBy(after),
+                    after.getClass().getSimpleName() + " does not hold what it was answered");
+        }
+    }
+
+    /** Every type {@code t} holds, read off the record in the order its positions are written. */
+    private static List<Type> typesHeldBy(Type t) {
+        List<Type> held = new ArrayList<>();
+        for (RecordComponent slot : t.getClass().getRecordComponents()) {
+            collect(read(slot, t), held);
+        }
+        return held;
+    }
+
+    private static void collect(Object value, List<Type> into) {
+        switch (value) {
+            case Type t -> into.add(t);
+            case java.util.Collection<?> xs -> xs.forEach(x -> collect(x, into));
+            case java.util.Map<?, ?> m -> m.values().forEach(x -> collect(x, into));
+            case Object[] xs -> {
+                for (Object x : xs) {
+                    collect(x, into);
                 }
             }
-            assertTrue(positions > 0, before.getClass().getSimpleName() + " holds no type");
+            case null, default -> { }
+        }
+    }
+
+    private static Object read(RecordComponent slot, Type of) {
+        try {
+            return slot.getAccessor().invoke(of);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("cannot read " + slot, e);
         }
     }
 
@@ -134,25 +171,4 @@ class EveryPositionOfATypeIsRewrittenTest {
         return out;
     }
 
-    /** Whatever types {@code slot} holds on {@code of}: the type itself, or each type in a list. */
-    private static List<Type> typesAt(RecordComponent slot, Type of) {
-        Object value;
-        try {
-            value = slot.getAccessor().invoke(of);
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError("cannot read " + slot, e);
-        }
-        if (value instanceof Type t) {
-            return List.of(t);
-        }
-        List<Type> held = new ArrayList<>();
-        if (value instanceof List<?> xs) {
-            for (Object x : xs) {
-                if (x instanceof Type t) {
-                    held.add(t);
-                }
-            }
-        }
-        return held;
-    }
 }


### PR DESCRIPTION
Closes #342.

## What was wrong

`Ast` and `Core` each have one walk that every pass delegates to, so a node kind added to either stops the build until every pass is told what its children are. `Type` had neither.

#266 made four *readers* of a type exhaustive. The walks that *rewrite* one were left beside it: `Substitution.zonk` and `toBottom` ended in `default -> t`, `fits` in `default -> TypeOps.assignable(...)`, `decide` in `default -> { }`. `settle` put the two halves of one question a line apart — an exhaustive `mentions` asking "does this still hold an undecided variable", and a catch-all `toBottom` writing the decided ones in.

Nothing was broken today. Every constructor those defaults received holds no nested type, so the catch-all and an exhaustive arm agreed.

## The change

Those four defaults received the same eight constructors: `Prim`, `Ref`, `Var`, `MetaVar`, `Nothing`, `Never`, `Erroneous`, `Union`. Nothing in the code said so — each walk spelled it `default` and meant "nothing inside this one", which is a fact about the constructor rather than about the walk.

So it is written where the constructor is. `Type` is sealed over `Leaf` and `Compound`, and a constructor added later picks a side at its declaration.

```java
public sealed interface Type permits Type.Leaf, Type.Compound {

    sealed interface Leaf extends Type
            permits Prim, Ref, Open, Nothing, Never, Erroneous, Union {}

    sealed interface Compound extends Type
            permits ListOf, SetOf, OptionOf, MapOf, TupleOf, FnOf {}
```

`mapChildren` and `forEachChild` are derived from one exhaustive switch over `Compound`, the way `Ast.mapChildren` and `forEachChild` are derived from `atSlots`, and answer the type they were given where nothing changed — so a walk that only reads allocates nothing.

What the callers become:

```java
private Type toBottom(Type t) {
    return t instanceof Type.MetaVar ? Type.NOTHING : Type.mapChildren(t, this::toBottom);
}
```

`zonk` is five lines. `fits`'s default is now `case Type.Leaf _`. `decide` reads both sides for a `MetaVar` ahead of its switch, because a guarded arm does not count towards exhaustiveness — the four combinations of an open left and an open right answer as they did. `mentions` descends through `forEachChild`.

Two walks keep naming every constructor, for the same reason. `show` writes something different for each, so listing them is the work. `collectNames` asks whether a type holds a *name*, which is a different question from whether it holds a type — `Ref` and `Union` are leaves that hold one — so it names the constructors and delegates only the descent. Where the positions of a compound are is still `atChildren`'s to say, and neither of these repeats it.

## Whether it holds

Constructors were added locally and the build run clean. javac stops reporting exhaustiveness after the first round, so each stop was filled and the build re-run.

A compound holding a type:

| round | stops at |
| --- | --- |
| 1 | `Type.atChildren`, `Type.show` |
| 2 | `Substitution.fits`, `Substitution.decide` |
| 3 | `HelperParams:1097`, and the readers below it |

`zonk`, `toBottom` and `mentions` never appear — they follow whatever the one walk was told. `fits` and `decide` appearing is the change; before this they compiled and silently answered for a constructor they had never heard of.

A leaf holding a `TypeName` (`record Alias(TypeName name) implements Leaf`) stops at `Type.show` and `Type.collectNames`, which is what keeps a published signature from carrying a name nothing qualified.

`EveryPositionOfATypeIsRewrittenTest` keeps the guard in the suite. It requires a sample for every permitted subclass of `Leaf` and of `Compound`, then gives each position of each compound a mark of its own and reads the result back off the record — any collection, a map's values, an array — comparing it against the marks in the order they were handed out. A position left alone holds no mark, one written twice holds a mark another position was given, and a rebuild that fills the wrong slot holds them out of order. Reading the record rather than the walk under test is what lets it count a position the walk never knew about. Dropping the `Map` key rewrite fails it.

## Cost

`mentions` gave up its short circuit to descend through the shared walk. Warm compile of the crm corpus, twice each:

```
before  median 128.0 / 125.3 ms   min 112.0 / 109.9
after   median 124.8 / 131.9 ms   min 116.9 / 111.5
```

Run-to-run spread of one jar covers the difference.

## Not in this change

The twenty-two files listed in #342 that match `Type.ListOf` without naming every constructor. Most are correct — a reader that only handles collections has no business with `FnOf` — and the proposal did not ask for them.

No ADR. `docs/adr/README.md` excludes an implementation caught up with a rule already stated; ADR-0036 stated it for `Ast` and #266 applied it to reading a type. This applies it to rewriting one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
