### PR TITLE
The invariant check reads a representation the checker typed

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -125,7 +125,7 @@ public final class CallElaborator {
         // it is not this walk's business, and a kept call with no rule types like any other.
         CompleteSignature kept = ctx.preserved().signatureOf(call.denotes());
         if (kept != null) {
-            return preservedCall(call, kept, env, ctx);
+            return preservedCall(call, kept, env, ctx, expected);
         }
         CallArgs ca = new CallArgs(call.args(), env, ctx);
         Type result = typeOfCall(ca, call, env, ctx, expected);
@@ -150,38 +150,13 @@ public final class CallElaborator {
      * try to emit.
      */
     private static Core preservedCall(Ast.Apply call, CompleteSignature kept, Scope env,
-                                      CheckContext ctx) {
+                                      CheckContext ctx, Type expected) {
         List<Type> params = kept.params();
         CallArgs ca = new CallArgs(call.args(), env, ctx);
         if (call.args().size() != params.size()) {
-            throw CompileException.of(
-                    Diagnostic.of(null, "check.arity").title("check.arity.title")
-                            .at(call.pos(), call.written().length())
-                            .args(call.written(), params.size(), call.args().size()).build(),
-                    "`" + call.written() + "` takes " + params.size()
-                            + " argument(s) but is applied to " + call.args().size());
+            arity(call, params.size());
         }
-        Map<String, Type> bind = new HashMap<>();
-        // The values first, so what they settle is in force when a function argument is read at the
-        // parameter types this call gives it — `List.map(f, xs)` decides `'a` from `xs` and hands `f`
-        // the element type rather than a variable.
-        // An argument that answers no value states nothing about one — an empty collection carries a
-        // bottom, and letting it fix a variable would hold every other argument to the element type
-        // of nothing. The ones that state something go first, and a bottom then widens to what they
-        // settled instead of the other way round.
-        List<Integer> stating = new ArrayList<>();
-        List<Integer> bottoms = new ArrayList<>();
-        for (int i = 0; i < params.size(); i++) {
-            if (params.get(i) instanceof Type.FnOf) {
-                continue;
-            }
-            (Type.mentions(ca.type(i), BottomInfer::answersNoValue) ? bottoms : stating).add(i);
-        }
-        stating.addAll(bottoms);
-        for (int i : stating) {
-            TypeOps.unify(params.get(i), ca.type(i), bind, ctx.symbols(),
-                    call.pos(), "argument " + (i + 1) + " of " + call.written());
-        }
+        Map<String, Type> bind = settledByValues(call, params, kept.result(), expected, ca::type, ctx);
         for (int i = 0; i < params.size(); i++) {
             if (params.get(i) instanceof Type.FnOf declared) {
                 Type.FnOf at = (Type.FnOf) TypeOps.substitute(declared, bind);
@@ -202,6 +177,56 @@ public final class CallElaborator {
         }
         return new Core.PreservedCall(call.denotes(), ca.cores(),
                 TypeOps.substitute(kept.result(), bind), call.pos());
+    }
+
+    /**
+     * What a call settles of the signature it applies, before any function argument is typed.
+     *
+     * <p>Two things state something about a polymorphic signature's variables, and they are asked in
+     * this order because the order is the whole of the rule.
+     *
+     * <ol>
+     *   <li>What the context expects of the result, where the signature takes a function at all. A
+     *       variable a function parameter mentions has to be decided before that function is typed,
+     *       and where no argument decides it the position the call stands in is the only thing that
+     *       does.</li>
+     *   <li>What each value argument states, the ones that state something first. An argument that
+     *       answers no value — an empty collection carries a bottom — says nothing about what it
+     *       holds, and letting it settle a variable would hold every other argument to the element
+     *       type of nothing. A bottom then widens to what the others settled instead of the other way
+     *       round.</li>
+     * </ol>
+     *
+     * <p>Every reader of a declared signature asks this: the call that expands one, the call that
+     * keeps one standing, and the walk that reads one to learn what a function it was handed takes.
+     * They differ in what they do with a function argument afterwards — a fold reads its result as
+     * the accumulator to grow, an ordinary application does not — and in nothing before it. Said once
+     * because a difference here is not a failure but a variable settled to the wrong type, which is
+     * reported somewhere else as something else.
+     */
+    static Map<String, Type> settledByValues(Ast.Apply call, List<Type> params, Type result,
+                                             Type expected,
+                                             java.util.function.IntFunction<Type> argType,
+                                             CheckContext ctx) {
+        Map<String, Type> bind = new HashMap<>();
+        if (params.stream().anyMatch(Type.FnOf.class::isInstance)) {
+            BottomInfer.pinResultTypeVars(result, expected, bind, ctx.symbols(),
+                    call.pos(), "result of " + call.written());
+        }
+        List<Integer> stating = new ArrayList<>();
+        List<Integer> bottoms = new ArrayList<>();
+        for (int i = 0; i < params.size(); i++) {
+            if (params.get(i) instanceof Type.FnOf) {
+                continue;
+            }
+            (Type.mentions(argType.apply(i), BottomInfer::answersNoValue) ? bottoms : stating).add(i);
+        }
+        stating.addAll(bottoms);
+        for (int i : stating) {
+            TypeOps.unify(params.get(i), argType.apply(i), bind, ctx.symbols(),
+                    call.pos(), "argument " + (i + 1) + " of " + call.written());
+        }
+        return bind;
     }
 
     /**
@@ -396,20 +421,8 @@ public final class CallElaborator {
             throw new IllegalStateException("`" + call.written() + "` reached signature application"
                     + " with " + args.size() + " argument(s) against " + signature.params().size());
         }
-        boolean takesAFunction = signature.params().stream().anyMatch(Type.FnOf.class::isInstance);
-        Map<String, Type> bind = new HashMap<>();
-        if (takesAFunction) {
-            BottomInfer.pinResultTypeVars(signature.result(), expected, bind, ctx.symbols(),
-                    call.pos(), "result of " + call.written());
-        }
-        for (int i = 0; i < args.size(); i++) {
-            Type param = signature.params().get(i);
-            if (param instanceof Type.FnOf) {
-                continue;
-            }
-            TypeOps.unify(param, ca.type(i), bind, ctx.symbols(),
-                    call.pos(), "argument " + (i + 1) + " of " + call.written());
-        }
+        Map<String, Type> bind = settledByValues(call, signature.params(), signature.result(),
+                expected, ca::type, ctx);
         try {
             for (int i = 0; i < args.size(); i++) {
                 if (signature.params().get(i) instanceof Type.FnOf declaredStep) {

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -177,11 +177,8 @@ public final class CallElaborator {
             }
             (Type.mentions(ca.type(i), BottomInfer::answersNoValue) ? bottoms : stating).add(i);
         }
+        stating.addAll(bottoms);
         for (int i : stating) {
-            TypeOps.unify(params.get(i), ca.type(i), bind, ctx.symbols(),
-                    call.pos(), "argument " + (i + 1) + " of " + call.written());
-        }
-        for (int i : bottoms) {
             TypeOps.unify(params.get(i), ca.type(i), bind, ctx.symbols(),
                     call.pos(), "argument " + (i + 1) + " of " + call.written());
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -165,11 +165,25 @@ public final class CallElaborator {
         // The values first, so what they settle is in force when a function argument is read at the
         // parameter types this call gives it — `List.map(f, xs)` decides `'a` from `xs` and hands `f`
         // the element type rather than a variable.
+        // An argument that answers no value states nothing about one — an empty collection carries a
+        // bottom, and letting it fix a variable would hold every other argument to the element type
+        // of nothing. The ones that state something go first, and a bottom then widens to what they
+        // settled instead of the other way round.
+        List<Integer> stating = new ArrayList<>();
+        List<Integer> bottoms = new ArrayList<>();
         for (int i = 0; i < params.size(); i++) {
-            if (!(params.get(i) instanceof Type.FnOf)) {
-                TypeOps.unify(params.get(i), ca.type(i), bind, ctx.symbols(),
-                        call.pos(), "argument " + (i + 1) + " of " + call.written());
+            if (params.get(i) instanceof Type.FnOf) {
+                continue;
             }
+            (Type.mentions(ca.type(i), BottomInfer::answersNoValue) ? bottoms : stating).add(i);
+        }
+        for (int i : stating) {
+            TypeOps.unify(params.get(i), ca.type(i), bind, ctx.symbols(),
+                    call.pos(), "argument " + (i + 1) + " of " + call.written());
+        }
+        for (int i : bottoms) {
+            TypeOps.unify(params.get(i), ca.type(i), bind, ctx.symbols(),
+                    call.pos(), "argument " + (i + 1) + " of " + call.written());
         }
         for (int i = 0; i < params.size(); i++) {
             if (params.get(i) instanceof Type.FnOf declared) {

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -119,6 +119,14 @@ public final class CallElaborator {
 
     static Core elaborateCall(Ast.Apply call, Scope env, CheckContext ctx,
                                       Type expected) {
+        // A call this representation said it keeps standing, asked before anything tries to expand or
+        // resolve it: what it names is settled, and the only question left is its signature. Asked of
+        // the representation and not of the operation — whether anything downstream has a rule about
+        // it is not this walk's business, and a kept call with no rule types like any other.
+        CompleteSignature kept = ctx.preserved().signatureOf(call.denotes());
+        if (kept != null) {
+            return preservedCall(call, kept, env, ctx);
+        }
         CallArgs ca = new CallArgs(call.args(), env, ctx);
         Type result = typeOfCall(ca, call, env, ctx, expected);
         // applying something this body binds is a different operation from calling something
@@ -130,6 +138,31 @@ public final class CallElaborator {
                     ca.cores(), result, call.pos());
         }
         return new Core.Call(call.reaches(), ca.cores(), result, call.pos());
+    }
+
+    /**
+     * A kept call, typed by applying the signature it was declared with.
+     *
+     * <p>The same application a recursive helper's call goes through: a declaration that is not
+     * expanded is typed from what it declares, and its type variables are settled by the arguments it
+     * was given. What differs is only that this one is a node of its own, so a reader that has no
+     * business with a call left standing meets it as itself rather than as an ordinary call it might
+     * try to emit.
+     */
+    private static Core preservedCall(Ast.Apply call, CompleteSignature kept, Scope env,
+                                      CheckContext ctx) {
+        Type.FnOf signature = kept.asFunction();
+        CallArgs ca = new CallArgs(call.args(), env, ctx);
+        if (call.args().size() != signature.params().size()) {
+            throw CompileException.of(
+                    Diagnostic.of(null, "check.arity").title("check.arity.title")
+                            .at(call.pos(), call.written().length())
+                            .args(call.written(), signature.params().size(), call.args().size()).build(),
+                    "`" + call.written() + "` takes " + signature.params().size()
+                            + " argument(s) but is applied to " + call.args().size());
+        }
+        Type result = applySignature(call, signature, ca, null, env, ctx).result();
+        return new Core.PreservedCall(call.denotes(), ca.cores(), result, call.pos());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -213,17 +213,24 @@ public final class CallElaborator {
             BottomInfer.pinResultTypeVars(result, expected, bind, ctx.symbols(),
                     call.pos(), "result of " + call.written());
         }
+        // Each value argument is asked once, here, in the order it is written. What the ordering
+        // below decides is which of them settles a variable first, and nothing about how many times
+        // an argument is read: typing one can decide a variable of the application it stands in, so a
+        // second reading is a second answer, and then the argument classified and the argument
+        // unified are not the same reading of it.
+        Type[] stated = new Type[params.size()];
         List<Integer> stating = new ArrayList<>();
         List<Integer> bottoms = new ArrayList<>();
         for (int i = 0; i < params.size(); i++) {
             if (params.get(i) instanceof Type.FnOf) {
                 continue;
             }
-            (Type.mentions(argType.apply(i), BottomInfer::answersNoValue) ? bottoms : stating).add(i);
+            stated[i] = argType.apply(i);
+            (Type.mentions(stated[i], BottomInfer::answersNoValue) ? bottoms : stating).add(i);
         }
         stating.addAll(bottoms);
         for (int i : stating) {
-            TypeOps.unify(params.get(i), argType.apply(i), bind, ctx.symbols(),
+            TypeOps.unify(params.get(i), stated[i], bind, ctx.symbols(),
                     call.pos(), "argument " + (i + 1) + " of " + call.written());
         }
         return bind;
@@ -252,11 +259,24 @@ public final class CallElaborator {
             this.ctx = ctx.makingAnOptional(false);
         }
 
-        /** The type of argument {@code i}, elaborated with no expected type (bottom-up). */
+        /**
+         * The type of argument {@code i}, elaborated with no expected type (bottom-up) the first
+         * time it is asked and remembered.
+         *
+         * <p>Remembered because elaborating an argument is not a question with a stable answer:
+         * typing it can decide a variable of the application it stands in, and the decision is
+         * written into the enclosing substitution. A second elaboration would then read the state the
+         * first one left, so two readers of one argument would be reading two arguments — and the
+         * Core that reached the tree would be the later one while the type a rule reasoned about was
+         * the earlier. A rule may ask in whatever order it types in ({@link #requireTyped} already
+         * rests on this), so the guarantee belongs here rather than in each rule remembering to ask
+         * once.
+         */
         Type type(int i) {
-            Core c = Elaborator.elaborate(args.get(i), env, ctx);
-            cores[i] = c;
-            return c.type();
+            if (cores[i] == null) {
+                cores[i] = Elaborator.elaborate(args.get(i), env, ctx);
+            }
+            return cores[i].type();
         }
 
         /** Argument {@code i} checked against {@code expected}, as {@link #requireType} does. */

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -151,18 +151,46 @@ public final class CallElaborator {
      */
     private static Core preservedCall(Ast.Apply call, CompleteSignature kept, Scope env,
                                       CheckContext ctx) {
-        Type.FnOf signature = kept.asFunction();
+        List<Type> params = kept.params();
         CallArgs ca = new CallArgs(call.args(), env, ctx);
-        if (call.args().size() != signature.params().size()) {
+        if (call.args().size() != params.size()) {
             throw CompileException.of(
                     Diagnostic.of(null, "check.arity").title("check.arity.title")
                             .at(call.pos(), call.written().length())
-                            .args(call.written(), signature.params().size(), call.args().size()).build(),
-                    "`" + call.written() + "` takes " + signature.params().size()
+                            .args(call.written(), params.size(), call.args().size()).build(),
+                    "`" + call.written() + "` takes " + params.size()
                             + " argument(s) but is applied to " + call.args().size());
         }
-        Type result = applySignature(call, signature, ca, null, env, ctx).result();
-        return new Core.PreservedCall(call.denotes(), ca.cores(), result, call.pos());
+        Map<String, Type> bind = new HashMap<>();
+        // The values first, so what they settle is in force when a function argument is read at the
+        // parameter types this call gives it — `List.map(f, xs)` decides `'a` from `xs` and hands `f`
+        // the element type rather than a variable.
+        for (int i = 0; i < params.size(); i++) {
+            if (!(params.get(i) instanceof Type.FnOf)) {
+                TypeOps.unify(params.get(i), ca.type(i), bind, ctx.symbols(),
+                        call.pos(), "argument " + (i + 1) + " of " + call.written());
+            }
+        }
+        for (int i = 0; i < params.size(); i++) {
+            if (params.get(i) instanceof Type.FnOf declared) {
+                Type.FnOf at = (Type.FnOf) TypeOps.substitute(declared, bind);
+                Type answered = ca.block(i, call.written(), at.params());
+                // What the function answers settles the rest: this is an application of a declared
+                // signature and nothing more. The fold rule that reads a step's result as an
+                // accumulator to grow is one operation's meaning, and an operation kept standing is
+                // kept because its meaning belongs to whoever reads it, not to this.
+                TypeOps.unify(declared.result(), answered, bind, ctx.symbols(),
+                        call.pos(), "argument " + (i + 1) + " of " + call.written());
+            }
+        }
+        for (int i = 0; i < params.size(); i++) {
+            if (!(params.get(i) instanceof Type.FnOf)) {
+                ca.requireTyped(i, TypeOps.substitute(params.get(i), bind),
+                        "argument " + (i + 1) + " of " + call.written());
+            }
+        }
+        return new Core.PreservedCall(call.denotes(), ca.cores(),
+                TypeOps.substitute(kept.result(), bind), call.pos());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/CheckContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CheckContext.java
@@ -15,7 +15,13 @@ import java.util.Map;
  * the expected type pushed down from the surrounding context — is passed separately.
  */
 public record CheckContext(Symbols symbols, Ast.Data data, Map<String, ReqSig> reqs,
-                           Map<String, ReqSig> callees, boolean makingAnOptional) {
+                           Map<String, ReqSig> callees, boolean makingAnOptional,
+                           Preserved preserved) {
+
+    public CheckContext(Symbols symbols, Ast.Data data, Map<String, ReqSig> reqs,
+                        Map<String, ReqSig> callees, boolean makingAnOptional) {
+        this(symbols, data, reqs, callees, makingAnOptional, Preserved.NONE);
+    }
 
     /** A context with no behavior callable by name — every construction that predates the
      *  distinction, and every position where only injected behaviors are in sight. */
@@ -36,18 +42,18 @@ public record CheckContext(Symbols symbols, Ast.Data data, Map<String, ReqSig> r
 
     /** The same context checking a different {@code data}'s invariant, decoder, or encoder. */
     public CheckContext forData(Ast.Data other) {
-        return new CheckContext(symbols, other, reqs, callees, makingAnOptional);
+        return new CheckContext(symbols, other, reqs, callees, makingAnOptional, preserved);
     }
 
     /** The same context with the behaviors a body may call in scope. */
     public CheckContext withReqs(Map<String, ReqSig> required) {
-        return new CheckContext(symbols, data, required, callees, makingAnOptional);
+        return new CheckContext(symbols, data, required, callees, makingAnOptional, preserved);
     }
 
     /** The same context with the behaviors a body may call by name in scope — the ones that require
      *  nothing (spec {@code [#calling-a-behavior]}). */
     public CheckContext withCallees(Map<String, ReqSig> callable) {
-        return new CheckContext(symbols, data, reqs, callable, makingAnOptional);
+        return new CheckContext(symbols, data, reqs, callable, makingAnOptional, preserved);
     }
 
     /**
@@ -60,6 +66,33 @@ public record CheckContext(Symbols symbols, Ast.Data data, Map<String, ReqSig> r
      * that value.
      */
     public CheckContext makingAnOptional(boolean making) {
-        return new CheckContext(symbols, data, reqs, callees, making);
+        return new CheckContext(symbols, data, reqs, callees, making, preserved);
+    }
+
+    /**
+     * The same context, typing a representation that keeps some calls standing.
+     *
+     * <p>Here rather than passed where a call is typed, because it does not change as the walk
+     * descends: which representation is being typed is decided before any of it, and a body does not
+     * become another representation part-way down.
+     */
+    public CheckContext preserving(Preserved kept) {
+        return new CheckContext(symbols, data, reqs, callees, makingAnOptional, kept);
+    }
+
+    /**
+     * The same context, starting a tree that belongs to another representation.
+     *
+     * <p>What a representation keeps standing does not travel to a tree that is not it. A body
+     * reaching a declaration's invariant reaches another tree, built by another question and holding
+     * whatever that question decided to keep — which is that representation's to say at its own
+     * entry, not something it receives by having been reached from here.
+     *
+     * <p>Named as the boundary rather than folded into {@link #forData}: which {@code data} is being
+     * checked changes within one representation too, and joining the two would make "a data is in
+     * scope" quietly mean "the permission is gone".
+     */
+    public CheckContext inAnotherRepresentation() {
+        return preserved == Preserved.NONE ? this : preserving(Preserved.NONE);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/CheckContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CheckContext.java
@@ -81,6 +81,18 @@ public record CheckContext(Symbols symbols, Ast.Data data, Map<String, ReqSig> r
     }
 
     /**
+     * The same context, typing the representation the invariant-discharge analysis reads: the
+     * language's own operations kept standing, because that is what the analysis has rules about.
+     *
+     * <p>Said once, though two trees are typed that way — a behavior's body and the invariants of the
+     * declarations it builds. They are two halves of one representation, and a line drawn in one of
+     * them and not the other is an analysis that quietly sees less.
+     */
+    public CheckContext forDischarge() {
+        return preserving(Preserved.byTheLanguagesOwnOperations());
+    }
+
+    /**
      * The same context, starting a tree that belongs to another representation.
      *
      * <p>What a representation keeps standing does not travel to a tree that is not it. A body

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -6,6 +6,7 @@ import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -35,6 +36,10 @@ final class Clauses {
     private final Map<Ast.Data, Map<String, Type>> fields = new HashMap<>();
     private final Map<Ast.Data, Map<String, BindingId>> bindings = new HashMap<>();
     private final Map<Ast.Expr, Optional<Core>> typed = new IdentityHashMap<>();
+    private final Map<TypeName, List<Ast.InvariantClause>> effective = new HashMap<>();
+    /** Which of a declaration's own fields each typed clause reads — what a construction has to have
+     * filled for the clause to be read at all. */
+    private final Map<Core, Set<BindingId>> readsFields = new IdentityHashMap<>();
 
     /**
      * @param inTheAnalysisRepresentation the clauses of the module being checked, in the
@@ -52,7 +57,8 @@ final class Clauses {
     /** Every invariant that applies to {@code named}, each in the analysis representation where this
      * module declares it. */
     List<Ast.InvariantClause> of(TypeName named, Ast.Data data) {
-        return TypeOps.effectiveInvariants(named, data, symbols, inTheAnalysisRepresentation::get);
+        return effective.computeIfAbsent(named, name ->
+                TypeOps.effectiveInvariants(name, data, symbols, inTheAnalysisRepresentation::get));
     }
 
     /** What {@code data}'s fields are. */
@@ -64,13 +70,6 @@ final class Clauses {
      * fills. */
     Map<String, BindingId> bindingsOf(Ast.Data data) {
         return bindings.computeIfAbsent(data, d -> TypeOps.fieldBindings(d, symbols));
-    }
-
-    /** The type of {@code field} read from {@code owner}, or null where that is not a field of a
-     * declaration this module can see. */
-    Type fieldType(Type owner, String field) {
-        return owner instanceof Type.Ref r && symbols.get(r.name()) instanceof Ast.Data data
-                ? fieldsOf(data).get(field) : null;
     }
 
     /**
@@ -87,8 +86,7 @@ final class Clauses {
             try {
                 return Optional.ofNullable(Elaborator.elaborate(written,
                         DataChecker.fieldScope(data, symbols),
-                        CheckContext.of(symbols).forData(data)
-                                .preserving(Preserved.byTheLanguagesOwnOperations()),
+                        CheckContext.of(symbols).forData(data).forDischarge(),
                         Type.BOOL));
             } catch (RuntimeException _) {
                 return Optional.empty();
@@ -109,14 +107,42 @@ final class Clauses {
         if (stated == null) {
             return null;
         }
-        Set<BindingId> declared = new HashSet<>(bindingsOf(data).values());
-        boolean[] whole = {true};
-        readsOf(stated, binding -> {
-            if (declared.contains(binding) && !given.containsKey(binding)) {
-                whole[0] = false;
+        return given.keySet().containsAll(fieldsRead(stated, data)) ? substituted(stated, given)
+                : null;
+    }
+
+    /**
+     * Every clause of {@code named}, each stated where its fields are given what {@code given} says,
+     * and the ones that state nothing this check can read left out.
+     *
+     * <p>Both directions ask this. What a clause guarantees where the value already exists and what
+     * it owes where one is being built are the same clauses read the same way, and they differ only
+     * in what the fields are given — a read of each field, or the value each is being handed.
+     */
+    List<Core> statedAt(TypeName named, Ast.Data data, Map<BindingId, Core> given) {
+        List<Core> stated = new ArrayList<>();
+        for (Ast.InvariantClause inv : of(named, data)) {
+            Core one = statedAt(inv.expr(), data, given);
+            if (one != null) {
+                stated.add(one);
             }
+        }
+        return stated;
+    }
+
+    /** Which of {@code data}'s own fields {@code clause} reads, remembered: a clause is read at every
+     * construction of its type, and what it reads does not change between them. */
+    private Set<BindingId> fieldsRead(Core clause, Ast.Data data) {
+        return readsFields.computeIfAbsent(clause, read -> {
+            Set<BindingId> declared = new HashSet<>(bindingsOf(data).values());
+            Set<BindingId> found = new HashSet<>();
+            readsOf(read, binding -> {
+                if (declared.contains(binding)) {
+                    found.add(binding);
+                }
+            });
+            return Set.copyOf(found);
         });
-        return whole[0] ? substituted(stated, given) : null;
     }
 
     /** {@code e} with each binding {@code given} names replaced by the value it was given. */
@@ -125,12 +151,10 @@ final class Clauses {
             Core value = given.get(r.binding());
             return value != null ? value : r;
         }
-        return Core.mapChildren(e, child -> substituted(child, given),
+        return Core.mapAll(e, child -> substituted(child, given),
                 // A name slot holds a binding and nothing else, so a value put there would be
                 // something the reader of that slot cannot load. Only another name may stand there.
-                name -> substituted(name, given) instanceof Core.Read r ? r : name,
-                nd -> (Core.NewData) Core.mapChildren(nd, child -> substituted(child, given),
-                        name -> substituted(name, given) instanceof Core.Read r ? r : name));
+                name -> substituted(name, given) instanceof Core.Read r ? r : name);
     }
 
     /** Every binding {@code e} reads, at any depth. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -1,0 +1,143 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The invariants of the declarations the discharge check reads: each clause typed once, over the
+ * fields it is written against, and read at a value by putting what each field is being given where
+ * that field is read.
+ *
+ * <p>That reading is what lets the check hold one representation. A clause belongs to a declaration
+ * and the values belong to a body, and a clause read over its own tree and a body read over another
+ * would be two term grammars that have to be kept naming the same value the same way. A field is a
+ * binding, so putting a value there is a substitution, and what comes out is an expression of the
+ * body's own kind.
+ *
+ * <p>Everything here is remembered, because both the seeding and every construction ask the same
+ * declaration the same questions.
+ */
+final class Clauses {
+
+    private final Symbols symbols;
+    private final Map<TypeName, List<Ast.InvariantClause>> inTheAnalysisRepresentation;
+    private final Map<Ast.Data, Map<String, Type>> fields = new HashMap<>();
+    private final Map<Ast.Data, Map<String, BindingId>> bindings = new HashMap<>();
+    private final Map<Ast.Expr, Optional<Core>> typed = new IdentityHashMap<>();
+
+    /**
+     * @param inTheAnalysisRepresentation the clauses of the module being checked, in the
+     *        representation the discharge rules are written at ({@link InliningPolicy#DISCHARGE}). A
+     *        type another module declares is absent, and its clause is read off the declaration in
+     *        the settled form — where the operations have already become the folds they are, so it
+     *        falls outside the fragment.
+     */
+    Clauses(Symbols symbols,
+            Map<TypeName, List<Ast.InvariantClause>> inTheAnalysisRepresentation) {
+        this.symbols = symbols;
+        this.inTheAnalysisRepresentation = inTheAnalysisRepresentation;
+    }
+
+    /** Every invariant that applies to {@code named}, each in the analysis representation where this
+     * module declares it. */
+    List<Ast.InvariantClause> of(TypeName named, Ast.Data data) {
+        return TypeOps.effectiveInvariants(named, data, symbols, inTheAnalysisRepresentation::get);
+    }
+
+    /** What {@code data}'s fields are. */
+    Map<String, Type> fieldsOf(Ast.Data data) {
+        return fields.computeIfAbsent(data, d -> TypeOps.fieldTypes(d, symbols));
+    }
+
+    /** Which binding each of {@code data}'s fields is — what a clause reads, and what a construction
+     * fills. */
+    Map<String, BindingId> bindingsOf(Ast.Data data) {
+        return bindings.computeIfAbsent(data, d -> TypeOps.fieldBindings(d, symbols));
+    }
+
+    /** The type of {@code field} read from {@code owner}, or null where that is not a field of a
+     * declaration this module can see. */
+    Type fieldType(Type owner, String field) {
+        return owner instanceof Type.Ref r && symbols.get(r.name()) instanceof Ast.Data data
+                ? fieldsOf(data).get(field) : null;
+    }
+
+    /**
+     * {@code clause} as the checker types it: over the declaration's own fields, each a binding, in
+     * the representation this check reads. Asked once per clause, because typing one walks it.
+     *
+     * <p>Null where the clause is not one this compiler could type there. That is the same answer as
+     * a clause naming something outside the fragment — the run-time check stands for it — and it is
+     * an answer rather than a failure because a declaration this check cannot read is not a
+     * declaration an author wrote wrongly.
+     */
+    Core typed(Ast.Expr clause, Ast.Data data) {
+        return typed.computeIfAbsent(clause, written -> {
+            try {
+                return Optional.ofNullable(Elaborator.elaborate(written,
+                        DataChecker.fieldScope(data, symbols),
+                        CheckContext.of(symbols).forData(data)
+                                .preserving(Preserved.byTheLanguagesOwnOperations()),
+                        Type.BOOL));
+            } catch (RuntimeException _) {
+                return Optional.empty();
+            }
+        }).orElse(null);
+    }
+
+    /**
+     * What a clause of {@code data} states where each field is given what {@code given} says, or
+     * {@code null} where it states nothing this check can read.
+     *
+     * <p>A field nothing was given — one a construction leaves out — leaves the clause naming a value
+     * that is not there, and the clause is left to the run-time check rather than read against
+     * nothing.
+     */
+    Core statedAt(Ast.Expr clause, Ast.Data data, Map<BindingId, Core> given) {
+        Core stated = typed(clause, data);
+        if (stated == null) {
+            return null;
+        }
+        Set<BindingId> declared = new HashSet<>(bindingsOf(data).values());
+        boolean[] whole = {true};
+        readsOf(stated, binding -> {
+            if (declared.contains(binding) && !given.containsKey(binding)) {
+                whole[0] = false;
+            }
+        });
+        return whole[0] ? substituted(stated, given) : null;
+    }
+
+    /** {@code e} with each binding {@code given} names replaced by the value it was given. */
+    static Core substituted(Core e, Map<BindingId, Core> given) {
+        if (e instanceof Core.Read r) {
+            Core value = given.get(r.binding());
+            return value != null ? value : r;
+        }
+        return Core.mapChildren(e, child -> substituted(child, given),
+                // A name slot holds a binding and nothing else, so a value put there would be
+                // something the reader of that slot cannot load. Only another name may stand there.
+                name -> substituted(name, given) instanceof Core.Read r ? r : name,
+                nd -> (Core.NewData) Core.mapChildren(nd, child -> substituted(child, given),
+                        name -> substituted(name, given) instanceof Core.Read r ? r : name));
+    }
+
+    /** Every binding {@code e} reads, at any depth. */
+    private static void readsOf(Core e, java.util.function.Consumer<BindingId> f) {
+        if (e instanceof Core.Read r) {
+            f.accept(r.binding());
+        }
+        Core.forEachChild(e, child -> readsOf(child, f));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/CompleteSignature.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CompleteSignature.java
@@ -42,8 +42,4 @@ public record CompleteSignature(List<Type> params, Type result) {
         return new CompleteSignature(params, result);
     }
 
-    /** This signature as the function type an application is settled against. */
-    public Type.FnOf asFunction() {
-        return (Type.FnOf) Type.fn(params, result);
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/CompleteSignature.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CompleteSignature.java
@@ -1,0 +1,49 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import java.util.List;
+
+/**
+ * A declaration that says what it answers as well as what it takes.
+ *
+ * <p>The condition a call has to meet to be kept standing. A declaration may leave its result to its
+ * body — most do, and nothing is wrong with that — but a call typed without expanding it has only
+ * what the declaration says, so an operation a representation keeps must say all of it. The
+ * requirement is on being kept, not on being a library function or a helper: it is the same
+ * condition whichever namespace the name is in, because it is the same thing being asked of it.
+ *
+ * <p>A type rather than a check, so the incompleteness cannot travel. Were the result allowed to be
+ * absent here, every reader of a kept call would have to answer for a result that is not there, and
+ * the first one that did not would fail somewhere with nothing to say about which operation or which
+ * representation was at fault.
+ */
+public record CompleteSignature(List<Type> params, Type result) {
+
+    public CompleteSignature {
+        params = List.copyOf(params);
+    }
+
+    /**
+     * The signature {@code operation} was declared with, refusing one that leaves its result to its
+     * body.
+     *
+     * <p>Raised where a representation says what it keeps, so an operation that cannot be typed
+     * without expanding it is answered for once, by name, rather than as a failure at whichever call
+     * happened to be reached first.
+     */
+    public static CompleteSignature of(ValueName operation, List<Type> params, Type result) {
+        if (result == null) {
+            throw new IllegalStateException("`" + operation + "` is kept standing by a representation"
+                    + " that reads it, so it must declare what it answers: a call kept unexpanded is"
+                    + " typed from its declaration alone");
+        }
+        return new CompleteSignature(params, result);
+    }
+
+    /** This signature as the function type an application is settled against. */
+    public Type.FnOf asFunction() {
+        return (Type.FnOf) Type.fn(params, result);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -549,7 +549,11 @@ public final class DataChecker {
             // proven total — is callable from an invariant, so its signature must be in scope here. A
             // field of the same name as a helper wins: a bare name in an invariant is a field reference.
             Scope invEnv = fieldScope(ctx).reaching(recursiveHelperFns);
-            Type t = Elaborator.typeOf(clause.expr(), invEnv, ctx);
+            // A clause is the declaration's, not the body's. Reached from a construction, this is
+            // where one tree stops and another starts, so what the tree being walked keeps standing
+            // is left behind: what this one keeps is its own to say, and a permission inherited by
+            // being reached from somewhere is not a permission a representation gave.
+            Type t = Elaborator.typeOf(clause.expr(), invEnv, ctx.inAnotherRepresentation());
             if (t != Type.BOOL) {
                 throw CompileException.of(
                         Diagnostic.of("E1101", "e1101.msg").at(clause.expr().pos())

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -567,11 +567,15 @@ public final class DataChecker {
         ctx.data().encoder().ifPresent(enc -> checkEncoder(enc, ctx));
     }
 
-    /** The bindings a declaration's own invariant reads: its fields, each as the binding it is. */
     private static Scope fieldScope(CheckContext ctx) {
-        Map<String, Type> types = TypeOps.fieldTypes(ctx.data(), ctx.symbols());
+        return fieldScope(ctx.data(), ctx.symbols());
+    }
+
+    /** The bindings a declaration's own invariant reads: its fields, each as the binding it is. */
+    static Scope fieldScope(Ast.Data data, Symbols symbols) {
+        Map<String, Type> types = TypeOps.fieldTypes(data, symbols);
         Map<BindingId, Scope.Binding> bindings = new LinkedHashMap<>();
-        TypeOps.fieldBindings(ctx.data(), ctx.symbols()).forEach((name, binding) ->
+        TypeOps.fieldBindings(data, symbols).forEach((name, binding) ->
                 bindings.put(binding, new Scope.Binding(name, types.get(name))));
         return Scope.of(bindings);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Denotations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Denotations.java
@@ -1,0 +1,50 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * What the body's bindings mean where the walk is.
+ *
+ * <p>A binding given a location <em>is</em> that location — the rule {@link Location} carries for
+ * a newtype's {@code .value}, read here of a binding instead of a field. It is what lets a
+ * construction survive being moved into a helper: an expansion binds each argument and answers
+ * the parameter's reads with that binding (see {@link HelperInliner}), so without it the body of
+ * a helper taking a record names locations the seeding never wrote, and everything an input's
+ * type guarantees stops at the call.
+ *
+ * <p>Nothing here is ever taken away. A binding is what it is, and a second binding of the same
+ * spelling is a second binding, so a fact about the first stays true of the first and nothing
+ * reads it under the second.
+ */
+record Denotations(Map<BindingId, Denotes> what, Map<BindingId, Core> values) {
+
+    static Denotations none() {
+        return new Denotations(Map.of(), Map.of());
+    }
+
+    /** What {@code binding} denotes, which is the location it is unless it was given something
+     * else. */
+    Denotes of(BindingId binding) {
+        Denotes given = what.get(binding);
+        return given != null ? given : new Denotes.At(Location.of(binding));
+    }
+
+    /** The value {@code binding} was given, or null where nothing recorded one. */
+    Core valueOf(BindingId binding) {
+        return values.get(binding);
+    }
+
+    Denotations binding(BindingId binding, Core value, Denotes denotes) {
+        Map<BindingId, Denotes> next = new HashMap<>(what);
+        next.put(binding, denotes);
+        Map<BindingId, Core> bound = new HashMap<>(values);
+        if (value != null) {
+            bound.put(binding, value);
+        }
+        return new Denotations(Map.copyOf(next), Map.copyOf(bound));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Denotations.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Denotations.java
@@ -20,31 +20,31 @@ import java.util.Map;
  * spelling is a second binding, so a fact about the first stays true of the first and nothing
  * reads it under the second.
  */
-record Denotations(Map<BindingId, Denotes> what, Map<BindingId, Core> values) {
+record Denotations(Map<BindingId, Bound> bound) {
+
+    /** What a binding was given: the value it was bound to, and what that value denotes. */
+    record Bound(Core value, Denotes denotes) {}
 
     static Denotations none() {
-        return new Denotations(Map.of(), Map.of());
+        return new Denotations(Map.of());
     }
 
     /** What {@code binding} denotes, which is the location it is unless it was given something
      * else. */
     Denotes of(BindingId binding) {
-        Denotes given = what.get(binding);
-        return given != null ? given : new Denotes.At(Location.of(binding));
+        Bound given = bound.get(binding);
+        return given != null ? given.denotes() : new Denotes.At(Location.of(binding));
     }
 
     /** The value {@code binding} was given, or null where nothing recorded one. */
     Core valueOf(BindingId binding) {
-        return values.get(binding);
+        Bound given = bound.get(binding);
+        return given == null ? null : given.value();
     }
 
     Denotations binding(BindingId binding, Core value, Denotes denotes) {
-        Map<BindingId, Denotes> next = new HashMap<>(what);
-        next.put(binding, denotes);
-        Map<BindingId, Core> bound = new HashMap<>(values);
-        if (value != null) {
-            bound.put(binding, value);
-        }
-        return new Denotations(Map.copyOf(next), Map.copyOf(bound));
+        Map<BindingId, Bound> next = new HashMap<>(bound);
+        next.put(binding, new Bound(value, denotes));
+        return new Denotations(Map.copyOf(next));
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Denotes.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Denotes.java
@@ -1,0 +1,49 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+
+/**
+ * What a binding denotes. A location is somewhere the seeding can have written about and a clause
+ * can have named; a term is a value known only by what computes it. Merging those two would put a
+ * computed value where a location is expected, which is the shape of a {@code let} answering
+ * differently from the expression it was given. A written value is apart from both because what
+ * it is has to travel with the name, and nothing is apart because only a term is assigned a form.
+ */
+sealed interface Denotes {
+
+    /** The key this is known by, or {@code null} where it is known by none. */
+    String key();
+
+    /** A place: a parameter, a field chain, or another location a binding was given. */
+    record At(Location where) implements Denotes {
+
+        @Override
+        public String key() {
+            return where.toString();
+        }
+    }
+
+    /**
+     * A value named by the expression that computes it. {@code readable} is true where there is
+     * something to say of it however it is reached — a form the numeric domain built, or a rule
+     * about how it was made; false where only a guard naming it makes a clause readable against
+     * it.
+     */
+    record Term(String key, boolean readable) implements Denotes {}
+
+    /**
+     * A value written out, kept as what was written. There is no guard an author could add about
+     * it, so it is never named at a construction; what it is, though, still has to travel with
+     * the name, or the same text would fold where it is written and not where it is bound.
+     */
+    record Written(String key, Core value) implements Denotes {}
+
+    /** Nothing this check can name. */
+    record Nothing() implements Denotes {
+
+        @Override
+        public String key() {
+            return null;
+        }
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -1,0 +1,236 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
+import souther.compiler.types.ValueName;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What the language's own operations do to the properties the invariant-discharge check tracks
+ * (spec §invariant-discharge-preservation).
+ *
+ * <p>This is the table that decides how much of a model the language tracks rather than leaves to a
+ * run-time check, and it is stated per operation because that is the level an author writes at. It is
+ * data and lookups and nothing else: what a rule is <em>used for</em> — seeding a closure's element,
+ * carrying a predicate to the container something was built from, naming a size — is the walk's, and
+ * lives with the walk.
+ *
+ * <p>Every rule is keyed by the operation a call reaches, not by how it was written: a module that
+ * imported an operation writes it bare and one that did not writes it qualified, and they are the
+ * same operation. It is also keyed by the operation a call still reaches when this tree is read,
+ * which is not every name an author can write — {@code List.fold} is rewritten to
+ * {@code List.foldFrom} before any of this, so a rule under that name could not be looked up.
+ * {@code InvariantCombinatorRulesTest} holds the table to both halves of that.
+ */
+final class DischargeRules {
+
+    /** The library operation written {@code qualified}, as what a name reaching it denotes. */
+    private static ValueName op(String qualified) {
+        return new ValueName.Stdlib(qualified);
+    }
+
+    /** A stdlib combinator whose closure (argument {@code closureArg}) is handed each element of its
+     * container argument ({@code listArg}) as closure parameter {@code elementParam} — mirrors
+     * {@link TotalityChecker}'s table, so a construction inside a {@code List.map} or
+     * {@code List.foldFrom} closure is analyzed with the element bound to the container's element
+     * type. */
+    record Combinator(int closureArg, int elementParam, int listArg) {}
+
+    private static final Map<ValueName, Combinator> COMBINATORS = Map.ofEntries(
+            Map.entry(op("List.foldFrom"), new Combinator(0, 1, 2)),
+            Map.entry(op("List.foldr"), new Combinator(0, 1, 2)),
+            Map.entry(op("List.map"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.filter"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.all"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.any"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.find"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.partition"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.concatMap"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.filterMap"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.sortBy"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.groupBy"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.indexBy"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.allUniqueBy"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.indexedMap"), new Combinator(0, 1, 1)),
+            Map.entry(op("Map.fold"), new Combinator(0, 2, 2)),
+            Map.entry(op("Map.map"), new Combinator(0, 1, 1)),
+            Map.entry(op("Map.filter"), new Combinator(0, 1, 1)),
+            Map.entry(op("Map.update"), new Combinator(1, 0, 2)),
+            Map.entry(op("Map.upsert"), new Combinator(2, 0, 3)),
+            Map.entry(op("Set.fold"), new Combinator(0, 1, 2)),
+            Map.entry(op("Set.map"), new Combinator(0, 0, 1)),
+            Map.entry(op("Set.filter"), new Combinator(0, 0, 1)),
+            Map.entry(op("Set.partition"), new Combinator(0, 0, 1)),
+            Map.entry(op("Option.map"), new Combinator(0, 0, 1)));
+
+    /** The operations the table has a rule for, for the test that holds it to being reachable. */
+    static Set<String> combinatorNames() {
+        Set<String> names = new LinkedHashSet<>();
+        COMBINATORS.keySet().forEach(operation -> names.add(operation.name()));
+        return names;
+    }
+
+    /** The pure, total stdlib calls whose result is a number the domain can name: the size of a
+     * container or a string. Each becomes an atom keyed by the call written over its argument's path
+     * — {@code List.length(b.items)} — so an invariant clause and a guard naming the same container
+     * name the same atom, and the guard discharges the clause. The argument must be a nameable path:
+     * {@code List.length(List.map(f, xs))} is not this atom, and nothing relates the two. */
+    private static final Set<ValueName> SIZE_CALLS = Set.of(
+            op("List.length"), op("String.length"), op("Set.size"), op("Map.size"));
+
+    /**
+     * What a construction of a container keeps of the container it was built from.
+     *
+     * <ul>
+     * <li>{@code PERMUTES} — the same elements in another order. Everything survives.
+     * <li>{@code SUBSET} — some of the same elements. Nothing new is there, so a property of every
+     *     element survives and the size can only fall.
+     * <li>{@code MAPS} — one new element for each. As many as before, and nothing is known of what
+     *     they are.
+     * <li>{@code COLLAPSES} — at most one new element for each. Neither the elements nor the count.
+     * </ul>
+     */
+    enum Shape {
+        PERMUTES, SUBSET, MAPS, COLLAPSES;
+
+        /** Whether the result has exactly as many as the container it was built from. */
+        boolean keepsSize() {
+            return this == PERMUTES || this == MAPS;
+        }
+    }
+
+    /** Which argument a container was built from, and what the building keeps of it. */
+    record Built(int from, Shape shape) {}
+
+    private static final Map<ValueName, Built> BUILT_FROM = Map.ofEntries(
+            Map.entry(op("List.reverse"), new Built(0, Shape.PERMUTES)),
+            Map.entry(op("List.sort"), new Built(0, Shape.PERMUTES)),
+            Map.entry(op("List.sortBy"), new Built(1, Shape.PERMUTES)),
+            Map.entry(op("List.map"), new Built(1, Shape.MAPS)),
+            Map.entry(op("List.indexedMap"), new Built(1, Shape.MAPS)),
+            Map.entry(op("Map.map"), new Built(1, Shape.MAPS)),
+            Map.entry(op("List.filter"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("List.distinct"), new Built(0, Shape.SUBSET)),
+            Map.entry(op("List.take"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("List.drop"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("Set.filter"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("Map.filter"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("List.filterMap"), new Built(1, Shape.COLLAPSES)),
+            Map.entry(op("Set.map"), new Built(1, Shape.COLLAPSES)));
+
+    /** Where a predicate reads its container, and which shapes of construction carry it there.
+     * {@code List.all} holds of any sublist of a list it holds of; {@code List.member} does not, and
+     * neither survives a mapping — what a mapped element is, the mapping alone does not say. */
+    record Carried(int container, Set<Shape> through) {}
+
+    private static final Map<ValueName, Carried> CARRIED = Map.of(
+            op("List.all"), new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            op("List.allUniqueBy"), new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            op("List.any"), new Carried(1, Set.of(Shape.PERMUTES)),
+            op("List.member"), new Carried(1, Set.of(Shape.PERMUTES)),
+            op("Set.contains"), new Carried(1, Set.of(Shape.PERMUTES)),
+            op("Map.containsKey"), new Carried(1, Set.of(Shape.PERMUTES)));
+
+    /** Where a predicate reads the projection it is stated over. A mapping keeps a projection when
+     * the closure copies that field from the element unchanged, so the predicate holds of the mapped
+     * list exactly when it holds of what was mapped, over the field it came from. */
+    private static final Map<ValueName, Integer> PROJECTION_OF = Map.of(op("List.allUniqueBy"), 0);
+
+    /** The calls that state their predicate of <em>every</em> element, so what they say of a
+     * container is what holds of each element a closure is handed. Which argument is the predicate
+     * and which the container is what {@link #combinator} already answers of any combinator, and how
+     * far the statement travels is what {@link #carried} already answers of any predicate — so a
+     * quantifier is the name and nothing else. {@code List.all} is the only one the library has. */
+    private static final Set<ValueName> QUANTIFIERS = Set.of(op("List.all"));
+
+    /** Emptiness, by the size call it means. This is not a rule about what an operation does to a
+     * property but about what a predicate <em>says</em>: {@code List.isEmpty(xs)} and
+     * {@code List.length(xs) == 0} are one statement, so a guard writing either discharges a clause
+     * writing the other. Without it the two would be unrelated, which is an accident of which one the
+     * author reached for. */
+    private static final Map<ValueName, ValueName> EMPTINESS = Map.of(
+            op("List.isEmpty"), op("List.length"),
+            op("Set.isEmpty"), op("Set.size"),
+            op("Map.isEmpty"), op("Map.size"),
+            op("String.isEmpty"), op("String.length"));
+
+    /**
+     * The library's function forms of the arithmetic operators, and the operator each one is. They
+     * reach the same kernel in the same argument order — {@code Int.add} is {@code IntMath.addExact},
+     * which is what {@code +} emits — so the two spellings compute one value and are read as one term.
+     * {@code divide} is absent: it answers a union rather than a number.
+     */
+    private static final Map<ValueName, Ast.BinOp> OPERATOR_CALLS = Map.of(
+            op("Int.add"), Ast.BinOp.ADD,
+            op("Int.subtract"), Ast.BinOp.SUB,
+            op("Int.multiply"), Ast.BinOp.MUL,
+            op("Decimal.add"), Ast.BinOp.ADD,
+            op("Decimal.subtract"), Ast.BinOp.SUB,
+            op("Decimal.multiply"), Ast.BinOp.MUL);
+
+    /** Denial, which the analysis representation keeps as the call it is. */
+    static final ValueName NOT = op("Bool.not");
+
+    static Combinator combinator(ValueName operation) {
+        return COMBINATORS.get(operation);
+    }
+
+    static Built builtFrom(ValueName operation) {
+        return BUILT_FROM.get(operation);
+    }
+
+    static Carried carried(ValueName operation) {
+        return CARRIED.get(operation);
+    }
+
+    /** Which argument of {@code operation} is the projection its predicate is stated over, or null
+     * where it is stated over the element itself. */
+    static Integer projectionOf(ValueName operation) {
+        return PROJECTION_OF.get(operation);
+    }
+
+    static boolean isSize(ValueName operation) {
+        return SIZE_CALLS.contains(operation);
+    }
+
+    static boolean isQuantifier(ValueName operation) {
+        return QUANTIFIERS.contains(operation);
+    }
+
+    /** The size call an emptiness check means, or null where {@code operation} is not one. */
+    static ValueName sizeMeantBy(ValueName operation) {
+        return EMPTINESS.get(operation);
+    }
+
+    /** The operator {@code operation} is, where it is one written as a function, else null. */
+    static Ast.BinOp operator(ValueName operation) {
+        return OPERATOR_CALLS.get(operation);
+    }
+
+    /** Whether the check has a rule about what a call answers, rather than only about how to render
+     * it. */
+    static boolean readsAsATerm(ValueName operation) {
+        return isSize(operation) || BUILT_FROM.containsKey(operation)
+                || CARRIED.containsKey(operation) || isQuantifier(operation)
+                || NOT.equals(operation);
+    }
+
+    /** The container a size is really the size of: an operation that keeps the size of what it was
+     * built from is peeled away, so {@code List.length(List.map(f, xs))} is the atom
+     * {@code List.length(xs)}. How the elements are made has no bearing on how many there are, which
+     * is why the closure does not enter the key. */
+    static Core sizeSource(Core e) {
+        if (e instanceof Core.PreservedCall call) {
+            Built built = builtFrom(call.operation());
+            if (built != null && built.shape().keepsSize() && built.from() < call.args().size()) {
+                return sizeSource(call.args().get(built.from()));
+            }
+        }
+        return e;
+    }
+
+    private DischargeRules() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -218,6 +218,13 @@ final class DischargeRules {
                 || NOT.equals(operation);
     }
 
+    /** The one container {@code e} asks the size of, or null where it is not a size call over one
+     * argument. Asked rather than tested, so no reader spells the shape of a size call itself. */
+    static Core sizeArgOf(Core e) {
+        return e instanceof Core.PreservedCall call && isSize(call.operation())
+                && call.args().size() == 1 ? call.args().get(0) : null;
+    }
+
     /** The container a size is really the size of: an operation that keeps the size of what it was
      * built from is peeled away, so {@code List.length(List.map(f, xs))} is the atom
      * {@code List.length(xs)}. How the elements are made has no bearing on how many there are, which

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -735,7 +735,12 @@ public final class Elaborator {
         List<Core> values = new ArrayList<>();
         Scope inner = env;
         for (Ast.Bound b : ex.bound()) {
-            Core value = elaborate(b.value(), env, ctx);
+            // A lambda bound rather than applied needs to be told what it takes — it is a block, and a
+            // block is a value only where something says its parameter types. The declaration this
+            // binding came from says them, and nothing else here does.
+            Type says = b.value() instanceof Ast.Block && b.declaredType() != null
+                    ? TypeOps.resolveParamType(b.declaredType(), ctx.symbols()) : null;
+            Core value = elaborate(b.value(), env, ctx, says instanceof Type.FnOf ? says : null);
             Type bindType = value.type();
             if (b.declaredType() != null) {
                 Type declared = TypeOps.resolveParamType(b.declaredType(), ctx.symbols());

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -1053,6 +1053,13 @@ public final class Elaborator {
     static void collectApplications(Ast.Binder binder, Ast.Expr e, Scope env,
                                             CheckContext ctx, List<List<Type>> out,
                                             Set<BindingId> inner) {
+        // Handed to something that declares what it takes. A call a representation keeps standing
+        // holds the application inside itself, so a function passed to one is applied nowhere this
+        // walk can see — but the declaration says the parameter types as plainly as an application
+        // would, and it says them at the position the function was given to.
+        if (e instanceof Ast.Apply call) {
+            handedOver(binder, call, env, ctx, out);
+        }
         if (e instanceof Ast.Apply call && call.denotes() instanceof ValueName.Local applied
                 && applied.id().equals(binder.id())
                 && call.args().stream().noneMatch(a -> reaches(a, inner))) {
@@ -1068,6 +1075,13 @@ public final class Elaborator {
             case Ast.LetIn li -> {
                 collectApplications(binder, li.value(), env, ctx, out, inner);
                 collectApplications(binder, li.body(), env, ctx, out, with(inner, List.of(li.binder())));
+                // A name given to this function is this function: what the second name is used for is
+                // what the first one is used for. Followed rather than left to the applications alone,
+                // because an alias may be the only thing that is ever applied or handed over.
+                if (li.value() instanceof Ast.Var v && v.denotes() instanceof ValueName.Local local
+                        && local.id().equals(binder.id())) {
+                    collectApplications(li.binder(), li.body(), env, ctx, out, inner);
+                }
             }
             case Ast.IfConstructed ic -> {
                 collectApplications(binder, ic.construct(), env, ctx, out, inner);
@@ -1086,6 +1100,47 @@ public final class Elaborator {
             }
             default -> TypeChecker.forEachChild(e,
                     sub -> collectApplications(binder, sub, env, ctx, out, inner));
+        }
+    }
+
+    /**
+     * What {@code call} says the parameter types are, where {@code binder} is the function it was
+     * given at a position declared to take one.
+     *
+     * <p>The declaration is polymorphic, so what it says depends on the call: {@code List.filter}
+     * takes {@code ('a) -> Bool} and the list beside it decides {@code 'a}. The other arguments are
+     * read first for that reason, and one that cannot be read yet leaves this call saying nothing —
+     * another use, or the author's annotation, answers instead.
+     */
+    private static void handedOver(Ast.Binder binder, Ast.Apply call, Scope env, CheckContext ctx,
+                                   List<List<Type>> out) {
+        CompleteSignature kept = ctx.preserved().signatureOf(call.denotes());
+        if (kept == null || kept.params().size() != call.args().size()) {
+            return;
+        }
+        for (int i = 0; i < call.args().size(); i++) {
+            if (!(call.args().get(i) instanceof Ast.Var v)
+                    || !(v.denotes() instanceof ValueName.Local local)
+                    || !local.id().equals(binder.id())
+                    || !(kept.params().get(i) instanceof Type.FnOf declared)) {
+                continue;
+            }
+            Map<String, Type> bind = new HashMap<>();
+            try {
+                for (int j = 0; j < call.args().size(); j++) {
+                    if (j != i && !(kept.params().get(j) instanceof Type.FnOf)) {
+                        TypeOps.unify(kept.params().get(j), typeOf(call.args().get(j), env, ctx),
+                                bind, ctx.symbols(), call.pos(),
+                                "argument " + (j + 1) + " of " + call.written());
+                    }
+                }
+            } catch (CompileException _) {
+                return;   // this call decides nothing here; what is wrong with it is reported there
+            }
+            Type.FnOf settled = (Type.FnOf) TypeOps.substitute(declared, bind);
+            if (settled.params().stream().noneMatch(p -> Type.mentions(p, t -> t instanceof Type.Var))) {
+                out.add(settled.params());
+            }
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -1125,15 +1125,13 @@ public final class Elaborator {
                     || !(kept.params().get(i) instanceof Type.FnOf declared)) {
                 continue;
             }
-            Map<String, Type> bind = new HashMap<>();
+            Map<String, Type> bind;
             try {
-                for (int j = 0; j < call.args().size(); j++) {
-                    if (j != i && !(kept.params().get(j) instanceof Type.FnOf)) {
-                        TypeOps.unify(kept.params().get(j), typeOf(call.args().get(j), env, ctx),
-                                bind, ctx.symbols(), call.pos(),
-                                "argument " + (j + 1) + " of " + call.written());
-                    }
-                }
+                // The same settling the call itself does — this walk is reading that call's own
+                // question one position early, and an answer that differed from the one the call
+                // reaches would be a parameter type nothing later agrees with.
+                bind = CallElaborator.settledByValues(call, kept.params(), kept.result(), null,
+                        j -> typeOf(call.args().get(j), env, ctx), ctx);
             } catch (CompileException _) {
                 return;   // this call decides nothing here; what is wrong with it is reported there
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1182,6 +1182,11 @@ public final class HelperInliner {
                 // the argument's own answer rather than deciding one for it
                 Map<BindingId, ValueName> substDenotes = new HashMap<>();
                 List<BindingId> scoped = new ArrayList<>();   // the lambdas given to fn params
+                // A scoped lambda is reduced where the parameter is applied, and a representation may
+                // hold the application inside a call it keeps standing, so some are not applied here at
+                // all. What is left then is a name for a lambda, which is a value a `let` can hold —
+                // kept ready and used only for the ones the expansion did not reduce away.
+                Map<BindingId, Ast.Bound> unreduced = new LinkedHashMap<>();
                 List<Ast.Bound> bound = new ArrayList<>();
                 List<Ast.Given> given = new ArrayList<>();
                 for (int i = 0; i < helper.params().size(); i++) {
@@ -1232,6 +1237,8 @@ public final class HelperInliner {
                                             declares == null ? null : declares.result(),
                                             new Ast.FnBody.Written(lambda.body()), lambda.pos()));
                             lambdaOrigins.put(f.id(), new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
+                            unreduced.put(f.id(),
+                                    new Ast.Bound(f, instantiated(p.type(), applied), lambda));
                         } else {
                             // Neither a name nor a lambda: a value written where the function goes —
                             // the argument-order mistake made with a named helper rather than a
@@ -1270,6 +1277,14 @@ public final class HelperInliner {
                 SourcePos at = keepsItsPositions(call) ? null : call.pos();
                 Copy copy = new Copy(helper.written(), ours);
                 Ast.Expr body = inline(rename(helper.written(), subst, substDenotes, at, copy));   // expand nested helpers too
+                // A scoped lambda the body still names was passed rather than applied, so nothing
+                // reduced it and the name would stand for nothing. It is bound to what it names, which
+                // is what a lambda given a name is anywhere else.
+                unreduced.forEach((id, lambda) -> {
+                    if (references(body, id)) {
+                        bound.add(lambda);
+                    }
+                });
                 scoped.forEach(scopedLambdas::remove);
                 scoped.forEach(lambdaOrigins::remove);
                 yield new Ast.Expansion(call.denotes(), mine, bound, given,

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1,31 +1,28 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.check.DischargeRules.Built;
+import souther.compiler.check.DischargeRules.Combinator;
+import souther.compiler.check.DischargeRules.Shape;
 import souther.compiler.check.NumericDomain.LinearForm;
-import souther.compiler.check.NumericDomain.Rel;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
-import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
-import souther.compiler.types.ValueName;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -50,6 +47,13 @@ import java.util.Set;
  * <p>Which value a fact is about is the binding a name was answered with ({@link Location}), so a
  * body that binds one spelling twice states two things and nothing has to be forgotten when it does.
  *
+ * <p>What is here is the walk: where to look, what is known where, and what to say about a
+ * construction. What it looks <em>with</em> is beside it — {@link DischargeRules} for what the
+ * language's operations keep, {@link Clauses} for a declaration's invariant read at a value,
+ * {@link Terms} for where a value is and what can be said of it, {@link Predicates} for what a clause
+ * owes and what a guard settles. Each of those is a question with one answer, and the walk is what
+ * asks them in order.
+ *
  * <p>The walk mirrors {@link TotalityChecker}: a {@code switch} over {@link Core} threading an
  * immutable environment. It is fail-open — any internal error is swallowed so an analysis bug can
  * never reject a valid program.
@@ -69,329 +73,33 @@ public final class InvariantChecker {
      */
     public record Source(Ast.Expr body, Map<TypeName, List<Ast.InvariantClause>> invariants) {}
 
-    /** The library operation written {@code qualified}, as what a name reaching it denotes. */
-    private static ValueName op(String qualified) {
-        return new ValueName.Stdlib(qualified);
-    }
-
-    /** A stdlib combinator whose closure (argument {@code closureArg}) is handed each element of its
-     * container argument ({@code listArg}) as closure parameter {@code elementParam} — mirrors
-     * {@link TotalityChecker}'s table, so a construction inside a {@code List.map} or
-     * {@code List.foldFrom} closure is analyzed with the element bound to the container's element type
-     * ({@link #elementType}).
-     *
-     * <p>A rule is keyed by the operation a call reaches when this tree is read, which is not every
-     * name an author can write: {@code List.fold} is rewritten to {@code List.foldFrom} before any of
-     * this, so a rule under that name could not be looked up. {@code InvariantCombinatorRulesTest}
-     * holds the table to both halves of that — every name survives the rewrite, and every name has a
-     * program that fires it. */
-    private record Combinator(int closureArg, int elementParam, int listArg) {}
-
-    private static final Map<ValueName, Combinator> COMBINATORS = Map.ofEntries(
-            Map.entry(op("List.foldFrom"), new Combinator(0, 1, 2)),
-            Map.entry(op("List.foldr"), new Combinator(0, 1, 2)),
-            Map.entry(op("List.map"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.filter"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.all"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.any"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.find"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.partition"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.concatMap"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.filterMap"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.sortBy"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.groupBy"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.indexBy"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.allUniqueBy"), new Combinator(0, 0, 1)),
-            Map.entry(op("List.indexedMap"), new Combinator(0, 1, 1)),
-            Map.entry(op("Map.fold"), new Combinator(0, 2, 2)),
-            Map.entry(op("Map.map"), new Combinator(0, 1, 1)),
-            Map.entry(op("Map.filter"), new Combinator(0, 1, 1)),
-            Map.entry(op("Map.update"), new Combinator(1, 0, 2)),
-            Map.entry(op("Map.upsert"), new Combinator(2, 0, 3)),
-            Map.entry(op("Set.fold"), new Combinator(0, 1, 2)),
-            Map.entry(op("Set.map"), new Combinator(0, 0, 1)),
-            Map.entry(op("Set.filter"), new Combinator(0, 0, 1)),
-            Map.entry(op("Set.partition"), new Combinator(0, 0, 1)),
-            Map.entry(op("Option.map"), new Combinator(0, 0, 1)));
-
-    /** The operations the table has a rule for, for the test that holds it to being reachable. */
-    static Set<String> combinatorNames() {
-        Set<String> names = new LinkedHashSet<>();
-        COMBINATORS.keySet().forEach(operation -> names.add(operation.name()));
-        return names;
-    }
-
-    /** The pure, total stdlib calls whose result is a number the domain can name: the size of a
-     * container or a string. Each becomes an atom keyed by the call written over its argument's path
-     * — {@code List.length(b.items)} — so an invariant clause and a guard naming the same container
-     * name the same atom, and the guard discharges the clause. The argument must be a nameable path:
-     * {@code List.length(List.map(f, xs))} is not this atom, and nothing relates the two. */
-    private static final Set<ValueName> SIZE_CALLS = Set.of(
-            op("List.length"), op("String.length"), op("Set.size"), op("Map.size"));
-
-    /**
-     * What a construction of a container keeps of the container it was built from. This is the table
-     * that decides how much of a model the language tracks rather than leaves to a run-time check
-     * (spec §invariant-discharge-preservation), and it is stated per operation because that is the
-     * level an author writes at.
-     *
-     * <ul>
-     * <li>{@code PERMUTES} — the same elements in another order. Everything survives.
-     * <li>{@code SUBSET} — some of the same elements. Nothing new is there, so a property of every
-     *     element survives and the size can only fall.
-     * <li>{@code MAPS} — one new element for each. As many as before, and nothing is known of what
-     *     they are.
-     * <li>{@code COLLAPSES} — at most one new element for each. Neither the elements nor the count.
-     * </ul>
-     */
-    private enum Shape {
-        PERMUTES, SUBSET, MAPS, COLLAPSES;
-
-        /** Whether the result has exactly as many as the container it was built from. */
-        boolean keepsSize() {
-            return this == PERMUTES || this == MAPS;
-        }
-    }
-
-    /** Which argument a container was built from, and what the building keeps of it. */
-    private record Built(int from, Shape shape) {}
-
-    private static final Map<ValueName, Built> BUILT_FROM = Map.ofEntries(
-            Map.entry(op("List.reverse"), new Built(0, Shape.PERMUTES)),
-            Map.entry(op("List.sort"), new Built(0, Shape.PERMUTES)),
-            Map.entry(op("List.sortBy"), new Built(1, Shape.PERMUTES)),
-            Map.entry(op("List.map"), new Built(1, Shape.MAPS)),
-            Map.entry(op("List.indexedMap"), new Built(1, Shape.MAPS)),
-            Map.entry(op("Map.map"), new Built(1, Shape.MAPS)),
-            Map.entry(op("List.filter"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("List.distinct"), new Built(0, Shape.SUBSET)),
-            Map.entry(op("List.take"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("List.drop"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("Set.filter"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("Map.filter"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("List.filterMap"), new Built(1, Shape.COLLAPSES)),
-            Map.entry(op("Set.map"), new Built(1, Shape.COLLAPSES)));
-
-    /** Where a predicate reads its container, and which shapes of construction carry it there.
-     * {@code List.all} holds of any sublist of a list it holds of; {@code List.member} does not, and
-     * neither survives a mapping — what a mapped element is, the mapping alone does not say. */
-    private record Carried(int container, Set<Shape> through) {}
-
-    /** Where a predicate reads the projection it is stated over. A mapping keeps a projection when
-     * the closure copies that field from the element unchanged, so the predicate holds of the mapped
-     * list exactly when it holds of what was mapped, over the field it came from. */
-    private static final Map<ValueName, Integer> PROJECTION_OF = Map.of(op("List.allUniqueBy"), 0);
-
-    private static final Map<ValueName, Carried> CARRIED = Map.of(
-            op("List.all"), new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
-            op("List.allUniqueBy"), new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
-            op("List.any"), new Carried(1, Set.of(Shape.PERMUTES)),
-            op("List.member"), new Carried(1, Set.of(Shape.PERMUTES)),
-            op("Set.contains"), new Carried(1, Set.of(Shape.PERMUTES)),
-            op("Map.containsKey"), new Carried(1, Set.of(Shape.PERMUTES)));
-
-    /** The calls that state their predicate of <em>every</em> element, so what they say of a
-     * container is what holds of each element a closure is handed. Which argument is the predicate
-     * and which the container is what {@link #COMBINATORS} already answers of any combinator, and how
-     * far the statement travels is what {@link #CARRIED} already answers of any predicate — so a
-     * quantifier is the name and nothing else. {@code List.all} is the only one the library has. */
-    private static final Set<ValueName> QUANTIFIERS = Set.of(op("List.all"));
-
     /** How many conditionals a construction opens before the rest is left to the run-time check.
      * Each one doubles the paths, and a value written over three of them is not what the bound is
      * protecting against so much as what it declines to spend the time on. */
     private static final int BRANCHES_OPENED = 3;
 
-    /** Emptiness, by the size call it means. This is not a rule about what an operation does to a
-     * property (spec §invariant-discharge-preservation) but about what a predicate <em>says</em>:
-     * {@code List.isEmpty(xs)} and {@code List.length(xs) == 0} are one statement, so a guard writing
-     * either discharges a clause writing the other. Without it the two would be unrelated, which is
-     * an accident of which one the author reached for. */
-    private static final Map<ValueName, ValueName> EMPTINESS = Map.of(
-            op("List.isEmpty"), op("List.length"),
-            op("Set.isEmpty"), op("Set.size"),
-            op("Map.isEmpty"), op("Map.size"),
-            op("String.isEmpty"), op("String.length"));
-
-    /**
-     * The library's function forms of the arithmetic operators, and the operator each one is. They
-     * reach the same kernel in the same argument order — {@code Int.add} is {@code IntMath.addExact},
-     * which is what {@code +} emits — so the two spellings compute one value and are read as one term.
-     * {@code divide} is absent: it answers a union rather than a number.
-     */
-    private static final Map<ValueName, Ast.BinOp> OPERATOR_CALLS = Map.of(
-            op("Int.add"), Ast.BinOp.ADD,
-            op("Int.subtract"), Ast.BinOp.SUB,
-            op("Int.multiply"), Ast.BinOp.MUL,
-            op("Decimal.add"), Ast.BinOp.ADD,
-            op("Decimal.subtract"), Ast.BinOp.SUB,
-            op("Decimal.multiply"), Ast.BinOp.MUL);
+    /** The operations the combinator table has a rule for, for the test that holds it to being
+     * reachable. */
+    static Set<String> combinatorNames() {
+        return DischargeRules.combinatorNames();
+    }
 
     private final Symbols symbols;
-    private final Map<TypeName, List<Ast.InvariantClause>> dischargeInvariants;
+    /** The declarations' invariants, typed where they are declared and read where a value is built. */
+    private final Clauses clauses;
+    /** Where a value is, what it is called, and what can be said of it. */
+    private final Terms terms;
+    /** What a clause owes and what a guard settles. */
+    private final Predicates predicates;
     private final List<CompileException> errors = new ArrayList<>();
     private final List<Diagnostic> warnings = new ArrayList<>();
 
     private InvariantChecker(Symbols symbols,
                              Map<TypeName, List<Ast.InvariantClause>> dischargeInvariants) {
         this.symbols = symbols;
-        this.dischargeInvariants = dischargeInvariants;
-    }
-
-    /** Every invariant that applies to {@code named}, each in the analysis representation where this
-     * module declares it. */
-    private List<Ast.InvariantClause> invariantsOf(TypeName named, Ast.Data data) {
-        return TypeOps.effectiveInvariants(named, data, symbols, dischargeInvariants::get);
-    }
-
-    /**
-     * A relation known of every element of a container. A fact settles the container as a whole and
-     * is keyed by the call that states it, which relates it to nothing inside; this keeps the
-     * relation as the clause it was written as, so it can be read again at the element a combinator's
-     * closure is handed.
-     *
-     * <p>{@code through} is how far it travels: a construction of one of those shapes holds only
-     * elements of what it was built from, so what was stated of the source still holds of each of
-     * them. The predicate is kept as the block it is, already read where the relation was stated, so
-     * every name in it means there what it meant there.
-     */
-    private record Quantified(String container, Set<Shape> through, Core.Block predicate) {}
-
-    /** What the guards have settled on the current path: numeric relations, predicates known to hold
-     * or to fail, and relations known of every element of a container. Threaded functionally through
-     * the walk, as the domain alone once was. */
-    private record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified,
-                         Set<String> spoken) {
-
-        static Known top() {
-            return new Known(NumericDomain.top(), PredicateFacts.none(), List.of(), Set.of());
-        }
-
-        Known with(NumericDomain n) {
-            return new Known(n, facts, quantified, spoken);
-        }
-
-        Known with(PredicateFacts f) {
-            return new Known(numbers, f, quantified, spoken);
-        }
-
-        /**
-         * This, with each of {@code terms} recorded as one an assumption on this path named. It is
-         * recorded where the assumption is made rather than searched for afterwards: what a guard
-         * spoke about is known exactly then, and reading it back out of a domain would mean matching
-         * key text, which is how a term that merely reads like another gets mistaken for it.
-         */
-        Known speaking(Collection<String> terms) {
-            if (terms.isEmpty()) {
-                return this;
-            }
-            Set<String> all = new HashSet<>(spoken);
-            all.addAll(terms);
-            return new Known(numbers, facts, quantified, all);
-        }
-
-        /** Whether an assumption on this path named {@code term}. */
-        boolean speaksOf(String term) {
-            return spoken.contains(term);
-        }
-
-        Known and(List<Quantified> more) {
-            if (more.isEmpty()) {
-                return this;
-            }
-            List<Quantified> all = new ArrayList<>(quantified);
-            all.addAll(more);
-            return new Known(numbers, facts, List.copyOf(all), spoken);
-        }
-    }
-
-    /**
-     * What the body's bindings mean where the walk is.
-     *
-     * <p>A binding given a location <em>is</em> that location — the rule {@link Location} carries for
-     * a newtype's {@code .value}, read here of a binding instead of a field. It is what lets a
-     * construction survive being moved into a helper: an expansion binds each argument and answers
-     * the parameter's reads with that binding (see {@link HelperInliner}), so without it the body of
-     * a helper taking a record names locations the seeding never wrote, and everything an input's
-     * type guarantees stops at the call.
-     *
-     * <p>Nothing here is ever taken away. A binding is what it is, and a second binding of the same
-     * spelling is a second binding, so a fact about the first stays true of the first and nothing
-     * reads it under the second.
-     */
-    private record Denotations(Map<BindingId, Denotes> what, Map<BindingId, Core> values) {
-
-        static Denotations none() {
-            return new Denotations(Map.of(), Map.of());
-        }
-
-        /** What {@code binding} denotes, which is the location it is unless it was given something
-         * else. */
-        Denotes of(BindingId binding) {
-            Denotes given = what.get(binding);
-            return given != null ? given : new Denotes.At(Location.of(binding));
-        }
-
-        /** The value {@code binding} was given, or null where nothing recorded one. */
-        Core valueOf(BindingId binding) {
-            return values.get(binding);
-        }
-
-        Denotations binding(BindingId binding, Core value, Denotes denotes) {
-            Map<BindingId, Denotes> next = new HashMap<>(what);
-            next.put(binding, denotes);
-            Map<BindingId, Core> bound = new HashMap<>(values);
-            if (value != null) {
-                bound.put(binding, value);
-            }
-            return new Denotations(Map.copyOf(next), Map.copyOf(bound));
-        }
-    }
-
-    /**
-     * What a binding denotes. A location is somewhere the seeding can have written about and a clause
-     * can have named; a term is a value known only by what computes it. Merging those two would put a
-     * computed value where a location is expected, which is the shape of a {@code let} answering
-     * differently from the expression it was given. A written value is apart from both because what
-     * it is has to travel with the name, and nothing is apart because only a term is assigned a form.
-     */
-    private sealed interface Denotes {
-
-        /** The key this is known by, or {@code null} where it is known by none. */
-        String key();
-
-        /** A place: a parameter, a field chain, or another location a binding was given. */
-        record At(Location where) implements Denotes {
-
-            @Override
-            public String key() {
-                return where.toString();
-            }
-        }
-
-        /**
-         * A value named by the expression that computes it. {@code readable} is true where there is
-         * something to say of it however it is reached — a form the numeric domain built, or a rule
-         * about how it was made; false where only a guard naming it makes a clause readable against
-         * it.
-         */
-        record Term(String key, boolean readable) implements Denotes {}
-
-        /**
-         * A value written out, kept as what was written. There is no guard an author could add about
-         * it, so it is never named at a construction; what it is, though, still has to travel with
-         * the name, or the same text would fold where it is written and not where it is bound.
-         */
-        record Written(String key, Core value) implements Denotes {}
-
-        /** Nothing this check can name. */
-        record Nothing() implements Denotes {
-
-            @Override
-            public String key() {
-                return null;
-            }
-        }
+        this.clauses = new Clauses(symbols, dischargeInvariants);
+        this.terms = new Terms(symbols);
+        this.predicates = new Predicates(terms, clauses);
     }
 
     /**
@@ -405,18 +113,18 @@ public final class InvariantChecker {
         InvariantChecker c = new InvariantChecker(symbols, Map.of());
         // Read over the declaration's own fields, each standing for itself: a construction hands one
         // value per field, so a clause naming a field names something wherever it is built.
-        Core stated = c.typed(clause, data);
-        List<Clause> owed;
+        Core stated = c.clauses.typed(clause, data);
+        List<Predicates.Clause> owed;
         try {
             owed = stated == null ? null
-                    : c.obligations(stated, Known.top(), Denotations.none(), false);
+                    : c.predicates.obligations(stated, Known.top(), Denotations.none(), false);
         } catch (RuntimeException _) {
             owed = null;   // fail-open, as the walk is
         }
         if (owed == null || owed.isEmpty()) {
             return ClauseDischarge.runtimeOnly(at, c.whyUnreadable(stated));
         }
-        for (Clause owe : owed) {
+        for (Predicates.Clause owe : owed) {
             if (owe.numeric() != null) {
                 return ClauseDischarge.derivable(at);
             }
@@ -452,7 +160,7 @@ public final class InvariantChecker {
         if (found[0] != null) {
             return found[0];
         }
-        return termKey(e, Denotations.none(), Map.of(), 0) == null ? e : null;
+        return terms.termKey(e, Denotations.none(), Map.of(), 0) == null ? e : null;
     }
 
     /**
@@ -489,19 +197,19 @@ public final class InvariantChecker {
             // and what the two readings find is said once. Every place a conditional can be given —
             // to a field, to a name, to a guard — is this one place.
             walk(value.cond(), k, at, depth);
-            String same = bodyKey(value, at);
+            String same = terms.bodyKey(value, at);
             say(reading(without(e, value, same, value.then(), at),
-                            assumeCond(value.cond(), k, at, true), at, depth),
+                            predicates.assumeCond(value.cond(), k, at, true), at, depth),
                     reading(without(e, value, same, value.els(), at),
-                            assumeCond(value.cond(), k, at, false), at, depth));
+                            predicates.assumeCond(value.cond(), k, at, false), at, depth));
             return;
         }
         checkIfConstruction(e, k, at, false);
         switch (e) {
             case Core.If iff -> {
                 walk(iff.cond(), k, at, depth);
-                walk(iff.then(), assumeCond(iff.cond(), k, at, true), at, depth);
-                walk(iff.els(), assumeCond(iff.cond(), k, at, false), at, depth);
+                walk(iff.then(), predicates.assumeCond(iff.cond(), k, at, true), at, depth);
+                walk(iff.els(), predicates.assumeCond(iff.cond(), k, at, false), at, depth);
             }
             case Core.IfConstructed ic -> {
                 // The attempt's own construction cannot abort — a failing invariant is the else
@@ -511,7 +219,7 @@ public final class InvariantChecker {
                 checkIfConstruction(ic.construct(), k, at, true);
                 Core.forEachChild(ic.construct(), child -> walk(child, k, at, depth));
                 // The attempt built the value, so the binding is that construction and no location
-                Known k2 = seedAt(read(ic.binder(), ic.construct().type(), ic.pos()), k, at, 0);
+                Known k2 = seedAt(Terms.read(ic.binder(), ic.construct().type(), ic.pos()), k, at, 0);
                 walk(ic.then(), k2, at, depth);
                 // Each departure stands where the invariant did not hold, and nothing was built
                 // there, so none of them is seeded with anything the attempt would have guaranteed.
@@ -527,15 +235,15 @@ public final class InvariantChecker {
                 // is recorded under that denotation and not under the binding. Recording it under the
                 // binding is what made a named subexpression a term of its own, answering differently
                 // from the very expression it was given.
-                Denotes what = denotationOf(li.value(), at, k);
+                Denotes what = terms.denotationOf(li.value(), at, k);
                 Known k2 = k;
                 // A binding that denotes what it was given is an alias and introduces no value, so
                 // there is nothing to record of it: what holds of what it names already holds.
                 // Recording it anyway assigns that name its own form, and an assignment drops what
                 // was known of what it assigns to — the bound on it would be lost to the copy. A
                 // location is always this; a term is where the form is that term's own atom.
-                if (what instanceof Denotes.Term term && isNumeric(li.value().type())) {
-                    LinearForm vf = affineOf(li.value(), at, k);
+                if (what instanceof Denotes.Term term && terms.isNumeric(li.value().type())) {
+                    LinearForm vf = terms.affineOf(li.value(), at, k);
                     if (vf != null && !vf.equals(LinearForm.atom(term.key()))) {
                         k2 = k2.with(k2.numbers().assign(term.key(), vf));
                     }
@@ -559,22 +267,22 @@ public final class InvariantChecker {
      * parameter to the container's element type (and seeding its invariant) so a construction inside
      * the closure is analyzed rather than left opaque. */
     private void walkCall(Core.PreservedCall call, Known k, Denotations at, int depth) {
-        Combinator combo = COMBINATORS.get(call.operation());
+        Combinator combo = DischargeRules.combinator(call.operation());
         for (int i = 0; i < call.args().size(); i++) {
             Core arg = call.args().get(i);
-            Core.Block step = combo != null && i == combo.closureArg() ? blockOf(arg, at) : null;
+            Core.Block step = combo != null && i == combo.closureArg() ? Terms.blockOf(arg, at) : null;
             if (step != null && combo.elementParam() < step.params().size()
                     && combo.listArg() < call.args().size()) {
                 Core container = call.args().get(combo.listArg());
-                Type elem = elementType(container.type());
+                Type elem = Terms.elementType(container.type());
                 // The container is read where the call is written, so what is known of its elements
                 // is looked up before the closure's parameter stands for anything.
                 List<Quantified> relations = elementRelations(container, k, at);
-                Core element = read(step.params().get(combo.elementParam()), elem, step.pos());
+                Core element = Terms.read(step.params().get(combo.elementParam()), elem, step.pos());
                 // an element of a container is not a location the body can otherwise name
                 Known k2 = seedAt(element, k, at, 0);   // the element carries its type's invariant
                 for (Quantified q : relations) {
-                    k2 = instantiate(q, element, k2, at);
+                    k2 = predicates.instantiate(q, element, k2, at);
                 }
                 walk(step.body(), k2, at, depth);
             } else {
@@ -590,7 +298,7 @@ public final class InvariantChecker {
         Set<Shape> crossed = EnumSet.noneOf(Shape.class);
         Core source = container;
         while (true) {
-            String key = bodyKey(source, at);
+            String key = terms.bodyKey(source, at);
             if (key != null) {
                 for (Quantified q : k.quantified()) {
                     if (key.equals(q.container()) && q.through().containsAll(crossed)) {
@@ -601,63 +309,13 @@ public final class InvariantChecker {
             if (!(source instanceof Core.PreservedCall call)) {
                 return found;
             }
-            Built built = BUILT_FROM.get(call.operation());
+            Built built = DischargeRules.builtFrom(call.operation());
             if (built == null || built.from() >= call.args().size()) {
                 return found;
             }
             crossed.add(built.shape());
             source = call.args().get(built.from());
         }
-    }
-
-    /** What {@code q} says of the value at {@code element}, taken into {@code k}. The predicate is
-     * read again with the quantifier's own parameter standing for that element — the same reading
-     * {@link #seedAt} does of a type's invariant, over the clause a quantifier holds. A relation the
-     * predicate in turn states of a container is recorded, so a container of containers reaches its
-     * innermost element. */
-    private Known instantiate(Quantified q, Core element, Known k, Denotations at) {
-        Core stated = substituted(q.predicate().body(),
-                Map.of(q.predicate().params().get(0).id(), element));
-        List<Quantified> nested = new ArrayList<>();
-        quantifiedBy(stated, at, true, nested);
-        return assume(obligations(stated, k, at, false), k).and(nested);
-    }
-
-    /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
-     * Mirrors {@link #obligations}: a conjunction states each of its sides, and a negation flips the
-     * polarity. Only a stated quantifier is recorded — denying one says some element fails the
-     * predicate, and which one is not something this check can name. */
-    private void quantifiedBy(Core raw, Denotations at, boolean positive, List<Quantified> out) {
-        Core e = asSizeComparison(raw);
-        if (e instanceof Core.Binary b && b.op() == Ast.BinOp.AND && positive) {
-            quantifiedBy(b.left(), at, true, out);
-            quantifiedBy(b.right(), at, true, out);
-            return;
-        }
-        Core under = negated(e);
-        if (under != null) {
-            quantifiedBy(under, at, !positive, out);
-            return;
-        }
-        if (!positive || !(e instanceof Core.PreservedCall call)
-                || !QUANTIFIERS.contains(call.operation())) {
-            return;
-        }
-        Combinator over = COMBINATORS.get(call.operation());
-        Carried carried = CARRIED.get(call.operation());
-        if (over == null || carried == null || over.closureArg() >= call.args().size()
-                || over.listArg() >= call.args().size()) {
-            return;
-        }
-        Core.Block p = blockOf(call.args().get(over.closureArg()), at);
-        if (p == null || p.params().size() != 1) {
-            return;
-        }
-        String container = bodyKey(call.args().get(over.listArg()), at);
-        if (container == null) {
-            return;
-        }
-        out.add(new Quantified(container, carried.through(), p));
     }
 
     // --- construction detection & discharge check ----------------------------------------------
@@ -671,11 +329,11 @@ public final class InvariantChecker {
         }
         // Closed arithmetic over a newtype builds one where it stands: the operands are unwrapped,
         // the operator applied, and the result constructed again, so the invariant is owed here.
-        if (asOperator(e) instanceof Core.Binary bin && isArith(bin.op())
+        if (Terms.asOperator(e) instanceof Core.Binary bin && Terms.isArith(bin.op())
                 && bin.type() instanceof Type.Ref r
                 && symbols.get(r.name()) instanceof Ast.Data type && type.newtype()) {
-            BindingId value = fieldBindingsOf(type).get("value");
-            if (value != null && affineOf(bin, at, k) != null) {
+            BindingId value = clauses.bindingsOf(type).get("value");
+            if (value != null && terms.affineOf(bin, at, k) != null) {
                 report(bin, type, bin.pos(), attempted,
                         verdictOf(r.name(), type, Map.of(value, bin), k, at, true));
             }
@@ -688,7 +346,7 @@ public final class InvariantChecker {
      * value and not a choice of two.
      */
     private Verdict verdictOf(Core.NewData nd, Ast.Data type, Known k, Denotations at) {
-        Map<String, BindingId> fields = fieldBindingsOf(type);
+        Map<String, BindingId> fields = clauses.bindingsOf(type);
         Map<BindingId, Core> given = new HashMap<>();
         for (Core.FieldInit fi : nd.inits()) {
             BindingId field = fields.get(fi.name());
@@ -697,32 +355,22 @@ public final class InvariantChecker {
             }
             // A name given a value written out hands over that value: the clause folds over what
             // was written, wherever the writing was done.
-            Core written = writtenValue(fi.value(), at);
+            Core written = Terms.writtenValue(fi.value(), at);
             given.put(field, written != null ? written : fi.value());
         }
         return verdictOf(nd.typeName(), type, given, k, at, !constantlyBuilt(type, nd));
     }
 
     /** Which of the values a construction hands over is not one a clause may be read against
-     * ({@link #siteKey}) — by identity, since it is these very values that stand in the clause. */
+     * ({@link Terms#siteKey}) — by identity, since it is these very values that stand in the clause. */
     private Set<Core> unnamed(Collection<Core> given, Known k, Denotations at) {
         Set<Core> out = Collections.newSetFromMap(new IdentityHashMap<>());
         for (Core value : given) {
-            if (siteKey(value, at, k) == null) {
+            if (terms.siteKey(value, at, k) == null) {
                 out.add(value);
             }
         }
         return out;
-    }
-
-    /** Whether {@code e} is, or names, one of {@code values}. */
-    private static boolean names(Core e, Set<Core> values) {
-        if (values.contains(e)) {
-            return true;
-        }
-        boolean[] found = {false};
-        Core.forEachChild(e, child -> found[0] = found[0] || names(child, values));
-        return found[0];
     }
 
     /**
@@ -755,7 +403,7 @@ public final class InvariantChecker {
      * {@code given}. */
     private Verdict verdictOf(TypeName named, Ast.Data type, Map<BindingId, Core> given, Known k,
                               Denotations at, boolean decidesFalse) {
-        List<Ast.InvariantClause> invs = invariantsOf(named, type);
+        List<Ast.InvariantClause> invs = clauses.of(named, type);
         if (invs.isEmpty()) {
             return Verdict.PROVED;
         }
@@ -763,14 +411,14 @@ public final class InvariantChecker {
         // them is left to the run-time check, and one that is decided outright is still decided: what
         // cannot be guarded is not the same as what cannot be computed.
         Set<Core> unnamed = unnamed(given.values(), k, at);
-        List<Clause> owed = new ArrayList<>();
+        List<Predicates.Clause> owed = new ArrayList<>();
         for (Ast.InvariantClause inv : invs) {
             // A newtype construction from a value written out is the constant check's to report: it
             // names the clause that failed. It reads the construction as written, so a name given the
             // value is not one it sees, and this check says it instead.
-            Core stated = statedAt(inv.expr(), type, given);
-            List<Clause> o = stated == null ? null
-                    : obligations(stated, k, at, unnamed, true, decidesFalse);
+            Core stated = clauses.statedAt(inv.expr(), type, given);
+            List<Predicates.Clause> o = stated == null ? null
+                    : predicates.obligations(stated, k, at, unnamed, decidesFalse);
             if (o != null) {
                 owed.addAll(o);
             }
@@ -779,13 +427,13 @@ public final class InvariantChecker {
             return Verdict.PROVED;   // nothing here is expressible — the run-time check stands for it
         }
         NumericDomain dom = k.numbers();
-        for (Clause c : owed) {
-            for (Constraint known : c.known()) {
+        for (Predicates.Clause c : owed) {
+            for (Predicates.Constraint known : c.known()) {
                 dom = dom.assume(known.form(), known.rel());
             }
         }
         Verdict out = Verdict.PROVED;
-        for (Clause c : owed) {
+        for (Predicates.Clause c : owed) {
             if (c.dischargedBy(dom, k.facts())) {
                 continue;
             }
@@ -801,7 +449,7 @@ public final class InvariantChecker {
      * it is built. That check names the clause that failed, so it is left to say it — and it reads
      * the construction as written, so a name given the value is not one it sees. */
     private static boolean constantlyBuilt(Ast.Data type, Core.NewData nd) {
-        return type.newtype() && nd.inits().size() == 1 && isWritten(nd.inits().get(0).value());
+        return type.newtype() && nd.inits().size() == 1 && Terms.isWritten(nd.inits().get(0).value());
     }
 
     /** Says what {@code verdict} found. A definite violation is an error and an unproven one a
@@ -870,16 +518,6 @@ public final class InvariantChecker {
      * construction the conditional is written inside.
      */
     private Capture capturing;
-
-    /** What each declaration's fields are. Asked at every field read the walk goes past, and building
-     * one walks the declaration's includes, so it is built once per declaration instead. */
-    private final Map<Ast.Data, Map<String, Type>> fieldsOf = new HashMap<>();
-
-    /** The same, for the binding each field is. */
-    private final Map<Ast.Data, Map<String, BindingId>> fieldBindings = new HashMap<>();
-
-    /** Each clause as the checker typed it, over the fields it is written against. */
-    private final Map<Ast.Expr, Optional<Core>> typedClauses = new IdentityHashMap<>();
 
     /** What a reading has found so far. */
     private record Capture(Map<Occurrence, Reported> found) {
@@ -950,7 +588,7 @@ public final class InvariantChecker {
      * make the guard say nothing about what is built.
      */
     private Core without(Core e, Core.If was, String key, Core becomes, Denotations at) {
-        if (e == was || (key != null && e instanceof Core.If && key.equals(bodyKey(e, at)))) {
+        if (e == was || (key != null && e instanceof Core.If && key.equals(terms.bodyKey(e, at)))) {
             return becomes;
         }
         if (e instanceof Core.Block) {
@@ -993,317 +631,7 @@ public final class InvariantChecker {
                 "constructing `" + type.name() + "` here violates its invariant on a reachable path"));
     }
 
-    // --- a clause, read where a value is built -------------------------------------------------
-
-    /**
-     * {@code clause} as the checker types it: over the declaration's own fields, each a binding, in
-     * the representation this check reads. Asked once per clause, because typing one walks it.
-     *
-     * <p>Null where the clause is not one this compiler could type there. That is the same answer as
-     * a clause naming something outside the fragment — the run-time check stands for it — and it is
-     * an answer rather than a failure because a declaration this check cannot read is not a
-     * declaration an author wrote wrongly.
-     */
-    private Core typed(Ast.Expr clause, Ast.Data data) {
-        return typedClauses.computeIfAbsent(clause, written -> {
-            try {
-                return Optional.ofNullable(Elaborator.elaborate(written, fieldScope(data),
-                        CheckContext.of(symbols).forData(data)
-                                .preserving(Preserved.byTheLanguagesOwnOperations()),
-                        Type.BOOL));
-            } catch (RuntimeException _) {
-                return Optional.empty();
-            }
-        }).orElse(null);
-    }
-
-    /** The bindings a declaration's own invariant reads: its fields, each as the binding it is. */
-    private Scope fieldScope(Ast.Data data) {
-        return DataChecker.fieldScope(data, symbols);
-    }
-
-    /**
-     * What a clause of {@code data} states where each field is given what {@code given} says, or
-     * {@code null} where it states nothing this check can read.
-     *
-     * <p>The clause is the declaration's and the values are the site's, and this is where the two
-     * become one expression: a field read stands for the value that field is being given, so what the
-     * clause says is read by the very rules the body is read by. A field nothing was given — one a
-     * construction leaves out — leaves the clause naming a value that is not there, and the clause is
-     * left to the run-time check rather than read against nothing.
-     */
-    private Core statedAt(Ast.Expr clause, Ast.Data data, Map<BindingId, Core> given) {
-        Core typed = typed(clause, data);
-        if (typed == null) {
-            return null;
-        }
-        Set<BindingId> fields = new HashSet<>(fieldBindingsOf(data).values());
-        boolean[] whole = {true};
-        readsOf(typed, binding -> {
-            if (fields.contains(binding) && !given.containsKey(binding)) {
-                whole[0] = false;
-            }
-        });
-        return whole[0] ? substituted(typed, given) : null;
-    }
-
-    /** {@code e} with each binding {@code given} names replaced by the value it was given. */
-    private static Core substituted(Core e, Map<BindingId, Core> given) {
-        if (e instanceof Core.Read r) {
-            Core value = given.get(r.binding());
-            return value != null ? value : r;
-        }
-        return Core.mapChildren(e, child -> substituted(child, given),
-                // A name slot holds a binding and nothing else, so a value put there would be
-                // something the reader of that slot cannot load. Only another name may stand there.
-                name -> substituted(name, given) instanceof Core.Read r ? r : name,
-                nd -> (Core.NewData) Core.mapChildren(nd, child -> substituted(child, given),
-                        name -> substituted(name, given) instanceof Core.Read r ? r : name));
-    }
-
-    /** Every binding {@code e} reads, at any depth. */
-    private static void readsOf(Core e, java.util.function.Consumer<BindingId> f) {
-        if (e instanceof Core.Read r) {
-            f.accept(r.binding());
-        }
-        Core.forEachChild(e, child -> readsOf(child, f));
-    }
-
     // --- invariant / condition -> constraints --------------------------------------------------
-
-    private record Constraint(LinearForm form, Rel rel) {}
-
-    /**
-     * A predicate stated of a term. {@code keys} is the term as written first, then each container it
-     * was built from by a construction that carries the predicate — any one of them settled is this
-     * clause established. Refuting reads only the first: denying a predicate of a list says nothing
-     * about a list built from it. {@code positive} is false for a clause written under a negation,
-     * and such a clause carries nowhere, since the implication runs the other way.
-     */
-    private record Fact(List<String> keys, boolean positive) {
-
-        boolean entailedBy(PredicateFacts facts) {
-            for (String key : keys) {
-                if (facts.entails(key, positive)) {
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        boolean refutedBy(PredicateFacts facts) {
-            return facts.refutes(keys.get(0), positive);
-        }
-    }
-
-    /** A clause that cannot hold, said in the language the domain reads: {@code -1 >= 0}. */
-    private static final Clause VIOLATED = new Clause(
-            new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE), null, List.of());
-
-    /**
-     * One clause of an invariant, and the two ways it can come out: a relation for the domain to
-     * prove, and the key a guard restating it settles. Either may be absent, and where both are
-     * present either one discharging the clause is enough — a guard is written one way and a clause
-     * another, and which of the two routes carries it is not the author's concern.
-     */
-    private record Clause(Constraint numeric, Fact fact, List<Constraint> known) {
-
-        boolean dischargedBy(NumericDomain d, PredicateFacts facts) {
-            return numeric != null && d.entails(numeric.form(), numeric.rel())
-                    || fact != null && fact.entailedBy(facts);
-        }
-
-        boolean refutedBy(NumericDomain d, PredicateFacts facts) {
-            return numeric != null && d.refutes(numeric.form(), numeric.rel())
-                    || fact != null && fact.refutedBy(facts);
-        }
-    }
-
-    /** What {@code inv} owes, where {@code decidesFalse} says a clause folding to the other answer
-     * than it is read with is this check's to report. A newtype's constant construction is checked
-     * elsewhere, and that check names the clause that failed rather than only saying one did, so it
-     * is left to say it. */
-    private List<Clause> obligations(Core inv, Known k, Denotations at, boolean decidesFalse) {
-        return obligations(inv, k, at, Set.of(), true, decidesFalse);
-    }
-
-    private List<Clause> obligations(Core rawInv, Known k, Denotations at, Set<Core> unnamed,
-                                     boolean positive, boolean decidesFalse) {
-        Core inv = asSizeComparison(rawInv);
-        if (inv instanceof Core.Binary b && b.op() == Ast.BinOp.AND && positive) {
-            // Each conjunct on its own: an invariant is a set of things that hold, and one the check
-            // cannot read leaves its own run-time check standing without costing the others theirs.
-            List<Clause> l = obligations(b.left(), k, at, unnamed, true, decidesFalse);
-            List<Clause> r = obligations(b.right(), k, at, unnamed, true, decidesFalse);
-            if (l == null && r == null) {
-                return null;
-            }
-            List<Clause> both = new ArrayList<>(l == null ? List.of() : l);
-            both.addAll(r == null ? List.of() : r);
-            return both;
-        }
-        Core under = negated(inv);
-        if (under != null) {
-            return obligations(under, k, at, unnamed, !positive, decidesFalse);
-        }
-        Boolean folded = decidedAt(inv);
-        if (folded != null) {
-            // The clause folds once the construction's own expressions stand where it read a field.
-            // Folding the way it is read owes nothing; folding the other way is a violation, and
-            // saying so needs no term to be named. Read under a denial it is the other answer that
-            // discharges, which is why the polarity is asked.
-            if (folded == positive) {
-                return List.of();
-            }
-            if (decidesFalse) {
-                return List.of(VIOLATED);
-            }
-        }
-        Constraint numeric = null;
-        if (inv instanceof Core.Binary b && relOf(b.op()) != null) {
-            Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
-            LinearForm la = eff == null ? null : affineOf(b.left(), at, k);
-            LinearForm ra = eff == null ? null : affineOf(b.right(), at, k);
-            if (la != null && ra != null) {
-                numeric = new Constraint(la.minus(ra), eff);
-            }
-        }
-        Polar polar = polar(inv, positive);
-        // A predicate over a value no guard could be written about is not a predicate a guard will
-        // settle, so it is not owed as one — where the domain can say something of that value it has
-        // already said it above, and where it cannot the run-time check stands for the clause.
-        List<String> keys = names(polar.expr(), unnamed) ? List.of() : factKeys(polar.expr(), at);
-        boolean stated = polar.positive();
-        Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);
-        if (numeric == null && fact == null) {
-            return null;
-        }
-        List<Constraint> known = new ArrayList<>();
-        sizeFacts(inv, at, known);
-        return List.of(new Clause(numeric, fact, known));
-    }
-
-    /** Whether {@code inv} is decided outright: the clause, with the construction's own values
-     * already standing where it read a field, folded. {@code null} where it does not fold — which is
-     * every clause reading anything computed at run time. */
-    private Boolean decidedAt(Core inv) {
-        Object folded = folded(inv);
-        return folded instanceof Boolean b ? b : null;
-    }
-
-    /** What {@code e} folds to where every part of it is written out, or {@code null} where any part
-     * of it is computed at run time and there is nothing to fold. */
-    private static Object folded(Core e) {
-        Ast.Expr written = asWrittenValue(e);
-        return written == null ? null : ConstEval.eval(written).orElse(null);
-    }
-
-    private static List<String> firstOnly(List<String> keys) {
-        return keys.isEmpty() ? keys : List.of(keys.get(0));
-    }
-
-    /** Refines {@code k} by asserting {@code cond} (or its negation): a comparison tightens the
-     * numeric domain, a stdlib predicate settles a fact. A condition of neither shape, and an operand
-     * outside the affine fragment, leave {@code k} unchanged (sound). */
-    private Known assumeCond(Core rawCond, Known k, Denotations at, boolean positive) {
-        Core cond = asSizeComparison(rawCond);
-        // `&&` asserted true gives both sides; `||` asserted false gives both sides negated.
-        if (cond instanceof Core.Binary b
-                && (b.op() == Ast.BinOp.AND && positive || b.op() == Ast.BinOp.OR && !positive)) {
-            return assumeCond(b.right(), assumeCond(b.left(), k, at, positive), at, positive);
-        }
-        Core under = negated(cond);
-        if (under != null) {
-            return assumeCond(under, k, at, !positive);
-        }
-        Known out = k;
-        // What holds of the sizes the condition names, whichever way the condition itself is read.
-        List<Constraint> known = new ArrayList<>();
-        sizeFacts(cond, at, known);
-        for (Constraint c : known) {
-            out = out.with(out.numbers().assume(c.form(), c.rel()));
-        }
-        if (cond instanceof Core.Binary b) {
-            Rel rel = relOf(b.op());
-            Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
-            LinearForm la = eff == null ? null : affineOf(b.left(), at, out);
-            LinearForm ra = eff == null ? null : affineOf(b.right(), at, out);
-            if (la != null && ra != null) {
-                out = out.with(out.numbers().assume(la.minus(ra), eff));
-            }
-            // What the comparison named, recorded as spoken about: a construction from one of these
-            // is one the author has said something about, whichever route ends up carrying it.
-            Set<String> named = new HashSet<>(spokenOf(b.left(), at, la));
-            named.addAll(spokenOf(b.right(), at, ra));
-            out = out.speaking(named);
-        }
-        List<Quantified> quantified = new ArrayList<>();
-        quantifiedBy(cond, at, positive, quantified);
-        out = out.and(quantified);
-        // Both routes, always: which one carries a clause is decided where the clause is read, and a
-        // guard does not know which that will be.
-        Polar polar = polar(cond, positive);
-        String key = bodyKey(polar.expr(), at);
-        return key == null ? out : out.with(out.facts().assume(key, polar.positive()));
-    }
-
-    /** The terms one side of a compared pair names: the expression itself, and each atom of the form it
-     * reduced to — {@code leftover + 1} says something about {@code leftover}. */
-    private Collection<String> spokenOf(Core side, Denotations at, LinearForm form) {
-        Set<String> terms = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
-        String written = bodyKey(side, at);
-        if (written != null) {
-            terms.add(written);
-        }
-        return terms;
-    }
-
-    /** A predicate as one of {@code ==}/{@code <} states it, and whether it is being stated or denied. */
-    private record Polar(Core expr, boolean positive) {}
-
-    /**
-     * {@code e}, asserted with polarity {@code positive}, as the comparison of {@code ==} or {@code <}
-     * that says the same thing: {@code a /= b} is {@code a == b} denied, {@code a >= b} is
-     * {@code a < b} denied, and {@code a > b} is {@code b < a}. A fact is settled by key equality, so
-     * without this the six ways to compare two terms are six facts, and a guard written one way would
-     * leave a clause written the other unsettled.
-     */
-    private static Polar polar(Core e, boolean positive) {
-        if (!(e instanceof Core.Binary b) || relOf(b.op()) == null) {
-            return new Polar(e, positive);
-        }
-        return switch (b.op()) {
-            case NE -> new Polar(comparison(Ast.BinOp.EQ, b.left(), b.right(), b), !positive);
-            case GE -> new Polar(comparison(Ast.BinOp.LT, b.left(), b.right(), b), !positive);
-            case GT -> new Polar(comparison(Ast.BinOp.LT, b.right(), b.left(), b), positive);
-            case LE -> new Polar(comparison(Ast.BinOp.LT, b.right(), b.left(), b), !positive);
-            default -> new Polar(e, positive);
-        };
-    }
-
-    private static Core.Binary comparison(Ast.BinOp op, Core left, Core right, Core.Binary of) {
-        return new Core.Binary(op, left, right, of.type(), of.pos());
-    }
-
-    /** What a negation is applied to, or {@code null} if {@code e} is not one. {@code Bool.not} is an
-     * ordinary helper: the analysis representation keeps it as a call, and a clause read off an
-     * imported declaration is the body it expands to — {@code if b then false else true} over a
-     * binding holding the argument. Both are read. */
-    private static Core negated(Core e) {
-        if (e instanceof Core.PreservedCall call && call.operation().equals(op("Bool.not"))
-                && call.args().size() == 1) {
-            return call.args().get(0);
-        }
-        if (e instanceof Core.LetIn li) {
-            Core inner = negated(li.body());
-            return inner instanceof Core.Read r && r.binding().equals(li.binder().id())
-                    ? li.value() : null;
-        }
-        return e instanceof Core.If iff
-                && iff.then() instanceof Core.Bool t && !t.value()
-                && iff.els() instanceof Core.Bool f && f.value()
-                ? iff.cond() : null;
-    }
 
     // --- seeding -------------------------------------------------------------------------------
 
@@ -1322,8 +650,8 @@ public final class InvariantChecker {
                 || !(symbols.get(ref.name()) instanceof Ast.Data data)) {
             return k;
         }
-        Map<String, Type> fields = fieldsOf(data);
-        Map<String, BindingId> bindings = fieldBindingsOf(data);
+        Map<String, Type> fields = clauses.fieldsOf(data);
+        Map<String, BindingId> bindings = clauses.bindingsOf(data);
         Map<BindingId, Core> given = new HashMap<>();
         fields.forEach((name, type) -> {
             BindingId field = bindings.get(name);
@@ -1333,13 +661,13 @@ public final class InvariantChecker {
         });
         Known out = k;
         List<Quantified> quantified = new ArrayList<>();
-        for (Ast.InvariantClause inv : invariantsOf(ref.name(), data)) {
-            Core stated = statedAt(inv.expr(), data, given);
+        for (Ast.InvariantClause inv : clauses.of(ref.name(), data)) {
+            Core stated = clauses.statedAt(inv.expr(), data, given);
             if (stated == null) {
                 continue;
             }
-            quantifiedBy(stated, at, true, quantified);
-            out = assume(obligations(stated, out, at, false), out);
+            predicates.quantifiedBy(stated, at, true, quantified);
+            out = predicates.assume(predicates.obligations(stated, out, at, false), out);
         }
         out = out.and(quantified);
         if (data.newtype()) {
@@ -1354,919 +682,4 @@ public final class InvariantChecker {
         return out;
     }
 
-    /** {@code k} with everything {@code owed} states taken as holding. What a clause owes at a
-     * construction is what it guarantees where it is already established, so the two read the same
-     * clauses through the same rule and differ only in direction. */
-    private Known assume(List<Clause> owed, Known k) {
-        if (owed == null) {
-            return k;
-        }
-        Known out = k;
-        for (Clause c : owed) {
-            for (Constraint known : c.known()) {
-                out = out.with(out.numbers().assume(known.form(), known.rel()));
-            }
-            if (c.numeric() != null) {
-                out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
-            }
-            if (c.fact() != null) {
-                // What is guaranteed is guaranteed of the term as written; a container built from it
-                // is another term, and reads the rules where it is constructed rather than here.
-                out = out.with(out.facts().assume(c.fact().keys().get(0), c.fact().positive()));
-            }
-        }
-        return out;
-    }
-
-    // --- affine forms --------------------------------------------------------------------------
-
-    /** The operator {@code e} is, where it is a library call written as a function, or {@code e}
-     * itself. Reading it as the operator is what puts it on the one path the operator already has,
-     * rather than on a second path that would have to be kept saying the same thing. */
-    private static Core asOperator(Core e) {
-        if (e instanceof Core.PreservedCall call && call.args().size() == 2) {
-            Ast.BinOp op = OPERATOR_CALLS.get(call.operation());
-            if (op != null) {
-                return new Core.Binary(op, call.args().get(0), call.args().get(1), call.type(),
-                        call.pos());
-            }
-        }
-        return e;
-    }
-
-    /** The shared affine walk: literals and {@code +}/{@code -} compose; every other node is handed to
-     * {@code leaf} (which decides whether it is an atom, a location, or opaque). */
-    private LinearForm affine(Core raw, java.util.function.Function<Core, LinearForm> leaf) {
-        Core e = asOperator(raw);
-        if (e instanceof Core.PreservedCall) {
-            // A call that folds is the number it folds to. `String.length("1A")` is 2, and a clause
-            // about it is decided rather than owed — the run-time check is not what should answer a
-            // question the compiler has already computed. Asked once: folding walks the subtree, and
-            // a pattern in it is a regex to run.
-            BigDecimal folded = constantNumber(e);
-            if (folded != null) {
-                return LinearForm.constant(folded);
-            }
-        }
-        return switch (e) {
-            case Core.Int i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
-            case Core.Decimal d -> LinearForm.constant(d.value());
-            case Core.Neg n -> negate(affine(n.operand(), leaf));
-            case Core.Binary b when b.op() == Ast.BinOp.ADD ->
-                    add(affine(b.left(), leaf), affine(b.right(), leaf), false);
-            case Core.Binary b when b.op() == Ast.BinOp.SUB ->
-                    add(affine(b.left(), leaf), affine(b.right(), leaf), true);
-            // scalar multiply by a constant (Amount * 2) is linear; `/` and a variable product are not
-            // (a divide truncates for Int, and a variable factor is non-linear), so leave those opaque.
-            case Core.Binary b when b.op() == Ast.BinOp.MUL ->
-                    scale(affine(b.left(), leaf), affine(b.right(), leaf));
-            // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what an
-            // arithmetic helper becomes, so reading through it is reading the arithmetic the author
-            // wrote.
-            case Core.LetIn li -> {
-                LinearForm bound = affine(li.value(), leaf);
-                yield bound == null ? leaf.apply(e) : affine(li.body(),
-                        n -> n instanceof Core.Read r && r.binding().equals(li.binder().id())
-                                ? bound : leaf.apply(n));
-            }
-            default -> leaf.apply(e);
-        };
-    }
-
-    /** The number {@code e} folds to at compile time, or {@code null} where it folds to none. */
-    private static BigDecimal constantNumber(Core e) {
-        Object folded = folded(e);
-        if (folded instanceof Long n) {
-            return BigDecimal.valueOf(n);
-        }
-        return folded instanceof BigDecimal d ? d : null;
-    }
-
-    /** A linear form scaled by a constant, when one side is a bare constant (a scalar multiply); null
-     * when neither side is constant (a non-linear product). */
-    private static LinearForm scale(LinearForm a, LinearForm b) {
-        if (a == null || b == null) {
-            return null;
-        }
-        if (a.coefs().isEmpty()) {
-            return b.times(a.constant());
-        }
-        return b.coefs().isEmpty() ? a.times(b.constant()) : null;
-    }
-
-    /** The affine form of an expression: a numeric atom, a newtype construct's wrapped value, or
-     * {@code null}. */
-    private LinearForm affineOf(Core e, Denotations at, Known k) {
-        return affine(e, n -> {
-            if (n instanceof Core.NewData nd && nd.spreads().isEmpty() && nd.inits().size() == 1
-                    && nd.inits().get(0).name().equals("value")
-                    && numericNewtype(Type.ref(nd.typeName()))) {
-                return affineOf(nd.inits().get(0).value(), at, k);
-            }
-            Core written = writtenValue(n, at);
-            if (written != null && written != n) {
-                return affineOf(written, at, k);
-            }
-            // A list written out has as many elements as it is written with, whatever they are.
-            BigDecimal counted = writtenSize(n, at);
-            if (counted != null) {
-                return LinearForm.constant(counted);
-            }
-            String atom = atomOf(n, at, k);
-            return atom == null ? null : LinearForm.atom(atom);
-        });
-    }
-
-    /** How many elements a size call over a value written out counts, or {@code null} where its
-     * argument is not one. */
-    private BigDecimal writtenSize(Core e, Denotations at) {
-        if (!(e instanceof Core.PreservedCall call) || !SIZE_CALLS.contains(call.operation())
-                || call.args().size() != 1) {
-            return null;
-        }
-        Core written = writtenValue(call.args().get(0), at);
-        return written instanceof Core.ListLit list
-                ? BigDecimal.valueOf(list.elements().size()) : null;
-    }
-
-    private static LinearForm negate(LinearForm f) {
-        return f == null ? null : f.negate();
-    }
-
-    private static LinearForm add(LinearForm a, LinearForm b, boolean subtract) {
-        if (a == null || b == null) {
-            return null;
-        }
-        return subtract ? a.minus(b) : a.plus(b);
-    }
-
-    /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value) or of
-     * a size call over a nameable container, or {@code null} if {@code e} is neither. */
-    private String atomOf(Core e, Denotations at, Known k) {
-        String size = sizeAtom(e, arg -> bodyKey(arg, at));
-        if (size != null) {
-            return size;
-        }
-        if (!isNumeric(e.type())) {
-            return null;
-        }
-        // A path rooted at a binding is the atom of what that binding denotes, and only where a clause
-        // could be read against it — otherwise a name would be an atom where the expression it was
-        // given is not one, and the two spellings would answer differently.
-        BindingId root = rootBinding(e);
-        if (root != null && !readable(at.of(root), k)) {
-            return null;
-        }
-        return pathKey(e, at);
-    }
-
-    /** An expression's canonical key: a location names itself, and everything else is read
-     * structurally. */
-    private String bodyKey(Core e, Denotations at) {
-        return termKey(e, at, Map.of(), 0);
-    }
-
-    /**
-     * How a value a construction is being given is named where a clause reads it: a location names
-     * itself, and a container built from one by an operation the table covers names that
-     * construction. Anything else names nothing.
-     *
-     * <p>The restriction is what ties the flagging to what is said. A location is always named: the
-     * seeding writes about locations, so a clause reading one reads something. A container built by an
-     * operation the table covers is named, since the table is a rule about it. A computed value is
-     * named only where a guard on this path spoke about it — then, and only then, the author has
-     * stated something the clause can be read against, and leaving the construction unreported would
-     * be dropping what they said.
-     *
-     * <p>A computed value nothing has spoken about is named by nothing, and its construction is
-     * silent. That is this check's flagging policy and not a proof: the run-time check stands for the
-     * whole of such an invariant. Widening it is a matter of naming more values here, which is where
-     * a stated result type or a stdlib rule would enter.
-     */
-    private String siteKey(Core e, Denotations at, Known k) {
-        // A value written out is not something a guard can be written about: there is nothing to
-        // state of `"xyz"` that the text does not already say. Where a clause reading it folds it is
-        // decided before this is asked, and where it does not fold there is no guard that would
-        // discharge it, so naming it here would only report what the author cannot answer.
-        Denotes d = denotationOf(e, at, k);
-        return readable(d, k) ? d.key() : null;
-    }
-
-    /** The atom key of {@code SIZE_CALL(container)} when {@code key} can name the container, else
-     * {@code null}. */
-    private static String sizeAtom(Core e, java.util.function.Function<Core, String> key) {
-        if (!(e instanceof Core.PreservedCall call) || !SIZE_CALLS.contains(call.operation())
-                || call.args().size() != 1) {
-            return null;
-        }
-        String arg = key.apply(sizeSource(call.args().get(0)));
-        return arg == null ? null : call.operation().name() + "(" + arg + ")";
-    }
-
-    /** The container a size is really the size of: an operation that keeps the size of what it was
-     * built from is peeled away, so {@code List.length(List.map(f, xs))} is the atom
-     * {@code List.length(xs)}. How the elements are made has no bearing on how many there are, which
-     * is why the closure does not enter the key. */
-    private static Core sizeSource(Core e) {
-        if (e instanceof Core.PreservedCall call) {
-            Built built = BUILT_FROM.get(call.operation());
-            if (built != null && built.shape().keepsSize() && built.from() < call.args().size()) {
-                return sizeSource(call.args().get(built.from()));
-            }
-        }
-        return e;
-    }
-
-    /** What is known of the size of every container an expression names: never negative, and no
-     * greater than the size of what it was built from wherever the building can only drop elements. */
-    private void sizeFacts(Core e, Denotations at, List<Constraint> out) {
-        // A name is what it was given, here as everywhere: what is known of a size does not depend on
-        // whether the size was written where it is read or bound first.
-        if (e instanceof Core.Read r && at.valueOf(r.binding()) != null) {
-            sizeFacts(at.valueOf(r.binding()), at, out);
-            return;
-        }
-        if (!(e instanceof Core.PreservedCall call)) {
-            Core.forEachChild(e, child -> sizeFacts(child, at, out));
-            return;
-        }
-        if (SIZE_CALLS.contains(call.operation()) && call.args().size() == 1) {
-            String atom = sizeAtom(call, arg -> bodyKey(arg, at));
-            if (atom != null) {
-                out.add(new Constraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
-                bounds(call.operation(), sizeSource(call.args().get(0)), at, out);
-            }
-        }
-        for (Core arg : call.args()) {
-            sizeFacts(arg, at, out);
-        }
-    }
-
-    /** {@code size(c) <= size(what c was built from)}, down the chain, wherever the building can only
-     * drop elements. */
-    private void bounds(ValueName sizeCall, Core container, Denotations at, List<Constraint> out) {
-        if (!(container instanceof Core.PreservedCall call)) {
-            return;
-        }
-        Built built = BUILT_FROM.get(call.operation());
-        if (built == null || built.shape().keepsSize() || built.from() >= call.args().size()) {
-            return;
-        }
-        Core source = sizeSource(call.args().get(built.from()));
-        String here = bodyKey(container, at);
-        String there = bodyKey(source, at);
-        if (here == null || there == null) {
-            return;
-        }
-        out.add(new Constraint(
-                LinearForm.atom(sizeCall.name() + "(" + here + ")")
-                        .minus(LinearForm.atom(sizeCall.name() + "(" + there + ")")),
-                Rel.LE));
-        bounds(sizeCall, source, at, out);
-    }
-
-    /** The keys a guard could have settled to establish this clause: the predicate as written, and
-     * the same predicate of each container the written one was built from by a construction that
-     * carries it. Stating {@code List.all(p, xs)} is stating it of every sublist of {@code xs}. */
-    private List<String> factKeys(Core inv, Denotations at) {
-        String written = bodyKey(inv, at);
-        if (written == null) {
-            return List.of();
-        }
-        List<String> keys = new ArrayList<>();
-        keys.add(written);
-        if (!(inv instanceof Core.PreservedCall call)) {
-            return keys;
-        }
-        Carried carried = CARRIED.get(call.operation());
-        if (carried == null || carried.container() >= call.args().size()) {
-            return keys;
-        }
-        // The predicate over each container the one it names was built from. The container is the
-        // construction's own expression, so the operations peeled off are the ones the body wrote.
-        Core container = call.args().get(carried.container());
-        Core.PreservedCall stated = call;
-        while (container instanceof Core.PreservedCall inner) {
-            Built built = BUILT_FROM.get(inner.operation());
-            if (built == null || built.from() >= inner.args().size()) {
-                break;
-            }
-            Core.PreservedCall next = carries(stated, carried, inner, built, at);
-            if (next == null) {
-                break;
-            }
-            Core source = inner.args().get(built.from());
-            String key = bodyKey(withArg(next, carried.container(), source), at);
-            if (key == null) {
-                break;
-            }
-            keys.add(key);
-            stated = next;
-            container = source;
-        }
-        return keys;
-    }
-
-    /**
-     * The predicate as it applies to what {@code inner} was built from, or {@code null} when it does
-     * not apply there. A construction the shape carries leaves the predicate as it was. A mapping
-     * carries nothing on its own, but a predicate stated over a projection carries when the closure
-     * copied that field across, over the field it came from.
-     */
-    private Core.PreservedCall carries(Core.PreservedCall stated, Carried carried,
-                                       Core.PreservedCall inner, Built built, Denotations at) {
-        if (carried.through().contains(built.shape())) {
-            return stated;
-        }
-        Integer projection = PROJECTION_OF.get(stated.operation());
-        if (built.shape() != Shape.MAPS || projection == null
-                || projection >= stated.args().size()) {
-            return null;
-        }
-        // Where the mapping's closure is written is already stated once, by the table that says which
-        // argument each combinator hands its elements to.
-        Combinator combo = COMBINATORS.get(inner.operation());
-        if (combo == null || combo.closureArg() >= inner.args().size()) {
-            return null;
-        }
-        Core traced = projectionThrough(stated.args().get(projection),
-                inner.args().get(combo.closureArg()), at);
-        return traced == null ? null : withArg(stated, projection, traced);
-    }
-
-    /**
-     * The projection over an element that a projection over a mapped list reduces to, or
-     * {@code null}.
-     *
-     * <p>{@code .product} over {@code List.map(r -> Line { product = r.product, ... }, xs)} is
-     * {@code .product} over {@code xs}: the closure copied that field across, so two mapped elements
-     * differ there exactly when the two they came from did. Bounded deliberately — a field a closure
-     * computes from others is not this.
-     *
-     * <p>What comes back is a projection to be keyed and nothing else. A block keys its parameter by
-     * where it is bound, so the chain built here is read at the position the closure's parameter
-     * stands in, whatever it is called and whatever it was read from.
-     */
-    private Core projectionThrough(Core projection, Core closure, Denotations at) {
-        Core.Block proj = blockOf(projection, at);
-        Core.Block step = blockOf(closure, at);
-        if (proj == null || proj.params().size() != 1 || step == null
-                || step.params().size() != 1) {
-            return null;
-        }
-        Ast.Binder element = step.params().get(0);
-        List<String> read = new Reads(proj.params().get(0).id()).chain(proj.body());
-        if (read == null) {
-            return null;
-        }
-        Reads reads = new Reads(element.id());
-        Core made = reads.produced(step.body());
-        List<String> traced;
-        if (read.isEmpty()) {
-            traced = reads.chain(made);   // the closure hands the element straight back
-        } else {
-            if (!(made instanceof Core.NewData nd) || !nd.spreads().isEmpty()) {
-                return null;
-            }
-            List<String> copied = null;
-            for (Core.FieldInit fi : nd.inits()) {
-                if (fi.name().equals(read.get(0))) {
-                    copied = reads.chain(fi.value());
-                }
-            }
-            if (copied == null) {
-                return null;
-            }
-            traced = new ArrayList<>(copied);
-            traced.addAll(read.subList(1, read.size()));
-        }
-        if (traced == null) {
-            return null;
-        }
-        Core on = read(element, elementType(step.type()), step.pos());
-        for (String field : traced) {
-            on = new Core.FieldAccess(on, field, fieldType(on.type(), field), step.pos());
-        }
-        return new Core.Block(List.of(element), on, step.type(), step.pos());
-    }
-
-    /**
-     * What the names in a closure read off the element it is handed: a field chain, or nothing this
-     * trace can follow. A binding introduces what it reads <em>where it is written</em> — an expansion
-     * splices {@code let $0_r = r in ...} into a closure — so what a name denotes is settled against
-     * the bindings before it and not reread later.
-     */
-    private static final class Reads {
-
-        private final BindingId element;
-        private final Map<BindingId, List<String>> chains = new HashMap<>();
-
-        private Reads(BindingId element) {
-            this.element = element;
-        }
-
-        /** The expression the body produces, with what the bindings on the way there read taken in. */
-        Core produced(Core body) {
-            Core cur = body;
-            while (cur instanceof Core.LetIn li) {
-                chains.put(li.binder().id(), chain(li.value()));
-                cur = li.body();
-            }
-            return cur;
-        }
-
-        /** The chain {@code e} reads off the element, or {@code null} if it reads anything else. */
-        List<String> chain(Core e) {
-            return switch (e) {
-                case Core.LetIn li -> {
-                    Reads inner = new Reads(element);
-                    inner.chains.putAll(chains);
-                    inner.chains.put(li.binder().id(), chain(li.value()));
-                    yield inner.chain(li.body());
-                }
-                case Core.FieldAccess fa -> {
-                    List<String> head = chain(fa.target());
-                    if (head == null) {
-                        yield null;
-                    }
-                    List<String> out = new ArrayList<>(head);
-                    out.add(fa.field());
-                    yield out;
-                }
-                case Core.Read r when chains.containsKey(r.binding()) -> chains.get(r.binding());
-                case Core.Read r -> r.binding().equals(element) ? List.of() : null;
-                default -> null;
-            };
-        }
-    }
-
-    private static Core.PreservedCall withArg(Core.PreservedCall call, int at, Core arg) {
-        List<Core> args = new ArrayList<>(call.args());
-        args.set(at, arg);
-        return new Core.PreservedCall(call.operation(), args, call.type(), call.pos());
-    }
-
-    /** An emptiness check as the comparison it means, or {@code e} unchanged. */
-    private static Core asSizeComparison(Core e) {
-        if (e instanceof Core.PreservedCall call && call.args().size() == 1
-                && EMPTINESS.containsKey(call.operation())) {
-            Core size = new Core.PreservedCall(EMPTINESS.get(call.operation()), call.args(),
-                    Type.INT, call.pos());
-            return new Core.Binary(Ast.BinOp.EQ, size, new Core.Int(0, Type.INT, call.pos()),
-                    Type.BOOL, call.pos());
-        }
-        return e;
-    }
-
-    /**
-     * The canonical key of an expression as a term, or {@code null} when nothing here can be named.
-     * Two expressions with one key compute one value, which is the whole of what the fact set knows:
-     * a guard and an invariant clause state the same predicate exactly when their calls key alike.
-     *
-     * <p>A location keys as the location it is, so which value a term is about is the binding it is
-     * rooted at. A closure parameter is keyed by where it is bound rather than by its binding, so
-     * {@code r -> r.a} and {@code row -> row.a} are one term while a free name inside the closure is
-     * still the value it is and so is part of the term. Anything outside this grammar keys as
-     * {@code null}, and the clause reading it is left opaque.
-     */
-    private String termKey(Core raw, Denotations at, Map<BindingId, String> bound, int depth) {
-        Core e = asOperator(raw);
-        BindingId root = rootBinding(e);
-        if (root != null) {
-            String here = bound.get(root);
-            return here != null ? chainOn(here, e) : pathKey(e, at);
-        }
-        return switch (e) {
-            case Core.Int i -> Long.toString(i.value());
-            case Core.Decimal d -> d.value().toPlainString() + "m";
-            case Core.Str s -> quoted(s.value());
-            case Core.Bool b -> Boolean.toString(b.value());
-            case Core.UnitValue u -> u.data().toString();
-            case Core.Neg n -> wrap("-", termKey(n.operand(), at, bound, depth));
-            case Core.Binary b -> {
-                String l = termKey(b.left(), at, bound, depth);
-                String r = termKey(b.right(), at, bound, depth);
-                yield l == null || r == null ? null : binaryKey(b.op(), l, r);
-            }
-            case Core.ListLit l -> elementsKey("[", l.elements(), at, bound, depth, "]");
-            case Core.Tuple t -> elementsKey("(", t.elements(), at, bound, depth, ")");
-            case Core.TupleGet g -> wrap("." + g.index(), termKey(g.tuple(), at, bound, depth));
-            case Core.If iff -> elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
-                    at, bound, depth, ")");
-            case Core.Block b -> {
-                Map<BindingId, String> inner = binding(bound, b.params(), depth);
-                yield wrap("\\" + b.params().size(), termKey(b.body(), at, inner, depth + 1));
-            }
-            case Core.LetIn li -> {
-                String value = termKey(li.value(), at, bound, depth);
-                Map<BindingId, String> inner = binding(bound, List.of(li.binder()), depth);
-                String body = termKey(li.body(), at, inner, depth + 1);
-                yield value == null || body == null ? null : "let(" + value + ", " + body + ")";
-            }
-            // A construction is a pure function of its fields, and a closure that builds one is what a
-            // mapping usually is. Fields are keyed in name order, so two sites writing them in
-            // different orders write one term.
-            case Core.NewData nd when nd.spreads().isEmpty() -> {
-                List<Core.FieldInit> inits = new ArrayList<>(nd.inits());
-                inits.sort(java.util.Comparator.comparing(Core.FieldInit::name));
-                StringBuilder sb = new StringBuilder(nd.typeName().toString()).append('{');
-                for (int i = 0; i < inits.size(); i++) {
-                    String v = termKey(inits.get(i).value(), at, bound, depth);
-                    if (v == null) {
-                        yield null;
-                    }
-                    sb.append(i == 0 ? "" : ", ").append(inits.get(i).name()).append('=').append(v);
-                }
-                yield sb.append('}').toString();
-            }
-            // Only the operations the representation kept standing: they are the library's own, so
-            // they are pure and one written call is one value.
-            case Core.PreservedCall c ->
-                    elementsKey(c.operation().name() + "(", c.args(), at, bound, depth, ")");
-            default -> null;
-        };
-    }
-
-    /** {@code bound} with each of {@code binders} keyed by where it is bound rather than by which
-     * binding it is, so two expressions that differ only in what they bound are one term. */
-    private static Map<BindingId, String> binding(Map<BindingId, String> bound,
-                                                  List<Ast.Binder> binders, int depth) {
-        Map<BindingId, String> inner = new HashMap<>(bound);
-        for (int i = 0; i < binders.size(); i++) {
-            inner.put(binders.get(i).id(), "#" + depth + "." + i);
-        }
-        return inner;
-    }
-
-    private String elementsKey(String open, List<Core> parts, Denotations at,
-                               Map<BindingId, String> bound, int depth, String close) {
-        StringBuilder sb = new StringBuilder(open);
-        for (int i = 0; i < parts.size(); i++) {
-            String part = termKey(parts.get(i), at, bound, depth);
-            if (part == null) {
-                return null;
-            }
-            sb.append(i == 0 ? "" : ", ").append(part);
-        }
-        return sb.append(close).toString();
-    }
-
-    /**
-     * A binary as a key. The six comparisons are two: {@code ==} over the pair in a settled order,
-     * since which side is written first is not part of what it says, and {@code <}, with the other
-     * three written as one of those denied. Two clauses comparing the same two terms are then one term
-     * however the author reached for it — which matters wherever the comparison is not the whole
-     * condition, since only there can the denial not be carried by the polarity instead.
-     */
-    private static String binaryKey(Ast.BinOp op, String l, String r) {
-        return switch (op) {
-            case EQ -> l.compareTo(r) <= 0 ? cmp("EQ", l, r) : cmp("EQ", r, l);
-            case NE -> "!" + binaryKey(Ast.BinOp.EQ, l, r);
-            case LT -> cmp("LT", l, r);
-            case GT -> cmp("LT", r, l);
-            case GE -> "!" + cmp("LT", l, r);
-            case LE -> "!" + cmp("LT", r, l);
-            default -> cmp(op.toString(), l, r);
-        };
-    }
-
-    private static String cmp(String op, String l, String r) {
-        return "(" + l + " " + op + " " + r + ")";
-    }
-
-    /** A string value written into a key with the punctuation the key itself uses escaped, so a value
-     * holding a quote or a comma cannot be read back as a different expression. */
-    private static String quoted(String value) {
-        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
-    }
-
-    private static String wrap(String prefix, String inner) {
-        return inner == null ? null : prefix + "(" + inner + ")";
-    }
-
-    /** The binding at the head of a {@code x}/{@code x.a.b} chain, or {@code null} if {@code e} is not
-     * one. */
-    private static BindingId rootBinding(Core e) {
-        return switch (e) {
-            case Core.Read r -> r.binding();
-            case Core.FieldAccess fa -> rootBinding(fa.target());
-            default -> null;
-        };
-    }
-
-    /** The field chain of {@code e} rebuilt on {@code head}. */
-    private static String chainOn(String head, Core e) {
-        return e instanceof Core.FieldAccess fa ? chainOn(head, fa.target()) + "." + fa.field() : head;
-    }
-
-    /**
-     * The key of a chain rooted at a binding: the location it is, or, where the binding was given a
-     * term rather than a location, that term with the fields read from it.
-     *
-     * <p>A newtype's {@code .value} is the same location as the newtype, which is {@link Location}'s
-     * rule and is read here of a term too, so a value keyed one way through a binding and the other
-     * way through a field is one value.
-     */
-    private String pathKey(Core e, Denotations at) {
-        Location located = locationOf(e, at);
-        if (located != null) {
-            return located.toString();
-        }
-        return switch (e) {
-            case Core.Read r -> at.of(r.binding()).key();
-            case Core.FieldAccess fa -> {
-                if (!Location.isStep(fa.target().type(), fa.field(), symbols)) {
-                    yield pathKey(fa.target(), at);
-                }
-                String base = pathKey(fa.target(), at);
-                yield base == null ? null : base + "." + fa.field();
-            }
-            default -> null;
-        };
-    }
-
-    /** The location {@code e} is, or {@code null} where it is a computed value rather than a place. */
-    private Location locationOf(Core e, Denotations at) {
-        return Location.of(e, symbols,
-                binding -> at.of(binding) instanceof Denotes.At located ? located.where() : null);
-    }
-
-    /**
-     * What a binding's initializer denotes: the location it is where it is one, else the term it
-     * computes, else nothing. A name is an alias and never a value of its own — this is the one place
-     * that decides it, so an expression answers the same whether it was written where it is used or
-     * given a name first.
-     */
-    private Denotes denotationOf(Core e, Denotations at, Known k) {
-        Core written = writtenValue(e, at);
-        if (written != null) {
-            return new Denotes.Written(bodyKey(written, at), written);
-        }
-        Location located = locationOf(e, at);
-        if (located != null) {
-            return new Denotes.At(located);
-        }
-        String term = bodyKey(e, at);
-        if (term == null) {
-            return new Denotes.Nothing();
-        }
-        // Readable where there is something to say of it: a form the numeric domain built, or a rule
-        // about how it was made. This is asked of the expression, so a name for it answers the same.
-        return new Denotes.Term(term, affineOf(e, at, k) != null || namedByRule(e, at));
-    }
-
-    /**
-     * Whether a clause may be read against what {@code d} denotes. A location always may: the seeding
-     * writes about locations. A computed term may where something can be said of it, or where a guard
-     * on this path has said something. Nothing never may.
-     *
-     * <p>Every question of the form "is this value one a clause can be read against" asks this, and
-     * asking it of a name gives the same answer as asking it of the expression the name was bound to.
-     * That is what makes naming an expression not change what is known of it.
-     */
-    private static boolean readable(Denotes d, Known k) {
-        return switch (d) {
-            case Denotes.At _ -> true;
-            case Denotes.Term term -> term.readable() || k.speaksOf(term.key());
-            case Denotes.Written _, Denotes.Nothing _ -> false;
-        };
-    }
-
-    /** What {@code e} is written as, where it is a written value or a name given one — and
-     * {@code null} where it is computed from anything. */
-    private static Core writtenValue(Core e, Denotations at) {
-        if (e instanceof Core.Read r) {
-            return at.of(r.binding()) instanceof Denotes.Written w ? w.value() : null;
-        }
-        return isWritten(e) ? e : null;
-    }
-
-    /**
-     * Whether {@code e} is a value written out rather than computed from anything: a literal, and a
-     * list or a construction whose every part is one. A table written into the source is this — every
-     * row of it is there to read — and there is no guard an author could add about it, which is what
-     * naming it at a construction site would ask for.
-     */
-    private static boolean isWritten(Core e) {
-        return isWritten(e, Set.of());
-    }
-
-    /** The same, where {@code written} names the bindings an expansion introduced for values that
-     * were themselves written. A helper called on written arguments is a written value: what it
-     * expands to binds each argument and reads it back, which is the source's own text moved. */
-    private static boolean isWritten(Core e, Set<BindingId> written) {
-        return switch (e) {
-            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.UnitValue _ -> true;
-            case Core.Neg n -> isWritten(n.operand(), written);
-            case Core.Read r -> written.contains(r.binding());
-            case Core.ListLit list -> list.elements().stream().allMatch(x -> isWritten(x, written));
-            case Core.Tuple t -> t.elements().stream().allMatch(x -> isWritten(x, written));
-            case Core.OptionSome s -> isWritten(s.value(), written);
-            case Core.NewData nd -> nd.spreads().isEmpty()
-                    && nd.inits().stream().allMatch(fi -> isWritten(fi.value(), written));
-            case Core.LetIn li -> {
-                if (!isWritten(li.value(), written)) {
-                    yield false;
-                }
-                Set<BindingId> inner = new HashSet<>(written);
-                inner.add(li.binder().id());
-                yield isWritten(li.body(), inner);
-            }
-            default -> false;
-        };
-    }
-
-    /** Whether {@code e} is a container built by an operation the preservation table covers, over an
-     * argument that is itself named. */
-    private boolean builtByRule(Core e, Denotations at) {
-        if (!(e instanceof Core.PreservedCall call)) {
-            return false;
-        }
-        Built built = BUILT_FROM.get(call.operation());
-        return built != null && built.from() < call.args().size()
-                && namedByRule(call.args().get(built.from()), at);
-    }
-
-    /**
-     * Whether {@code e} names something without a guard having to have spoken about it: it is read all
-     * the way down. A location is; so is a value composed of ones by a shape the term grammar reads —
-     * a concatenation, a conditional, arithmetic, a container the preservation table covers. A call
-     * the check has no rule about is not, and neither is anything built from one: nothing follows from
-     * naming it, and its construction is left to the run-time check.
-     */
-    private boolean namedByRule(Core e, Denotations at) {
-        if (locationOf(e, at) != null) {
-            return true;
-        }
-        if (e instanceof Core.Read r) {
-            return at.of(r.binding()) instanceof Denotes.Term t && t.readable();
-        }
-        Core read = asOperator(e);
-        if (read instanceof Core.PreservedCall call && !readsAsATerm(call)) {
-            return builtByRule(read, at);
-        }
-        // A call the representation did not keep standing answers something this check has no rule
-        // about, whatever the operation behind it was.
-        if (read instanceof Core.Call || read instanceof Core.Apply) {
-            return false;
-        }
-        // Arithmetic is the numeric domain's to name. Where the domain builds a form, that form is
-        // what a clause is read against; where it declines to — a variable product, an integer divide
-        // — declining is a decision about what this check reasons over, and reporting a construction
-        // it has decided not to reason over would be reporting the decision as the author's to fix.
-        if (read instanceof Core.Binary bin && isArith(bin.op())) {
-            return false;
-        }
-        // A conditional is one of its branches and which one is not decided here. Saying only that it
-        // is that term reports every construction over one, including where both branches satisfy the
-        // clause. Reading it is checking the construction on each branch under its own condition,
-        // which this walk does not do, so it is not named until it does.
-        if (read instanceof Core.If) {
-            return false;
-        }
-        boolean[] all = {true};
-        // A closure is not part of what names the value: the tables are rules about how many elements
-        // there are and where they came from, and how each one is made has no bearing on either.
-        Core.forEachChild(read, child -> all[0] = all[0]
-                && (child instanceof Core.Block || namedByRule(child, at)));
-        return all[0];
-    }
-
-    /** Whether the check has a rule about what a call answers, rather than only about how to render it. */
-    private static boolean readsAsATerm(Core.PreservedCall call) {
-        return SIZE_CALLS.contains(call.operation()) || BUILT_FROM.containsKey(call.operation())
-                || CARRIED.containsKey(call.operation()) || QUANTIFIERS.contains(call.operation())
-                || call.operation().equals(op("Bool.not"));
-    }
-
-    // --- what the two representations share ----------------------------------------------------
-
-    /**
-     * {@code e} as the value it is written as, for the one reader that is defined over written values:
-     * the constant folder. A value written out is the same value in either representation, so this is
-     * a rendering and not a second tree — everything computed answers with nothing, and the fold then
-     * has nothing to fold.
-     */
-    private static Ast.Expr asWrittenValue(Core e) {
-        return switch (e) {
-            case Core.Int i -> new Ast.IntLit(i.value(), i.pos());
-            case Core.Decimal d -> new Ast.DecimalLit(d.value(), d.pos());
-            case Core.Str s -> new Ast.StringLit(s.value(), s.pos());
-            case Core.Bool b -> new Ast.BoolLit(b.value(), b.pos());
-            case Core.Neg n -> {
-                Ast.Expr operand = asWrittenValue(n.operand());
-                yield operand == null ? null : new Ast.Neg(operand, n.pos());
-            }
-            case Core.Binary b -> {
-                Ast.Expr left = asWrittenValue(b.left());
-                Ast.Expr right = asWrittenValue(b.right());
-                yield left == null || right == null ? null
-                        : new Ast.Binary(b.op(), left, right, b.pos());
-            }
-            case Core.PreservedCall call -> {
-                List<Ast.Expr> args = new ArrayList<>();
-                for (Core arg : call.args()) {
-                    Ast.Expr written = asWrittenValue(arg);
-                    if (written == null) {
-                        yield null;
-                    }
-                    args.add(written);
-                }
-                yield new Ast.Apply(call.operation().name(), call.operation(), args,
-                        ConstructionOrigin.own(), call.pos());
-            }
-            case null, default -> null;
-        };
-    }
-
-    // --- helpers -------------------------------------------------------------------------------
-
-    /** A read of {@code binder}, as the expression naming the value it holds. */
-    private static Core.Read read(Ast.Binder binder, Type type, SourcePos pos) {
-        return new Core.Read(binder.name(), binder.id(), type, pos);
-    }
-
-    /** The block {@code e} is, following a name given one: a lambda handed to an operation the
-     * representation keeps standing is never applied here, so it is bound to a name like any other
-     * value and reaches the call as that name. */
-    private static Core.Block blockOf(Core e, Denotations at) {
-        if (e instanceof Core.Block b) {
-            return b;
-        }
-        return e instanceof Core.Read r && at.valueOf(r.binding()) instanceof Core.Block b ? b : null;
-    }
-
-    /** What {@code data}'s fields are, remembered. */
-    private Map<String, Type> fieldsOf(Ast.Data data) {
-        return fieldsOf.computeIfAbsent(data, d -> TypeOps.fieldTypes(d, symbols));
-    }
-
-    /** Which binding each of {@code data}'s fields is, remembered. */
-    private Map<String, BindingId> fieldBindingsOf(Ast.Data data) {
-        return fieldBindings.computeIfAbsent(data, d -> TypeOps.fieldBindings(d, symbols));
-    }
-
-    /** The type of {@code field} read from {@code owner}, or null where that is not a field of a
-     * declaration this module can see. */
-    private Type fieldType(Type owner, String field) {
-        return owner instanceof Type.Ref r && symbols.get(r.name()) instanceof Ast.Data data
-                ? fieldsOf(data).get(field) : null;
-    }
-
-    /** What a container hands its closure: a list's or set's element, a map's value (the key is the
-     * other closure parameter and is not the one the table credits), an option's payload, and a
-     * function's first parameter where what is held is the closure itself. */
-    private static Type elementType(Type t) {
-        if (t instanceof Type.ListOf list) {
-            return list.element();
-        }
-        if (t instanceof Type.SetOf set) {
-            return set.element();
-        }
-        if (t instanceof Type.MapOf map) {
-            return map.value();
-        }
-        if (t instanceof Type.OptionOf opt) {
-            return opt.element();
-        }
-        if (t instanceof Type.FnOf fn && !fn.params().isEmpty()) {
-            return fn.params().get(0);
-        }
-        return null;
-    }
-
-    private boolean numericNewtype(Type t) {
-        return TypeOps.directNumericNewtypeBase(t, symbols) != null;
-    }
-
-    private boolean isNumeric(Type t) {
-        return t == Type.INT || t == Type.DECIMAL || numericNewtype(t);
-    }
-
-    private static boolean isArith(Ast.BinOp op) {
-        return op == Ast.BinOp.ADD || op == Ast.BinOp.SUB || op == Ast.BinOp.MUL || op == Ast.BinOp.DIV;
-    }
-
-    private static Rel relOf(Ast.BinOp op) {
-        return switch (op) {
-            case GE -> Rel.GE;
-            case GT -> Rel.GT;
-            case LE -> Rel.LE;
-            case LT -> Rel.LT;
-            case EQ -> Rel.EQ;
-            case NE -> Rel.NE;
-            default -> null;
-        };
-    }
-
-    private static Rel negateRel(Rel rel) {
-        return switch (rel) {
-            case GE -> Rel.LT;
-            case GT -> Rel.LE;
-            case LE -> Rel.GT;
-            case LT -> Rel.GE;
-            case EQ -> Rel.NE;
-            case NE -> Rel.EQ;
-        };
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1,18 +1,23 @@
 package souther.compiler.check;
 
-import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.NumericDomain.LinearForm;
 import souther.compiler.check.NumericDomain.Rel;
+import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
@@ -20,8 +25,8 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 
 /**
  * The intraprocedural invariant-discharge check (spec §invariant-discharge). It walks a behavior's
@@ -30,12 +35,22 @@ import java.util.function.Function;
  * invariants and refined along each {@code guard}/{@code if} guard (a {@code guard} is already an
  * {@code if} here). At every construction whose invariant it can carry, it asks whether the guards
  * <em>discharge</em> it. A construction proven to violate its invariant on a reachable path is a
- * compile error (the path-sensitive generalization of the constant check {@code 金額(-5)}); one it
+ * compile error (the path-sensitive generalization of the constant check {@code Amount(-5)}); one it
  * cannot prove is a warning (a possible abort — guard it, or reify the relation into a type
  * invariant). An invariant naming something it cannot name is left opaque (no diagnostic; the
  * run-time check stays), so every flagged construction has a guard that discharges it.
  *
- * <p>The walk mirrors {@link TotalityChecker}: a {@code switch} over {@code Ast.Expr} threading an
+ * <p>What it reads is Core: the body in the representation the rules are written at
+ * ({@link InliningPolicy#DISCHARGE}), typed by the checker like any other, and each declaration's
+ * invariant typed the same way against the fields it is written over. A clause is then read at a
+ * construction by putting the value each field is being given where that field is read — one
+ * expression in one representation, so what a clause says and what the body says meet as terms
+ * rather than as two spellings that have to be kept agreeing.
+ *
+ * <p>Which value a fact is about is the binding a name was answered with ({@link Location}), so a
+ * body that binds one spelling twice states two things and nothing has to be forgotten when it does.
+ *
+ * <p>The walk mirrors {@link TotalityChecker}: a {@code switch} over {@link Core} threading an
  * immutable environment. It is fail-open — any internal error is swallowed so an analysis bug can
  * never reject a valid program.
  */
@@ -54,49 +69,56 @@ public final class InvariantChecker {
      */
     public record Source(Ast.Expr body, Map<TypeName, List<Ast.InvariantClause>> invariants) {}
 
+    /** The library operation written {@code qualified}, as what a name reaching it denotes. */
+    private static ValueName op(String qualified) {
+        return new ValueName.Stdlib(qualified);
+    }
+
     /** A stdlib combinator whose closure (argument {@code closureArg}) is handed each element of its
      * container argument ({@code listArg}) as closure parameter {@code elementParam} — mirrors
      * {@link TotalityChecker}'s table, so a construction inside a {@code List.map} or
      * {@code List.foldFrom} closure is analyzed with the element bound to the container's element type
      * ({@link #elementType}).
      *
-     * <p>A rule is keyed by the name a call still has when this tree is read, which is not every name
-     * an author can write: {@code List.fold} is rewritten to {@code List.foldFrom} before any of this,
-     * so a rule under that name could not be looked up. {@code InvariantCombinatorRulesTest} holds the
-     * table to both halves of that — every name survives the rewrite, and every name has a program
-     * that fires it. */
+     * <p>A rule is keyed by the operation a call reaches when this tree is read, which is not every
+     * name an author can write: {@code List.fold} is rewritten to {@code List.foldFrom} before any of
+     * this, so a rule under that name could not be looked up. {@code InvariantCombinatorRulesTest}
+     * holds the table to both halves of that — every name survives the rewrite, and every name has a
+     * program that fires it. */
     private record Combinator(int closureArg, int elementParam, int listArg) {}
 
-    private static final Map<String, Combinator> COMBINATORS = Map.ofEntries(
-            Map.entry("List.foldFrom", new Combinator(0, 1, 2)),
-            Map.entry("List.foldr", new Combinator(0, 1, 2)),
-            Map.entry("List.map", new Combinator(0, 0, 1)),
-            Map.entry("List.filter", new Combinator(0, 0, 1)),
-            Map.entry("List.all", new Combinator(0, 0, 1)),
-            Map.entry("List.any", new Combinator(0, 0, 1)),
-            Map.entry("List.find", new Combinator(0, 0, 1)),
-            Map.entry("List.partition", new Combinator(0, 0, 1)),
-            Map.entry("List.concatMap", new Combinator(0, 0, 1)),
-            Map.entry("List.filterMap", new Combinator(0, 0, 1)),
-            Map.entry("List.sortBy", new Combinator(0, 0, 1)),
-            Map.entry("List.groupBy", new Combinator(0, 0, 1)),
-            Map.entry("List.indexBy", new Combinator(0, 0, 1)),
-            Map.entry("List.allUniqueBy", new Combinator(0, 0, 1)),
-            Map.entry("List.indexedMap", new Combinator(0, 1, 1)),
-            Map.entry("Map.fold", new Combinator(0, 2, 2)),
-            Map.entry("Map.map", new Combinator(0, 1, 1)),
-            Map.entry("Map.filter", new Combinator(0, 1, 1)),
-            Map.entry("Map.update", new Combinator(1, 0, 2)),
-            Map.entry("Map.upsert", new Combinator(2, 0, 3)),
-            Map.entry("Set.fold", new Combinator(0, 1, 2)),
-            Map.entry("Set.map", new Combinator(0, 0, 1)),
-            Map.entry("Set.filter", new Combinator(0, 0, 1)),
-            Map.entry("Set.partition", new Combinator(0, 0, 1)),
-            Map.entry("Option.map", new Combinator(0, 0, 1)));
+    private static final Map<ValueName, Combinator> COMBINATORS = Map.ofEntries(
+            Map.entry(op("List.foldFrom"), new Combinator(0, 1, 2)),
+            Map.entry(op("List.foldr"), new Combinator(0, 1, 2)),
+            Map.entry(op("List.map"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.filter"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.all"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.any"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.find"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.partition"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.concatMap"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.filterMap"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.sortBy"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.groupBy"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.indexBy"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.allUniqueBy"), new Combinator(0, 0, 1)),
+            Map.entry(op("List.indexedMap"), new Combinator(0, 1, 1)),
+            Map.entry(op("Map.fold"), new Combinator(0, 2, 2)),
+            Map.entry(op("Map.map"), new Combinator(0, 1, 1)),
+            Map.entry(op("Map.filter"), new Combinator(0, 1, 1)),
+            Map.entry(op("Map.update"), new Combinator(1, 0, 2)),
+            Map.entry(op("Map.upsert"), new Combinator(2, 0, 3)),
+            Map.entry(op("Set.fold"), new Combinator(0, 1, 2)),
+            Map.entry(op("Set.map"), new Combinator(0, 0, 1)),
+            Map.entry(op("Set.filter"), new Combinator(0, 0, 1)),
+            Map.entry(op("Set.partition"), new Combinator(0, 0, 1)),
+            Map.entry(op("Option.map"), new Combinator(0, 0, 1)));
 
     /** The operations the table has a rule for, for the test that holds it to being reachable. */
     static Set<String> combinatorNames() {
-        return COMBINATORS.keySet();
+        Set<String> names = new LinkedHashSet<>();
+        COMBINATORS.keySet().forEach(operation -> names.add(operation.name()));
+        return names;
     }
 
     /** The pure, total stdlib calls whose result is a number the domain can name: the size of a
@@ -104,8 +126,8 @@ public final class InvariantChecker {
      * — {@code List.length(b.items)} — so an invariant clause and a guard naming the same container
      * name the same atom, and the guard discharges the clause. The argument must be a nameable path:
      * {@code List.length(List.map(f, xs))} is not this atom, and nothing relates the two. */
-    private static final Set<String> SIZE_CALLS =
-            Set.of("List.length", "String.length", "Set.size", "Map.size");
+    private static final Set<ValueName> SIZE_CALLS = Set.of(
+            op("List.length"), op("String.length"), op("Set.size"), op("Map.size"));
 
     /**
      * What a construction of a container keeps of the container it was built from. This is the table
@@ -134,46 +156,46 @@ public final class InvariantChecker {
     /** Which argument a container was built from, and what the building keeps of it. */
     private record Built(int from, Shape shape) {}
 
-    private static final Map<String, Built> BUILT_FROM = Map.ofEntries(
-            Map.entry("List.reverse", new Built(0, Shape.PERMUTES)),
-            Map.entry("List.sort", new Built(0, Shape.PERMUTES)),
-            Map.entry("List.sortBy", new Built(1, Shape.PERMUTES)),
-            Map.entry("List.map", new Built(1, Shape.MAPS)),
-            Map.entry("List.indexedMap", new Built(1, Shape.MAPS)),
-            Map.entry("Map.map", new Built(1, Shape.MAPS)),
-            Map.entry("List.filter", new Built(1, Shape.SUBSET)),
-            Map.entry("List.distinct", new Built(0, Shape.SUBSET)),
-            Map.entry("List.take", new Built(1, Shape.SUBSET)),
-            Map.entry("List.drop", new Built(1, Shape.SUBSET)),
-            Map.entry("Set.filter", new Built(1, Shape.SUBSET)),
-            Map.entry("Map.filter", new Built(1, Shape.SUBSET)),
-            Map.entry("List.filterMap", new Built(1, Shape.COLLAPSES)),
-            Map.entry("Set.map", new Built(1, Shape.COLLAPSES)));
+    private static final Map<ValueName, Built> BUILT_FROM = Map.ofEntries(
+            Map.entry(op("List.reverse"), new Built(0, Shape.PERMUTES)),
+            Map.entry(op("List.sort"), new Built(0, Shape.PERMUTES)),
+            Map.entry(op("List.sortBy"), new Built(1, Shape.PERMUTES)),
+            Map.entry(op("List.map"), new Built(1, Shape.MAPS)),
+            Map.entry(op("List.indexedMap"), new Built(1, Shape.MAPS)),
+            Map.entry(op("Map.map"), new Built(1, Shape.MAPS)),
+            Map.entry(op("List.filter"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("List.distinct"), new Built(0, Shape.SUBSET)),
+            Map.entry(op("List.take"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("List.drop"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("Set.filter"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("Map.filter"), new Built(1, Shape.SUBSET)),
+            Map.entry(op("List.filterMap"), new Built(1, Shape.COLLAPSES)),
+            Map.entry(op("Set.map"), new Built(1, Shape.COLLAPSES)));
 
     /** Where a predicate reads its container, and which shapes of construction carry it there.
      * {@code List.all} holds of any sublist of a list it holds of; {@code List.member} does not, and
-     * neither survives a mapping — what a mapped element is, is #226's question. */
+     * neither survives a mapping — what a mapped element is, the mapping alone does not say. */
     private record Carried(int container, Set<Shape> through) {}
 
     /** Where a predicate reads the projection it is stated over. A mapping keeps a projection when
      * the closure copies that field from the element unchanged, so the predicate holds of the mapped
      * list exactly when it holds of what was mapped, over the field it came from. */
-    private static final Map<String, Integer> PROJECTION_OF = Map.of("List.allUniqueBy", 0);
+    private static final Map<ValueName, Integer> PROJECTION_OF = Map.of(op("List.allUniqueBy"), 0);
 
-    private static final Map<String, Carried> CARRIED = Map.of(
-            "List.all", new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
-            "List.allUniqueBy", new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
-            "List.any", new Carried(1, Set.of(Shape.PERMUTES)),
-            "List.member", new Carried(1, Set.of(Shape.PERMUTES)),
-            "Set.contains", new Carried(1, Set.of(Shape.PERMUTES)),
-            "Map.containsKey", new Carried(1, Set.of(Shape.PERMUTES)));
+    private static final Map<ValueName, Carried> CARRIED = Map.of(
+            op("List.all"), new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            op("List.allUniqueBy"), new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            op("List.any"), new Carried(1, Set.of(Shape.PERMUTES)),
+            op("List.member"), new Carried(1, Set.of(Shape.PERMUTES)),
+            op("Set.contains"), new Carried(1, Set.of(Shape.PERMUTES)),
+            op("Map.containsKey"), new Carried(1, Set.of(Shape.PERMUTES)));
 
     /** The calls that state their predicate of <em>every</em> element, so what they say of a
      * container is what holds of each element a closure is handed. Which argument is the predicate
      * and which the container is what {@link #COMBINATORS} already answers of any combinator, and how
      * far the statement travels is what {@link #CARRIED} already answers of any predicate — so a
      * quantifier is the name and nothing else. {@code List.all} is the only one the library has. */
-    private static final Set<String> QUANTIFIERS = Set.of("List.all");
+    private static final Set<ValueName> QUANTIFIERS = Set.of(op("List.all"));
 
     /** How many conditionals a construction opens before the rest is left to the run-time check.
      * Each one doubles the paths, and a value written over three of them is not what the bound is
@@ -185,11 +207,25 @@ public final class InvariantChecker {
      * {@code List.isEmpty(xs)} and {@code List.length(xs) == 0} are one statement, so a guard writing
      * either discharges a clause writing the other. Without it the two would be unrelated, which is
      * an accident of which one the author reached for. */
-    private static final Map<String, String> EMPTINESS = Map.of(
-            "List.isEmpty", "List.length",
-            "Set.isEmpty", "Set.size",
-            "Map.isEmpty", "Map.size",
-            "String.isEmpty", "String.length");
+    private static final Map<ValueName, ValueName> EMPTINESS = Map.of(
+            op("List.isEmpty"), op("List.length"),
+            op("Set.isEmpty"), op("Set.size"),
+            op("Map.isEmpty"), op("Map.size"),
+            op("String.isEmpty"), op("String.length"));
+
+    /**
+     * The library's function forms of the arithmetic operators, and the operator each one is. They
+     * reach the same kernel in the same argument order — {@code Int.add} is {@code IntMath.addExact},
+     * which is what {@code +} emits — so the two spellings compute one value and are read as one term.
+     * {@code divide} is absent: it answers a union rather than a number.
+     */
+    private static final Map<ValueName, Ast.BinOp> OPERATOR_CALLS = Map.of(
+            op("Int.add"), Ast.BinOp.ADD,
+            op("Int.subtract"), Ast.BinOp.SUB,
+            op("Int.multiply"), Ast.BinOp.MUL,
+            op("Decimal.add"), Ast.BinOp.ADD,
+            op("Decimal.subtract"), Ast.BinOp.SUB,
+            op("Decimal.multiply"), Ast.BinOp.MUL);
 
     private final Symbols symbols;
     private final Map<TypeName, List<Ast.InvariantClause>> dischargeInvariants;
@@ -211,25 +247,15 @@ public final class InvariantChecker {
     /**
      * A relation known of every element of a container. A fact settles the container as a whole and
      * is keyed by the call that states it, which relates it to nothing inside; this keeps the
-     * relation as the clause it was written as, together with the rule that names its free leaves, so
-     * it can be read again at the element a combinator's closure is handed.
+     * relation as the clause it was written as, so it can be read again at the element a combinator's
+     * closure is handed.
      *
      * <p>{@code through} is how far it travels: a construction of one of those shapes holds only
      * elements of what it was built from, so what was stated of the source still holds of each of
-     * them. {@code reads} is every term the <em>predicate</em> names from outside itself; a binding
-     * that takes over one of those names leaves the predicate saying something else. The container is
-     * kept apart from them because it is read where the call is written rather than inside the
-     * closure, so a closure parameter spelling its root does not reach it.
+     * them. The predicate is kept as the block it is, already read where the relation was stated, so
+     * every name in it means there what it meant there.
      */
-    private record Quantified(String container, Set<Shape> through, Ast.Block predicate,
-                              Bindings binds, List<String> reads) {
-
-        /** Whether a binding that drops what {@code drop} matches leaves the predicate intact. The
-         * container is not asked: it is read outside the closure this is instantiated in. */
-        boolean survives(java.util.function.Predicate<String> drop) {
-            return reads.stream().noneMatch(drop);
-        }
-    }
+    private record Quantified(String container, Set<Shape> through, Core.Block predicate) {}
 
     /** What the guards have settled on the current path: numeric relations, predicates known to hold
      * or to fail, and relations known of every element of a container. Threaded functionally through
@@ -277,84 +303,53 @@ public final class InvariantChecker {
             all.addAll(more);
             return new Known(numbers, facts, List.copyOf(all), spoken);
         }
-
-        Known forgetIf(java.util.function.Predicate<String> drop) {
-            List<Quantified> kept = new ArrayList<>();
-            for (Quantified q : quantified) {
-                // Here the container is asked too: a relation this walk carries past the binding is
-                // one it may look up anywhere after it, where the name means what the binding gave.
-                if (!drop.test(q.container()) && q.survives(drop)) {
-                    kept.add(q);
-                }
-            }
-            Set<String> said = new HashSet<>(spoken);
-            said.removeIf(drop);
-            return new Known(numbers.forgetIf(drop), facts.forgetIf(drop), List.copyOf(kept),
-                    Set.copyOf(said));
-        }
     }
 
     /**
-     * What the body's names mean where the walk is: the type of each, and, for a binding given a
-     * location, the location it reads.
+     * What the body's bindings mean where the walk is.
      *
-     * <p>A binding given a location <em>is</em> that location — the rule {@link #pathKey} already
-     * applies to a newtype's {@code .value}, read here of a name instead of a field. It is what lets
-     * a construction survive being moved into a helper: an expansion binds each argument and answers
+     * <p>A binding given a location <em>is</em> that location — the rule {@link Location} carries for
+     * a newtype's {@code .value}, read here of a binding instead of a field. It is what lets a
+     * construction survive being moved into a helper: an expansion binds each argument and answers
      * the parameter's reads with that binding (see {@link HelperInliner}), so without it the body of
      * a helper taking a record names locations the seeding never wrote, and everything an input's
      * type guarantees stops at the call.
+     *
+     * <p>Nothing here is ever taken away. A binding is what it is, and a second binding of the same
+     * spelling is a second binding, so a fact about the first stays true of the first and nothing
+     * reads it under the second.
      */
-    private record Scope(Map<String, Type> types, Map<String, Denotes> denotations) {
+    private record Denotations(Map<BindingId, Denotes> what, Map<BindingId, Core> values) {
 
-        static Scope of(Map<String, Type> types) {
-            return new Scope(types, Map.of());
+        static Denotations none() {
+            return new Denotations(Map.of(), Map.of());
         }
 
-        Type typeOf(String name) {
-            return types.get(name);
+        /** What {@code binding} denotes, which is the location it is unless it was given something
+         * else. */
+        Denotes of(BindingId binding) {
+            Denotes given = what.get(binding);
+            return given != null ? given : new Denotes.At(Location.of(binding));
         }
 
-        /** What {@code name} denotes, which is the location it is unless it was given something else. */
-        Denotes denotes(String name) {
-            return denotations.getOrDefault(name, new Denotes.Location(name));
+        /** The value {@code binding} was given, or null where nothing recorded one. */
+        Core valueOf(BindingId binding) {
+            return values.get(binding);
         }
 
-        /** The key {@code name} is known by, whichever kind of thing it denotes, or {@code null} where
-         * it denotes nothing. */
-        String keyOf(String name) {
-            return denotes(name).key();
-        }
-
-        /**
-         * This scope with {@code name} bound to {@code type} and to what it denotes. A binding whose
-         * denotation was rooted at {@code name} loses it: the name it was written as denotes something
-         * else from here, so what it stood for can no longer be said.
-         */
-        /** This scope with {@code name} bound to {@code type}, denoting the location it is. */
-        Scope binding(String name, Type type) {
-            return binding(name, type, new Denotes.Location(name));
-        }
-
-        Scope binding(String name, Type type, Denotes what) {
-            Map<String, Type> t = new HashMap<>(types);
-            if (type == null) {
-                t.remove(name);
-            } else {
-                t.put(name, type);
+        Denotations binding(BindingId binding, Core value, Denotes denotes) {
+            Map<BindingId, Denotes> next = new HashMap<>(what);
+            next.put(binding, denotes);
+            Map<BindingId, Core> bound = new HashMap<>(values);
+            if (value != null) {
+                bound.put(binding, value);
             }
-            Map<String, Denotes> at = new HashMap<>(denotations);
-            at.values().removeIf(d -> d.key() != null && mentions(d.key(), name));
-            at.remove(name);
-            if (!(what instanceof Denotes.Location loc && loc.key().equals(name))) {
-                at.put(name, what);
-            }
-            return new Scope(Map.copyOf(t), Map.copyOf(at));
+            return new Denotations(Map.copyOf(next), Map.copyOf(bound));
         }
     }
 
     /**
-     * What a name denotes. A location is somewhere the seeding can have written about and a clause
+     * What a binding denotes. A location is somewhere the seeding can have written about and a clause
      * can have named; a term is a value known only by what computes it. Merging those two would put a
      * computed value where a location is expected, which is the shape of a {@code let} answering
      * differently from the expression it was given. A written value is apart from both because what
@@ -366,7 +361,13 @@ public final class InvariantChecker {
         String key();
 
         /** A place: a parameter, a field chain, or another location a binding was given. */
-        record Location(String key) implements Denotes {}
+        record At(Location where) implements Denotes {
+
+            @Override
+            public String key() {
+                return where.toString();
+            }
+        }
 
         /**
          * A value named by the expression that computes it. {@code readable} is true where there is
@@ -381,7 +382,7 @@ public final class InvariantChecker {
          * it, so it is never named at a construction; what it is, though, still has to travel with
          * the name, or the same text would fold where it is written and not where it is bound.
          */
-        record Written(String key, Ast.Expr value) implements Denotes {}
+        record Written(String key, Core value) implements Denotes {}
 
         /** Nothing this check can name. */
         record Nothing() implements Denotes {
@@ -402,18 +403,18 @@ public final class InvariantChecker {
     public static ClauseDischarge capabilityOf(Ast.Expr clause, SourcePos at, Ast.Data data,
                                                Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols, Map.of());
-        Map<String, Type> fields = c.fieldsOf(data);
-        Bindings binds = Bindings.ofPaths(
-                name -> fields.containsKey(name) ? LinearForm.atom(name) : null,
-                name -> fields.containsKey(name) ? name : null, fields);
+        // Read over the declaration's own fields, each standing for itself: a construction hands one
+        // value per field, so a clause naming a field names something wherever it is built.
+        Core stated = c.typed(clause, data);
         List<Clause> owed;
         try {
-            owed = c.obligations(Ast.asBindings(clause), binds, false);
+            owed = stated == null ? null
+                    : c.obligations(stated, Known.top(), Denotations.none(), false);
         } catch (RuntimeException _) {
             owed = null;   // fail-open, as the walk is
         }
         if (owed == null || owed.isEmpty()) {
-            return ClauseDischarge.runtimeOnly(at, c.whyUnreadable(Ast.asBindings(clause), binds));
+            return ClauseDischarge.runtimeOnly(at, c.whyUnreadable(stated));
         }
         for (Clause owe : owed) {
             if (owe.numeric() != null) {
@@ -424,43 +425,26 @@ public final class InvariantChecker {
     }
 
     /** What in {@code clause} the check cannot read, said so an author can act on it. */
-    private String whyUnreadable(Ast.Expr clause, Bindings binds) {
-        Ast.Expr blocked = unreadable(clause);
-        if (blocked instanceof Ast.Apply call) {
-            return "it calls `" + call.written() + "`, which the check reads as a value and not as a term";
+    private String whyUnreadable(Core clause) {
+        if (clause == null) {
+            return "it is not a rule this check could read as one expression";
+        }
+        Core blocked = unreadable(clause);
+        if (blocked instanceof Core.PreservedCall call) {
+            return "it calls `" + call.operation().name()
+                    + "`, which the check reads as a value and not as a term";
         }
         if (blocked != null) {
             return "it is not one of the shapes the check reads";
         }
-        String name = unnamed(clause, binds, Set.of());
-        if (name != null) {
-            return "it reads `" + name + "`, and a clause is read through the fields the construction"
-                    + " fills";
-        }
         return "it names a term the check cannot name";
-    }
-
-    /** A name the clause reads that is neither a field of the declaration nor bound inside the clause,
-     * or {@code null} if it reads none. */
-    private String unnamed(Ast.Expr e, Bindings binds, Set<String> bound) {
-        if (e instanceof Ast.Var v) {
-            return bound.contains(v.name()) || binds.path().apply(v.name()) != null ? null : v.name();
-        }
-        Set<String> scope = taken(e, bound);
-        String[] found = {null};
-        Ast.forEachChild(e, child -> {
-            if (found[0] == null) {
-                found[0] = unnamed(child, binds, scope);
-            }
-        });
-        return found[0];
     }
 
     /** The innermost part of {@code e} the term grammar cannot read, or {@code null} if it reads all
      * of it. Every location is granted, so what is left is the shape. */
-    private Ast.Expr unreadable(Ast.Expr e) {
-        Ast.Expr[] found = {null};
-        Ast.forEachChild(e, child -> {
+    private Core unreadable(Core e) {
+        Core[] found = {null};
+        Core.forEachChild(e, child -> {
             if (found[0] == null) {
                 found[0] = unreadable(child);
             }
@@ -468,24 +452,27 @@ public final class InvariantChecker {
         if (found[0] != null) {
             return found[0];
         }
-        return termKey(e, x -> rootName(x) != null ? "?" : null, Map.of(), 0) == null ? e : null;
+        return termKey(e, Denotations.none(), Map.of(), 0) == null ? e : null;
     }
 
-    /** Analyzes one behavior body against its input scope. Never throws. A {@code null} source is a
-     * body the analysis representation could not be built for, and is not analyzed at all. */
-    static Findings analyze(Source source, Map<String, Type> params, Symbols symbols) {
-        InvariantChecker c = new InvariantChecker(symbols, source == null ? Map.of() : source.invariants());
-        if (source == null) {
+    /**
+     * Analyzes one behavior body against the bindings its inputs are. Never throws. A {@code null}
+     * body is one the analysis representation could not be built or typed for, and is not analyzed at
+     * all.
+     */
+    static Findings analyze(Core body, Map<TypeName, List<Ast.InvariantClause>> invariants,
+                            Scope params, Symbols symbols) {
+        InvariantChecker c = new InvariantChecker(symbols, invariants);
+        if (body == null) {
             return new Findings(c.errors, c.warnings);
         }
         try {
             Known k = Known.top();
-            for (Map.Entry<String, Type> p : params.entrySet()) {
-                k = c.seedParam(p.getKey(), p.getValue(), k);
+            for (Map.Entry<BindingId, Scope.Binding> p : params.bindings().entrySet()) {
+                k = c.seedAt(new Core.Read(p.getValue().name(), p.getKey(), p.getValue().type(),
+                        body.pos()), k, Denotations.none(), 0);
             }
-            // read as the bindings an expansion writes: what may be discharged is a question about
-            // which value reached which position, and a call is the code it stands for
-            c.walk(Ast.asBindings(source.body()), k, Scope.of(params), 0);
+            c.walk(body, k, Denotations.none(), 0);
         } catch (RuntimeException _) {
             // fail-open: the run-time invariant check remains the backstop
         }
@@ -494,135 +481,116 @@ public final class InvariantChecker {
 
     // --- the walk ------------------------------------------------------------------------------
 
-    private void walk(Ast.Expr e, Known k, Scope scope, int depth) {
-        Ast.If value = conditionalValueIn(e);
+    private void walk(Core e, Known k, Denotations at, int depth) {
+        Core.If value = conditionalValueIn(e);
         if (value != null && depth < BRANCHES_OPENED) {
             // A conditional in a value position is one of its two branches, and which one is decided
             // by its condition. So this is read once with each standing there, under that condition,
             // and what the two readings find is said once. Every place a conditional can be given —
             // to a field, to a name, to a guard — is this one place.
-            walk(value.cond(), k, scope, depth);
-            String same = bodyKey(value, scope);
-            say(reading(without(e, value, same, value.then(), scope),
-                            assumeCond(value.cond(), k, scope, true), scope, depth),
-                    reading(without(e, value, same, value.els(), scope),
-                            assumeCond(value.cond(), k, scope, false), scope, depth));
+            walk(value.cond(), k, at, depth);
+            String same = bodyKey(value, at);
+            say(reading(without(e, value, same, value.then(), at),
+                            assumeCond(value.cond(), k, at, true), at, depth),
+                    reading(without(e, value, same, value.els(), at),
+                            assumeCond(value.cond(), k, at, false), at, depth));
             return;
         }
-        checkIfConstruction(e, k, scope, false);
+        checkIfConstruction(e, k, at, false);
         switch (e) {
-            case Ast.If iff -> {
-                walk(iff.cond(), k, scope, depth);
-                walk(iff.then(), assumeCond(iff.cond(), k, scope, true), scope, depth);
-                walk(iff.els(), assumeCond(iff.cond(), k, scope, false), scope, depth);
+            case Core.If iff -> {
+                walk(iff.cond(), k, at, depth);
+                walk(iff.then(), assumeCond(iff.cond(), k, at, true), at, depth);
+                walk(iff.els(), assumeCond(iff.cond(), k, at, false), at, depth);
             }
-            case Ast.IfConstructed ic -> {
+            case Core.IfConstructed ic -> {
                 // The attempt's own construction cannot abort — a failing invariant is the else
                 // branch — so it is checked for a decided violation and never warned about as a
                 // possible one. Its field values are walked on their own so a construction nested
                 // inside an argument is still an ordinary, aborting one.
-                checkIfConstruction(ic.construct(), k, scope, true);
-                Ast.forEachChild(ic.construct(), child -> walk(child, k, scope, depth));
-                Known k2 = rebind(k, ic.binderName());
-                Type built = typeExpr(ic.construct(), scope);
+                checkIfConstruction(ic.construct(), k, at, true);
+                Core.forEachChild(ic.construct(), child -> walk(child, k, at, depth));
                 // The attempt built the value, so the binding is that construction and no location
-                if (built != null) {
-                    k2 = seedParam(ic.binderName(), built, k2);   // on this branch the invariant holds
-                }
-                walk(ic.then(), k2, scope.binding(ic.binderName(), built), depth);
+                Known k2 = seedAt(read(ic.binder(), ic.construct().type(), ic.pos()), k, at, 0);
+                walk(ic.then(), k2, at, depth);
                 // Each departure stands where the invariant did not hold, and nothing was built
                 // there, so none of them is seeded with anything the attempt would have guaranteed.
-                ic.els().forEach(arm -> walk(arm.body(), k, scope, depth));
+                ic.els().forEach(arm -> walk(arm.body(), k, at, depth));
             }
-            case Ast.LetIn li -> {
-                walk(li.value(), k, scope, depth);
-                Type vt = typeExpr(li.value(), scope);
+            case Core.LetIn li -> {
+                // A closure is read where it is applied: what its parameter holds is decided there,
+                // and reading it here would read every construction in it with the element unknown.
+                if (!(li.value() instanceof Core.Block)) {
+                    walk(li.value(), k, at, depth);
+                }
                 // The name is an alias for what its initializer denotes, so what is recorded about it
-                // is recorded under that denotation and not under the spelling. Recording it under the
-                // name is what made a named subexpression a term of its own, answering differently
+                // is recorded under that denotation and not under the binding. Recording it under the
+                // binding is what made a named subexpression a term of its own, answering differently
                 // from the very expression it was given.
-                Denotes what = denotationOf(li.value(), scope, k);
-                Known k2 = rebind(k, li.name());
+                Denotes what = denotationOf(li.value(), at, k);
+                Known k2 = k;
                 // A binding that denotes what it was given is an alias and introduces no value, so
                 // there is nothing to record of it: what holds of what it names already holds.
                 // Recording it anyway assigns that name its own form, and an assignment drops what
                 // was known of what it assigns to — the bound on it would be lost to the copy. A
                 // location is always this; a term is where the form is that term's own atom.
-                if (what instanceof Denotes.Term term && isNumeric(vt)) {
-                    LinearForm vf = affineOf(li.value(), scope, k);
+                if (what instanceof Denotes.Term term && isNumeric(li.value().type())) {
+                    LinearForm vf = affineOf(li.value(), at, k);
                     if (vf != null && !vf.equals(LinearForm.atom(term.key()))) {
                         k2 = k2.with(k2.numbers().assign(term.key(), vf));
                     }
                 }
-                walk(li.body(), k2, scope.binding(li.name(), vt, what), depth);
+                walk(li.body(), k2, at.binding(li.binder().id(), li.value(), what), depth);
             }
-            case Ast.Match m -> {
-                walk(m.scrutinee(), k, scope, depth);
-                for (Ast.Case c : m.cases()) {
-                    Scope s2 = scope;
-                    Known k2 = k;
-                    if (c.binding() != null) {
-                        k2 = rebind(k, c.bindingName());
-                        Type bound = c.caseTypes().size() == 1
-                                ? MatchElaborator.caseBindType(c.caseTypes().get(0).denotes()) : null;
-                        // A sum has no fields of its own, so the scrutinee is not a location any
-                        // clause could have named — the case's value names only itself.
-                        s2 = scope.binding(c.bindingName(), bound);
-                    }
-                    walk(c.body(), k2, s2, depth);
+            case Core.Match m -> {
+                walk(m.scrutinee(), k, at, depth);
+                for (Core.Case c : m.cases()) {
+                    // A sum has no fields of its own, so the scrutinee is not a location any clause
+                    // could have named — the case's value names only itself.
+                    walk(c.body(), k, at, depth);
                 }
             }
-            case Ast.Apply call -> walkCall(call, k, scope, depth);
-            default -> Ast.forEachChild(e, child -> walk(child, k, scope, depth));
+            case Core.PreservedCall call -> walkCall(call, k, at, depth);
+            default -> Core.forEachChild(e, child -> walk(child, k, at, depth));
         }
     }
 
-    /** Walks a call, binding a combinator closure's element parameter to the list's element type (and
-     * seeding its invariant) so a construction inside the closure is analyzed rather than left opaque. */
-    private void walkCall(Ast.Apply call, Known k, Scope scope, int depth) {
-        Combinator combo = COMBINATORS.get(call.reaches());
+    /** Walks a call the representation kept standing, binding a combinator closure's element
+     * parameter to the container's element type (and seeding its invariant) so a construction inside
+     * the closure is analyzed rather than left opaque. */
+    private void walkCall(Core.PreservedCall call, Known k, Denotations at, int depth) {
+        Combinator combo = COMBINATORS.get(call.operation());
         for (int i = 0; i < call.args().size(); i++) {
-            Ast.Expr arg = call.args().get(i);
-            if (combo != null && i == combo.closureArg() && arg instanceof Ast.Block step
-                    && combo.elementParam() < step.params().size()
+            Core arg = call.args().get(i);
+            Core.Block step = combo != null && i == combo.closureArg() ? blockOf(arg, at) : null;
+            if (step != null && combo.elementParam() < step.params().size()
                     && combo.listArg() < call.args().size()) {
-                Ast.Expr container = call.args().get(combo.listArg());
-                Type elem = elementType(typeExpr(container, scope));
+                Core container = call.args().get(combo.listArg());
+                Type elem = elementType(container.type());
                 // The container is read where the call is written, so what is known of its elements
-                // is looked up before the closure's parameter takes any name over. Reading it after
-                // would make an argument spelling that name — `List.map(cart -> ..., cart.items)` —
-                // answer differently from one spelling any other, which is nothing the program says.
-                List<Quantified> relations = elementRelations(container, k, scope);
-                String p = step.params().get(combo.elementParam()).name();
+                // is looked up before the closure's parameter stands for anything.
+                List<Quantified> relations = elementRelations(container, k, at);
+                Core element = read(step.params().get(combo.elementParam()), elem, step.pos());
                 // an element of a container is not a location the body can otherwise name
-                Scope s2 = scope.binding(p, elem);
-                Known k2 = rebind(k, p);
-                if (elem != null) {
-                    k2 = seedParam(p, elem, k2);   // the element carries its type's invariant
-                }
+                Known k2 = seedAt(element, k, at, 0);   // the element carries its type's invariant
                 for (Quantified q : relations) {
-                    // What the predicate reads besides the element is still read inside the closure,
-                    // so a parameter that takes one of those names over does leave it saying
-                    // something else.
-                    if (q.survives(key -> mentions(key, p))) {
-                        k2 = instantiate(q, p, elem, k2);
-                    }
+                    k2 = instantiate(q, element, k2, at);
                 }
-                walk(step.body(), k2, s2, depth);
+                walk(step.body(), k2, at, depth);
             } else {
-                walk(arg, k, scope, depth);
+                walk(arg, k, at, depth);
             }
         }
     }
 
     /** The relations known of every element of {@code container}: those stated of it as written, and
      * those stated of a container it was built from that travel every construction in between. */
-    private List<Quantified> elementRelations(Ast.Expr container, Known k, Scope scope) {
+    private List<Quantified> elementRelations(Core container, Known k, Denotations at) {
         List<Quantified> found = new ArrayList<>();
-        Set<Shape> crossed = java.util.EnumSet.noneOf(Shape.class);
-        Ast.Expr source = container;
+        Set<Shape> crossed = EnumSet.noneOf(Shape.class);
+        Core source = container;
         while (true) {
-            String key = bodyKey(source, scope);
+            String key = bodyKey(source, at);
             if (key != null) {
                 for (Quantified q : k.quantified()) {
                     if (key.equals(q.container()) && q.through().containsAll(crossed)) {
@@ -630,10 +598,10 @@ public final class InvariantChecker {
                     }
                 }
             }
-            if (!(source instanceof Ast.Apply call)) {
+            if (!(source instanceof Core.PreservedCall call)) {
                 return found;
             }
-            Built built = BUILT_FROM.get(call.reaches());
+            Built built = BUILT_FROM.get(call.operation());
             if (built == null || built.from() >= call.args().size()) {
                 return found;
             }
@@ -642,103 +610,75 @@ public final class InvariantChecker {
         }
     }
 
-    /** What {@code q} says of the element bound to {@code element}, taken into {@code k}. The clause
-     * is read again with the quantifier's own parameter standing for that element — the same reading
+    /** What {@code q} says of the value at {@code element}, taken into {@code k}. The predicate is
+     * read again with the quantifier's own parameter standing for that element — the same reading
      * {@link #seedAt} does of a type's invariant, over the clause a quantifier holds. A relation the
-     * clause in turn states of a container is recorded, so a container of containers reaches its
+     * predicate in turn states of a container is recorded, so a container of containers reaches its
      * innermost element. */
-    private Known instantiate(Quantified q, String element, Type elementType, Known k) {
-        Ast.Binder param = q.predicate().params().get(0);
-        Map<String, Type> fields = new HashMap<>(q.binds().fields());
-        if (elementType != null) {
-            fields.put(param.name(), elementType);
-        }
-        Bindings at = new Bindings(
-                name -> param.name().equals(name)
-                        ? LinearForm.atom(element) : q.binds().form().apply(name),
-                name -> param.name().equals(name) ? element : q.binds().path().apply(name),
-                q.binds().given(), q.binds().bodyKey(), fields);
+    private Known instantiate(Quantified q, Core element, Known k, Denotations at) {
+        Core stated = substituted(q.predicate().body(),
+                Map.of(q.predicate().params().get(0).id(), element));
         List<Quantified> nested = new ArrayList<>();
-        quantifiedBy(q.predicate().body(), at, true, nested);
-        return assume(obligations(q.predicate().body(), at, false), k).and(nested);
+        quantifiedBy(stated, at, true, nested);
+        return assume(obligations(stated, k, at, false), k).and(nested);
     }
 
     /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
      * Mirrors {@link #obligations}: a conjunction states each of its sides, and a negation flips the
      * polarity. Only a stated quantifier is recorded — denying one says some element fails the
      * predicate, and which one is not something this check can name. */
-    private void quantifiedBy(Ast.Expr raw, Bindings binds, boolean positive, List<Quantified> out) {
-        Ast.Expr e = asSizeComparison(raw);
-        if (e instanceof Ast.Binary b && b.op() == Ast.BinOp.AND && positive) {
-            quantifiedBy(b.left(), binds, true, out);
-            quantifiedBy(b.right(), binds, true, out);
+    private void quantifiedBy(Core raw, Denotations at, boolean positive, List<Quantified> out) {
+        Core e = asSizeComparison(raw);
+        if (e instanceof Core.Binary b && b.op() == Ast.BinOp.AND && positive) {
+            quantifiedBy(b.left(), at, true, out);
+            quantifiedBy(b.right(), at, true, out);
             return;
         }
-        Ast.Expr under = negated(e);
+        Core under = negated(e);
         if (under != null) {
-            quantifiedBy(under, binds, !positive, out);
+            quantifiedBy(under, at, !positive, out);
             return;
         }
-        if (!positive || !(e instanceof Ast.Apply call) || !QUANTIFIERS.contains(call.reaches())) {
+        if (!positive || !(e instanceof Core.PreservedCall call)
+                || !QUANTIFIERS.contains(call.operation())) {
             return;
         }
-        Combinator over = COMBINATORS.get(call.reaches());
-        Carried carried = CARRIED.get(call.reaches());
+        Combinator over = COMBINATORS.get(call.operation());
+        Carried carried = CARRIED.get(call.operation());
         if (over == null || carried == null || over.closureArg() >= call.args().size()
-                || over.listArg() >= call.args().size()
-                || !(call.args().get(over.closureArg()) instanceof Ast.Block p)
-                || p.params().size() != 1) {
+                || over.listArg() >= call.args().size()) {
             return;
         }
-        String container = siteOf(binds).apply(call.args().get(over.listArg()));
+        Core.Block p = blockOf(call.args().get(over.closureArg()), at);
+        if (p == null || p.params().size() != 1) {
+            return;
+        }
+        String container = bodyKey(call.args().get(over.listArg()), at);
         if (container == null) {
             return;
         }
-        List<String> named = new ArrayList<>();
-        reads(p, binds, Set.of(), named);   // the predicate's own parameter is its own, and left out
-        out.add(new Quantified(container, carried.through(), p, binds, List.copyOf(named)));
-    }
-
-    /** Every term {@code e} names from outside itself, as the clause's own rule names it. A name the
-     * clause binds is its own and is left out; anything else the rule cannot name is kept as written,
-     * which can only drop the relation sooner. */
-    private void reads(Ast.Expr e, Bindings binds, Set<String> bound, List<String> out) {
-        String root = rootName(e);
-        if (root != null) {
-            if (!bound.contains(root)) {
-                String path = invPath(e, binds);
-                out.add(path == null ? root : path);
-            }
-            return;
-        }
-        Set<String> scope = taken(e, bound);
-        Ast.forEachChild(e, child -> reads(child, binds, scope, out));
+        out.add(new Quantified(container, carried.through(), p));
     }
 
     // --- construction detection & discharge check ----------------------------------------------
 
-    private void checkIfConstruction(Ast.Expr e, Known k, Scope scope,
-                                     boolean attempted) {
-        switch (e) {
-            case Ast.NewData nd when nd.spreads().isEmpty() -> {
-                if (symbols.get(nd.typeName().denotes()) instanceof Ast.Data type) {
-                    report(nd, type, nd.pos(), attempted, verdictOf(nd, type, k, scope));
-                }
+    private void checkIfConstruction(Core e, Known k, Denotations at, boolean attempted) {
+        if (e instanceof Core.NewData nd && nd.spreads().isEmpty()) {
+            if (symbols.get(nd.typeName()) instanceof Ast.Data type) {
+                report(nd, type, nd.pos(), attempted, verdictOf(nd, type, k, at));
             }
-            case Ast.Expr arith when asOperator(arith) instanceof Ast.Binary bin
-                    && isArith(bin.op()) -> {
-                if (typeExpr(bin, scope) instanceof Type.Ref r
-                        && symbols.get(r.name()) instanceof Ast.Data type && type.newtype()) {
-                    LinearForm value = affineOf(bin, scope, k);
-                    if (value != null) {
-                        // an arithmetic result is a form, not a location, so it names no path
-                        report(bin, type, bin.pos(), attempted, verdictOf(r.name(), type,
-                                Bindings.ofPaths(name -> "value".equals(name) ? value : null, _ -> null,
-                                        fieldsOf(type)), k, true));
-                    }
-                }
+            return;
+        }
+        // Closed arithmetic over a newtype builds one where it stands: the operands are unwrapped,
+        // the operator applied, and the result constructed again, so the invariant is owed here.
+        if (asOperator(e) instanceof Core.Binary bin && isArith(bin.op())
+                && bin.type() instanceof Type.Ref r
+                && symbols.get(r.name()) instanceof Ast.Data type && type.newtype()) {
+            BindingId value = fieldBindingsOf(type).get("value");
+            if (value != null && affineOf(bin, at, k) != null) {
+                report(bin, type, bin.pos(), attempted,
+                        verdictOf(r.name(), type, Map.of(value, bin), k, at, true));
             }
-            default -> { }
         }
     }
 
@@ -747,70 +687,42 @@ public final class InvariantChecker {
      * reaches here: the walk opens it before anything is checked, so what a field is given is a
      * value and not a choice of two.
      */
-    private Verdict verdictOf(Ast.NewData nd, Ast.Data type, Known k, Scope scope) {
-        Map<String, LinearForm> forms = new HashMap<>();
-        Map<String, String> paths = new HashMap<>();
-        Map<String, Ast.Expr> given = new HashMap<>();
-        Function<Ast.Expr, String> bodyKey = value -> siteKey(value, scope, k);
-        for (Ast.FieldInit fi : nd.inits()) {
-            LinearForm f = affineOf(fi.value(), scope, k);
-            if (f != null) {
-                forms.put(fi.name(), f);
-            }
-            String p = bodyKey.apply(fi.value());
-            if (p != null) {
-                paths.put(fi.name(), p);
+    private Verdict verdictOf(Core.NewData nd, Ast.Data type, Known k, Denotations at) {
+        Map<String, BindingId> fields = fieldBindingsOf(type);
+        Map<BindingId, Core> given = new HashMap<>();
+        for (Core.FieldInit fi : nd.inits()) {
+            BindingId field = fields.get(fi.name());
+            if (field == null) {
+                continue;
             }
             // A name given a value written out hands over that value: the clause folds over what
             // was written, wherever the writing was done.
-            Ast.Expr written = writtenValue(fi.value(), scope);
-            given.put(fi.name(), written != null ? written : fi.value());
+            Core written = writtenValue(fi.value(), at);
+            given.put(field, written != null ? written : fi.value());
         }
-        return verdictOf(nd.typeName().denotes(), type,
-                new Bindings(forms::get, paths::get, given::get, bodyKey,
-                        fieldsOf(type)), k, !constantlyBuilt(type, nd));
+        return verdictOf(nd.typeName(), type, given, k, at, !constantlyBuilt(type, nd));
     }
 
-    /** How an invariant's leaf names resolve at a construction site: to the affine form of what the
-     * field is being given, and to that value's canonical path — so a size call over the field names
-     * the same atom the body names when it calls the same function on the same container. */
-    private record Bindings(Function<String, LinearForm> form, Function<String, String> path,
-                            Function<String, Ast.Expr> given, Function<Ast.Expr, String> bodyKey,
-                            Map<String, Type> fields) {
-
-        /** A clause naming only fields, with nothing of the site to look through — what seeding has. */
-        static Bindings ofPaths(Function<String, LinearForm> form, Function<String, String> path,
-                                Map<String, Type> fields) {
-            return new Bindings(form, path, _ -> null, _ -> null, fields);
+    /** Which of the values a construction hands over is not one a clause may be read against
+     * ({@link #siteKey}) — by identity, since it is these very values that stand in the clause. */
+    private Set<Core> unnamed(Collection<Core> given, Known k, Denotations at) {
+        Set<Core> out = Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Core value : given) {
+            if (siteKey(value, at, k) == null) {
+                out.add(value);
+            }
         }
-
-        /** Nothing to substitute: what the body's own expressions are read with. */
-        static Bindings ofBody(Function<Ast.Expr, String> bodyKey) {
-            return new Bindings(_ -> null, _ -> null, _ -> null, bodyKey, Map.of());
-        }
-
-        /** A clause written in the body's own scope, where every name already stands for itself —
-         * what a guard states, read by the rule a type's clause is read by. */
-        static Bindings ofScope(Scope scope) {
-            return ofPaths(name -> scope.keyOf(name) == null ? null : LinearForm.atom(scope.keyOf(name)),
-                    scope::keyOf,
-                    scope.types());
-        }
+        return out;
     }
 
-    /** How a clause's own expression is named: through the fields the construction is filling, and
-     * through nothing else. A body expression reaches the same space of keys only by being
-     * substituted for a field, which is what {@link #resolve} does. */
-    private Function<Ast.Expr, String> siteOf(Bindings binds) {
-        return e -> termKey(e, x -> invPath(x, binds), Map.of(), 0);
-    }
-
-    /** The expression a clause's leaf stands for at the construction site, or {@code null} when the
-     * clause names something the site does not hand over. A rule about how a container was built has
-     * to read the construction's own expression: the clause writes {@code value}, and what
-     * {@code value} is being given is where the operations are. */
-    private static Ast.Expr atSite(Ast.Expr e, Bindings binds) {
-        return e instanceof Ast.Var v ? binds.given().apply(v.name()) : null;
+    /** Whether {@code e} is, or names, one of {@code values}. */
+    private static boolean names(Core e, Set<Core> values) {
+        if (values.contains(e)) {
+            return true;
+        }
+        boolean[] found = {false};
+        Core.forEachChild(e, child -> found[0] = found[0] || names(child, values));
+        return found[0];
     }
 
     /**
@@ -839,20 +751,26 @@ public final class InvariantChecker {
         }
     }
 
-    /** The discharge verdict for a construction of {@code type} whose field values resolve through
-     * {@code binds}. */
-    private Verdict verdictOf(TypeName named, Ast.Data type, Bindings binds, Known k,
-                              boolean decidesFalse) {
+    /** The discharge verdict for a construction of {@code type} whose fields are being given
+     * {@code given}. */
+    private Verdict verdictOf(TypeName named, Ast.Data type, Map<BindingId, Core> given, Known k,
+                              Denotations at, boolean decidesFalse) {
         List<Ast.InvariantClause> invs = invariantsOf(named, type);
         if (invs.isEmpty()) {
             return Verdict.PROVED;
         }
+        // What the construction hands over that no clause may be read against. A clause naming one of
+        // them is left to the run-time check, and one that is decided outright is still decided: what
+        // cannot be guarded is not the same as what cannot be computed.
+        Set<Core> unnamed = unnamed(given.values(), k, at);
         List<Clause> owed = new ArrayList<>();
         for (Ast.InvariantClause inv : invs) {
             // A newtype construction from a value written out is the constant check's to report: it
             // names the clause that failed. It reads the construction as written, so a name given the
             // value is not one it sees, and this check says it instead.
-            List<Clause> o = obligations(inv.expr(), binds, decidesFalse);
+            Core stated = statedAt(inv.expr(), type, given);
+            List<Clause> o = stated == null ? null
+                    : obligations(stated, k, at, unnamed, true, decidesFalse);
             if (o != null) {
                 owed.addAll(o);
             }
@@ -882,7 +800,7 @@ public final class InvariantChecker {
     /** Whether the constant check reads this construction: a newtype's, over a value written where
      * it is built. That check names the clause that failed, so it is left to say it — and it reads
      * the construction as written, so a name given the value is not one it sees. */
-    private static boolean constantlyBuilt(Ast.Data type, Ast.NewData nd) {
+    private static boolean constantlyBuilt(Ast.Data type, Core.NewData nd) {
         return type.newtype() && nd.inits().size() == 1 && isWritten(nd.inits().get(0).value());
     }
 
@@ -890,8 +808,7 @@ public final class InvariantChecker {
      * warning; a discharged or non-expressible invariant says nothing. An {@code attempted}
      * construction raises no warning: what the warning reports is a possible abort, and an attempt
      * takes its else branch instead. */
-    private void report(Ast.Expr at, Ast.Data type, SourcePos pos, boolean attempted,
-                        Verdict verdict) {
+    private void report(Core at, Ast.Data type, SourcePos pos, boolean attempted, Verdict verdict) {
         if (capturing != null) {
             capturing.found().put(new Occurrence(asWritten(at)),
                     new Reported(type, pos, verdict, attempted));
@@ -920,7 +837,7 @@ public final class InvariantChecker {
      * One written inside the replacement is only in the reading that reached it, and one beside it
      * is the very node, unchanged.
      */
-    private record Occurrence(Ast.Expr of) {
+    private record Occurrence(Core of) {
 
         @Override
         public boolean equals(Object other) {
@@ -934,12 +851,12 @@ public final class InvariantChecker {
     }
 
     /** What each node a rewrite built stands for, so a construction keeps its identity through one. */
-    private final Map<Ast.Expr, Ast.Expr> rebuilt = new IdentityHashMap<>();
+    private final Map<Core, Core> rebuilt = new IdentityHashMap<>();
 
     /** The node {@code e} was built from, however many rewrites ago. */
-    private Ast.Expr asWritten(Ast.Expr e) {
-        Ast.Expr from = e;
-        Ast.Expr next;
+    private Core asWritten(Core e) {
+        Core from = e;
+        Core next;
         while ((next = rebuilt.get(from)) != null) {
             from = next;
         }
@@ -954,9 +871,15 @@ public final class InvariantChecker {
      */
     private Capture capturing;
 
-    /** What each declaration's fields are. Asked at every field read the local typer walks past, and
-     * building one walks the declaration's includes, so it is built once per declaration instead. */
+    /** What each declaration's fields are. Asked at every field read the walk goes past, and building
+     * one walks the declaration's includes, so it is built once per declaration instead. */
     private final Map<Ast.Data, Map<String, Type>> fieldsOf = new HashMap<>();
+
+    /** The same, for the binding each field is. */
+    private final Map<Ast.Data, Map<String, BindingId>> fieldBindings = new HashMap<>();
+
+    /** Each clause as the checker typed it, over the fields it is written against. */
+    private final Map<Ast.Expr, Optional<Core>> typedClauses = new IdentityHashMap<>();
 
     /** What a reading has found so far. */
     private record Capture(Map<Occurrence, Reported> found) {
@@ -968,7 +891,7 @@ public final class InvariantChecker {
 
     /** What reading {@code e} finds, or nothing where the conditions along the way contradict — a
      * branch nothing reaches finds nothing, and what is not there violates nothing. */
-    private Map<Occurrence, Reported> reading(Ast.Expr e, Known k, Scope scope, int depth) {
+    private Map<Occurrence, Reported> reading(Core e, Known k, Denotations at, int depth) {
         if (k.numbers().isBottom()) {
             return Map.of();
         }
@@ -976,7 +899,7 @@ public final class InvariantChecker {
         Capture mine = Capture.empty();
         capturing = mine;
         try {
-            walk(e, k, scope, depth + 1);
+            walk(e, k, at, depth + 1);
         } finally {
             capturing = outer;
         }
@@ -989,14 +912,14 @@ public final class InvariantChecker {
      * body — is where the walk goes next rather than a value it is handed, and a closure's body is
      * read where the closure is applied.
      */
-    private static Ast.If conditionalValueIn(Ast.Expr e) {
+    private static Core.If conditionalValueIn(Core e) {
         return switch (e) {
             // Where the walk goes next is not a value it is handed: an `if`'s own branches, a `let`'s
             // body and a case's body are read after this, each with what is known there.
-            case Ast.If iff -> conditionalIn(iff.cond());
-            case Ast.IfConstructed ic -> conditionalIn(ic.construct());
-            case Ast.LetIn li -> conditionalIn(li.value());
-            case Ast.Match m -> conditionalIn(m.scrutinee());
+            case Core.If iff -> conditionalIn(iff.cond());
+            case Core.IfConstructed ic -> conditionalIn(ic.construct());
+            case Core.LetIn li -> conditionalIn(li.value());
+            case Core.Match m -> conditionalIn(m.scrutinee());
             default -> conditionalIn(e);
         };
     }
@@ -1004,15 +927,15 @@ public final class InvariantChecker {
     /** The first conditional inside a value. Everything under one is part of it, including the body
      * of a binding an expansion introduced — {@code let $0 = r in if $0.a > b then ...} is a helper
      * called on an argument, which is one value however many bindings writing it took. */
-    private static Ast.If conditionalIn(Ast.Expr e) {
-        if (e instanceof Ast.If iff) {
+    private static Core.If conditionalIn(Core e) {
+        if (e instanceof Core.If iff) {
             return iff;
         }
-        if (e instanceof Ast.Block) {
+        if (e instanceof Core.Block) {
             return null;   // read where the closure is applied
         }
-        Ast.If[] found = {null};
-        Ast.forEachChild(e, child -> {
+        Core.If[] found = {null};
+        Core.forEachChild(e, child -> {
             if (found[0] == null) {
                 found[0] = conditionalIn(child);
             }
@@ -1026,15 +949,17 @@ public final class InvariantChecker {
      * once to guard on and once to build from — wrote one value, and reading the two as two would
      * make the guard say nothing about what is built.
      */
-    private Ast.Expr without(Ast.Expr e, Ast.If was, String key, Ast.Expr becomes, Scope scope) {
-        if (e == was || (key != null && e instanceof Ast.If && key.equals(bodyKey(e, scope)))) {
+    private Core without(Core e, Core.If was, String key, Core becomes, Denotations at) {
+        if (e == was || (key != null && e instanceof Core.If && key.equals(bodyKey(e, at)))) {
             return becomes;
         }
-        if (e instanceof Ast.Block) {
+        if (e instanceof Core.Block) {
             return e;
         }
-        Ast.Expr made = Ast.mapChildren(e, child -> without(child, was, key, becomes, scope),
-                name -> name);
+        Core made = Core.mapChildren(e, child -> without(child, was, key, becomes, at),
+                name -> name,
+                nd -> (Core.NewData) Core.mapChildren(nd,
+                        child -> without(child, was, key, becomes, at), name -> name));
         if (made != e) {
             rebuilt.put(made, e);
         }
@@ -1068,6 +993,82 @@ public final class InvariantChecker {
                 "constructing `" + type.name() + "` here violates its invariant on a reachable path"));
     }
 
+    // --- a clause, read where a value is built -------------------------------------------------
+
+    /**
+     * {@code clause} as the checker types it: over the declaration's own fields, each a binding, in
+     * the representation this check reads. Asked once per clause, because typing one walks it.
+     *
+     * <p>Null where the clause is not one this compiler could type there. That is the same answer as
+     * a clause naming something outside the fragment — the run-time check stands for it — and it is
+     * an answer rather than a failure because a declaration this check cannot read is not a
+     * declaration an author wrote wrongly.
+     */
+    private Core typed(Ast.Expr clause, Ast.Data data) {
+        return typedClauses.computeIfAbsent(clause, written -> {
+            try {
+                return Optional.ofNullable(Elaborator.elaborate(written, fieldScope(data),
+                        CheckContext.of(symbols).forData(data)
+                                .preserving(Preserved.byTheLanguagesOwnOperations()),
+                        Type.BOOL));
+            } catch (RuntimeException _) {
+                return Optional.empty();
+            }
+        }).orElse(null);
+    }
+
+    /** The bindings a declaration's own invariant reads: its fields, each as the binding it is. */
+    private Scope fieldScope(Ast.Data data) {
+        return DataChecker.fieldScope(data, symbols);
+    }
+
+    /**
+     * What a clause of {@code data} states where each field is given what {@code given} says, or
+     * {@code null} where it states nothing this check can read.
+     *
+     * <p>The clause is the declaration's and the values are the site's, and this is where the two
+     * become one expression: a field read stands for the value that field is being given, so what the
+     * clause says is read by the very rules the body is read by. A field nothing was given — one a
+     * construction leaves out — leaves the clause naming a value that is not there, and the clause is
+     * left to the run-time check rather than read against nothing.
+     */
+    private Core statedAt(Ast.Expr clause, Ast.Data data, Map<BindingId, Core> given) {
+        Core typed = typed(clause, data);
+        if (typed == null) {
+            return null;
+        }
+        Set<BindingId> fields = new HashSet<>(fieldBindingsOf(data).values());
+        boolean[] whole = {true};
+        readsOf(typed, binding -> {
+            if (fields.contains(binding) && !given.containsKey(binding)) {
+                whole[0] = false;
+            }
+        });
+        return whole[0] ? substituted(typed, given) : null;
+    }
+
+    /** {@code e} with each binding {@code given} names replaced by the value it was given. */
+    private static Core substituted(Core e, Map<BindingId, Core> given) {
+        if (e instanceof Core.Read r) {
+            Core value = given.get(r.binding());
+            return value != null ? value : r;
+        }
+        return Core.mapChildren(e, child -> substituted(child, given),
+                // A name slot holds a binding and nothing else, so a value put there would be
+                // something the reader of that slot cannot load. Only another name may stand there.
+                name -> substituted(name, given) instanceof Core.Read r ? r : name,
+                nd -> (Core.NewData) Core.mapChildren(nd, child -> substituted(child, given),
+                        name -> substituted(name, given) instanceof Core.Read r ? r : name));
+    }
+
+    /** Every binding {@code e} reads, at any depth. */
+    private static void readsOf(Core e, java.util.function.Consumer<BindingId> f) {
+        if (e instanceof Core.Read r) {
+            f.accept(r.binding());
+        }
+        Core.forEachChild(e, child -> readsOf(child, f));
+    }
+
     // --- invariant / condition -> constraints --------------------------------------------------
 
     private record Constraint(LinearForm form, Rel rel) {}
@@ -1095,16 +1096,16 @@ public final class InvariantChecker {
         }
     }
 
+    /** A clause that cannot hold, said in the language the domain reads: {@code -1 >= 0}. */
+    private static final Clause VIOLATED = new Clause(
+            new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE), null, List.of());
+
     /**
      * One clause of an invariant, and the two ways it can come out: a relation for the domain to
      * prove, and the key a guard restating it settles. Either may be absent, and where both are
      * present either one discharging the clause is enough — a guard is written one way and a clause
      * another, and which of the two routes carries it is not the author's concern.
      */
-    /** A clause that cannot hold, said in the language the domain reads: {@code -1 >= 0}. */
-    private static final Clause VIOLATED = new Clause(
-            new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE), null, List.of());
-
     private record Clause(Constraint numeric, Fact fact, List<Constraint> known) {
 
         boolean dischargedBy(NumericDomain d, PredicateFacts facts) {
@@ -1118,26 +1119,22 @@ public final class InvariantChecker {
         }
     }
 
-    /** What an invariant expression owes under {@code binds} (field/{@code value} name -> what it is
-     * being given), or {@code null} if it names nothing this check can carry. A comparison the domain
-     * can express is owed to the domain; anything else is owed as a fact, which a guard stating the
-     * same thing of the same term settles. */
     /** What {@code inv} owes, where {@code decidesFalse} says a clause folding to the other answer
      * than it is read with is this check's to report. A newtype's constant construction is checked
      * elsewhere, and that check names the clause that failed rather than only saying one did, so it
      * is left to say it. */
-    private List<Clause> obligations(Ast.Expr inv, Bindings binds, boolean decidesFalse) {
-        return obligations(inv, binds, true, decidesFalse);
+    private List<Clause> obligations(Core inv, Known k, Denotations at, boolean decidesFalse) {
+        return obligations(inv, k, at, Set.of(), true, decidesFalse);
     }
 
-    private List<Clause> obligations(Ast.Expr rawInv, Bindings binds, boolean positive,
-                                     boolean decidesFalse) {
-        Ast.Expr inv = asSizeComparison(rawInv);
-        if (inv instanceof Ast.Binary b && b.op() == Ast.BinOp.AND && positive) {
+    private List<Clause> obligations(Core rawInv, Known k, Denotations at, Set<Core> unnamed,
+                                     boolean positive, boolean decidesFalse) {
+        Core inv = asSizeComparison(rawInv);
+        if (inv instanceof Core.Binary b && b.op() == Ast.BinOp.AND && positive) {
             // Each conjunct on its own: an invariant is a set of things that hold, and one the check
             // cannot read leaves its own run-time check standing without costing the others theirs.
-            List<Clause> l = obligations(b.left(), binds, true, decidesFalse);
-            List<Clause> r = obligations(b.right(), binds, true, decidesFalse);
+            List<Clause> l = obligations(b.left(), k, at, unnamed, true, decidesFalse);
+            List<Clause> r = obligations(b.right(), k, at, unnamed, true, decidesFalse);
             if (l == null && r == null) {
                 return null;
             }
@@ -1145,13 +1142,13 @@ public final class InvariantChecker {
             both.addAll(r == null ? List.of() : r);
             return both;
         }
-        Ast.Expr under = negated(inv);
+        Core under = negated(inv);
         if (under != null) {
-            return obligations(under, binds, !positive, decidesFalse);
+            return obligations(under, k, at, unnamed, !positive, decidesFalse);
         }
-        Boolean folded = decidedAt(inv, binds);
+        Boolean folded = decidedAt(inv);
         if (folded != null) {
-            // The clause folds once the construction's own expressions stand where it wrote a field.
+            // The clause folds once the construction's own expressions stand where it read a field.
             // Folding the way it is read owes nothing; folding the other way is a violation, and
             // saying so needs no term to be named. Read under a denial it is the other answer that
             // discharges, which is why the polarity is asked.
@@ -1163,71 +1160,42 @@ public final class InvariantChecker {
             }
         }
         Constraint numeric = null;
-        if (inv instanceof Ast.Binary b && relOf(b.op()) != null) {
+        if (inv instanceof Core.Binary b && relOf(b.op()) != null) {
             Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
-            LinearForm la = eff == null ? null : affine(b.left(), resolveLeaf(binds));
-            LinearForm ra = eff == null ? null : affine(b.right(), resolveLeaf(binds));
+            LinearForm la = eff == null ? null : affineOf(b.left(), at, k);
+            LinearForm ra = eff == null ? null : affineOf(b.right(), at, k);
             if (la != null && ra != null) {
                 numeric = new Constraint(la.minus(ra), eff);
             }
         }
         Polar polar = polar(inv, positive);
-        List<String> keys = factKeys(polar.expr(), binds);
+        // A predicate over a value no guard could be written about is not a predicate a guard will
+        // settle, so it is not owed as one — where the domain can say something of that value it has
+        // already said it above, and where it cannot the run-time check stands for the clause.
+        List<String> keys = names(polar.expr(), unnamed) ? List.of() : factKeys(polar.expr(), at);
         boolean stated = polar.positive();
         Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);
         if (numeric == null && fact == null) {
             return null;
         }
         List<Constraint> known = new ArrayList<>();
-        sizeFacts(inv, binds, known);
+        sizeFacts(inv, at, known);
         return List.of(new Clause(numeric, fact, known));
     }
 
-    /** Whether {@code inv} is decided outright at this construction: the clause with each field it
-     * names replaced by what the construction gives that field, folded. {@code null} where it does not
-     * fold — which is every clause reading anything computed at run time. */
-    private Boolean decidedAt(Ast.Expr inv, Bindings binds) {
-        Object folded = ConstEval.eval(substituted(inv, binds, Set.of())).orElse(null);
+    /** Whether {@code inv} is decided outright: the clause, with the construction's own values
+     * already standing where it read a field, folded. {@code null} where it does not fold — which is
+     * every clause reading anything computed at run time. */
+    private Boolean decidedAt(Core inv) {
+        Object folded = folded(inv);
         return folded instanceof Boolean b ? b : null;
     }
 
-    /** {@code bound} with whatever names {@code e} itself binds — a closure's parameters, a
-     * binding's name. A name a binding took over is that binding's and not a field's. */
-    private static Set<String> taken(Ast.Expr e, Set<String> bound) {
-        if (e instanceof Ast.Block b && !b.params().isEmpty()) {
-            Set<String> inner = new HashSet<>(bound);
-            inner.addAll(b.paramNames());
-            return inner;
-        }
-        if (e instanceof Ast.LetIn li) {
-            Set<String> inner = new HashSet<>(bound);
-            inner.add(li.name());
-            return inner;
-        }
-        return bound;
-    }
-
-    /** {@code inv} with every name the construction fills replaced by the expression filling it. A
-     * name a binding inside the clause has taken over is that binding's and not a field's, so it is
-     * left alone: {@code List.all(x -> x > 0, x)} says two different things by one spelling. */
-    private static Ast.Expr substituted(Ast.Expr e, Bindings binds, Set<String> bound) {
-        if (e instanceof Ast.Var v && bound.contains(v.name())) {
-            return e;
-        }
-        Ast.Expr given = atSite(e, binds);
-        if (given != null) {
-            return given;
-        }
-        if (e instanceof Ast.LetIn li) {
-            // The initializer is read where the binding is not yet in scope, so a field the clause
-            // names keeps its meaning there even where the binding takes the same spelling over.
-            Set<String> inner = taken(e, bound);
-            return new Ast.LetIn(li.binder(), substituted(li.value(), binds, bound),
-                    li.declaredType(), li.annotated(), li.opens(),
-                    substituted(li.body(), binds, inner), li.pos());
-        }
-        Set<String> taken = taken(e, bound);
-        return Ast.mapChildren(e, child -> substituted(child, binds, taken), name -> name);
+    /** What {@code e} folds to where every part of it is written out, or {@code null} where any part
+     * of it is computed at run time and there is nothing to fold. */
+    private static Object folded(Core e) {
+        Ast.Expr written = asWrittenValue(e);
+        return written == null ? null : ConstEval.eval(written).orElse(null);
     }
 
     private static List<String> firstOnly(List<String> keys) {
@@ -1237,53 +1205,53 @@ public final class InvariantChecker {
     /** Refines {@code k} by asserting {@code cond} (or its negation): a comparison tightens the
      * numeric domain, a stdlib predicate settles a fact. A condition of neither shape, and an operand
      * outside the affine fragment, leave {@code k} unchanged (sound). */
-    private Known assumeCond(Ast.Expr rawCond, Known k, Scope scope, boolean positive) {
-        Ast.Expr cond = asSizeComparison(rawCond);
+    private Known assumeCond(Core rawCond, Known k, Denotations at, boolean positive) {
+        Core cond = asSizeComparison(rawCond);
         // `&&` asserted true gives both sides; `||` asserted false gives both sides negated.
-        if (cond instanceof Ast.Binary b
+        if (cond instanceof Core.Binary b
                 && (b.op() == Ast.BinOp.AND && positive || b.op() == Ast.BinOp.OR && !positive)) {
-            return assumeCond(b.right(), assumeCond(b.left(), k, scope, positive), scope, positive);
+            return assumeCond(b.right(), assumeCond(b.left(), k, at, positive), at, positive);
         }
-        Ast.Expr under = negated(cond);
+        Core under = negated(cond);
         if (under != null) {
-            return assumeCond(under, k, scope, !positive);
+            return assumeCond(under, k, at, !positive);
         }
         Known out = k;
         // What holds of the sizes the condition names, whichever way the condition itself is read.
         List<Constraint> known = new ArrayList<>();
-        sizeFacts(cond, scope, known);
+        sizeFacts(cond, at, known);
         for (Constraint c : known) {
             out = out.with(out.numbers().assume(c.form(), c.rel()));
         }
-        if (cond instanceof Ast.Binary b) {
+        if (cond instanceof Core.Binary b) {
             Rel rel = relOf(b.op());
             Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
-            LinearForm la = eff == null ? null : affineOf(b.left(), scope, out);
-            LinearForm ra = eff == null ? null : affineOf(b.right(), scope, out);
+            LinearForm la = eff == null ? null : affineOf(b.left(), at, out);
+            LinearForm ra = eff == null ? null : affineOf(b.right(), at, out);
             if (la != null && ra != null) {
                 out = out.with(out.numbers().assume(la.minus(ra), eff));
             }
             // What the comparison named, recorded as spoken about: a construction from one of these
             // is one the author has said something about, whichever route ends up carrying it.
-            Set<String> named = new HashSet<>(spokenOf(b.left(), scope, la));
-            named.addAll(spokenOf(b.right(), scope, ra));
+            Set<String> named = new HashSet<>(spokenOf(b.left(), at, la));
+            named.addAll(spokenOf(b.right(), at, ra));
             out = out.speaking(named);
         }
         List<Quantified> quantified = new ArrayList<>();
-        quantifiedBy(cond, Bindings.ofScope(scope), positive, quantified);
+        quantifiedBy(cond, at, positive, quantified);
         out = out.and(quantified);
         // Both routes, always: which one carries a clause is decided where the clause is read, and a
         // guard does not know which that will be.
         Polar polar = polar(cond, positive);
-        String key = bodyKey(polar.expr(), scope);
+        String key = bodyKey(polar.expr(), at);
         return key == null ? out : out.with(out.facts().assume(key, polar.positive()));
     }
 
     /** The terms one side of a compared pair names: the expression itself, and each atom of the form it
      * reduced to — {@code leftover + 1} says something about {@code leftover}. */
-    private Collection<String> spokenOf(Ast.Expr side, Scope scope, LinearForm form) {
+    private Collection<String> spokenOf(Core side, Denotations at, LinearForm form) {
         Set<String> terms = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
-        String written = bodyKey(side, scope);
+        String written = bodyKey(side, at);
         if (written != null) {
             terms.add(written);
         }
@@ -1291,7 +1259,7 @@ public final class InvariantChecker {
     }
 
     /** A predicate as one of {@code ==}/{@code <} states it, and whether it is being stated or denied. */
-    private record Polar(Ast.Expr expr, boolean positive) {}
+    private record Polar(Core expr, boolean positive) {}
 
     /**
      * {@code e}, asserted with polarity {@code positive}, as the comparison of {@code ==} or {@code <}
@@ -1300,8 +1268,8 @@ public final class InvariantChecker {
      * without this the six ways to compare two terms are six facts, and a guard written one way would
      * leave a clause written the other unsettled.
      */
-    private static Polar polar(Ast.Expr e, boolean positive) {
-        if (!(e instanceof Ast.Binary b) || relOf(b.op()) == null) {
+    private static Polar polar(Core e, boolean positive) {
+        if (!(e instanceof Core.Binary b) || relOf(b.op()) == null) {
             return new Polar(e, positive);
         }
         return switch (b.op()) {
@@ -1313,36 +1281,77 @@ public final class InvariantChecker {
         };
     }
 
-    private static Ast.Binary comparison(Ast.BinOp op, Ast.Expr left, Ast.Expr right, Ast.Binary of) {
-        return new Ast.Binary(op, left, right, of.pos());
+    private static Core.Binary comparison(Ast.BinOp op, Core left, Core right, Core.Binary of) {
+        return new Core.Binary(op, left, right, of.type(), of.pos());
     }
 
     /** What a negation is applied to, or {@code null} if {@code e} is not one. {@code Bool.not} is an
      * ordinary helper: the analysis representation keeps it as a call, and a clause read off an
      * imported declaration is the body it expands to — {@code if b then false else true} over a
      * binding holding the argument. Both are read. */
-    private static Ast.Expr negated(Ast.Expr e) {
-        if (e instanceof Ast.Apply call && "Bool.not".equals(call.reaches()) && call.args().size() == 1) {
+    private static Core negated(Core e) {
+        if (e instanceof Core.PreservedCall call && call.operation().equals(op("Bool.not"))
+                && call.args().size() == 1) {
             return call.args().get(0);
         }
-        if (e instanceof Ast.LetIn li) {
-            Ast.Expr inner = negated(li.body());
-            return inner instanceof Ast.Var v && v.name().equals(li.name()) ? li.value() : null;
+        if (e instanceof Core.LetIn li) {
+            Core inner = negated(li.body());
+            return inner instanceof Core.Read r && r.binding().equals(li.binder().id())
+                    ? li.value() : null;
         }
-        return e instanceof Ast.If iff
-                && iff.then() instanceof Ast.BoolLit t && !t.value()
-                && iff.els() instanceof Ast.BoolLit f && f.value()
+        return e instanceof Core.If iff
+                && iff.then() instanceof Core.Bool t && !t.value()
+                && iff.els() instanceof Core.Bool f && f.value()
                 ? iff.cond() : null;
     }
 
     // --- seeding -------------------------------------------------------------------------------
 
-    /** Seeds the check with what a parameter's type guarantees: a numeric newtype's own invariant on
-     * its value, a predicate its invariant states of it, or a product data's invariant over its fields
-     * (and one level of fields), each substituted onto the parameter's own term. Sound by closed
-     * construction — an input of type T was built through T's checked constructor. */
-    private Known seedParam(String name, Type t, Known k) {
-        return seedAt(name, t, k, 0);
+    /**
+     * Seeds the check with what the type of the value at {@code root} guarantees: a numeric newtype's
+     * own invariant on its value, a predicate its invariant states of it, or a product data's
+     * invariant over its fields (and one level of fields), each read at that very value. Sound by
+     * closed construction — a value of type T was built through T's checked constructor.
+     *
+     * <p>Which is the same reading a construction gets, over field reads instead of field values: the
+     * clause is the declaration's either way, and where it is established and where it is owed differ
+     * only in direction.
+     */
+    private Known seedAt(Core root, Known k, Denotations at, int depth) {
+        if (depth > 2 || !(root.type() instanceof Type.Ref ref)
+                || !(symbols.get(ref.name()) instanceof Ast.Data data)) {
+            return k;
+        }
+        Map<String, Type> fields = fieldsOf(data);
+        Map<String, BindingId> bindings = fieldBindingsOf(data);
+        Map<BindingId, Core> given = new HashMap<>();
+        fields.forEach((name, type) -> {
+            BindingId field = bindings.get(name);
+            if (field != null) {
+                given.put(field, new Core.FieldAccess(root, name, type, root.pos()));
+            }
+        });
+        Known out = k;
+        List<Quantified> quantified = new ArrayList<>();
+        for (Ast.InvariantClause inv : invariantsOf(ref.name(), data)) {
+            Core stated = statedAt(inv.expr(), data, given);
+            if (stated == null) {
+                continue;
+            }
+            quantifiedBy(stated, at, true, quantified);
+            out = assume(obligations(stated, out, at, false), out);
+        }
+        out = out.and(quantified);
+        if (data.newtype()) {
+            // A newtype's `.value` is the same location as the newtype, so what its base guarantees is
+            // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
+            Core value = given.get(bindings.get("value"));
+            return value == null ? out : seedAt(value, out, at, depth + 1);
+        }
+        for (Core value : given.values()) {
+            out = seedAt(value, out, at, depth + 1);
+        }
+        return out;
     }
 
     /** {@code k} with everything {@code owed} states taken as holding. What a clause owes at a
@@ -1369,76 +1378,27 @@ public final class InvariantChecker {
         return out;
     }
 
-    private Known seedAt(String path, Type t, Known k, int depth) {
-        if (depth > 2 || !(t instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)) {
-            return k;
-        }
-        Map<String, Type> fields = fieldsOf(data);
-        Function<String, String> resolvePath = fieldName -> {
-            if (data.newtype() && fieldName.equals("value")) {
-                return path;
-            }
-            return fields.containsKey(fieldName) ? path + "." + fieldName : null;
-        };
-        Bindings binds = Bindings.ofPaths(
-                fieldName -> {
-                    String p = resolvePath.apply(fieldName);
-                    return p == null ? null : LinearForm.atom(p);
-                },
-                resolvePath, fields);
-        Known out = k;
-        List<Quantified> quantified = new ArrayList<>();
-        for (Ast.InvariantClause inv : invariantsOf(ref.name(), data)) {
-            quantifiedBy(inv.expr(), binds, true, quantified);
-            out = assume(obligations(inv.expr(), binds, false), out);
-        }
-        out = out.and(quantified);
-        if (data.newtype()) {
-            // A newtype's `.value` is the same location as the newtype, so what its base guarantees is
-            // guaranteed of this very atom: `data Outer = Inner` carries Inner's invariant.
-            out = seedAt(path, fields.get("value"), out, depth + 1);
-        } else {
-            for (Map.Entry<String, Type> f : fields.entrySet()) {
-                out = seedAt(path + "." + f.getKey(), f.getValue(), out, depth + 1);
-            }
-        }
-        return out;
-    }
-
     // --- affine forms --------------------------------------------------------------------------
-
-    /**
-     * The library's function forms of the arithmetic operators, and the operator each one is. They
-     * reach the same kernel in the same argument order — {@code Int.add} is {@code IntMath.addExact},
-     * which is what {@code +} emits — so the two spellings compute one value and are read as one term.
-     * {@code divide} is absent: it answers a union rather than a number.
-     */
-    private static final Map<String, Ast.BinOp> OPERATOR_CALLS = Map.of(
-            "Int.add", Ast.BinOp.ADD,
-            "Int.subtract", Ast.BinOp.SUB,
-            "Int.multiply", Ast.BinOp.MUL,
-            "Decimal.add", Ast.BinOp.ADD,
-            "Decimal.subtract", Ast.BinOp.SUB,
-            "Decimal.multiply", Ast.BinOp.MUL);
 
     /** The operator {@code e} is, where it is a library call written as a function, or {@code e}
      * itself. Reading it as the operator is what puts it on the one path the operator already has,
      * rather than on a second path that would have to be kept saying the same thing. */
-    private static Ast.Expr asOperator(Ast.Expr e) {
-        if (e instanceof Ast.Apply call && call.args().size() == 2) {
-            Ast.BinOp op = OPERATOR_CALLS.get(call.reaches());
+    private static Core asOperator(Core e) {
+        if (e instanceof Core.PreservedCall call && call.args().size() == 2) {
+            Ast.BinOp op = OPERATOR_CALLS.get(call.operation());
             if (op != null) {
-                return new Ast.Binary(op, call.args().get(0), call.args().get(1), call.pos());
+                return new Core.Binary(op, call.args().get(0), call.args().get(1), call.type(),
+                        call.pos());
             }
         }
         return e;
     }
 
     /** The shared affine walk: literals and {@code +}/{@code -} compose; every other node is handed to
-     * {@code leaf} (which decides whether it is an atom, a resolved field, or opaque). */
-    private LinearForm affine(Ast.Expr raw, Function<Ast.Expr, LinearForm> leaf) {
-        Ast.Expr e = asOperator(raw);
-        if (e instanceof Ast.Apply) {
+     * {@code leaf} (which decides whether it is an atom, a location, or opaque). */
+    private LinearForm affine(Core raw, java.util.function.Function<Core, LinearForm> leaf) {
+        Core e = asOperator(raw);
+        if (e instanceof Core.PreservedCall) {
             // A call that folds is the number it folds to. `String.length("1A")` is 2, and a clause
             // about it is decided rather than owed — the run-time check is not what should answer a
             // question the compiler has already computed. Asked once: folding walks the subtree, and
@@ -1449,25 +1409,24 @@ public final class InvariantChecker {
             }
         }
         return switch (e) {
-            case Ast.IntLit i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
-            case Ast.DecimalLit dd -> LinearForm.constant(dd.value());
-            case Ast.Neg n -> negate(affine(n.operand(), leaf));
-            case Ast.Binary b when b.op() == Ast.BinOp.ADD ->
+            case Core.Int i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
+            case Core.Decimal d -> LinearForm.constant(d.value());
+            case Core.Neg n -> negate(affine(n.operand(), leaf));
+            case Core.Binary b when b.op() == Ast.BinOp.ADD ->
                     add(affine(b.left(), leaf), affine(b.right(), leaf), false);
-            case Ast.Binary b when b.op() == Ast.BinOp.SUB ->
+            case Core.Binary b when b.op() == Ast.BinOp.SUB ->
                     add(affine(b.left(), leaf), affine(b.right(), leaf), true);
-            // scalar multiply by a constant (金額 * 2) is linear; `/` and a variable product are not
+            // scalar multiply by a constant (Amount * 2) is linear; `/` and a variable product are not
             // (a divide truncates for Int, and a variable factor is non-linear), so leave those opaque.
-            case Ast.Binary b when b.op() == Ast.BinOp.MUL ->
+            case Core.Binary b when b.op() == Ast.BinOp.MUL ->
                     scale(affine(b.left(), leaf), affine(b.right(), leaf));
-            // A binding an expansion introduced ({@code let $0_n = n.value in $0_n * 2}) is what an
+            // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what an
             // arithmetic helper becomes, so reading through it is reading the arithmetic the author
-            // wrote. An inner binding of the same name makes its own rule first, which is what
-            // shadowing is.
-            case Ast.LetIn li -> {
+            // wrote.
+            case Core.LetIn li -> {
                 LinearForm bound = affine(li.value(), leaf);
                 yield bound == null ? leaf.apply(e) : affine(li.body(),
-                        n -> n instanceof Ast.Var v && v.name().equals(li.name())
+                        n -> n instanceof Core.Read r && r.binding().equals(li.binder().id())
                                 ? bound : leaf.apply(n));
             }
             default -> leaf.apply(e);
@@ -1475,8 +1434,8 @@ public final class InvariantChecker {
     }
 
     /** The number {@code e} folds to at compile time, or {@code null} where it folds to none. */
-    private static BigDecimal constantNumber(Ast.Expr e) {
-        Object folded = ConstEval.eval(e).orElse(null);
+    private static BigDecimal constantNumber(Core e) {
+        Object folded = folded(e);
         if (folded instanceof Long n) {
             return BigDecimal.valueOf(n);
         }
@@ -1495,119 +1454,39 @@ public final class InvariantChecker {
         return b.coefs().isEmpty() ? a.times(b.constant()) : null;
     }
 
-    /** The affine form of a body expression: a numeric atom, a newtype construct's wrapped value, or
+    /** The affine form of an expression: a numeric atom, a newtype construct's wrapped value, or
      * {@code null}. */
-    private LinearForm affineOf(Ast.Expr e, Scope scope, Known k) {
+    private LinearForm affineOf(Core e, Denotations at, Known k) {
         return affine(e, n -> {
-            if (n instanceof Ast.NewData nd && nd.spreads().isEmpty() && nd.inits().size() == 1
+            if (n instanceof Core.NewData nd && nd.spreads().isEmpty() && nd.inits().size() == 1
                     && nd.inits().get(0).name().equals("value")
-                    && numericNewtype(Type.ref(nd.typeName().denotes()))) {
-                return affineOf(nd.inits().get(0).value(), scope, k);
+                    && numericNewtype(Type.ref(nd.typeName()))) {
+                return affineOf(nd.inits().get(0).value(), at, k);
             }
-            Ast.Expr written = writtenValue(n, scope);
+            Core written = writtenValue(n, at);
             if (written != null && written != n) {
-                return affineOf(written, scope, k);
+                return affineOf(written, at, k);
             }
-            if (n instanceof Ast.LetIn li) {
-                // A binding an expansion introduced is read the way the walk reads one: the name is
-                // what it was given. Without that, a helper called on a record is opaque here while
-                // the body it expands to is not, and the call and its expansion disagree.
-                return affineOf(li.body(), scope.binding(li.name(),
-                        typeExpr(li.value(), scope), denotationOf(li.value(), scope, k)), k);
+            // A list written out has as many elements as it is written with, whatever they are.
+            BigDecimal counted = writtenSize(n, at);
+            if (counted != null) {
+                return LinearForm.constant(counted);
             }
-            String atom = atomOf(n, scope, k);
+            String atom = atomOf(n, at, k);
             return atom == null ? null : LinearForm.atom(atom);
         });
     }
 
-    /** The leaf rule for an invariant expression: a bare name resolves to its field/{@code value}, a
-     * chain read off one to that location, and a size call over one to that container's size atom.
-     * A bare name goes through the form because what a construction gives a field may be an
-     * arithmetic result rather than a location; a chain read off it is a location either way. */
-    private Function<Ast.Expr, LinearForm> resolveLeaf(Bindings binds) {
-        return n -> {
-            BigDecimal folded = clauseSizeConstant(n, binds);
-            if (folded != null) {
-                return LinearForm.constant(folded);
-            }
-            String size = clauseSizeAtom(n, binds);
-            if (size != null) {
-                return LinearForm.atom(size);
-            }
-            if (n instanceof Ast.Var v) {
-                return binds.form().apply(v.name());
-            }
-            if (n instanceof Ast.FieldAccess) {
-                String path = invPath(n, binds);
-                return path == null ? null : LinearForm.atom(path);
-            }
-            return null;
-        };
-    }
-
-    /** A container a clause names, as the term it stands for, and the rule that names that term. */
-    private record Named(Ast.Expr term, Function<Ast.Expr, String> key) {}
-
-    /** What a clause's container argument really is: the construction's own expression where the
-     * clause names a field, the clause's own expression otherwise. {@code peel} takes the
-     * size-keeping operations off — a size reads how many, and how the elements are made has no
-     * bearing on that. */
-    private Named resolve(Ast.Expr arg, Bindings binds, boolean peel) {
-        Ast.Expr here = peel ? sizeSource(arg) : arg;
-        Ast.Expr given = atSite(here, binds);
-        if (given == null) {
-            return new Named(here, siteOf(binds));
-        }
-        return new Named(peel ? sizeSource(given) : given, binds.bodyKey());
-    }
-
-    /** The number a size call in a clause folds to once the construction's own expression stands where
-     * the clause wrote a field — {@code String.length(value)} over {@code Code("1A")} is 2 — or
-     * {@code null} where it folds to none. */
-    private BigDecimal clauseSizeConstant(Ast.Expr e, Bindings binds) {
-        if (!(e instanceof Ast.Apply call) || !SIZE_CALLS.contains(call.reaches())
+    /** How many elements a size call over a value written out counts, or {@code null} where its
+     * argument is not one. */
+    private BigDecimal writtenSize(Core e, Denotations at) {
+        if (!(e instanceof Core.PreservedCall call) || !SIZE_CALLS.contains(call.operation())
                 || call.args().size() != 1) {
             return null;
         }
-        Ast.Expr arg = call.args().get(0);
-        Ast.Expr given = atSite(arg, binds);
-        Ast.Expr container = given == null ? arg : given;
-        // A list written out has as many elements as it is written with, whatever the elements are.
-        if (container instanceof Ast.ListLit list) {
-            return BigDecimal.valueOf(list.elements().size());
-        }
-        return constantNumber(new Ast.Apply(call.function(), List.of(container),
-                call.origin(), call.pos()));
-    }
-
-    /** The atom a size call in a clause names, or {@code null}. */
-    private String clauseSizeAtom(Ast.Expr e, Bindings binds) {
-        if (!(e instanceof Ast.Apply call) || !SIZE_CALLS.contains(call.reaches()) || call.args().size() != 1) {
-            return null;
-        }
-        Named named = resolve(call.args().get(0), binds, true);
-        String key = named.key().apply(named.term());
-        return key == null ? null : call.written() + "(" + key + ")";
-    }
-
-    /** The path an invariant expression names at the construction site: a bare field name through the
-     * bindings, then plain field steps. */
-    private String invPath(Ast.Expr e, Bindings binds) {
-        // A clause is a path over the declaration's own fields, read by the very rule a body path is
-        // read by — so a newtype's `.value` is the same location on both sides — and then the field it
-        // is rooted at is replaced by what the construction is giving that field. One rule for what a
-        // location is, applied twice, rather than two rules that have to be kept agreeing.
-        String local = pathKey(e, Scope.of(binds.fields()));
-        if (local == null) {
-            return null;
-        }
-        int dot = local.indexOf('.');
-        String root = dot < 0 ? local : local.substring(0, dot);
-        String given = binds.path().apply(root);
-        if (given == null) {
-            return null;
-        }
-        return dot < 0 ? given : given + local.substring(dot);
+        Core written = writtenValue(call.args().get(0), at);
+        return written instanceof Core.ListLit list
+                ? BigDecimal.valueOf(list.elements().size()) : null;
     }
 
     private static LinearForm negate(LinearForm f) {
@@ -1623,28 +1502,28 @@ public final class InvariantChecker {
 
     /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value) or of
      * a size call over a nameable container, or {@code null} if {@code e} is neither. */
-    private String atomOf(Ast.Expr e, Scope scope, Known k) {
-        String size = sizeAtom(e, arg -> bodyKey(arg, scope));
+    private String atomOf(Core e, Denotations at, Known k) {
+        String size = sizeAtom(e, arg -> bodyKey(arg, at));
         if (size != null) {
             return size;
         }
-        if (!isNumeric(typeExpr(e, scope))) {
+        if (!isNumeric(e.type())) {
             return null;
         }
-        // A path rooted at a name is the atom of what that name denotes, and only where a clause
+        // A path rooted at a binding is the atom of what that binding denotes, and only where a clause
         // could be read against it — otherwise a name would be an atom where the expression it was
         // given is not one, and the two spellings would answer differently.
-        String root = rootName(e);
-        if (root != null && !readable(scope.denotes(root), k)) {
+        BindingId root = rootBinding(e);
+        if (root != null && !readable(at.of(root), k)) {
             return null;
         }
-        return pathKey(e, scope);
+        return pathKey(e, at);
     }
 
-    /** A body expression's canonical key: a location names itself, and everything else is read
+    /** An expression's canonical key: a location names itself, and everything else is read
      * structurally. */
-    private String bodyKey(Ast.Expr e, Scope scope) {
-        return termKey(e, x -> pathKey(x, scope), Map.of(), 0);
+    private String bodyKey(Core e, Denotations at) {
+        return termKey(e, at, Map.of(), 0);
     }
 
     /**
@@ -1664,32 +1543,33 @@ public final class InvariantChecker {
      * whole of such an invariant. Widening it is a matter of naming more values here, which is where
      * a stated result type or a stdlib rule would enter.
      */
-    private String siteKey(Ast.Expr e, Scope scope, Known k) {
+    private String siteKey(Core e, Denotations at, Known k) {
         // A value written out is not something a guard can be written about: there is nothing to
         // state of `"xyz"` that the text does not already say. Where a clause reading it folds it is
         // decided before this is asked, and where it does not fold there is no guard that would
         // discharge it, so naming it here would only report what the author cannot answer.
-        Denotes d = denotationOf(e, scope, k);
+        Denotes d = denotationOf(e, at, k);
         return readable(d, k) ? d.key() : null;
     }
 
     /** The atom key of {@code SIZE_CALL(container)} when {@code key} can name the container, else
      * {@code null}. */
-    private static String sizeAtom(Ast.Expr e, Function<Ast.Expr, String> key) {
-        if (!(e instanceof Ast.Apply call) || !SIZE_CALLS.contains(call.reaches()) || call.args().size() != 1) {
+    private static String sizeAtom(Core e, java.util.function.Function<Core, String> key) {
+        if (!(e instanceof Core.PreservedCall call) || !SIZE_CALLS.contains(call.operation())
+                || call.args().size() != 1) {
             return null;
         }
         String arg = key.apply(sizeSource(call.args().get(0)));
-        return arg == null ? null : call.written() + "(" + arg + ")";
+        return arg == null ? null : call.operation().name() + "(" + arg + ")";
     }
 
     /** The container a size is really the size of: an operation that keeps the size of what it was
      * built from is peeled away, so {@code List.length(List.map(f, xs))} is the atom
      * {@code List.length(xs)}. How the elements are made has no bearing on how many there are, which
      * is why the closure does not enter the key. */
-    private static Ast.Expr sizeSource(Ast.Expr e) {
-        if (e instanceof Ast.Apply call) {
-            Built built = BUILT_FROM.get(call.reaches());
+    private static Core sizeSource(Core e) {
+        if (e instanceof Core.PreservedCall call) {
+            Built built = BUILT_FROM.get(call.operation());
             if (built != null && built.shape().keepsSize() && built.from() < call.args().size()) {
                 return sizeSource(call.args().get(built.from()));
             }
@@ -1697,95 +1577,86 @@ public final class InvariantChecker {
         return e;
     }
 
-    /** What is known of the size of every container a clause names: never negative, and no greater
-     * than the size of what it was built from wherever the building can only drop elements. */
-    private void sizeFacts(Ast.Expr e, Bindings binds, List<Constraint> out) {
-        if (!(e instanceof Ast.Apply call)) {
-            Ast.forEachChild(e, child -> sizeFacts(child, binds, out));
+    /** What is known of the size of every container an expression names: never negative, and no
+     * greater than the size of what it was built from wherever the building can only drop elements. */
+    private void sizeFacts(Core e, Denotations at, List<Constraint> out) {
+        // A name is what it was given, here as everywhere: what is known of a size does not depend on
+        // whether the size was written where it is read or bound first.
+        if (e instanceof Core.Read r && at.valueOf(r.binding()) != null) {
+            sizeFacts(at.valueOf(r.binding()), at, out);
             return;
         }
-        if (SIZE_CALLS.contains(call.reaches()) && call.args().size() == 1) {
-            Named named = resolve(call.args().get(0), binds, true);
-            String atom = clauseSizeAtom(e, binds);
+        if (!(e instanceof Core.PreservedCall call)) {
+            Core.forEachChild(e, child -> sizeFacts(child, at, out));
+            return;
+        }
+        if (SIZE_CALLS.contains(call.operation()) && call.args().size() == 1) {
+            String atom = sizeAtom(call, arg -> bodyKey(arg, at));
             if (atom != null) {
                 out.add(new Constraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
-                bounds(call.written(), named.term(), named.key(), out);
+                bounds(call.operation(), sizeSource(call.args().get(0)), at, out);
             }
         }
-        for (Ast.Expr arg : call.args()) {
-            sizeFacts(arg, binds, out);
+        for (Core arg : call.args()) {
+            sizeFacts(arg, at, out);
         }
-    }
-
-    /** The same, over a body expression, where a term is only ever itself. */
-    private void sizeFacts(Ast.Expr e, Scope scope, List<Constraint> out) {
-        sizeFacts(e, Bindings.ofBody(x -> bodyKey(x, scope)), out);
     }
 
     /** {@code size(c) <= size(what c was built from)}, down the chain, wherever the building can only
      * drop elements. */
-    private void bounds(String sizeCall, Ast.Expr container, Function<Ast.Expr, String> key,
-                        List<Constraint> out) {
-        if (!(container instanceof Ast.Apply call)) {
+    private void bounds(ValueName sizeCall, Core container, Denotations at, List<Constraint> out) {
+        if (!(container instanceof Core.PreservedCall call)) {
             return;
         }
-        Built built = BUILT_FROM.get(call.reaches());
+        Built built = BUILT_FROM.get(call.operation());
         if (built == null || built.shape().keepsSize() || built.from() >= call.args().size()) {
             return;
         }
-        Ast.Expr source = sizeSource(call.args().get(built.from()));
-        String here = key.apply(container);
-        String there = key.apply(source);
+        Core source = sizeSource(call.args().get(built.from()));
+        String here = bodyKey(container, at);
+        String there = bodyKey(source, at);
         if (here == null || there == null) {
             return;
         }
         out.add(new Constraint(
-                LinearForm.atom(sizeCall + "(" + here + ")")
-                        .minus(LinearForm.atom(sizeCall + "(" + there + ")")),
+                LinearForm.atom(sizeCall.name() + "(" + here + ")")
+                        .minus(LinearForm.atom(sizeCall.name() + "(" + there + ")")),
                 Rel.LE));
-        bounds(sizeCall, source, key, out);
+        bounds(sizeCall, source, at, out);
     }
 
     /** The keys a guard could have settled to establish this clause: the predicate as written, and
      * the same predicate of each container the written one was built from by a construction that
      * carries it. Stating {@code List.all(p, xs)} is stating it of every sublist of {@code xs}. */
-    private List<String> factKeys(Ast.Expr inv, Bindings binds) {
-        String written = siteOf(binds).apply(inv);
+    private List<String> factKeys(Core inv, Denotations at) {
+        String written = bodyKey(inv, at);
         if (written == null) {
             return List.of();
         }
         List<String> keys = new ArrayList<>();
         keys.add(written);
-        if (!(inv instanceof Ast.Apply call)) {
+        if (!(inv instanceof Core.PreservedCall call)) {
             return keys;
         }
-        Carried carried = CARRIED.get(call.reaches());
+        Carried carried = CARRIED.get(call.operation());
         if (carried == null || carried.container() >= call.args().size()) {
             return keys;
         }
-        // The predicate over each container the one it names was built from — read at the site, so
-        // the operations the construction wrote are the ones peeled off. The peeled container is a
-        // term of the body, and the rest of the call is the clause's, so each is named by its own
-        // rule and the two meet in the key.
-        Named named = resolve(call.args().get(carried.container()), binds, false);
-        Ast.Expr container = named.term();
-        Ast.Apply stated = call;
-        while (container instanceof Ast.Apply inner) {
-            Built built = BUILT_FROM.get(inner.reaches());
+        // The predicate over each container the one it names was built from. The container is the
+        // construction's own expression, so the operations peeled off are the ones the body wrote.
+        Core container = call.args().get(carried.container());
+        Core.PreservedCall stated = call;
+        while (container instanceof Core.PreservedCall inner) {
+            Built built = BUILT_FROM.get(inner.operation());
             if (built == null || built.from() >= inner.args().size()) {
                 break;
             }
-            Ast.Apply next = carries(stated, carried, inner, built);
+            Core.PreservedCall next = carries(stated, carried, inner, built, at);
             if (next == null) {
                 break;
             }
-            Ast.Expr source = inner.args().get(built.from());
-            String inside = named.key().apply(source);
-            if (inside == null) {
-                break;
-            }
-            String key = termKey(next, spliced(call.args().get(carried.container()), inside, binds),
-                    Map.of(), 0);
+            Core source = inner.args().get(built.from());
+            String key = bodyKey(withArg(next, carried.container(), source), at);
             if (key == null) {
                 break;
             }
@@ -1802,22 +1673,25 @@ public final class InvariantChecker {
      * carries nothing on its own, but a predicate stated over a projection carries when the closure
      * copied that field across, over the field it came from.
      */
-    private Ast.Apply carries(Ast.Apply stated, Carried carried, Ast.Apply inner, Built built) {
+    private Core.PreservedCall carries(Core.PreservedCall stated, Carried carried,
+                                       Core.PreservedCall inner, Built built, Denotations at) {
         if (carried.through().contains(built.shape())) {
             return stated;
         }
-        Integer at = PROJECTION_OF.get(stated.reaches());
-        if (built.shape() != Shape.MAPS || at == null || at >= stated.args().size()) {
+        Integer projection = PROJECTION_OF.get(stated.operation());
+        if (built.shape() != Shape.MAPS || projection == null
+                || projection >= stated.args().size()) {
             return null;
         }
         // Where the mapping's closure is written is already stated once, by the table that says which
         // argument each combinator hands its elements to.
-        Combinator combo = COMBINATORS.get(inner.reaches());
+        Combinator combo = COMBINATORS.get(inner.operation());
         if (combo == null || combo.closureArg() >= inner.args().size()) {
             return null;
         }
-        Ast.Expr traced = projectionThrough(stated.args().get(at), inner.args().get(combo.closureArg()));
-        return traced == null ? null : withArg(stated, at, traced);
+        Core traced = projectionThrough(stated.args().get(projection),
+                inner.args().get(combo.closureArg()), at);
+        return traced == null ? null : withArg(stated, projection, traced);
     }
 
     /**
@@ -1828,28 +1702,34 @@ public final class InvariantChecker {
      * {@code .product} over {@code xs}: the closure copied that field across, so two mapped elements
      * differ there exactly when the two they came from did. Bounded deliberately — a field a closure
      * computes from others is not this.
+     *
+     * <p>What comes back is a projection to be keyed and nothing else. A block keys its parameter by
+     * where it is bound, so the chain built here is read at the position the closure's parameter
+     * stands in, whatever it is called and whatever it was read from.
      */
-    private Ast.Expr projectionThrough(Ast.Expr projection, Ast.Expr closure) {
-        if (!(projection instanceof Ast.Block proj) || proj.params().size() != 1
-                || !(closure instanceof Ast.Block step) || step.params().size() != 1) {
+    private Core projectionThrough(Core projection, Core closure, Denotations at) {
+        Core.Block proj = blockOf(projection, at);
+        Core.Block step = blockOf(closure, at);
+        if (proj == null || proj.params().size() != 1 || step == null
+                || step.params().size() != 1) {
             return null;
         }
         Ast.Binder element = step.params().get(0);
-        List<String> read = new Reads(proj.params().get(0).name()).chain(proj.body());
+        List<String> read = new Reads(proj.params().get(0).id()).chain(proj.body());
         if (read == null) {
             return null;
         }
-        Reads reads = new Reads(element.name());
-        Ast.Expr made = reads.produced(step.body());
+        Reads reads = new Reads(element.id());
+        Core made = reads.produced(step.body());
         List<String> traced;
         if (read.isEmpty()) {
             traced = reads.chain(made);   // the closure hands the element straight back
         } else {
-            if (!(made instanceof Ast.NewData nd) || !nd.spreads().isEmpty()) {
+            if (!(made instanceof Core.NewData nd) || !nd.spreads().isEmpty()) {
                 return null;
             }
             List<String> copied = null;
-            for (Ast.FieldInit fi : nd.inits()) {
+            for (Core.FieldInit fi : nd.inits()) {
                 if (fi.name().equals(read.get(0))) {
                     copied = reads.chain(fi.value());
                 }
@@ -1863,52 +1743,48 @@ public final class InvariantChecker {
         if (traced == null) {
             return null;
         }
-        Ast.Expr on = Ast.Var.local(element, step.pos());
+        Core on = read(element, elementType(step.type()), step.pos());
         for (String field : traced) {
-            on = new Ast.FieldAccess(on, field, step.pos());
+            on = new Core.FieldAccess(on, field, fieldType(on.type(), field), step.pos());
         }
-        return new Ast.Block(List.of(element), on, step.pos());
+        return new Core.Block(List.of(element), on, step.type(), step.pos());
     }
 
     /**
      * What the names in a closure read off the element it is handed: a field chain, or nothing this
      * trace can follow. A binding introduces what it reads <em>where it is written</em> — an expansion
-     * splices {@code let $0_r = r in ...} into a closure, and the closure may bind over its own
-     * parameter or over a name an earlier binding read — so what a name denotes is settled against the
-     * bindings before it and not reread later. Keeping the expression instead and substituting by
-     * spelling cannot say that: {@code let r = r} would stand for itself, which is the identity here
-     * and an endless walk there.
+     * splices {@code let $0_r = r in ...} into a closure — so what a name denotes is settled against
+     * the bindings before it and not reread later.
      */
     private static final class Reads {
 
-        private final String element;
-        private final Map<String, List<String>> chains = new HashMap<>();
+        private final BindingId element;
+        private final Map<BindingId, List<String>> chains = new HashMap<>();
 
-        private Reads(String element) {
+        private Reads(BindingId element) {
             this.element = element;
         }
 
         /** The expression the body produces, with what the bindings on the way there read taken in. */
-        Ast.Expr produced(Ast.Expr body) {
-            Ast.Expr cur = body;
-            while (cur instanceof Ast.LetIn li) {
-                List<String> read = chain(li.value());
-                chains.put(li.name(), read);
+        Core produced(Core body) {
+            Core cur = body;
+            while (cur instanceof Core.LetIn li) {
+                chains.put(li.binder().id(), chain(li.value()));
                 cur = li.body();
             }
             return cur;
         }
 
         /** The chain {@code e} reads off the element, or {@code null} if it reads anything else. */
-        List<String> chain(Ast.Expr e) {
+        List<String> chain(Core e) {
             return switch (e) {
-                case Ast.LetIn li -> {
+                case Core.LetIn li -> {
                     Reads inner = new Reads(element);
                     inner.chains.putAll(chains);
-                    inner.chains.put(li.name(), chain(li.value()));
+                    inner.chains.put(li.binder().id(), chain(li.value()));
                     yield inner.chain(li.body());
                 }
-                case Ast.FieldAccess fa -> {
+                case Core.FieldAccess fa -> {
                     List<String> head = chain(fa.target());
                     if (head == null) {
                         yield null;
@@ -1917,34 +1793,27 @@ public final class InvariantChecker {
                     out.add(fa.field());
                     yield out;
                 }
-                case Ast.Var v when chains.containsKey(v.name()) -> chains.get(v.name());
-                case Ast.Var v -> v.name().equals(element) ? List.of() : null;
+                case Core.Read r when chains.containsKey(r.binding()) -> chains.get(r.binding());
+                case Core.Read r -> r.binding().equals(element) ? List.of() : null;
                 default -> null;
             };
         }
     }
 
-    /** The clause's naming rule with one argument already named: what lets a key hold a term of the
-     * clause and a term of the body at once. */
-    private Function<Ast.Expr, String> spliced(Ast.Expr at, String named, Bindings binds) {
-        return e -> e == at ? named : invPath(e, binds);
-    }
-
-    private static Ast.Apply withArg(Ast.Apply call, int at, Ast.Expr arg) {
-        List<Ast.Expr> args = new ArrayList<>(call.args());
+    private static Core.PreservedCall withArg(Core.PreservedCall call, int at, Core arg) {
+        List<Core> args = new ArrayList<>(call.args());
         args.set(at, arg);
-        return call.withArgs(args);
+        return new Core.PreservedCall(call.operation(), args, call.type(), call.pos());
     }
 
     /** An emptiness check as the comparison it means, or {@code e} unchanged. */
-    private static Ast.Expr asSizeComparison(Ast.Expr e) {
-        if (e instanceof Ast.Apply call && call.args().size() == 1
-                && EMPTINESS.containsKey(call.reaches())) {
-            String sizeName = EMPTINESS.get(call.reaches());
-            Ast.Apply size = new Ast.Apply(sizeName, new souther.compiler.types.ValueName.Stdlib(sizeName), call.args(),
-                    call.origin(),
-                    call.pos());
-            return new Ast.Binary(Ast.BinOp.EQ, size, new Ast.IntLit(0, call.pos()), call.pos());
+    private static Core asSizeComparison(Core e) {
+        if (e instanceof Core.PreservedCall call && call.args().size() == 1
+                && EMPTINESS.containsKey(call.operation())) {
+            Core size = new Core.PreservedCall(EMPTINESS.get(call.operation()), call.args(),
+                    Type.INT, call.pos());
+            return new Core.Binary(Ast.BinOp.EQ, size, new Core.Int(0, Type.INT, call.pos()),
+                    Type.BOOL, call.pos());
         }
         return e;
     }
@@ -1954,60 +1823,55 @@ public final class InvariantChecker {
      * Two expressions with one key compute one value, which is the whole of what the fact set knows:
      * a guard and an invariant clause state the same predicate exactly when their calls key alike.
      *
-     * <p>A location is asked of {@code site} — the body's path rule, or the invariant's rule for what
-     * a field is being given — so the two sides meet on the construction's own names. A closure
-     * parameter is keyed by where it is bound rather than by its spelling, so {@code r -> r.a} and
-     * {@code row -> row.a} are one term while a free name inside the closure is still resolved
-     * through {@code site} and so is part of the term. Anything outside this grammar keys as
+     * <p>A location keys as the location it is, so which value a term is about is the binding it is
+     * rooted at. A closure parameter is keyed by where it is bound rather than by its binding, so
+     * {@code r -> r.a} and {@code row -> row.a} are one term while a free name inside the closure is
+     * still the value it is and so is part of the term. Anything outside this grammar keys as
      * {@code null}, and the clause reading it is left opaque.
      */
-    private String termKey(Ast.Expr raw, Function<Ast.Expr, String> site, Map<String, String> bound,
-                           int depth) {
-        Ast.Expr e = asOperator(raw);
-        String root = rootName(e);
+    private String termKey(Core raw, Denotations at, Map<BindingId, String> bound, int depth) {
+        Core e = asOperator(raw);
+        BindingId root = rootBinding(e);
         if (root != null) {
-            String at = bound.get(root);
-            return at != null ? chainOn(at, e) : site.apply(e);
-        }
-        String named = site.apply(e);
-        if (named != null) {
-            return named;   // a subterm the site has already named — see spliced
+            String here = bound.get(root);
+            return here != null ? chainOn(here, e) : pathKey(e, at);
         }
         return switch (e) {
-            case Ast.IntLit i -> Long.toString(i.value());
-            case Ast.DecimalLit d -> d.value().toPlainString() + "m";
-            case Ast.StringLit s -> quoted(s.value());
-            case Ast.BoolLit b -> Boolean.toString(b.value());
-            case Ast.Neg n -> wrap("-", termKey(n.operand(), site, bound, depth));
-            case Ast.Binary b -> {
-                String l = termKey(b.left(), site, bound, depth);
-                String r = termKey(b.right(), site, bound, depth);
+            case Core.Int i -> Long.toString(i.value());
+            case Core.Decimal d -> d.value().toPlainString() + "m";
+            case Core.Str s -> quoted(s.value());
+            case Core.Bool b -> Boolean.toString(b.value());
+            case Core.UnitValue u -> u.data().toString();
+            case Core.Neg n -> wrap("-", termKey(n.operand(), at, bound, depth));
+            case Core.Binary b -> {
+                String l = termKey(b.left(), at, bound, depth);
+                String r = termKey(b.right(), at, bound, depth);
                 yield l == null || r == null ? null : binaryKey(b.op(), l, r);
             }
-            case Ast.ListLit l -> elementsKey("[", l.elements(), site, bound, depth, "]");
-            case Ast.Tuple t -> elementsKey("(", t.elements(), site, bound, depth, ")");
-            case Ast.TupleGet g -> wrap("." + g.index(), termKey(g.tuple(), site, bound, depth));
-            case Ast.If iff -> elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
-                    site, bound, depth, ")");
-            case Ast.Block b -> {
-                Map<String, String> inner = binding(bound, b.paramNames(), depth);
-                yield wrap("\\" + b.params().size(), termKey(b.body(), site, inner, depth + 1));
+            case Core.ListLit l -> elementsKey("[", l.elements(), at, bound, depth, "]");
+            case Core.Tuple t -> elementsKey("(", t.elements(), at, bound, depth, ")");
+            case Core.TupleGet g -> wrap("." + g.index(), termKey(g.tuple(), at, bound, depth));
+            case Core.If iff -> elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
+                    at, bound, depth, ")");
+            case Core.Block b -> {
+                Map<BindingId, String> inner = binding(bound, b.params(), depth);
+                yield wrap("\\" + b.params().size(), termKey(b.body(), at, inner, depth + 1));
             }
-            case Ast.LetIn li -> {
-                String value = termKey(li.value(), site, bound, depth);
-                Map<String, String> inner = binding(bound, List.of(li.name()), depth);
-                String body = termKey(li.body(), site, inner, depth + 1);
+            case Core.LetIn li -> {
+                String value = termKey(li.value(), at, bound, depth);
+                Map<BindingId, String> inner = binding(bound, List.of(li.binder()), depth);
+                String body = termKey(li.body(), at, inner, depth + 1);
                 yield value == null || body == null ? null : "let(" + value + ", " + body + ")";
             }
             // A construction is a pure function of its fields, and a closure that builds one is what a
             // mapping usually is. Fields are keyed in name order, so two sites writing them in
             // different orders write one term.
-            case Ast.NewData nd when nd.spreads().isEmpty() -> {
-                List<Ast.FieldInit> inits = new ArrayList<>(nd.inits());
-                inits.sort(java.util.Comparator.comparing(Ast.FieldInit::name));
-                StringBuilder sb = new StringBuilder(nd.typeName().denotes().toString()).append('{');
+            case Core.NewData nd when nd.spreads().isEmpty() -> {
+                List<Core.FieldInit> inits = new ArrayList<>(nd.inits());
+                inits.sort(java.util.Comparator.comparing(Core.FieldInit::name));
+                StringBuilder sb = new StringBuilder(nd.typeName().toString()).append('{');
                 for (int i = 0; i < inits.size(); i++) {
-                    String v = termKey(inits.get(i).value(), site, bound, depth);
+                    String v = termKey(inits.get(i).value(), at, bound, depth);
                     if (v == null) {
                         yield null;
                     }
@@ -2015,28 +1879,30 @@ public final class InvariantChecker {
                 }
                 yield sb.append('}').toString();
             }
-            // Only the library's own functions: they are pure, so one written call is one value.
-            case Ast.Apply c when Prelude.isLibraryFunction(c.reaches()) ->
-                    elementsKey(c.reaches() + "(", c.args(), site, bound, depth, ")");
+            // Only the operations the representation kept standing: they are the library's own, so
+            // they are pure and one written call is one value.
+            case Core.PreservedCall c ->
+                    elementsKey(c.operation().name() + "(", c.args(), at, bound, depth, ")");
             default -> null;
         };
     }
 
-    /** {@code bound} with each of {@code names} keyed by where it is bound rather than by its
-     * spelling, so two expressions that differ only in what they called a binding are one term. */
-    private static Map<String, String> binding(Map<String, String> bound, List<String> names, int depth) {
-        Map<String, String> inner = new HashMap<>(bound);
-        for (int i = 0; i < names.size(); i++) {
-            inner.put(names.get(i), "#" + depth + "." + i);
+    /** {@code bound} with each of {@code binders} keyed by where it is bound rather than by which
+     * binding it is, so two expressions that differ only in what they bound are one term. */
+    private static Map<BindingId, String> binding(Map<BindingId, String> bound,
+                                                  List<Ast.Binder> binders, int depth) {
+        Map<BindingId, String> inner = new HashMap<>(bound);
+        for (int i = 0; i < binders.size(); i++) {
+            inner.put(binders.get(i).id(), "#" + depth + "." + i);
         }
         return inner;
     }
 
-    private String elementsKey(String open, List<Ast.Expr> parts, Function<Ast.Expr, String> site,
-                               Map<String, String> bound, int depth, String close) {
+    private String elementsKey(String open, List<Core> parts, Denotations at,
+                               Map<BindingId, String> bound, int depth, String close) {
         StringBuilder sb = new StringBuilder(open);
         for (int i = 0; i < parts.size(); i++) {
-            String part = termKey(parts.get(i), site, bound, depth);
+            String part = termKey(parts.get(i), at, bound, depth);
             if (part == null) {
                 return null;
             }
@@ -2078,26 +1944,51 @@ public final class InvariantChecker {
         return inner == null ? null : prefix + "(" + inner + ")";
     }
 
-    /** The name at the head of a {@code x}/{@code x.a.b} chain, or {@code null} if {@code e} is not one. */
-    private static String rootName(Ast.Expr e) {
+    /** The binding at the head of a {@code x}/{@code x.a.b} chain, or {@code null} if {@code e} is not
+     * one. */
+    private static BindingId rootBinding(Core e) {
         return switch (e) {
-            case Ast.Var v -> v.name();
-            case Ast.FieldAccess fa -> rootName(fa.target());
+            case Core.Read r -> r.binding();
+            case Core.FieldAccess fa -> rootBinding(fa.target());
             default -> null;
         };
     }
 
     /** The field chain of {@code e} rebuilt on {@code head}. */
-    private static String chainOn(String head, Ast.Expr e) {
-        return e instanceof Ast.FieldAccess fa ? chainOn(head, fa.target()) + "." + fa.field() : head;
+    private static String chainOn(String head, Core e) {
+        return e instanceof Core.FieldAccess fa ? chainOn(head, fa.target()) + "." + fa.field() : head;
     }
 
-    /** The location {@code e} is, or {@code null} where it is a computed value rather than a place.
-     * The same walk {@link #pathKey} makes, asking each name for a location instead of for whatever
-     * key it has — so a chain read off a computed value is computed too. */
-    private String locationKey(Ast.Expr e, Scope scope) {
-        return chainKey(e, scope,
-                name -> scope.denotes(name) instanceof Denotes.Location loc ? loc.key() : null);
+    /**
+     * The key of a chain rooted at a binding: the location it is, or, where the binding was given a
+     * term rather than a location, that term with the fields read from it.
+     *
+     * <p>A newtype's {@code .value} is the same location as the newtype, which is {@link Location}'s
+     * rule and is read here of a term too, so a value keyed one way through a binding and the other
+     * way through a field is one value.
+     */
+    private String pathKey(Core e, Denotations at) {
+        Location located = locationOf(e, at);
+        if (located != null) {
+            return located.toString();
+        }
+        return switch (e) {
+            case Core.Read r -> at.of(r.binding()).key();
+            case Core.FieldAccess fa -> {
+                if (!Location.isStep(fa.target().type(), fa.field(), symbols)) {
+                    yield pathKey(fa.target(), at);
+                }
+                String base = pathKey(fa.target(), at);
+                yield base == null ? null : base + "." + fa.field();
+            }
+            default -> null;
+        };
+    }
+
+    /** The location {@code e} is, or {@code null} where it is a computed value rather than a place. */
+    private Location locationOf(Core e, Denotations at) {
+        return Location.of(e, symbols,
+                binding -> at.of(binding) instanceof Denotes.At located ? located.where() : null);
     }
 
     /**
@@ -2106,23 +1997,22 @@ public final class InvariantChecker {
      * that decides it, so an expression answers the same whether it was written where it is used or
      * given a name first.
      */
-    private Denotes denotationOf(Ast.Expr e, Scope scope, Known k) {
-        Ast.Expr written = writtenValue(e, scope);
+    private Denotes denotationOf(Core e, Denotations at, Known k) {
+        Core written = writtenValue(e, at);
         if (written != null) {
-            return new Denotes.Written(bodyKey(written, scope), written);
+            return new Denotes.Written(bodyKey(written, at), written);
         }
-        String located = locationKey(e, scope);
+        Location located = locationOf(e, at);
         if (located != null) {
-            return new Denotes.Location(located);
+            return new Denotes.At(located);
         }
-        String term = bodyKey(e, scope);
+        String term = bodyKey(e, at);
         if (term == null) {
             return new Denotes.Nothing();
         }
         // Readable where there is something to say of it: a form the numeric domain built, or a rule
         // about how it was made. This is asked of the expression, so a name for it answers the same.
-        return new Denotes.Term(term,
-                affineOf(e, scope, k) != null || namedByRule(e, scope));
+        return new Denotes.Term(term, affineOf(e, at, k) != null || namedByRule(e, at));
     }
 
     /**
@@ -2136,7 +2026,7 @@ public final class InvariantChecker {
      */
     private static boolean readable(Denotes d, Known k) {
         return switch (d) {
-            case Denotes.Location _ -> true;
+            case Denotes.At _ -> true;
             case Denotes.Term term -> term.readable() || k.speaksOf(term.key());
             case Denotes.Written _, Denotes.Nothing _ -> false;
         };
@@ -2144,9 +2034,9 @@ public final class InvariantChecker {
 
     /** What {@code e} is written as, where it is a written value or a name given one — and
      * {@code null} where it is computed from anything. */
-    private Ast.Expr writtenValue(Ast.Expr e, Scope scope) {
-        if (e instanceof Ast.Var v) {
-            return scope.denotes(v.name()) instanceof Denotes.Written w ? w.value() : null;
+    private static Core writtenValue(Core e, Denotations at) {
+        if (e instanceof Core.Read r) {
+            return at.of(r.binding()) instanceof Denotes.Written w ? w.value() : null;
         }
         return isWritten(e) ? e : null;
     }
@@ -2157,27 +2047,29 @@ public final class InvariantChecker {
      * row of it is there to read — and there is no guard an author could add about it, which is what
      * naming it at a construction site would ask for.
      */
-    private static boolean isWritten(Ast.Expr e) {
+    private static boolean isWritten(Core e) {
         return isWritten(e, Set.of());
     }
 
     /** The same, where {@code written} names the bindings an expansion introduced for values that
      * were themselves written. A helper called on written arguments is a written value: what it
      * expands to binds each argument and reads it back, which is the source's own text moved. */
-    private static boolean isWritten(Ast.Expr e, Set<String> written) {
+    private static boolean isWritten(Core e, Set<BindingId> written) {
         return switch (e) {
-            case Ast.Expr lit when BinaryElaborator.isLiteralExpr(lit) -> true;
-            case Ast.Var v -> written.contains(v.name());
-            case Ast.ListLit list -> list.elements().stream().allMatch(x -> isWritten(x, written));
-            case Ast.Tuple t -> t.elements().stream().allMatch(x -> isWritten(x, written));
-            case Ast.NewData nd -> nd.spreads().isEmpty()
+            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.UnitValue _ -> true;
+            case Core.Neg n -> isWritten(n.operand(), written);
+            case Core.Read r -> written.contains(r.binding());
+            case Core.ListLit list -> list.elements().stream().allMatch(x -> isWritten(x, written));
+            case Core.Tuple t -> t.elements().stream().allMatch(x -> isWritten(x, written));
+            case Core.OptionSome s -> isWritten(s.value(), written);
+            case Core.NewData nd -> nd.spreads().isEmpty()
                     && nd.inits().stream().allMatch(fi -> isWritten(fi.value(), written));
-            case Ast.LetIn li -> {
+            case Core.LetIn li -> {
                 if (!isWritten(li.value(), written)) {
                     yield false;
                 }
-                Set<String> inner = new HashSet<>(written);
-                inner.add(li.name());
+                Set<BindingId> inner = new HashSet<>(written);
+                inner.add(li.binder().id());
                 yield isWritten(li.body(), inner);
             }
             default -> false;
@@ -2186,13 +2078,13 @@ public final class InvariantChecker {
 
     /** Whether {@code e} is a container built by an operation the preservation table covers, over an
      * argument that is itself named. */
-    private boolean builtByRule(Ast.Expr e, Scope scope) {
-        if (!(e instanceof Ast.Apply call)) {
+    private boolean builtByRule(Core e, Denotations at) {
+        if (!(e instanceof Core.PreservedCall call)) {
             return false;
         }
-        Built built = BUILT_FROM.get(call.reaches());
+        Built built = BUILT_FROM.get(call.operation());
         return built != null && built.from() < call.args().size()
-                && namedByRule(call.args().get(built.from()), scope);
+                && namedByRule(call.args().get(built.from()), at);
     }
 
     /**
@@ -2202,67 +2094,106 @@ public final class InvariantChecker {
      * the check has no rule about is not, and neither is anything built from one: nothing follows from
      * naming it, and its construction is left to the run-time check.
      */
-    private boolean namedByRule(Ast.Expr e, Scope scope) {
-        if (locationKey(e, scope) != null) {
+    private boolean namedByRule(Core e, Denotations at) {
+        if (locationOf(e, at) != null) {
             return true;
         }
-        if (e instanceof Ast.Var v) {
-            return scope.denotes(v.name()) instanceof Denotes.Term t && t.readable();
+        if (e instanceof Core.Read r) {
+            return at.of(r.binding()) instanceof Denotes.Term t && t.readable();
         }
-        Ast.Expr read = asOperator(e);
-        if (read instanceof Ast.Apply call && !readsAsATerm(call)) {
-            return builtByRule(read, scope);
+        Core read = asOperator(e);
+        if (read instanceof Core.PreservedCall call && !readsAsATerm(call)) {
+            return builtByRule(read, at);
+        }
+        // A call the representation did not keep standing answers something this check has no rule
+        // about, whatever the operation behind it was.
+        if (read instanceof Core.Call || read instanceof Core.Apply) {
+            return false;
         }
         // Arithmetic is the numeric domain's to name. Where the domain builds a form, that form is
         // what a clause is read against; where it declines to — a variable product, an integer divide
         // — declining is a decision about what this check reasons over, and reporting a construction
         // it has decided not to reason over would be reporting the decision as the author's to fix.
-        if (read instanceof Ast.Binary bin && isArith(bin.op())) {
+        if (read instanceof Core.Binary bin && isArith(bin.op())) {
             return false;
         }
         // A conditional is one of its branches and which one is not decided here. Saying only that it
         // is that term reports every construction over one, including where both branches satisfy the
         // clause. Reading it is checking the construction on each branch under its own condition,
         // which this walk does not do, so it is not named until it does.
-        if (read instanceof Ast.If) {
+        if (read instanceof Core.If) {
             return false;
         }
         boolean[] all = {true};
         // A closure is not part of what names the value: the tables are rules about how many elements
         // there are and where they came from, and how each one is made has no bearing on either.
-        Ast.forEachChild(read, child -> all[0] = all[0]
-                && (child instanceof Ast.Block || namedByRule(child, scope)));
+        Core.forEachChild(read, child -> all[0] = all[0]
+                && (child instanceof Core.Block || namedByRule(child, at)));
         return all[0];
     }
 
     /** Whether the check has a rule about what a call answers, rather than only about how to render it. */
-    private static boolean readsAsATerm(Ast.Apply call) {
-        return SIZE_CALLS.contains(call.reaches()) || BUILT_FROM.containsKey(call.reaches())
-                || CARRIED.containsKey(call.reaches()) || QUANTIFIERS.contains(call.reaches())
-                || "Bool.not".equals(call.reaches());
+    private static boolean readsAsATerm(Core.PreservedCall call) {
+        return SIZE_CALLS.contains(call.operation()) || BUILT_FROM.containsKey(call.operation())
+                || CARRIED.containsKey(call.operation()) || QUANTIFIERS.contains(call.operation())
+                || call.operation().equals(op("Bool.not"));
     }
 
-    private String pathKey(Ast.Expr e, Scope scope) {
-        // a name given a location is that location, as a newtype's `.value` is its own
-        return chainKey(e, scope, scope::keyOf);
-    }
+    // --- what the two representations share ----------------------------------------------------
 
-    /** The key of a {@code x}/{@code x.a.b} chain, with {@code ofName} saying what the name at its
-     * head is. A newtype's {@code .value} is the same location as the newtype, which is the one rule
-     * this walk carries and the reason there is one walk rather than one per caller. */
-    private String chainKey(Ast.Expr e, Scope scope, Function<String, String> ofName) {
+    /**
+     * {@code e} as the value it is written as, for the one reader that is defined over written values:
+     * the constant folder. A value written out is the same value in either representation, so this is
+     * a rendering and not a second tree — everything computed answers with nothing, and the fold then
+     * has nothing to fold.
+     */
+    private static Ast.Expr asWrittenValue(Core e) {
         return switch (e) {
-            case Ast.Var v -> ofName.apply(v.name());
-            case Ast.FieldAccess fa -> {
-                Type owner = typeExpr(fa.target(), scope);
-                if (fa.field().equals("value") && TypeOps.isSingleValueNewtype(owner, symbols)) {
-                    yield chainKey(fa.target(), scope, ofName);
-                }
-                String base = chainKey(fa.target(), scope, ofName);
-                yield base == null ? null : base + "." + fa.field();
+            case Core.Int i -> new Ast.IntLit(i.value(), i.pos());
+            case Core.Decimal d -> new Ast.DecimalLit(d.value(), d.pos());
+            case Core.Str s -> new Ast.StringLit(s.value(), s.pos());
+            case Core.Bool b -> new Ast.BoolLit(b.value(), b.pos());
+            case Core.Neg n -> {
+                Ast.Expr operand = asWrittenValue(n.operand());
+                yield operand == null ? null : new Ast.Neg(operand, n.pos());
             }
-            default -> null;
+            case Core.Binary b -> {
+                Ast.Expr left = asWrittenValue(b.left());
+                Ast.Expr right = asWrittenValue(b.right());
+                yield left == null || right == null ? null
+                        : new Ast.Binary(b.op(), left, right, b.pos());
+            }
+            case Core.PreservedCall call -> {
+                List<Ast.Expr> args = new ArrayList<>();
+                for (Core arg : call.args()) {
+                    Ast.Expr written = asWrittenValue(arg);
+                    if (written == null) {
+                        yield null;
+                    }
+                    args.add(written);
+                }
+                yield new Ast.Apply(call.operation().name(), call.operation(), args,
+                        ConstructionOrigin.own(), call.pos());
+            }
+            case null, default -> null;
         };
+    }
+
+    // --- helpers -------------------------------------------------------------------------------
+
+    /** A read of {@code binder}, as the expression naming the value it holds. */
+    private static Core.Read read(Ast.Binder binder, Type type, SourcePos pos) {
+        return new Core.Read(binder.name(), binder.id(), type, pos);
+    }
+
+    /** The block {@code e} is, following a name given one: a lambda handed to an operation the
+     * representation keeps standing is never applied here, so it is bound to a name like any other
+     * value and reaches the call as that name. */
+    private static Core.Block blockOf(Core e, Denotations at) {
+        if (e instanceof Core.Block b) {
+            return b;
+        }
+        return e instanceof Core.Read r && at.valueOf(r.binding()) instanceof Core.Block b ? b : null;
     }
 
     /** What {@code data}'s fields are, remembered. */
@@ -2270,78 +2201,21 @@ public final class InvariantChecker {
         return fieldsOf.computeIfAbsent(data, d -> TypeOps.fieldTypes(d, symbols));
     }
 
-    /** What is known after a binding takes over {@code name}: everything that mentioned it is dropped,
-     * because the name now denotes something else. The test is on the key's text and errs towards
-     * dropping — a term that merely reads like it mentions the name loses a fact it could have kept,
-     * which costs precision and never soundness. */
-    private static Known rebind(Known k, String name) {
-        return k.forgetIf(key -> mentions(key, name));
+    /** Which binding each of {@code data}'s fields is, remembered. */
+    private Map<String, BindingId> fieldBindingsOf(Ast.Data data) {
+        return fieldBindings.computeIfAbsent(data, d -> TypeOps.fieldBindings(d, symbols));
     }
 
-    /** Whether {@code key} contains {@code name} as a whole identifier. */
-    private static boolean mentions(String key, String name) {
-        for (int i = key.indexOf(name); i >= 0; i = key.indexOf(name, i + 1)) {
-            int end = i + name.length();
-            boolean left = i == 0 || !Character.isUnicodeIdentifierPart(key.charAt(i - 1));
-            boolean right = end == key.length() || !Character.isUnicodeIdentifierPart(key.charAt(end));
-            if (left && right) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    // --- a minimal local typer (enough for atom/affine detection) ------------------------------
-
-    private Type typeExpr(Ast.Expr raw, Scope scope) {
-        Ast.Expr e = asOperator(raw);
-        return switch (e) {
-            case Ast.IntLit _ -> Type.INT;
-            case Ast.DecimalLit _ -> Type.DECIMAL;
-            case Ast.Var v -> scope.typeOf(v.name());
-            case Ast.FieldAccess fa -> {
-                Type owner = typeExpr(fa.target(), scope);
-                yield owner instanceof Type.Ref r && symbols.get(r.name()) instanceof Ast.Data d
-                        ? fieldsOf(d).get(fa.field()) : null;
-            }
-            case Ast.NewData nd -> Type.ref(nd.typeName().denotes());
-            case Ast.LetIn li -> {
-                Type bound = typeExpr(li.value(), scope);
-                yield typeExpr(li.body(),
-                        scope.binding(li.name(), bound, denotationOf(li.value(), scope, Known.top())));
-            }
-            case Ast.Neg n -> typeExpr(n.operand(), scope);
-            // The library says what its own calls answer, so this typer asks it rather than listing
-            // the ones it has needed so far. Without a type a name bound to a call is not the atom
-            // the expression it was given is.
-            case Ast.Apply call when Prelude.entry(call.reaches()) != null ->
-                    Prelude.entry(call.reaches()).signature().result();
-            case Ast.Binary b when isArith(b.op()) -> arithType(b, scope);
-            default -> null;
-        };
-    }
-
-    /** The result type of an arithmetic binary: the newtype for closed {@code +}/{@code -}
-     * (via the checker's shared rule), else the numeric base, else {@code null}. */
-    private Type arithType(Ast.Binary b, Scope scope) {
-        Type lt = typeExpr(b.left(), scope);
-        Type rt = typeExpr(b.right(), scope);
-        // Closed `+`/`-` and scalar `*`/`/` both yield the newtype (the checker has already validated
-        // admissibility, so a newtype operand here means the result is that newtype).
-        if (isArith(b.op())) {
-            Type nt = TypeOps.closedNewtypeArithResult(lt, rt, symbols);
-            if (nt != null) {
-                return nt;
-            }
-        }
-        if (lt == Type.INT || lt == Type.DECIMAL) {
-            return lt;
-        }
-        return rt == Type.INT || rt == Type.DECIMAL ? rt : null;
+    /** The type of {@code field} read from {@code owner}, or null where that is not a field of a
+     * declaration this module can see. */
+    private Type fieldType(Type owner, String field) {
+        return owner instanceof Type.Ref r && symbols.get(r.name()) instanceof Ast.Data data
+                ? fieldsOf(data).get(field) : null;
     }
 
     /** What a container hands its closure: a list's or set's element, a map's value (the key is the
-     * other closure parameter and is not the one the table credits), an option's payload. */
+     * other closure parameter and is not the one the table credits), an option's payload, and a
+     * function's first parameter where what is held is the closure itself. */
     private static Type elementType(Type t) {
         if (t instanceof Type.ListOf list) {
             return list.element();
@@ -2355,6 +2229,9 @@ public final class InvariantChecker {
         if (t instanceof Type.OptionOf opt) {
             return opt.element();
         }
+        if (t instanceof Type.FnOf fn && !fn.params().isEmpty()) {
+            return fn.params().get(0);
+        }
         return null;
     }
 
@@ -2365,8 +2242,6 @@ public final class InvariantChecker {
     private boolean isNumeric(Type t) {
         return t == Type.INT || t == Type.DECIMAL || numericNewtype(t);
     }
-
-    // --- helpers -------------------------------------------------------------------------------
 
     private static boolean isArith(Ast.BinOp op) {
         return op == Ast.BinOp.ADD || op == Ast.BinOp.SUB || op == Ast.BinOp.MUL || op == Ast.BinOp.DIV;

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1,9 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
-import souther.compiler.check.DischargeRules.Built;
 import souther.compiler.check.DischargeRules.Combinator;
-import souther.compiler.check.DischargeRules.Shape;
 import souther.compiler.check.NumericDomain.LinearForm;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
@@ -16,7 +14,6 @@ import souther.compiler.types.TypeName;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
@@ -27,8 +24,7 @@ import java.util.Set;
 
 /**
  * The intraprocedural invariant-discharge check (spec §invariant-discharge). It walks a behavior's
- * body threading what the guards have settled — a {@link NumericDomain} of relations and a
- * {@link PredicateFacts} of everything that states no relation — seeded from the input types'
+ * body threading what the guards have settled ({@link Known}), seeded from the input types'
  * invariants and refined along each {@code guard}/{@code if} guard (a {@code guard} is already an
  * {@code if} here). At every construction whose invariant it can carry, it asks whether the guards
  * <em>discharge</em> it. A construction proven to violate its invariant on a reachable path is a
@@ -78,11 +74,10 @@ public final class InvariantChecker {
      * protecting against so much as what it declines to spend the time on. */
     private static final int BRANCHES_OPENED = 3;
 
-    /** The operations the combinator table has a rule for, for the test that holds it to being
-     * reachable. */
-    static Set<String> combinatorNames() {
-        return DischargeRules.combinatorNames();
-    }
+    /** How far into a value's fields the seeding reads. A type's own invariant is what its fields
+     * guarantee, and a field's type carries its own; past a couple of levels what a clause could be
+     * read against is a value the body would have had to name, and it names it by reading it. */
+    private static final int FIELDS_SEEDED = 2;
 
     private final Symbols symbols;
     /** The declarations' invariants, typed where they are declared and read where a value is built. */
@@ -99,7 +94,7 @@ public final class InvariantChecker {
         this.symbols = symbols;
         this.clauses = new Clauses(symbols, dischargeInvariants);
         this.terms = new Terms(symbols);
-        this.predicates = new Predicates(terms, clauses);
+        this.predicates = new Predicates(terms);
     }
 
     /**
@@ -160,7 +155,7 @@ public final class InvariantChecker {
         if (found[0] != null) {
             return found[0];
         }
-        return terms.termKey(e, Denotations.none(), Map.of(), 0) == null ? e : null;
+        return terms.bodyKey(e, Denotations.none()) == null ? e : null;
     }
 
     /**
@@ -197,10 +192,10 @@ public final class InvariantChecker {
             // and what the two readings find is said once. Every place a conditional can be given —
             // to a field, to a name, to a guard — is this one place.
             walk(value.cond(), k, at, depth);
-            String same = terms.bodyKey(value, at);
-            say(reading(without(e, value, same, value.then(), at),
+            Set<Core> alike = sameConditional(e, value, at);
+            say(reading(without(e, alike, value.then()),
                             predicates.assumeCond(value.cond(), k, at, true), at, depth),
-                    reading(without(e, value, same, value.els(), at),
+                    reading(without(e, alike, value.els()),
                             predicates.assumeCond(value.cond(), k, at, false), at, depth));
             return;
         }
@@ -277,7 +272,7 @@ public final class InvariantChecker {
                 Type elem = Terms.elementType(container.type());
                 // The container is read where the call is written, so what is known of its elements
                 // is looked up before the closure's parameter stands for anything.
-                List<Quantified> relations = elementRelations(container, k, at);
+                List<Quantified> relations = predicates.elementRelations(container, k, at);
                 Core element = Terms.read(step.params().get(combo.elementParam()), elem, step.pos());
                 // an element of a container is not a location the body can otherwise name
                 Known k2 = seedAt(element, k, at, 0);   // the element carries its type's invariant
@@ -288,33 +283,6 @@ public final class InvariantChecker {
             } else {
                 walk(arg, k, at, depth);
             }
-        }
-    }
-
-    /** The relations known of every element of {@code container}: those stated of it as written, and
-     * those stated of a container it was built from that travel every construction in between. */
-    private List<Quantified> elementRelations(Core container, Known k, Denotations at) {
-        List<Quantified> found = new ArrayList<>();
-        Set<Shape> crossed = EnumSet.noneOf(Shape.class);
-        Core source = container;
-        while (true) {
-            String key = terms.bodyKey(source, at);
-            if (key != null) {
-                for (Quantified q : k.quantified()) {
-                    if (key.equals(q.container()) && q.through().containsAll(crossed)) {
-                        found.add(q);
-                    }
-                }
-            }
-            if (!(source instanceof Core.PreservedCall call)) {
-                return found;
-            }
-            Built built = DischargeRules.builtFrom(call.operation());
-            if (built == null || built.from() >= call.args().size()) {
-                return found;
-            }
-            crossed.add(built.shape());
-            source = call.args().get(built.from());
         }
     }
 
@@ -403,22 +371,16 @@ public final class InvariantChecker {
      * {@code given}. */
     private Verdict verdictOf(TypeName named, Ast.Data type, Map<BindingId, Core> given, Known k,
                               Denotations at, boolean decidesFalse) {
-        List<Ast.InvariantClause> invs = clauses.of(named, type);
-        if (invs.isEmpty()) {
-            return Verdict.PROVED;
-        }
         // What the construction hands over that no clause may be read against. A clause naming one of
         // them is left to the run-time check, and one that is decided outright is still decided: what
         // cannot be guarded is not the same as what cannot be computed.
         Set<Core> unnamed = unnamed(given.values(), k, at);
         List<Predicates.Clause> owed = new ArrayList<>();
-        for (Ast.InvariantClause inv : invs) {
-            // A newtype construction from a value written out is the constant check's to report: it
-            // names the clause that failed. It reads the construction as written, so a name given the
-            // value is not one it sees, and this check says it instead.
-            Core stated = clauses.statedAt(inv.expr(), type, given);
-            List<Predicates.Clause> o = stated == null ? null
-                    : predicates.obligations(stated, k, at, unnamed, decidesFalse);
+        // A newtype construction from a value written out is the constant check's to report: it names
+        // the clause that failed. It reads the construction as written, so a name given the value is
+        // not one it sees, and this check says it instead — which is what `decidesFalse` carries.
+        for (Core stated : clauses.statedAt(named, type, given)) {
+            List<Predicates.Clause> o = predicates.obligations(stated, k, at, unnamed, decidesFalse);
             if (o != null) {
                 owed.addAll(o);
             }
@@ -587,21 +549,42 @@ public final class InvariantChecker {
      * once to guard on and once to build from — wrote one value, and reading the two as two would
      * make the guard say nothing about what is built.
      */
-    private Core without(Core e, Core.If was, String key, Core becomes, Denotations at) {
-        if (e == was || (key != null && e instanceof Core.If && key.equals(terms.bodyKey(e, at)))) {
+    private Core without(Core e, Set<Core> was, Core becomes) {
+        if (was.contains(e)) {
             return becomes;
         }
         if (e instanceof Core.Block) {
             return e;
         }
-        Core made = Core.mapChildren(e, child -> without(child, was, key, becomes, at),
-                name -> name,
-                nd -> (Core.NewData) Core.mapChildren(nd,
-                        child -> without(child, was, key, becomes, at), name -> name));
+        Core made = Core.mapAll(e, child -> without(child, was, becomes), name -> name);
         if (made != e) {
             rebuilt.put(made, e);
         }
         return made;
+    }
+
+    /** Every conditional in {@code e} that computes what {@code value} computes, {@code value}
+     * included. Asked once for the two readings, since which nodes those are does not depend on which
+     * branch is being read. */
+    private Set<Core> sameConditional(Core e, Core.If value, Denotations at) {
+        Set<Core> alike = Collections.newSetFromMap(new IdentityHashMap<>());
+        alike.add(value);
+        String key = terms.bodyKey(value, at);
+        if (key != null) {
+            collectAlike(e, key, at, alike);
+        }
+        return alike;
+    }
+
+    private void collectAlike(Core e, String key, Denotations at, Set<Core> alike) {
+        if (e instanceof Core.Block) {
+            return;
+        }
+        if (e instanceof Core.If && key.equals(terms.bodyKey(e, at))) {
+            alike.add(e);
+            return;
+        }
+        Core.forEachChild(e, child -> collectAlike(child, key, at, alike));
     }
 
     /** Says of each construction the two readings reached what the two of them together decide. One
@@ -631,8 +614,6 @@ public final class InvariantChecker {
                 "constructing `" + type.name() + "` here violates its invariant on a reachable path"));
     }
 
-    // --- invariant / condition -> constraints --------------------------------------------------
-
     // --- seeding -------------------------------------------------------------------------------
 
     /**
@@ -646,7 +627,7 @@ public final class InvariantChecker {
      * only in direction.
      */
     private Known seedAt(Core root, Known k, Denotations at, int depth) {
-        if (depth > 2 || !(root.type() instanceof Type.Ref ref)
+        if (depth > FIELDS_SEEDED || !(root.type() instanceof Type.Ref ref)
                 || !(symbols.get(ref.name()) instanceof Ast.Data data)) {
             return k;
         }
@@ -661,11 +642,7 @@ public final class InvariantChecker {
         });
         Known out = k;
         List<Quantified> quantified = new ArrayList<>();
-        for (Ast.InvariantClause inv : clauses.of(ref.name(), data)) {
-            Core stated = clauses.statedAt(inv.expr(), data, given);
-            if (stated == null) {
-                continue;
-            }
+        for (Core stated : clauses.statedAt(ref.name(), data, given)) {
             predicates.quantifiedBy(stated, at, true, quantified);
             out = predicates.assume(predicates.obligations(stated, out, at, false), out);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -6,9 +6,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/** What the guards have settled on the current path: numeric relations, predicates known to hold
- * or to fail, and relations known of every element of a container. Threaded functionally through
- * the walk, as the domain alone once was. */
+/** What the guards have settled on the current path: numeric relations, predicates known to hold or
+ * to fail, relations known of every element of a container, and the terms an assumption named — which
+ * is what makes a computed value one a clause may be read against. Threaded functionally through the
+ * walk, as the domain alone once was. */
 record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified,
                      Set<String> spoken) {
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -1,0 +1,55 @@
+package souther.compiler.check;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/** What the guards have settled on the current path: numeric relations, predicates known to hold
+ * or to fail, and relations known of every element of a container. Threaded functionally through
+ * the walk, as the domain alone once was. */
+record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified,
+                     Set<String> spoken) {
+
+    static Known top() {
+        return new Known(NumericDomain.top(), PredicateFacts.none(), List.of(), Set.of());
+    }
+
+    Known with(NumericDomain n) {
+        return new Known(n, facts, quantified, spoken);
+    }
+
+    Known with(PredicateFacts f) {
+        return new Known(numbers, f, quantified, spoken);
+    }
+
+    /**
+     * This, with each of {@code terms} recorded as one an assumption on this path named. It is
+     * recorded where the assumption is made rather than searched for afterwards: what a guard
+     * spoke about is known exactly then, and reading it back out of a domain would mean matching
+     * key text, which is how a term that merely reads like another gets mistaken for it.
+     */
+    Known speaking(Collection<String> terms) {
+        if (terms.isEmpty()) {
+            return this;
+        }
+        Set<String> all = new HashSet<>(spoken);
+        all.addAll(terms);
+        return new Known(numbers, facts, quantified, all);
+    }
+
+    /** Whether an assumption on this path named {@code term}. */
+    boolean speaksOf(String term) {
+        return spoken.contains(term);
+    }
+
+    Known and(List<Quantified> more) {
+        if (more.isEmpty()) {
+            return this;
+        }
+        List<Quantified> all = new ArrayList<>(quantified);
+        all.addAll(more);
+        return new Known(numbers, facts, List.copyOf(all), spoken);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Location.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Location.java
@@ -3,7 +3,6 @@ package souther.compiler.check;
 import souther.compiler.core.Core;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
-import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -24,18 +23,14 @@ import java.util.List;
  * dropping every fact that mentioned the name was the alternative, which drops facts that merely read
  * like they mention it.
  *
- * <p>A step carries the type it is read from, so a field is a field of something rather than a
- * spelling: two types may both declare {@code value}, and only one of them is the newtype whose
- * {@code value} is the newtype itself.
+ * <p>Which fields are steps is decided from what each is read from and not from how it is spelled
+ * ({@link #isStep}), so two types that both declare {@code value} keep their locations apart.
  */
-public record Location(BindingId root, List<Step> path) {
+public record Location(BindingId root, List<String> path) {
 
     public Location {
         path = List.copyOf(path);
     }
-
-    /** One field read, and the type it was read from. */
-    public record Step(TypeName owner, String field) {}
 
     public static Location of(BindingId root) {
         return new Location(root, List.of());
@@ -54,8 +49,8 @@ public record Location(BindingId root, List<Step> path) {
         if (!isStep(readFrom, field, symbols)) {
             return this;
         }
-        List<Step> longer = new ArrayList<>(path);
-        longer.add(new Step(readFrom instanceof Type.Ref r ? r.name() : null, field));
+        List<String> longer = new ArrayList<>(path);
+        longer.add(field);
         return new Location(root, longer);
     }
 
@@ -71,18 +66,12 @@ public record Location(BindingId root, List<Step> path) {
     }
 
     /**
-     * The location {@code e} names, or null where it names none.
+     * The location {@code e} names, or null where it names none, with {@code rooted} saying where a
+     * binding is.
      *
      * <p>A location is a binding and the fields read from it. Anything else — a call, an arithmetic
      * expression, a literal — is a value that was computed, and a computed value is not somewhere a
      * fact can be about.
-     */
-    public static Location of(Core e, Symbols symbols) {
-        return of(e, symbols, Location::of);
-    }
-
-    /**
-     * The same, where {@code rooted} says where a binding is.
      *
      * <p>A binding is the location it is unless it was given another one — a helper's parameter is
      * the argument it was handed, and a name given a field chain is that chain — so a reader that
@@ -104,8 +93,8 @@ public record Location(BindingId root, List<Step> path) {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(String.valueOf(root));
-        for (Step s : path) {
-            sb.append('.').append(s.field());
+        for (String field : path) {
+            sb.append('.').append(field);
         }
         return sb.toString();
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Location.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Location.java
@@ -51,12 +51,23 @@ public record Location(BindingId root, List<Step> path) {
      * ordinary data that happens to declare a field of that name keeps its two locations apart.
      */
     public Location then(Type readFrom, String field, Symbols symbols) {
-        if (field.equals("value") && TypeOps.isSingleValueNewtype(readFrom, symbols)) {
+        if (!isStep(readFrom, field, symbols)) {
             return this;
         }
         List<Step> longer = new ArrayList<>(path);
         longer.add(new Step(readFrom instanceof Type.Ref r ? r.name() : null, field));
         return new Location(root, longer);
+    }
+
+    /**
+     * Whether reading {@code field} from {@code readFrom} reaches somewhere else at all.
+     *
+     * <p>The rule above, asked on its own. A term this is read of is not a location — nothing binds
+     * it — and it is still the same value read the same two ways, so the rule is one and its two
+     * readers ask it here rather than each stating it.
+     */
+    public static boolean isStep(Type readFrom, String field, Symbols symbols) {
+        return !(field.equals("value") && TypeOps.isSingleValueNewtype(readFrom, symbols));
     }
 
     /**
@@ -67,10 +78,23 @@ public record Location(BindingId root, List<Step> path) {
      * fact can be about.
      */
     public static Location of(Core e, Symbols symbols) {
+        return of(e, symbols, Location::of);
+    }
+
+    /**
+     * The same, where {@code rooted} says where a binding is.
+     *
+     * <p>A binding is the location it is unless it was given another one — a helper's parameter is
+     * the argument it was handed, and a name given a field chain is that chain — so a reader that
+     * knows what its bindings were given answers with what they were given, and the rest of the walk
+     * is the same walk.
+     */
+    public static Location of(Core e, Symbols symbols,
+                              java.util.function.Function<BindingId, Location> rooted) {
         return switch (e) {
-            case Core.Read read -> of(read.binding());
+            case Core.Read read -> rooted.apply(read.binding());
             case Core.FieldAccess fa -> {
-                Location base = of(fa.target(), symbols);
+                Location base = of(fa.target(), symbols, rooted);
                 yield base == null ? null : base.then(fa.target().type(), fa.field(), symbols);
             }
             default -> null;

--- a/souther-compiler/src/main/java/souther/compiler/check/Location.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Location.java
@@ -1,0 +1,88 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Where a value is, as the thing itself rather than as the text that named it: the binding it is
+ * rooted at, and the fields read from there.
+ *
+ * <p>What a fact is about. Two facts are about one value when they are about one of these, and that
+ * is decided by the binding a name was answered with — not by the name. A body may bind {@code a}
+ * twice and mean two values; an expansion may write one body into another and carry a spelling that
+ * means something else where it landed. Neither is a question the text can answer, and both are
+ * settled here by construction, because a second binding is a second {@link BindingId} and the two
+ * are simply different locations.
+ *
+ * <p>So nothing has to be forgotten when a name is bound again. A fact about the old binding stays
+ * true of the old binding, and nothing reads it under the new one — where reading the key's text and
+ * dropping every fact that mentioned the name was the alternative, which drops facts that merely read
+ * like they mention it.
+ *
+ * <p>A step carries the type it is read from, so a field is a field of something rather than a
+ * spelling: two types may both declare {@code value}, and only one of them is the newtype whose
+ * {@code value} is the newtype itself.
+ */
+public record Location(BindingId root, List<Step> path) {
+
+    public Location {
+        path = List.copyOf(path);
+    }
+
+    /** One field read, and the type it was read from. */
+    public record Step(TypeName owner, String field) {}
+
+    public static Location of(BindingId root) {
+        return new Location(root, List.of());
+    }
+
+    /**
+     * This location with {@code field} read from it, or this location unchanged where the field is a
+     * transparent newtype's {@code value}.
+     *
+     * <p>{@code x} and {@code x.value} are one location when {@code x} is a newtype over a single
+     * value: the newtype is what it holds, so a guard on one is a guard on the other. Decided from
+     * what the field is read from rather than from the field being spelled {@code value}, so an
+     * ordinary data that happens to declare a field of that name keeps its two locations apart.
+     */
+    public Location then(Type readFrom, String field, Symbols symbols) {
+        if (field.equals("value") && TypeOps.isSingleValueNewtype(readFrom, symbols)) {
+            return this;
+        }
+        List<Step> longer = new ArrayList<>(path);
+        longer.add(new Step(readFrom instanceof Type.Ref r ? r.name() : null, field));
+        return new Location(root, longer);
+    }
+
+    /**
+     * The location {@code e} names, or null where it names none.
+     *
+     * <p>A location is a binding and the fields read from it. Anything else — a call, an arithmetic
+     * expression, a literal — is a value that was computed, and a computed value is not somewhere a
+     * fact can be about.
+     */
+    public static Location of(Core e, Symbols symbols) {
+        return switch (e) {
+            case Core.Read read -> of(read.binding());
+            case Core.FieldAccess fa -> {
+                Location base = of(fa.target(), symbols);
+                yield base == null ? null : base.then(fa.target().type(), fa.field(), symbols);
+            }
+            default -> null;
+        };
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder(String.valueOf(root));
+        for (Step s : path) {
+            sb.append('.').append(s.field());
+        }
+        return sb.toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -315,32 +315,28 @@ final class NumericDomain {
         return v == null ? null : v.negate();
     }
 
-    private NumericDomain forget(String atom) {
-        return forgetIf(atom::equals);
-    }
-
-    /** The domain with every fact about a matching atom dropped — what an assignment leaves behind of
+    /** The domain with every fact about {@code atom} dropped — what an assignment leaves behind of
      * what it assigns to. */
-    private NumericDomain forgetIf(java.util.function.Predicate<String> drop) {
+    private NumericDomain forget(String atom) {
         if (bottom) {
             return this;
         }
         Map<String, BigDecimal> nlo = new HashMap<>(lo);
         Map<String, BigDecimal> nhi = new HashMap<>(hi);
-        nlo.keySet().removeIf(drop);
-        nhi.keySet().removeIf(drop);
+        nlo.remove(atom);
+        nhi.remove(atom);
         Map<String, Map<String, BigDecimal>> nd = new HashMap<>();
         diff.forEach((a, row) -> {
-            if (!drop.test(a)) {
+            if (!a.equals(atom)) {
                 Map<String, BigDecimal> nr = new HashMap<>(row);
-                nr.keySet().removeIf(drop);
+                nr.remove(atom);
                 if (!nr.isEmpty()) {
                     nd.put(a, nr);
                 }
             }
         });
         List<Asserted> nk = new ArrayList<>(kept);
-        nk.removeIf(a -> a.f().coefs().keySet().stream().anyMatch(drop));
+        nk.removeIf(a -> a.f().coefs().containsKey(atom));
         return new NumericDomain(false, nlo, nhi, nd, List.copyOf(nk));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NumericDomain.java
@@ -319,10 +319,9 @@ final class NumericDomain {
         return forgetIf(atom::equals);
     }
 
-    /** The domain with every fact about a matching atom dropped. A binding that rebinds a name
-     * invalidates each atom rooted at it — the name now denotes something else — and the caller,
-     * which owns the atom-key syntax, decides which those are. */
-    NumericDomain forgetIf(java.util.function.Predicate<String> drop) {
+    /** The domain with every fact about a matching atom dropped — what an assignment leaves behind of
+     * what it assigns to. */
+    private NumericDomain forgetIf(java.util.function.Predicate<String> drop) {
         if (bottom) {
             return this;
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PredicateFacts.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.function.Predicate;
 
 /**
  * The predicates the guards have settled on the current path, each keyed by a canonical rendering of
@@ -59,15 +58,4 @@ final class PredicateFacts {
         return !bottom && (positive ? fails : holds).contains(key);
     }
 
-    /** The facts with every matching key dropped — what a binding that rebinds a name leaves behind. */
-    PredicateFacts forgetIf(Predicate<String> drop) {
-        if (bottom || (holds.stream().noneMatch(drop) && fails.stream().noneMatch(drop))) {
-            return this;
-        }
-        Set<String> h = new HashSet<>(holds);
-        Set<String> f = new HashSet<>(fails);
-        h.removeIf(drop);
-        f.removeIf(drop);
-        return new PredicateFacts(false, Set.copyOf(h), Set.copyOf(f));
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -15,6 +15,7 @@ import souther.compiler.types.ValueName;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -37,11 +38,36 @@ import java.util.Set;
 final class Predicates {
 
     private final Terms terms;
-    private final Clauses clauses;
 
-    Predicates(Terms terms, Clauses clauses) {
+    Predicates(Terms terms) {
         this.terms = terms;
-        this.clauses = clauses;
+    }
+
+    /** The relations known of every element of {@code container}: those stated of it as written, and
+     * those stated of a container it was built from that travel every construction in between. */
+    List<Quantified> elementRelations(Core container, Known k, Denotations at) {
+        List<Quantified> found = new ArrayList<>();
+        Set<Shape> crossed = EnumSet.noneOf(Shape.class);
+        Core source = container;
+        while (true) {
+            String key = terms.bodyKey(source, at);
+            if (key != null) {
+                for (Quantified q : k.quantified()) {
+                    if (key.equals(q.container()) && q.through().containsAll(crossed)) {
+                        found.add(q);
+                    }
+                }
+            }
+            if (!(source instanceof Core.PreservedCall call)) {
+                return found;
+            }
+            Built built = DischargeRules.builtFrom(call.operation());
+            if (built == null || built.from() >= call.args().size()) {
+                return found;
+            }
+            crossed.add(built.shape());
+            source = call.args().get(built.from());
+        }
     }
 
     /** What {@code q} says of the value at {@code element}, taken into {@code k}. The predicate is
@@ -157,7 +183,7 @@ final class Predicates {
      * elsewhere, and that check names the clause that failed rather than only saying one did, so it
      * is left to say it. */
     List<Clause> obligations(Core inv, Known k, Denotations at, boolean decidesFalse) {
-        return obligations(inv, k, at, Set.of(), decidesFalse);
+        return obligations(inv, k, at, Set.of(), true, decidesFalse);
     }
 
     /** The same, where {@code unnamed} holds the values the site hands over that no clause may be
@@ -212,7 +238,8 @@ final class Predicates {
         // A predicate over a value no guard could be written about is not a predicate a guard will
         // settle, so it is not owed as one — where the domain can say something of that value it has
         // already said it above, and where it cannot the run-time check stands for the clause.
-        List<String> keys = names(polar.expr(), unnamed) ? List.of() : factKeys(polar.expr(), at);
+        List<String> keys = !unnamed.isEmpty() && names(polar.expr(), unnamed)
+                ? List.of() : factKeys(polar.expr(), at);
         boolean stated = polar.positive();
         Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);
         if (numeric == null && fact == null) {
@@ -378,11 +405,12 @@ final class Predicates {
             Core.forEachChild(e, child -> sizeFacts(child, at, out));
             return;
         }
-        if (DischargeRules.isSize(call.operation()) && call.args().size() == 1) {
+        Core container = DischargeRules.sizeArgOf(call);
+        if (container != null) {
             String atom = Terms.sizeAtom(call, arg -> terms.bodyKey(arg, at));
             if (atom != null) {
                 out.add(new Constraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
-                bounds(call.operation(), DischargeRules.sizeSource(call.args().get(0)), at, out);
+                bounds(call.operation(), DischargeRules.sizeSource(container), at, out);
             }
         }
         for (Core arg : call.args()) {
@@ -407,8 +435,8 @@ final class Predicates {
             return;
         }
         out.add(new Constraint(
-                LinearForm.atom(sizeCall.name() + "(" + here + ")")
-                        .minus(LinearForm.atom(sizeCall.name() + "(" + there + ")")),
+                LinearForm.atom(Terms.sizeKey(sizeCall, here))
+                        .minus(LinearForm.atom(Terms.sizeKey(sizeCall, there))),
                 Rel.LE));
         bounds(sizeCall, source, at, out);
     }
@@ -533,7 +561,7 @@ final class Predicates {
         }
         Core on = Terms.read(element, Terms.elementType(step.type()), step.pos());
         for (String field : traced) {
-            on = new Core.FieldAccess(on, field, clauses.fieldType(on.type(), field), step.pos());
+            on = new Core.FieldAccess(on, field, terms.fieldType(on.type(), field), step.pos());
         }
         return new Core.Block(List.of(element), on, step.type(), step.pos());
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -1,0 +1,632 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.DischargeRules.Built;
+import souther.compiler.check.DischargeRules.Carried;
+import souther.compiler.check.DischargeRules.Combinator;
+import souther.compiler.check.DischargeRules.Shape;
+import souther.compiler.check.NumericDomain.LinearForm;
+import souther.compiler.check.NumericDomain.Rel;
+import souther.compiler.core.Core;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * How a predicate is read: what a clause owes where a value is built, what a guard settles where one
+ * is written, and the keys by which the two meet.
+ *
+ * <p>One language, read in two directions. An invariant clause and a guard are the same kind of
+ * expression, and a clause is discharged exactly when a guard has stated what it owes — so what a
+ * clause owes and what a guard establishes come out of one reading, differing only in which way it
+ * runs. Written apart, the two would drift, and every drift is a clause an author guarded and the
+ * check still reported.
+ *
+ * <p>Nothing here decides anything about a program. It answers what is owed and what is known, and
+ * the walk that threads {@link Known} is what asks.
+ */
+final class Predicates {
+
+    private final Terms terms;
+    private final Clauses clauses;
+
+    Predicates(Terms terms, Clauses clauses) {
+        this.terms = terms;
+        this.clauses = clauses;
+    }
+
+    /** What {@code q} says of the value at {@code element}, taken into {@code k}. The predicate is
+     * read again with the quantifier's own parameter standing for that element — the same reading the
+     * seeding does of a type's invariant, over the clause a quantifier holds. A relation the
+     * predicate in turn states of a container is recorded, so a container of containers reaches its
+     * innermost element. */
+    Known instantiate(Quantified q, Core element, Known k, Denotations at) {
+        Core stated = Clauses.substituted(q.predicate().body(),
+                Map.of(q.predicate().params().get(0).id(), element));
+        List<Quantified> nested = new ArrayList<>();
+        quantifiedBy(stated, at, true, nested);
+        return assume(obligations(stated, k, at, false), k).and(nested);
+    }
+
+    /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
+     * Mirrors {@link #obligations}: a conjunction states each of its sides, and a negation flips the
+     * polarity. Only a stated quantifier is recorded — denying one says some element fails the
+     * predicate, and which one is not something this check can name. */
+    void quantifiedBy(Core raw, Denotations at, boolean positive, List<Quantified> out) {
+        Core e = asSizeComparison(raw);
+        if (e instanceof Core.Binary b && b.op() == Ast.BinOp.AND && positive) {
+            quantifiedBy(b.left(), at, true, out);
+            quantifiedBy(b.right(), at, true, out);
+            return;
+        }
+        Core under = negated(e);
+        if (under != null) {
+            quantifiedBy(under, at, !positive, out);
+            return;
+        }
+        if (!positive || !(e instanceof Core.PreservedCall call)
+                || !DischargeRules.isQuantifier(call.operation())) {
+            return;
+        }
+        Combinator over = DischargeRules.combinator(call.operation());
+        Carried carried = DischargeRules.carried(call.operation());
+        if (over == null || carried == null || over.closureArg() >= call.args().size()
+                || over.listArg() >= call.args().size()) {
+            return;
+        }
+        Core.Block p = Terms.blockOf(call.args().get(over.closureArg()), at);
+        if (p == null || p.params().size() != 1) {
+            return;
+        }
+        String container = terms.bodyKey(call.args().get(over.listArg()), at);
+        if (container == null) {
+            return;
+        }
+        out.add(new Quantified(container, carried.through(), p));
+    }
+
+    /** Whether {@code e} is, or names, one of {@code values}. */
+    static boolean names(Core e, Set<Core> values) {
+        if (values.contains(e)) {
+            return true;
+        }
+        boolean[] found = {false};
+        Core.forEachChild(e, child -> found[0] = found[0] || names(child, values));
+        return found[0];
+    }
+
+    record Constraint(LinearForm form, Rel rel) {}
+
+    /**
+     * A predicate stated of a term. {@code keys} is the term as written first, then each container it
+     * was built from by a construction that carries the predicate — any one of them settled is this
+     * clause established. Refuting reads only the first: denying a predicate of a list says nothing
+     * about a list built from it. {@code positive} is false for a clause written under a negation,
+     * and such a clause carries nowhere, since the implication runs the other way.
+     */
+    record Fact(List<String> keys, boolean positive) {
+
+        boolean entailedBy(PredicateFacts facts) {
+            for (String key : keys) {
+                if (facts.entails(key, positive)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        boolean refutedBy(PredicateFacts facts) {
+            return facts.refutes(keys.get(0), positive);
+        }
+    }
+
+    /** A clause that cannot hold, said in the language the domain reads: {@code -1 >= 0}. */
+    static final Clause VIOLATED = new Clause(
+            new Constraint(LinearForm.constant(BigDecimal.ONE.negate()), Rel.GE), null, List.of());
+
+    /**
+     * One clause of an invariant, and the two ways it can come out: a relation for the domain to
+     * prove, and the key a guard restating it settles. Either may be absent, and where both are
+     * present either one discharging the clause is enough — a guard is written one way and a clause
+     * another, and which of the two routes carries it is not the author's concern.
+     */
+    record Clause(Constraint numeric, Fact fact, List<Constraint> known) {
+
+        boolean dischargedBy(NumericDomain d, PredicateFacts facts) {
+            return numeric != null && d.entails(numeric.form(), numeric.rel())
+                    || fact != null && fact.entailedBy(facts);
+        }
+
+        boolean refutedBy(NumericDomain d, PredicateFacts facts) {
+            return numeric != null && d.refutes(numeric.form(), numeric.rel())
+                    || fact != null && fact.refutedBy(facts);
+        }
+    }
+
+    /** What {@code inv} owes, where {@code decidesFalse} says a clause folding to the other answer
+     * than it is read with is this check's to report. A newtype's constant construction is checked
+     * elsewhere, and that check names the clause that failed rather than only saying one did, so it
+     * is left to say it. */
+    List<Clause> obligations(Core inv, Known k, Denotations at, boolean decidesFalse) {
+        return obligations(inv, k, at, Set.of(), decidesFalse);
+    }
+
+    /** The same, where {@code unnamed} holds the values the site hands over that no clause may be
+     * read against. */
+    List<Clause> obligations(Core inv, Known k, Denotations at, Set<Core> unnamed,
+                             boolean decidesFalse) {
+        return obligations(inv, k, at, unnamed, true, decidesFalse);
+    }
+
+    private List<Clause> obligations(Core rawInv, Known k, Denotations at, Set<Core> unnamed,
+                                     boolean positive, boolean decidesFalse) {
+        Core inv = asSizeComparison(rawInv);
+        if (inv instanceof Core.Binary b && b.op() == Ast.BinOp.AND && positive) {
+            // Each conjunct on its own: an invariant is a set of things that hold, and one the check
+            // cannot read leaves its own run-time check standing without costing the others theirs.
+            List<Clause> l = obligations(b.left(), k, at, unnamed, true, decidesFalse);
+            List<Clause> r = obligations(b.right(), k, at, unnamed, true, decidesFalse);
+            if (l == null && r == null) {
+                return null;
+            }
+            List<Clause> both = new ArrayList<>(l == null ? List.of() : l);
+            both.addAll(r == null ? List.of() : r);
+            return both;
+        }
+        Core under = negated(inv);
+        if (under != null) {
+            return obligations(under, k, at, unnamed, !positive, decidesFalse);
+        }
+        Boolean folded = decidedAt(inv);
+        if (folded != null) {
+            // The clause folds once the construction's own expressions stand where it read a field.
+            // Folding the way it is read owes nothing; folding the other way is a violation, and
+            // saying so needs no term to be named. Read under a denial it is the other answer that
+            // discharges, which is why the polarity is asked.
+            if (folded == positive) {
+                return List.of();
+            }
+            if (decidesFalse) {
+                return List.of(VIOLATED);
+            }
+        }
+        Constraint numeric = null;
+        if (inv instanceof Core.Binary b && relOf(b.op()) != null) {
+            Rel eff = positive ? relOf(b.op()) : negateRel(relOf(b.op()));
+            LinearForm la = eff == null ? null : terms.affineOf(b.left(), at, k);
+            LinearForm ra = eff == null ? null : terms.affineOf(b.right(), at, k);
+            if (la != null && ra != null) {
+                numeric = new Constraint(la.minus(ra), eff);
+            }
+        }
+        Polar polar = polar(inv, positive);
+        // A predicate over a value no guard could be written about is not a predicate a guard will
+        // settle, so it is not owed as one — where the domain can say something of that value it has
+        // already said it above, and where it cannot the run-time check stands for the clause.
+        List<String> keys = names(polar.expr(), unnamed) ? List.of() : factKeys(polar.expr(), at);
+        boolean stated = polar.positive();
+        Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);
+        if (numeric == null && fact == null) {
+            return null;
+        }
+        List<Constraint> known = new ArrayList<>();
+        sizeFacts(inv, at, known);
+        return List.of(new Clause(numeric, fact, known));
+    }
+
+    /** Whether {@code inv} is decided outright: the clause, with the construction's own values
+     * already standing where it read a field, folded. {@code null} where it does not fold — which is
+     * every clause reading anything computed at run time. */
+    Boolean decidedAt(Core inv) {
+        Object folded = Terms.folded(inv);
+        return folded instanceof Boolean b ? b : null;
+    }
+
+    static List<String> firstOnly(List<String> keys) {
+        return keys.isEmpty() ? keys : List.of(keys.get(0));
+    }
+
+    /** Refines {@code k} by asserting {@code cond} (or its negation): a comparison tightens the
+     * numeric domain, a stdlib predicate settles a fact. A condition of neither shape, and an operand
+     * outside the affine fragment, leave {@code k} unchanged (sound). */
+    Known assumeCond(Core rawCond, Known k, Denotations at, boolean positive) {
+        Core cond = asSizeComparison(rawCond);
+        // `&&` asserted true gives both sides; `||` asserted false gives both sides negated.
+        if (cond instanceof Core.Binary b
+                && (b.op() == Ast.BinOp.AND && positive || b.op() == Ast.BinOp.OR && !positive)) {
+            return assumeCond(b.right(), assumeCond(b.left(), k, at, positive), at, positive);
+        }
+        Core under = negated(cond);
+        if (under != null) {
+            return assumeCond(under, k, at, !positive);
+        }
+        Known out = k;
+        // What holds of the sizes the condition names, whichever way the condition itself is read.
+        List<Constraint> known = new ArrayList<>();
+        sizeFacts(cond, at, known);
+        for (Constraint c : known) {
+            out = out.with(out.numbers().assume(c.form(), c.rel()));
+        }
+        if (cond instanceof Core.Binary b) {
+            Rel rel = relOf(b.op());
+            Rel eff = rel == null ? null : positive ? rel : negateRel(rel);
+            LinearForm la = eff == null ? null : terms.affineOf(b.left(), at, out);
+            LinearForm ra = eff == null ? null : terms.affineOf(b.right(), at, out);
+            if (la != null && ra != null) {
+                out = out.with(out.numbers().assume(la.minus(ra), eff));
+            }
+            // What the comparison named, recorded as spoken about: a construction from one of these
+            // is one the author has said something about, whichever route ends up carrying it.
+            Set<String> named = new HashSet<>(spokenOf(b.left(), at, la));
+            named.addAll(spokenOf(b.right(), at, ra));
+            out = out.speaking(named);
+        }
+        List<Quantified> quantified = new ArrayList<>();
+        quantifiedBy(cond, at, positive, quantified);
+        out = out.and(quantified);
+        // Both routes, always: which one carries a clause is decided where the clause is read, and a
+        // guard does not know which that will be.
+        Polar polar = polar(cond, positive);
+        String key = terms.bodyKey(polar.expr(), at);
+        return key == null ? out : out.with(out.facts().assume(key, polar.positive()));
+    }
+
+    /** The terms one side of a compared pair names: the expression itself, and each atom of the form it
+     * reduced to — {@code leftover + 1} says something about {@code leftover}. */
+    Collection<String> spokenOf(Core side, Denotations at, LinearForm form) {
+        Set<String> named = new HashSet<>(form == null ? Set.of() : form.coefs().keySet());
+        String written = terms.bodyKey(side, at);
+        if (written != null) {
+            named.add(written);
+        }
+        return named;
+    }
+
+    /** A predicate as one of {@code ==}/{@code <} states it, and whether it is being stated or denied. */
+    record Polar(Core expr, boolean positive) {}
+
+    /**
+     * {@code e}, asserted with polarity {@code positive}, as the comparison of {@code ==} or {@code <}
+     * that says the same thing: {@code a /= b} is {@code a == b} denied, {@code a >= b} is
+     * {@code a < b} denied, and {@code a > b} is {@code b < a}. A fact is settled by key equality, so
+     * without this the six ways to compare two terms are six facts, and a guard written one way would
+     * leave a clause written the other unsettled.
+     */
+    static Polar polar(Core e, boolean positive) {
+        if (!(e instanceof Core.Binary b) || relOf(b.op()) == null) {
+            return new Polar(e, positive);
+        }
+        return switch (b.op()) {
+            case NE -> new Polar(comparison(Ast.BinOp.EQ, b.left(), b.right(), b), !positive);
+            case GE -> new Polar(comparison(Ast.BinOp.LT, b.left(), b.right(), b), !positive);
+            case GT -> new Polar(comparison(Ast.BinOp.LT, b.right(), b.left(), b), positive);
+            case LE -> new Polar(comparison(Ast.BinOp.LT, b.right(), b.left(), b), !positive);
+            default -> new Polar(e, positive);
+        };
+    }
+
+    static Core.Binary comparison(Ast.BinOp op, Core left, Core right, Core.Binary of) {
+        return new Core.Binary(op, left, right, of.type(), of.pos());
+    }
+
+    /** What a negation is applied to, or {@code null} if {@code e} is not one. {@code Bool.not} is an
+     * ordinary helper: the analysis representation keeps it as a call, and a clause read off an
+     * imported declaration is the body it expands to — {@code if b then false else true} over a
+     * binding holding the argument. Both are read. */
+    static Core negated(Core e) {
+        if (e instanceof Core.PreservedCall call && call.operation().equals(DischargeRules.NOT)
+                && call.args().size() == 1) {
+            return call.args().get(0);
+        }
+        if (e instanceof Core.LetIn li) {
+            Core inner = negated(li.body());
+            return inner instanceof Core.Read r && r.binding().equals(li.binder().id())
+                    ? li.value() : null;
+        }
+        return e instanceof Core.If iff
+                && iff.then() instanceof Core.Bool t && !t.value()
+                && iff.els() instanceof Core.Bool f && f.value()
+                ? iff.cond() : null;
+    }
+
+
+    /** {@code k} with everything {@code owed} states taken as holding. What a clause owes at a
+     * construction is what it guarantees where it is already established, so the two read the same
+     * clauses through the same rule and differ only in direction. */
+    Known assume(List<Clause> owed, Known k) {
+        if (owed == null) {
+            return k;
+        }
+        Known out = k;
+        for (Clause c : owed) {
+            for (Constraint known : c.known()) {
+                out = out.with(out.numbers().assume(known.form(), known.rel()));
+            }
+            if (c.numeric() != null) {
+                out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
+            }
+            if (c.fact() != null) {
+                // What is guaranteed is guaranteed of the term as written; a container built from it
+                // is another term, and reads the rules where it is constructed rather than here.
+                out = out.with(out.facts().assume(c.fact().keys().get(0), c.fact().positive()));
+            }
+        }
+        return out;
+    }
+
+    // --- affine forms --------------------------------------------------------------------------
+
+    /** What is known of the size of every container an expression names: never negative, and no
+     * greater than the size of what it was built from wherever the building can only drop elements. */
+    void sizeFacts(Core e, Denotations at, List<Constraint> out) {
+        // A name is what it was given, here as everywhere: what is known of a size does not depend on
+        // whether the size was written where it is read or bound first.
+        if (e instanceof Core.Read r && at.valueOf(r.binding()) != null) {
+            sizeFacts(at.valueOf(r.binding()), at, out);
+            return;
+        }
+        if (!(e instanceof Core.PreservedCall call)) {
+            Core.forEachChild(e, child -> sizeFacts(child, at, out));
+            return;
+        }
+        if (DischargeRules.isSize(call.operation()) && call.args().size() == 1) {
+            String atom = Terms.sizeAtom(call, arg -> terms.bodyKey(arg, at));
+            if (atom != null) {
+                out.add(new Constraint(LinearForm.atom(atom), Rel.GE));   // a size is never negative
+                bounds(call.operation(), DischargeRules.sizeSource(call.args().get(0)), at, out);
+            }
+        }
+        for (Core arg : call.args()) {
+            sizeFacts(arg, at, out);
+        }
+    }
+
+    /** {@code size(c) <= size(what c was built from)}, down the chain, wherever the building can only
+     * drop elements. */
+    void bounds(ValueName sizeCall, Core container, Denotations at, List<Constraint> out) {
+        if (!(container instanceof Core.PreservedCall call)) {
+            return;
+        }
+        Built built = DischargeRules.builtFrom(call.operation());
+        if (built == null || built.shape().keepsSize() || built.from() >= call.args().size()) {
+            return;
+        }
+        Core source = DischargeRules.sizeSource(call.args().get(built.from()));
+        String here = terms.bodyKey(container, at);
+        String there = terms.bodyKey(source, at);
+        if (here == null || there == null) {
+            return;
+        }
+        out.add(new Constraint(
+                LinearForm.atom(sizeCall.name() + "(" + here + ")")
+                        .minus(LinearForm.atom(sizeCall.name() + "(" + there + ")")),
+                Rel.LE));
+        bounds(sizeCall, source, at, out);
+    }
+
+    /** The keys a guard could have settled to establish this clause: the predicate as written, and
+     * the same predicate of each container the written one was built from by a construction that
+     * carries it. Stating {@code List.all(p, xs)} is stating it of every sublist of {@code xs}. */
+    List<String> factKeys(Core inv, Denotations at) {
+        String written = terms.bodyKey(inv, at);
+        if (written == null) {
+            return List.of();
+        }
+        List<String> keys = new ArrayList<>();
+        keys.add(written);
+        if (!(inv instanceof Core.PreservedCall call)) {
+            return keys;
+        }
+        Carried carried = DischargeRules.carried(call.operation());
+        if (carried == null || carried.container() >= call.args().size()) {
+            return keys;
+        }
+        // The predicate over each container the one it names was built from. The container is the
+        // construction's own expression, so the operations peeled off are the ones the body wrote.
+        Core container = call.args().get(carried.container());
+        Core.PreservedCall stated = call;
+        while (container instanceof Core.PreservedCall inner) {
+            Built built = DischargeRules.builtFrom(inner.operation());
+            if (built == null || built.from() >= inner.args().size()) {
+                break;
+            }
+            Core.PreservedCall next = carries(stated, carried, inner, built, at);
+            if (next == null) {
+                break;
+            }
+            Core source = inner.args().get(built.from());
+            String key = terms.bodyKey(withArg(next, carried.container(), source), at);
+            if (key == null) {
+                break;
+            }
+            keys.add(key);
+            stated = next;
+            container = source;
+        }
+        return keys;
+    }
+
+    /**
+     * The predicate as it applies to what {@code inner} was built from, or {@code null} when it does
+     * not apply there. A construction the shape carries leaves the predicate as it was. A mapping
+     * carries nothing on its own, but a predicate stated over a projection carries when the closure
+     * copied that field across, over the field it came from.
+     */
+    Core.PreservedCall carries(Core.PreservedCall stated, Carried carried,
+                                       Core.PreservedCall inner, Built built, Denotations at) {
+        if (carried.through().contains(built.shape())) {
+            return stated;
+        }
+        Integer projection = DischargeRules.projectionOf(stated.operation());
+        if (built.shape() != Shape.MAPS || projection == null
+                || projection >= stated.args().size()) {
+            return null;
+        }
+        // Where the mapping's closure is written is already stated once, by the table that says which
+        // argument each combinator hands its elements to.
+        Combinator combo = DischargeRules.combinator(inner.operation());
+        if (combo == null || combo.closureArg() >= inner.args().size()) {
+            return null;
+        }
+        Core traced = projectionThrough(stated.args().get(projection),
+                inner.args().get(combo.closureArg()), at);
+        return traced == null ? null : withArg(stated, projection, traced);
+    }
+
+    /**
+     * The projection over an element that a projection over a mapped list reduces to, or
+     * {@code null}.
+     *
+     * <p>{@code .product} over {@code List.map(r -> Line { product = r.product, ... }, xs)} is
+     * {@code .product} over {@code xs}: the closure copied that field across, so two mapped elements
+     * differ there exactly when the two they came from did. Bounded deliberately — a field a closure
+     * computes from others is not this.
+     *
+     * <p>What comes back is a projection to be keyed and nothing else. A block keys its parameter by
+     * where it is bound, so the chain built here is read at the position the closure's parameter
+     * stands in, whatever it is called and whatever it was read from.
+     */
+    Core projectionThrough(Core projection, Core closure, Denotations at) {
+        Core.Block proj = Terms.blockOf(projection, at);
+        Core.Block step = Terms.blockOf(closure, at);
+        if (proj == null || proj.params().size() != 1 || step == null
+                || step.params().size() != 1) {
+            return null;
+        }
+        Ast.Binder element = step.params().get(0);
+        List<String> read = new Reads(proj.params().get(0).id()).chain(proj.body());
+        if (read == null) {
+            return null;
+        }
+        Reads reads = new Reads(element.id());
+        Core made = reads.produced(step.body());
+        List<String> traced;
+        if (read.isEmpty()) {
+            traced = reads.chain(made);   // the closure hands the element straight back
+        } else {
+            if (!(made instanceof Core.NewData nd) || !nd.spreads().isEmpty()) {
+                return null;
+            }
+            List<String> copied = null;
+            for (Core.FieldInit fi : nd.inits()) {
+                if (fi.name().equals(read.get(0))) {
+                    copied = reads.chain(fi.value());
+                }
+            }
+            if (copied == null) {
+                return null;
+            }
+            traced = new ArrayList<>(copied);
+            traced.addAll(read.subList(1, read.size()));
+        }
+        if (traced == null) {
+            return null;
+        }
+        Core on = Terms.read(element, Terms.elementType(step.type()), step.pos());
+        for (String field : traced) {
+            on = new Core.FieldAccess(on, field, clauses.fieldType(on.type(), field), step.pos());
+        }
+        return new Core.Block(List.of(element), on, step.type(), step.pos());
+    }
+
+    /**
+     * What the names in a closure read off the element it is handed: a field chain, or nothing this
+     * trace can follow. A binding introduces what it reads <em>where it is written</em> — an expansion
+     * splices {@code let $0_r = r in ...} into a closure — so what a name denotes is settled against
+     * the bindings before it and not reread later.
+     */
+    private static final class Reads {
+
+        private final BindingId element;
+        private final Map<BindingId, List<String>> chains = new HashMap<>();
+
+        private Reads(BindingId element) {
+            this.element = element;
+        }
+
+        /** The expression the body produces, with what the bindings on the way there read taken in. */
+        Core produced(Core body) {
+            Core cur = body;
+            while (cur instanceof Core.LetIn li) {
+                chains.put(li.binder().id(), chain(li.value()));
+                cur = li.body();
+            }
+            return cur;
+        }
+
+        /** The chain {@code e} reads off the element, or {@code null} if it reads anything else. */
+        List<String> chain(Core e) {
+            return switch (e) {
+                case Core.LetIn li -> {
+                    Reads inner = new Reads(element);
+                    inner.chains.putAll(chains);
+                    inner.chains.put(li.binder().id(), chain(li.value()));
+                    yield inner.chain(li.body());
+                }
+                case Core.FieldAccess fa -> {
+                    List<String> head = chain(fa.target());
+                    if (head == null) {
+                        yield null;
+                    }
+                    List<String> out = new ArrayList<>(head);
+                    out.add(fa.field());
+                    yield out;
+                }
+                case Core.Read r when chains.containsKey(r.binding()) -> chains.get(r.binding());
+                case Core.Read r -> r.binding().equals(element) ? List.of() : null;
+                default -> null;
+            };
+        }
+    }
+
+    static Core.PreservedCall withArg(Core.PreservedCall call, int at, Core arg) {
+        List<Core> args = new ArrayList<>(call.args());
+        args.set(at, arg);
+        return new Core.PreservedCall(call.operation(), args, call.type(), call.pos());
+    }
+
+    /** An emptiness check as the comparison it means, or {@code e} unchanged. */
+    static Core asSizeComparison(Core e) {
+        if (e instanceof Core.PreservedCall call && call.args().size() == 1
+                && DischargeRules.sizeMeantBy(call.operation()) != null) {
+            Core size = new Core.PreservedCall(DischargeRules.sizeMeantBy(call.operation()), call.args(),
+                    Type.INT, call.pos());
+            return new Core.Binary(Ast.BinOp.EQ, size, new Core.Int(0, Type.INT, call.pos()),
+                    Type.BOOL, call.pos());
+        }
+        return e;
+    }
+
+
+    static Rel relOf(Ast.BinOp op) {
+        return switch (op) {
+            case GE -> Rel.GE;
+            case GT -> Rel.GT;
+            case LE -> Rel.LE;
+            case LT -> Rel.LT;
+            case EQ -> Rel.EQ;
+            case NE -> Rel.NE;
+            default -> null;
+        };
+    }
+
+    static Rel negateRel(Rel rel) {
+        return switch (rel) {
+            case GE -> Rel.LT;
+            case GT -> Rel.LE;
+            case LE -> Rel.GT;
+            case LT -> Rel.GE;
+            case EQ -> Rel.NE;
+            case NE -> Rel.EQ;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.Prelude;
-import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.LinkedHashMap;

--- a/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
@@ -1,0 +1,71 @@
+package souther.compiler.check;
+
+import souther.compiler.Prelude;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The calls the representation being typed keeps standing, and the signature each was declared with.
+ *
+ * <p>Which calls a representation keeps is the representation's to decide
+ * ({@link InliningPolicy}), so it is decided once, where that representation is built, and handed to
+ * the checker as this. The checker asks only whether this call is one of them: what the operation
+ * means to whoever reads the representation — that a {@code List.map} carries a property of every
+ * element, that a {@code List.filter} can only lose elements — is that reader's, and typing a call
+ * does not depend on anyone having a rule for it.
+ *
+ * <p>That separation is the point. An operation kept by a representation with no rule about it types
+ * like any other and simply states nothing, so being able to type a call and being able to reason
+ * about it stay independent. Were the two joined, adding a rule would mean teaching the checker, and
+ * a rule missing would mean a program that does not type.
+ *
+ * <p>What is not here is not kept. A call standing in a representation that keeps none of them, or
+ * one this representation never said it would keep, is this compiler having failed to expand it, and
+ * is reported as that rather than typed.
+ */
+public record Preserved(Map<ValueName, CompleteSignature> operations) {
+
+    /** Every representation that keeps nothing standing — the tree the backend emits from, and every
+     *  expression checked outside one. */
+    public static final Preserved NONE = new Preserved(Map.of());
+
+    /**
+     * What {@link InliningPolicy#DISCHARGE} keeps: the language's own operations, each under the
+     * signature the library declared it with.
+     *
+     * <p>The line is the one that policy draws. The language defines what these do to the properties
+     * an analysis tracks and every module already has them, so leaving one standing says something; a
+     * module's own helper has no such definition and is expanded. Asked of the library rather than
+     * listed here, so an operation the library gains is kept without this being edited — and one it
+     * rewrites away before any of this ({@code List.fold} becomes {@code List.foldFrom}) has no
+     * declaration to keep and is absent, as it must be.
+     */
+    public static Preserved byTheLanguagesOwnOperations() {
+        Map<ValueName, CompleteSignature> operations = new LinkedHashMap<>();
+        Prelude.entries().forEach((qualified, entry) -> {
+            ValueName.Stdlib operation = new ValueName.Stdlib(qualified);
+            operations.put(operation, CompleteSignature.of(
+                    operation, entry.signature().params(), entry.signature().result()));
+        });
+        return new Preserved(operations);
+    }
+
+    public Preserved {
+        operations = Map.copyOf(operations);
+    }
+
+    /**
+     * The signature {@code operation} was declared with, or null where this representation does not
+     * keep it standing.
+     *
+     * <p>Asked of what the name was resolved to rather than of how it was written: a module that
+     * imported an operation writes it bare, and one that did not writes it qualified, and they are
+     * the same operation. Two operations that share a type are not.
+     */
+    public CompleteSignature signatureOf(ValueName operation) {
+        return operation == null ? null : operations.get(operation);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
@@ -42,8 +42,17 @@ public record Preserved(Map<ValueName, CompleteSignature> operations) {
      * listed here, so an operation the library gains is kept without this being edited — and one it
      * rewrites away before any of this ({@code List.fold} becomes {@code List.foldFrom}) has no
      * declaration to keep and is absent, as it must be.
+     *
+     * <p>Built once. The library is the same library for every tree that keeps it standing, and this
+     * is asked once per definition typed in such a representation.
      */
     public static Preserved byTheLanguagesOwnOperations() {
+        return THE_LANGUAGES_OWN;
+    }
+
+    private static final Preserved THE_LANGUAGES_OWN = readTheLibrary();
+
+    private static Preserved readTheLibrary() {
         Map<ValueName, CompleteSignature> operations = new LinkedHashMap<>();
         Prelude.entries().forEach((qualified, entry) -> {
             ValueName.Stdlib operation = new ValueName.Stdlib(qualified);

--- a/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
@@ -46,10 +46,18 @@ public record Preserved(Map<ValueName, CompleteSignature> operations) {
      * is asked once per definition typed in such a representation.
      */
     public static Preserved byTheLanguagesOwnOperations() {
-        return THE_LANGUAGES_OWN;
+        return TheLanguagesOwn.OPERATIONS;
     }
 
-    private static final Preserved THE_LANGUAGES_OWN = readTheLibrary();
+    /**
+     * Built on the first ask and not before. What is required of these signatures is required of a
+     * representation that keeps them standing, so a checker that keeps none must not be held to it —
+     * and a class is initialized whole, so building this beside {@link #NONE} would raise the
+     * discharge representation's demand the moment anything asked for no representation at all.
+     */
+    private static final class TheLanguagesOwn {
+        private static final Preserved OPERATIONS = readTheLibrary();
+    }
 
     private static Preserved readTheLibrary() {
         Map<ValueName, CompleteSignature> operations = new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/Quantified.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Quantified.java
@@ -1,0 +1,19 @@
+package souther.compiler.check;
+
+import souther.compiler.check.DischargeRules.Shape;
+import souther.compiler.core.Core;
+
+import java.util.Set;
+
+/**
+ * A relation known of every element of a container. A fact settles the container as a whole and
+ * is keyed by the call that states it, which relates it to nothing inside; this keeps the
+ * relation as the clause it was written as, so it can be read again at the element a combinator's
+ * closure is handed.
+ *
+ * <p>{@code through} is how far it travels: a construction of one of those shapes holds only
+ * elements of what it was built from, so what was stated of the source still holds of each of
+ * them. The predicate is kept as the block it is, already read where the relation was stated, so
+ * every name in it means there what it meant there.
+ */
+record Quantified(String container, Set<Shape> through, Core.Block predicate) {}

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -398,7 +398,7 @@ public final class SpecChecker {
         Core dischargeBody = discharge == null ? null
                 : Elaborator.elaborate(discharge.body(), tenv,
                         new CheckContext(symbols, null, reqSigs).withCallees(calleeSigs)
-                                .preserving(Preserved.byTheLanguagesOwnOperations()), output);
+                                .forDischarge(), output);
         InvariantChecker.Findings inv = InvariantChecker.analyze(dischargeBody,
                 discharge == null ? Map.of() : discharge.invariants(), env, symbols);
         warnings.addAll(inv.warnings());

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -391,8 +391,12 @@ public final class SpecChecker {
         // A guard-discharged one is silent; an unproven one is a warning (a possible abort); one the
         // guards prove must fail on a reachable path is an error (the path-sensitive generalization of
         // the constant `金額(-5)` check).
-        // the invariant analysis reads its own atoms off the spellings a body writes, so it is
-        // handed the name view rather than the bindings
+        // The discharge representation is typed by the checker like any other, keeping the language's
+        // own operations standing because that is what the analysis reading it has rules about.
+        Core dischargeBody = discharge == null ? null
+                : Elaborator.elaborate(discharge.body(), tenv,
+                        new CheckContext(symbols, null, reqSigs).withCallees(calleeSigs)
+                                .preserving(Preserved.byTheLanguagesOwnOperations()), output);
         InvariantChecker.Findings inv = InvariantChecker.analyze(discharge, env.byName(), symbols);
         warnings.addAll(inv.warnings());
         if (!inv.errors().isEmpty()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -392,12 +392,15 @@ public final class SpecChecker {
         // guards prove must fail on a reachable path is an error (the path-sensitive generalization of
         // the constant `金額(-5)` check).
         // The discharge representation is typed by the checker like any other, keeping the language's
-        // own operations standing because that is what the analysis reading it has rules about.
+        // own operations standing because that is what the analysis reading it has rules about. A
+        // representation there is none of is not analyzed at all, rather than analyzed over the
+        // emitted tree, whose operations are no longer operations.
         Core dischargeBody = discharge == null ? null
                 : Elaborator.elaborate(discharge.body(), tenv,
                         new CheckContext(symbols, null, reqSigs).withCallees(calleeSigs)
                                 .preserving(Preserved.byTheLanguagesOwnOperations()), output);
-        InvariantChecker.Findings inv = InvariantChecker.analyze(discharge, env.byName(), symbols);
+        InvariantChecker.Findings inv = InvariantChecker.analyze(dischargeBody,
+                discharge == null ? Map.of() : discharge.invariants(), env, symbols);
         warnings.addAll(inv.warnings());
         if (!inv.errors().isEmpty()) {
             throw inv.errors().get(0);

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -8,6 +8,8 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -36,6 +38,7 @@ import java.util.Set;
 final class Terms {
 
     private final Symbols symbols;
+    private final Map<TypeName, Boolean> numericNewtypes = new HashMap<>();
 
     Terms(Symbols symbols) {
         this.symbols = symbols;
@@ -55,8 +58,10 @@ final class Terms {
         return e;
     }
 
-    /** The shared affine walk: literals and {@code +}/{@code -} compose; every other node is handed to
-     * {@code leaf} (which decides whether it is an atom, a location, or opaque). */
+    /** The affine walk: literals and {@code +}/{@code -} compose; every other node is handed to
+     * {@code leaf} (which decides whether it is an atom, a location, or opaque). It takes the leaf
+     * rule rather than fixing one because a binding it reads through answers with what that binding
+     * was given. */
     LinearForm affine(Core raw, java.util.function.Function<Core, LinearForm> leaf) {
         Core e = asOperator(raw);
         if (e instanceof Core.PreservedCall) {
@@ -148,11 +153,11 @@ final class Terms {
     /** How many elements a size call over a value written out counts, or {@code null} where its
      * argument is not one. */
     BigDecimal writtenSize(Core e, Denotations at) {
-        if (!(e instanceof Core.PreservedCall call) || !DischargeRules.isSize(call.operation())
-                || call.args().size() != 1) {
+        Core container = DischargeRules.sizeArgOf(e);
+        if (container == null) {
             return null;
         }
-        Core written = writtenValue(call.args().get(0), at);
+        Core written = writtenValue(container, at);
         return written instanceof Core.ListLit list
                 ? BigDecimal.valueOf(list.elements().size()) : null;
     }
@@ -223,12 +228,19 @@ final class Terms {
     /** The atom key of {@code SIZE_CALL(container)} when {@code key} can name the container, else
      * {@code null}. */
     static String sizeAtom(Core e, java.util.function.Function<Core, String> key) {
-        if (!(e instanceof Core.PreservedCall call) || !DischargeRules.isSize(call.operation())
-                || call.args().size() != 1) {
+        Core container = DischargeRules.sizeArgOf(e);
+        if (container == null) {
             return null;
         }
-        String arg = key.apply(DischargeRules.sizeSource(call.args().get(0)));
-        return arg == null ? null : call.operation().name() + "(" + arg + ")";
+        String arg = key.apply(DischargeRules.sizeSource(container));
+        return arg == null ? null : sizeKey(((Core.PreservedCall) e).operation(), arg);
+    }
+
+    /** How a size over a named container is written as an atom. The same string a call keys as
+     * ({@link #termKey}), said here so a guard's term and a clause's atom cannot drift apart — they
+     * meet by this key and by nothing else. */
+    static String sizeKey(ValueName size, String container) {
+        return size.name() + "(" + container + ")";
     }
 
 
@@ -243,7 +255,7 @@ final class Terms {
      * still the value it is and so is part of the term. Anything outside this grammar keys as
      * {@code null}, and the clause reading it is left opaque.
      */
-    String termKey(Core raw, Denotations at, Map<BindingId, String> bound, int depth) {
+    private String termKey(Core raw, Denotations at, Map<BindingId, String> bound, int depth) {
         Core e = asOperator(raw);
         BindingId root = rootBinding(e);
         if (root != null) {
@@ -606,6 +618,14 @@ final class Terms {
     }
 
 
+    /** The type of {@code field} read from {@code owner}, or null where that is not a field of a
+     * declaration this module can see. Asked of the one field, since resolving the whole
+     * declaration's fields is a question about a declaration this reader may not own. */
+    Type fieldType(Type owner, String field) {
+        return owner instanceof Type.Ref r && symbols.get(r.name()) instanceof Ast.Data data
+                ? TypeOps.fieldType(data, field, symbols) : null;
+    }
+
     /** What a container hands its closure: a list's or set's element, a map's value (the key is the
      * other closure parameter and is not the one the table credits), an option's payload, and a
      * function's first parameter where what is held is the closure itself. */
@@ -628,8 +648,14 @@ final class Terms {
         return null;
     }
 
+    /** Whether {@code t} is a newtype over a number, remembered by the type it names. Asked at every
+     * leaf of every affine walk, and answering it walks the declaration's fields. */
     boolean numericNewtype(Type t) {
-        return TypeOps.directNumericNewtypeBase(t, symbols) != null;
+        if (!(t instanceof Type.Ref ref)) {
+            return TypeOps.directNumericNewtypeBase(t, symbols) != null;
+        }
+        return numericNewtypes.computeIfAbsent(ref.name(),
+                _ -> TypeOps.directNumericNewtypeBase(t, symbols) != null);
     }
 
     boolean isNumeric(Type t) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -1,0 +1,643 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.DischargeRules.Built;
+import souther.compiler.check.NumericDomain.LinearForm;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.Type;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What a value is to the invariant-discharge check: where it is, what it is called, and whether
+ * anything can be said of it.
+ *
+ * <p>One question asked in one place. A guard states something of a value and a clause is read
+ * against a value, and the two meet only by being named alike — so the naming is here rather than at
+ * either end of it, and asking it of a name gives the same answer as asking it of the expression the
+ * name was bound to. That is what makes naming an expression not change what is known of it.
+ *
+ * <p>Three answers, and they are not the same question. Where a value is, is a {@link Location} and
+ * is what the seeding writes about. What a value is called, is a key: two expressions with one key
+ * compute one value, which is the whole of what the fact set knows. What can be said of a value, is
+ * whether a clause read against it could ever be discharged — a location always can, a computed value
+ * only where a rule or a guard reaches it — and it is what decides whether a construction is reported
+ * at all.
+ */
+final class Terms {
+
+    private final Symbols symbols;
+
+    Terms(Symbols symbols) {
+        this.symbols = symbols;
+    }
+
+    /** The operator {@code e} is, where it is a library call written as a function, or {@code e}
+     * itself. Reading it as the operator is what puts it on the one path the operator already has,
+     * rather than on a second path that would have to be kept saying the same thing. */
+    static Core asOperator(Core e) {
+        if (e instanceof Core.PreservedCall call && call.args().size() == 2) {
+            Ast.BinOp op = DischargeRules.operator(call.operation());
+            if (op != null) {
+                return new Core.Binary(op, call.args().get(0), call.args().get(1), call.type(),
+                        call.pos());
+            }
+        }
+        return e;
+    }
+
+    /** The shared affine walk: literals and {@code +}/{@code -} compose; every other node is handed to
+     * {@code leaf} (which decides whether it is an atom, a location, or opaque). */
+    LinearForm affine(Core raw, java.util.function.Function<Core, LinearForm> leaf) {
+        Core e = asOperator(raw);
+        if (e instanceof Core.PreservedCall) {
+            // A call that folds is the number it folds to. `String.length("1A")` is 2, and a clause
+            // about it is decided rather than owed — the run-time check is not what should answer a
+            // question the compiler has already computed. Asked once: folding walks the subtree, and
+            // a pattern in it is a regex to run.
+            BigDecimal folded = constantNumber(e);
+            if (folded != null) {
+                return LinearForm.constant(folded);
+            }
+        }
+        return switch (e) {
+            case Core.Int i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
+            case Core.Decimal d -> LinearForm.constant(d.value());
+            case Core.Neg n -> negate(affine(n.operand(), leaf));
+            case Core.Binary b when b.op() == Ast.BinOp.ADD ->
+                    add(affine(b.left(), leaf), affine(b.right(), leaf), false);
+            case Core.Binary b when b.op() == Ast.BinOp.SUB ->
+                    add(affine(b.left(), leaf), affine(b.right(), leaf), true);
+            // scalar multiply by a constant (Amount * 2) is linear; `/` and a variable product are not
+            // (a divide truncates for Int, and a variable factor is non-linear), so leave those opaque.
+            case Core.Binary b when b.op() == Ast.BinOp.MUL ->
+                    scale(affine(b.left(), leaf), affine(b.right(), leaf));
+            // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what an
+            // arithmetic helper becomes, so reading through it is reading the arithmetic the author
+            // wrote.
+            case Core.LetIn li -> {
+                LinearForm bound = affine(li.value(), leaf);
+                yield bound == null ? leaf.apply(e) : affine(li.body(),
+                        n -> n instanceof Core.Read r && r.binding().equals(li.binder().id())
+                                ? bound : leaf.apply(n));
+            }
+            default -> leaf.apply(e);
+        };
+    }
+
+    /** What {@code e} folds to where every part of it is written out, or {@code null} where any part
+     * of it is computed at run time and there is nothing to fold. */
+    static Object folded(Core e) {
+        Ast.Expr written = asWrittenValue(e);
+        return written == null ? null : ConstEval.eval(written).orElse(null);
+    }
+
+    /** The number {@code e} folds to at compile time, or {@code null} where it folds to none. */
+    static BigDecimal constantNumber(Core e) {
+        Object folded = folded(e);
+        if (folded instanceof Long n) {
+            return BigDecimal.valueOf(n);
+        }
+        return folded instanceof BigDecimal d ? d : null;
+    }
+
+    /** A linear form scaled by a constant, when one side is a bare constant (a scalar multiply); null
+     * when neither side is constant (a non-linear product). */
+    static LinearForm scale(LinearForm a, LinearForm b) {
+        if (a == null || b == null) {
+            return null;
+        }
+        if (a.coefs().isEmpty()) {
+            return b.times(a.constant());
+        }
+        return b.coefs().isEmpty() ? a.times(b.constant()) : null;
+    }
+
+    /** The affine form of an expression: a numeric atom, a newtype construct's wrapped value, or
+     * {@code null}. */
+    LinearForm affineOf(Core e, Denotations at, Known k) {
+        return affine(e, n -> {
+            if (n instanceof Core.NewData nd && nd.spreads().isEmpty() && nd.inits().size() == 1
+                    && nd.inits().get(0).name().equals("value")
+                    && numericNewtype(Type.ref(nd.typeName()))) {
+                return affineOf(nd.inits().get(0).value(), at, k);
+            }
+            Core written = writtenValue(n, at);
+            if (written != null && written != n) {
+                return affineOf(written, at, k);
+            }
+            // A list written out has as many elements as it is written with, whatever they are.
+            BigDecimal counted = writtenSize(n, at);
+            if (counted != null) {
+                return LinearForm.constant(counted);
+            }
+            String atom = atomOf(n, at, k);
+            return atom == null ? null : LinearForm.atom(atom);
+        });
+    }
+
+    /** How many elements a size call over a value written out counts, or {@code null} where its
+     * argument is not one. */
+    BigDecimal writtenSize(Core e, Denotations at) {
+        if (!(e instanceof Core.PreservedCall call) || !DischargeRules.isSize(call.operation())
+                || call.args().size() != 1) {
+            return null;
+        }
+        Core written = writtenValue(call.args().get(0), at);
+        return written instanceof Core.ListLit list
+                ? BigDecimal.valueOf(list.elements().size()) : null;
+    }
+
+    static LinearForm negate(LinearForm f) {
+        return f == null ? null : f.negate();
+    }
+
+    static LinearForm add(LinearForm a, LinearForm b, boolean subtract) {
+        if (a == null || b == null) {
+            return null;
+        }
+        return subtract ? a.minus(b) : a.plus(b);
+    }
+
+    /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value) or of
+     * a size call over a nameable container, or {@code null} if {@code e} is neither. */
+    String atomOf(Core e, Denotations at, Known k) {
+        String size = sizeAtom(e, arg -> bodyKey(arg, at));
+        if (size != null) {
+            return size;
+        }
+        if (!isNumeric(e.type())) {
+            return null;
+        }
+        // A path rooted at a binding is the atom of what that binding denotes, and only where a clause
+        // could be read against it — otherwise a name would be an atom where the expression it was
+        // given is not one, and the two spellings would answer differently.
+        BindingId root = rootBinding(e);
+        if (root != null && !readable(at.of(root), k)) {
+            return null;
+        }
+        return pathKey(e, at);
+    }
+
+    /** An expression's canonical key: a location names itself, and everything else is read
+     * structurally. */
+    String bodyKey(Core e, Denotations at) {
+        return termKey(e, at, Map.of(), 0);
+    }
+
+    /**
+     * How a value a construction is being given is named where a clause reads it: a location names
+     * itself, and a container built from one by an operation the table covers names that
+     * construction. Anything else names nothing.
+     *
+     * <p>The restriction is what ties the flagging to what is said. A location is always named: the
+     * seeding writes about locations, so a clause reading one reads something. A container built by an
+     * operation the table covers is named, since the table is a rule about it. A computed value is
+     * named only where a guard on this path spoke about it — then, and only then, the author has
+     * stated something the clause can be read against, and leaving the construction unreported would
+     * be dropping what they said.
+     *
+     * <p>A computed value nothing has spoken about is named by nothing, and its construction is
+     * silent. That is this check's flagging policy and not a proof: the run-time check stands for the
+     * whole of such an invariant. Widening it is a matter of naming more values here, which is where
+     * a stated result type or a stdlib rule would enter.
+     */
+    String siteKey(Core e, Denotations at, Known k) {
+        // A value written out is not something a guard can be written about: there is nothing to
+        // state of `"xyz"` that the text does not already say. Where a clause reading it folds it is
+        // decided before this is asked, and where it does not fold there is no guard that would
+        // discharge it, so naming it here would only report what the author cannot answer.
+        Denotes d = denotationOf(e, at, k);
+        return readable(d, k) ? d.key() : null;
+    }
+
+    /** The atom key of {@code SIZE_CALL(container)} when {@code key} can name the container, else
+     * {@code null}. */
+    static String sizeAtom(Core e, java.util.function.Function<Core, String> key) {
+        if (!(e instanceof Core.PreservedCall call) || !DischargeRules.isSize(call.operation())
+                || call.args().size() != 1) {
+            return null;
+        }
+        String arg = key.apply(DischargeRules.sizeSource(call.args().get(0)));
+        return arg == null ? null : call.operation().name() + "(" + arg + ")";
+    }
+
+
+    /**
+     * The canonical key of an expression as a term, or {@code null} when nothing here can be named.
+     * Two expressions with one key compute one value, which is the whole of what the fact set knows:
+     * a guard and an invariant clause state the same predicate exactly when their calls key alike.
+     *
+     * <p>A location keys as the location it is, so which value a term is about is the binding it is
+     * rooted at. A closure parameter is keyed by where it is bound rather than by its binding, so
+     * {@code r -> r.a} and {@code row -> row.a} are one term while a free name inside the closure is
+     * still the value it is and so is part of the term. Anything outside this grammar keys as
+     * {@code null}, and the clause reading it is left opaque.
+     */
+    String termKey(Core raw, Denotations at, Map<BindingId, String> bound, int depth) {
+        Core e = asOperator(raw);
+        BindingId root = rootBinding(e);
+        if (root != null) {
+            String here = bound.get(root);
+            return here != null ? chainOn(here, e) : pathKey(e, at);
+        }
+        return switch (e) {
+            case Core.Int i -> Long.toString(i.value());
+            case Core.Decimal d -> d.value().toPlainString() + "m";
+            case Core.Str s -> quoted(s.value());
+            case Core.Bool b -> Boolean.toString(b.value());
+            case Core.UnitValue u -> u.data().toString();
+            case Core.Neg n -> wrap("-", termKey(n.operand(), at, bound, depth));
+            case Core.Binary b -> {
+                String l = termKey(b.left(), at, bound, depth);
+                String r = termKey(b.right(), at, bound, depth);
+                yield l == null || r == null ? null : binaryKey(b.op(), l, r);
+            }
+            case Core.ListLit l -> elementsKey("[", l.elements(), at, bound, depth, "]");
+            case Core.Tuple t -> elementsKey("(", t.elements(), at, bound, depth, ")");
+            case Core.TupleGet g -> wrap("." + g.index(), termKey(g.tuple(), at, bound, depth));
+            case Core.If iff -> elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
+                    at, bound, depth, ")");
+            case Core.Block b -> {
+                Map<BindingId, String> inner = binding(bound, b.params(), depth);
+                yield wrap("\\" + b.params().size(), termKey(b.body(), at, inner, depth + 1));
+            }
+            case Core.LetIn li -> {
+                String value = termKey(li.value(), at, bound, depth);
+                Map<BindingId, String> inner = binding(bound, List.of(li.binder()), depth);
+                String body = termKey(li.body(), at, inner, depth + 1);
+                yield value == null || body == null ? null : "let(" + value + ", " + body + ")";
+            }
+            // A construction is a pure function of its fields, and a closure that builds one is what a
+            // mapping usually is. Fields are keyed in name order, so two sites writing them in
+            // different orders write one term.
+            case Core.NewData nd when nd.spreads().isEmpty() -> {
+                List<Core.FieldInit> inits = new ArrayList<>(nd.inits());
+                inits.sort(java.util.Comparator.comparing(Core.FieldInit::name));
+                StringBuilder sb = new StringBuilder(nd.typeName().toString()).append('{');
+                for (int i = 0; i < inits.size(); i++) {
+                    String v = termKey(inits.get(i).value(), at, bound, depth);
+                    if (v == null) {
+                        yield null;
+                    }
+                    sb.append(i == 0 ? "" : ", ").append(inits.get(i).name()).append('=').append(v);
+                }
+                yield sb.append('}').toString();
+            }
+            // Only the operations the representation kept standing: they are the library's own, so
+            // they are pure and one written call is one value.
+            case Core.PreservedCall c ->
+                    elementsKey(c.operation().name() + "(", c.args(), at, bound, depth, ")");
+            default -> null;
+        };
+    }
+
+    /** {@code bound} with each of {@code binders} keyed by where it is bound rather than by which
+     * binding it is, so two expressions that differ only in what they bound are one term. */
+    static Map<BindingId, String> binding(Map<BindingId, String> bound,
+                                                  List<Ast.Binder> binders, int depth) {
+        Map<BindingId, String> inner = new HashMap<>(bound);
+        for (int i = 0; i < binders.size(); i++) {
+            inner.put(binders.get(i).id(), "#" + depth + "." + i);
+        }
+        return inner;
+    }
+
+    String elementsKey(String open, List<Core> parts, Denotations at,
+                               Map<BindingId, String> bound, int depth, String close) {
+        StringBuilder sb = new StringBuilder(open);
+        for (int i = 0; i < parts.size(); i++) {
+            String part = termKey(parts.get(i), at, bound, depth);
+            if (part == null) {
+                return null;
+            }
+            sb.append(i == 0 ? "" : ", ").append(part);
+        }
+        return sb.append(close).toString();
+    }
+
+    /**
+     * A binary as a key. The six comparisons are two: {@code ==} over the pair in a settled order,
+     * since which side is written first is not part of what it says, and {@code <}, with the other
+     * three written as one of those denied. Two clauses comparing the same two terms are then one term
+     * however the author reached for it — which matters wherever the comparison is not the whole
+     * condition, since only there can the denial not be carried by the polarity instead.
+     */
+    static String binaryKey(Ast.BinOp op, String l, String r) {
+        return switch (op) {
+            case EQ -> l.compareTo(r) <= 0 ? cmp("EQ", l, r) : cmp("EQ", r, l);
+            case NE -> "!" + binaryKey(Ast.BinOp.EQ, l, r);
+            case LT -> cmp("LT", l, r);
+            case GT -> cmp("LT", r, l);
+            case GE -> "!" + cmp("LT", l, r);
+            case LE -> "!" + cmp("LT", r, l);
+            default -> cmp(op.toString(), l, r);
+        };
+    }
+
+    static String cmp(String op, String l, String r) {
+        return "(" + l + " " + op + " " + r + ")";
+    }
+
+    /** A string value written into a key with the punctuation the key itself uses escaped, so a value
+     * holding a quote or a comma cannot be read back as a different expression. */
+    static String quoted(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+
+    static String wrap(String prefix, String inner) {
+        return inner == null ? null : prefix + "(" + inner + ")";
+    }
+
+    /** The binding at the head of a {@code x}/{@code x.a.b} chain, or {@code null} if {@code e} is not
+     * one. */
+    static BindingId rootBinding(Core e) {
+        return switch (e) {
+            case Core.Read r -> r.binding();
+            case Core.FieldAccess fa -> rootBinding(fa.target());
+            default -> null;
+        };
+    }
+
+    /** The field chain of {@code e} rebuilt on {@code head}. */
+    static String chainOn(String head, Core e) {
+        return e instanceof Core.FieldAccess fa ? chainOn(head, fa.target()) + "." + fa.field() : head;
+    }
+
+    /**
+     * The key of a chain rooted at a binding: the location it is, or, where the binding was given a
+     * term rather than a location, that term with the fields read from it.
+     *
+     * <p>A newtype's {@code .value} is the same location as the newtype, which is {@link Location}'s
+     * rule and is read here of a term too, so a value keyed one way through a binding and the other
+     * way through a field is one value.
+     */
+    String pathKey(Core e, Denotations at) {
+        Location located = locationOf(e, at);
+        if (located != null) {
+            return located.toString();
+        }
+        return switch (e) {
+            case Core.Read r -> at.of(r.binding()).key();
+            case Core.FieldAccess fa -> {
+                if (!Location.isStep(fa.target().type(), fa.field(), symbols)) {
+                    yield pathKey(fa.target(), at);
+                }
+                String base = pathKey(fa.target(), at);
+                yield base == null ? null : base + "." + fa.field();
+            }
+            default -> null;
+        };
+    }
+
+    /** The location {@code e} is, or {@code null} where it is a computed value rather than a place. */
+    Location locationOf(Core e, Denotations at) {
+        return Location.of(e, symbols,
+                binding -> at.of(binding) instanceof Denotes.At located ? located.where() : null);
+    }
+
+    /**
+     * What a binding's initializer denotes: the location it is where it is one, else the term it
+     * computes, else nothing. A name is an alias and never a value of its own — this is the one place
+     * that decides it, so an expression answers the same whether it was written where it is used or
+     * given a name first.
+     */
+    Denotes denotationOf(Core e, Denotations at, Known k) {
+        Core written = writtenValue(e, at);
+        if (written != null) {
+            return new Denotes.Written(bodyKey(written, at), written);
+        }
+        Location located = locationOf(e, at);
+        if (located != null) {
+            return new Denotes.At(located);
+        }
+        String term = bodyKey(e, at);
+        if (term == null) {
+            return new Denotes.Nothing();
+        }
+        // Readable where there is something to say of it: a form the numeric domain built, or a rule
+        // about how it was made. This is asked of the expression, so a name for it answers the same.
+        return new Denotes.Term(term, affineOf(e, at, k) != null || namedByRule(e, at));
+    }
+
+    /**
+     * Whether a clause may be read against what {@code d} denotes. A location always may: the seeding
+     * writes about locations. A computed term may where something can be said of it, or where a guard
+     * on this path has said something. Nothing never may.
+     *
+     * <p>Every question of the form "is this value one a clause can be read against" asks this, and
+     * asking it of a name gives the same answer as asking it of the expression the name was bound to.
+     * That is what makes naming an expression not change what is known of it.
+     */
+    static boolean readable(Denotes d, Known k) {
+        return switch (d) {
+            case Denotes.At _ -> true;
+            case Denotes.Term term -> term.readable() || k.speaksOf(term.key());
+            case Denotes.Written _, Denotes.Nothing _ -> false;
+        };
+    }
+
+    /** What {@code e} is written as, where it is a written value or a name given one — and
+     * {@code null} where it is computed from anything. */
+    static Core writtenValue(Core e, Denotations at) {
+        if (e instanceof Core.Read r) {
+            return at.of(r.binding()) instanceof Denotes.Written w ? w.value() : null;
+        }
+        return isWritten(e) ? e : null;
+    }
+
+    /**
+     * Whether {@code e} is a value written out rather than computed from anything: a literal, and a
+     * list or a construction whose every part is one. A table written into the source is this — every
+     * row of it is there to read — and there is no guard an author could add about it, which is what
+     * naming it at a construction site would ask for.
+     */
+    static boolean isWritten(Core e) {
+        return isWritten(e, Set.of());
+    }
+
+    /** The same, where {@code written} names the bindings an expansion introduced for values that
+     * were themselves written. A helper called on written arguments is a written value: what it
+     * expands to binds each argument and reads it back, which is the source's own text moved. */
+    static boolean isWritten(Core e, Set<BindingId> written) {
+        return switch (e) {
+            case Core.Int _, Core.Decimal _, Core.Str _, Core.Bool _, Core.UnitValue _ -> true;
+            case Core.Neg n -> isWritten(n.operand(), written);
+            case Core.Read r -> written.contains(r.binding());
+            case Core.ListLit list -> list.elements().stream().allMatch(x -> isWritten(x, written));
+            case Core.Tuple t -> t.elements().stream().allMatch(x -> isWritten(x, written));
+            case Core.OptionSome s -> isWritten(s.value(), written);
+            case Core.NewData nd -> nd.spreads().isEmpty()
+                    && nd.inits().stream().allMatch(fi -> isWritten(fi.value(), written));
+            case Core.LetIn li -> {
+                if (!isWritten(li.value(), written)) {
+                    yield false;
+                }
+                Set<BindingId> inner = new HashSet<>(written);
+                inner.add(li.binder().id());
+                yield isWritten(li.body(), inner);
+            }
+            default -> false;
+        };
+    }
+
+    /** Whether {@code e} is a container built by an operation the preservation table covers, over an
+     * argument that is itself named. */
+    boolean builtByRule(Core e, Denotations at) {
+        if (!(e instanceof Core.PreservedCall call)) {
+            return false;
+        }
+        Built built = DischargeRules.builtFrom(call.operation());
+        return built != null && built.from() < call.args().size()
+                && namedByRule(call.args().get(built.from()), at);
+    }
+
+    /**
+     * Whether {@code e} names something without a guard having to have spoken about it: it is read all
+     * the way down. A location is; so is a value composed of ones by a shape the term grammar reads —
+     * a concatenation, a conditional, arithmetic, a container the preservation table covers. A call
+     * the check has no rule about is not, and neither is anything built from one: nothing follows from
+     * naming it, and its construction is left to the run-time check.
+     */
+    boolean namedByRule(Core e, Denotations at) {
+        if (locationOf(e, at) != null) {
+            return true;
+        }
+        if (e instanceof Core.Read r) {
+            return at.of(r.binding()) instanceof Denotes.Term t && t.readable();
+        }
+        Core read = asOperator(e);
+        if (read instanceof Core.PreservedCall call
+                && !DischargeRules.readsAsATerm(call.operation())) {
+            return builtByRule(read, at);
+        }
+        // A call the representation did not keep standing answers something this check has no rule
+        // about, whatever the operation behind it was.
+        if (read instanceof Core.Call || read instanceof Core.Apply) {
+            return false;
+        }
+        // Arithmetic is the numeric domain's to name. Where the domain builds a form, that form is
+        // what a clause is read against; where it declines to — a variable product, an integer divide
+        // — declining is a decision about what this check reasons over, and reporting a construction
+        // it has decided not to reason over would be reporting the decision as the author's to fix.
+        if (read instanceof Core.Binary bin && isArith(bin.op())) {
+            return false;
+        }
+        // A conditional is one of its branches and which one is not decided here. Saying only that it
+        // is that term reports every construction over one, including where both branches satisfy the
+        // clause. Reading it is checking the construction on each branch under its own condition,
+        // which this walk does not do, so it is not named until it does.
+        if (read instanceof Core.If) {
+            return false;
+        }
+        boolean[] all = {true};
+        // A closure is not part of what names the value: the tables are rules about how many elements
+        // there are and where they came from, and how each one is made has no bearing on either.
+        Core.forEachChild(read, child -> all[0] = all[0]
+                && (child instanceof Core.Block || namedByRule(child, at)));
+        return all[0];
+    }
+
+    // --- what the two representations share ----------------------------------------------------
+
+    /**
+     * {@code e} as the value it is written as, for the one reader that is defined over written values:
+     * the constant folder. A value written out is the same value in either representation, so this is
+     * a rendering and not a second tree — everything computed answers with nothing, and the fold then
+     * has nothing to fold.
+     */
+    static Ast.Expr asWrittenValue(Core e) {
+        return switch (e) {
+            case Core.Int i -> new Ast.IntLit(i.value(), i.pos());
+            case Core.Decimal d -> new Ast.DecimalLit(d.value(), d.pos());
+            case Core.Str s -> new Ast.StringLit(s.value(), s.pos());
+            case Core.Bool b -> new Ast.BoolLit(b.value(), b.pos());
+            case Core.Neg n -> {
+                Ast.Expr operand = asWrittenValue(n.operand());
+                yield operand == null ? null : new Ast.Neg(operand, n.pos());
+            }
+            case Core.Binary b -> {
+                Ast.Expr left = asWrittenValue(b.left());
+                Ast.Expr right = asWrittenValue(b.right());
+                yield left == null || right == null ? null
+                        : new Ast.Binary(b.op(), left, right, b.pos());
+            }
+            case Core.PreservedCall call -> {
+                List<Ast.Expr> args = new ArrayList<>();
+                for (Core arg : call.args()) {
+                    Ast.Expr written = asWrittenValue(arg);
+                    if (written == null) {
+                        yield null;
+                    }
+                    args.add(written);
+                }
+                yield new Ast.Apply(call.operation().name(), call.operation(), args,
+                        ConstructionOrigin.own(), call.pos());
+            }
+            case null, default -> null;
+        };
+    }
+
+    // --- helpers -------------------------------------------------------------------------------
+
+
+    /** A read of {@code binder}, as the expression naming the value it holds. */
+    static Core.Read read(Ast.Binder binder, Type type, SourcePos pos) {
+        return new Core.Read(binder.name(), binder.id(), type, pos);
+    }
+
+    /** The block {@code e} is, following a name given one: a lambda handed to an operation the
+     * representation keeps standing is never applied here, so it is bound to a name like any other
+     * value and reaches the call as that name. */
+    static Core.Block blockOf(Core e, Denotations at) {
+        if (e instanceof Core.Block b) {
+            return b;
+        }
+        return e instanceof Core.Read r && at.valueOf(r.binding()) instanceof Core.Block b ? b : null;
+    }
+
+
+    /** What a container hands its closure: a list's or set's element, a map's value (the key is the
+     * other closure parameter and is not the one the table credits), an option's payload, and a
+     * function's first parameter where what is held is the closure itself. */
+    static Type elementType(Type t) {
+        if (t instanceof Type.ListOf list) {
+            return list.element();
+        }
+        if (t instanceof Type.SetOf set) {
+            return set.element();
+        }
+        if (t instanceof Type.MapOf map) {
+            return map.value();
+        }
+        if (t instanceof Type.OptionOf opt) {
+            return opt.element();
+        }
+        if (t instanceof Type.FnOf fn && !fn.params().isEmpty()) {
+            return fn.params().get(0);
+        }
+        return null;
+    }
+
+    boolean numericNewtype(Type t) {
+        return TypeOps.directNumericNewtypeBase(t, symbols) != null;
+    }
+
+    boolean isNumeric(Type t) {
+        return t == Type.INT || t == Type.DECIMAL || numericNewtype(t);
+    }
+
+
+    static boolean isArith(Ast.BinOp op) {
+        return op == Ast.BinOp.ADD || op == Ast.BinOp.SUB || op == Ast.BinOp.MUL || op == Ast.BinOp.DIV;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -53,19 +53,6 @@ final class BodyGen {
     private final String pkg;
     private final Symbols symbols;
 
-    /**
-     * What the emitter says about a call a representation kept standing.
-     *
-     * <p>Decided by the node and not by the operation: whether this emitter has bytecode for what the
-     * call names is beside the point, because the tree it emits from keeps no call standing at all.
-     * Answering by looking the operation up would make the refusal depend on a table, and a table is
-     * the thing that quietly grows an exception.
-     */
-    static IllegalStateException refuse(Core.PreservedCall call) {
-        return new IllegalStateException("a preserved call (" + call.operation()
-                + ") reached the emitter, at " + call.pos());
-    }
-
     private ClassDesc cd(TypeName typeName) {
         return ctx.cd(typeName);
     }
@@ -652,7 +639,7 @@ final class BodyGen {
                 // A call a representation kept standing for an analysis to read. Refused by what the
                 // node is, not by whether the operation is one this emitter knows: the tree this
                 // emits from keeps none, and one arriving means it was handed another tree.
-                case Core.PreservedCall p -> throw refuse(p);
+                case Core.PreservedCall p -> throw p.unexpectedIn("the emitter");
                 case Core.Int x -> code.loadConstant(x.value());
                 case Core.Decimal x -> {
                     code.new_(CD_BigDecimal);
@@ -1933,7 +1920,7 @@ final class BodyGen {
 
         private void collectFree(Core e, Set<BindingId> bound, Reaches free) {
             switch (e) {
-                case Core.PreservedCall p -> throw refuse(p);
+                case Core.PreservedCall p -> throw p.unexpectedIn("the emitter");
                 case Core.Read v -> reaches(v, bound, free);
                 case Core.Call c -> {
                     // an injected behavior the body calls is handed over too: the lambda is a class

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -53,6 +53,19 @@ final class BodyGen {
     private final String pkg;
     private final Symbols symbols;
 
+    /**
+     * What the emitter says about a call a representation kept standing.
+     *
+     * <p>Decided by the node and not by the operation: whether this emitter has bytecode for what the
+     * call names is beside the point, because the tree it emits from keeps no call standing at all.
+     * Answering by looking the operation up would make the refusal depend on a table, and a table is
+     * the thing that quietly grows an exception.
+     */
+    static IllegalStateException refuse(Core.PreservedCall call) {
+        return new IllegalStateException("a preserved call (" + call.operation()
+                + ") reached the emitter, at " + call.pos());
+    }
+
     private ClassDesc cd(TypeName typeName) {
         return ctx.cd(typeName);
     }
@@ -636,6 +649,10 @@ final class BodyGen {
             }
             emitLine(e);
             switch (e) {
+                // A call a representation kept standing for an analysis to read. Refused by what the
+                // node is, not by whether the operation is one this emitter knows: the tree this
+                // emits from keeps none, and one arriving means it was handed another tree.
+                case Core.PreservedCall p -> throw refuse(p);
                 case Core.Int x -> code.loadConstant(x.value());
                 case Core.Decimal x -> {
                     code.new_(CD_BigDecimal);
@@ -1916,6 +1933,7 @@ final class BodyGen {
 
         private void collectFree(Core e, Set<BindingId> bound, Reaches free) {
             switch (e) {
+                case Core.PreservedCall p -> throw refuse(p);
                 case Core.Read v -> reaches(v, bound, free);
                 case Core.Call c -> {
                     // an injected behavior the body calls is handed over too: the lambda is a class

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -84,7 +84,19 @@ public sealed interface Core {
      * one.
      */
     record PreservedCall(ValueName operation, List<Core> args, Type type,
-                         SourcePos pos) implements Core {}
+                         SourcePos pos) implements Core {
+
+        /**
+         * What a reader that keeps no call standing says when one reaches it: this compiler failed to
+         * expand it. Said here so every such reader says it the same way, and says it about the node
+         * rather than about the operation — which of them a reader has bytecode for is not the
+         * question.
+         */
+        public IllegalStateException unexpectedIn(String reader) {
+            return new IllegalStateException(
+                    "a preserved call (" + operation + ") reached " + reader + ", at " + pos);
+        }
+    }
 
     /**
      * Applying a function value the body holds: a helper's function parameter, or a lambda a
@@ -359,6 +371,17 @@ public sealed interface Core {
                             java.util.function.UnaryOperator<Read> onNameSlot,
                             java.util.function.UnaryOperator<NewData> onConstructionSlot) {
         return atSlots(e, onExprSlot, onNameSlot, onConstructionSlot);
+    }
+
+    /**
+     * The same, recursing into a construction slot with the operators the other slots are given —
+     * what a pass that rewrites expressions wants, since a construction an attempt holds is as much
+     * an expression as anything else and no such pass has anything else to say about one.
+     */
+    static Core mapAll(Core e, java.util.function.UnaryOperator<Core> onExprSlot,
+                       java.util.function.UnaryOperator<Read> onNameSlot) {
+        return atSlots(e, onExprSlot, onNameSlot,
+                nd -> atSlots(nd, onExprSlot, onNameSlot));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -3,6 +3,7 @@ package souther.compiler.core;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.ast.Ast;
 
@@ -65,6 +66,25 @@ public sealed interface Core {
      * method — each reached by the name it is declared under, none of them bound by this body. A
      * non-recursive helper is already inlined. */
     record Call(String fn, List<Core> args, Type type, SourcePos pos) implements Core {}
+
+    /**
+     * A call a representation kept standing on purpose: resolved to the declaration it names, typed
+     * from that declaration's signature, and deliberately not expanded.
+     *
+     * <p>Not a call this compiler failed to expand. Which calls survive is a representation's to
+     * decide ({@link souther.compiler.check.InliningPolicy}): an analysis that has rules about an
+     * operation loses them the moment the operation becomes the algorithm it is, so the
+     * representation that analysis reads keeps the operation. The tree the backend emits from keeps
+     * none, and one arriving there is this compiler having failed to expand it.
+     *
+     * <p>{@code operation} is what the name was resolved to, not how it was written: two spellings
+     * that reach one operation are one of these, and having a type in common is not being the same
+     * operation. A reader with no rule for what this names types it and learns nothing from it,
+     * which is the difference between a representation keeping a call and an analysis understanding
+     * one.
+     */
+    record PreservedCall(ValueName operation, List<Core> args, Type type,
+                         SourcePos pos) implements Core {}
 
     /**
      * Applying a function value the body holds: a helper's function parameter, or a lambda a
@@ -217,6 +237,13 @@ public sealed interface Core {
             case Call c -> {
                 List<Core> args = each(c.args(), atExpr);
                 yield args == c.args() ? c : new Call(c.fn(), args, c.type(), c.pos());
+            }
+            // Its arguments are children like any other, so a pass that asks what a body reads
+            // reaches them without knowing what was kept standing over them.
+            case PreservedCall p -> {
+                List<Core> args = each(p.args(), atExpr);
+                yield args == p.args() ? p
+                        : new PreservedCall(p.operation(), args, p.type(), p.pos());
             }
             // what is applied is a binding holding a function: a name slot, the same kind a spread is
             case Apply a -> {

--- a/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
@@ -430,6 +430,10 @@ public final class GrowingFold {
                 }
                 return new Core.Match(m.scrutinee(), cases, m.type(), m.pos());
             }
+            // A call a representation kept standing is not part of the tree a fold grows in: this
+            // reads what the backend emits, and that keeps none.
+            case Core.PreservedCall p -> throw new IllegalStateException(
+                    "a preserved call (" + p.operation() + ") reached fold growing, at " + p.pos());
             default -> {
                 Core grown = growth.at(e, acc);
                 if (grown != null) {

--- a/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
@@ -432,8 +432,7 @@ public final class GrowingFold {
             }
             // A call a representation kept standing is not part of the tree a fold grows in: this
             // reads what the backend emits, and that keeps none.
-            case Core.PreservedCall p -> throw new IllegalStateException(
-                    "a preserved call (" + p.operation() + ") reached fold growing, at " + p.pos());
+            case Core.PreservedCall p -> throw p.unexpectedIn("fold growing");
             default -> {
                 Core grown = growth.at(e, acc);
                 if (grown != null) {

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -164,6 +164,12 @@ public final class CoverageSites {
                     walk(b.right());
                 }
                 case Core.Call c -> c.args().forEach(this::walk);
+                // What a representation kept standing for an analysis to read. Coverage is measured
+                // over the tree that runs, which keeps none of these, so reaching one would mean this
+                // count was taken over a tree nothing executes.
+                case Core.PreservedCall p -> throw new IllegalStateException(
+                        "a preserved call (" + p.operation() + ") reached coverage numbering, at "
+                                + p.pos());
                 case Core.Apply a -> a.args().forEach(this::walk);
                 case Core.LetIn li -> {
                     walk(li.value());

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -167,9 +167,7 @@ public final class CoverageSites {
                 // What a representation kept standing for an analysis to read. Coverage is measured
                 // over the tree that runs, which keeps none of these, so reaching one would mean this
                 // count was taken over a tree nothing executes.
-                case Core.PreservedCall p -> throw new IllegalStateException(
-                        "a preserved call (" + p.operation() + ") reached coverage numbering, at "
-                                + p.pos());
+                case Core.PreservedCall p -> throw p.unexpectedIn("coverage numbering");
                 case Core.Apply a -> a.args().forEach(this::walk);
                 case Core.LetIn li -> {
                     walk(li.value());

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -120,6 +120,11 @@ public final class GuardThresholds {
                         && TypeOps.isSingleValueNewtype(fa.target().type(), symbols)
                         ? base : base.then(fa.field());
             }
+            // A call kept standing names no location, and its presence says this walk was handed a
+            // representation it does not read. Said rather than answered with "no path", which would
+            // be the same answer a number gives.
+            case Core.PreservedCall p -> throw new IllegalStateException(
+                    "a preserved call (" + p.operation() + ") reached guard thresholds, at " + p.pos());
             case null, default -> null;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -127,8 +127,7 @@ public final class GuardThresholds {
             // A call kept standing names no location, and its presence says this walk was handed a
             // representation it does not read. Said rather than answered with "no path", which would
             // be the same answer a number gives.
-            case Core.PreservedCall p -> throw new IllegalStateException(
-                    "a preserved call (" + p.operation() + ") reached guard thresholds, at " + p.pos());
+            case Core.PreservedCall p -> throw p.unexpectedIn("guard thresholds");
             case null, default -> null;
         };
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.check.Location;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.core.Core;
@@ -103,10 +104,14 @@ public final class GuardThresholds {
     /**
      * The input position a comparison names, spelled the way a parameter's own path is spelled.
      *
-     * <p>A newtype's {@code value} is not a step: {@code request.cost} and {@code request.cost.value}
-     * are one location, and if the two spellings disagreed the same position would become two axes,
-     * one of which no row would ever cover. This is the rule {@code InvariantChecker} follows over the
-     * surface tree; the same rule, over the tree the checker produced.
+     * <p>Which fields are steps is {@link Location}'s rule, asked here rather than restated: a
+     * newtype's {@code value} is not one, so {@code request.cost} and {@code request.cost.value} are
+     * one position, and if the two spellings disagreed the same position would become two axes, one
+     * of which no row would ever cover.
+     *
+     * <p>The root is not that rule's. A partition is derived from what a behavior declares, and a
+     * declared parameter is not a binding — a behavior with no implementation has axes all the same —
+     * so this path is rooted at the parameter and {@link Location} at the binding a body gave it.
      */
     static TermPath pathOf(Core e, List<String> parameters, Symbols symbols) {
         return switch (e) {
@@ -116,9 +121,8 @@ public final class GuardThresholds {
                 if (base == null) {
                     yield null;
                 }
-                yield fa.field().equals("value")
-                        && TypeOps.isSingleValueNewtype(fa.target().type(), symbols)
-                        ? base : base.then(fa.field());
+                yield Location.isStep(fa.target().type(), fa.field(), symbols)
+                        ? base.then(fa.field()) : base;
             }
             // A call kept standing names no location, and its presence says this walk was handed a
             // representation it does not read. Said rather than answered with "no path", which would

--- a/souther-compiler/src/main/resources/souther/bool.sou
+++ b/souther-compiler/src/main/resources/souther/bool.sou
@@ -3,4 +3,4 @@ module souther.bool
 // The first self-hosted standard-library function (ADR-0028): logical negation, written in
 // Souther rather than as a primitive. `not` is auto-imported into every user module and, being a
 // non-recursive helper, is expanded inline at each call site — so no class is generated for it.
-let not (b: Bool) = if b then false else true
+let not (b: Bool): Bool = if b then false else true

--- a/souther-compiler/src/main/resources/souther/decimal.sou
+++ b/souther-compiler/src/main/resources/souther/decimal.sou
@@ -40,7 +40,7 @@ let fromInt (n: Int) : Decimal = intrinsic "decimal.fromInt"
 // differs still answers by numeric value, as `compare` does. `clamp(lo, hi, d)` keeps a rate or a
 // ratio inside a range without a `match`, and the bounds keep their own scale — clamping returns one
 // of the three values written, never a re-scaled copy.
-let abs (d: Decimal) = if d < 0.0m then 0.0m - d else d
-let min (a: Decimal, b: Decimal) = if a < b then a else b
-let max (a: Decimal, b: Decimal) = if a > b then a else b
-let clamp (lo: Decimal, hi: Decimal, d: Decimal) = if d < lo then lo else if d > hi then hi else d
+let abs (d: Decimal): Decimal = if d < 0.0m then 0.0m - d else d
+let min (a: Decimal, b: Decimal): Decimal = if a < b then a else b
+let max (a: Decimal, b: Decimal): Decimal = if a > b then a else b
+let clamp (lo: Decimal, hi: Decimal, d: Decimal): Decimal = if d < lo then lo else if d > hi then hi else d

--- a/souther-compiler/src/main/resources/souther/int.sou
+++ b/souther-compiler/src/main/resources/souther/int.sou
@@ -33,7 +33,7 @@ let modBy (divisor: Int, n: Int) : Int = intrinsic "int.modBy"
 // `min` / `max` are the two-value form the comparison operators imply; `List.min` / `List.max` are
 // the list form and answer an optional, since a list may be empty. `clamp(lo, hi, n)` holds a value
 // inside a range (Elm's `clamp low high number`), the subject last as the pipe convention wants.
-let abs (n: Int) = if n < 0 then 0 - n else n
-let min (a: Int, b: Int) = if a < b then a else b
-let max (a: Int, b: Int) = if a > b then a else b
-let clamp (lo: Int, hi: Int, n: Int) = if n < lo then lo else if n > hi then hi else n
+let abs (n: Int): Int = if n < 0 then 0 - n else n
+let min (a: Int, b: Int): Int = if a < b then a else b
+let max (a: Int, b: Int): Int = if a > b then a else b
+let clamp (lo: Int, hi: Int, n: Int): Int = if n < lo then lo else if n > hi then hi else n

--- a/souther-compiler/src/main/resources/souther/list.sou
+++ b/souther-compiler/src/main/resources/souther/list.sou
@@ -31,17 +31,17 @@ let foldFrom (step: ('acc, 'a) -> 'acc, seed: 'acc, xs: List<'a>, i: Int) : 'acc
         | Some x -> List.foldFrom(step, step(seed, x), xs, i + 1)
         | None -> seed
 
-let map (f: ('a) -> 'b, xs: List<'a>) = List.fold((acc, x) -> acc ++ [f(x)], [], xs)
-let filter (keep: ('a) -> Bool, xs: List<'a>) = List.fold((acc, x) -> if keep(x) then acc ++ [x] else acc, [], xs)
-let all (p: ('a) -> Bool, xs: List<'a>) = List.fold((acc, x) -> acc && p(x), true, xs)
-let any (p: ('a) -> Bool, xs: List<'a>) = List.fold((acc, x) -> acc || p(x), false, xs)
+let map (f: ('a) -> 'b, xs: List<'a>): List<'b> = List.fold((acc, x) -> acc ++ [f(x)], [], xs)
+let filter (keep: ('a) -> Bool, xs: List<'a>): List<'a> = List.fold((acc, x) -> if keep(x) then acc ++ [x] else acc, [], xs)
+let all (p: ('a) -> Bool, xs: List<'a>): Bool = List.fold((acc, x) -> acc && p(x), true, xs)
+let any (p: ('a) -> Bool, xs: List<'a>): Bool = List.fold((acc, x) -> acc || p(x), false, xs)
 
 // `indexedMap` is Elm's `List.indexedMap`: it applies `f(index, element)` down the list, the index
 // starting at 0. `fold` carries no index of its own, so it threads one in a pair accumulator
 // `(i, ys)` — the same tuple-accumulator shape as `distinct`/`partition` below — and drops the
 // counter at the end. It saves the caller from hand-rolling that `(i, acc)` fold for a weighted sum
 // or a positional transform (a check-digit weighting reads `indexedMap((i, c) -> w(i) * d(c)) |> sum`).
-let indexedMap (f: (Int, 'a) -> 'b, xs: List<'a>) = {
+let indexedMap (f: (Int, 'a) -> 'b, xs: List<'a>): List<'b> = {
     let (_, out) = List.fold((acc, x) -> {
         let (i, ys) = acc
         let mapped = ys ++ [f(i, x)]
@@ -56,7 +56,7 @@ let indexedMap (f: (Int, 'a) -> 'b, xs: List<'a>) = {
 // `map2(f, xs, ys)`. A length mismatch truncates to the shorter list rather than aborting, as Elm's
 // `map2` does — `zip` walks `xs` with the same `(i, ys)` pair accumulator `indexedMap` uses and reads
 // the partner with `List.get`, so a missing partner simply ends the pairing.
-let zip (xs: List<'a>, ys: List<'b>) = {
+let zip (xs: List<'a>, ys: List<'b>): List<('a, 'b)> = {
     let (_, out) = List.fold((acc, x) -> {
         let (i, pairs) = acc
         let next = i + 1
@@ -67,7 +67,7 @@ let zip (xs: List<'a>, ys: List<'b>) = {
     out
 }
 
-let unzip (ps: List<('a, 'b)>) =
+let unzip (ps: List<('a, 'b)>): (List<'a>, List<'b>) =
     List.fold((acc, p) -> {
         let (xs, ys) = acc
         let (x, y) = p
@@ -93,15 +93,15 @@ let reverse (xs: List<'a>) : List<'a> = intrinsic "list.reverse"
 // of them is summed by mapping to the wrapped value first.
 let sum (xs: List<'a>) : 'a = intrinsic "list.sum"
 let product (xs: List<'a>) : 'a = intrinsic "list.product"
-let concat (xss: List<List<'a>>) = List.fold((acc, xs) -> acc ++ xs, [], xss)
-let member (e: 'a, xs: List<'a>) = List.fold((acc, x) -> acc || x == e, false, xs)
-let isEmpty (xs: List<'a>) = List.length(xs) == 0
+let concat (xss: List<List<'a>>): List<'a> = List.fold((acc, xs) -> acc ++ xs, [], xss)
+let member (e: 'a, xs: List<'a>): Bool = List.fold((acc, x) -> acc || x == e, false, xs)
+let isEmpty (xs: List<'a>): Bool = List.length(xs) == 0
 
 // `take` keeps the first `n` elements and `drop` skips them (Elm's `List.take` / `List.drop`). Both
 // clamp rather than fail: a count of 0 or less takes nothing / drops nothing, and a count past the
 // end takes the whole list / leaves it empty. They thread the same `(i, ys)` pair accumulator
 // `indexedMap` uses, keeping the elements whose index falls on the wanted side of `n`.
-let take (n: Int, xs: List<'a>) = {
+let take (n: Int, xs: List<'a>): List<'a> = {
     let (_, out) = List.fold((acc, x) -> {
         let (i, ys) = acc
         let next = i + 1
@@ -110,7 +110,7 @@ let take (n: Int, xs: List<'a>) = {
     out
 }
 
-let drop (n: Int, xs: List<'a>) = {
+let drop (n: Int, xs: List<'a>): List<'a> = {
     let (_, out) = List.fold((acc, x) -> {
         let (i, ys) = acc
         let next = i + 1
@@ -125,7 +125,7 @@ let drop (n: Int, xs: List<'a>) = {
 // a `Set` (O(log n)) rather than scanning the growing list with `member` (O(n)) is what keeps it
 // O(n log n); the result list keeps first-seen order. The seen-set is discarded at the end. This is
 // the same shape as `groupBy`, which grows a `Map` accumulator from within `List.fold`.
-let distinct (xs: List<'a>) = {
+let distinct (xs: List<'a>): List<'a> = {
     let (_, out) = List.fold((acc, x) -> {
         let (seen, ys) = acc
         if Set.contains(x, seen) then acc else (Set.insert(x, seen), ys ++ [x])
@@ -138,12 +138,12 @@ let distinct (xs: List<'a>) = {
 // a `length(distinct(map ...)) == length` by hand. It projects with `map`, drops duplicate keys with
 // `distinct`, and holds when nothing was dropped. Deriving from the total `fold` (through
 // `map`/`distinct`), it may stand in an invariant, like `distinct` itself.
-let allUniqueBy (key: ('a) -> 'k, xs: List<'a>) =
+let allUniqueBy (key: ('a) -> 'k, xs: List<'a>): Bool =
     List.length(List.distinct(List.map(key, xs))) == List.length(xs)
 
 // `partition` splits the list by a predicate into (kept, rest), preserving order in each (Elm's
 // List.partition). It folds a pair of empty lists `([], [])`, appending each element to one side.
-let partition (keep: ('a) -> Bool, xs: List<'a>) =
+let partition (keep: ('a) -> Bool, xs: List<'a>): (List<'a>, List<'a>) =
     List.fold((acc, x) -> {
         let (yes, no) = acc
         if keep(x) then (yes ++ [x], no) else (yes, no ++ [x])
@@ -153,7 +153,7 @@ let partition (keep: ('a) -> Bool, xs: List<'a>) =
 // order (Elm's Dict-based grouping). It folds `Map.empty`, reading the current bucket with `Map.get`
 // (a `None` starts a new one) and writing back the extended bucket — a Map accumulator grown the same
 // way `distinct` grows a list, its key and value types recovered from the block.
-let groupBy (key: ('a) -> 'k, xs: List<'a>) =
+let groupBy (key: ('a) -> 'k, xs: List<'a>): Map<'k, List<'a>> =
     List.fold((acc, x) ->
         Map.insert(key(x),
             match Map.get(key(x), acc) with
@@ -173,7 +173,7 @@ let groupBy (key: ('a) -> 'k, xs: List<'a>) =
 // So `filterMap` serves the absence a model reads. Absence the model owns — a sum case with nothing
 // to give — cannot reach it, because nothing but the core builds an optional; that projection answers
 // a list of nought or one and `concatMap` joins them (issue #166).
-let filterMap (f: ('a) -> 'b?, xs: List<'a>) =
+let filterMap (f: ('a) -> 'b?, xs: List<'a>): List<'b> =
     List.fold((acc, x) ->
         match f(x) with
             | None -> acc
@@ -183,7 +183,7 @@ let filterMap (f: ('a) -> 'b?, xs: List<'a>) =
 // F#'s `List.collect`). Writing it as `map` then `concat` builds an intermediate `List<List<'b>>`,
 // which is why the shape is usually hand-rolled as a fold with `++` in the step — this is that fold,
 // named.
-let concatMap (f: ('a) -> List<'b>, xs: List<'a>) = List.fold((acc, x) -> acc ++ f(x), [], xs)
+let concatMap (f: ('a) -> List<'b>, xs: List<'a>): List<'b> = List.fold((acc, x) -> acc ++ f(x), [], xs)
 
 // `foldr` walks from the end (Elm's `List.foldr`, the counterpart of the left `fold`). It is the left
 // fold over the reversed list: `reverse` is an O(n) intrinsic, so this costs one extra pass and keeps
@@ -196,7 +196,7 @@ let foldr (step: ('acc, 'a) -> 'acc, seed: 'acc, xs: List<'a>) : 'acc =
 // lookup, so a caller reads a key instead of scanning the list once per lookup. Two elements with the
 // same key collapse and the later one wins, as `Map.fromList` does — say the key is an id with
 // `List.allUniqueBy` and the collapse cannot happen.
-let indexBy (key: ('a) -> 'k, xs: List<'a>) =
+let indexBy (key: ('a) -> 'k, xs: List<'a>): Map<'k, 'a> =
     List.fold((acc, x) -> Map.insert(key(x), x, acc), Map.empty, xs)
 
 // `sort` orders by the elements' natural order (Elm `List.sort`). Like Elm it is a native

--- a/souther-compiler/src/main/resources/souther/set.sou
+++ b/souther-compiler/src/main/resources/souther/set.sou
@@ -43,7 +43,7 @@ let filter (keep: ('a) -> Bool, s: Set<'a>) : Set<'a> =
     Set.fromList(List.filter(keep, Set.toList(s)))
 
 // `partition` answers the pair (kept, rest), the same shape `List.partition` gives.
-let partition (keep: ('a) -> Bool, s: Set<'a>) =
+let partition (keep: ('a) -> Bool, s: Set<'a>): (Set<'a>, Set<'a>) =
     Set.fold((acc, x) -> {
         let (yes, no) = acc
         if keep(x) then (Set.insert(x, yes), no) else (yes, Set.insert(x, no))

--- a/souther-compiler/src/main/resources/souther/string.sou
+++ b/souther-compiler/src/main/resources/souther/string.sou
@@ -26,7 +26,7 @@ let endsWith (suffix: String, s: String) : Bool = intrinsic "string.endsWith"
 // newtype invariant: a derived decoder recognises `String.length(value) >= 1` and reports a violation
 // as `too_short` with its bound, while the helper's inlined form leaves it the generic
 // `invariant_violation` (§codec-constraints).
-let isEmpty (s: String) = String.length(s) == 0
+let isEmpty (s: String): Bool = String.length(s) == 0
 
 // Whole-string regex match (Java Pattern flavour, anchored), for format-constrained values in an
 // invariant — `invariant String.matches("[0-9]{3}-[0-9]{4}", value)`. The pattern must be a string

--- a/souther-compiler/src/test/java/souther/compiler/check/ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.ast.Ast;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
@@ -41,6 +42,26 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
         Core.PreservedCall kept = assertInstanceOf(Core.PreservedCall.class, typed);
         assertEquals(new ValueName.Stdlib("List.length"), kept.operation());
         assertEquals(Type.INT, kept.type());
+    }
+
+    @Test
+    void whatAFunctionArgumentAnswersSettlesTheRest() {
+        // List.concatMap : (('a) -> List<'b>, List<'a>) -> List<'b>. The declared result of the
+        // function argument is `List<'b>` and not `'b`, so reading it as an accumulator to grow —
+        // which is one operation's meaning and not what applying a signature is — leaves `'b` a
+        // variable and refuses the call. Applying the signature settles it from what the function
+        // answered.
+        Ast.Binders binders = new Ast.Binders(new BindingOwner.OfValue("demo", "test"));
+        Ast.Block step = new Ast.Block(List.of(binders.binder("x", POS)),
+                new Ast.ListLit(List.of(new Ast.IntLit(1, POS)), POS), POS);
+        Ast.Expr call = new Ast.Apply("List.concatMap", new ValueName.Stdlib("List.concatMap"),
+                List.of(step, new Ast.ListLit(List.of(new Ast.IntLit(2, POS)), POS)),
+                ConstructionOrigin.own(), POS);
+
+        Core typed = Elaborator.elaborate(call, Scope.NONE,
+                CheckContext.of(Symbols.none()).preserving(KEPT));
+
+        assertEquals(Type.list(Type.INT), typed.type());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest.java
@@ -1,0 +1,74 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The operations the discharge representation keeps are the language's own, and each types from the
+ * signature the library declared it with — variables and all, settled by the arguments it was given.
+ * Nothing about the operation is written here: what is kept comes from the library, so one it gains
+ * is kept without this being told.
+ */
+class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+    private static final Preserved KEPT = Preserved.byTheLanguagesOwnOperations();
+
+    @Test
+    void aPolymorphicOperationSettlesItsVariablesFromItsArguments() {
+        // List.length : (List<'a>) -> Int — the argument decides 'a, and the result is not a variable
+        Ast.Expr call = new Ast.Apply("List.length", new ValueName.Stdlib("List.length"),
+                List.of(new Ast.ListLit(List.of(new Ast.IntLit(1, POS)), POS)),
+                ConstructionOrigin.own(), POS);
+
+        Core typed = Elaborator.elaborate(call, Scope.NONE,
+                CheckContext.of(Symbols.none()).preserving(KEPT));
+
+        Core.PreservedCall kept = assertInstanceOf(Core.PreservedCall.class, typed);
+        assertEquals(new ValueName.Stdlib("List.length"), kept.operation());
+        assertEquals(Type.INT, kept.type());
+    }
+
+    @Test
+    void theOperationsKeptAreTheLibrarysAndNotAListWrittenHere() {
+        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("List.map")),
+                "an operation the discharge rules are written about");
+        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("String.length")),
+                "and one they are not — what is kept is not decided by having a rule");
+    }
+
+    @Test
+    void anOperationRewrittenAwayBeforeAnyOfThisIsNotKept() {
+        // `List.fold` becomes `List.foldFrom` before this tree exists, so it has no declaration to
+        // keep — and a rule keyed by it could never be looked up either
+        assertTrue(KEPT.signatureOf(new ValueName.Stdlib("List.fold")) == null,
+                "sugar has no declaration of its own");
+        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("List.foldFrom")),
+                "what it becomes does");
+    }
+
+    @Test
+    void aModulesOwnHelperIsNotKeptByThisPolicy() {
+        // nothing could be derived from leaving it standing, so it is expanded — and a tree that
+        // still holds one is this compiler having failed to do that
+        Ast.Expr call = new Ast.Apply("half", new ValueName.Helper("demo", "half"),
+                List.of(new Ast.IntLit(1, POS)), ConstructionOrigin.own(), POS);
+
+        assertThrows(RuntimeException.class, () -> Elaborator.elaborate(call, Scope.NONE,
+                CheckContext.of(Symbols.none()).preserving(KEPT)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest.java
@@ -1,0 +1,45 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Typing is defined over what a representation is allowed to hold. The tree the backend emits from
+ * has every call it cannot emit already expanded, so one arriving at call elaboration there is this
+ * compiler having failed to expand it — not a program to type. That guard is what stops an expansion
+ * bug from being emitted as something else, and it is fixed here before any representation is given
+ * permission to keep a call standing.
+ */
+class AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    @Test
+    void aStandardLibraryCallLeftStandingIsNotSomethingToType() {
+        Ast.Expr call = new Ast.Apply("List.map", new ValueName.Stdlib("List.map"),
+                List.of(new Ast.IntLit(1, POS)), ConstructionOrigin.own(), POS);
+
+        assertThrows(RuntimeException.class, () -> Elaborator.elaborate(call, Scope.NONE,
+                CheckContext.of(Symbols.none())));
+    }
+
+    @Test
+    void aHelperLeftStandingIsNotSomethingToTypeEither() {
+        // a module's own `let` is expanded into the body that called it, so this is the same failure
+        // as above and not a different one — the guard is about the representation, not about which
+        // namespace the name was in
+        Ast.Expr call = new Ast.Apply("half", new ValueName.Helper("demo", "half"),
+                List.of(new Ast.IntLit(1, POS)), ConstructionOrigin.own(), POS);
+
+        assertThrows(RuntimeException.class, () -> Elaborator.elaborate(call, Scope.NONE,
+                CheckContext.of(Symbols.none())));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
@@ -1,0 +1,131 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.ast.Ast;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A clause the declaration check accepts is one this analysis can type.
+ *
+ * <p>The check reads clauses in a representation of their own and types them there, and a clause it
+ * cannot type is answered with silence: the run-time check stands for it and nothing is reported.
+ * That is the right answer for a clause outside the fragment and the wrong one for a clause this
+ * compiler simply failed to type, and the two are indistinguishable from the outside — a suite stays
+ * green either way, with one warning fewer. So the property is held here rather than left to be
+ * noticed, one lost discharge at a time.
+ *
+ * <p>What is fixed is the property and not a count. A clause that names something the fragment does
+ * not reach may still be answered with silence; what may not happen is a clause of a declaration this
+ * compiler accepted failing to become typed Core.
+ */
+class EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest {
+
+    private static final List<String> DECLARATIONS = List.of(
+            """
+            module demo
+            data Amount = Decimal
+                invariant value >= 0m
+            data Positive = Int
+                invariant value >= 1
+            behavior f : (a: Amount) -> Amount
+            let f (a) = a
+            """,
+            """
+            module demo
+            data Code = String
+                invariant String.length(value) >= 2 && String.startsWith("x", value)
+            behavior f : (c: Code) -> Code
+            let f (c) = c
+            """,
+            """
+            module demo
+            data Line = { product: String, qty: Int }
+            data Order = { lines: List<Line> }
+                invariant List.length(lines) >= 1
+                    && List.all(l -> l.qty >= 1, lines)
+                    && List.allUniqueBy(.product, lines)
+            behavior f : (o: Order) -> Int
+            let f (o) = List.length(o.lines)
+            """,
+            """
+            module demo
+            data Range = { low: Int, high: Int }
+                invariant low <= high
+            data Window = { at: Range, label: String? }
+                invariant String.length(Option.withDefault("x", label)) >= 1
+            behavior f : (w: Window) -> Int
+            let f (w) = w.at.high
+            """,
+            """
+            module demo
+            data Named = { name: String }
+                invariant String.length(name) >= 1
+            data Priced = { amount: Int }
+                invariant amount >= 0
+            data Item = { ...Named, ...Priced }
+            behavior f : (i: Item) -> Int
+            let f (i) = i.amount
+            """,
+            """
+            module demo
+            let remainder (n: Int) : Int = Int.modBy(2, n)
+            data Even = Int
+                invariant remainder(value) == 0
+            behavior f : (e: Even) -> Int
+            let f (e) = e.value
+            """,
+            """
+            module demo
+            data Tag = Small | Large
+            data Batch = { tag: Tag, sizes: List<Int> }
+                invariant List.all(s -> s >= 0, sizes)
+            behavior f : (b: Batch) -> Int
+            let f (b) = List.length(b.sizes)
+            """);
+
+    @Test
+    void everyClauseOfAnAcceptedDeclarationBecomesTypedCore() {
+        for (String source : DECLARATIONS) {
+            // it compiles at all — a clause of a declaration this compiler refused says nothing
+            assertFalse(Compiler.compile(source).isEmpty(), "this program is supposed to compile");
+            Compilation compilation = Compilation.ofSource(source, "Main");
+            compilation.answerEverything();
+
+            String module = compilation.modules().get(0);
+            Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+            Map<TypeName, List<Ast.InvariantClause>> declared =
+                    compilation.db().ask(new Shapes.InvariantsForDischarge(module)).value();
+            Ast.Module prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+            assertNotNull(symbols);
+            assertNotNull(declared);
+            assertNotNull(prepared);
+
+            Clauses clauses = new Clauses(symbols, declared);
+            int read = 0;
+            for (Ast.Def def : prepared.defs()) {
+                if (!(def instanceof Ast.Data data)) {
+                    continue;
+                }
+                TypeName named = new TypeName(module, data.name());
+                for (Ast.InvariantClause clause : clauses.of(named, data)) {
+                    assertNotNull(clauses.typed(clause.expr(), data),
+                            "`" + data.name() + "` declares a clause this check could not type:\n"
+                                    + source);
+                    read++;
+                }
+            }
+            assertTrue(read > 0, "no clause was read at all, so nothing was held:\n" + source);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
@@ -229,7 +229,7 @@ class InvariantCombinatorRulesTest {
 
     @Test
     void everyRuleIsKeyedByANameTheAnalysisStillSees() {
-        for (String fn : InvariantChecker.combinatorNames()) {
+        for (String fn : DischargeRules.combinatorNames()) {
             assertTrue(Prelude.isLibraryFunction(fn), fn + " is not a standard-library operation");
             assertFalse(Prelude.sugared(fn),
                     fn + " is rewritten to another call before this tree is read, so its rule cannot"
@@ -240,7 +240,7 @@ class InvariantCombinatorRulesTest {
     @Test
     void everyRuleHasAProgramThatFiresIt() {
         Set<String> covered = FIRES.stream().map(Fires::fn).collect(Collectors.toCollection(TreeSet::new));
-        assertEquals(new TreeSet<>(InvariantChecker.combinatorNames()), covered,
+        assertEquals(new TreeSet<>(DischargeRules.combinatorNames()), covered,
                 "a rule is registered with no program that fires it, or the other way round");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
  * Applying a declared signature is one act, and a call settles it the same way wherever it is
@@ -82,6 +83,41 @@ class OneCallSettlesOneSignatureTest {
         Compiler.Compiled compiled = Compiler.compileWithWarnings(source);
 
         assertFalse(compiled.classes().isEmpty(), "the function's parameter type was read");
+    }
+
+    @Test
+    void everyValueArgumentIsReadOnceAndTheFunctionArgumentsNotAtAll() {
+        // Reading an argument decides variables of the application it stands in, so a second reading
+        // answers from the state the first one left. The settlement classifies and then unifies, and
+        // both are that one reading.
+        List<Type> params = List.of(
+                Type.fn(List.of(new Type.Var("a", false)), Type.BOOL),
+                Type.list(new Type.Var("a", false)));
+        int[] reads = new int[params.size()];
+        Ast.Apply call = (Ast.Apply) filterOverAnEmptyList();
+
+        CallElaborator.settledByValues(call, params, Type.list(new Type.Var("a", false)),
+                Type.list(Type.INT), i -> {
+                    reads[i]++;
+                    return Type.list(Type.INT);
+                }, CheckContext.of(Symbols.none()));
+
+        assertEquals(0, reads[0], "a function argument is typed after the values, not here");
+        assertEquals(1, reads[1], "and a value argument is read once, however it is ordered");
+    }
+
+    @Test
+    void anArgumentIsElaboratedOnceHoweverOftenARuleAsksItsType() {
+        // The same guarantee where the answers come from: what a rule reasoned about and what reached
+        // the tree are one elaboration of one argument.
+        CallElaborator.CallArgs args = new CallElaborator.CallArgs(
+                List.of(new Ast.IntLit(1, POS)), Scope.NONE, CheckContext.of(Symbols.none()));
+
+        args.type(0);
+        Core first = args.cores().get(0);
+        args.type(0);
+
+        assertSame(first, args.cores().get(0), "asked twice, elaborated once");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
@@ -1,0 +1,107 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+/**
+ * Applying a declared signature is one act, and a call settles it the same way wherever it is
+ * applied: from what the context expects of the result, and then from what the value arguments state.
+ *
+ * <p>Held here because a difference between the two readers is not a failure anyone sees. A variable
+ * settled from an empty collection instead of from the expected type leaves a closure typed over
+ * {@code Nothing}, which either reports an arithmetic error in the author's own predicate or —
+ * worse — types quietly and leaves an analysis reading a tree that says less than the one the backend
+ * emits from.
+ */
+class OneCallSettlesOneSignatureTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+    private static final Preserved KEPT = Preserved.byTheLanguagesOwnOperations();
+    private static final Ast.Binders BINDERS = new Ast.Binders(new BindingOwner.OfValue("demo", "t"));
+
+    /** {@code List.filter(x -> true, [])} — nothing in the call says what the list holds. */
+    private static Ast.Expr filterOverAnEmptyList() {
+        Ast.Block predicate = new Ast.Block(List.of(BINDERS.binder("x", POS)),
+                new Ast.BoolLit(true, POS), POS);
+        return new Ast.Apply("List.filter", new ValueName.Stdlib("List.filter"),
+                List.of(predicate, new Ast.ListLit(List.of(), POS)), ConstructionOrigin.own(), POS);
+    }
+
+    @Test
+    void anExpectedResultPinsAnEmptyContainerBeforeThePreservedClosureIsTyped() {
+        Core typed = Elaborator.elaborate(filterOverAnEmptyList(), Scope.NONE,
+                CheckContext.of(Symbols.none()).preserving(KEPT), Type.list(Type.INT));
+
+        Core.PreservedCall kept = assertInstanceOf(Core.PreservedCall.class, typed);
+        assertEquals(Type.list(Type.INT), kept.type(),
+                "the position the call stands in is the only thing that says what the list holds");
+    }
+
+    @Test
+    void andTheClosureIsTypedOverWhatWasPinnedRatherThanOverNothing() {
+        Core typed = Elaborator.elaborate(filterOverAnEmptyList(), Scope.NONE,
+                CheckContext.of(Symbols.none()).preserving(KEPT), Type.list(Type.INT));
+
+        Core.PreservedCall kept = assertInstanceOf(Core.PreservedCall.class, typed);
+        Core.Block predicate = assertInstanceOf(Core.Block.class, kept.args().get(0));
+        assertEquals(List.of(Type.INT), ((Type.FnOf) predicate.type()).params(),
+                "a predicate over `Nothing` is one the author's own body cannot use");
+    }
+
+    @Test
+    void aFunctionHandedToAPreservedCallLearnsWhatTheValuesSettle() {
+        // A lambda a `let` binds is never applied where a preserved call holds the application, so
+        // what it takes is read off the declaration at the position it was handed to — through the
+        // same settlement, so the parameter type that walk learns is the one the call reaches.
+        String source = """
+                module demo
+                data Amount = Int
+                    invariant value >= 1
+                behavior f : (xs: List<Int>) -> List<Amount>
+                    constructs Amount
+                let f (xs) = {
+                    let positive = y -> y > 0
+                    List.map(y -> Amount(y), List.filter(positive, xs))
+                }
+                """;
+
+        Compiler.Compiled compiled = Compiler.compileWithWarnings(source);
+
+        assertFalse(compiled.classes().isEmpty(), "the function's parameter type was read");
+    }
+
+    @Test
+    void anArgumentThatAnswersNoValueDoesNotSettleWhatOneThatDoesHasSaid() {
+        // Option.withDefault : ('a, Option<'a>) -> 'a. The empty list states nothing about what it
+        // holds, so the option beside it is what decides — the other order holds the option to the
+        // element type of nothing.
+        Ast.Expr call = new Ast.Apply("Option.withDefault",
+                new ValueName.Stdlib("Option.withDefault"),
+                List.of(new Ast.ListLit(List.of(), POS),
+                        new Ast.Apply("List.get", new ValueName.Stdlib("List.get"),
+                                List.of(new Ast.IntLit(0, POS),
+                                        new Ast.ListLit(List.of(new Ast.ListLit(
+                                                List.of(new Ast.IntLit(1, POS)), POS)), POS)),
+                                ConstructionOrigin.own(), POS)),
+                ConstructionOrigin.own(), POS);
+
+        Core typed = Elaborator.elaborate(call, Scope.NONE,
+                CheckContext.of(Symbols.none()).preserving(KEPT));
+
+        assertEquals(Type.list(Type.INT), typed.type());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/OneValueIsOneLocationHoweverItWasSpelledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneValueIsOneLocationHoweverItWasSpelledTest.java
@@ -54,10 +54,10 @@ class OneValueIsOneLocationHoweverItWasSpelledTest {
 
     @Test
     void whatIsComputedIsNowhereAFactCanBeAbout() {
-        assertNull(Location.of(new Core.Int(1, Type.INT, POS), Symbols.none()));
-        assertNull(Location.of(new Core.Binary(Ast.BinOp.ADD,
+        assertNull(of(new Core.Int(1, Type.INT, POS)));
+        assertNull(of(new Core.Binary(Ast.BinOp.ADD,
                 new Core.Int(1, Type.INT, POS), new Core.Int(2, Type.INT, POS),
-                Type.INT, POS), Symbols.none()));
+                Type.INT, POS)));
     }
 
     private static Core read(BindingId binding, String spelledAs) {
@@ -65,6 +65,6 @@ class OneValueIsOneLocationHoweverItWasSpelledTest {
     }
 
     private static Location of(Core e) {
-        return Location.of(e, Symbols.none());
+        return Location.of(e, Symbols.none(), Location::of);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/OneValueIsOneLocationHoweverItWasSpelledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneValueIsOneLocationHoweverItWasSpelledTest.java
@@ -1,0 +1,70 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A fact is about a value, and which value is decided by the binding a name was answered with. Two
+ * bindings of one spelling are two values, and one binding read twice is one value — neither of
+ * which the text can say.
+ */
+class OneValueIsOneLocationHoweverItWasSpelledTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+    private static final Ast.Binders BINDERS =
+            new Ast.Binders(new BindingOwner.OfValue("demo", "test"));
+
+    @Test
+    void oneSpellingBoundTwiceIsTwoLocations() {
+        BindingId first = BINDERS.binder("a", POS).id();
+        BindingId second = BINDERS.binder("a", POS).id();
+
+        assertNotEquals(Location.of(first), Location.of(second),
+                "a second binding is a second value, whatever it is called");
+    }
+
+    @Test
+    void oneBindingReadTwiceIsOneLocation() {
+        BindingId a = BINDERS.binder("a", POS).id();
+
+        assertEquals(Location.of(a), Location.of(a));
+        assertEquals(of(read(a, "a")), of(read(a, "written-another-way")),
+                "how a read was spelled says nothing about which value it is");
+    }
+
+    @Test
+    void aFieldPathIsPartOfTheLocation() {
+        BindingId i = BINDERS.binder("i", POS).id();
+        Location root = Location.of(i);
+
+        assertNotEquals(root, root.then(Type.INT, "n", Symbols.none()));
+        assertNotEquals(root.then(Type.INT, "n", Symbols.none()),
+                root.then(Type.INT, "m", Symbols.none()));
+    }
+
+    @Test
+    void whatIsComputedIsNowhereAFactCanBeAbout() {
+        assertNull(Location.of(new Core.Int(1, Type.INT, POS), Symbols.none()));
+        assertNull(Location.of(new Core.Binary(Ast.BinOp.ADD,
+                new Core.Int(1, Type.INT, POS), new Core.Int(2, Type.INT, POS),
+                Type.INT, POS), Symbols.none()));
+    }
+
+    private static Core read(BindingId binding, String spelledAs) {
+        return new Core.Read(spelledAs, binding, Type.INT, POS);
+    }
+
+    private static Location of(Core e) {
+        return Location.of(e, Symbols.none());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARepresentationKeepsIsTheRepresentationsToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARepresentationKeepsIsTheRepresentationsToSayTest.java
@@ -1,0 +1,101 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Which calls survive is decided where a representation is built, and the checker is told. It asks
+ * only whether this call is one of them — not what the operation means, which belongs to whoever
+ * reads the representation. So an operation kept with no rule about it types like any other and
+ * states nothing, and typing a call never waits on someone having a rule for it.
+ */
+class WhatARepresentationKeepsIsTheRepresentationsToSayTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+    private static final ValueName MAP = new ValueName.Stdlib("List.map");
+
+    /** `(Int) -> Int`, standing for whatever the operation was declared as. */
+    private static final Type.FnOf SIGNATURE = (Type.FnOf) Type.fn(List.of(Type.INT), Type.INT);
+
+    @Test
+    void aKeptCallIsTypedFromTheSignatureItWasDeclaredWith() {
+        Core typed = elaborate(callTo(MAP), keeping(MAP, SIGNATURE));
+
+        Core.PreservedCall kept = assertInstanceOf(Core.PreservedCall.class, typed);
+        assertEquals(MAP, kept.operation(), "what the name resolved to, not how it was written");
+        assertEquals(Type.INT, kept.type());
+    }
+
+    @Test
+    void aRepresentationThatKeepsNothingStillRefusesIt() {
+        assertThrows(RuntimeException.class, () -> elaborate(callTo(MAP), Preserved.NONE));
+    }
+
+    @Test
+    void anOperationThisRepresentationNeverSaidItKeepsIsStillARefusal() {
+        // keeping one operation is not keeping the namespace it is in: a call this representation
+        // never claimed is this compiler having failed to expand it, whichever library it names
+        Preserved keepsMapOnly = keeping(MAP, SIGNATURE);
+
+        assertThrows(RuntimeException.class,
+                () -> elaborate(callTo(new ValueName.Stdlib("List.filter")), keepsMapOnly));
+    }
+
+    @Test
+    void aKeptCallAppliedToTheWrongNumberOfArgumentsIsSaidAsThat() {
+        Ast.Expr twoArgs = new Ast.Apply("List.map", MAP,
+                List.of(new Ast.IntLit(1, POS), new Ast.IntLit(2, POS)),
+                ConstructionOrigin.own(), POS);
+
+        assertThrows(RuntimeException.class, () -> elaborate(twoArgs, keeping(MAP, SIGNATURE)));
+    }
+
+    @Test
+    void aTreeThatBelongsToAnotherRepresentationDoesNotInheritThePermission() {
+        // a body reaching a declaration's invariant reaches another tree, built by another question.
+        // What it keeps is its own to say at its own entry; being reached from here is not a
+        // representation having said anything.
+        CheckContext keeping = CheckContext.of(Symbols.none()).preserving(keeping(MAP, SIGNATURE));
+
+        assertEquals(Preserved.NONE, keeping.inAnotherRepresentation().preserved());
+        assertEquals(Preserved.NONE, keeping.inAnotherRepresentation().forData(null).preserved(),
+                "and it stays left behind as that tree is walked");
+    }
+
+    @Test
+    void whichDataIsBeingCheckedIsNotWhereARepresentationEnds() {
+        // `forData` moves within one representation as well, so it must not quietly mean the
+        // permission is gone
+        CheckContext keeping = CheckContext.of(Symbols.none()).preserving(keeping(MAP, SIGNATURE));
+
+        assertEquals(keeping.preserved(), keeping.forData(null).preserved());
+    }
+
+    private static Ast.Expr callTo(ValueName operation) {
+        return new Ast.Apply(operation.name(), operation, List.of(new Ast.IntLit(1, POS)),
+                ConstructionOrigin.own(), POS);
+    }
+
+    private static Preserved keeping(ValueName operation, Type.FnOf signature) {
+        return new Preserved(Map.of(operation,
+                new CompleteSignature(signature.params(), signature.result())));
+    }
+
+    private static Core elaborate(Ast.Expr e, Preserved kept) {
+        return Elaborator.elaborate(e, Scope.NONE,
+                CheckContext.of(Symbols.none()).preserving(kept));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/codegen/APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest.java
@@ -44,8 +44,8 @@ class APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest {
     }
 
     private static void assertRefused(ValueName operation) {
-        IllegalStateException e = BodyGen.refuse(
-                new Core.PreservedCall(operation, List.of(), Type.INT, POS));
+        IllegalStateException e = new Core.PreservedCall(operation, List.of(), Type.INT, POS)
+                .unexpectedIn("the emitter");
 
         assertEquals(IllegalStateException.class, e.getClass());
         assertTrue(e.getMessage().contains(String.valueOf(operation)), e.getMessage());

--- a/souther-compiler/src/test/java/souther/compiler/codegen/APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest.java
@@ -1,0 +1,54 @@
+package souther.compiler.codegen;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A representation keeps a call standing for the analysis that has rules about the operation. The
+ * tree the backend emits from keeps none, so one reaching the emitter means it was handed another
+ * tree — and that is decided by what the node is.
+ *
+ * <p>Not by what the call names. An emitter that refused only the operations it had no bytecode for
+ * would emit the ones it happened to know, which is the same table lookup that let the two
+ * representations be confused in the first place: {@code List.sortBy} has an emitter and
+ * {@code List.map} does not, and neither of them belongs in a tree that runs.
+ */
+class APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest {
+
+    private static final SourcePos POS = new SourcePos(3, 7);
+
+    @Test
+    void anOperationTheEmitterHasNoBytecodeForIsRefused() {
+        assertRefused(new ValueName.Stdlib("List.map"));
+    }
+
+    @Test
+    void anOperationTheEmitterDoesHaveBytecodeForIsRefusedTheSameWay() {
+        // `List.sortBy` is written out by name in the emitter's own call dispatch, so this is the
+        // case an operation-keyed refusal would have let through
+        assertRefused(new ValueName.Stdlib("List.sortBy"));
+    }
+
+    @Test
+    void soIsOneThatNamesAModulesOwnHelper() {
+        assertRefused(new ValueName.Helper("demo", "half"));
+    }
+
+    private static void assertRefused(ValueName operation) {
+        IllegalStateException e = BodyGen.refuse(
+                new Core.PreservedCall(operation, List.of(), Type.INT, POS));
+
+        assertEquals(IllegalStateException.class, e.getClass());
+        assertTrue(e.getMessage().contains(String.valueOf(operation)), e.getMessage());
+        assertTrue(e.getMessage().contains("3:7"), "and where it was: " + e.getMessage());
+    }
+}


### PR DESCRIPTION
Closes the work on #343.

The invariant-discharge check carried its own typer and its own name identity. The issue read that as two cleanups that had not reached one file; measured, it is one cause with two consequences — this analysis read the only representation in the compiler the checker could not type, so it had to rebuild typing and name resolution locally, and that is what kept it outside every correction the rest of the compiler received.

So the order is: the discharge representation becomes one the checker can type, and the rest follows.

## The representation is typed

A call the analysis keeps standing had nowhere to be typed: `CallElaborator` treated a standard-library name arriving unexpanded as an internal error, because typing was defined only over the fully-expanded vocabulary.

- Which calls a representation keeps is that representation's to say (`Preserved`), and the checker asks only whether this call is one of them. An operation kept with no discharge rule types like any other and simply states nothing, so being able to type a call and being able to reason about one stay independent.
- A kept call is typed from its declared signature onto a node of its own, `Core.PreservedCall`, carrying what the name resolved to rather than how it was written. Refused by node kind rather than by operation name — a `sealed` interface caught only one of the four readers that had to change; two exhaustive switches in `BodyGen` and one `default ->` in `GrowingFold` passed it silently.
- An operation kept standing must declare what it answers, raised where the representation says what it keeps rather than at whichever call was reached first. 28 operations in the `.sou` library gained their return types.

Five things a preserved call had been hiding came out of this — a signature's application is not a fold's, a lambda not reduced away is a lambda given a name, the argument that states nothing must not settle the variable, a bound block needs an expected type, and a function-typed `let` reads its parameter types from being handed over and not only from being applied.

## The analysis reads it

The walk is over typed Core, so nothing in the check derives a type: the local typer is gone and so is the scope of names it needed. Which value a fact is about is the binding a name was answered with (`Location`), so a body that binds one spelling twice states two things by construction — nothing has to be forgotten when a name is bound again, and the walk no longer drops every fact whose text mentioned it.

The clause had to be typed too. A clause read over one tree and a body over another are two term grammars that must keep producing the same key for the same value, which is the agreement discharge rests on and nothing would have held them to. A declaration's fields are bindings already, so a clause is elaborated once and read at a construction by putting the value each field is being given where that field is read. That deletes the machinery that used to carry a clause's names to a site: the bindings record, the two path rules, the term-and-rule pair a container resolved to, the splice that let one key hold a term of each tree, and the string identity underneath all of it.

Measured over the suite, 1050 clauses type and 34 do not — every one of the 34 in a program that is already an error where it is declared.

## What is left is separated

One file of 2397 lines becomes the walk (662) and five files it reads with: what the language's operations keep (`DischargeRules`), a declaration's invariant read at a value (`Clauses`), where a value is and what can be said of it (`Terms`), what a clause owes and what a guard settles (`Predicates`), and the values threaded through all of it (`Known`, `Denotations`).

`GuardThresholds` asks `Location` which fields are steps instead of restating the rule. Its own path stays its own: a partition is derived from what a behavior declares, and a declared parameter is not a binding — a behavior with no implementation has axes all the same. So the issue's proposal to delete `TermPath` is not taken, and the reason is written where the two meet.

## What this leaves for later

- `preservedCall` does not go through `applySignature`: the two differ in how a function argument is typed, and joining them is a change to how a signature is applied.
- `Elaborator.handedOver` settles a kept signature without the bottoms-last ordering `preservedCall` has, so an empty collection argument can settle a variable differently in the two places.
- `DischargeRules`' combinator table and `TotalityChecker`'s are 24 of 25 identical rows under two key types.

## Verification

The whole suite is green — 2709 in the compiler, 151 in the language server, 109 in the syntax, 1 in the CLI. Warm compile is 144.5 ms for crm and 18.1 ms for issuetracker, against 144.8 and 18.1 on `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
