### PR TITLE
The inliner holds one kind of state, and the facts it used to rebuild are asked once

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperGraph.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperGraph.java
@@ -1,0 +1,95 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Which declaration calls which, over one {@link HelperTable}, and which of them recurse.
+ *
+ * <p>A function of the table it was built from and of nothing else. Two bodies of one module are
+ * expanded against one table and so read one graph — before this each expansion built its own, which
+ * meant walking every one of the standard library's bodies again for each, and eleven answers that
+ * had to agree.
+ *
+ * <p>A helper recurses iff it can reach itself through helper calls; every member of a mutual cycle
+ * is reached from itself, so all are marked. Both a module's own helpers and the shipped prelude ones
+ * are walked: {@code List.foldFrom} is a recursive prelude helper and has to be left standing —
+ * lowered to a method, not inlined — exactly as a module-own recursive helper is, or its self-call is
+ * expanded forever.
+ *
+ * <p>Built over the table as it stands. A table narrowed for an expansion ({@link HelperTable#hiding})
+ * narrows what a call reaches and changes nothing here: a graph taken over the narrowed table would
+ * find the very helper being expanded non-recursive.
+ */
+public record HelperGraph(Map<String, Set<String>> callsOf, Set<String> recursive) {
+
+    /** The graph of {@code table}: what each declaration in it calls, and which of them recurse. */
+    public static HelperGraph of(HelperTable table) {
+        Map<String, Set<String>> callsOf = new LinkedHashMap<>();
+        for (Map.Entry<String, Ast.FnDef> e : table.reachable().entrySet()) {
+            Set<String> called = new LinkedHashSet<>();
+            HelperInliner.helperCallsIn(e.getValue().writtenBody(), table.reachable(), called);
+            callsOf.put(e.getKey(), called);
+        }
+        Set<String> recursive = new LinkedHashSet<>();
+        for (String name : table.reachable().keySet()) {
+            if (reaches(callsOf, name, name, new HashSet<>())) {
+                recursive.add(name);
+            }
+        }
+        return new HelperGraph(Map.copyOf(callsOf), Set.copyOf(recursive));
+    }
+
+    /** Whether {@code name} is on a call cycle, so a call of it is left standing rather than
+     * expanded (spec 13.1). */
+    public boolean recurses(String name) {
+        return recursive.contains(name);
+    }
+
+    /** What {@code name}'s body calls directly, or an empty set where it calls nothing this table
+     * reaches. */
+    public Set<String> calls(String name) {
+        return callsOf.getOrDefault(name, Set.of());
+    }
+
+    /** Everything reachable from {@code seeds} through call edges, the seeds included. */
+    public Set<String> reachedFrom(Collection<String> seeds) {
+        Set<String> reached = new LinkedHashSet<>(seeds);
+        Deque<String> work = new ArrayDeque<>(seeds);
+        while (!work.isEmpty()) {
+            for (String called : calls(work.poll())) {
+                if (reached.add(called)) {
+                    work.add(called);
+                }
+            }
+        }
+        return reached;
+    }
+
+    /** Whether {@code target} is reachable from {@code from}. Prelude helpers never call a module's
+     * own helpers, so a cycle stays within the module's own helpers. */
+    private static boolean reaches(Map<String, Set<String>> callsOf, String from, String target,
+                                   Set<String> seen) {
+        Set<String> called = callsOf.get(from);
+        if (called == null) {
+            return false;
+        }
+        for (String c : called) {
+            if (c.equals(target)) {
+                return true;
+            }
+            if (seen.add(c) && reaches(callsOf, c, target, seen)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperGraph.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperGraph.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 
 import java.util.ArrayDeque;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -45,7 +46,21 @@ public record HelperGraph(Map<String, Set<String>> callsOf, Set<String> recursiv
                 recursive.add(name);
             }
         }
-        return new HelperGraph(Map.copyOf(callsOf), Set.copyOf(recursive));
+        return new HelperGraph(fixed(callsOf), Set.copyOf(recursive));
+    }
+
+    /**
+     * {@code callsOf} as a graph nothing can change, edges included.
+     *
+     * <p>Fixing the map alone leaves each of its sets the one that was built here, and both accessors
+     * hand one out. A graph is a module's answer and it is shared: what one reader did to it would be
+     * what every reader after it read, and a query answer that changes under its readers is one the
+     * store cannot tell has changed.
+     */
+    private static Map<String, Set<String>> fixed(Map<String, Set<String>> callsOf) {
+        Map<String, Set<String>> out = new LinkedHashMap<>();
+        callsOf.forEach((name, called) -> out.put(name, Collections.unmodifiableSet(called)));
+        return Collections.unmodifiableMap(out);
     }
 
     /** Whether {@code name} is on a call cycle, so a call of it is left standing rather than

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -73,7 +73,10 @@ public final class HelperInliner {
      * a fact about the module rather than about any one body.
      */
     private Map<String, Integer> callableBehaviors = Map.of();
-    private final Set<String> recursive = new HashSet<>();   // own helpers on a call cycle (spec 13.1)
+    /** What each declaration this table reaches calls, and which of them recurse. A function of the
+     * table, so a narrowed table does not narrow it: what recurses was settled over the table as it
+     * was built. */
+    private final HelperGraph graph;
     private int counter = 0;
     /** The body being expanded, and the bindings this expansion introduces into it. An expansion
      * writes bindings no source wrote, so they belong to it rather than to the definition whose text
@@ -108,8 +111,9 @@ public final class HelperInliner {
      * another author's line. */
     private record LambdaOrigin(String param, String owner, SourcePos pos) {}
 
-    private HelperInliner(HelperTable table) {
+    private HelperInliner(HelperTable table, HelperGraph graph) {
         this.table = table;
+        this.graph = graph;
     }
 
     /** The body of {@code fn} in this module — what an expansion written into it belongs to. */
@@ -135,9 +139,8 @@ public final class HelperInliner {
      * than imports.
      */
     public static HelperInliner forModule(Ast.Module module, Map<String, Ast.FnDef> imported) {
-        HelperInliner inliner =
-                new HelperInliner(HelperTable.of(module, imported, InliningPolicy.FULL));
-        inliner.classifyRecursion();
+        HelperTable table = HelperTable.of(module, imported, InliningPolicy.FULL);
+        HelperInliner inliner = new HelperInliner(table, HelperGraph.of(table));
         inliner.computeReferencedPreludeRecursive(module);
         return inliner;
     }
@@ -176,9 +179,19 @@ public final class HelperInliner {
      */
     public static HelperInliner forHelpers(String module, Map<String, Ast.FnDef> own,
                                            Map<String, Ast.FnDef> imported, InliningPolicy policy) {
-        HelperInliner inliner = new HelperInliner(HelperTable.of(module, own, imported, policy));
-        inliner.classifyRecursion();
-        return inliner;
+        HelperTable table = HelperTable.of(module, own, imported, policy);
+        return over(table, HelperGraph.of(table));
+    }
+
+    /**
+     * The inlining over a table and the graph of that table, both worked out elsewhere.
+     *
+     * <p>What a call reaches and what recurses are facts about a module's declarations, so a compile
+     * asks them once and every body of that module is expanded against the same two answers. The
+     * factories above are for a caller holding declarations rather than answers.
+     */
+    public static HelperInliner over(HelperTable table, HelperGraph graph) {
+        return new HelperInliner(table, graph);
     }
 
     /**
@@ -221,39 +234,26 @@ public final class HelperInliner {
     /** Walks the module's fn bodies and data invariants, collecting the prelude recursive helpers they
      * reach transitively — those must be emitted as this module's own methods. */
     private void computeReferencedPreludeRecursive(Ast.Module module) {
-        Set<String> reachable = new HashSet<>();
-        java.util.Deque<String> work = new java.util.ArrayDeque<>();
+        Set<String> named = new LinkedHashSet<>();
         for (Ast.FnDef fn : module.fns()) {
-            collectHelperCalls(fn.writtenBody(), reachable);
+            collectHelperCalls(fn.writtenBody(), named);
         }
         for (Ast.Def d : module.defs()) {
             if (d instanceof Ast.Data data) {
                 for (Ast.InvariantClause clause : data.invariants()) {
-                    collectHelperCalls(clause.expr(), reachable);
+                    collectHelperCalls(clause.expr(), named);
                 }
             }
         }
-        forEachExampleExpr(module, e -> collectHelperCalls(e, reachable));
-        work.addAll(reachable);
-        while (!work.isEmpty()) {
-            Set<String> calls = callsOf.get(work.poll());
-            if (calls == null) {
-                continue;
-            }
-            for (String c : calls) {
-                if (reachable.add(c)) {
-                    work.add(c);
-                }
-            }
-        }
-        for (String name : reachable) {
-            if (recursive.contains(name) && !table.declares(name)) {
+        forEachExampleExpr(module, e -> collectHelperCalls(e, named));
+        for (String name : graph.reachedFrom(named)) {
+            if (graph.recurses(name) && !table.declares(name)) {
                 referencedPreludeRecursive.add(name);
             }
         }
         exampleHelpers.addAll(exampleHelpers(module, table.reachable()));
         exampleHelpers.removeAll(referencedPreludeRecursive);
-        exampleHelpers.removeIf(recursive::contains);   // already emitted as a recursive helper
+        exampleHelpers.removeIf(graph::recurses);   // already emitted as a recursive helper
     }
 
     /** Every expression an {@code example} or a {@code fake} of {@code module} writes: a row's inputs,
@@ -353,7 +353,7 @@ public final class HelperInliner {
      * module does not reach, so {@code inline} never expands one that slips in through a nested body. */
     public Set<String> recursiveHelpers() {
         Set<String> result = new java.util.LinkedHashSet<>();
-        for (String name : recursive) {
+        for (String name : graph.recursive()) {
             if (table.declares(name)) {
                 result.add(name);
             }
@@ -397,7 +397,7 @@ public final class HelperInliner {
      * body of something else it imported.
      */
     public Ast.FnDef closeAcross(Ast.FnDef fn, String module) {
-        Ast.Expr closed = recursive.contains(fn.name())
+        Ast.Expr closed = graph.recurses(fn.name())
                 ? inlineRecursiveBody(fn) : inline(fn.writtenBody(), bodyOf(fn.name()));
         return new Ast.FnDef(HelperNames.qualified(module, fn.name()), fn.params(), fn.declaredReturn(),
                 new Ast.FnBody.Written(
@@ -927,7 +927,7 @@ public final class HelperInliner {
         // a recursive helper is reached by the name it is declared under; a lambda a binding
         // holds is not one, whatever it is called
         boolean standing = !(call.denotes() instanceof ValueName.Local)
-                && recursive.contains(call.reaches());
+                && graph.recurses(call.reaches());
         if (helper == null || standing) {
             // builtin, injected behavior, a function-typed parameter, or a recursive helper —
             // a recursive helper is lowered to a method, so its call stays a Call (spec 13.1);
@@ -1217,7 +1217,7 @@ public final class HelperInliner {
             return v;
         }
         Ast.FnDef value = table.reached(v.reaches());
-        if (value == null || value.body() == null || recursive.contains(v.name())) {
+        if (value == null || value.body() == null || graph.recurses(v.name())) {
             return v;
         }
         return HelperNames.carriedByValue(inline(value.writtenBody()));
@@ -1567,27 +1567,6 @@ public final class HelperInliner {
         return out;
     }
 
-    /** Records the module's own helpers that lie on a call cycle (self or mutual). A recursive helper
-     * is lowered to a method that may call itself, rather than inlined (spec 13.1). A helper is
-     * recursive iff it can reach itself through helper calls; every member of a mutual cycle is
-     * reached from itself, so all are marked. */
-    private void classifyRecursion() {
-        // Both a module's own helpers and the shipped prelude helpers are scanned: `souther.list`'s
-        // `foldFrom` is a recursive prelude helper, and it must be left standing (lowered to a method,
-        // not inlined) exactly as a module-own recursive helper is, or the inliner would expand its
-        // self-call forever.
-        for (Map.Entry<String, Ast.FnDef> e : table.reachable().entrySet()) {
-            Set<String> called = new HashSet<>();
-            collectHelperCalls(e.getValue().writtenBody(), called);
-            callsOf.put(e.getKey(), called);
-        }
-        for (String name : table.reachable().keySet()) {
-            if (reaches(name, name, new HashSet<>())) {
-                recursive.add(name);
-            }
-        }
-    }
-
     /**
      * The value a spread copies, or null where it copies something else — a parameter, a binding, or
      * a name that merely shares a value's spelling.
@@ -1604,30 +1583,7 @@ public final class HelperInliner {
         String reached = spread.name();
         Ast.FnDef value = table.own().get(reached);
         return value == null || !value.params().isEmpty() || value.body() == null
-                || recursive.contains(reached) ? null : value;
-    }
-
-    /** Which helpers each helper's body calls. Built once, before the cycle search: {@link #reaches}
-     * walks this graph from every helper, so scanning a body per edge scanned the shipped prelude —
-     * a few hundred call sites — once per path through it rather than once. */
-    private final Map<String, Set<String>> callsOf = new HashMap<>();
-
-    /** Whether {@code target} is reachable from {@code from} through helper-call edges. Prelude
-     * helpers never call a module's own helpers, so a cycle stays within the module's own helpers. */
-    private boolean reaches(String from, String target, Set<String> seen) {
-        Set<String> called = callsOf.get(from);
-        if (called == null) {
-            return false;
-        }
-        for (String c : called) {
-            if (c.equals(target)) {
-                return true;
-            }
-            if (seen.add(c) && reaches(c, target, seen)) {
-                return true;
-            }
-        }
-        return false;
+                || graph.recurses(reached) ? null : value;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -53,16 +53,6 @@ public final class HelperInliner {
      */
     private HelperTable table;
     /**
-     * The lambdas this pass expands as helpers, each under the binding it is bound to: a lambda a
-     * block's {@code let} binds, and a lambda handed to a function parameter.
-     *
-     * <p>Apart from {@link #table} because they are apart: a declaration is reached by a name, a
-     * lambda is reached by a binding. Held together, a lambda bound to {@code f} took the place of a
-     * declared {@code f} for as long as it was in scope, which is why applying it had to be told from
-     * applying the declaration by a spelling and why a lambda naming itself had to be refused.
-     */
-    private final Map<BindingId, ScopedLambda> scopedLambdas = new HashMap<>();
-    /**
      * The behaviors a body expanded here may name, with how many inputs each takes — the module's
      * own callable ones and the ones it borrows (spec {@code [#calling-a-behavior]}).
      *
@@ -92,12 +82,37 @@ public final class HelperInliner {
      * with each would give two of them the same binding.
      */
     private final Map<BindingOwner, Integer> written = new HashMap<>();
-    /** The body being expanded, and the bindings this expansion introduces into it. An expansion
-     * writes bindings no source wrote, so they belong to it rather than to the definition whose text
-     * it is splicing, which is what keeps two copies of one helper's body apart. */
-    private Ast.Binders binders;
-    /** The body being expanded into, which the copies of a helper's bindings belong under. */
-    private BindingOwner into;
+
+    /**
+     * One writing of one body, and everything that is true only while it runs.
+     *
+     * <p>Four things were four fields, each saved and put back on its own, and one of them was left
+     * standing after a refusal because the line that emptied it was on the path that did not run.
+     * Held together they are made whole and dropped whole: what a writing holds is the writing's, and
+     * a writing that did not finish takes it with it.
+     *
+     * @param into the body being written, which the bindings an expansion introduces belong under
+     * @param binders the minter for those bindings — an expansion writes names no source wrote, so
+     *                they belong to this writing rather than to the definition whose text it splices
+     * @param dependencies which bindings the {@code depends on} parameters of a behavior's
+     *                     {@code let} are; empty while writing anything else, because only a
+     *                     behavior's {@code let} has them (spec §depends-on)
+     * @param scopedLambdas the lambdas reached by a binding rather than by a name: one a block's
+     *                      {@code let} binds, one handed to a function parameter. Apart from
+     *                      {@link #table} because they are apart — a declaration is reached by a name
+     *                      — and inside the writing because a lambda is in scope for as long as the
+     *                      body holding it is being written and not one call longer
+     */
+    private record Writing(BindingOwner into, Ast.Binders binders, Set<BindingId> dependencies,
+                           Map<BindingId, ScopedLambda> scopedLambdas) {
+
+        Writing(BindingOwner into, Ast.Binders binders, Set<BindingId> dependencies) {
+            this(into, binders, dependencies, new HashMap<>());
+        }
+    }
+
+    /** The writing in force, or null outside one. Nothing public reads it without starting one. */
+    private Writing writing;
 
     /**
      * A lambda reached by a binding, and where the author wrote it.
@@ -710,8 +725,14 @@ public final class HelperInliner {
             // applying something that is not a name: what is applied is worked out by the expression,
             // and no declaration stands behind it
             case null -> null;
+            // A binding holds a lambda only inside the writing that put it there, so asked outside
+            // one — which is where a check reads a call without expanding anything — a binding stands
+            // for nothing this can answer with. It was answered that way before by a table that
+            // happened to be empty there; it is answered that way now because there is no writing to
+            // ask.
             case ValueName.Local local -> {
-                ScopedLambda lambda = scopedLambdas.get(local.id());
+                ScopedLambda lambda = writing == null ? null
+                        : writing.scopedLambdas().get(local.id());
                 yield lambda == null ? null : lambda.fn();
             }
             case ValueName.Helper _, ValueName.Stdlib _ -> table.reached(reachedBy);
@@ -740,7 +761,7 @@ public final class HelperInliner {
      * both call the wrong thing and report a value as an uncallable name.
      */
     private List<Ast.Expr> forwardDependencies(Ast.FnDef callee, List<Ast.Expr> args) {
-        if (callee == null || dependencies.isEmpty()) {
+        if (callee == null || writing.dependencies().isEmpty()) {
             return args;
         }
         List<Ast.Expr> out = new ArrayList<>(args);
@@ -749,7 +770,7 @@ public final class HelperInliner {
             Ast.FnType want = declared == null ? null : declared.asFn();
             if (want == null || !(out.get(i) instanceof Ast.Var v)
                     || !(v.denotes() instanceof ValueName.Local local)
-                    || !dependencies.contains(local.id())) {
+                    || !writing.dependencies().contains(local.id())) {
                 continue;
             }
             out.set(i, etaExpand(v, want.params().size(), _ -> "$" + next() + "_" + v.name()));
@@ -757,21 +778,10 @@ public final class HelperInliner {
         return out;
     }
 
-    /** Which bindings the {@code depends on} parameters of the behavior {@code let} being expanded
-     * are. Empty while expanding anything else: only a behavior's {@code let} has them
-     * (spec §depends-on). */
-    private Set<BindingId> dependencies = Set.of();
-
-    /** As {@link #inline(Ast.Expr)}, for the body of a behavior {@code let} whose {@code depends on}
-     * parameters are bound at {@code binders}. */
+    /** As {@link #inline(Ast.Expr, BindingOwner)}, for the body of a behavior {@code let} whose
+     * {@code depends on} parameters are the trailing bindings named in {@code dependencies}. */
     public Ast.Expr inline(Ast.Expr e, Set<BindingId> dependencies, BindingOwner into) {
-        Set<BindingId> outer = this.dependencies;
-        this.dependencies = dependencies;
-        try {
-            return inline(e, into);
-        } finally {
-            this.dependencies = outer;
-        }
+        return writing(into, dependencies, () -> inline(e));
     }
 
     /**
@@ -781,24 +791,40 @@ public final class HelperInliner {
      * so two copies of one helper's body spliced into two definitions do not answer as one binding.
      */
     public Ast.Expr inline(Ast.Expr e, BindingOwner into) {
-        Ast.Binders outerBinders = binders;
-        BindingOwner outerInto = this.into;
-        this.into = into;
+        return writing(into, Set.of(), () -> inline(e));
+    }
+
+    /**
+     * Runs {@code expansion} as one writing into {@code into}.
+     *
+     * <p>The writing is a value and it is made whole: nothing it holds is left from the writing
+     * before, and nothing it holds outlives it — including where an expansion was refused partway
+     * through, which is a thing that happens, because a caller records a refusal and hands the next
+     * body to the same pass.
+     *
+     * <p>A writing may hold another. A helper's body is expanded while the body that called it is
+     * being expanded, so the one in force is put back when this one is done rather than dropped.
+     */
+    private Ast.Expr writing(BindingOwner into, Set<BindingId> dependencies,
+                             java.util.function.Supplier<Ast.Expr> expansion) {
+        Writing outer = writing;
         // Numbered among what this pass has written into that body, so a second writing into it — a
         // second clause of one invariant, a second argument of one helper — writes bindings of its
         // own rather than the first one's over again.
-        binders = new Ast.Binders(new BindingOwner.Synthesized(into, BindingOwner.Pass.INLINER, next()));
+        writing = new Writing(into,
+                new Ast.Binders(new BindingOwner.Synthesized(into, BindingOwner.Pass.INLINER,
+                        written.merge(into, 1, Integer::sum) - 1)),
+                dependencies);
         try {
-            return inline(e);
+            return expansion.get();
         } finally {
-            binders = outerBinders;
-            this.into = outerInto;
+            writing = outer;
         }
     }
 
     /** The next number this pass has for the body it is writing into. */
     private int next() {
-        return written.merge(into, 1, Integer::sum) - 1;
+        return written.merge(writing.into(), 1, Integer::sum) - 1;
     }
 
     /** How the source wrote an expression that is a name or a chain of field reads off one, or null
@@ -814,18 +840,17 @@ public final class HelperInliner {
         };
     }
 
-    /** Rewrites every helper call in {@code e} to its inlined body, into the body already named. */
-    public Ast.Expr inline(Ast.Expr e) {
-        if (binders == null) {
-            throw new IllegalStateException("nothing said which body this expansion is written into");
-        }
+    /** Rewrites every helper call in {@code e} to its inlined body, into the body this writing names.
+     * Private, because there is no body to write into until a writing says which, and the writings
+     * are started above. */
+    private Ast.Expr inline(Ast.Expr e) {
         return switch (e) {
             // Applying something other than a name. The applied expression is bound first and the
             // application reads the binding, which is the shape every reader downstream already has
             // — and which says outright what the order is: the function is worked out once, before
             // any argument, and the binding is what is applied.
             case Ast.Apply raw when !raw.appliesAName() -> {
-                Ast.Binder f = binders.binder("$fn" + next(), raw.function().pos());
+                Ast.Binder f = writing.binders().binder("$fn" + next(), raw.function().pos());
                 // What the application reaches is the binding, and what a report about it quotes is
                 // what the author wrote — a field read applied (`deps.count(x)`) has a spelling, and
                 // quoting the binding would name `$fn0`, which is nowhere in the source. The two are
@@ -877,9 +902,9 @@ public final class HelperInliner {
                 Ast.FnDef aliased = value instanceof Ast.Var v ? expands(v.denotes(), v.reaches()) : null;
                 if (aliased != null) {
                     BindingId alias = li.binder().id();
-                    scopedLambdas.put(alias, new ScopedLambda(aliased));
+                    writing.scopedLambdas().put(alias, new ScopedLambda(aliased));
                     Ast.Expr aliasBody = inline(li.body());
-                    scopedLambdas.remove(alias);
+                    writing.scopedLambdas().remove(alias);
                     yield references(aliasBody, alias)
                             ? new Ast.LetIn(li.binder(), value, li.declaredType(), li.annotated(),
                                     li.opens(), aliasBody, li.pos())
@@ -902,11 +927,11 @@ public final class HelperInliner {
                     params.add(new Ast.FnParam(p, null));
                 }
                 BindingId bound = li.binder().id();
-                scopedLambdas.put(bound, new ScopedLambda(
+                writing.scopedLambdas().put(bound, new ScopedLambda(
                         new Ast.FnDef(li.name(), params, null,
                                 new Ast.FnBody.Written(lambda.body()), li.pos())));
                 Ast.Expr body = inline(li.body());
-                scopedLambdas.remove(bound);
+                writing.scopedLambdas().remove(bound);
                 // if the binding is still read, the function was used as a value, not just applied —
                 // it escapes, which needs a runtime closure. Keep the binding so the check that
                 // reports an escaping block sees it.
@@ -971,7 +996,7 @@ public final class HelperInliner {
         // declared return is carried on, and every binding copied out of the callee's body.
         // One minter, so no two of them are the same binding, and a reader can ask of any of
         // them which call it came from.
-        BindingOwner mine = new BindingOwner.Expansion(into, call.denotes(), next());
+        BindingOwner mine = new BindingOwner.Expansion(writing.into(), call.denotes(), next());
         Ast.Binders ours = new Ast.Binders(mine);
         // What the callee's signature leaves open, this call decides. Its variables are
         // instantiated once, here, over the whole signature at once — so a variable it wrote
@@ -995,7 +1020,7 @@ public final class HelperInliner {
                 bound.add(lambda);
             }
         });
-        arguments.unreduced().keySet().forEach(scopedLambdas::remove);
+        arguments.unreduced().keySet().forEach(writing.scopedLambdas()::remove);
         return new Ast.Expansion(call.denotes(), mine, bound, arguments.given(),
                 instantiated(helper.declaredReturn(), applied), body, call.pos());
     }
@@ -1010,7 +1035,7 @@ public final class HelperInliner {
      */
     private CompileException wrongArity(Ast.Apply call, Ast.FnDef helper, int given) {
         ScopedLambda applied = call.denotes() instanceof ValueName.Local local
-                ? scopedLambdas.get(local.id()) : null;
+                ? writing.scopedLambdas().get(local.id()) : null;
         LambdaOrigin origin = applied == null ? null : applied.origin();
         if (origin != null) {
             return CompileException.of(
@@ -1103,7 +1128,7 @@ public final class HelperInliner {
                     }
                     // the lambda's body is caller code, so it is not renamed by this helper's
                     // substitution — only the enclosing helper body is.
-                    scopedLambdas.put(f.id(), new ScopedLambda(
+                    writing.scopedLambdas().put(f.id(), new ScopedLambda(
                             new Ast.FnDef(f.name(), lparams,
                                     declares == null ? null : declares.result(),
                                     new Ast.FnBody.Written(lambda.body()), lambda.pos()),
@@ -1163,7 +1188,7 @@ public final class HelperInliner {
         List<Ast.Binder> params = new ArrayList<>();
         List<Ast.Expr> args = new ArrayList<>();
         for (int i = 0; i < arity; i++) {
-            Ast.Binder p = binders.binder(binderName.apply(i), function.pos());
+            Ast.Binder p = writing.binders().binder(binderName.apply(i), function.pos());
             params.add(p);
             args.add(Ast.Var.local(p, function.pos()));
         }
@@ -1263,7 +1288,7 @@ public final class HelperInliner {
                 spreads.add(spread);
                 continue;
             }
-            Ast.Binder name = binders.binder("$s" + next() + "_" + spread.bare(), spread.pos());
+            Ast.Binder name = writing.binders().binder("$s" + next() + "_" + spread.bare(), spread.pos());
             bound.add(name);
             values.add(HelperNames.carriedByValue(inline(value.writtenBody())));
             spreads.add(Ast.Var.local(name, spread.pos()));

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -56,7 +56,7 @@ public final class HelperInliner {
      * declared {@code f} for as long as it was in scope, which is why applying it had to be told from
      * applying the declaration by a spelling and why a lambda naming itself had to be refused.
      */
-    private final Map<BindingId, Ast.FnDef> scopedLambdas = new HashMap<>();
+    private final Map<BindingId, ScopedLambda> scopedLambdas = new HashMap<>();
     /**
      * The behaviors a body expanded here may name, with how many inputs each takes — the module's
      * own callable ones and the ones it borrows (spec {@code [#calling-a-behavior]}).
@@ -69,11 +69,6 @@ public final class HelperInliner {
      */
     private Map<String, Integer> callableBehaviors = Map.of();
     private final Set<String> recursive = new HashSet<>();   // own helpers on a call cycle (spec 13.1)
-    /** Where a lambda given to a function parameter was written, by the binding it was registered
-     * under. Asked by the binding and not by the spelling: two combinators nested one inside the
-     * other give their function parameters the same name as often as not, and a report that found
-     * the outer one's lambda would point at another author's line. */
-    private final Map<BindingId, LambdaOrigin> lambdaOrigins = new HashMap<>();
     private int counter = 0;
     /** The body being expanded, and the bindings this expansion introduces into it. An expansion
      * writes bindings no source wrote, so they belong to it rather than to the definition whose text
@@ -82,10 +77,30 @@ public final class HelperInliner {
     /** The body being expanded into, which the copies of a helper's bindings belong under. */
     private BindingOwner into;
 
+    /**
+     * A lambda reached by a binding, and where the author wrote it.
+     *
+     * <p>The two are one fact about one binding, so they are registered and dropped together. Held in
+     * two tables they had to be put and removed twice, and a binding that made it into one of them
+     * alone is a lambda a report cannot name or a name an expansion cannot reach.
+     *
+     * <p>{@code origin} is null where a {@code let} bound the lambda: the binding is then written
+     * where the author wrote it, and a report about the lambda has nowhere else to point. It says
+     * something only when a call site handed the lambda to a function parameter, because the lambda is
+     * then registered under a synthetic name — a spelling that must never reach a diagnostic.
+     */
+    private record ScopedLambda(Ast.FnDef fn, LambdaOrigin origin) {
+
+        ScopedLambda(Ast.FnDef fn) {
+            this(fn, null);
+        }
+    }
+
     /** Where a lambda given to a function parameter was written: the parameter it fills, the helper
-     * that declares that parameter, and the lambda's own position. The lambda is inlined under a
-     * synthetic name, which is a spelling and must never reach a diagnostic — an error about it is
-     * reported against these instead. */
+     * that declares that parameter, and the lambda's own position. Asked by the binding and not by
+     * the spelling: two combinators nested one inside the other give their function parameters the
+     * same name as often as not, and a report that found the outer one's lambda would point at
+     * another author's line. */
     private record LambdaOrigin(String param, String owner, SourcePos pos) {}
 
     private HelperInliner(String module, Map<String, Ast.FnDef> helpers, Map<String, Ast.FnDef> own) {
@@ -123,7 +138,6 @@ public final class HelperInliner {
         HelperInliner inliner = new HelperInliner(module.name(), withPrelude(table),
                 new LinkedHashMap<>(own));
         inliner.classifyRecursion();
-        inliner.rejectValueCycles();
         inliner.computeReferencedPreludeRecursive(module);
         return inliner;
     }
@@ -170,7 +184,6 @@ public final class HelperInliner {
                 ? withPrelude(joined) : joined;
         HelperInliner inliner = new HelperInliner(module, table, new LinkedHashMap<>(own));
         inliner.classifyRecursion();
-        inliner.rejectValueCycles();
         return inliner;
     }
 
@@ -308,7 +321,7 @@ public final class HelperInliner {
             Ast.Expr e = work.poll();
             reader.collectHelperCalls(e, called);
             Set<String> named = new LinkedHashSet<>();
-            reader.collectValueNames(e, named);
+            ValueCycles.valuesRead(e, table, named);
             for (String value : named) {
                 Ast.FnDef def = table.get(value);
                 if (def != null && def.params().isEmpty()
@@ -403,344 +416,16 @@ public final class HelperInliner {
     public Ast.FnDef closeAcross(Ast.FnDef fn, String module) {
         Ast.Expr closed = recursive.contains(fn.name())
                 ? inlineRecursiveBody(fn) : inline(fn.writtenBody(), bodyOf(fn.name()));
-        return new Ast.FnDef(qualified(module, fn.name()), fn.params(), fn.declaredReturn(),
-                new Ast.FnBody.Written(publishedBy(qualifyHelpersOf(closed, module), module)),
+        return new Ast.FnDef(HelperNames.qualified(module, fn.name()), fn.params(), fn.declaredReturn(),
+                new Ast.FnBody.Written(
+                        HelperNames.publishedBy(HelperNames.qualifyHelpersOf(closed, module), module)),
                 fn.modifiers(), fn.pos());
     }
 
-    /**
-     * {@code e} with every construction in it marked as {@code module}'s.
-     *
-     * <p>What a published body builds is built where that body was written, and the reader is handed
-     * the result. Expanding it puts the construction in the reader's body, where the permission check
-     * would ask the reader to declare it — for a type the declaring module may keep to itself, under a
-     * name the reader has none of. The mark is what tells the two apart afterwards, and it names the
-     * module rather than saying only that the construction came from somewhere: a body may build a
-     * type of a third module, and that one is nobody's to hand over (ADR-0059).
-     */
-    private static Ast.Expr publishedBy(Ast.Expr e, String module) {
-        // a spread names a value, and a value is not a construction: what it built was built where it
-        // was defined, so the mark is already on it
-        Ast.Expr rebuilt = Ast.mapChildren(e, c -> publishedBy(c, module), s -> s);
-        return switch (rebuilt) {
-            case Ast.NewData nd -> nd.publishedBy(module);
-            // a unit data is constructed by being named, so the name is where it says where it came
-            // from — there is no construction node to say it on
-            case Ast.Var v when v.denotes() instanceof ValueName.OfType named ->
-                    v.denoting(named.publishedBy(module));
-            default -> rebuilt;
-        };
-    }
-
-    /**
-     * {@code e} with every construction in it marked as one a value made.
-     *
-     * <p>A value is substituted at each reference, so what its definition built ends up standing in
-     * the body that named it, as the node that body's own construction would be. The mark is what
-     * keeps the permission check reading the model rather than the substitution: a behavior stating a
-     * rule against a named limit compares against a value, and originates none of it. A limit is
-     * written as a value so that the figure has one place to live and one comment saying where it
-     * comes from, and naming it is not supposed to cost every rule that reads it an authority it does
-     * not use.
-     *
-     * <p>Unlike a published body's mark this names no module. What the value built is the value
-     * definition's however the type got its declaration, and a behavior reading the name is not the
-     * one that made it either way. A helper is the other case and stays the other case: its body is
-     * checked as though it had been written inline, which is what tells a helper from a behavior.
-     *
-     * <p>Three things can stand for a construction and each takes the mark. A construction node
-     * carries its own; a unit data is constructed by being named, so the name carries it; and a
-     * recursive helper is lowered to a method rather than expanded, so what it builds stays behind a
-     * call, and the call carries it. Without the third, whether a value's constructions belonged to
-     * the value would turn on whether a helper on the way could be expanded — the substitution
-     * showing through the rule again, in the one place expansion cannot reach.
-     */
-    private static Ast.Expr carriedByValue(Ast.Expr e) {
-        Ast.Expr rebuilt = Ast.mapChildren(e, HelperInliner::carriedByValue, s -> s);
-        return switch (rebuilt) {
-            case Ast.NewData nd -> nd.carriedByValue();
-            case Ast.Var v when v.denotes() instanceof ValueName.OfType named ->
-                    v.denoting(named.carriedByValue());
-            case Ast.Apply call -> call.carriedByValue();
-            default -> rebuilt;
-        };
-    }
-
-    /** How a definition of {@code module} is named outside it. */
-    public static String qualified(String module, String name) {
-        return module + "." + name;
-    }
-
-    /**
-     * {@code m} with every name that denotes another module's definition written qualified.
-     *
-     * <p>A reader writes an imported value or helper bare, and the pair (module, name) is what it
-     * denotes. From here on the two agree: the spelling a body carries is the definition's identity,
-     * so everything downstream — the table a call is expanded against, the method a recursive helper
-     * is emitted as — reads the identity by reading the name, and two modules publishing a
-     * {@code tally} stay two definitions. Done once, here, because the spelling travels as far as the
-     * emitted method name; deciding it at each reader is how one of them comes to disagree.
-     */
-    public static Ast.Module qualifyImports(Ast.Module m) {
-        List<Ast.FnDef> fns = new ArrayList<>();
-        for (Ast.FnDef fn : m.fns()) {
-            fns.add(fn.body() instanceof Ast.FnBody.Written w
-                    ? new Ast.FnDef(fn.written(), fn.params(), fn.declaredReturn(),
-                            new Ast.FnBody.Written(qualifyForeign(w.expr(), m.name())),
-                            fn.modifiers(), fn.pos())
-                    : fn);
-        }
-        List<Ast.Def> defs = qualifiedInvariants(m);
-        List<Ast.Example> examples = new ArrayList<>();
-        for (Ast.Example ex : m.examples()) {
-            List<Ast.ExampleRow> rows = new ArrayList<>();
-            for (Ast.ExampleRow row : ex.rows()) {
-                List<Ast.Expr> inputs = new ArrayList<>();
-                for (Ast.Expr in : row.inputs()) {
-                    inputs.add(qualifyForeign(in, m.name()));
-                }
-                List<Ast.With> withs = new ArrayList<>();
-                for (Ast.With w : row.withs()) {
-                    withs.add(new Ast.With(w.dep(), qualifyForeign(w.value(), m.name()), w.pos()));
-                }
-                rows.add(new Ast.ExampleRow(row.description(), inputs, withs,
-                        qualifyForeign(row.expected(), m.name()), row.pos()));
-            }
-            examples.add(new Ast.Example(ex.target(), rows, ex.pos()));
-        }
-        List<Ast.Fake> fakes = new ArrayList<>();
-        for (Ast.Fake fake : m.fakes()) {
-            List<Ast.FakeRow> rows = new ArrayList<>();
-            for (Ast.FakeRow row : fake.rows()) {
-                List<Ast.Expr> inputs = null;
-                if (row.inputs() != null) {   // a default row matches anything and writes none
-                    inputs = new ArrayList<>();
-                    for (Ast.Expr in : row.inputs()) {
-                        inputs.add(qualifyForeign(in, m.name()));
-                    }
-                }
-                rows.add(new Ast.FakeRow(inputs, qualifyForeign(row.output(), m.name()),
-                        row.isDefault(), row.pos()));
-            }
-            fakes.add(new Ast.Fake(fake.target(), rows, fake.pos()));
-        }
-        return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
-                m.behaviors(), fns, examples, fakes, m.exampleFileTarget(), m.pos());
-    }
-
-    /** {@code m} with the foreign names in its invariants written qualified, and nothing else
-     * changed. An invariant is read before the bodies are — settled here, classified for discharge
-     * there — so this is the part of {@link #qualifyImports} that has to be available on its own. */
-    public static Ast.Module withQualifiedInvariants(Ast.Module m) {
-        List<Ast.Def> defs = qualifiedInvariants(m);
-        return defs.equals(m.defs()) ? m
-                : new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
-                        m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(),
-                        m.pos());
-    }
-
-    /** {@code m}'s declarations with every name in an invariant that denotes another module's
-     * definition written qualified. */
-    private static List<Ast.Def> qualifiedInvariants(Ast.Module m) {
-        List<Ast.Def> defs = new ArrayList<>();
-        for (Ast.Def def : m.defs()) {
-            defs.add(def instanceof Ast.Data d && !d.invariants().isEmpty()
-                    ? new Ast.Data(d.written(), d.newtype(), d.includes(), d.fields(),
-                            Ast.mapClauses(d.invariants(), inv -> qualifyForeign(inv, m.name())),
-                            d.decoder(), d.encoder(), d.pos())
-                    : def);
-        }
-        return defs;
-    }
-
-    /** {@code e} with every name denoting a helper of a module other than {@code self} written
-     * qualified. */
-    private static Ast.Expr qualifyForeign(Ast.Expr e, String self) {
-        return qualifyHelpers(e, helper -> !helper.module().equals(self));
-    }
-
-    /** {@code e} with every name still denoting a helper of {@code module} written qualified. Only a
-     * recursive helper survives closing, so this is what those calls become. */
-    private static Ast.Expr qualifyHelpersOf(Ast.Expr e, String module) {
-        return qualifyHelpers(e, helper -> helper.module().equals(module));
-    }
-
-    /**
-     * {@code e} with every name denoting a helper {@code which} accepts written qualified.
-     *
-     * <p>It reads what a name denotes rather than how it is spelled: a binding of the same spelling is
-     * a binding, and a prelude helper belongs to the prelude and keeps the qualified name it already
-     * has. The new spelling is read off the same answer, so running this twice says what running it
-     * once said.
-     */
-    private static Ast.Expr qualifyHelpers(Ast.Expr e, Predicate<ValueName.Helper> which) {
-        // a name slot takes the same rewrite as a name standing on its own: a spread names a value
-        // the way any other position does
-        Ast.Expr rebuilt = Ast.mapChildren(e, c -> qualifyHelpers(c, which),
-                s -> qualified(s, which));
-        return switch (rebuilt) {
-            case Ast.Apply call when foreign(call.denotes(), which) ->
-                    new Ast.Apply(qualifiedName(call.denotes()), call.denotes(), call.args(),
-                            call.origin(),
-                            call.pos());
-            case Ast.Var v -> qualified(v, which);
-            default -> rebuilt;
-        };
-    }
-
-    /** {@code name} written qualified where it denotes a helper {@code which} accepts. */
-    private static Ast.Var qualified(Ast.Var name, Predicate<ValueName.Helper> which) {
-        return foreign(name.denotes(), which)
-                ? new Ast.Var(qualifiedName(name.denotes()), name.denotes(), name.pos())
-                : name;
-    }
-
-    /** Whether {@code denotes} is a helper {@code which} accepts. */
-    private static boolean foreign(ValueName denotes, Predicate<ValueName.Helper> which) {
-        return denotes instanceof ValueName.Helper helper && which.test(helper);
-    }
-
-    /**
-     * The helpers {@code e} still reaches — what a body closed by {@link #closeAcross} could not
-     * expand away, which is the recursive ones.
-     *
-     * <p>Each is given as what it denotes rather than as a spelling, because the two questions a
-     * caller then has differ: which module declares it decides how it is keyed, and a binding that
-     * shares a helper's spelling is not one of these at all.
-     */
-    public static Set<ValueName.Helper> helpersReached(Ast.Expr e) {
-        Set<ValueName.Helper> out = new LinkedHashSet<>();
-        collectHelpersOf(e, out);
-        return out;
-    }
-
-    private static void collectHelpersOf(Ast.Expr e, Set<ValueName.Helper> out) {
-        if (e == null) {
-            return;
-        }
-        ValueName denotes = switch (e) {
-            case Ast.Apply call -> call.denotes();
-            case Ast.Var v -> v.denotes();
-            default -> null;
-        };
-        if (denotes instanceof ValueName.Helper helper) {
-            out.add(helper);
-        }
-        Ast.forEachChild(e, c -> collectHelpersOf(c, out));
-    }
-
-    /** The name a helper is reached by outside the module that declares it. Read off what the name
-     * denotes, so applying it to a name already written this way answers the same thing. */
-    private static String qualifiedName(ValueName denotes) {
-        ValueName.Helper helper = (ValueName.Helper) denotes;
-        return qualified(helper.module(), helper.name());
-    }
-
-    /**
-     * The key {@code helper} is filed under in the table of the module named {@code module} — bare for
-     * one that module declares, qualified for one it imported.
-     *
-     * <p>Read off what the name denotes and never off how it was written. A reader writes an imported
-     * definition bare, so the spelling is a key only after {@link #qualifyImports} has run, and a check
-     * that keyed by the spelling would answer differently on either side of that pass — silently,
-     * because a miss is what a table does with a key it has not got. The pair (module, name) is what
-     * the definition is (ADR-0072), so it is what a table of definitions is asked with.
-     */
-    public static String keyIn(String module, ValueName.Helper helper) {
-        return helper.module().equals(module) ? helper.name() : qualified(helper.module(), helper.name());
-    }
-
-    /** The module these helpers belong to — what {@link #keyIn} compares a name's declaring module
-     * against. */
+    /** The module these helpers belong to — what {@link HelperNames#keyIn} compares a name's
+     * declaring module against. */
     public String moduleName() {
         return module;
-    }
-
-    /**
-     * Settles the helper parameter types the author left unwritten, then inlines the helper calls in
-     * every data's {@code invariant}.
-     *
-     * <p>The two go together: expanding a call carries the parameter's type onto the binding the call
-     * becomes, so a type settled afterwards would never reach this expansion (issue #178). An
-     * invariant is inlined well before the module is lowered — an importer reads an included data's
-     * invariant through the symbol table, so it must already be expanded there — which is why the
-     * settling is done here as well as in {@link Lower}. It is idempotent: a parameter already typed
-     * is left alone, and {@code Lower} settles what only the fully desugared module can determine.
-     *
-     * <p>An invariant is pure and cannot call an injected behavior (spec §invariant-expressions), so
-     * nothing here needs the injected signatures to settle the helpers an invariant reaches.
-     *
-     * <p>{@code published} is what the modules this one imports offer it. An invariant names what is
-     * in scope where it is written, and an imported definition is in scope there as it is in a body; it
-     * is substituted here for the reason a body's is, so what the invariant carries afterwards names
-     * nothing of the module that declared it. The names are written qualified first, because that is
-     * the spelling the table is keyed by — {@link #qualifyImports} does it again for the bodies below,
-     * and says the same thing both times.
-     */
-    public static Ast.Module withSettledInvariants(Ast.Module m, Symbols symbols,
-                                                   Map<String, Ast.FnDef> published) {
-        Ast.Module settled = withQualifiedInvariants(HelperParams.settle(m, symbols, Map.of()));
-        return forModule(settled, published).withInlinedInvariants(settled);
-    }
-
-    /**
-     * Inlines helper calls inside every data's {@code invariant}, so a rule named with a {@code let}
-     * (e.g. {@code invariant 正の数(value)}) expands to its body before the invariant is type-checked
-     * or emitted — the same lowering a behavior body gets (spec 12.5, §invariant-expressions).
-     */
-    /**
-     * Each declaration's invariant in the representation the invariant-discharge analysis reads: the
-     * helpers it can name expanded, the language's own operations left standing
-     * ({@link InliningPolicy#DISCHARGE}). Keyed by the declaration's name in {@code m}.
-     *
-     * <p>This is the same settling {@link #withSettledInvariants} does, stopped one step earlier, and
-     * it reads the same table: what the clause names is substituted whether this module declared it or
-     * imported it. The settled form is what travels to an importer and what the backend emits; an
-     * importer therefore reads an imported invariant in the settled form and finds nothing here for
-     * it, which is where an imported clause falls outside the statically dischargeable fragment (spec
-     * §invariant-discharge).
-     */
-    public static Map<TypeName, List<Ast.InvariantClause>> invariantsForDischarge(
-            Ast.Module m, Symbols symbols, Map<String, Ast.FnDef> published) {
-        Ast.Module settled = withQualifiedInvariants(HelperParams.settle(m, symbols, Map.of()));
-        HelperInliner inliner =
-                forHelpers(m.name(), helpersOf(settled), published, InliningPolicy.DISCHARGE);
-        Map<TypeName, List<Ast.InvariantClause>> out = new LinkedHashMap<>();
-        for (Ast.Def def : settled.defs()) {
-            if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
-                TypeName declared = new TypeName(m.name(), d.name());
-                out.put(declared, Ast.mapClauses(d.invariants(),
-                        clause -> inliner.inline(clause, new BindingOwner.OfData(declared))));
-            }
-        }
-        return out;
-    }
-
-    Ast.Module withInlinedInvariants(Ast.Module m) {
-        List<Ast.Def> defs = new ArrayList<>();
-        for (Ast.Def def : m.defs()) {
-            if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
-                BindingOwner declared = new BindingOwner.OfData(new TypeName(m.name(), d.name()));
-                defs.add(new Ast.Data(d.written(), d.newtype(), d.includes(), d.fields(),
-                        Ast.mapClauses(d.invariants(), clause -> inline(clause, declared)),
-                        d.decoder(), d.encoder(), d.pos()));
-            } else {
-                defs.add(def);
-            }
-        }
-        return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
-                defs, m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
-    }
-
-    /** The conjuncts of an invariant expression, flattened, in the order they are written — what a
-     * reader sees as separate clauses. */
-    public static List<Ast.Expr> conjunctsOf(Ast.Expr e) {
-        if (e instanceof Ast.Binary b && b.op() == Ast.BinOp.AND) {
-            List<Ast.Expr> out = new ArrayList<>(conjunctsOf(b.left()));
-            out.addAll(conjunctsOf(b.right()));
-            return out;
-        }
-        return List.of(e);
     }
 
     /** The declaration reached by {@code name} across the prelude and the module's own helpers, or
@@ -1026,7 +711,10 @@ public final class HelperInliner {
             // applying something that is not a name: what is applied is worked out by the expression,
             // and no declaration stands behind it
             case null -> null;
-            case ValueName.Local local -> scopedLambdas.get(local.id());
+            case ValueName.Local local -> {
+                ScopedLambda lambda = scopedLambdas.get(local.id());
+                yield lambda == null ? null : lambda.fn();
+            }
             case ValueName.Helper _, ValueName.Stdlib _ -> helpers.get(reachedBy);
             // a construction, an injected behavior, `None`, or a name that denotes nothing: each is
             // applied by something other than an expansion, and each is reported where it belongs
@@ -1141,181 +829,7 @@ public final class HelperInliner {
                                 raw.args(), raw.origin(), spelling(raw.function()), raw.pos()),
                         raw.pos()));
             }
-            case Ast.Apply rawCall -> {
-                checkFunctionArgumentPlacement(rawCall);
-                Ast.Apply call = desugarNamedBlock(desugar(rawCall));
-                List<Ast.Expr> args = new ArrayList<>();
-                for (Ast.Expr a : call.args()) {
-                    args.add(inline(a));
-                }
-                Ast.FnDef helper = appliedHelper(call);
-                // a recursive helper is reached by the name it is declared under; a lambda a binding
-                // holds is not one, whatever it is called
-                boolean standing = !(call.denotes() instanceof ValueName.Local)
-                        && recursive.contains(call.reaches());
-                if (helper == null || standing) {
-                    // builtin, injected behavior, a function-typed parameter, or a recursive helper —
-                    // a recursive helper is lowered to a method, so its call stays a Call (spec 13.1);
-                    // only its args inline.
-                    yield call.withArgs(forwardDependencies(helper, args));
-                }
-                // A declaration written with no parameter list is a value ([#fn-declaration]), so
-                // applying it applies whatever function that value is — not the declaration, which
-                // takes nothing. The value is substituted and the arguments are applied to it.
-                if (helper.params().isEmpty() && !args.isEmpty()
-                        && call.function() instanceof Ast.Var named) {
-                    yield inline(new Ast.Apply(valueOf(named), args, call.origin(), call.pos()));
-                }
-                if (args.size() != helper.params().size()) {
-                    LambdaOrigin origin = call.denotes() instanceof ValueName.Local applied
-                            ? lambdaOrigins.get(applied.id()) : null;
-                    if (origin != null) {
-                        // the callee is a lambda the caller wrote, applied by the combinator it was
-                        // given to: report the parameter count against the lambda, not the synthetic
-                        // name it is inlined under.
-                        throw CompileException.of(
-                                Diagnostic.of(null, "check.fn.blockparam.arity").title("check.fn.title")
-                                        .at(origin.pos())
-                                        .args(origin.param(), origin.owner(), args.size(),
-                                                helper.params().size()).build(),
-                                "the block passed to `" + origin.param() + "` of `let " + origin.owner()
-                                        + "` takes " + args.size() + " argument(s) but is written with "
-                                        + helper.params().size());
-                    }
-                    throw CompileException.of(
-                            Diagnostic.of(null, "check.helper.arity").title("check.arity.title")
-                                    .at(call.name().region())
-                                    .args(helper.name(), helper.params().size(), args.size()).build(),
-                            "helper `let " + helper.name() + "` takes " + helper.params().size()
-                                    + " argument(s) but is called with " + args.size());
-                }
-                // Everything this expansion writes belongs to it: the bindings its arguments become,
-                // the one a lambda given to a function parameter is registered under, the one its
-                // declared return is carried on, and every binding copied out of the callee's body.
-                // One minter, so no two of them are the same binding, and a reader can ask of any of
-                // them which call it came from.
-                BindingOwner mine = new BindingOwner.Expansion(into, call.denotes(), counter++);
-                Ast.Binders ours = new Ast.Binders(mine);
-                // What the callee's signature leaves open, this call decides. Its variables are
-                // instantiated once, here, over the whole signature at once — so a variable it wrote
-                // in two of its parameters is one variable in what this expansion writes, and two
-                // calls of it decide separately. Splitting the signature into a binding per parameter
-                // is what would otherwise lose that: each binding's type would be read on its own,
-                // and nothing left afterwards says the two came from one application.
-                Map<String, Type> applied = instantiation(helper, mine);
-                Map<BindingId, String> subst = new HashMap<>();
-                // what each substituted callee resolved to at the call site, so the expansion carries
-                // the argument's own answer rather than deciding one for it
-                Map<BindingId, ValueName> substDenotes = new HashMap<>();
-                List<BindingId> scoped = new ArrayList<>();   // the lambdas given to fn params
-                // A scoped lambda is reduced where the parameter is applied, and a representation may
-                // hold the application inside a call it keeps standing, so some are not applied here at
-                // all. What is left then is a name for a lambda, which is a value a `let` can hold —
-                // kept ready and used only for the ones the expansion did not reduce away.
-                Map<BindingId, Ast.Bound> unreduced = new LinkedHashMap<>();
-                List<Ast.Bound> bound = new ArrayList<>();
-                List<Ast.Given> given = new ArrayList<>();
-                for (int i = 0; i < helper.params().size(); i++) {
-                    Ast.FnParam p = helper.params().get(i);
-                    Ast.Expr arg = args.get(i);
-                    if (p.type() != null && p.type().asFn() != null) {
-                        // a function argument is not a value, so it cannot be bound to a let. A named
-                        // function is substituted directly (f(x) becomes inc(x)); a lambda is
-                        // registered under a fresh name as a scoped helper, so each application of the
-                        // parameter β-reduces to the lambda's body, as a let-bound lambda does (spec 12.5).
-                        // Asked of the callee as written, not of what it expanded to: applying a
-                        // function parameter is what removes it, because the application β-reduces
-                        // to the lambda's body, so the expansion holds no reference either way.
-                        given.add(new Ast.Given(instantiated(p.type(), applied), arg,
-                                references(helper.writtenBody(), p.binder().id()), arrivesAs(arg)));
-                        Ast.FnType declares = declaredFn(p.type(), applied);
-                        if (arg instanceof Ast.Var fnName) {
-                            // A name handed to a function parameter is substituted through: what
-                            // applies it applies what it stands for. What it stands for is declared
-                            // somewhere — a helper's own parameter, a binding, a function an
-                            // enclosing call gave — and that declaration is carried on the boundary,
-                            // so the two are read against each other without either being re-typed.
-                            subst.put(p.binder().id(), fnName.name());
-                            substDenotes.put(p.binder().id(), fnName.denotes());
-                        } else if (arg instanceof Ast.Block lambda) {
-                            Ast.Binder f = ours.binder("$" + p.name(), lambda.pos());
-                            subst.put(p.binder().id(), f.name());
-                            substDenotes.put(p.binder().id(), new ValueName.Local(f.name(), f.id()));
-                            scoped.add(f.id());
-                            // The lambda is registered under what the callee declared of the
-                            // parameter it was given to, this application's variables written in. So
-                            // where the callee applies it, that application expands like any other
-                            // call and is read against the signature there — in the one place the
-                            // types this application decided are in force. Registering it bare is
-                            // what used to throw the signature away at the point it was reduced,
-                            // leaving nothing between the caller's function and what was declared of
-                            // it (issues #318, #320).
-                            List<Ast.FnParam> lparams = new ArrayList<>();
-                            for (int lp = 0; lp < lambda.params().size(); lp++) {
-                                lparams.add(new Ast.FnParam(lambda.params().get(lp),
-                                        declares == null || lp >= declares.params().size() ? null
-                                                : declares.params().get(lp)));
-                            }
-                            // the lambda's body is caller code, so it is not renamed by this helper's
-                            // substitution — only the enclosing helper body is.
-                            scopedLambdas.put(f.id(),
-                                    new Ast.FnDef(f.name(), lparams,
-                                            declares == null ? null : declares.result(),
-                                            new Ast.FnBody.Written(lambda.body()), lambda.pos()));
-                            lambdaOrigins.put(f.id(), new LambdaOrigin(p.name(), helper.name(), lambda.pos()));
-                            unreduced.put(f.id(),
-                                    new Ast.Bound(f, instantiated(p.type(), applied), lambda));
-                        } else {
-                            // Neither a name nor a lambda: a value written where the function goes —
-                            // the argument-order mistake made with a named helper rather than a
-                            // lambda. Named against the call as written, with the declared order.
-                            List<Ast.FnParam> written = declaredParams(rawCall);
-                            String shape = written == null ? null : written.stream()
-                                    .map(Ast.FnParam::name)
-                                    .collect(java.util.stream.Collectors.joining(", "));
-                            Diagnostic.Builder d = Diagnostic.of(null, "check.fn.argnotvalue")
-                                    .title("check.fn.title").at(arg.pos())
-                                    .args(rawCall.written(), i + 1, p.name(), shape);
-                            if (shape != null) {
-                                d.hint("check.fn.argnotvalue.hint");
-                            }
-                            throw CompileException.of(d.build(),
-                                    "argument " + (i + 1) + " of `" + rawCall.written() + "` is `" + p.name()
-                                            + "`, which takes a function: pass a named function or a lambda"
-                                            + (shape == null ? ""
-                                                    : ". Write `" + rawCall.written() + "(" + shape + ")`."));
-                        }
-                    } else {
-                        // the binding the argument is bound to; the reads of the parameter inside the
-                        // body are answered with it, so a read says which binding it is rather than
-                        // where it happens to be written
-                        Ast.Binder f = ours.binder(p.name(), call.pos());
-                        subst.put(p.binder().id(), f.name());
-                        substDenotes.put(p.binder().id(), new ValueName.Local(f.name(), f.id()));
-                        // carry the parameter's declared type onto the binding, so a value known to
-                        // be a sum (an annotated `s: S`) is not narrowed to the argument's specific
-                        // case when the body is re-checked inline — a `match s` inside still sees S.
-                        bound.add(new Ast.Bound(f, instantiated(p.type(), applied), arg));
-                    }
-                }
-                // a prelude helper's body is stamped with the call site, so errors inside it point at
-                // the user's call, not at the shipped source of souther.*
-                SourcePos at = keepsItsPositions(call) ? null : call.pos();
-                Copy copy = new Copy(helper.writtenBody(), ours);
-                Ast.Expr body = inline(rename(helper.writtenBody(), subst, substDenotes, at, copy));   // expand nested helpers too
-                // A scoped lambda the body still names was passed rather than applied, so nothing
-                // reduced it and the name would stand for nothing. It is bound to what it names, which
-                // is what a lambda given a name is anywhere else.
-                unreduced.forEach((id, lambda) -> {
-                    if (references(body, id)) {
-                        bound.add(lambda);
-                    }
-                });
-                scoped.forEach(scopedLambdas::remove);
-                scoped.forEach(lambdaOrigins::remove);
-                yield new Ast.Expansion(call.denotes(), mine, bound, given,
-                        instantiated(helper.declaredReturn(), applied), body, call.pos());
-            }
+            case Ast.Apply rawCall -> expandCall(rawCall);
             case Ast.FieldAccess fa -> new Ast.FieldAccess(inline(fa.target()), fa.field(), fa.pos());
             case Ast.Binary bin -> new Ast.Binary(bin.op(), inline(bin.left()), inline(bin.right()), bin.pos());
             case Ast.Neg neg -> new Ast.Neg(inline(neg.operand()), neg.pos());
@@ -1356,7 +870,7 @@ public final class HelperInliner {
                 Ast.FnDef aliased = value instanceof Ast.Var v ? expands(v.denotes(), v.reaches()) : null;
                 if (aliased != null) {
                     BindingId alias = li.binder().id();
-                    scopedLambdas.put(alias, aliased);
+                    scopedLambdas.put(alias, new ScopedLambda(aliased));
                     Ast.Expr aliasBody = inline(li.body());
                     scopedLambdas.remove(alias);
                     yield references(aliasBody, alias)
@@ -1381,9 +895,9 @@ public final class HelperInliner {
                     params.add(new Ast.FnParam(p, null));
                 }
                 BindingId bound = li.binder().id();
-                scopedLambdas.put(bound,
+                scopedLambdas.put(bound, new ScopedLambda(
                         new Ast.FnDef(li.name(), params, null,
-                                new Ast.FnBody.Written(lambda.body()), li.pos()));
+                                new Ast.FnBody.Written(lambda.body()), li.pos())));
                 Ast.Expr body = inline(li.body());
                 scopedLambdas.remove(bound);
                 // if the binding is still read, the function was used as a value, not just applied —
@@ -1406,6 +920,227 @@ public final class HelperInliner {
             case Ast.Unreachable _ -> e;
             case Ast.Var v -> valueOf(v);
         };
+    }
+
+    /**
+     * One call of a name, with the callee's body in place of it where a body stands behind the name.
+     *
+     * <p>Not every call has one. A builtin, an injected behavior, a function-typed parameter and a
+     * recursive helper are all applied by something other than an expansion, so the call stays a call
+     * and only its arguments are expanded. What is left — a non-recursive helper, a value that is a
+     * function, a lambda a binding holds — becomes an {@link Ast.Expansion}: one node, because the
+     * callee's signature is one statement and this call decides its variables once.
+     */
+    private Ast.Expr expandCall(Ast.Apply rawCall) {
+        checkFunctionArgumentPlacement(rawCall);
+        Ast.Apply call = desugarNamedBlock(desugar(rawCall));
+        List<Ast.Expr> args = new ArrayList<>();
+        for (Ast.Expr a : call.args()) {
+            args.add(inline(a));
+        }
+        Ast.FnDef helper = appliedHelper(call);
+        // a recursive helper is reached by the name it is declared under; a lambda a binding
+        // holds is not one, whatever it is called
+        boolean standing = !(call.denotes() instanceof ValueName.Local)
+                && recursive.contains(call.reaches());
+        if (helper == null || standing) {
+            // builtin, injected behavior, a function-typed parameter, or a recursive helper —
+            // a recursive helper is lowered to a method, so its call stays a Call (spec 13.1);
+            // only its args inline.
+            return call.withArgs(forwardDependencies(helper, args));
+        }
+        // A declaration written with no parameter list is a value ([#fn-declaration]), so
+        // applying it applies whatever function that value is — not the declaration, which
+        // takes nothing. The value is substituted and the arguments are applied to it.
+        if (helper.params().isEmpty() && !args.isEmpty()
+                && call.function() instanceof Ast.Var named) {
+            return inline(new Ast.Apply(valueOf(named), args, call.origin(), call.pos()));
+        }
+        if (args.size() != helper.params().size()) {
+            throw wrongArity(call, helper, args.size());
+        }
+        // Everything this expansion writes belongs to it: the bindings its arguments become,
+        // the one a lambda given to a function parameter is registered under, the one its
+        // declared return is carried on, and every binding copied out of the callee's body.
+        // One minter, so no two of them are the same binding, and a reader can ask of any of
+        // them which call it came from.
+        BindingOwner mine = new BindingOwner.Expansion(into, call.denotes(), counter++);
+        Ast.Binders ours = new Ast.Binders(mine);
+        // What the callee's signature leaves open, this call decides. Its variables are
+        // instantiated once, here, over the whole signature at once — so a variable it wrote
+        // in two of its parameters is one variable in what this expansion writes, and two
+        // calls of it decide separately. Splitting the signature into a binding per parameter
+        // is what would otherwise lose that: each binding's type would be read on its own,
+        // and nothing left afterwards says the two came from one application.
+        Map<String, Type> applied = instantiation(helper, mine);
+        Arguments arguments = bindArguments(rawCall, call, helper, args, applied, ours);
+        // a prelude helper's body is stamped with the call site, so errors inside it point at
+        // the user's call, not at the shipped source of souther.*
+        Renaming renaming = new Renaming(arguments.subst(), new Copy(helper.writtenBody(), ours),
+                keepsItsPositions(call) ? null : call.pos());
+        Ast.Expr body = inline(rename(helper.writtenBody(), renaming));   // expand nested helpers too
+        List<Ast.Bound> bound = new ArrayList<>(arguments.bound());
+        // A scoped lambda the body still names was passed rather than applied, so nothing
+        // reduced it and the name would stand for nothing. It is bound to what it names, which
+        // is what a lambda given a name is anywhere else.
+        arguments.unreduced().forEach((id, lambda) -> {
+            if (references(body, id)) {
+                bound.add(lambda);
+            }
+        });
+        arguments.unreduced().keySet().forEach(scopedLambdas::remove);
+        return new Ast.Expansion(call.denotes(), mine, bound, arguments.given(),
+                instantiated(helper.declaredReturn(), applied), body, call.pos());
+    }
+
+    /**
+     * A call written with a different number of arguments than the callee takes, named against
+     * whichever of the two the author wrote.
+     *
+     * <p>A lambda given to a function parameter is inlined under a synthetic name, so a report that
+     * quoted the callee would quote a name nowhere in the source. Where the callee is one of those,
+     * the parameter count is reported against the lambda instead.
+     */
+    private CompileException wrongArity(Ast.Apply call, Ast.FnDef helper, int given) {
+        ScopedLambda applied = call.denotes() instanceof ValueName.Local local
+                ? scopedLambdas.get(local.id()) : null;
+        LambdaOrigin origin = applied == null ? null : applied.origin();
+        if (origin != null) {
+            return CompileException.of(
+                    Diagnostic.of(null, "check.fn.blockparam.arity").title("check.fn.title")
+                            .at(origin.pos())
+                            .args(origin.param(), origin.owner(), given,
+                                    helper.params().size()).build(),
+                    "the block passed to `" + origin.param() + "` of `let " + origin.owner()
+                            + "` takes " + given + " argument(s) but is written with "
+                            + helper.params().size());
+        }
+        return CompileException.of(
+                Diagnostic.of(null, "check.helper.arity").title("check.arity.title")
+                        .at(call.name().region())
+                        .args(helper.name(), helper.params().size(), given).build(),
+                "helper `let " + helper.name() + "` takes " + helper.params().size()
+                        + " argument(s) but is called with " + given);
+    }
+
+    /**
+     * What one call's arguments become where the callee's body is spliced in.
+     *
+     * <p>A value argument becomes a binding the body reads by name; a function argument becomes
+     * neither — it leaves no binding, so what the signature said about it is held in {@code given}
+     * and nowhere else. {@code subst} answers the callee's parameters in both cases, so the copied
+     * body reads one thing per parameter however the parameter arrives.
+     *
+     * <p>{@code unreduced} holds the lambdas registered under a fresh binding, each with the binding
+     * a {@code let} would hold it in. They are the ones this expansion may not reduce away — a
+     * representation that keeps a call standing keeps the application inside it — so the binding is
+     * built ahead and used only for the ones the body still names afterwards. Being the keys of that
+     * map is also what says which registrations this call has to drop when it is done.
+     */
+    private record Arguments(Map<BindingId, Substituted> subst, List<Ast.Bound> bound,
+                             List<Ast.Given> given, Map<BindingId, Ast.Bound> unreduced) {}
+
+    /**
+     * Binds one call's arguments against the callee's parameters, this call's variables written in.
+     *
+     * <p>{@code rawCall} is the call as the author wrote it, which is what a report about an argument
+     * quotes; {@code call} is what it desugared to, which is what the expansion is built from.
+     */
+    private Arguments bindArguments(Ast.Apply rawCall, Ast.Apply call, Ast.FnDef helper,
+                                    List<Ast.Expr> args, Map<String, Type> applied,
+                                    Ast.Binders ours) {
+        // what stands in the body for each of the callee's parameters: the name it is written
+        // as and what that name resolved to at the call site, so the expansion carries the
+        // argument's own answer rather than deciding one for it
+        Map<BindingId, Substituted> subst = new HashMap<>();
+        Map<BindingId, Ast.Bound> unreduced = new LinkedHashMap<>();
+        List<Ast.Bound> bound = new ArrayList<>();
+        List<Ast.Given> given = new ArrayList<>();
+        for (int i = 0; i < helper.params().size(); i++) {
+            Ast.FnParam p = helper.params().get(i);
+            Ast.Expr arg = args.get(i);
+            if (p.type() != null && p.type().asFn() != null) {
+                // a function argument is not a value, so it cannot be bound to a let. A named
+                // function is substituted directly (f(x) becomes inc(x)); a lambda is
+                // registered under a fresh name as a scoped helper, so each application of the
+                // parameter β-reduces to the lambda's body, as a let-bound lambda does (spec 12.5).
+                // Asked of the callee as written, not of what it expanded to: applying a
+                // function parameter is what removes it, because the application β-reduces
+                // to the lambda's body, so the expansion holds no reference either way.
+                given.add(new Ast.Given(instantiated(p.type(), applied), arg,
+                        references(helper.writtenBody(), p.binder().id()), arrivesAs(arg)));
+                Ast.FnType declares = declaredFn(p.type(), applied);
+                if (arg instanceof Ast.Var fnName) {
+                    // A name handed to a function parameter is substituted through: what
+                    // applies it applies what it stands for. What it stands for is declared
+                    // somewhere — a helper's own parameter, a binding, a function an
+                    // enclosing call gave — and that declaration is carried on the boundary,
+                    // so the two are read against each other without either being re-typed.
+                    subst.put(p.binder().id(), new Substituted(fnName.name(), fnName.denotes()));
+                } else if (arg instanceof Ast.Block lambda) {
+                    Ast.Binder f = ours.binder("$" + p.name(), lambda.pos());
+                    subst.put(p.binder().id(), Substituted.of(f));
+                    // The lambda is registered under what the callee declared of the
+                    // parameter it was given to, this application's variables written in. So
+                    // where the callee applies it, that application expands like any other
+                    // call and is read against the signature there — in the one place the
+                    // types this application decided are in force. Registering it bare is
+                    // what used to throw the signature away at the point it was reduced,
+                    // leaving nothing between the caller's function and what was declared of
+                    // it (issues #318, #320).
+                    List<Ast.FnParam> lparams = new ArrayList<>();
+                    for (int lp = 0; lp < lambda.params().size(); lp++) {
+                        lparams.add(new Ast.FnParam(lambda.params().get(lp),
+                                declares == null || lp >= declares.params().size() ? null
+                                        : declares.params().get(lp)));
+                    }
+                    // the lambda's body is caller code, so it is not renamed by this helper's
+                    // substitution — only the enclosing helper body is.
+                    scopedLambdas.put(f.id(), new ScopedLambda(
+                            new Ast.FnDef(f.name(), lparams,
+                                    declares == null ? null : declares.result(),
+                                    new Ast.FnBody.Written(lambda.body()), lambda.pos()),
+                            new LambdaOrigin(p.name(), helper.name(), lambda.pos())));
+                    unreduced.put(f.id(),
+                            new Ast.Bound(f, instantiated(p.type(), applied), lambda));
+                } else {
+                    throw notAFunction(rawCall, p, i, arg);
+                }
+            } else {
+                // the binding the argument is bound to; the reads of the parameter inside the
+                // body are answered with it, so a read says which binding it is rather than
+                // where it happens to be written
+                Ast.Binder f = ours.binder(p.name(), call.pos());
+                subst.put(p.binder().id(), Substituted.of(f));
+                // carry the parameter's declared type onto the binding, so a value known to
+                // be a sum (an annotated `s: S`) is not narrowed to the argument's specific
+                // case when the body is re-checked inline — a `match s` inside still sees S.
+                bound.add(new Ast.Bound(f, instantiated(p.type(), applied), arg));
+            }
+        }
+        return new Arguments(subst, bound, given, unreduced);
+    }
+
+    /**
+     * A value written where a function goes — the argument-order mistake made with a named helper
+     * rather than a lambda. Named against the call as written, with the declared order.
+     */
+    private CompileException notAFunction(Ast.Apply rawCall, Ast.FnParam p, int index, Ast.Expr arg) {
+        List<Ast.FnParam> written = declaredParams(rawCall);
+        String shape = written == null ? null : written.stream()
+                .map(Ast.FnParam::name)
+                .collect(java.util.stream.Collectors.joining(", "));
+        Diagnostic.Builder d = Diagnostic.of(null, "check.fn.argnotvalue")
+                .title("check.fn.title").at(arg.pos())
+                .args(rawCall.written(), index + 1, p.name(), shape);
+        if (shape != null) {
+            d.hint("check.fn.argnotvalue.hint");
+        }
+        return CompileException.of(d.build(),
+                "argument " + (index + 1) + " of `" + rawCall.written() + "` is `" + p.name()
+                        + "`, which takes a function: pass a named function or a lambda"
+                        + (shape == null ? ""
+                                : ". Write `" + rawCall.written() + "(" + shape + ")`."));
     }
 
     /**
@@ -1500,7 +1235,7 @@ public final class HelperInliner {
         if (value == null || value.body() == null || recursive.contains(v.name())) {
             return v;
         }
-        return carriedByValue(inline(value.writtenBody()));
+        return HelperNames.carriedByValue(inline(value.writtenBody()));
     }
 
     /**
@@ -1523,7 +1258,7 @@ public final class HelperInliner {
             }
             Ast.Binder name = binders.binder("$s" + counter++ + "_" + spread.bare(), spread.pos());
             bound.add(name);
-            values.add(carriedByValue(inline(value.writtenBody())));
+            values.add(HelperNames.carriedByValue(inline(value.writtenBody())));
             spreads.add(Ast.Var.local(name, spread.pos()));
         }
         Ast.Expr built = new Ast.NewData(nd.typeName(), inlineInits(nd.inits()), spreads,
@@ -1620,6 +1355,54 @@ public final class HelperInliner {
     }
 
     /**
+     * What stands in the body for one of the callee's parameters: the name it is written as, and what
+     * that name means.
+     *
+     * <p>One fact and one value. Written as two tables it was possible to put a name into one and no
+     * answer into the other, so a read of the name had to be checked at run time against the table
+     * that was supposed to answer it — and the two could only be made to agree by a check, never by
+     * construction. Here the name and its answer are put in together or not at all.
+     */
+    private record Substituted(String name, ValueName denotes) {
+
+        /** The binding an expansion made, read as the name the body will read. */
+        static Substituted of(Ast.Binder binder) {
+            return new Substituted(binder.name(), new ValueName.Local(binder.name(), binder.id()));
+        }
+    }
+
+    /**
+     * What one expansion rewrites as it copies the callee's body: which parameter reads become which
+     * names, which of the body's own bindings become which, and what position the copy carries.
+     *
+     * <p>The three are fixed for the whole copy and none of them changes as the walk descends, so they
+     * travel together rather than as three parameters threaded through every node kind.
+     */
+    private record Renaming(Map<BindingId, Substituted> subst, Copy copy, SourcePos at) {
+
+        /** What {@code denotes} stands for in this copy, or null where nothing does — an inner binder
+         * that happens to spell a parameter's name is a different binding with a different id, so a
+         * reference under it is not in the substitution and is left to {@link #copy}. */
+        Substituted substituted(ValueName denotes) {
+            return denotes instanceof ValueName.Local local ? subst.get(local.id()) : null;
+        }
+
+        /**
+         * The position a rebuilt node carries: the call site where the copy is stamped with it, and
+         * otherwise the node's own.
+         *
+         * <p>A prelude helper is copied with the call site stamped over it, so a type error inside its
+         * body points at the user's call — {@code filter(xs, x -> x * 2)} — rather than at a line of
+         * {@code souther.list} the user never wrote. A module-own helper, and a lambda given to a fn
+         * parameter, keep the positions their bodies have ({@link HelperInliner#keepsItsPositions}).
+         * The caller's argument expressions are spliced in separately and keep their own either way.
+         */
+        SourcePos at(SourcePos own) {
+            return at != null ? at : own;
+        }
+    }
+
+    /**
      * Every binder written inside {@code e}, itself included where {@code e} is one.
      *
      * <p>The node kinds that introduce a binding are named here and nowhere else in this pass, so a
@@ -1664,62 +1447,57 @@ public final class HelperInliner {
      * fall out of step with. A spelling that means something else — a builtin, a helper — was
      * resolved to that before renaming and is not a {@code ValueName.Local}, so it is left alone.
      *
-     * <p>{@code at}, when non-null, is stamped onto every rebuilt node in place of its own position.
-     * A prelude helper is expanded with the call site as {@code at}, so a type error inside its body
-     * points at the user's call — {@code filter(xs, x -> x * 2)} — not at a line of {@code souther.list}
-     * the user never wrote. A module-own helper, and a lambda given to a fn parameter, pass {@code
-     * null} and keep the positions their bodies have ({@link #keepsItsPositions}). The caller's
-     * argument expressions, spliced in separately, keep their own positions either way.
+     * <p>What each rebuilt node's position becomes is {@link Renaming#at}'s to say, and it says it
+     * once for every node kind here.
      */
-    private Ast.Expr rename(Ast.Expr e, Map<BindingId, String> subst,
-                            Map<BindingId, ValueName> substDenotes, SourcePos at, Copy copy) {
+    private Ast.Expr rename(Ast.Expr e, Renaming renaming) {
         return switch (e) {
-            case Ast.Var v -> renameVar(v, subst, substDenotes, at, copy);
-            case Ast.FieldAccess fa -> new Ast.FieldAccess(rename(fa.target(), subst, substDenotes, at, copy), fa.field(), at(at, fa.pos()));
+            case Ast.Var v -> renameVar(v, renaming);
+            case Ast.FieldAccess fa -> new Ast.FieldAccess(rename(fa.target(), renaming), fa.field(), renaming.at(fa.pos()));
             // the callee is renamed as the expression it is, like every other subexpression. A name
             // applied is an `Ast.Var` held here, so it goes through the arm above and is substituted
             // exactly as a read of it would be — the position cannot ask a different question.
             case Ast.Apply call -> new Ast.Apply(
-                    rename(call.function(), subst, substDenotes, at, copy),
-                    renameList(call.args(), subst, substDenotes, at, copy),
-                    call.origin(), call.appliedAs(), at(at, call.pos()));
-            case Ast.Binary bin -> new Ast.Binary(bin.op(), rename(bin.left(), subst, substDenotes, at, copy), rename(bin.right(), subst, substDenotes, at, copy), at(at, bin.pos()));
-            case Ast.Neg neg -> new Ast.Neg(rename(neg.operand(), subst, substDenotes, at, copy), at(at, neg.pos()));
+                    rename(call.function(), renaming),
+                    renameList(call.args(), renaming),
+                    call.origin(), call.appliedAs(), renaming.at(call.pos()));
+            case Ast.Binary bin -> new Ast.Binary(bin.op(), rename(bin.left(), renaming), rename(bin.right(), renaming), renaming.at(bin.pos()));
+            case Ast.Neg neg -> new Ast.Neg(rename(neg.operand(), renaming), renaming.at(neg.pos()));
             case Ast.NewData nd -> {
                 List<Ast.FieldInit> inits = new ArrayList<>();
                 for (Ast.FieldInit i : nd.inits()) {
-                    inits.add(new Ast.FieldInit(i.name(), rename(i.value(), subst, substDenotes, at, copy), at(at, i.pos())));
+                    inits.add(new Ast.FieldInit(i.name(), rename(i.value(), renaming), renaming.at(i.pos())));
                 }
                 // `..param` copies the renamed binding: a name slot asks what a name asks
                 List<Ast.Var> spreads = new ArrayList<>();
                 for (Ast.Var s : nd.spreads()) {
-                    spreads.add(renameVar(s, subst, substDenotes, at, copy));
+                    spreads.add(renameVar(s, renaming));
                 }
-                yield new Ast.NewData(nd.typeName(), inits, spreads, nd.origin(), at(at, nd.pos()));
+                yield new Ast.NewData(nd.typeName(), inits, spreads, nd.origin(), renaming.at(nd.pos()));
             }
             case Ast.Match m -> {
                 List<Ast.Case> cases = new ArrayList<>();
                 for (Ast.Case c : m.cases()) {
                     cases.add(new Ast.Case(c.caseTypes(),
-                            c.binding() == null ? null : copy.of(c.binding()),
-                            rename(c.body(), subst, substDenotes, at, copy),
-                            c.unwrapAsserts(), at(at, c.pos())));
+                            c.binding() == null ? null : renaming.copy().of(c.binding()),
+                            rename(c.body(), renaming),
+                            c.unwrapAsserts(), renaming.at(c.pos())));
                 }
-                yield new Ast.Match(rename(m.scrutinee(), subst, substDenotes, at, copy), cases, at(at, m.pos()));
+                yield new Ast.Match(rename(m.scrutinee(), renaming), cases, renaming.at(m.pos()));
             }
-            case Ast.If iff -> new Ast.If(rename(iff.cond(), subst, substDenotes, at, copy), rename(iff.then(), subst, substDenotes, at, copy), rename(iff.els(), subst, substDenotes, at, copy), at(at, iff.pos()));
+            case Ast.If iff -> new Ast.If(rename(iff.cond(), renaming), rename(iff.then(), renaming), rename(iff.els(), renaming), renaming.at(iff.pos()));
             // the success binder has its own BindingId, so a reference to it is not a candidate for
             // substitution, and neither the construction nor the else value can reach it
             case Ast.IfConstructed ic -> new Ast.IfConstructed(
-                    rename(ic.construct(), subst, substDenotes, at, copy), copy.of(ic.binder()),
-                    rename(ic.then(), subst, substDenotes, at, copy),
-                    Ast.mapArms(ic.els(), body -> rename(body, subst, substDenotes, at, copy)),
-                    at(at, ic.pos()));
+                    rename(ic.construct(), renaming), renaming.copy().of(ic.binder()),
+                    rename(ic.then(), renaming),
+                    Ast.mapArms(ic.els(), body -> rename(body, renaming)),
+                    renaming.at(ic.pos()));
             case Ast.LetIn li -> {
-                Ast.Expr value = rename(li.value(), subst, substDenotes, at, copy);
-                Ast.Expr body = rename(li.body(), subst, substDenotes, at, copy);
-                yield new Ast.LetIn(copy.of(li.binder()), value, li.declaredType(), li.annotated(),
-                        li.opens(), body, at(at, li.pos()));
+                Ast.Expr value = rename(li.value(), renaming);
+                Ast.Expr body = rename(li.body(), renaming);
+                yield new Ast.LetIn(renaming.copy().of(li.binder()), value, li.declaredType(), li.annotated(),
+                        li.opens(), body, renaming.at(li.pos()));
             }
             // A body already expanded once, being copied into another caller. The signature comes
             // along as it stands: what its variables stand for is settled while each copy is typed,
@@ -1728,31 +1506,31 @@ public final class HelperInliner {
             case Ast.Expansion ex -> {
                 List<Ast.Bound> bound = new ArrayList<>();
                 for (Ast.Bound b : ex.bound()) {
-                    bound.add(new Ast.Bound(copy.of(b.binder()), b.declaredType(),
-                            rename(b.value(), subst, substDenotes, at, copy)));
+                    bound.add(new Ast.Bound(renaming.copy().of(b.binder()), b.declaredType(),
+                            rename(b.value(), renaming)));
                 }
                 List<Ast.Given> given = new ArrayList<>();
                 for (Ast.Given g : ex.given()) {
                     given.add(new Ast.Given(g.declaredType(),
-                            rename(g.value(), subst, substDenotes, at, copy), g.applied(),
+                            rename(g.value(), renaming), g.applied(),
                             g.arrivesAs()));
                 }
                 yield new Ast.Expansion(ex.callee(), ex.application(), bound, given,
-                        ex.declaredReturn(), rename(ex.body(), subst, substDenotes, at, copy),
-                        at(at, ex.pos()));
+                        ex.declaredReturn(), rename(ex.body(), renaming),
+                        renaming.at(ex.pos()));
             }
-            case Ast.ListLit lit -> new Ast.ListLit(renameList(lit.elements(), subst, substDenotes, at, copy), at(at, lit.pos()));
-            case Ast.Tuple tup -> new Ast.Tuple(renameList(tup.elements(), subst, substDenotes, at, copy), at(at, tup.pos()));
-            case Ast.TupleGet tg -> new Ast.TupleGet(rename(tg.tuple(), subst, substDenotes, at, copy), tg.index(), tg.arity(), at(at, tg.pos()));
-            case Ast.ListComp comp -> new Ast.ListComp(rename(comp.element(), subst, substDenotes, at, copy), renameList(comp.guards(), subst, substDenotes, at, copy), at(at, comp.pos()));
+            case Ast.ListLit lit -> new Ast.ListLit(renameList(lit.elements(), renaming), renaming.at(lit.pos()));
+            case Ast.Tuple tup -> new Ast.Tuple(renameList(tup.elements(), renaming), renaming.at(tup.pos()));
+            case Ast.TupleGet tg -> new Ast.TupleGet(rename(tg.tuple(), renaming), tg.index(), tg.arity(), renaming.at(tg.pos()));
+            case Ast.ListComp comp -> new Ast.ListComp(rename(comp.element(), renaming), renameList(comp.guards(), renaming), renaming.at(comp.pos()));
             case Ast.Block block -> {
                 List<Ast.Binder> params = new ArrayList<>();
                 for (Ast.Binder p : block.params()) {
-                    params.add(copy.of(p));
+                    params.add(renaming.copy().of(p));
                 }
                 yield new Ast.Block(params,
-                        rename(block.body(), subst, substDenotes, at, copy),
-                        at(at, block.pos()));
+                        rename(block.body(), renaming),
+                        renaming.at(block.pos()));
             }
             case Ast.IntLit _ -> e;
             case Ast.DecimalLit _ -> e;
@@ -1782,12 +1560,6 @@ public final class HelperInliner {
         };
     }
 
-    /** The position to stamp on a rebuilt node: the override {@code at} for a prelude helper, or the
-     * node's own position when {@code at} is null (see {@link #keepsItsPositions}). */
-    private static SourcePos at(SourcePos at, SourcePos own) {
-        return at != null ? at : own;
-    }
-
     /**
      * One name renamed — what {@link #rename} does wherever a name stands, whether that is an
      * expression of its own or the name a spread holds.
@@ -1795,36 +1567,19 @@ public final class HelperInliner {
      * <p>A substituted name keeps what the argument resolved to, so a named function handed to a
      * combinator stays the helper it is rather than becoming a binding of that spelling.
      */
-    private Ast.Var renameVar(Ast.Var v, Map<BindingId, String> subst,
-                              Map<BindingId, ValueName> substDenotes, SourcePos at, Copy copy) {
-        return v.denotes() instanceof ValueName.Local p && subst.containsKey(p.id())
-                ? new Ast.Var(subst.get(p.id()), substituted(substDenotes, p.id()), at(at, v.pos()))
-                : new Ast.Var(v.name(), copy.of(v.denotes()), at(at, v.pos()));
+    private Ast.Var renameVar(Ast.Var v, Renaming renaming) {
+        Substituted stands = renaming.substituted(v.denotes());
+        return stands != null
+                ? new Ast.Var(stands.name(), stands.denotes(), renaming.at(v.pos()))
+                : new Ast.Var(v.name(), renaming.copy().of(v.denotes()), renaming.at(v.pos()));
     }
 
-    private List<Ast.Expr> renameList(List<Ast.Expr> es, Map<BindingId, String> subst,
-                                      Map<BindingId, ValueName> substDenotes,
-                                      SourcePos at, Copy copy) {
+    private List<Ast.Expr> renameList(List<Ast.Expr> es, Renaming renaming) {
         List<Ast.Expr> out = new ArrayList<>();
         for (Ast.Expr e : es) {
-            out.add(rename(e, subst, substDenotes, at, copy));
+            out.add(rename(e, renaming));
         }
         return out;
-    }
-
-    /**
-     * What this expansion substituted for {@code name}.
-     *
-     * <p>Every name the substitution rewrites was given an answer when it was put there — the
-     * argument's own, or the binding this expansion made for it — so there is no name to be answered
-     * with a guess. One missing is a substitution written without saying what it means.
-     */
-    private static ValueName substituted(Map<BindingId, ValueName> substDenotes, BindingId param) {
-        ValueName denotes = substDenotes.get(param);
-        if (denotes == null) {
-            throw new IllegalStateException(param + " was substituted without an answer");
-        }
-        return denotes;
     }
 
     /** Records the module's own helpers that lie on a call cycle (self or mutual). A recursive helper
@@ -1849,54 +1604,6 @@ public final class HelperInliner {
     }
 
     /**
-     * A value that reaches itself has nothing to be substituted with, so it is refused here, naming
-     * the path it goes round.
-     *
-     * <p>The value graph is not the call graph. A helper on a call cycle is lowered to a method and
-     * recurses at run time (ADR-0038); a value has no such form, so a cycle that passes through one is
-     * an error however it is closed — by naming a value, or by calling a helper that names it. The two
-     * are reported apart: a value cycle sent through the recursion check would be told to declare a
-     * return type it never wrote.
-     */
-    private void rejectValueCycles() {
-        Map<String, Set<String>> edges = new LinkedHashMap<>();
-        for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
-            Set<String> out = new LinkedHashSet<>(callsOf.getOrDefault(e.getKey(), Set.of()));
-            collectValueNames(e.getValue().writtenBody(), out);
-            edges.put(e.getKey(), out);
-        }
-        for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
-            if (!e.getValue().params().isEmpty()) {
-                continue;   // a helper's own recursion is the call graph's business
-            }
-            // A value stands for a value. A block written as one — a `.field` getter, whose parameter
-            // the compiler synthesizes — is refused where it is written rather than where it is used.
-            //
-            // Unless the definition says it is a function. Then the block is what that says it is,
-            // and its parameters are the ones the written type names.
-            boolean declaredAFunction = e.getValue().declaredReturn() != null
-                    && e.getValue().declaredReturn().asFn() != null;
-            if (!declaredAFunction && e.getValue().writtenBody() instanceof Ast.Block block) {
-                throw CompileException.of(
-                        Diagnostic.of(null, "check.block.notvalue").title("check.block.title")
-                                .at(block.pos()).build(),
-                        "a block is not a value: `let " + e.getKey() + "` writes no parameters, so it"
-                                + " defines a value, and a block cannot be one (spec 12.5)");
-            }
-            List<String> path = new ArrayList<>();
-            if (pathBackTo(e.getKey(), e.getKey(), edges, new LinkedHashSet<>(), path)) {
-                path.add(0, e.getKey());
-                String written = String.join(" -> ", path);
-                throw CompileException.of(
-                        Diagnostic.of(null, "check.value.cycle").title("check.value.cycle.title")
-                                .at(e.getValue().pos(), e.getKey().length())
-                                .args(e.getKey(), written).build(),
-                        "`let " + e.getKey() + "` is defined in terms of itself (" + written + ")");
-            }
-        }
-    }
-
-    /**
      * The value a spread copies, or null where it copies something else — a parameter, a binding, or
      * a name that merely shares a value's spelling.
      *
@@ -1913,37 +1620,6 @@ public final class HelperInliner {
         Ast.FnDef value = own.get(reached);
         return value == null || !value.params().isEmpty() || value.body() == null
                 || recursive.contains(reached) ? null : value;
-    }
-
-    /** The names of this module's values that {@code e} reads. A value is written bare, so a
-     * reference to one is a {@code Var} and never reaches the call graph. */
-    private void collectValueNames(Ast.Expr e, Set<String> out) {
-        if (e == null) {
-            return;
-        }
-        if (e instanceof Ast.Var v && v.denotes() instanceof ValueName.Helper) {
-            Ast.FnDef d = own.get(v.name());
-            if (d != null && d.params().isEmpty()) {
-                out.add(v.name());
-            }
-        }
-        forEachChild(e, c -> collectValueNames(c, out));
-    }
-
-    /** Records into {@code path} a route from {@code from} back to {@code target}, or answers false. */
-    private boolean pathBackTo(String from, String target, Map<String, Set<String>> edges,
-                               Set<String> seen, List<String> path) {
-        for (String next : edges.getOrDefault(from, Set.of())) {
-            path.add(next);
-            if (next.equals(target)) {
-                return true;
-            }
-            if (seen.add(next) && pathBackTo(next, target, edges, seen, path)) {
-                return true;
-            }
-            path.remove(path.size() - 1);
-        }
-        return false;
     }
 
     /** Which helpers each helper's body calls. Built once, before the cycle search: {@link #reaches}
@@ -1991,6 +1667,17 @@ public final class HelperInliner {
     }
 
     private void collectHelperCalls(Ast.Expr e, Set<String> out) {
+        helperCallsIn(e, helpers, out);
+    }
+
+    /**
+     * The helpers of {@code table} that {@code e} calls, added to {@code out}.
+     *
+     * <p>Static because the value-cycle check asks it of a table it builds for itself, before an
+     * inliner exists. One walk either way: an edge of this graph is what it is, and a reader that
+     * counted a different set of them would be reading a different graph.
+     */
+    static void helperCallsIn(Ast.Expr e, Map<String, Ast.FnDef> table, Set<String> out) {
         // Applying a function-typed parameter, or a binding holding a function, is not a call to
         // whatever else bears that name. The call carries what it resolved to, so it is asked rather
         // than matched against the helper table — a parameter named like a helper was reaching the
@@ -1999,11 +1686,19 @@ public final class HelperInliner {
             // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches the
             // recursive `foldFrom` — recursion classification and prelude-injection must see that.
             String fn = "List.fold".equals(call.reaches()) ? "List.foldFrom" : call.reaches();
-            if (helpers.containsKey(fn)) {
+            if (table.containsKey(fn)) {
                 out.add(fn);
             }
         }
-        forEachChild(e, c -> collectHelperCalls(c, out));
+        forEachChild(e, c -> helperCallsIn(c, table, out));
+    }
+
+    /** The table a body of {@code module} is expanded against: the prelude, what other modules
+     * publish here, and the module's own helpers, each under the name it is reached by. */
+    static Map<String, Ast.FnDef> tableFor(Ast.Module module, Map<String, Ast.FnDef> imported) {
+        Map<String, Ast.FnDef> table = new LinkedHashMap<>(imported);
+        table.putAll(helpersOf(module));
+        return withPrelude(table);
     }
 
     /** Applies {@code f} to every direct subexpression of {@code e}; the one exhaustive walk

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -42,16 +42,21 @@ import java.util.function.Predicate;
  */
 public final class HelperInliner {
 
-    /** The module whose bodies this expands into. A binding an expansion makes belongs to a
-     * definition of this module, which is what tells it from the same helper expanded elsewhere. */
-    private final String module;
-    private final Map<String, Ast.FnDef> helpers;   // prelude + module-own, by the name they are reached by
-    private final Map<String, Ast.FnDef> own;       // the module's own helpers (standalone check)
+    /**
+     * Which declaration each name reaches, and the module they are reached in. A binding an expansion
+     * makes belongs to a definition of that module, which is what tells it from the same helper
+     * expanded elsewhere.
+     *
+     * <p>Not final: a recursive helper's own body is expanded against a table narrowed by its
+     * parameters ({@link #inlineRecursiveBody}), and what that narrows is what a call reaches — never
+     * what recurses, which {@link #recursive} settled over the table as it was built.
+     */
+    private HelperTable table;
     /**
      * The lambdas this pass expands as helpers, each under the binding it is bound to: a lambda a
      * block's {@code let} binds, and a lambda handed to a function parameter.
      *
-     * <p>Apart from {@link #helpers} because they are apart: a declaration is reached by a name, a
+     * <p>Apart from {@link #table} because they are apart: a declaration is reached by a name, a
      * lambda is reached by a binding. Held together, a lambda bound to {@code f} took the place of a
      * declared {@code f} for as long as it was in scope, which is why applying it had to be told from
      * applying the declaration by a spelling and why a lambda naming itself had to be refused.
@@ -103,15 +108,13 @@ public final class HelperInliner {
      * another author's line. */
     private record LambdaOrigin(String param, String owner, SourcePos pos) {}
 
-    private HelperInliner(String module, Map<String, Ast.FnDef> helpers, Map<String, Ast.FnDef> own) {
-        this.module = module;
-        this.helpers = helpers;
-        this.own = own;
+    private HelperInliner(HelperTable table) {
+        this.table = table;
     }
 
     /** The body of {@code fn} in this module — what an expansion written into it belongs to. */
     public BindingOwner bodyOf(String fn) {
-        return new BindingOwner.OfValue(module, fn);
+        return new BindingOwner.OfValue(table.module(), fn);
     }
 
     /** A helper is a fn whose name is not a behavior's; behavior fns are lowered on their own. The
@@ -132,11 +135,8 @@ public final class HelperInliner {
      * than imports.
      */
     public static HelperInliner forModule(Ast.Module module, Map<String, Ast.FnDef> imported) {
-        Map<String, Ast.FnDef> own = helpersOf(module);
-        Map<String, Ast.FnDef> table = new LinkedHashMap<>(imported);
-        table.putAll(own);
-        HelperInliner inliner = new HelperInliner(module.name(), withPrelude(table),
-                new LinkedHashMap<>(own));
+        HelperInliner inliner =
+                new HelperInliner(HelperTable.of(module, imported, InliningPolicy.FULL));
         inliner.classifyRecursion();
         inliner.computeReferencedPreludeRecursive(module);
         return inliner;
@@ -176,13 +176,7 @@ public final class HelperInliner {
      */
     public static HelperInliner forHelpers(String module, Map<String, Ast.FnDef> own,
                                            Map<String, Ast.FnDef> imported, InliningPolicy policy) {
-        // In the order they are written, so a module with two helpers to complain about complains
-        // about the earlier one first.
-        Map<String, Ast.FnDef> joined = new LinkedHashMap<>(imported);
-        joined.putAll(own);
-        Map<String, Ast.FnDef> table = policy == InliningPolicy.FULL
-                ? withPrelude(joined) : joined;
-        HelperInliner inliner = new HelperInliner(module, table, new LinkedHashMap<>(own));
+        HelperInliner inliner = new HelperInliner(HelperTable.of(module, own, imported, policy));
         inliner.classifyRecursion();
         return inliner;
     }
@@ -198,16 +192,6 @@ public final class HelperInliner {
     public HelperInliner namingBehaviors(Map<String, Integer> arities) {
         this.callableBehaviors = Map.copyOf(arities);
         return this;
-    }
-
-    /** prelude helpers are keyed by their qualified name (`List.map`); a module's own helpers by their
-     * bare name (`対象明細`), and a definition another module publishes by the qualified name it is
-     * reached by here. A qualified call resolves to whichever of the two declared it, a bare call to
-     * the module's own — the standard library has no bare names (spec §stdlib). */
-    private static Map<String, Ast.FnDef> withPrelude(Map<String, Ast.FnDef> helpers) {
-        Map<String, Ast.FnDef> table = new HashMap<>(Prelude.helpers());
-        table.putAll(helpers);
-        return table;
     }
 
     /** A module's helpers: the fns that implement no behavior, keyed by name. */
@@ -263,11 +247,11 @@ public final class HelperInliner {
             }
         }
         for (String name : reachable) {
-            if (recursive.contains(name) && !own.containsKey(name)) {
+            if (recursive.contains(name) && !table.declares(name)) {
                 referencedPreludeRecursive.add(name);
             }
         }
-        exampleHelpers.addAll(exampleHelpers(module, helpers));
+        exampleHelpers.addAll(exampleHelpers(module, table.reachable()));
         exampleHelpers.removeAll(referencedPreludeRecursive);
         exampleHelpers.removeIf(recursive::contains);   // already emitted as a recursive helper
     }
@@ -309,7 +293,6 @@ public final class HelperInliner {
      */
     public static Set<String> exampleHelpers(Ast.Module module, Map<String, Ast.FnDef> table) {
         Set<String> called = new LinkedHashSet<>();
-        HelperInliner reader = new HelperInliner(module.name(), table, table);
         // A row may name a value rather than write the input again (ADR-0072), and that value's body
         // is read the way the row's own text is — so a helper it applies is applied when the row is
         // evaluated. The bodies are followed as far as they name each other, which is how a chain of
@@ -319,7 +302,7 @@ public final class HelperInliner {
         forEachExampleExpr(module, work::add);
         while (!work.isEmpty()) {
             Ast.Expr e = work.poll();
-            reader.collectHelperCalls(e, called);
+            helperCallsIn(e, table, called);
             Set<String> named = new LinkedHashSet<>();
             ValueCycles.valuesRead(e, table, named);
             for (String value : named) {
@@ -354,10 +337,10 @@ public final class HelperInliner {
     public Map<String, Ast.FnDef> injectedExampleHelpers() {
         Map<String, Ast.FnDef> out = new java.util.LinkedHashMap<>();
         for (String name : exampleHelpers) {
-            if (own.containsKey(name)) {
+            if (table.declares(name)) {
                 continue;
             }
-            Ast.FnDef def = helpers.get(name);
+            Ast.FnDef def = table.reached(name);
             out.put(name, new Ast.FnDef(name, def.params(), def.declaredReturn(),
                     def.body(), def.modifiers(), def.pos()));
         }
@@ -371,7 +354,7 @@ public final class HelperInliner {
     public Set<String> recursiveHelpers() {
         Set<String> result = new java.util.LinkedHashSet<>();
         for (String name : recursive) {
-            if (own.containsKey(name)) {
+            if (table.declares(name)) {
                 result.add(name);
             }
         }
@@ -385,7 +368,7 @@ public final class HelperInliner {
     public Map<String, Ast.FnDef> injectedRecursiveHelpers() {
         Map<String, Ast.FnDef> out = new java.util.LinkedHashMap<>();
         for (String qualified : referencedPreludeRecursive) {
-            Ast.FnDef def = helpers.get(qualified);
+            Ast.FnDef def = table.reached(qualified);
             out.put(qualified, new Ast.FnDef(qualified, def.params(), def.declaredReturn(),
                     def.body(), def.modifiers(), def.pos()));
         }
@@ -395,7 +378,7 @@ public final class HelperInliner {
     /** The module's own helper fns, keyed by name (for the standalone signature check). The
      * auto-imported prelude helpers are excluded — they are validated once, on their own. */
     public Map<String, Ast.FnDef> helpers() {
-        return own;
+        return table.own();
     }
 
     /**
@@ -425,7 +408,7 @@ public final class HelperInliner {
     /** The module these helpers belong to — what {@link HelperNames#keyIn} compares a name's
      * declaring module against. */
     public String moduleName() {
-        return module;
+        return table.module();
     }
 
     /** The declaration reached by {@code name} across the prelude and the module's own helpers, or
@@ -433,7 +416,7 @@ public final class HelperInliner {
      * the recursive helpers, say. A reader holding a call asks {@link #applied} instead, because what
      * a call applies is not decided by how it is spelled. */
     public Ast.FnDef helper(String name) {
-        return helpers.get(name);
+        return table.reached(name);
     }
 
     /** The body {@code call} applies, or null where it applies something no body stands behind. */
@@ -474,17 +457,19 @@ public final class HelperInliner {
      * is a parameter application, not a call to that helper, so the same-named helpers are hidden while
      * the body is expanded. */
     public Ast.Expr inlineRecursiveBody(Ast.FnDef h) {
-        Map<String, Ast.FnDef> shadowed = new HashMap<>();
+        List<String> parameters = new ArrayList<>();
         for (Ast.FnParam p : h.params()) {
-            Ast.FnDef hidden = helpers.remove(p.name());
-            if (hidden != null) {
-                shadowed.put(p.name(), hidden);
-            }
+            parameters.add(p.name());
         }
+        HelperTable outer = table;
+        // Narrowed, not rebuilt: what a call reaches changes, what recurses does not. A graph taken
+        // over the narrowed table would find this very helper non-recursive and expand its own call
+        // forever.
+        table = table.hiding(parameters);
         try {
             return inline(h.writtenBody(), bodyOf(h.name()));
         } finally {
-            helpers.putAll(shadowed);
+            table = outer;
         }
     }
 
@@ -627,10 +612,10 @@ public final class HelperInliner {
     private List<Ast.FnParam> declaredParams(Ast.Apply call) {
         Prelude.Rewrite rewrite = Prelude.rewriteOf(call.reaches());
         if (rewrite != null && call.args().size() == rewrite.keptArgs()) {
-            Ast.FnDef target = helpers.get(rewrite.target());
+            Ast.FnDef target = table.reached(rewrite.target());
             return target == null ? null : target.params().subList(0, rewrite.keptArgs());
         }
-        Ast.FnDef helper = helpers.get(call.reaches());
+        Ast.FnDef helper = table.reached(call.reaches());
         return helper == null ? null : helper.params();
     }
 
@@ -715,7 +700,7 @@ public final class HelperInliner {
                 ScopedLambda lambda = scopedLambdas.get(local.id());
                 yield lambda == null ? null : lambda.fn();
             }
-            case ValueName.Helper _, ValueName.Stdlib _ -> helpers.get(reachedBy);
+            case ValueName.Helper _, ValueName.Stdlib _ -> table.reached(reachedBy);
             // a construction, an injected behavior, `None`, or a name that denotes nothing: each is
             // applied by something other than an expansion, and each is reported where it belongs
             case ValueName.OfType _, ValueName.Behavior _, ValueName.Builtin _,
@@ -1191,7 +1176,7 @@ public final class HelperInliner {
                 yield declared == null ? 0 : declared.params().size();
             }
             case ValueName.Helper _ -> {
-                Ast.FnDef declared = helpers.get(v.reaches());
+                Ast.FnDef declared = table.reached(v.reaches());
                 yield declared == null || declared.body() == null ? 0 : declared.params().size();
             }
             // A behavior's name handed over is the behavior: the block applies the behavior, so the
@@ -1231,7 +1216,7 @@ public final class HelperInliner {
         if (!(v.denotes() instanceof ValueName.Helper)) {
             return v;
         }
-        Ast.FnDef value = helpers.get(v.reaches());
+        Ast.FnDef value = table.reached(v.reaches());
         if (value == null || value.body() == null || recursive.contains(v.name())) {
             return v;
         }
@@ -1554,7 +1539,7 @@ public final class HelperInliner {
             // a lambda, wherever it came from: the caller wrote it, or a prelude body wrote it and
             // was stamped with the call site when that body was renamed
             case ValueName.Local _ -> true;
-            case ValueName.Helper helper -> helper.module().equals(module);
+            case ValueName.Helper helper -> helper.module().equals(table.module());
             case ValueName.Stdlib _, ValueName.Behavior _, ValueName.OfType _,
                     ValueName.Builtin _, ValueName.Unresolved _ -> false;
         };
@@ -1591,12 +1576,12 @@ public final class HelperInliner {
         // `foldFrom` is a recursive prelude helper, and it must be left standing (lowered to a method,
         // not inlined) exactly as a module-own recursive helper is, or the inliner would expand its
         // self-call forever.
-        for (Map.Entry<String, Ast.FnDef> e : helpers.entrySet()) {
+        for (Map.Entry<String, Ast.FnDef> e : table.reachable().entrySet()) {
             Set<String> called = new HashSet<>();
             collectHelperCalls(e.getValue().writtenBody(), called);
             callsOf.put(e.getKey(), called);
         }
-        for (String name : helpers.keySet()) {
+        for (String name : table.reachable().keySet()) {
             if (reaches(name, name, new HashSet<>())) {
                 recursive.add(name);
             }
@@ -1617,7 +1602,7 @@ public final class HelperInliner {
         }
         // by the name it is reached by here, which for another module's value is the qualified one
         String reached = spread.name();
-        Ast.FnDef value = own.get(reached);
+        Ast.FnDef value = table.own().get(reached);
         return value == null || !value.params().isEmpty() || value.body() == null
                 || recursive.contains(reached) ? null : value;
     }
@@ -1667,7 +1652,7 @@ public final class HelperInliner {
     }
 
     private void collectHelperCalls(Ast.Expr e, Set<String> out) {
-        helperCallsIn(e, helpers, out);
+        helperCallsIn(e, table.reachable(), out);
     }
 
     /**
@@ -1691,14 +1676,6 @@ public final class HelperInliner {
             }
         }
         forEachChild(e, c -> helperCallsIn(c, table, out));
-    }
-
-    /** The table a body of {@code module} is expanded against: the prelude, what other modules
-     * publish here, and the module's own helpers, each under the name it is reached by. */
-    static Map<String, Ast.FnDef> tableFor(Ast.Module module, Map<String, Ast.FnDef> imported) {
-        Map<String, Ast.FnDef> table = new LinkedHashMap<>(imported);
-        table.putAll(helpersOf(module));
-        return withPrelude(table);
     }
 
     /** Applies {@code f} to every direct subexpression of {@code e}; the one exhaustive walk

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -77,7 +77,21 @@ public final class HelperInliner {
      * table, so a narrowed table does not narrow it: what recurses was settled over the table as it
      * was built. */
     private final HelperGraph graph;
-    private int counter = 0;
+    /**
+     * How much this pass has written into each body, which is what tells two of its writings apart.
+     *
+     * <p>Counted per body and not per pass. What a body is written into is not affected by what was
+     * written into another — {@link BindingOwner.Expansion} says so of its ordinal — and one pass
+     * expands many bodies: a helper checked on its own and then the behavior that calls it, every
+     * definition a module publishes, every clause of a declaration's invariant. Counted across all of
+     * them, a body's bindings moved when a body beside it gained an expansion or lost one to a
+     * refusal, and a query answer that moves is a query answer everything below it is recomputed for.
+     *
+     * <p>Counted per body and not per writing, either. Two writings can share one body — one per
+     * clause of an invariant, one per argument of a helper being checked — so a count that restarted
+     * with each would give two of them the same binding.
+     */
+    private final Map<BindingOwner, Integer> written = new HashMap<>();
     /** The body being expanded, and the bindings this expansion introduces into it. An expansion
      * writes bindings no source wrote, so they belong to it rather than to the definition whose text
      * it is splicing, which is what keeps two copies of one helper's body apart. */
@@ -738,7 +752,7 @@ public final class HelperInliner {
                     || !dependencies.contains(local.id())) {
                 continue;
             }
-            out.set(i, etaExpand(v, want.params().size(), _ -> "$" + counter++ + "_" + v.name()));
+            out.set(i, etaExpand(v, want.params().size(), _ -> "$" + next() + "_" + v.name()));
         }
         return out;
     }
@@ -770,13 +784,21 @@ public final class HelperInliner {
         Ast.Binders outerBinders = binders;
         BindingOwner outerInto = this.into;
         this.into = into;
-        binders = new Ast.Binders(new BindingOwner.Synthesized(into, BindingOwner.Pass.INLINER, 0));
+        // Numbered among what this pass has written into that body, so a second writing into it — a
+        // second clause of one invariant, a second argument of one helper — writes bindings of its
+        // own rather than the first one's over again.
+        binders = new Ast.Binders(new BindingOwner.Synthesized(into, BindingOwner.Pass.INLINER, next()));
         try {
             return inline(e);
         } finally {
             binders = outerBinders;
             this.into = outerInto;
         }
+    }
+
+    /** The next number this pass has for the body it is writing into. */
+    private int next() {
+        return written.merge(into, 1, Integer::sum) - 1;
     }
 
     /** How the source wrote an expression that is a name or a chain of field reads off one, or null
@@ -803,7 +825,7 @@ public final class HelperInliner {
             // — and which says outright what the order is: the function is worked out once, before
             // any argument, and the binding is what is applied.
             case Ast.Apply raw when !raw.appliesAName() -> {
-                Ast.Binder f = binders.binder("$fn" + counter++, raw.function().pos());
+                Ast.Binder f = binders.binder("$fn" + next(), raw.function().pos());
                 // What the application reaches is the binding, and what a report about it quotes is
                 // what the author wrote — a field read applied (`deps.count(x)`) has a spelling, and
                 // quoting the binding would name `$fn0`, which is nowhere in the source. The two are
@@ -949,7 +971,7 @@ public final class HelperInliner {
         // declared return is carried on, and every binding copied out of the callee's body.
         // One minter, so no two of them are the same binding, and a reader can ask of any of
         // them which call it came from.
-        BindingOwner mine = new BindingOwner.Expansion(into, call.denotes(), counter++);
+        BindingOwner mine = new BindingOwner.Expansion(into, call.denotes(), next());
         Ast.Binders ours = new Ast.Binders(mine);
         // What the callee's signature leaves open, this call decides. Its variables are
         // instantiated once, here, over the whole signature at once — so a variable it wrote
@@ -1210,7 +1232,7 @@ public final class HelperInliner {
     private Ast.Expr valueOf(Ast.Var v) {
         OptionalInt arity = declarationArity(v);
         if (arity.isPresent()) {
-            int k = counter++;
+            int k = next();
             return inline(etaExpand(v, arity.getAsInt(), i -> "$v" + k + "_" + i));
         }
         if (!(v.denotes() instanceof ValueName.Helper)) {
@@ -1241,7 +1263,7 @@ public final class HelperInliner {
                 spreads.add(spread);
                 continue;
             }
-            Ast.Binder name = binders.binder("$s" + counter++ + "_" + spread.bare(), spread.pos());
+            Ast.Binder name = binders.binder("$s" + next() + "_" + spread.bare(), spread.pos());
             bound.add(name);
             values.add(HelperNames.carriedByValue(inline(value.writtenBody())));
             spreads.add(Ast.Var.local(name, spread.pos()));
@@ -1289,7 +1311,7 @@ public final class HelperInliner {
         if (helper == null) {
             return call;   // a bare name that stands for no body is left for the type checker to report
         }
-        int k = counter++;
+        int k = next();
         Ast.Block block = etaExpand(v, helper.params().size(), i -> "$b" + k + "_" + i);
         List<Ast.Expr> args = new ArrayList<>(call.args());
         args.set(idx, block);

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInvariants.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInvariants.java
@@ -1,0 +1,119 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.TypeName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A declaration's {@code invariant} with the helpers it names expanded.
+ *
+ * <p>An invariant is expanded well before a body is. An importer reads an included data's invariant
+ * through the symbol table, so it has to be expanded by the time the table is built, and the settling
+ * of the helper parameter types it reaches has to happen first — expanding a call carries the
+ * parameter's type onto the binding the call becomes, so a type settled afterwards would never reach
+ * the expansion. The two are done together here, in that order, and each caller says which of the two
+ * representations it wants.
+ *
+ * <p>There are two, and they are read by different things. The settled form is what travels to an
+ * importer and what the backend emits; the discharge form leaves the language's own operations
+ * standing, because the analysis has rules about them ({@link InliningPolicy}).
+ */
+public final class HelperInvariants {
+
+    private HelperInvariants() {}
+
+    /**
+     * Settles the helper parameter types the author left unwritten, then inlines the helper calls in
+     * every data's {@code invariant}.
+     *
+     * <p>The settling is done here as well as in {@link Lower}, and is idempotent: a parameter already
+     * typed is left alone, and {@code Lower} settles what only the fully desugared module can
+     * determine.
+     *
+     * <p>An invariant is pure and cannot call an injected behavior (spec §invariant-expressions), so
+     * nothing here needs the injected signatures to settle the helpers an invariant reaches.
+     *
+     * <p>{@code published} is what the modules this one imports offer it. An invariant names what is
+     * in scope where it is written, and an imported definition is in scope there as it is in a body; it
+     * is substituted here for the reason a body's is, so what the invariant carries afterwards names
+     * nothing of the module that declared it. The names are written qualified first, because that is
+     * the spelling the table is keyed by — {@link HelperNames#qualifyImports} does it again for the
+     * bodies below, and says the same thing both times.
+     */
+    public static Ast.Module withSettledInvariants(Ast.Module m, Symbols symbols,
+                                                   Map<String, Ast.FnDef> published) {
+        Ast.Module settled = settled(m, symbols);
+        return withInlinedInvariants(HelperInliner.forModule(settled, published), settled);
+    }
+
+    /**
+     * Each declaration's invariant in the representation the invariant-discharge analysis reads: the
+     * helpers it can name expanded, the language's own operations left standing
+     * ({@link InliningPolicy#DISCHARGE}). Keyed by the declaration's name in {@code m}.
+     *
+     * <p>This is the same settling {@link #withSettledInvariants} does, stopped one step earlier, and
+     * it reads the same table: what the clause names is substituted whether this module declared it or
+     * imported it. An importer reads an imported invariant in the settled form and finds nothing here
+     * for it, which is where an imported clause falls outside the statically dischargeable fragment
+     * (spec §invariant-discharge).
+     */
+    public static Map<TypeName, List<Ast.InvariantClause>> invariantsForDischarge(
+            Ast.Module m, Symbols symbols, Map<String, Ast.FnDef> published) {
+        Ast.Module settled = settled(m, symbols);
+        HelperInliner inliner = HelperInliner.forHelpers(m.name(), HelperInliner.helpersOf(settled),
+                published, InliningPolicy.DISCHARGE);
+        Map<TypeName, List<Ast.InvariantClause>> out = new LinkedHashMap<>();
+        for (Ast.Def def : settled.defs()) {
+            if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
+                TypeName declared = new TypeName(m.name(), d.name());
+                out.put(declared, Ast.mapClauses(d.invariants(),
+                        clause -> inliner.inline(clause, new BindingOwner.OfData(declared))));
+            }
+        }
+        return out;
+    }
+
+    /** {@code m} with its helper parameter types settled and the names in its invariants written
+     * qualified — what both representations are expanded from, so neither reads a table the other
+     * would key differently. */
+    private static Ast.Module settled(Ast.Module m, Symbols symbols) {
+        return HelperNames.withQualifiedInvariants(HelperParams.settle(m, symbols, Map.of()));
+    }
+
+    /**
+     * Inlines helper calls inside every data's {@code invariant}, so a rule named with a {@code let}
+     * (e.g. {@code invariant 正の数(value)}) expands to its body before the invariant is type-checked
+     * or emitted — the same lowering a behavior body gets (spec 12.5, §invariant-expressions).
+     */
+    private static Ast.Module withInlinedInvariants(HelperInliner inliner, Ast.Module m) {
+        List<Ast.Def> defs = new ArrayList<>();
+        for (Ast.Def def : m.defs()) {
+            if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
+                BindingOwner declared = new BindingOwner.OfData(new TypeName(m.name(), d.name()));
+                defs.add(new Ast.Data(d.written(), d.newtype(), d.includes(), d.fields(),
+                        Ast.mapClauses(d.invariants(), clause -> inliner.inline(clause, declared)),
+                        d.decoder(), d.encoder(), d.pos()));
+            } else {
+                defs.add(def);
+            }
+        }
+        return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
+                defs, m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
+    }
+
+    /** The conjuncts of an invariant expression, flattened, in the order they are written — what a
+     * reader sees as separate clauses. */
+    public static List<Ast.Expr> conjunctsOf(Ast.Expr e) {
+        if (e instanceof Ast.Binary b && b.op() == Ast.BinOp.AND) {
+            List<Ast.Expr> out = new ArrayList<>(conjunctsOf(b.left()));
+            out.addAll(conjunctsOf(b.right()));
+            return out;
+        }
+        return List.of(e);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -1,0 +1,272 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * How a definition is named outside the module that declares it, and what a body carries out of the
+ * module it was written in.
+ *
+ * <p>A reader writes an imported value or helper bare, and the pair (module, name) is what it
+ * denotes. Writing the qualified spelling into the tree makes the two agree, so everything
+ * downstream — the table a call is expanded against, the method a recursive helper is emitted as —
+ * reads the identity by reading the name, and two modules publishing a {@code tally} stay two
+ * definitions. Every rewrite here reads what a name denotes and never how it was spelled, so running
+ * one twice says what running it once said.
+ *
+ * <p>The marks a construction carries belong here for the same reason. What a published body builds
+ * is built where that body was written; expanding it puts the construction in the reader's body,
+ * where nothing left in the tree would say otherwise. The mark is what says so, and it is written
+ * where the name is.
+ *
+ * <p>Nothing here reads a helper table or writes a binding: these are questions about names, and the
+ * answers are the same whichever module is asking.
+ */
+public final class HelperNames {
+
+    private HelperNames() {}
+
+    /** How a definition of {@code module} is named outside it. */
+    public static String qualified(String module, String name) {
+        return module + "." + name;
+    }
+
+    /**
+     * {@code m} with every name that denotes another module's definition written qualified.
+     *
+     * <p>Done once, here, because the spelling travels as far as the emitted method name; deciding it
+     * at each reader is how one of them comes to disagree.
+     */
+    public static Ast.Module qualifyImports(Ast.Module m) {
+        List<Ast.FnDef> fns = new ArrayList<>();
+        for (Ast.FnDef fn : m.fns()) {
+            fns.add(fn.body() instanceof Ast.FnBody.Written w
+                    ? new Ast.FnDef(fn.written(), fn.params(), fn.declaredReturn(),
+                            new Ast.FnBody.Written(qualifyForeign(w.expr(), m.name())),
+                            fn.modifiers(), fn.pos())
+                    : fn);
+        }
+        List<Ast.Def> defs = qualifiedInvariants(m);
+        List<Ast.Example> examples = new ArrayList<>();
+        for (Ast.Example ex : m.examples()) {
+            List<Ast.ExampleRow> rows = new ArrayList<>();
+            for (Ast.ExampleRow row : ex.rows()) {
+                List<Ast.Expr> inputs = new ArrayList<>();
+                for (Ast.Expr in : row.inputs()) {
+                    inputs.add(qualifyForeign(in, m.name()));
+                }
+                List<Ast.With> withs = new ArrayList<>();
+                for (Ast.With w : row.withs()) {
+                    withs.add(new Ast.With(w.dep(), qualifyForeign(w.value(), m.name()), w.pos()));
+                }
+                rows.add(new Ast.ExampleRow(row.description(), inputs, withs,
+                        qualifyForeign(row.expected(), m.name()), row.pos()));
+            }
+            examples.add(new Ast.Example(ex.target(), rows, ex.pos()));
+        }
+        List<Ast.Fake> fakes = new ArrayList<>();
+        for (Ast.Fake fake : m.fakes()) {
+            List<Ast.FakeRow> rows = new ArrayList<>();
+            for (Ast.FakeRow row : fake.rows()) {
+                List<Ast.Expr> inputs = null;
+                if (row.inputs() != null) {   // a default row matches anything and writes none
+                    inputs = new ArrayList<>();
+                    for (Ast.Expr in : row.inputs()) {
+                        inputs.add(qualifyForeign(in, m.name()));
+                    }
+                }
+                rows.add(new Ast.FakeRow(inputs, qualifyForeign(row.output(), m.name()),
+                        row.isDefault(), row.pos()));
+            }
+            fakes.add(new Ast.Fake(fake.target(), rows, fake.pos()));
+        }
+        return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
+                m.behaviors(), fns, examples, fakes, m.exampleFileTarget(), m.pos());
+    }
+
+    /** {@code m} with the foreign names in its invariants written qualified, and nothing else
+     * changed. An invariant is read before the bodies are — settled here, classified for discharge
+     * there — so this is the part of {@link #qualifyImports} that has to be available on its own. */
+    public static Ast.Module withQualifiedInvariants(Ast.Module m) {
+        List<Ast.Def> defs = qualifiedInvariants(m);
+        return defs.equals(m.defs()) ? m
+                : new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
+                        m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(),
+                        m.pos());
+    }
+
+    /** {@code m}'s declarations with every name in an invariant that denotes another module's
+     * definition written qualified. */
+    private static List<Ast.Def> qualifiedInvariants(Ast.Module m) {
+        List<Ast.Def> defs = new ArrayList<>();
+        for (Ast.Def def : m.defs()) {
+            defs.add(def instanceof Ast.Data d && !d.invariants().isEmpty()
+                    ? new Ast.Data(d.written(), d.newtype(), d.includes(), d.fields(),
+                            Ast.mapClauses(d.invariants(), inv -> qualifyForeign(inv, m.name())),
+                            d.decoder(), d.encoder(), d.pos())
+                    : def);
+        }
+        return defs;
+    }
+
+    /** {@code e} with every name denoting a helper of a module other than {@code self} written
+     * qualified. */
+    private static Ast.Expr qualifyForeign(Ast.Expr e, String self) {
+        return qualifyHelpers(e, helper -> !helper.module().equals(self));
+    }
+
+    /** {@code e} with every name still denoting a helper of {@code module} written qualified. Only a
+     * recursive helper survives closing, so this is what those calls become. */
+    static Ast.Expr qualifyHelpersOf(Ast.Expr e, String module) {
+        return qualifyHelpers(e, helper -> helper.module().equals(module));
+    }
+
+    /**
+     * {@code e} with every name denoting a helper {@code which} accepts written qualified.
+     *
+     * <p>It reads what a name denotes rather than how it is spelled: a binding of the same spelling is
+     * a binding, and a prelude helper belongs to the prelude and keeps the qualified name it already
+     * has. The new spelling is read off the same answer, so running this twice says what running it
+     * once said.
+     */
+    private static Ast.Expr qualifyHelpers(Ast.Expr e, Predicate<ValueName.Helper> which) {
+        // a name slot takes the same rewrite as a name standing on its own: a spread names a value
+        // the way any other position does
+        Ast.Expr rebuilt = Ast.mapChildren(e, c -> qualifyHelpers(c, which),
+                s -> qualified(s, which));
+        return switch (rebuilt) {
+            case Ast.Apply call when foreign(call.denotes(), which) ->
+                    new Ast.Apply(qualifiedName(call.denotes()), call.denotes(), call.args(),
+                            call.origin(),
+                            call.pos());
+            case Ast.Var v -> qualified(v, which);
+            default -> rebuilt;
+        };
+    }
+
+    /** {@code name} written qualified where it denotes a helper {@code which} accepts. */
+    private static Ast.Var qualified(Ast.Var name, Predicate<ValueName.Helper> which) {
+        return foreign(name.denotes(), which)
+                ? new Ast.Var(qualifiedName(name.denotes()), name.denotes(), name.pos())
+                : name;
+    }
+
+    /** Whether {@code denotes} is a helper {@code which} accepts. */
+    private static boolean foreign(ValueName denotes, Predicate<ValueName.Helper> which) {
+        return denotes instanceof ValueName.Helper helper && which.test(helper);
+    }
+
+    /**
+     * {@code e} with every construction in it marked as {@code module}'s.
+     *
+     * <p>What a published body builds is built where that body was written, and the reader is handed
+     * the result. Expanding it puts the construction in the reader's body, where the permission check
+     * would ask the reader to declare it — for a type the declaring module may keep to itself, under a
+     * name the reader has none of. The mark is what tells the two apart afterwards, and it names the
+     * module rather than saying only that the construction came from somewhere: a body may build a
+     * type of a third module, and that one is nobody's to hand over (ADR-0059).
+     */
+    static Ast.Expr publishedBy(Ast.Expr e, String module) {
+        // a spread names a value, and a value is not a construction: what it built was built where it
+        // was defined, so the mark is already on it
+        Ast.Expr rebuilt = Ast.mapChildren(e, c -> publishedBy(c, module), s -> s);
+        return switch (rebuilt) {
+            case Ast.NewData nd -> nd.publishedBy(module);
+            // a unit data is constructed by being named, so the name is where it says where it came
+            // from — there is no construction node to say it on
+            case Ast.Var v when v.denotes() instanceof ValueName.OfType named ->
+                    v.denoting(named.publishedBy(module));
+            default -> rebuilt;
+        };
+    }
+
+    /**
+     * {@code e} with every construction in it marked as one a value made.
+     *
+     * <p>A value is substituted at each reference, so what its definition built ends up standing in
+     * the body that named it, as the node that body's own construction would be. The mark is what
+     * keeps the permission check reading the model rather than the substitution: a behavior stating a
+     * rule against a named limit compares against a value, and originates none of it. A limit is
+     * written as a value so that the figure has one place to live and one comment saying where it
+     * comes from, and naming it is not supposed to cost every rule that reads it an authority it does
+     * not use.
+     *
+     * <p>Unlike a published body's mark this names no module. What the value built is the value
+     * definition's however the type got its declaration, and a behavior reading the name is not the
+     * one that made it either way. A helper is the other case and stays the other case: its body is
+     * checked as though it had been written inline, which is what tells a helper from a behavior.
+     *
+     * <p>Three things can stand for a construction and each takes the mark. A construction node
+     * carries its own; a unit data is constructed by being named, so the name carries it; and a
+     * recursive helper is lowered to a method rather than expanded, so what it builds stays behind a
+     * call, and the call carries it. Without the third, whether a value's constructions belonged to
+     * the value would turn on whether a helper on the way could be expanded — the substitution
+     * showing through the rule again, in the one place expansion cannot reach.
+     */
+    static Ast.Expr carriedByValue(Ast.Expr e) {
+        Ast.Expr rebuilt = Ast.mapChildren(e, HelperNames::carriedByValue, s -> s);
+        return switch (rebuilt) {
+            case Ast.NewData nd -> nd.carriedByValue();
+            case Ast.Var v when v.denotes() instanceof ValueName.OfType named ->
+                    v.denoting(named.carriedByValue());
+            case Ast.Apply call -> call.carriedByValue();
+            default -> rebuilt;
+        };
+    }
+
+    /**
+     * The helpers {@code e} still reaches — what a body closed by
+     * {@link HelperInliner#closeAcross} could not expand away, which is the recursive ones.
+     *
+     * <p>Each is given as what it denotes rather than as a spelling, because the two questions a
+     * caller then has differ: which module declares it decides how it is keyed, and a binding that
+     * shares a helper's spelling is not one of these at all.
+     */
+    public static Set<ValueName.Helper> helpersReached(Ast.Expr e) {
+        Set<ValueName.Helper> out = new LinkedHashSet<>();
+        collectHelpersOf(e, out);
+        return out;
+    }
+
+    private static void collectHelpersOf(Ast.Expr e, Set<ValueName.Helper> out) {
+        if (e == null) {
+            return;
+        }
+        ValueName denotes = switch (e) {
+            case Ast.Apply call -> call.denotes();
+            case Ast.Var v -> v.denotes();
+            default -> null;
+        };
+        if (denotes instanceof ValueName.Helper helper) {
+            out.add(helper);
+        }
+        Ast.forEachChild(e, c -> collectHelpersOf(c, out));
+    }
+
+    /** The name a helper is reached by outside the module that declares it. Read off what the name
+     * denotes, so applying it to a name already written this way answers the same thing. */
+    private static String qualifiedName(ValueName denotes) {
+        ValueName.Helper helper = (ValueName.Helper) denotes;
+        return qualified(helper.module(), helper.name());
+    }
+
+    /**
+     * The key {@code helper} is filed under in the table of the module named {@code module} — bare for
+     * one that module declares, qualified for one it imported.
+     *
+     * <p>Read off what the name denotes and never off how it was written. A reader writes an imported
+     * definition bare, so the spelling is a key only after {@link #qualifyImports} has run, and a check
+     * that keyed by the spelling would answer differently on either side of that pass — silently,
+     * because a miss is what a table does with a key it has not got. The pair (module, name) is what
+     * the definition is (ADR-0072), so it is what a table of definitions is asked with.
+     */
+    public static String keyIn(String module, ValueName.Helper helper) {
+        return helper.module().equals(module) ? helper.name() : qualified(helper.module(), helper.name());
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
@@ -1,0 +1,127 @@
+package souther.compiler.check;
+
+import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Which declaration a name reaches where a body of one module is expanded.
+ *
+ * <p>A value, and the same value for every body of that module: which helper a call expands to
+ * follows from the declarations around it and from nothing about the call. Held as a value rather
+ * than built per expansion, so the eleven questions that expand something in a compile are reading
+ * one answer rather than eleven that have to agree.
+ *
+ * <p>Prelude helpers are keyed by their qualified name ({@code List.map}); a module's own helpers by
+ * their bare name ({@code 対象明細}), and a definition another module publishes by the qualified name
+ * it is reached by here. A qualified call resolves to whichever of the two declared it, a bare call
+ * to the module's own — the standard library has no bare names (spec §stdlib).
+ *
+ * <p>{@link #own} keeps the order the module wrote its helpers in, and that is load-bearing: the
+ * checks walk it and stop at the first helper they find wrong, so the order decides which one the
+ * author is told about. An author reads their file from the top.
+ *
+ * <p>What is in the table depends on {@link InliningPolicy}, which is what an expanded tree is a
+ * representation <em>of</em>. Two policies are two tables and not one table read two ways.
+ */
+public final class HelperTable {
+
+    private final String module;
+    private final InliningPolicy policy;
+    private final Map<String, Ast.FnDef> reached;
+    private final Map<String, Ast.FnDef> own;
+
+    private HelperTable(String module, InliningPolicy policy,
+                        Map<String, Ast.FnDef> reached, Map<String, Ast.FnDef> own) {
+        this.module = module;
+        this.policy = policy;
+        this.reached = reached;
+        this.own = own;
+    }
+
+    /**
+     * The table a body of {@code module} is expanded against: what it declares itself, what the
+     * modules it imports publish to it, and — under {@link InliningPolicy#FULL} — the standard
+     * library underneath both.
+     */
+    public static HelperTable of(String module, Map<String, Ast.FnDef> own,
+                                 Map<String, Ast.FnDef> imported, InliningPolicy policy) {
+        // In the order they are written, so a module with two helpers to complain about complains
+        // about the earlier one first.
+        Map<String, Ast.FnDef> joined = new LinkedHashMap<>(imported);
+        joined.putAll(own);
+        Map<String, Ast.FnDef> reached;
+        if (policy == InliningPolicy.FULL) {
+            reached = new LinkedHashMap<>(Prelude.helpers());
+            reached.putAll(joined);
+        } else {
+            reached = joined;
+        }
+        return new HelperTable(module, policy, reached, new LinkedHashMap<>(own));
+    }
+
+    /** The same, for a module whose own helpers are read off its declarations. */
+    public static HelperTable of(Ast.Module module, Map<String, Ast.FnDef> imported,
+                                 InliningPolicy policy) {
+        return of(module.name(), HelperInliner.helpersOf(module), imported, policy);
+    }
+
+    /**
+     * The same table with {@code names} unreachable.
+     *
+     * <p>What a body of a recursive helper reaches is narrowed by its own parameters: a parameter
+     * sharing a helper's name — {@code foldFrom}'s function parameter {@code step} in a module that
+     * also declares a helper {@code step} — is a parameter application and not a call to that helper.
+     *
+     * <p>This narrows what a call expands to. It does not change what recurses: the call graph is a
+     * fact about the declarations, worked out over the table as it was built, and a graph taken over
+     * a narrowed table would find {@code foldFrom} non-recursive and expand its self-call forever.
+     */
+    public HelperTable hiding(Collection<String> names) {
+        Map<String, Ast.FnDef> narrowed = new LinkedHashMap<>(reached);
+        boolean any = false;
+        for (String name : names) {
+            any |= narrowed.remove(name) != null;
+        }
+        return any ? new HelperTable(module, policy, narrowed, own) : this;
+    }
+
+    /** The module whose body this expands into. */
+    public String module() {
+        return module;
+    }
+
+    /** What an expanded tree read against this table is a representation of. */
+    public InliningPolicy policy() {
+        return policy;
+    }
+
+    /** The declaration {@code name} reaches, or null where it reaches none. */
+    public Ast.FnDef reached(String name) {
+        return reached.get(name);
+    }
+
+    /** Whether {@code name} reaches a declaration here. */
+    public boolean reaches(String name) {
+        return reached.containsKey(name);
+    }
+
+    /** Everything reachable, by the name it is reached by — what the call graph is built over. */
+    public Map<String, Ast.FnDef> reachable() {
+        return Collections.unmodifiableMap(reached);
+    }
+
+    /** The module's own helpers, in the order it wrote them. */
+    public Map<String, Ast.FnDef> own() {
+        return Collections.unmodifiableMap(own);
+    }
+
+    /** Whether the module declares {@code name} itself. */
+    public boolean declares(String name) {
+        return own.containsKey(name);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
@@ -124,4 +124,28 @@ public final class HelperTable {
     public boolean declares(String name) {
         return own.containsKey(name);
     }
+
+    /**
+     * Two tables are the same table when they hold the same declarations for the same module under
+     * the same policy.
+     *
+     * <p>Said outright because a query answer is compared this way: an answer that differed between
+     * two readings of one source would make every edit look like a change to everything downstream.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other instanceof HelperTable t
+                && module.equals(t.module) && policy == t.policy
+                && reached.equals(t.reached) && own.equals(t.own);
+    }
+
+    @Override
+    public int hashCode() {
+        return java.util.Objects.hash(module, policy, reached, own);
+    }
+
+    @Override
+    public String toString() {
+        return "HelperTable[" + module + ", " + policy + ", " + reached.size() + " reachable]";
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -37,7 +37,7 @@ import java.util.TreeSet;
  * rest on what building the graph happened to visit. Whether a name is {@code partial} is read off the
  * declaration it reaches, not off a set collected on the way — a clause names what it names, whether
  * or not a helper of this module names it too. And which declaration a name reaches is read off what
- * the name denotes ({@link HelperInliner#keyIn}), not off how it was spelled, so the answer is the same
+ * the name denotes ({@link HelperNames#keyIn}), not off how it was spelled, so the answer is the same
  * before and after the pass that writes an imported name out qualified.
  *
  * <p>A path is the shortest one, found breadth-first with each node's callees taken in name order, so
@@ -209,7 +209,7 @@ final class PartialReachability {
      */
     private static String keyOf(ValueName denotes, HelperInliner inliner) {
         return switch (denotes) {
-            case ValueName.Helper helper -> HelperInliner.keyIn(inliner.moduleName(), helper);
+            case ValueName.Helper helper -> HelperNames.keyIn(inliner.moduleName(), helper);
             case ValueName.Stdlib lib -> lib.qualified();
             case null, default -> null;
         };

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -1,0 +1,130 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A value defined in terms of itself, refused before anything is expanded.
+ *
+ * <p>A value is substituted at each of its references (ADR-0072), so one that reaches itself is
+ * substituted into itself and there is no body to reach the end of. It has to be refused before the
+ * first expansion rather than caught by whatever depth guard the expansion runs into, which reports
+ * a nesting the author did not write.
+ *
+ * <p>The value graph is not the call graph. A helper on a call cycle is lowered to a method and
+ * recurses at run time (ADR-0038); a value has no such form, so a cycle that passes through one is an
+ * error however it is closed — by naming a value, or by calling a helper that names it. The two are
+ * reported apart: a value cycle sent through the recursion check would be told to declare a return
+ * type it never wrote.
+ */
+public final class ValueCycles {
+
+    private ValueCycles() {}
+
+    /**
+     * Refuses a value of {@code m} that reaches itself, or answers.
+     *
+     * <p>Asked of the module as it was written, before its helper parameter types are settled and
+     * before any body is expanded. Settling expands the bodies it reads, so a cycle left standing
+     * until then is substituted into itself there — and what comes back is a depth guard naming a
+     * nesting the author did not write.
+     *
+     * <p>Building the edges it needs rather than taking an expansion table: what it reads is the
+     * module's own definitions and what each of them calls, which is settled by nothing.
+     */
+    public static void rejectIn(Ast.Module m, Map<String, Ast.FnDef> published) {
+        Map<String, Ast.FnDef> own = HelperInliner.helpersOf(m);
+        Map<String, Ast.FnDef> table = HelperInliner.tableFor(m, published);
+        Map<String, Set<String>> callsOf = new LinkedHashMap<>();
+        for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
+            Set<String> called = new LinkedHashSet<>();
+            HelperInliner.helperCallsIn(e.getValue().writtenBody(), table, called);
+            callsOf.put(e.getKey(), called);
+        }
+        reject(own, callsOf);
+    }
+
+    /**
+     * Refuses the first value of {@code own} that reaches itself, naming the path it goes round.
+     *
+     * <p>{@code callsOf} is the call graph over the same table: a cycle may be closed by calling a
+     * helper that names the value, so the two kinds of edge are followed together.
+     */
+    static void reject(Map<String, Ast.FnDef> own, Map<String, Set<String>> callsOf) {
+        Map<String, Set<String>> edges = new LinkedHashMap<>();
+        for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
+            Set<String> out = new LinkedHashSet<>(callsOf.getOrDefault(e.getKey(), Set.of()));
+            valuesRead(e.getValue().writtenBody(), own, out);
+            edges.put(e.getKey(), out);
+        }
+        for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
+            if (!e.getValue().params().isEmpty()) {
+                continue;   // a helper's own recursion is the call graph's business
+            }
+            // A value stands for a value. A block written as one — a `.field` getter, whose parameter
+            // the compiler synthesizes — is refused where it is written rather than where it is used.
+            //
+            // Unless the definition says it is a function. Then the block is what that says it is,
+            // and its parameters are the ones the written type names.
+            boolean declaredAFunction = e.getValue().declaredReturn() != null
+                    && e.getValue().declaredReturn().asFn() != null;
+            if (!declaredAFunction && e.getValue().writtenBody() instanceof Ast.Block block) {
+                throw CompileException.of(
+                        Diagnostic.of(null, "check.block.notvalue").title("check.block.title")
+                                .at(block.pos()).build(),
+                        "a block is not a value: `let " + e.getKey() + "` writes no parameters, so it"
+                                + " defines a value, and a block cannot be one (spec 12.5)");
+            }
+            List<String> path = new ArrayList<>();
+            if (pathBackTo(e.getKey(), e.getKey(), edges, new LinkedHashSet<>(), path)) {
+                path.add(0, e.getKey());
+                String written = String.join(" -> ", path);
+                throw CompileException.of(
+                        Diagnostic.of(null, "check.value.cycle").title("check.value.cycle.title")
+                                .at(e.getValue().written().region())
+                                .args(e.getKey(), written).build(),
+                        "`let " + e.getKey() + "` is defined in terms of itself (" + written + ")");
+            }
+        }
+    }
+
+    /** The names of {@code own}'s values that {@code e} reads. A value is written bare, so a
+     * reference to one is a {@code Var} and never reaches the call graph. */
+    static void valuesRead(Ast.Expr e, Map<String, Ast.FnDef> own, Set<String> out) {
+        if (e == null) {
+            return;
+        }
+        if (e instanceof Ast.Var v && v.denotes() instanceof ValueName.Helper) {
+            Ast.FnDef d = own.get(v.name());
+            if (d != null && d.params().isEmpty()) {
+                out.add(v.name());
+            }
+        }
+        Ast.forEachChild(e, c -> valuesRead(c, own, out));
+    }
+
+    /** Records into {@code path} a route from {@code from} back to {@code target}, or answers false. */
+    private static boolean pathBackTo(String from, String target, Map<String, Set<String>> edges,
+                                      Set<String> seen, List<String> path) {
+        for (String next : edges.getOrDefault(from, Set.of())) {
+            path.add(next);
+            if (next.equals(target)) {
+                return true;
+            }
+            if (seen.add(next) && pathBackTo(next, target, edges, seen, path)) {
+                return true;
+            }
+            path.remove(path.size() - 1);
+        }
+        return false;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -42,15 +42,14 @@ public final class ValueCycles {
      * module's own definitions and what each of them calls, which is settled by nothing.
      */
     public static void rejectIn(Ast.Module m, Map<String, Ast.FnDef> published) {
-        Map<String, Ast.FnDef> own = HelperInliner.helpersOf(m);
-        Map<String, Ast.FnDef> table = HelperInliner.tableFor(m, published);
+        HelperTable table = HelperTable.of(m, published, InliningPolicy.FULL);
         Map<String, Set<String>> callsOf = new LinkedHashMap<>();
-        for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
+        for (Map.Entry<String, Ast.FnDef> e : table.own().entrySet()) {
             Set<String> called = new LinkedHashSet<>();
-            HelperInliner.helperCallsIn(e.getValue().writtenBody(), table, called);
+            HelperInliner.helperCallsIn(e.getValue().writtenBody(), table.reachable(), called);
             callsOf.put(e.getKey(), called);
         }
-        reject(own, callsOf);
+        reject(table.own(), callsOf);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.HelperInliner;
+import souther.compiler.check.HelperNames;
 import souther.compiler.check.InjectionSigs;
 import souther.compiler.check.InliningPolicy;
 import souther.compiler.check.InvariantChecker;
@@ -624,8 +625,8 @@ public final class Bodies {
         HelperInliner inliner = HelperInliner.forHelpers(from.name(), table);
         Deque<String> work = new ArrayDeque<>(out.keySet());
         while (!work.isEmpty()) {
-            for (ValueName.Helper reached : HelperInliner.helpersReached(out.get(work.poll()).writtenBody())) {
-                String qualified = HelperInliner.qualified(reached.module(), reached.name());
+            for (ValueName.Helper reached : HelperNames.helpersReached(out.get(work.poll()).writtenBody())) {
+                String qualified = HelperNames.qualified(reached.module(), reached.name());
                 if (out.containsKey(qualified)) {
                     continue;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -4,7 +4,9 @@ import souther.compiler.ast.Ast;
 import souther.compiler.check.BehaviorRequirement;
 import souther.compiler.check.DataChecker;
 import souther.compiler.check.HelperInliner;
+import souther.compiler.check.HelperGraph;
 import souther.compiler.check.HelperNames;
+import souther.compiler.check.HelperTable;
 import souther.compiler.check.InjectionSigs;
 import souther.compiler.check.InliningPolicy;
 import souther.compiler.check.InvariantChecker;
@@ -682,12 +684,55 @@ public final class Bodies {
 
         @Override
         public Answer<Set<String>> compute(Db db) {
+            Answer<HelperInliner> inliner = expanding(db, name, InliningPolicy.FULL);
+            return inliner.present() ? Answer.of(inliner.value().recursiveHelpers())
+                    : Answer.absent();
+        }
+    }
+
+    /**
+     * What a body of {@code module} is expanded against: which declaration each name reaches, and
+     * which of them recurse.
+     *
+     * <p>Both are facts about the module's declarations and neither is about any one body, so they
+     * are worked out once. Before this every question that expanded something built its own —
+     * walking each of the standard library's hundred-odd bodies again for each — and the answers only
+     * agreed because they were computed the same way.
+     *
+     * <p>Keyed by the policy as well as the module, because the two policies are two tables: the
+     * discharge representation leaves the language's own operations standing, so it does not have
+     * them to call and does not find them recursive. One answer shared by both would put the fold
+     * that {@code List.map} is into the tree the discharge rules read.
+     */
+    public record Expanding(String name, InliningPolicy policy) implements Key<Expanding.Of> {
+
+        /** @param table which declaration each name reaches
+         *  @param graph what each of them calls, and which of them recurse */
+        public record Of(HelperTable table, HelperGraph graph) {}
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Of> compute(Db db) {
             Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(name));
             if (!helpers.present()) {
                 return Answer.absent();
             }
-            return Answer.of(HelperInliner.forHelpers(name, helpers.value()).recursiveHelpers());
+            HelperTable table = HelperTable.of(name, helpers.value(), Map.of(), policy);
+            return Answer.of(new Of(table, HelperGraph.of(table)));
         }
+    }
+
+    /** An inliner over {@link Expanding}'s answer — a fresh one, because an expansion writes bindings
+     * as it runs and what it writes belongs to the body it is written into. */
+    private static Answer<HelperInliner> expanding(Db db, String module, InliningPolicy policy) {
+        Answer<Expanding.Of> against = db.ask(new Expanding(module, policy));
+        return against.present()
+                ? Answer.of(HelperInliner.over(against.value().table(), against.value().graph()))
+                : Answer.absent();
     }
 
     /**
@@ -749,17 +794,16 @@ public final class Bodies {
         @Override
         public Answer<Ast.FnDef> compute(Db db) {
             Answer<Ast.FnDef> def = db.ask(new SettledFn(module, fn));
-            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(module));
+            Answer<HelperInliner> inliner = expanding(db, module, InliningPolicy.FULL);
             Answer<Set<String>> recursive = db.ask(new RecursiveHelpers(module));
             Answer<Map<String, Integer>> behaviors = db.ask(new NamedBehaviorArity(module));
-            if (!def.present() || !helpers.present() || !recursive.present()
+            if (!def.present() || !inliner.present() || !recursive.present()
                     || !behaviors.present()) {
                 return Answer.absent();
             }
             try {
                 return Answer.of(Lower.body(def.value(),
-                        HelperInliner.forHelpers(module, helpers.value())
-                                .namingBehaviors(behaviors.value()),
+                        inliner.value().namingBehaviors(behaviors.value()),
                         recursive.value().contains(fn), dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);
@@ -781,17 +825,16 @@ public final class Bodies {
         @Override
         public Answer<Ast.FnDef> compute(Db db) {
             Answer<Ast.FnDef> def = db.ask(new SettledFn(module, fn));
-            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(module));
+            Answer<HelperInliner> inliner = expanding(db, module, InliningPolicy.DISCHARGE);
             Answer<Set<String>> recursive = db.ask(new RecursiveHelpers(module));
             Answer<Map<String, Integer>> behaviors = db.ask(new NamedBehaviorArity(module));
-            if (!def.present() || !helpers.present() || !recursive.present()
+            if (!def.present() || !inliner.present() || !recursive.present()
                     || !behaviors.present()) {
                 return Answer.absent();
             }
             try {
                 return Answer.of(Lower.body(def.value(),
-                        HelperInliner.forHelpers(module, helpers.value(), InliningPolicy.DISCHARGE)
-                                .namingBehaviors(behaviors.value()),
+                        inliner.value().namingBehaviors(behaviors.value()),
                         recursive.value().contains(fn), dependencyParams(db, module, fn)));
             } catch (CompileException e) {
                 return Answer.absent(e);
@@ -861,14 +904,13 @@ public final class Bodies {
 
         @Override
         public Answer<Map<String, Type>> compute(Db db) {
-            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(name));
+            Answer<HelperInliner> inliner = expanding(db, name, InliningPolicy.FULL);
             Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
-            if (!helpers.present() || !scope.present()) {
+            if (!inliner.present() || !scope.present()) {
                 return Answer.absent();
             }
             try {
-                return Answer.of(TypeChecker.recursiveHelperSigs(
-                        HelperInliner.forHelpers(name, helpers.value()), scope.value()));
+                return Answer.of(TypeChecker.recursiveHelperSigs(inliner.value(), scope.value()));
             } catch (CompileException e) {
                 // A recursive helper that does not say what it returns costs the signatures of all of
                 // them, and there is no module to check without them.
@@ -888,10 +930,10 @@ public final class Bodies {
 
         @Override
         public Answer<Map<String, DataChecker.Constructs>> compute(Db db) {
-            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(name));
+            Answer<HelperInliner> inliner = expanding(db, name, InliningPolicy.FULL);
             Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(name));
             Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
-            if (!helpers.present() || !sigs.present() || !scope.present()) {
+            if (!inliner.present() || !sigs.present() || !scope.present()) {
                 return Answer.absent();
             }
             Map<String, Ast.Expr> bodies = new LinkedHashMap<>();
@@ -904,7 +946,7 @@ public final class Bodies {
             }
             try {
                 return Answer.of(TypeChecker.recursiveHelperConstructs(sigs.value().keySet(), bodies,
-                        HelperInliner.forHelpers(name, helpers.value()), scope.value()));
+                        inliner.value(), scope.value()));
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -977,7 +1019,7 @@ public final class Bodies {
             Answer<Symbols> scope = db.ask(new Shapes.Scope(module));
             Answer<Map<String, ReqSig>> calleeSigs = db.ask(new CalleeSigs(module));
             Answer<Map<String, ReqSig>> reqSigs = db.ask(new ReqSigs(module));
-            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(module));
+            Answer<HelperInliner> inliner = expanding(db, module, InliningPolicy.FULL);
             Answer<Map<String, Type>> sigs = db.ask(new RecursiveHelperSigs(module));
             Answer<Map<String, DataChecker.Constructs>> constructs =
                     db.ask(new RecursiveHelperConstructs(module));
@@ -985,7 +1027,7 @@ public final class Bodies {
             Answer<Map<TypeName, List<Ast.InvariantClause>>> dischargeInvariants =
                     db.ask(new Shapes.InvariantsForDischarge(module));
             if (!spec.present() || !fn.present() || !body.present() || !scope.present()
-                    || !calleeSigs.present() || !reqSigs.present() || !helpers.present()
+                    || !calleeSigs.present() || !reqSigs.present() || !inliner.present()
                     || !sigs.present() || !constructs.present()) {
                 return Answer.absent();
             }
@@ -1000,7 +1042,7 @@ public final class Bodies {
             try {
                 Core core = TypeChecker.checkBehavior(spec.value(), fn.value(), body.value().writtenBody(),
                         dischargeSource, scope.value(), calleeSigs.value(), reqSigs.value(),
-                        HelperInliner.forHelpers(module, helpers.value()), sigs.value(), constructs.value(),
+                        inliner.value(), sigs.value(), constructs.value(),
                         warnings);
                 List<Report> reports = new ArrayList<>();
                 for (Diagnostic warning : warnings) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -57,19 +57,14 @@ public final class Shapes {
 
         @Override
         public Answer<Ast.Module> compute(Db db) {
-            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            // The module to expand, which is the resolved one where its values are well founded.
+            // Everything below here expands a body of it.
+            Answer<Ast.Module> resolved = db.ask(new Expandable(name));
             if (!resolved.present()) {
                 return Answer.absent();
             }
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
             if (!scope.present()) {
-                return Answer.absent();
-            }
-            // Nothing below expands a body of a module whose values are not well founded: a value is
-            // substituted at each of its references, so one that reaches itself is substituted into
-            // itself. Asked rather than checked here, so the refusal has one owner however many
-            // questions have to know it.
-            if (!db.ask(new NoValueReachesItself(name)).present()) {
                 return Answer.absent();
             }
             Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
@@ -115,30 +110,36 @@ public final class Shapes {
     }
 
     /**
-     * Whether no value of this module is defined in terms of itself.
+     * The module, where a body of it may be expanded — which is where no value of it is defined in
+     * terms of itself.
      *
      * <p>A value is substituted at each of its references (ADR-0072), so one that reaches itself is
      * substituted into itself and there is no body to reach the end of. Everything that expands a body
-     * of this module needs it to be true, and needs it before it expands anything: left until the
-     * expansion runs out of stack, what comes back names a nesting the author did not write.
+     * of this module needs that to be false, and needs to know before it expands anything: left until
+     * the expansion runs out of stack, what comes back names a nesting the author did not write.
      *
-     * <p>Its own question, and the reason it is one. The rule used to be checked wherever an expansion
-     * table was built, which is eleven places in a compile — so the refusal was raised by whichever of
-     * them ran first, from inside whatever question that was, and a question that does not expect a
-     * refusal from a table it is merely building passes it on as a failure of its own. Asked here it is
-     * answered once and read by name, and a reader that needs it says so.
+     * <p>It hands over the module rather than answering whether. The rule used to be checked wherever
+     * an expansion table was built, which is eleven places in a compile, so the refusal was raised by
+     * whichever of them ran first — from inside whatever question that was, which passed it on as a
+     * failure of its own. Answering whether moved the problem rather than removing it: three questions
+     * read the module and expand it, each said the condition over again, and one of them said it and
+     * two did not. A condition a reader has to remember is a condition a reader can forget.
+     *
+     * <p>So there is one thing to ask for and it is the thing they want. A question that expands a
+     * body asks for a module to expand and gets one or gets nothing; there is no answer here that
+     * hands over a module without having checked it, and nothing left to remember beside it.
      *
      * <p>Read off the resolved module, which is the earliest form that says what each name denotes —
      * and what a name denotes is what decides whether it is an edge at all.
      */
-    public record NoValueReachesItself(String name) implements Key<Boolean> {
+    public record Expandable(String name) implements Key<Ast.Module> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Boolean> compute(Db db) {
+        public Answer<Ast.Module> compute(Db db) {
             Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
             if (!resolved.present()) {
                 return Answer.absent();
@@ -147,7 +148,7 @@ public final class Shapes {
             try {
                 ValueCycles.rejectIn(resolved.value(),
                         imported.present() ? imported.value() : Map.of());
-                return Answer.of(Boolean.TRUE);
+                return Answer.of(resolved.value());
             } catch (CompileException e) {
                 return Answer.absent(e);
             }
@@ -306,7 +307,7 @@ public final class Shapes {
 
         @Override
         public Answer<Map<TypeName, List<ClauseDischarge>>> compute(Db db) {
-            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            Answer<Ast.Module> resolved = db.ask(new Expandable(name));
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
             if (!resolved.present() || !scope.present()) {
                 return Answer.absent();
@@ -386,10 +387,9 @@ public final class Shapes {
 
         @Override
         public Answer<Map<TypeName, List<Ast.InvariantClause>>> compute(Db db) {
-            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            Answer<Ast.Module> resolved = db.ask(new Expandable(name));
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
-            Answer<Boolean> founded = db.ask(new NoValueReachesItself(name));
-            if (!resolved.present() || !scope.present() || !founded.present()) {
+            if (!resolved.present() || !scope.present()) {
                 return Answer.absent();
             }
             Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -3,10 +3,13 @@ package souther.compiler.query;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.ClauseDischarge;
 import souther.compiler.check.HelperInliner;
+import souther.compiler.check.HelperInvariants;
+import souther.compiler.check.HelperNames;
 import souther.compiler.check.InliningPolicy;
 import souther.compiler.check.InvariantChecker;
 import souther.compiler.check.NewtypeDesugar;
 import souther.compiler.check.TypeChecker;
+import souther.compiler.check.ValueCycles;
 import souther.compiler.check.Symbols;
 import souther.compiler.derive.Deriver;
 import souther.compiler.diag.CompileException;
@@ -62,6 +65,13 @@ public final class Shapes {
             if (!scope.present()) {
                 return Answer.absent();
             }
+            // Nothing below expands a body of a module whose values are not well founded: a value is
+            // substituted at each of its references, so one that reaches itself is substituted into
+            // itself. Asked rather than checked here, so the refusal has one owner however many
+            // questions have to know it.
+            if (!db.ask(new NoValueReachesItself(name)).present()) {
+                return Answer.absent();
+            }
             Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
             // A module whose imports form a cycle takes nothing from them. The cycle is reported where
             // it is found; an invariant naming an imported definition is left unsettled and reported
@@ -77,7 +87,7 @@ public final class Shapes {
                 // normalizing here rather than with the bodies is what leaves one spelling for every
                 // check over an invariant to read.
                 return Answer.of(NewtypeDesugar.rewriteInvariants(
-                        HelperInliner.withSettledInvariants(derived, scope.value(), published),
+                        HelperInvariants.withSettledInvariants(derived, scope.value(), published),
                         scope.value()));
             } catch (CompileException e) {
                 return Answer.absent(e);
@@ -101,6 +111,46 @@ public final class Shapes {
             return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
                     List.copyOf(kept), m.behaviors(), m.fns(), m.examples(), m.fakes(),
                     m.exampleFileTarget(), m.pos());
+        }
+    }
+
+    /**
+     * Whether no value of this module is defined in terms of itself.
+     *
+     * <p>A value is substituted at each of its references (ADR-0072), so one that reaches itself is
+     * substituted into itself and there is no body to reach the end of. Everything that expands a body
+     * of this module needs it to be true, and needs it before it expands anything: left until the
+     * expansion runs out of stack, what comes back names a nesting the author did not write.
+     *
+     * <p>Its own question, and the reason it is one. The rule used to be checked wherever an expansion
+     * table was built, which is eleven places in a compile — so the refusal was raised by whichever of
+     * them ran first, from inside whatever question that was, and a question that does not expect a
+     * refusal from a table it is merely building passes it on as a failure of its own. Asked here it is
+     * answered once and read by name, and a reader that needs it says so.
+     *
+     * <p>Read off the resolved module, which is the earliest form that says what each name denotes —
+     * and what a name denotes is what decides whether it is an edge at all.
+     */
+    public record NoValueReachesItself(String name) implements Key<Boolean> {
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Boolean> compute(Db db) {
+            Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
+            if (!resolved.present()) {
+                return Answer.absent();
+            }
+            Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
+            try {
+                ValueCycles.rejectIn(resolved.value(),
+                        imported.present() ? imported.value() : Map.of());
+                return Answer.of(Boolean.TRUE);
+            } catch (CompileException e) {
+                return Answer.absent(e);
+            }
         }
     }
 
@@ -205,7 +255,7 @@ public final class Shapes {
             // Spelling it that way, once, is what lets everything downstream — the table a call
             // expands against, the method a recursive helper becomes — read the identity by reading
             // the name.
-            Ast.Module m = HelperInliner.qualifyImports(desugared.value());
+            Ast.Module m = HelperNames.qualifyImports(desugared.value());
             try {
                 HelperInliner inliner = HelperInliner.forModule(m, published);
                 Map<String, Ast.FnDef> injected =
@@ -266,7 +316,7 @@ public final class Shapes {
             // What the clause says is what the check reads, so an imported bound is substituted here
             // as it is where the invariant is settled. A clause left naming it would be classified as
             // a rule this analysis cannot read, and a construction the bound rejects would compile.
-            Ast.Module declaring = HelperInliner.withQualifiedInvariants(resolved.value());
+            Ast.Module declaring = HelperNames.withQualifiedInvariants(resolved.value());
             try {
                 Map<TypeName, List<ClauseDischarge>> out = new LinkedHashMap<>();
                 for (Ast.Def def : declaring.defs()) {
@@ -283,7 +333,7 @@ public final class Shapes {
                     // discharge, so `a && b` under one name is classified twice under that name: what
                     // discharges each half is what an author needs, and the name is what a caller reads.
                     for (Ast.InvariantClause declared : data.invariants()) {
-                        for (Ast.Expr written : HelperInliner.conjunctsOf(declared.expr())) {
+                        for (Ast.Expr written : HelperInvariants.conjunctsOf(declared.expr())) {
                             clauses.add(InvariantChecker.capabilityOf(
                                     inliner.inline(written, new BindingOwner.OfData(
                                             new TypeName(name, data.name()))),
@@ -338,13 +388,14 @@ public final class Shapes {
         public Answer<Map<TypeName, List<Ast.InvariantClause>>> compute(Db db) {
             Answer<Ast.Module> resolved = db.ask(new Names.Resolved(name));
             Answer<Symbols> scope = Names.symbols(db, name, Names.Stage.RESOLVED);
-            if (!resolved.present() || !scope.present()) {
+            Answer<Boolean> founded = db.ask(new NoValueReachesItself(name));
+            if (!resolved.present() || !scope.present() || !founded.present()) {
                 return Answer.absent();
             }
             Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
             Map<String, Ast.FnDef> published = imported.present() ? imported.value() : Map.of();
             try {
-                return Answer.of(HelperInliner.invariantsForDischarge(
+                return Answer.of(HelperInvariants.invariantsForDischarge(
                         resolved.value(), scope.value(), published));
             } catch (CompileException e) {
                 return Answer.absent(e);

--- a/souther-compiler/src/test/java/souther/compiler/AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest.java
@@ -1,0 +1,103 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A module with two helpers to complain about complains about the earlier one first.
+ *
+ * <p>The helpers are checked one after another and the first one wrong is what the author is told
+ * about, so which one that is comes from the order the table holds them in — and the order the table
+ * holds them in should be the order they were written. An author reads their file from the top; a
+ * report about the last of eight helpers, when the first is wrong the same way, sends them to the
+ * wrong end of it.
+ *
+ * <p>Nothing about a helper table makes this true. A table built for lookup keeps whatever order its
+ * hashing gives it, and the two orders agree often enough that a reordering shows up as a report
+ * moving rather than as anything failing. So it is stated here, with a helper at each end of the
+ * module wrong the same way.
+ */
+class AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest {
+
+    /**
+     * Eight helpers, of which the first and the last say nothing about what they take and have a body
+     * that settles nothing either. A helper is typed by its body and never by its call sites
+     * (ADR-0066), so each of those two has to be annotated and neither is. The six between them are
+     * written correctly and are there to put the two ends far apart.
+     */
+    private static final String BOTH_ENDS_WRONG = """
+            module demo
+
+            data In = { n: Int }
+            data Out = { n: Int }
+
+            let alpha (n) = n
+            let bravo (n: Int) : Int = n + 1
+            let charlie (n: Int) : Int = n + 2
+            let delta (n: Int) : Int = n + 3
+            let echo (n: Int) : Int = n + 4
+            let foxtrot (n: Int) : Int = n + 5
+            let golf (n: Int) : Int = n + 6
+            let zulu (n) = n
+
+            behavior go : (i: In) -> Out
+                constructs Out
+            let go (i) = Out { n = alpha(i.n) + zulu(i.n) }
+            """;
+
+    private static final String ALPHA_ANNOTATED = "let alpha (n: Int) : Int = n";
+    private static final String ZULU_ANNOTATED = "let zulu (n: Int) : Int = n";
+
+    private static List<Diagnostic> refusalsFor(String source) {
+        return assertThrows(CompileException.class, () -> Compiler.compile(source)).diagnostics();
+    }
+
+    /** What each report quotes, so a failure message says which helper was named. */
+    private static List<List<Object>> quoted(List<Diagnostic> found) {
+        return found.stream().map(d -> List.of(d.args())).toList();
+    }
+
+    private static boolean names(List<Diagnostic> found, String helper) {
+        return found.stream().anyMatch(d -> List.of(d.args()).contains(helper));
+    }
+
+    @Test
+    void theEarlierOfTwoHelpersWrongTheSameWayIsTheOneReported() {
+        List<Diagnostic> found = refusalsFor(BOTH_ENDS_WRONG);
+
+        assertTrue(names(found, "alpha"),
+                "the first helper written is the one reported: " + quoted(found));
+        assertFalse(names(found, "zulu"),
+                "and the last is not, because the first stopped the check: " + quoted(found));
+    }
+
+    /**
+     * The same module with only the last helper wrong. Without this the test above would pass on a
+     * table that never reached the far end at all.
+     */
+    @Test
+    void theLastOneIsReportedWhenItIsTheOnlyOneWrong() {
+        List<Diagnostic> found =
+                refusalsFor(BOTH_ENDS_WRONG.replace("let alpha (n) = n", ALPHA_ANNOTATED));
+
+        assertTrue(names(found, "zulu"),
+                "the one that is wrong is the one reported: " + quoted(found));
+    }
+
+    @Test
+    void allEightCompileWhenNoneOfThemIsWrong() {
+        String none = BOTH_ENDS_WRONG
+                .replace("let alpha (n) = n", ALPHA_ANNOTATED)
+                .replace("let zulu (n) = n", ZULU_ANNOTATED);
+
+        assertFalse(Compiler.compile(none).isEmpty(), "the module compiles");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnUnmarkedHelperMayNotReachAPartialOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnUnmarkedHelperMayNotReachAPartialOneTest.java
@@ -1,6 +1,6 @@
 package souther.compiler;
 
-import souther.compiler.check.HelperInliner;
+import souther.compiler.check.HelperNames;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Located;
@@ -516,8 +516,8 @@ class AnUnmarkedHelperMayNotReachAPartialOneTest {
         ValueName.Helper foreign = new ValueName.Helper("maths", "spin");
         ValueName.Helper own = new ValueName.Helper("order", "spin");
 
-        assertEquals("maths.spin", HelperInliner.keyIn("order", foreign));
-        assertEquals("spin", HelperInliner.keyIn("order", own));
+        assertEquals("maths.spin", HelperNames.keyIn("order", foreign));
+        assertEquals("spin", HelperNames.keyIn("order", own));
     }
 
     /** An imported `partial` helper may not be handed over either. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AParameterHidesTheDeclarationItIsNamedLikeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AParameterHidesTheDeclarationItIsNamedLikeTest.java
@@ -1,0 +1,80 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.ast.Ast;
+import souther.compiler.frontend.CstFrontend;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Expanding a recursive helper's own body narrows what its parameters reach, and narrows nothing else.
+ *
+ * <p>A recursive helper is lowered to a method, and its body is expanded with its own parameters in
+ * force. A parameter sharing a declaration's name — {@code List.foldFrom}'s function parameter
+ * {@code step}, in a module that also declares {@code let step} — is a parameter application there and
+ * not a call to that declaration.
+ *
+ * <p>Stated on the table rather than only through a compile, because getting it wrong does not fail:
+ * a table that hid nothing would expand the declaration where the parameter is applied and keep
+ * expanding, and what the author would see is the compile not finishing. A run that never comes back
+ * is not a red test.
+ */
+class AParameterHidesTheDeclarationItIsNamedLikeTest {
+
+    /** A module that declares a helper named like {@code foldFrom}'s function parameter, and folds. */
+    private static final String DECLARES_STEP = """
+            module demo
+
+            data In = { ns: List<Int> }
+            data Out = { n: Int }
+
+            let step (n: Int) : Int = n + 1
+
+            behavior go : (i: In) -> Out
+                constructs Out
+            let go (i) = Out { n = List.fold((acc, x) -> acc + step(x), 0, i.ns) }
+            """;
+
+    private static HelperTable tableOf(String source) {
+        Ast.Module parsed = CstFrontend.parse(source);
+        Ast.Module resolved = Resolve.module(parsed, Symbols.of(parsed));
+        return HelperTable.of(resolved, Map.of(), InliningPolicy.FULL);
+    }
+
+    @Test
+    void aHiddenNameReachesNothingAndTheOthersAreUntouched() {
+        HelperTable table = tableOf(DECLARES_STEP);
+
+        assertNotNull(table.reached("step"), "the module declares it");
+        assertNotNull(table.reached("List.foldFrom"), "and the library declares this");
+
+        HelperTable inside = table.hiding(List.of("step"));
+
+        assertNull(inside.reached("step"), "a parameter named like it hides it");
+        assertNotNull(inside.reached("List.foldFrom"), "and hides nothing else");
+        assertNotNull(table.reached("step"), "the table it was taken from is unchanged");
+    }
+
+    @Test
+    void hidingANameNothingReachesChangesNothing() {
+        HelperTable table = tableOf(DECLARES_STEP);
+
+        assertTrue(table.hiding(List.of("nobodyWroteThis")) == table,
+                "a table narrowed by nothing is the table it was");
+    }
+
+    /** What the narrowing is for: the module above compiles, rather than expanding the declaration
+     * where the fold applies its parameter and never stopping. */
+    @Test
+    void aModuleDeclaringAHelperNamedLikeAFoldsParameterCompiles() {
+        assertFalse(Compiler.compile(DECLARES_STEP).isEmpty());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest.java
@@ -1,0 +1,116 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.TypeName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A body expanded after one that was refused is expanded as if nothing had been refused.
+ *
+ * <p>Expanding is not all-or-nothing to the caller. {@code HelperParams} settles the helpers of a
+ * module one at a time and keeps going past one it cannot read, and {@code TypeChecker} records a
+ * refusal and checks the next unit, so a module reports more than one mistake. Both hand the same
+ * inliner the next body. What the refused expansion had written down by the time it was refused is
+ * therefore still there when the next one starts.
+ *
+ * <p>Nothing states that, and the way it would be found is not a failure but a difference: a body
+ * expanded into a tree that is subtly not the one it would have been. So the two are compared —
+ * one expansion after a refusal, one on its own — and they have to be equal.
+ */
+class AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest {
+
+    /**
+     * {@code applyTwice} hands its function parameter two arguments where the lambda given to it
+     * takes one, so expanding {@code wrong} is refused — after the lambda has been registered under
+     * the binding the expansion made for it, and before the expansion has finished with it.
+     */
+    private static final String MODULE = """
+            module demo
+
+            data X = Int
+
+            let applyTwice (f: (Int) -> Int, n: Int) : Int = f(n, n)
+            let doubled (n: Int) : Int = n * 2
+            let wrong (m: Int) : Int = applyTwice((x) -> x + 1, m)
+            let right (m: Int) : Int = doubled(m) + 1
+
+            behavior f : (x: X) -> X
+            let f (x) = x
+            """;
+
+    private static HelperInliner inliner() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        return HelperInliner.forModule(Resolve.module(parsed, Symbols.of(parsed)));
+    }
+
+    private static Ast.Expr expand(HelperInliner inliner, String helper) {
+        return inliner.inline(inliner.helpers().get(helper).writtenBody(), inliner.bodyOf(helper));
+    }
+
+    @Test
+    void theOneWrittenWrongIsRefused() {
+        assertThrows(CompileException.class, () -> expand(inliner(), "wrong"));
+    }
+
+    @Test
+    void theNextBodyIsExpandedAsThoughTheRefusalHadNotHappened() {
+        HelperInliner afterARefusal = inliner();
+        assertThrows(CompileException.class, () -> expand(afterARefusal, "wrong"));
+        Ast.Expr next = expand(afterARefusal, "right");
+
+        Ast.Expr onItsOwn = expand(inliner(), "right");
+
+        assertEquals(onItsOwn, next,
+                "what the refused expansion left behind changed what came after it");
+    }
+
+    /**
+     * The other half of the same rule. A body can be written into more than once — one writing per
+     * clause of a declaration's invariant, one per argument of a helper being checked — and the two
+     * writings are still two, so what they write are different bindings.
+     */
+    @Test
+    void twoWritingsIntoOneBodyDoNotWriteTheSameBinding() {
+        HelperInliner inliner = inliner();
+        BindingOwner body = new BindingOwner.OfData(new TypeName("demo", "X"));
+        Ast.Expr clause = inliner.helpers().get("right").writtenBody();
+
+        Set<BindingId> first = bindingsOf(inliner.inline(clause, body));
+        Set<BindingId> second = bindingsOf(inliner.inline(clause, body));
+
+        assertFalse(first.isEmpty(), "the expansion writes bindings");
+        assertTrue(Collections.disjoint(first, second),
+                "the second writing wrote the first one's bindings over again: " + first);
+    }
+
+    /** Every binding written inside {@code e}. */
+    private static Set<BindingId> bindingsOf(Ast.Expr e) {
+        Set<BindingId> out = new LinkedHashSet<>();
+        collect(e, out);
+        return out;
+    }
+
+    private static void collect(Ast.Expr e, Set<BindingId> out) {
+        if (e instanceof Ast.LetIn li) {
+            out.add(li.binder().id());
+        }
+        if (e instanceof Ast.Expansion ex) {
+            ex.bound().forEach(b -> out.add(b.binder().id()));
+        }
+        Ast.forEachChild(e, c -> collect(c, out));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/AValueThatReachesItselfIsRefusedOnceAtItsNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AValueThatReachesItselfIsRefusedOnceAtItsNameTest.java
@@ -1,0 +1,130 @@
+package souther.compiler.query;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.Region;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A value defined in terms of itself is refused once, by one owner, at the name it was declared under.
+ *
+ * <p>Which value reaches which is a fact about the module, asked and answered once. It used to be
+ * worked out again by everything that built an expansion table — a body being lowered, a signature
+ * being read, a module being checked — and each of those threw the refusal from wherever it happened
+ * to be standing. So which question reported it, and how many of them did, was decided by the order
+ * the questions happened to run in rather than by anything about the module.
+ *
+ * <p>Both halves are stated here because either can regress on its own. A second, unrelated mistake
+ * must not change the first report: if the cycle is refused from inside a question the second mistake
+ * also reaches, the two are answered as one and the reader is told about the wrong one.
+ */
+class AValueThatReachesItselfIsRefusedOnceAtItsNameTest {
+
+    private static final String CYCLE = """
+            module demo
+
+            data In = { n: Int }
+            data Out = { n: Int }
+
+            let step = step
+
+            behavior go : (i: In) -> Out
+                constructs Out
+            let go (i) = Out { n = i.n + step }
+            """;
+
+    /** The same module with a mistake of its own beside the cycle: a helper multiplying by a string. */
+    private static final String CYCLE_AND_ONE_MORE = """
+            module demo
+
+            data In = { n: Int }
+            data Out = { n: Int }
+
+            let step = step
+
+            let doubled (n: Int) : Int = n * "two"
+
+            behavior go : (i: In) -> Out
+                constructs Out
+            let go (i) = Out { n = doubled(i.n) + step }
+            """;
+
+    private static List<Diagnostic> diagnose(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", source);
+        return Located.diagnosticsOf(Compiler.diagnoseModules(byId, Set.of())).get("a.sou");
+    }
+
+    private static Diagnostic cycleIn(List<Diagnostic> found) {
+        List<Diagnostic> cycles = found.stream()
+                .filter(d -> "check.value.cycle".equals(d.messageKey()))
+                .toList();
+        assertEquals(1, cycles.size(), "one value reaching itself, one refusal: " + found);
+        return cycles.get(0);
+    }
+
+    @Test
+    void aValueReachingItselfIsOneDiagnostic() {
+        List<Diagnostic> found = diagnose(CYCLE);
+
+        assertEquals(1, found.size(), "one mistake, one report: " + found);
+        assertEquals("check.value.cycle", found.get(0).messageKey());
+    }
+
+    @Test
+    void aSecondMistakeBesideItChangesNothingAboutTheFirst() {
+        Diagnostic alone = cycleIn(diagnose(CYCLE));
+        Diagnostic beside = cycleIn(diagnose(CYCLE_AND_ONE_MORE));
+
+        assertEquals(alone.messageKey(), beside.messageKey());
+        assertEquals(List.of(alone.args()), List.of(beside.args()));
+        assertEquals(alone.region(), beside.region(),
+                "the refusal is about `step`, and where `step` is written did not move");
+    }
+
+    /**
+     * A cycle is refused before anything about the module's bodies is worked out, and it stays one
+     * report when it is.
+     *
+     * <p>It has to be refused first: a value is substituted at each of its references, so one that
+     * reaches itself is substituted into itself and there is no body to reach the end of. Nothing
+     * below can be said about a module with one, and the reader is told the one thing that can be.
+     * What this pins is the count — a refusal thrown from wherever an expansion table happened to be
+     * built is thrown once per table, and there are eleven of those.
+     */
+    @Test
+    void nothingElseIsSaidAboutAModuleWithOne() {
+        List<Diagnostic> found = diagnose(CYCLE_AND_ONE_MORE);
+
+        assertTrue(found.stream().anyMatch(d -> "check.value.cycle".equals(d.messageKey())),
+                "the cycle: " + found);
+        assertEquals(1, found.size(), "one refusal, said once: " + found);
+    }
+
+    /**
+     * The underline covers the name and only the name. A refusal about {@code let step} is about
+     * {@code step}; starting it at the {@code let} four columns earlier underlines a keyword the
+     * author did not get wrong, and measuring it in the name rather than in what was written stops it
+     * short wherever a spelling is wider than the name it denotes.
+     */
+    @Test
+    void theRefusalUnderlinesTheNameAndNotTheKeywordInFrontOfIt() {
+        Region region = cycleIn(diagnose(CYCLE)).region();
+
+        assertEquals(region.start().line(), region.end().line(), "a name is one line's worth");
+        assertEquals("let step = step".indexOf("step") + 1, region.start().column(),
+                "the underline starts at the name");
+        assertEquals("step".length(), region.end().column() - region.start().column(),
+                "the underline is as wide as the name");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/NothingExpandsAModuleThatWasNotHandedOverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/NothingExpandsAModuleThatWasNotHandedOverTest.java
@@ -1,0 +1,105 @@
+package souther.compiler.query;
+
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A question that expands a body of a module asks for a module to expand, and gets nothing where
+ * there is none.
+ *
+ * <p>Expanding a value substitutes its definition at each reference, so a value that reaches itself
+ * is substituted into itself: the expansion does not answer, it runs out of stack. What comes back
+ * from that is a report about an expression nesting too deeply, which is about nothing the author
+ * wrote. So the module has to be known to be well founded before anything expands a body of it.
+ *
+ * <p>That was a condition each question stated for itself, and one of the three did not. A condition
+ * a reader has to remember is a condition a reader can forget, and forgetting it is not caught by
+ * compiling a module through the front door: the questions here are asked directly, by name, and
+ * two of the three are not on the path a plain compile takes to a report.
+ *
+ * <p>A row per question that expands. Adding a question that does means adding a row.
+ */
+class NothingExpandsAModuleThatWasNotHandedOverTest {
+
+    /**
+     * A module whose invariant reads a value defined in terms of itself.
+     *
+     * <p>Read from an invariant rather than from a behavior's body, because that is what reaches the
+     * questions about invariants — and those are the ones that read the module directly rather than
+     * through what a body was lowered to.
+     */
+    private static final String CYCLE_UNDER_AN_INVARIANT = """
+            module m.a
+
+            let floor = floor
+
+            data Amount = Int
+                invariant value >= floor
+
+            data In = { n: Int }
+            data Out = { n: Int }
+
+            behavior go : (i: In) -> Out
+                constructs Out
+            let go (i) = Out { n = i.n }
+            """;
+
+    /** The same module with the value defined as a value, so every question below answers. */
+    private static final String WELL_FOUNDED =
+            CYCLE_UNDER_AN_INVARIANT.replace("let floor = floor", "let floor = 0");
+
+    /** Each question that expands a body of a module, by the answer it is asked for. */
+    private static final Map<String, Function<String, Key<?>>> EXPANDING = Map.of(
+            "the derived module", Shapes.Derived::new,
+            "the invariants the discharge analysis reads", Shapes.InvariantsForDischarge::new,
+            "what each clause of an invariant can be discharged by", Shapes.InvariantCapabilities::new,
+            "the module a body is prepared from", Shapes.Prepared::new,
+            "one body as the backend emits it", name -> new Bodies.LoweredBody(name, "go"));
+
+    private static Db dbFor(String source) {
+        return Compilation.ofDocuments(Map.of("a.sou", source), Set.of(), ModulePath.EMPTY).db();
+    }
+
+    @Test
+    void noneOfThemExpandsAModuleWhoseValuesAreNotWellFounded() {
+        Db db = dbFor(CYCLE_UNDER_AN_INVARIANT);
+        for (Map.Entry<String, Function<String, Key<?>>> asked : EXPANDING.entrySet()) {
+            assertFalse(db.ask(asked.getValue().apply("m.a")).present(),
+                    asked.getKey() + " was answered for a module with a value reaching itself");
+        }
+    }
+
+    @Test
+    void allOfThemAnswerWhenTheyAre() {
+        Db db = dbFor(WELL_FOUNDED);
+        for (Map.Entry<String, Function<String, Key<?>>> asked : EXPANDING.entrySet()) {
+            assertTrue(db.ask(asked.getValue().apply("m.a")).present(),
+                    asked.getKey() + " went absent on a module with nothing wrong with it");
+        }
+    }
+
+    /**
+     * And the refusal is still one report, said by the one question that owns it. The others are
+     * absent for its reason rather than for one of their own.
+     */
+    @Test
+    void theRefusalIsTheOneTheOwnerSaid() {
+        Db db = dbFor(CYCLE_UNDER_AN_INVARIANT);
+        EXPANDING.values().forEach(key -> db.ask(key.apply("m.a")));
+
+        List<Report> reports = db.ask(new Shapes.Expandable("m.a")).reports();
+        assertFalse(reports.isEmpty(), "the question that owns the rule says what is wrong");
+        assertTrue(reports.stream().anyMatch(r -> r.diagnostic() != null
+                        && "check.value.cycle".equals(r.diagnostic().messageKey())),
+                "and says it as a value cycle: " + reports);
+    }
+}


### PR DESCRIPTION
`HelperInliner` was 2015 lines and the most-changed file in the compiler — 73 of the last 400 commits.
Reading those commit subjects, most of them are the same defect coming back rather than new work.
The cause is that one object held three kinds of state with three different lifetimes: facts about the
module, the frame one body is expanded in, and the substitution one call writes. What lived on it
followed from that rather than from what it does.

Each of the five commits takes one of those apart. Nothing about the language changes.

## What moves out

`HelperNames` answers how a definition is named outside the module that declares it, and carries the
marks a body takes with it. `HelperInvariants` answers what a declaration's invariant becomes, in both
representations that read one, and settles once for the two rather than once each. Neither reads an
expansion table.

## What changes hands

A value reaching itself was refused wherever an expansion table was built, which is eleven places in a
compile — so the refusal came from whichever ran first, and a question that does not expect a refusal
from a table it is merely building passed it on as a failure of its own. `Bodies.RecursiveHelpers`
had no `try` around it at all, so the refusal left `compute` as a thrown exception rather than as an
absent answer. It is now `Shapes.NoValueReachesItself`, asked by name by the two questions that expand
a body. It underlines the name the value was declared under rather than the `let` in front of it.

## What is asked once

The table a body is expanded against, and the call graph over it, are facts about the module's
declarations. Both were rebuilt by every expansion — walking each of the standard library's hundred
and thirty-odd bodies again each time. They are `HelperTable` and `HelperGraph` now, held by
`Bodies.Expanding` and keyed by the policy as well as the module, because the two policies are two
tables and one answer shared by both would put the fold that `List.map` is into the tree the discharge
rules read.

Type checking is shorter for it. On the bench corpora, median of twenty walks: crm 26.3 → 22.7 ms,
issuetracker 3.8 → 3.2 ms.

## What was two and is one

Three pairs held one fact between them: a substituted parameter (a name, and what the name means — with
a run-time check standing between the two maps to catch one being written without the other), a scoped
lambda (a body, and where the author wrote it), and what one call writes for its arguments (counted
twice, once as a list and once as the keys of the map beside it). The renaming a copy carries travels
as one value too, so the rule about which position a rebuilt node takes is written once rather than at
every node kind.

The four things true only while a body is being expanded are one `Writing`, made whole when one starts
and dropped when it ends — refused or not. Expanding can no longer be asked for without saying which
body it is written into, so the run-time check that said so is gone.

## What was found on the way

Two defects turned up that were not what the work set out to do, and both are fixed here.

The number an expansion is written under came from one counter for the whole pass, but a pass expands
many bodies. A body's bindings moved when a body beside it gained an expansion — or lost one to a
refusal — and a query answer that moves is a query answer everything below it is recomputed for.
`BindingOwner.Expansion` says of its own ordinal that expanding something elsewhere moves nothing here;
it did. Counted per body now. Not per writing either: two writings can share one body, and a count that
restarted with each was already handing the second the first one's bindings, from a hardcoded zero.

## Tests

Five new test classes, thirteen tests, each stating a rule rather than pinning a symptom.

- a value reaching itself is one refusal, at the name, and a second mistake beside it changes nothing about it
- a module is told about its helpers in the order it wrote them — the table's order decides which report the author reads, and nothing made that true
- a parameter hides the declaration it is named like, and hides nothing else
- a body expanded after a refusal is what it would have been, and two writings into one body do not write the same binding

Three of those exist because the way the rule breaks is not a red test. Hiding nothing does not fail,
it fails to finish. A counter shared across bodies does not fail, it moves an answer.

Every step was checked with a mutant that has to make a named test fail. Two of the mutants the plan
predicted did not: substituting a parameter's spelling while keeping its denotation survives the whole
suite, because spelling decides nothing (which is what ADR-0067 was for), and a scoped lambda outliving
its writing is unobservable once bindings are numbered per body.

## Verification

`mvn clean verify` green at every commit: compiler 2881, LSP 166, runtime 109, syntax 109.
`souther-examples` builds green against this branch — through a split local repository, so the shared
`~/.m2` was not written to.

Follow-up, not in this PR: the table is still keyed by a string that `HelperNames.keyIn` builds, and
its own javadoc says the spelling is a key only after `qualifyImports` has run. `TotalityChecker:57`
tells an injected prelude helper from a module-own one by looking for a dot in that string, so a
module-own helper with a dot in its name would skip the totality check. I will file that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
