### PR TITLE
A field written after a spread takes the key back out when it is None

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -875,7 +875,10 @@ public final class FixtureReader {
                     neutral.shapeOf(declared.get(fi.name())));
             // `None` on a `T?` field yields a null; leave the key out so the optional decoder reads
             // it as absent (spec 8, absent -> None), the same neutral form as omitting the field.
+            // A spread already wrote the field, so leaving the key out means taking it back out —
+            // not writing nothing, which would leave what the spread copied standing.
             if (v == null) {
+                map.remove(fi.name());
                 continue;
             }
             map.put(fi.name(), v);

--- a/souther-compiler/src/test/java/souther/compiler/ExampleSpreadFixtureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ExampleSpreadFixtureTest.java
@@ -245,4 +245,68 @@ class ExampleSpreadFixtureTest {
                     | "an extra field is not copied" : (narrow) -> Answer { label = "x" }
                 """));
     }
+
+    private static final String NOTES = """
+            module demo
+
+            data Note   = { body: String, tag: String? }
+            data Answer = { label: String }
+
+            let tagged = Note { body = "b", tag = "t" }
+
+            behavior tagOf : (n: Note) -> Answer
+                constructs Answer
+
+            let tagOf (n) =
+                match n.tag with
+                    | Some t -> Answer { label = t }
+                    | None   -> Answer { label = "none" }
+
+            behavior clearTag : (n: Note) -> Note
+                constructs Note
+
+            let clearTag (n) = Note { ...n, tag = None }
+            """;
+
+    @Test
+    void anOverrideToNoneSurvivesTheSpread() {
+        assertDoesNotThrow(() -> Compiler.compile(NOTES + """
+
+                example tagOf
+                    | "None written after a spread that brought a value"
+                        : (Note { ...tagged, tag = None }) -> Answer { label = "none" }
+                """));
+    }
+
+    @Test
+    void aSpreadDoesNotSupplyTheValueAnOverrideToNoneTookAway() {
+        // The row above holds because the override took, not because both sides drop it: written the
+        // other way — the value the spread brought — the same input must not hold.
+        assertThrows(CompileException.class, () -> Compiler.compile(NOTES + """
+
+                example tagOf
+                    | "the spread's value is gone"
+                        : (Note { ...tagged, tag = None }) -> Answer { label = "t" }
+                """));
+    }
+
+    @Test
+    void anExpectedValueOverriddenToNoneIsTheAbsentOptional() {
+        assertDoesNotThrow(() -> Compiler.compile(NOTES + """
+
+                example clearTag
+                    | "the expected side writes the override the input side does"
+                        : (tagged) -> Note { ...tagged, tag = None }
+                """));
+    }
+
+    @Test
+    void anExpectedValueThatKeepsTheSpreadsValueDoesNotHold() {
+        assertThrows(CompileException.class, () -> Compiler.compile(NOTES + """
+
+                example clearTag
+                    | "an expectation still carrying the tag"
+                        : (tagged) -> Note { ...tagged }
+                """));
+    }
 }


### PR DESCRIPTION
Fixes #361.

## What was wrong

`FixtureReader.record()` builds the neutral form a fixture's decoder reads. An absent optional is a key that is not there (spec 8, absent -> None), and the reader wrote that by *not writing the key*: a field init whose value came out null did `continue` instead of `map.put`.

Not writing a key is only the same as leaving it out when nothing has written it. A spread writes one first — the reader copies every field of the spread source into the map, then walks the inits over the top. So `Note { ...tagged, tag = None }` kept `tagged`'s `tag`.

Both sides of a row go through this, and so does the adequacy report. That is why the failure is silent in the shape the issue describes: a row whose expectation spreads the same source drops the override on both sides, the two sides agree with each other, and the row is green without ever exercising `None`.

## Why it is only the fixture path

`codegen/BodyGen` decides one declared field at a time — the explicit init if there is one, the spread otherwise — so an override wins by construction. `FixtureReader` accumulates instead: spreads first, inits over them. An accumulating writer that means to leave a key out has to take it out.

The fix is `map.remove(fi.name())` before the `continue`.

## Tests

Four rows in `ExampleSpreadFixtureTest`, covering the input side and the expected side. Three of them fail without the `map.remove` (checked by reverting it). The fourth is the other half of a pair: it asserts that an expectation still carrying the spread's value does *not* hold, which is what shows the first row is not green for both readings at once.

`mvn clean test` is green across all modules.