### PR TITLE
An attempt is answered by both its readings

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -559,6 +559,14 @@ public final class InvariantChecker {
         Core made = Core.mapAll(e, child -> without(child, was, becomes), name -> name);
         if (made != e) {
             rebuilt.put(made, e);
+            // What an attempt tries to build is rebuilt through the construction slot, which does not
+            // come back through here, so its rebuild is recorded here instead. Unrecorded, the two
+            // readings key one construction under two occurrences, and the branch that refutes it is
+            // said on its own rather than answered by the branch that proves it.
+            if (made instanceof Core.IfConstructed x && e instanceof Core.IfConstructed from
+                    && x.construct() != from.construct()) {
+                rebuilt.put(x.construct(), from.construct());
+            }
         }
         return made;
     }

--- a/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
@@ -217,6 +217,36 @@ class CompileAttemptedConstructionTest {
         assertEquals("E2010", e.code(), e.getMessage());
     }
 
+    /**
+     * A violation one branch of a conditional reaches is not a decided one. Which of the two values
+     * is built is settled where the attempt runs, so the branch that refutes the invariant is the
+     * else branch and not an error — and the attempt says nothing about the branch it cannot decide
+     * either. The plain construction over the same conditional answers with the possible-violation
+     * warning, which is what says the two readings were combined rather than reported one at a time.
+     */
+    @Test
+    void aViolationOnlyOneBranchReachesIsNotDecidedInsideAnAttempt() {
+        String src = """
+                module demo
+                data Reason = A | B
+                data NotRequired = { reasons: List<Reason> }
+                    invariant List.length(reasons) >= 1
+                data Required = { note: String }
+
+                behavior judge : (age: Int) -> Required | NotRequired
+                    constructs Required, NotRequired, A
+
+                let judge (age) =
+                    if NotRequired { reasons = [ A | age >= 75 ] } as excluded
+                    then excluded
+                    else Required { note = "covered" }
+                """;
+        Compiler.Compiled c = Compiler.compileWithWarnings(src);
+        assertEquals(0, c.warnings().stream()
+                        .filter(d -> d.severity() == Severity.WARNING && "E2011".equals(d.code())).count(),
+                "the empty list is the else branch, not a violation to report or to warn about");
+    }
+
     /** An attempt builds the value on its success branch, so it needs the permission any other
      * construction needs. */
     @Test


### PR DESCRIPTION
An attempted construction whose field is given a conditional was reported as a decided
invariant violation (E2010) when only one branch of that conditional refutes the invariant.

```
data NotRequired = { reasons: List<Reason> }
    invariant List.length(reasons) >= 1

let judge (age) =
    if NotRequired { reasons = [ A | age >= 75 ] } as excluded   // E2010
    then excluded
    else Required { note = "covered" }
```

The empty list is what the else branch is for, so there is nothing to report. The same
conditional in a plain construction comes out unproven and warns (E2011), which is the
answer this one should have had too.

## Why

A construction over a conditional is read once per branch and the two readings are combined
by identity: each reading reports the construction it rebuilt, and `rebuilt` maps that back
to the one that was written. A construction an attempt holds is rebuilt through the
construction slot, which `Core.mapAll` walks on its own rather than through `without`, where
the rebuild is recorded. Unrecorded, the two readings keyed one construction under two
occurrences, and `say` read that as a construction only one branch reached — so the reading
that refuted it was reported on its own.

The instrumented occurrences, before the fix:

```
plain      asWritten=589987187  / 589987187   -> combined -> UNKNOWN -> E2011
attempted  asWritten=1232373427 / 1900366749  -> separate -> REFUTED -> E2010
```

ADR-0070 keeps E2010 inside an attempt for a violation the compiler *decides*, because with
the outcome settled at compile time there was never a branch. This one is settled where the
attempt runs.

## Checks

- New test in `CompileAttemptedConstructionTest` fails with E2010 before the change, passes after
- `aDecidedViolationIsStillReportedInsideAnAttempt` and `anAttemptedConstructionIsNotAPossibleViolation` unchanged
- `mvn -o test` green across every module, `souther-bench` corpus included

Found from souther-examples, where `hr/socialinsurance.sou` stopped compiling against `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)