### PR TITLE
The discharge rules resolve against the call, and are bound to the declarations they are about

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Combinators.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Combinators.java
@@ -83,19 +83,27 @@ final class Combinators {
      * The same, off the tree an author wrote — where a closure written as anything but a block is one
      * this says nothing about, the tree not yet having been read for what names denote.
      *
-     * <p>Nor is a call written with fewer arguments than the operation takes. That is not this table
-     * disagreeing with a signature — it is what the surface tree still holds: the walk that reads it
-     * runs beside the checks that report an arity, not after them, so a call already known to be
-     * wrong reaches here. Nothing about the arguments it does not have is true, so nothing is said,
-     * and the arity is reported by the check whose question it is. The tree a representation keeps
-     * standing needs no such answer: a {@code PreservedCall} is built only where the signature it was
-     * applied to accepted the arguments, so one that exists has them.
+     * <p>Nor is a call the operation would not have accepted — written with fewer arguments than it
+     * takes, or handed a block with fewer parameters than it applies one to. That is not this table
+     * disagreeing with a signature: it is what the surface tree still holds, the walk that reads it
+     * running beside the checks that report an arity rather than after them, so a call already known
+     * to be wrong reaches here. A sugar is how both arrive — it has no declaration of its own, so
+     * what is said about the arity of {@code List.fold} is said against the call it becomes, and by
+     * then this has already read it. Nothing about arguments or parameters a call does not have is
+     * true, so nothing is said, and the arity is reported by the check whose question it is.
+     *
+     * <p>The tree a representation keeps standing needs no such answer: a {@code PreservedCall} is
+     * built only where the signature it was applied to accepted the arguments and typed the block it
+     * was handed, so one that exists has both.
      */
     static Written handedTo(Ast.Apply call) {
         Combinator rule = of(call.denotes());
         if (rule == null || rule.closureArg() >= call.args().size()
                 || rule.containerArg() >= call.args().size()
                 || !(call.args().get(rule.closureArg()) instanceof Ast.Block step)) {
+            return null;
+        }
+        if (rule.elementParam() >= step.params().size()) {
             return null;
         }
         return new Written(step, step.params().get(rule.elementParam()),

--- a/souther-compiler/src/main/java/souther/compiler/check/Combinators.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Combinators.java
@@ -1,6 +1,8 @@
 package souther.compiler.check;
 
 import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
@@ -38,7 +40,9 @@ import java.util.Set;
 final class Combinators {
 
     /** A combinator's closure, the parameter its element arrives on, and the container it comes
-     * from — all as argument positions of the call. */
+     * from — all as argument positions of the call. Read by the rules that resolve a call
+     * ({@link #handedTo}, {@link DischargeRules.Reads}) and by nothing else: a position is only
+     * meaningful beside the call it is a position in. */
     record Combinator(int closureArg, int elementParam, int containerArg) {}
 
     /** What {@code operation} hands its closure, or null where it hands one nothing a container
@@ -46,6 +50,56 @@ final class Combinators {
      * library operation. */
     static Combinator of(ValueName operation) {
         return operation == null ? null : Derived.RULES.get(operation);
+    }
+
+    /** What a call hands its closure: the argument that takes the function, the block that argument
+     * is, the parameter the element arrives on, and the container it comes from. */
+    record Handed(Core closure, Core.Block step, Ast.Binder element, Core container) {}
+
+    /** The same, off the tree an author wrote, where a closure is the block as written. */
+    record Written(Ast.Block step, Ast.Binder element, Ast.Expr container) {}
+
+    /**
+     * What {@code call} hands its closure, or null where it hands one nothing a container holds — or
+     * where what stands in the closure argument is not a block this can read.
+     *
+     * <p>{@code at} is what the names around the call denote, since a closure may be written as a
+     * name bound to a block. It is the denotations where the call stands: what a name means depends
+     * on which bindings it is under, so it is asked per call and not once per body.
+     */
+    static Handed handedTo(Core.PreservedCall call, Denotations at) {
+        Combinator rule = of(call.operation());
+        if (rule == null) {
+            return null;
+        }
+        Core closure = call.args().get(rule.closureArg());
+        Core.Block step = Terms.blockOf(closure, at);
+        return step == null ? null
+                : new Handed(closure, step, step.params().get(rule.elementParam()),
+                        call.args().get(rule.containerArg()));
+    }
+
+    /**
+     * The same, off the tree an author wrote — where a closure written as anything but a block is one
+     * this says nothing about, the tree not yet having been read for what names denote.
+     *
+     * <p>Nor is a call written with fewer arguments than the operation takes. That is not this table
+     * disagreeing with a signature — it is what the surface tree still holds: the walk that reads it
+     * runs beside the checks that report an arity, not after them, so a call already known to be
+     * wrong reaches here. Nothing about the arguments it does not have is true, so nothing is said,
+     * and the arity is reported by the check whose question it is. The tree a representation keeps
+     * standing needs no such answer: a {@code PreservedCall} is built only where the signature it was
+     * applied to accepted the arguments, so one that exists has them.
+     */
+    static Written handedTo(Ast.Apply call) {
+        Combinator rule = of(call.denotes());
+        if (rule == null || rule.closureArg() >= call.args().size()
+                || rule.containerArg() >= call.args().size()
+                || !(call.args().get(rule.closureArg()) instanceof Ast.Block step)) {
+            return null;
+        }
+        return new Written(step, step.params().get(rule.elementParam()),
+                call.args().get(rule.containerArg()));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -327,6 +327,13 @@ final class DischargeRules {
         return Bound.CARRIERS.keySet();
     }
 
+    /** Which shapes of construction carry the predicate {@code operation} states, for the test that
+     * holds each rule to a program on both sides of what it names. */
+    static Set<Shape> carriedThrough(String operation) {
+        Carried carried = Bound.CARRIERS.get(op(operation));
+        return carried == null ? Set.of() : carried.through();
+    }
+
     static Set<ValueName> emptinessChecks() {
         return EMPTINESS.keySet();
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -327,11 +327,37 @@ final class DischargeRules {
         return Bound.CARRIERS.keySet();
     }
 
-    /** Which shapes of construction carry the predicate {@code operation} states, for the test that
-     * holds each rule to a program on both sides of what it names. */
-    static Set<Shape> carriedThrough(String operation) {
-        Carried carried = Bound.CARRIERS.get(op(operation));
-        return carried == null ? Set.of() : carried.through();
+    /**
+     * The kinds of container the library builds, each with the shape the building has — {@code
+     * "List.SUBSET"}, {@code "Map.MAPS"}.
+     *
+     * <p>For the test that holds a carrying rule to every shape. A shape no construction of a kind
+     * has is a cell no program can be written for, and which cells those are is the library's to say:
+     * a set holds its elements in no order, so nothing permutes one, and that stops being true the day
+     * an operation says otherwise. Read off the building table, whose every row already answers to a
+     * program that fires it.
+     */
+    static Set<String> constructionKinds() {
+        Set<String> kinds = new LinkedHashSet<>();
+        Bound.BUILDINGS.forEach((operation, built) -> {
+            Prelude.PreludeEntry entry = Prelude.entry(operation.name());
+            String kind = entry == null ? null : kindOf(entry.signature().result());
+            if (kind != null) {
+                kinds.add(kind + "." + built.shape());
+            }
+        });
+        return kinds;
+    }
+
+    /** What a container type is a container of, as the namespace its operations are written under. */
+    private static String kindOf(Type built) {
+        if (built instanceof Type.ListOf) {
+            return "List";
+        }
+        if (built instanceof Type.SetOf) {
+            return "Set";
+        }
+        return built instanceof Type.MapOf ? "Map" : null;
     }
 
     static Set<ValueName> emptinessChecks() {
@@ -410,7 +436,7 @@ final class DischargeRules {
             List<Type> params = entry.signature().params();
             Reads at = reads.apply(rule);
             int position = at.positionIn(operation);
-            if (position >= params.size()) {
+            if (position < 0 || position >= params.size()) {
                 throw new IllegalStateException(operation.name() + " takes " + params.size()
                         + " argument(s), and the rule about " + what + " reads argument "
                         + (position + 1));

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -1,12 +1,18 @@
 package souther.compiler.check;
 
+import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.core.Core;
+import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * What the language's own operations do to the properties the invariant-discharge check tracks
@@ -21,6 +27,11 @@ import java.util.Set;
  * imported an operation writes it bare and one that did not writes it qualified, and they are the
  * same operation. What the operations do to the closure they are handed is not here but in
  * {@link Combinators}, which the totality check reads as well and neither of the two states.
+ *
+ * <p>A rule answers a call, not a position in one. Which argument it reads is written as {@link Reads}
+ * and settled here, so no reader turns a number back into an argument and none has to ask whether the
+ * number was one this call has. What makes that safe is the binding below: every row is held to the
+ * declaration it was written for before any of them is read.
  */
 final class DischargeRules {
 
@@ -58,32 +69,111 @@ final class DischargeRules {
         }
     }
 
+    /**
+     * Which argument a rule reads.
+     *
+     * <p>Either the position the declaration puts it at, or the part it plays in what the operation
+     * hands its closure — which {@link Combinators} already reads off the signature. A rule that names
+     * the part restates nothing and cannot come to disagree with the declaration; one that writes a
+     * position is a decision the signature does not settle, and is held to the declaration where the
+     * tables are bound.
+     *
+     * <p>Nothing outside this asks for the number. A reader is answered with the argument.
+     */
+    sealed interface Reads {
+
+        /** Which parameter of {@code operation} this names. */
+        int positionIn(ValueName operation);
+
+        /** The argument {@code call} passes there. */
+        default Core of(Core.PreservedCall call) {
+            return call.args().get(positionIn(call.operation()));
+        }
+
+        /** {@code call} with that argument replaced by {@code value}. */
+        default Core.PreservedCall replacedIn(Core.PreservedCall call, Core value) {
+            List<Core> args = new ArrayList<>(call.args());
+            args.set(positionIn(call.operation()), value);
+            return new Core.PreservedCall(call.operation(), args, call.type(), call.pos());
+        }
+
+        /** The argument at a written position. */
+        record At(int position) implements Reads {
+            @Override
+            public int positionIn(ValueName operation) {
+                return position;
+            }
+        }
+
+        /** The argument holding what the operation hands its closure. */
+        record TheContainer() implements Reads {
+            @Override
+            public int positionIn(ValueName operation) {
+                return handing(operation, "the container").containerArg();
+            }
+        }
+
+        /** The argument the operation applies to what a container holds. */
+        record TheClosure() implements Reads {
+            @Override
+            public int positionIn(ValueName operation) {
+                return handing(operation, "the closure").closureArg();
+            }
+        }
+
+        private static Combinators.Combinator handing(ValueName operation, String part) {
+            Combinators.Combinator handed = Combinators.of(operation);
+            if (handed == null) {
+                throw new IllegalStateException("a rule about " + operation.name() + " names " + part
+                        + " of what it hands its closure, and its signature says it hands one nothing"
+                        + " a container holds");
+            }
+            return handed;
+        }
+    }
+
+    /** The argument the signature already says the elements come from, where the operation takes a
+     * closure at all — so a rule about such an operation writes no position of its own. */
+    private static final Reads CONTAINER = new Reads.TheContainer();
+
+    /** The closure itself, for a rule stated over what the closure answers. */
+    private static final Reads CLOSURE = new Reads.TheClosure();
+
+    /** The argument at {@code position}, for an operation whose signature does not say which one it
+     * is: one that takes no closure, or one given two containers. */
+    private static Reads at(int position) {
+        return new Reads.At(position);
+    }
+
     /** Which argument a container was built from, and what the building keeps of it. */
-    record Built(int from, Shape shape) {}
+    record Built(Reads from, Shape shape) {}
+
+    /** The container {@code call} built its result from, and what the building kept of it. */
+    record Source(Core container, Shape shape) {}
 
     private static final Map<ValueName, Built> BUILT_FROM = Map.ofEntries(
-            Map.entry(op("List.reverse"), new Built(0, Shape.PERMUTES)),
-            Map.entry(op("List.sort"), new Built(0, Shape.PERMUTES)),
-            Map.entry(op("List.sortBy"), new Built(1, Shape.PERMUTES)),
-            Map.entry(op("List.map"), new Built(1, Shape.MAPS)),
-            Map.entry(op("List.mapIndexed"), new Built(1, Shape.MAPS)),
-            Map.entry(op("Map.mapValues"), new Built(1, Shape.MAPS)),
-            Map.entry(op("List.filter"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("List.distinct"), new Built(0, Shape.SUBSET)),
-            Map.entry(op("List.take"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("List.drop"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("Set.filter"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("Map.filterEntries"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("List.distinctBy"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("Map.remove"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("Set.remove"), new Built(1, Shape.SUBSET)),
-            Map.entry(op("Map.intersection"), new Built(0, Shape.SUBSET)),
-            Map.entry(op("Map.difference"), new Built(0, Shape.SUBSET)),
-            Map.entry(op("Set.intersection"), new Built(0, Shape.SUBSET)),
-            Map.entry(op("Set.difference"), new Built(0, Shape.SUBSET)),
-            Map.entry(op("Map.updateIfPresent"), new Built(2, Shape.MAPS)),
-            Map.entry(op("List.filterMap"), new Built(1, Shape.COLLAPSES)),
-            Map.entry(op("Set.map"), new Built(1, Shape.COLLAPSES)));
+            Map.entry(op("List.reverse"), new Built(at(0), Shape.PERMUTES)),
+            Map.entry(op("List.sort"), new Built(at(0), Shape.PERMUTES)),
+            Map.entry(op("List.sortBy"), new Built(CONTAINER, Shape.PERMUTES)),
+            Map.entry(op("List.map"), new Built(CONTAINER, Shape.MAPS)),
+            Map.entry(op("List.mapIndexed"), new Built(CONTAINER, Shape.MAPS)),
+            Map.entry(op("Map.mapValues"), new Built(CONTAINER, Shape.MAPS)),
+            Map.entry(op("List.filter"), new Built(CONTAINER, Shape.SUBSET)),
+            Map.entry(op("List.distinct"), new Built(at(0), Shape.SUBSET)),
+            Map.entry(op("List.take"), new Built(at(1), Shape.SUBSET)),
+            Map.entry(op("List.drop"), new Built(at(1), Shape.SUBSET)),
+            Map.entry(op("Set.filter"), new Built(CONTAINER, Shape.SUBSET)),
+            Map.entry(op("Map.filterEntries"), new Built(CONTAINER, Shape.SUBSET)),
+            Map.entry(op("List.distinctBy"), new Built(CONTAINER, Shape.SUBSET)),
+            Map.entry(op("Map.remove"), new Built(at(1), Shape.SUBSET)),
+            Map.entry(op("Set.remove"), new Built(at(1), Shape.SUBSET)),
+            Map.entry(op("Map.intersection"), new Built(at(0), Shape.SUBSET)),
+            Map.entry(op("Map.difference"), new Built(at(0), Shape.SUBSET)),
+            Map.entry(op("Set.intersection"), new Built(at(0), Shape.SUBSET)),
+            Map.entry(op("Set.difference"), new Built(at(0), Shape.SUBSET)),
+            Map.entry(op("Map.updateIfPresent"), new Built(CONTAINER, Shape.MAPS)),
+            Map.entry(op("List.filterMap"), new Built(CONTAINER, Shape.COLLAPSES)),
+            Map.entry(op("Set.map"), new Built(CONTAINER, Shape.COLLAPSES)));
 
     /**
      * The constructions this says nothing of, in three groups. Each reason is about what a shape can
@@ -114,20 +204,47 @@ final class DischargeRules {
     /** Where a predicate reads its container, and which shapes of construction carry it there.
      * {@code List.all} holds of any sublist of a list it holds of; {@code List.contains} does not, and
      * neither survives a mapping — what a mapped element is, the mapping alone does not say. */
-    record Carried(int container, Set<Shape> through) {}
+    record Carried(Reads container, Set<Shape> through) {}
 
     private static final Map<ValueName, Carried> CARRIED = Map.of(
-            op("List.all"), new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
-            op("List.allDistinctBy"), new Carried(1, Set.of(Shape.PERMUTES, Shape.SUBSET)),
-            op("List.any"), new Carried(1, Set.of(Shape.PERMUTES)),
-            op("List.contains"), new Carried(1, Set.of(Shape.PERMUTES)),
-            op("Set.contains"), new Carried(1, Set.of(Shape.PERMUTES)),
-            op("Map.containsKey"), new Carried(1, Set.of(Shape.PERMUTES)));
+            op("List.all"), new Carried(CONTAINER, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            op("List.allDistinctBy"), new Carried(CONTAINER, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            op("List.any"), new Carried(CONTAINER, Set.of(Shape.PERMUTES)),
+            op("List.contains"), new Carried(at(1), Set.of(Shape.PERMUTES)),
+            op("Set.contains"), new Carried(at(1), Set.of(Shape.PERMUTES)),
+            op("Map.containsKey"), new Carried(at(1), Set.of(Shape.PERMUTES)));
+
+    /** Where a predicate reads its container at a call, and how far its statement travels. */
+    record Carrying(Core.PreservedCall stated, Reads at, Set<Shape> through) {
+
+        Core container() {
+            return at.of(stated);
+        }
+
+        /** {@code call} — a call to the same operation — with the container it reads replaced. */
+        Core.PreservedCall over(Core.PreservedCall call, Core container) {
+            if (!call.operation().equals(stated.operation())) {
+                throw new IllegalStateException("a rule read for " + stated.operation().name()
+                        + " was asked to rewrite a call to " + call.operation().name());
+            }
+            return at.replacedIn(call, container);
+        }
+    }
 
     /** Where a predicate reads the projection it is stated over. A mapping keeps a projection when
      * the closure copies that field from the element unchanged, so the predicate holds of the mapped
      * list exactly when it holds of what was mapped, over the field it came from. */
-    private static final Map<ValueName, Integer> PROJECTION_OF = Map.of(op("List.allDistinctBy"), 0);
+    private static final Map<ValueName, Reads> PROJECTION_OF =
+            Map.of(op("List.allDistinctBy"), CLOSURE);
+
+    /** The projection a predicate at a call is stated over, as the block it answers with. */
+    record Projection(Core.PreservedCall stated, Reads at, Core.Block projection) {
+
+        /** The call this was read for, stated over {@code value} instead. */
+        Core.PreservedCall over(Core value) {
+            return at.replacedIn(stated, value);
+        }
+    }
 
     /** The calls that state their predicate of <em>every</em> element, so what they say of a
      * container is what holds of each element a closure is handed. Which argument is the predicate
@@ -203,11 +320,11 @@ final class DischargeRules {
     /** The operations each table has a rule for. What is asked of them is {@link Question}'s to
      * settle; these are so it can hold a rule to being one an operation is asked for. */
     static Set<ValueName> builtOperations() {
-        return BUILT_FROM.keySet();
+        return Bound.BUILDINGS.keySet();
     }
 
     static Set<ValueName> carryingOperations() {
-        return CARRIED.keySet();
+        return Bound.CARRIERS.keySet();
     }
 
     static Set<ValueName> emptinessChecks() {
@@ -219,7 +336,7 @@ final class DischargeRules {
     }
 
     static Set<ValueName> projections() {
-        return PROJECTION_OF.keySet();
+        return Bound.PROJECTIONS.keySet();
     }
 
     static Set<ValueName> sizeCalls() {
@@ -234,22 +351,100 @@ final class DischargeRules {
      * it discharges. */
     static Set<String> builtNames() {
         Set<String> names = new LinkedHashSet<>();
-        BUILT_FROM.keySet().forEach(operation -> names.add(operation.name()));
+        builtOperations().forEach(operation -> names.add(operation.name()));
         return names;
     }
 
-    static Built builtFrom(ValueName operation) {
-        return BUILT_FROM.get(operation);
+    /**
+     * The tables, held to the declarations they were written for.
+     *
+     * <p>A row names an argument of an operation, and what an operation's arguments are is the
+     * library's to say. Where the two disagree there is nothing to be done at a call — the rule is
+     * about an argument that is not there, or is not the kind of thing the rule is about — so it is
+     * said here, once, before any call is read, rather than met as a missing answer at whichever
+     * reader arrives first.
+     *
+     * <p>Every row of every table, not the row a call happens to reach: a rule that disagrees with a
+     * declaration is wrong whether or not a program calls it, and finding out when one does is the
+     * same silence deferred.
+     *
+     * <p>Read on the first ask and not before, as {@link Combinators} and {@link Preserved} are: what
+     * this requires of the library is required of a check that reads these rules, and a checker that
+     * reads none must not be held to it.
+     */
+    private static final class Bound {
+
+        private static final Map<ValueName, Built> BUILDINGS =
+                bind(BUILT_FROM, Built::from, CONTAINER, Question::holdsElements,
+                        "the container something is built from");
+        private static final Map<ValueName, Carried> CARRIERS =
+                bind(CARRIED, Carried::container, CONTAINER, Question::holdsElements,
+                        "the container a predicate reads");
+        private static final Map<ValueName, Reads> PROJECTIONS =
+                bind(PROJECTION_OF, Function.identity(), CLOSURE, t -> t instanceof Type.FnOf,
+                        "the projection a predicate is stated over");
     }
 
-    static Carried carried(ValueName operation) {
-        return CARRIED.get(operation);
+    /**
+     * {@code rules}, once every row has been held to the operation it is about: the operation is one
+     * the library declares, the argument it names is one that declaration has, and what stands there
+     * is what the rule is about. A row naming a part of something the signature says the operation
+     * does not hand is caught by {@link Reads}; one that writes a position the signature already
+     * answers is caught here, since two answers to one question are what come apart later.
+     */
+    static <T> Map<ValueName, T> bind(Map<ValueName, T> rules, Function<T, Reads> reads,
+                                      Reads derived, Predicate<Type> required, String what) {
+        rules.forEach((operation, rule) -> {
+            Prelude.PreludeEntry entry = Prelude.entry(operation.name());
+            if (entry == null) {
+                throw new IllegalStateException("a rule about " + what + " is written for "
+                        + operation.name() + ", which the library does not declare");
+            }
+            List<Type> params = entry.signature().params();
+            Reads at = reads.apply(rule);
+            int position = at.positionIn(operation);
+            if (position >= params.size()) {
+                throw new IllegalStateException(operation.name() + " takes " + params.size()
+                        + " argument(s), and the rule about " + what + " reads argument "
+                        + (position + 1));
+            }
+            if (!required.test(params.get(position))) {
+                throw new IllegalStateException("argument " + (position + 1) + " of "
+                        + operation.name() + " is not " + what);
+            }
+            if (at instanceof Reads.At && Combinators.of(operation) != null
+                    && derived.positionIn(operation) == position) {
+                throw new IllegalStateException("the rule about " + what + " for " + operation.name()
+                        + " writes the argument its signature already answers — say which part it is"
+                        + " rather than where, so the two cannot come apart");
+            }
+        });
+        return rules;
     }
 
-    /** Which argument of {@code operation} is the projection its predicate is stated over, or null
-     * where it is stated over the element itself. */
-    static Integer projectionOf(ValueName operation) {
-        return PROJECTION_OF.get(operation);
+    /** The container {@code call} built its result from, or null where the check has no rule about
+     * what the operation keeps. */
+    static Source builtFrom(Core.PreservedCall call) {
+        Built built = Bound.BUILDINGS.get(call.operation());
+        return built == null ? null : new Source(built.from().of(call), built.shape());
+    }
+
+    /** Where {@code call} reads the container it states its predicate of, or null where it is not a
+     * predicate this carries anywhere. */
+    static Carrying carried(Core.PreservedCall call) {
+        Carried carried = Bound.CARRIERS.get(call.operation());
+        return carried == null ? null : new Carrying(call, carried.container(), carried.through());
+    }
+
+    /** The projection {@code call}'s predicate is stated over, or null where it is stated over the
+     * element itself — or where what stands in that argument is not a block this can read. */
+    static Projection projectionOf(Core.PreservedCall call, Denotations at) {
+        Reads reads = Bound.PROJECTIONS.get(call.operation());
+        if (reads == null) {
+            return null;
+        }
+        Core.Block projection = Terms.blockOf(reads.of(call), at);
+        return projection == null ? null : new Projection(call, reads, projection);
     }
 
     static boolean isSize(ValueName operation) {
@@ -273,8 +468,8 @@ final class DischargeRules {
     /** Whether the check has a rule about what a call answers, rather than only about how to render
      * it. */
     static boolean readsAsATerm(ValueName operation) {
-        return isSize(operation) || BUILT_FROM.containsKey(operation)
-                || CARRIED.containsKey(operation) || isQuantifier(operation)
+        return isSize(operation) || builtOperations().contains(operation)
+                || carryingOperations().contains(operation) || isQuantifier(operation)
                 || NOT.equals(operation);
     }
 
@@ -291,9 +486,9 @@ final class DischargeRules {
      * is why the closure does not enter the key. */
     static Core sizeSource(Core e) {
         if (e instanceof Core.PreservedCall call) {
-            Built built = builtFrom(call.operation());
-            if (built != null && built.shape().keepsSize() && built.from() < call.args().size()) {
-                return sizeSource(call.args().get(built.from()));
+            Source built = builtFrom(call);
+            if (built != null && built.shape().keepsSize()) {
+                return sizeSource(built.container());
             }
         }
         return e;

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1,7 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
-import souther.compiler.check.Combinators.Combinator;
+import souther.compiler.check.Combinators.Handed;
 import souther.compiler.check.NumericDomain.LinearForm;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
@@ -262,27 +262,26 @@ public final class InvariantChecker {
      * parameter to the container's element type (and seeding its invariant) so a construction inside
      * the closure is analyzed rather than left opaque. */
     private void walkCall(Core.PreservedCall call, Known k, Denotations at, int depth) {
-        Combinator combo = Combinators.of(call.operation());
-        for (int i = 0; i < call.args().size(); i++) {
-            Core arg = call.args().get(i);
-            Core.Block step = combo != null && i == combo.closureArg() ? Terms.blockOf(arg, at) : null;
-            if (step != null && combo.elementParam() < step.params().size()
-                    && combo.containerArg() < call.args().size()) {
-                Core container = call.args().get(combo.containerArg());
-                Type elem = Terms.elementType(container.type());
-                // The container is read where the call is written, so what is known of its elements
-                // is looked up before the closure's parameter stands for anything.
-                List<Quantified> relations = predicates.elementRelations(container, k, at);
-                Core element = Terms.read(step.params().get(combo.elementParam()), elem, step.pos());
-                // an element of a container is not a location the body can otherwise name
-                Known k2 = seedAt(element, k, at, 0);   // the element carries its type's invariant
-                for (Quantified q : relations) {
-                    k2 = predicates.instantiate(q, element, k2, at);
-                }
-                walk(step.body(), k2, at, depth);
-            } else {
+        Handed handed = Combinators.handedTo(call, at);
+        for (Core arg : call.args()) {
+            // The closure is asked by identity: a call may write one expression twice, and only the
+            // argument the operation applies is the one an element arrives in.
+            if (handed == null || arg != handed.closure()) {
                 walk(arg, k, at, depth);
+                continue;
             }
+            Core container = handed.container();
+            Type elem = Terms.elementType(container.type());
+            // The container is read where the call is written, so what is known of its elements
+            // is looked up before the closure's parameter stands for anything.
+            List<Quantified> relations = predicates.elementRelations(container, k, at);
+            Core element = Terms.read(handed.element(), elem, handed.step().pos());
+            // an element of a container is not a location the body can otherwise name
+            Known k2 = seedAt(element, k, at, 0);   // the element carries its type's invariant
+            for (Quantified q : relations) {
+                k2 = predicates.instantiate(q, element, k2, at);
+            }
+            walk(handed.step().body(), k2, at, depth);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -1,10 +1,11 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
-import souther.compiler.check.DischargeRules.Built;
-import souther.compiler.check.DischargeRules.Carried;
-import souther.compiler.check.Combinators.Combinator;
+import souther.compiler.check.Combinators.Handed;
+import souther.compiler.check.DischargeRules.Carrying;
+import souther.compiler.check.DischargeRules.Projection;
 import souther.compiler.check.DischargeRules.Shape;
+import souther.compiler.check.DischargeRules.Source;
 import souther.compiler.check.NumericDomain.LinearForm;
 import souther.compiler.check.NumericDomain.Rel;
 import souther.compiler.core.Core;
@@ -61,12 +62,12 @@ final class Predicates {
             if (!(source instanceof Core.PreservedCall call)) {
                 return found;
             }
-            Built built = DischargeRules.builtFrom(call.operation());
-            if (built == null || built.from() >= call.args().size()) {
+            Source built = DischargeRules.builtFrom(call);
+            if (built == null) {
                 return found;
             }
             crossed.add(built.shape());
-            source = call.args().get(built.from());
+            source = built.container();
         }
     }
 
@@ -103,21 +104,19 @@ final class Predicates {
                 || !DischargeRules.isQuantifier(call.operation())) {
             return;
         }
-        Combinator over = Combinators.of(call.operation());
-        Carried carried = DischargeRules.carried(call.operation());
-        if (over == null || carried == null || over.closureArg() >= call.args().size()
-                || over.containerArg() >= call.args().size()) {
+        Handed over = Combinators.handedTo(call, at);
+        Carrying carried = DischargeRules.carried(call);
+        if (over == null || carried == null || over.step().params().size() != 1) {
             return;
         }
-        Core.Block p = Terms.blockOf(call.args().get(over.closureArg()), at);
-        if (p == null || p.params().size() != 1) {
-            return;
-        }
-        String container = terms.bodyKey(call.args().get(over.containerArg()), at);
+        // The container is the carrying rule's, which is the one argument this predicate is about.
+        // What the operation hands its closure answers the same question about the same argument, and
+        // is asked here only for the closure.
+        String container = terms.bodyKey(carried.container(), at);
         if (container == null) {
             return;
         }
-        out.add(new Quantified(container, carried.through(), p));
+        out.add(new Quantified(container, carried.through(), over.step()));
     }
 
     /** Whether {@code e} is, or names, one of {@code values}. */
@@ -424,11 +423,11 @@ final class Predicates {
         if (!(container instanceof Core.PreservedCall call)) {
             return;
         }
-        Built built = DischargeRules.builtFrom(call.operation());
-        if (built == null || built.shape().keepsSize() || built.from() >= call.args().size()) {
+        Source built = DischargeRules.builtFrom(call);
+        if (built == null || built.shape().keepsSize()) {
             return;
         }
-        Core source = DischargeRules.sizeSource(call.args().get(built.from()));
+        Core source = DischargeRules.sizeSource(built.container());
         String here = terms.bodyKey(container, at);
         String there = terms.bodyKey(source, at);
         if (here == null || there == null) {
@@ -454,25 +453,25 @@ final class Predicates {
         if (!(inv instanceof Core.PreservedCall call)) {
             return keys;
         }
-        Carried carried = DischargeRules.carried(call.operation());
-        if (carried == null || carried.container() >= call.args().size()) {
+        Carrying carried = DischargeRules.carried(call);
+        if (carried == null) {
             return keys;
         }
         // The predicate over each container the one it names was built from. The container is the
         // construction's own expression, so the operations peeled off are the ones the body wrote.
-        Core container = call.args().get(carried.container());
+        Core container = carried.container();
         Core.PreservedCall stated = call;
         while (container instanceof Core.PreservedCall inner) {
-            Built built = DischargeRules.builtFrom(inner.operation());
-            if (built == null || built.from() >= inner.args().size()) {
+            Source built = DischargeRules.builtFrom(inner);
+            if (built == null) {
                 break;
             }
             Core.PreservedCall next = carries(stated, carried, inner, built, at);
             if (next == null) {
                 break;
             }
-            Core source = inner.args().get(built.from());
-            String key = terms.bodyKey(withArg(next, carried.container(), source), at);
+            Core source = built.container();
+            String key = terms.bodyKey(carried.over(next, source), at);
             if (key == null) {
                 break;
             }
@@ -489,25 +488,23 @@ final class Predicates {
      * carries nothing on its own, but a predicate stated over a projection carries when the closure
      * copied that field across, over the field it came from.
      */
-    Core.PreservedCall carries(Core.PreservedCall stated, Carried carried,
-                                       Core.PreservedCall inner, Built built, Denotations at) {
+    Core.PreservedCall carries(Core.PreservedCall stated, Carrying carried,
+                                       Core.PreservedCall inner, Source built, Denotations at) {
         if (carried.through().contains(built.shape())) {
             return stated;
         }
-        Integer projection = DischargeRules.projectionOf(stated.operation());
-        if (built.shape() != Shape.MAPS || projection == null
-                || projection >= stated.args().size()) {
+        Projection projection = DischargeRules.projectionOf(stated, at);
+        if (built.shape() != Shape.MAPS || projection == null) {
             return null;
         }
         // Where the mapping's closure is written is already stated once, by the table that says which
         // argument each combinator hands its elements to.
-        Combinator combo = Combinators.of(inner.operation());
-        if (combo == null || combo.closureArg() >= inner.args().size()) {
+        Handed combo = Combinators.handedTo(inner, at);
+        if (combo == null) {
             return null;
         }
-        Core traced = projectionThrough(stated.args().get(projection),
-                inner.args().get(combo.closureArg()), at);
-        return traced == null ? null : withArg(stated, projection, traced);
+        Core traced = projectionThrough(projection.projection(), combo.step(), at);
+        return traced == null ? null : projection.over(traced);
     }
 
     /**
@@ -523,11 +520,8 @@ final class Predicates {
      * where it is bound, so the chain built here is read at the position the closure's parameter
      * stands in, whatever it is called and whatever it was read from.
      */
-    Core projectionThrough(Core projection, Core closure, Denotations at) {
-        Core.Block proj = Terms.blockOf(projection, at);
-        Core.Block step = Terms.blockOf(closure, at);
-        if (proj == null || proj.params().size() != 1 || step == null
-                || step.params().size() != 1) {
+    Core projectionThrough(Core.Block proj, Core.Block step, Denotations at) {
+        if (proj.params().size() != 1 || step.params().size() != 1) {
             return null;
         }
         Ast.Binder element = step.params().get(0);
@@ -614,12 +608,6 @@ final class Predicates {
                 default -> null;
             };
         }
-    }
-
-    static Core.PreservedCall withArg(Core.PreservedCall call, int at, Core arg) {
-        List<Core> args = new ArrayList<>(call.args());
-        args.set(at, arg);
-        return new Core.PreservedCall(call.operation(), args, call.type(), call.pos());
     }
 
     /** An emptiness check as the comparison it means, or {@code e} unchanged. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -41,7 +41,7 @@ enum Question {
 
         @Override
         boolean answeredFor(ValueName operation) {
-            return Combinators.of(operation) != null;
+            return Combinators.answered().contains(operation);
         }
 
         @Override
@@ -67,7 +67,7 @@ enum Question {
 
         @Override
         boolean answeredFor(ValueName operation) {
-            return DischargeRules.builtFrom(operation) != null;
+            return DischargeRules.builtOperations().contains(operation);
         }
 
         @Override
@@ -93,7 +93,7 @@ enum Question {
 
         @Override
         boolean answeredFor(ValueName operation) {
-            return DischargeRules.carried(operation) != null;
+            return DischargeRules.carryingOperations().contains(operation);
         }
 
         @Override
@@ -176,7 +176,7 @@ enum Question {
 
         @Override
         boolean answeredFor(ValueName operation) {
-            return DischargeRules.projectionOf(operation) != null;
+            return DischargeRules.projections().contains(operation);
         }
 
         @Override
@@ -282,8 +282,10 @@ enum Question {
         return entry != null && asksOf(entry.signature());
     }
 
-    /** Whether a construction over {@code t} is one whose elements a shape can speak of. */
-    private static boolean holdsElements(Type t) {
+    /** Whether a construction over {@code t} is one whose elements a shape can speak of. Read where
+     * the rules are bound as well: what a rule about a container may be written over is the same
+     * question as what puts an operation in range of one. */
+    static boolean holdsElements(Type t) {
         return t instanceof Type.ListOf || t instanceof Type.SetOf || t instanceof Type.MapOf;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -1,7 +1,6 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
-import souther.compiler.check.DischargeRules.Built;
 import souther.compiler.check.NumericDomain.LinearForm;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
@@ -508,9 +507,8 @@ final class Terms {
         if (!(e instanceof Core.PreservedCall call)) {
             return false;
         }
-        Built built = DischargeRules.builtFrom(call.operation());
-        return built != null && built.from() < call.args().size()
-                && namedByRule(call.args().get(built.from()), at);
+        DischargeRules.Source built = DischargeRules.builtFrom(call);
+        return built != null && namedByRule(built.container(), at);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -321,29 +321,27 @@ final class TotalityChecker {
                 if (group.contains(call.reaches())) {
                     calls.add(new RecCall(call.written(), call, lt, eq));
                 }
-                Combinators.Combinator combo = Combinators.of(call.denotes());
-                for (int ai = 0; ai < call.args().size(); ai++) {
-                    Ast.Expr arg = call.args().get(ai);
-                    if (combo != null && ai == combo.closureArg() && arg instanceof Ast.Block step
-                            && combo.elementParam() < step.params().size()
-                            && combo.containerArg() < call.args().size()) {
-                        // `step` consumes the container argument; each value it is handed (a list
-                        // element, a map's value, or an option's unwrapped payload) is a sub-term of that
-                        // container, so if the container is (part of) a parameter, the value is a strictly
-                        // smaller part of it. Bind the element parameter accordingly for the step body. An
-                        // operation the library states no such thing of is treated as handing its closure
-                        // nothing, which rejects a recursion rather than wrongly accepting one; a
-                        // freshly-constructed container (`Some(p)`) roots at no parameter, so its payload
-                        // is not credited as smaller either.
-                        Set<BindingId> elemRoots =
-                                rootParams(call.args().get(combo.containerArg()), lt, eq, paramNames);
-                        Map<BindingId, Set<BindingId>> inner = elemRoots.isEmpty()
-                                ? lt
-                                : with(lt, step.params().get(combo.elementParam()).id(), elemRoots);
-                        walk(step.body(), group, paramNames, inner, eq, calls);
-                    } else {
+                Combinators.Written handed = Combinators.handedTo(call);
+                for (Ast.Expr arg : call.args()) {
+                    // The closure is asked by identity: a call may write one expression twice, and
+                    // only the argument the operation applies is the one an element arrives in.
+                    if (handed == null || arg != handed.step()) {
                         walk(arg, group, paramNames, lt, eq, calls);
+                        continue;
                     }
+                    // The step consumes the container argument; each value it is handed (a list
+                    // element, a map's value, or an option's unwrapped payload) is a sub-term of that
+                    // container, so if the container is (part of) a parameter, the value is a strictly
+                    // smaller part of it. Bind the element parameter accordingly for the step body. An
+                    // operation the library states no such thing of is treated as handing its closure
+                    // nothing, which rejects a recursion rather than wrongly accepting one; a
+                    // freshly-constructed container (`Some(p)`) roots at no parameter, so its payload
+                    // is not credited as smaller either.
+                    Set<BindingId> elemRoots = rootParams(handed.container(), lt, eq, paramNames);
+                    Map<BindingId, Set<BindingId>> inner = elemRoots.isEmpty()
+                            ? lt
+                            : with(lt, handed.element().id(), elemRoots);
+                    walk(handed.step().body(), group, paramNames, inner, eq, calls);
                 }
             }
             default -> forEachChild(e, child -> walk(child, group, paramNames, lt, eq, calls));

--- a/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
@@ -1,0 +1,208 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.check.DischargeRules.Shape;
+import souther.compiler.diag.Severity;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * How far a predicate travels is a rule about meaning, and no signature answers it: that
+ * {@code List.all} holds of any sublist of a list it holds of, and {@code List.contains} does not, is
+ * true of what the operations mean and not of what they are declared to be. So it is written down,
+ * and a written rule is one that can be written wrong.
+ *
+ * <p>Wrong in two directions, which fail differently. A rule too narrow loses a discharge: an author
+ * guards a predicate and the check reports the construction anyway. A rule too wide accepts one that
+ * can abort — the check says a property holds where it does not. The second is the one that matters,
+ * and no program that discharges can detect it, being already discharged.
+ *
+ * <p>So every shape of every rule is answered for here, from both sides: a shape that carries has a
+ * program that discharges only because it does, and a shape that does not has the same program over
+ * that shape's construction, which must still be reported. What each shape does is written <em>here</em>
+ * and not read off the table being held to it — a witness that asks the table what to expect agrees
+ * with the table however the table changes, which is no witness at all.
+ *
+ * <p>What is left is the cells no program can be written for, because the library has no construction
+ * of that kind with that shape. Those are named with the reason. A rule whose every carrying shape is
+ * one of them reaches nothing, which is worth knowing about a rule — {@code Set.contains} and
+ * {@code Map.containsKey} are both that today, and say so here rather than looking witnessed.
+ */
+class APredicateCarriesExactlyAsFarAsItsRuleSaysTest {
+
+    /** What a construction of a given shape does to a predicate. */
+    private enum Travels {
+        /** The predicate holds of what was built, so the guard discharges the clause. */
+        CARRIES,
+        /** It does not, so the clause stands however the container was guarded. */
+        STOPS,
+        /** The library builds no container of this kind that way. */
+        NO_SUCH_CONSTRUCTION
+    }
+
+    /** A predicate of the carrying table: the container kind it reads, and how it is written. */
+    private record Predicate(String kind, String of, String stated, Map<Shape, Travels> travels) {}
+
+    private static Map<Shape, Travels> travels(Travels permutes, Travels subset, Travels maps,
+                                               Travels collapses) {
+        return Map.of(Shape.PERMUTES, permutes, Shape.SUBSET, subset, Shape.MAPS, maps,
+                Shape.COLLAPSES, collapses);
+    }
+
+    /**
+     * Every rule, and what every shape does to it. Written out rather than derived: this is the
+     * second statement of the rule, and two statements only hold each other up while they are made
+     * apart.
+     */
+    private static final List<Predicate> PREDICATES = List.of(
+            // A property of every element survives a reordering and survives dropping elements. It
+            // does not survive a mapping — what a mapped element is, the mapping alone does not say.
+            new Predicate("List", "List<Int>", "List.all(n -> n >= 1, %s)",
+                    travels(Travels.CARRIES, Travels.CARRIES, Travels.STOPS, Travels.STOPS)),
+            // Elements distinct by a projection stay distinct in another order and in fewer of them.
+            new Predicate("List", "List<Int>", "List.allDistinctBy(n -> n, %s)",
+                    travels(Travels.CARRIES, Travels.CARRIES, Travels.STOPS, Travels.STOPS)),
+            // That some element holds says nothing once elements can be dropped: the one that held
+            // may be the one dropped.
+            new Predicate("List", "List<Int>", "List.any(n -> n >= 1, %s)",
+                    travels(Travels.CARRIES, Travels.STOPS, Travels.STOPS, Travels.STOPS)),
+            // Nor that a particular element is there.
+            new Predicate("List", "List<Int>", "List.contains(1, %s)",
+                    travels(Travels.CARRIES, Travels.STOPS, Travels.STOPS, Travels.STOPS)),
+            new Predicate("Set", "Set<Int>", "Set.contains(1, %s)",
+                    travels(Travels.NO_SUCH_CONSTRUCTION, Travels.STOPS,
+                            Travels.NO_SUCH_CONSTRUCTION, Travels.STOPS)),
+            // A mapping over a map answers one value for each key and leaves the keys alone, so a key
+            // being there does survive it — and `MAPS` does not say that, being about the elements
+            // and not about what they are held under. Stating it would need a shape that does.
+            new Predicate("Map", "Map<String, Int>", "Map.containsKey(\"a\", %s)",
+                    travels(Travels.NO_SUCH_CONSTRUCTION, Travels.STOPS, Travels.STOPS,
+                            Travels.NO_SUCH_CONSTRUCTION)));
+
+    /** How a container of each kind is built from another of the same kind, by shape, or null where
+     * the library has no such construction. */
+    private static String built(String kind, Shape shape) {
+        return switch (kind + "." + shape) {
+            case "List.PERMUTES" -> "List.reverse(c)";
+            case "List.SUBSET" -> "List.filter(n -> n >= 5, c)";
+            case "List.MAPS" -> "List.map(n -> 0, c)";
+            case "List.COLLAPSES" -> "List.filterMap(n -> List.get(0, [0]), c)";
+            case "Set.SUBSET" -> "Set.filter(n -> n >= 5, c)";
+            case "Set.COLLAPSES" -> "Set.map(n -> 0, c)";
+            case "Map.SUBSET" -> "Map.filterEntries((k, v) -> v >= 5, c)";
+            case "Map.MAPS" -> "Map.mapValues((k, v) -> 0, c)";
+            default -> null;
+        };
+    }
+
+    /**
+     * A program that guards the predicate over a container and constructs a value whose invariant
+     * states it, from a container built off the guarded one. It discharges exactly when the rule
+     * carries the predicate through that construction, and is reported otherwise.
+     */
+    private static String module(Predicate p, Shape shape) {
+        return """
+                module demo
+                data Bad
+                data Held = %s
+                    invariant %s
+                behavior build : (c: %s) -> Held | Bad constructs Held, Bad
+                let build (c) = {
+                    guard %s
+                        else Bad
+                    Held(%s)
+                }
+                """.formatted(p.of(), p.stated().formatted("value"), p.of(),
+                p.stated().formatted("c"), built(p.kind(), shape));
+    }
+
+    private static long warnings(String src) {
+        return Compiler.compileWithWarnings(src).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    /** The operation a predicate names, which is the row of the table it is written against. */
+    private static String operationOf(Predicate p) {
+        return p.stated().substring(0, p.stated().indexOf('('));
+    }
+
+    /** Every row of the table is answered for here, and every answer here is a row. */
+    @Test
+    void everyRowIsAnsweredFor() {
+        assertEquals(DischargeRules.carryingOperations().stream().map(ValueName::name)
+                        .collect(Collectors.toCollection(TreeSet::new)),
+                PREDICATES.stream().map(APredicateCarriesExactlyAsFarAsItsRuleSaysTest::operationOf)
+                        .collect(Collectors.toCollection(TreeSet::new)),
+                "a carrying rule has no program written against it, or the other way round");
+    }
+
+    /** A shape that carries discharges the clause, and one that does not leaves it reported. */
+    @Test
+    void eachShapeCarriesWhatItIsSaidTo() {
+        Map<String, String> wrong = new LinkedHashMap<>();
+        for (Predicate p : PREDICATES) {
+            for (Shape shape : Shape.values()) {
+                Travels travels = p.travels().get(shape);
+                if (travels == Travels.NO_SUCH_CONSTRUCTION) {
+                    continue;
+                }
+                long warnings = warnings(module(p, shape));
+                if (travels == Travels.CARRIES && warnings != 0) {
+                    wrong.put(operationOf(p) + " through " + shape,
+                            "the guard should discharge the clause and does not");
+                }
+                if (travels == Travels.STOPS && warnings == 0) {
+                    wrong.put(operationOf(p) + " through " + shape,
+                            "the clause discharges, and the predicate does not travel there");
+                }
+            }
+        }
+        assertEquals(Map.of(), wrong);
+    }
+
+    /** And a shape said to have no construction has none, so nothing above went untested by being
+     * quietly skipped. */
+    @Test
+    void aShapeSaidToHaveNoConstructionHasNone() {
+        List<String> wrong = new ArrayList<>();
+        for (Predicate p : PREDICATES) {
+            for (Shape shape : Shape.values()) {
+                boolean none = p.travels().get(shape) == Travels.NO_SUCH_CONSTRUCTION;
+                if (none != (built(p.kind(), shape) == null)) {
+                    wrong.add(operationOf(p) + " through " + shape);
+                }
+            }
+        }
+        assertEquals(List.of(), wrong,
+                "these say the library has no construction of the kind and shape, and it has one, or"
+                        + " the other way round");
+    }
+
+    /** Which rules a program can reach at all: one whose only carrying shape has no construction
+     * carries nothing, however true it is. */
+    @Test
+    void whichRulesAnyProgramCanReach() {
+        List<String> reaching = new ArrayList<>();
+        for (Predicate p : PREDICATES) {
+            for (Shape shape : Shape.values()) {
+                if (p.travels().get(shape) == Travels.CARRIES) {
+                    reaching.add(operationOf(p));
+                    break;
+                }
+            }
+        }
+        assertEquals(List.of("List.all", "List.allDistinctBy", "List.any", "List.contains"), reaching,
+                "these are the carrying rules a program can reach; the rest name a shape no"
+                        + " construction of their kind has, and carry nothing");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
@@ -173,22 +173,31 @@ class APredicateCarriesExactlyAsFarAsItsRuleSaysTest {
         assertEquals(Map.of(), wrong);
     }
 
-    /** And a shape said to have no construction has none, so nothing above went untested by being
-     * quietly skipped. */
+    /**
+     * And a shape said to have no construction is one <em>the library</em> does not build, not merely
+     * one this file has no program for. Both are checked against what the building table says the
+     * library builds, so gaining a construction of a kind and shape fails here — the cell above stops
+     * being one that can be skipped, and someone has to say what the predicate does through it.
+     */
     @Test
-    void aShapeSaidToHaveNoConstructionHasNone() {
+    void aShapeSaidToHaveNoConstructionIsOneTheLibraryDoesNotBuild() {
         List<String> wrong = new ArrayList<>();
         for (Predicate p : PREDICATES) {
             for (Shape shape : Shape.values()) {
-                boolean none = p.travels().get(shape) == Travels.NO_SUCH_CONSTRUCTION;
-                if (none != (built(p.kind(), shape) == null)) {
-                    wrong.add(operationOf(p) + " through " + shape);
+                boolean builds = DischargeRules.constructionKinds().contains(p.kind() + "." + shape);
+                if (builds != (p.travels().get(shape) != Travels.NO_SUCH_CONSTRUCTION)) {
+                    wrong.add(operationOf(p) + " through " + shape
+                            + (builds ? ": the library builds this and no answer is written"
+                                    : ": said to be answerable and the library builds no such thing"));
+                }
+                if (builds != (built(p.kind(), shape) != null)) {
+                    wrong.add(p.kind() + "." + shape
+                            + (builds ? ": the library builds this and no program is written for it"
+                                    : ": a program is written for what the library does not build"));
                 }
             }
         }
-        assertEquals(List.of(), wrong,
-                "these say the library has no construction of the kind and shape, and it has one, or"
-                        + " the other way round");
+        assertEquals(List.of(), wrong);
     }
 
     /** Which rules a program can reach at all: one whose only carrying shape has no construction

--- a/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
@@ -139,10 +140,12 @@ class APredicateCarriesExactlyAsFarAsItsRuleSaysTest {
     /** Every row of the table is answered for here, and every answer here is a row. */
     @Test
     void everyRowIsAnsweredFor() {
-        assertEquals(DischargeRules.carryingOperations().stream().map(ValueName::name)
-                        .collect(Collectors.toCollection(TreeSet::new)),
-                PREDICATES.stream().map(APredicateCarriesExactlyAsFarAsItsRuleSaysTest::operationOf)
-                        .collect(Collectors.toCollection(TreeSet::new)),
+        Set<String> written = DischargeRules.carryingOperations().stream().map(ValueName::name)
+                .collect(Collectors.toCollection(TreeSet::new));
+        Set<String> answered = PREDICATES.stream()
+                .map(APredicateCarriesExactlyAsFarAsItsRuleSaysTest::operationOf)
+                .collect(Collectors.toCollection(TreeSet::new));
+        assertEquals(written, answered,
                 "a carrying rule has no program written against it, or the other way round");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
@@ -1,0 +1,111 @@
+package souther.compiler.check;
+
+import souther.compiler.check.DischargeRules.Built;
+import souther.compiler.check.DischargeRules.Carried;
+import souther.compiler.check.DischargeRules.Reads;
+import souther.compiler.check.DischargeRules.Shape;
+import souther.compiler.types.Type;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule names an argument of an operation, and what an operation's arguments are is the library's to
+ * say. Where the two disagree there is nothing to be done at a call — the rule is about an argument
+ * that is not there, or is not the kind of thing the rule is about — so the disagreement is said where
+ * the tables are bound rather than met as a missing answer at whichever reader arrives first.
+ *
+ * <p>This holds the binding to saying it. Each rule below is one a reader would have had to defend
+ * itself against, and each is now a build that does not start.
+ */
+class ARuleIsHeldToTheDeclarationItIsAboutTest {
+
+    private static ValueName op(String qualified) {
+        return new ValueName.Stdlib(qualified);
+    }
+
+    private static void bindCarried(String operation, Reads container) {
+        DischargeRules.bind(
+                Map.of(op(operation), new Carried(container, Set.of(Shape.PERMUTES))),
+                Carried::container, new Reads.TheContainer(), Question::holdsElements,
+                "the container a predicate reads");
+    }
+
+    private static void bindBuilt(String operation, Reads from) {
+        DischargeRules.bind(
+                Map.of(op(operation), new Built(from, Shape.SUBSET)),
+                Built::from, new Reads.TheContainer(), Question::holdsElements,
+                "the container something is built from");
+    }
+
+    @Test
+    void anArgumentTheDeclarationDoesNotHave() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> bindCarried("String.contains", new Reads.At(7)));
+        assertTrue(e.getMessage().contains("String.contains takes 2 argument(s)"), e.getMessage());
+    }
+
+    @Test
+    void anArgumentThatIsNotWhatTheRuleIsAbout() {
+        // `String.contains(needle, haystack)` reads a string, and a shape says what became of a
+        // container's elements — of a string this names only its length.
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> bindCarried("String.contains", new Reads.At(1)));
+        assertTrue(e.getMessage().contains("is not the container a predicate reads"), e.getMessage());
+    }
+
+    @Test
+    void aPartOfSomethingTheSignatureSaysItDoesNotHand() {
+        // `List.contains(value, xs)` applies no closure, so there is no container it hands one.
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> bindCarried("List.contains", new Reads.TheContainer()));
+        assertTrue(e.getMessage().contains("hands one nothing a container holds"), e.getMessage());
+    }
+
+    @Test
+    void anOperationTheLibraryDoesNotDeclare() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> bindCarried("List.containsTwice", new Reads.At(1)));
+        assertTrue(e.getMessage().contains("which the library does not declare"), e.getMessage());
+    }
+
+    /**
+     * A position written where the signature already answers is two answers to one question, and two
+     * answers are what come apart later — which is what {@code List.all} had, its container written in
+     * one table and derived in another.
+     */
+    @Test
+    void aPositionTheSignatureAlreadyAnswers() {
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> bindBuilt("List.filter", new Reads.At(1)));
+        assertTrue(e.getMessage().contains("writes the argument its signature already answers"),
+                e.getMessage());
+    }
+
+    /** And the rules the library actually has: every row of every table, on the first ask. */
+    @Test
+    void theRulesTheCheckShipsWith() {
+        assertDoesNotThrow(() -> {
+            DischargeRules.builtOperations();
+            DischargeRules.carryingOperations();
+            DischargeRules.projections();
+        });
+    }
+
+    /** The binding reads what the declaration says, so a table it agrees with binds. */
+    @Test
+    void aRuleThatAgreesWithTheDeclaration() {
+        assertDoesNotThrow(() -> DischargeRules.bind(
+                Map.of(op("List.reverse"), new Reads.At(0)),
+                Function.identity(), new Reads.TheContainer(),
+                (Type t) -> Question.holdsElements(t), "the container something is built from"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/TheSurfaceTreeStillHoldsACallOfTheWrongArityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheSurfaceTreeStillHoldsACallOfTheWrongArityTest.java
@@ -1,0 +1,75 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which of the two trees can hold a call the operation's signature would not accept.
+ *
+ * <p>The one a representation keeps standing cannot: a {@code PreservedCall} is built only where the
+ * signature accepted the arguments, so a rule about the operation reads an argument that is there.
+ * The one an author wrote can, and does — the totality check runs beside the checks that report an
+ * arity rather than after them, so it reads a call already known to be wrong.
+ *
+ * <p>So {@link Combinators#handedTo(souther.compiler.ast.Ast.Apply)} says nothing about such a call,
+ * and the arity is reported by the check whose question it is. Held here because the difference
+ * between the two trees is the whole reason one of them is asked and the other is not: were it to
+ * stop holding, this fails rather than the walk crediting an element off an argument that is absent.
+ */
+class TheSurfaceTreeStillHoldsACallOfTheWrongArityTest {
+
+    private static void arityIsWhatIsReported(String written, String src) {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileWithWarnings(src));
+        assertTrue(e.getMessage().contains("argument(s)"),
+                written + " should be reported as the arity it is, and was: " + e.getMessage());
+    }
+
+    /** A combinator inside a recursive helper — the one body the totality check walks. */
+    @Test
+    void aCombinatorWrittenWithoutItsContainer() {
+        arityIsWhatIsReported("List.sortBy", """
+                module demo
+                let go (xs: List<Int>) : List<Int> = List.sortBy(x -> go([x]))
+                behavior f : (xs: List<Int>) -> List<Int>
+                let f (xs) = go(xs)
+                """);
+    }
+
+    /**
+     * And a sugar, which the totality check reads under the name the author wrote. A sugar is the
+     * call it becomes with some arguments already supplied, so one written with too few is not that
+     * call and is reported as no operation at all — a different question with a different answer, and
+     * either way not this walk's.
+     */
+    @Test
+    void aSugarWrittenWithoutItsContainer() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compileWithWarnings("""
+                module demo
+                let go (xs: List<Int>) : Int = List.fold((acc, x) -> acc + go([x]), 0)
+                behavior f : (xs: List<Int>) -> Int
+                let f (xs) = go(xs)
+                """));
+        assertTrue(e.getMessage().contains("List.fold"),
+                "the call should be reported as what is wrong with it: " + e.getMessage());
+    }
+
+    /** The same where another error is collected first, so nothing is fatal before the walk runs. */
+    @Test
+    void aCombinatorOfTheWrongArityBesideAnotherError() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compileWithWarnings("""
+                module demo
+                let go (xs: List<Int>) : List<Int> = List.sortBy(x -> go([x]))
+                let other (n: Int) : Int = nosuchthing(n)
+                behavior f : (xs: List<Int>) -> List<Int>
+                let f (xs) = go(xs)
+                """));
+        assertTrue(e.getMessage().contains("argument(s)") || e.getMessage().contains("nosuchthing"),
+                "one of the two errors, and not an internal failure: " + e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/TheSurfaceTreeStillHoldsACallOfTheWrongArityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheSurfaceTreeStillHoldsACallOfTheWrongArityTest.java
@@ -12,14 +12,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * Which of the two trees can hold a call the operation's signature would not accept.
  *
  * <p>The one a representation keeps standing cannot: a {@code PreservedCall} is built only where the
- * signature accepted the arguments, so a rule about the operation reads an argument that is there.
- * The one an author wrote can, and does — the totality check runs beside the checks that report an
- * arity rather than after them, so it reads a call already known to be wrong.
+ * signature accepted the arguments and typed the block it was handed, so a rule about the operation
+ * reads an argument that is there and a parameter the block has. The one an author wrote can, and
+ * does — the totality check runs beside the checks that report an arity rather than after them, so it
+ * reads a call already known to be wrong.
+ *
+ * <p>Two ways for one to be wrong, and both arrive. A call written with fewer arguments than the
+ * operation takes, and a block written with fewer parameters than the operation applies one to. A
+ * sugar is how each gets this far: it has no declaration of its own, so what is said about the arity
+ * of {@code List.fold} is said against the call it becomes, and by then the walk has read it.
  *
  * <p>So {@link Combinators#handedTo(souther.compiler.ast.Ast.Apply)} says nothing about such a call,
  * and the arity is reported by the check whose question it is. Held here because the difference
  * between the two trees is the whole reason one of them is asked and the other is not: were it to
- * stop holding, this fails rather than the walk crediting an element off an argument that is absent.
+ * stop holding, this fails rather than the walk crediting an element off something that is absent.
  */
 class TheSurfaceTreeStillHoldsACallOfTheWrongArityTest {
 
@@ -59,17 +65,62 @@ class TheSurfaceTreeStillHoldsACallOfTheWrongArityTest {
                 "the call should be reported as what is wrong with it: " + e.getMessage());
     }
 
+    /**
+     * A block written with fewer parameters than the operation applies one to. The element arrives on
+     * a parameter the block does not have, which is nothing to say rather than something to read off
+     * the parameter list at that position.
+     */
+    @Test
+    void aStepWrittenWithoutTheParameterItsElementArrivesOn() {
+        parameterCountIsWhatIsReported("""
+                module demo
+                let go (xs: List<Int>) : Int = List.fold(acc -> go(xs), 0, xs)
+                behavior f : (xs: List<Int>) -> Int
+                let f (xs) = go(xs)
+                """);
+        parameterCountIsWhatIsReported("""
+                module demo
+                let go (s: Set<Int>) : Int = Set.fold(acc -> go(s), 0, s)
+                behavior f : (s: Set<Int>) -> Int
+                let f (s) = go(s)
+                """);
+    }
+
+    private static void parameterCountIsWhatIsReported(String src) {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileWithWarnings(src));
+        // Which check reports it depends on whether the sugar's target is expanded or applied, and
+        // the two word it differently. That either says it is the point; an internal failure would
+        // not be a CompileException at all.
+        assertTrue(e.getMessage().contains("parameter(s)") || e.getMessage().contains("argument(s)"),
+                "the block should be reported for what it is written with, and was: "
+                        + e.getMessage());
+    }
+
     /** The same where another error is collected first, so nothing is fatal before the walk runs. */
     @Test
     void aCombinatorOfTheWrongArityBesideAnotherError() {
-        CompileException e = assertThrows(CompileException.class, () -> Compiler.compileWithWarnings("""
+        besideAnotherError("""
                 module demo
                 let go (xs: List<Int>) : List<Int> = List.sortBy(x -> go([x]))
                 let other (n: Int) : Int = nosuchthing(n)
                 behavior f : (xs: List<Int>) -> List<Int>
                 let f (xs) = go(xs)
-                """));
-        assertTrue(e.getMessage().contains("argument(s)") || e.getMessage().contains("nosuchthing"),
+                """);
+        besideAnotherError("""
+                module demo
+                let go (xs: List<Int>) : Int = List.fold(acc -> go(xs), 0, xs)
+                let other (n: Int) : Int = nosuchthing(n)
+                behavior f : (xs: List<Int>) -> Int
+                let f (xs) = go(xs)
+                """);
+    }
+
+    private static void besideAnotherError(String src) {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compileWithWarnings(src));
+        assertTrue(e.getMessage().contains("argument(s)") || e.getMessage().contains("nosuchthing")
+                        || e.getMessage().contains("List.fold"),
                 "one of the two errors, and not an internal failure: " + e.getMessage());
     }
 }


### PR DESCRIPTION
Follow-up from #354.

## What was wrong

`DischargeRules` answered `Built.from()`, `Carried.container()` and `projectionOf` as `int`, and `Combinators` its three positions the same way. None means anything on its own, so every reader turned one back into an argument and guarded the turn — twelve sites, fourteen bounds checks.

Measured before changing anything: thirteen of the fourteen are dead. Making every guard throw and running the whole suite (3098 tests) fires none of them, and every arity mismatch an author can write — argument count, closure parameter count, intrinsic or inlined — is reported before the discharge check reads a call. A `PreservedCall` is built only where the signature accepted the arguments, so one that exists has them.

What the guards were defending against is a row disagreeing with a declaration, and each answered that by returning quietly at whichever site was reached first. Nothing said the row was wrong: adding `String.contains -> Carried(7, PERMUTES)` passed all 2822 tests, including both `Question` ones, which range over whether a row exists and not over what it says.

## What this does

**A rule answers a call.** `builtFrom`, `carried` and `projectionOf` take one and answer with the container, the shapes, the projection; `Combinators.handedTo` answers with the block, the parameter the element arrives on, and the container it comes from. No reader indexes anything.

**Which argument a rule reads is written as the part it plays**, wherever the signature already answers it (`Reads.TheContainer`, `Reads.TheClosure`) — fifteen of the twenty-nine rows, every one of which was restating a position `Combinators` derives. `List.all` had its container written in one table and derived in another; now it has one. The fourteen that remain are decisions a signature does not settle: an operation given two containers, or one that takes no closure.

**Every row of every table is held to the operation it is about, on the first ask** — as `Combinators` and `Preserved` already are, not eagerly. The operation is declared, the argument is one that declaration has, what stands there is the kind of thing the rule is about, and a position the signature already answers is refused. `String.contains` reading argument 8 now fails the build.

**One guard survives, and it is not about the tables.** The totality check reads the tree an author wrote, beside the checks that report an arity rather than after them, so it does reach a call already known to be wrong — `List.sortBy(x -> go([x]))` inside a recursive helper gets there. That is a fact about the surface tree, so it is answered once in `Combinators.handedTo(Ast.Apply)` with the reason, and pinned by a test.

**A carrying rule is held to what each shape does, from both sides.** `BUILT_FROM` and `Combinators` each had a test holding every row to a program; `CARRIED` had none. A rule too narrow loses a discharge; a rule too wide accepts a construction that can abort, and no program that discharges can detect that. Every shape of every carrying rule now has a program on the side it belongs to, written in the test rather than read off the table it holds.

## Two things writing the cells out surfaced

`Set.contains` and `Map.containsKey` carry through `PERMUTES`, and no set or map construction permutes — a set holds its elements in no order. Both rules are true and reach nothing any program can write. Now said, rather than left looking witnessed.

A mapping over a map leaves its keys alone, so `Map.containsKey` does survive one. Not stated, because `MAPS` is about the elements and not about what they are held under; saying it would need a shape that does.

## Held to

- a row reading an argument the declaration does not have, one that is not a container, one naming a part of something the signature says the operation does not hand, one for an operation the library does not declare, and one writing a position the signature already answers — each fails the binding
- widening `List.contains` to carry through `SUBSET`, and narrowing `List.all` to drop it — each fails the carrying witness
- `Set.intersection` reading the other of its two containers — fails the building witness
- a combinator of the wrong arity in a recursive helper is reported as what is wrong with it

3112 tests, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)