### PR TITLE
An optional field reads None from a written null, not only from an absent key

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -79,7 +79,7 @@ final class CodecGen {
 
     private static MethodTypeDesc srcFieldMtd(Src s) { return s == Src.JOOQ ? MTD_fieldJooq : MTD_field; }
 
-    private static MethodTypeDesc srcOptFieldMtd(Src s) { return s == Src.JOOQ ? MTD_optFieldJooq : MTD_optionalField; }
+    private static MethodTypeDesc srcNullableFieldMtd(Src s) { return s == Src.JOOQ ? MTD_nullableFieldJooq : MTD_nullableField; }
 
     /** Leaf value decoders: JSON reads a JsonNode, the map/jOOQ column value is an Object. */
     private static ClassDesc srcLeafOwner(Src s) { return s == Src.JSON ? CD_JsonDecoders : CD_ObjectDecoders; }
@@ -1041,7 +1041,7 @@ final class CodecGen {
             code.loadConstant(bind.key());
             if (bind.ref() instanceof Ast.OptionDecRef opt) {
                 emitDecoderObject(code, opt.element(), src);
-                code.invokestatic(srcFieldOwner(src), "optionalField", srcOptFieldMtd(src));
+                code.invokestatic(srcFieldOwner(src), "nullableField", srcNullableFieldMtd(src));
             } else {
                 emitDecoderObject(code, bind.ref(), src);
                 code.invokestatic(srcFieldOwner(src), "field", srcFieldMtd(src));
@@ -1089,8 +1089,7 @@ final class CodecGen {
             code.checkcast(CD_ROk);
             code.invokevirtual(CD_ROk, "value", MTD_Object);
             if (bind.ref() instanceof Ast.OptionDecRef) {
-                code.checkcast(CD_JavaOptional);
-                code.invokestatic(CD_Option, "ofOptional", MTD_ofOptional, true);
+                code.invokestatic(CD_Option, "ofNullable", MTD_ofNullable, true);
                 int vSlot = gen.slot(t);
                 code.astore(vSlot);
                 gen.bind(bind.binder(), vSlot, t);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
@@ -275,7 +275,7 @@ final class Descriptors {
     static final MethodTypeDesc MTD_leafDecimal = MethodTypeDesc.of(CD_DecimalDecoder);
     static final MethodTypeDesc MTD_leafTemporal = MethodTypeDesc.of(CD_TemporalDecoder);
     static final MethodTypeDesc MTD_field = MethodTypeDesc.of(CD_CombinePart, CD_String, CD_RDecoder);
-    static final MethodTypeDesc MTD_optionalField = MethodTypeDesc.of(CD_CombinePart, CD_String, CD_RDecoder);
+    static final MethodTypeDesc MTD_nullableField = MethodTypeDesc.of(CD_CombinePart, CD_String, CD_RDecoder);
     /** {@code CombinePart}'s own decode, and the conversion for a position that wants a decoder. */
     static final MethodTypeDesc MTD_partDecode = MethodTypeDesc.of(CD_RResult, CD_Object, CD_RPath);
     static final MethodTypeDesc MTD_asDecoder = MethodTypeDesc.of(CD_RDecoder);
@@ -387,15 +387,14 @@ final class Descriptors {
     static final MethodTypeDesc MTD_Issues_isEmpty = MethodTypeDesc.of(ConstantDescs.CD_boolean);
     static final MethodTypeDesc MTD_Err_issues = MethodTypeDesc.of(CD_RIssues);
     static final MethodTypeDesc MTD_nested = MethodTypeDesc.of(CD_RDecoder, CD_RDecoder);
-    static final ClassDesc CD_JavaOptional = ClassDesc.of("java.util.Optional");
-    static final MethodTypeDesc MTD_ofOptional = MethodTypeDesc.of(CD_Option, CD_JavaOptional);
+    static final MethodTypeDesc MTD_ofNullable = MethodTypeDesc.of(CD_Option, CD_Object);
     static final MethodTypeDesc MTD_error = MethodTypeDesc.of(CD_Object);
     // Per-source (JSON / jOOQ) decode targets (spec 10.6). Every source's `field` answers a
     // `CombinePart`; the three differ only in the input type they read, which is erased.
     static final ClassDesc CD_JooqRecordDecoder = ClassDesc.of("net.unit8.raoh.jooq.JooqRecordDecoder");
     static final MethodTypeDesc MTD_fieldJooq =
             MethodTypeDesc.of(CD_CombinePart, CD_String, CD_RDecoder);
-    static final MethodTypeDesc MTD_optFieldJooq =
+    static final MethodTypeDesc MTD_nullableFieldJooq =
             MethodTypeDesc.of(CD_CombinePart, CD_String, CD_RDecoder);
 
     // Value-equality / hashCode targets, shared by the value-class equality codegen and `==`. The

--- a/souther-compiler/src/test/java/souther/compiler/OptionalFieldReadsAWrittenNullTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/OptionalFieldReadsAWrittenNullTest.java
@@ -1,0 +1,158 @@
+package souther.compiler;
+
+import net.unit8.raoh.Err;
+import net.unit8.raoh.Ok;
+import net.unit8.raoh.Result;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.jooq.Field;
+import org.jooq.Record;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code T?} field is {@code None} when the key is absent <em>and</em> when a value is written for
+ * it that says there is none (spec 10.6): a JSON {@code null}, a map entry holding a null, a record
+ * whose column is NULL. Only a value of some other shape is a failure.
+ *
+ * <p>A decoder is generated once per source, so a rule about reading holds or fails per source, and
+ * it read a written null as a value to be decoded — the element decoder was handed it and reported
+ * the field as required, which is what an optional field never is (issue #362). The rule was stated
+ * in the specification, in two comments and in the javadoc of the test beside this one, and asserted
+ * nowhere; every source is here so that the next source, or the next combinator, is not a fourth
+ * place to state it.
+ */
+class OptionalFieldReadsAWrittenNullTest {
+
+    @TempDir
+    Path dir;
+
+    private static final String MODULE = """
+            module demo
+
+            data Id = String
+            data Trip = { id: Id, approver: Id? }
+            """;
+
+    private final JsonMapper mapper = JsonMapper.builder().build();
+
+    private BytesClassLoader loader() {
+        return new BytesClassLoader(Compiler.compile(MODULE), getClass().getClassLoader());
+    }
+
+    private static Object approverOf(Result<?> r) throws Exception {
+        Object trip = ((Ok<?>) r).value();
+        return trip.getClass().getMethod("approver").invoke(trip);
+    }
+
+    // === the three generated decoders ===
+
+    @Test
+    void theNeutralDecoderReadsANullEntryAsNone() throws Exception {
+        BytesClassLoader loader = loader();
+        Map<String, Object> raw = new HashMap<>();
+        raw.put("id", "t-1");
+        raw.put("approver", null);
+
+        Result<?> r = Codecs.decode(loader, "demo.Trip", raw);
+
+        assertInstanceOf(Ok.class, r, "an entry written null is None, not a failure");
+        assertEquals("None", approverOf(r).getClass().getSimpleName());
+        Map<?, ?> out = (Map<?, ?>) Codecs.encode(loader, "demo.Trip", ((Ok<?>) r).value());
+        assertFalse(out.containsKey("approver"), "and it encodes back as an omitted key");
+    }
+
+    @Test
+    void theJsonDecoderReadsANullValueAsNone() throws Exception {
+        JsonNode node = mapper.readTree("{\"id\":\"t-1\",\"approver\":null}");
+
+        Result<?> r = Codecs.decode(loader(), "demo.Trip", "jsonDecoder", node);
+
+        assertInstanceOf(Ok.class, r, "a JSON null is None, not a failure");
+        assertEquals("None", approverOf(r).getClass().getSimpleName());
+    }
+
+    @Test
+    void theRecordDecoderReadsANullColumnAsNone() throws Exception {
+        Field<String> id = DSL.field(DSL.name("id"), String.class);
+        Field<String> approver = DSL.field(DSL.name("approver"), String.class);
+        Record record = DSL.using(SQLDialect.DEFAULT).newRecord(id, approver);
+        record.set(id, "t-1");
+        record.set(approver, null);
+
+        Result<?> r = Codecs.decode(loader(), "demo.Trip", "recordDecoder", record);
+
+        assertInstanceOf(Ok.class, r, "a NULL column is None, not a failure");
+        assertEquals("None", approverOf(r).getClass().getSimpleName());
+    }
+
+    // === what is still a failure, and what it says ===
+
+    @Test
+    void aValueOfAnotherShapeStillFailsAndSaysWhatItWanted() throws Exception {
+        JsonNode node = mapper.readTree("{\"id\":\"t-1\",\"approver\":42}");
+
+        Result<?> r = Codecs.decode(loader(), "demo.Trip", "jsonDecoder", node);
+
+        Err<?> err = assertInstanceOf(Err.class, r, "a number is not a value this field can hold");
+        String message = err.issues().asList().getFirst().message();
+        assertTrue(message.contains("string"), message);
+        assertFalse(message.contains("required"),
+                "an optional field is never required, so it must not be told it is");
+    }
+
+    @Test
+    void aRequiredFieldWrittenNullIsStillRequired() throws Exception {
+        JsonNode node = mapper.readTree("{\"id\":null,\"approver\":\"e-9\"}");
+
+        Result<?> r = Codecs.decode(loader(), "demo.Trip", "jsonDecoder", node);
+
+        Err<?> err = assertInstanceOf(Err.class, r, "`id` has no `?`, so a null is not a value for it");
+        assertTrue(err.issues().asList().getFirst().message().contains("required"),
+                "the message optional fields must not get is the one a required field does get");
+    }
+
+    // === end to end, the way it was reported ===
+
+    @Test
+    void runReadsANullOptionalFromTheInput() throws Exception {
+        Path file = dir.resolve("opt.sou");
+        Files.writeString(file, """
+                module opt
+
+                data Note = { body: String, tag: String? }
+
+                behavior echo : (n: Note) -> Note
+
+                let echo (n) = n
+                """);
+
+        assertEquals("{\"body\":\"b\"}",
+                Runner.run(file, "echo", "{\"body\":\"b\",\"tag\":null}").trim());
+        assertEquals("{\"body\":\"b\"}",
+                Runner.run(file, "echo", "{\"body\":\"b\"}").trim(),
+                "an absent key answers the same, which is what makes the two one case");
+        assertEquals("{\"body\":\"b\",\"tag\":\"t\"}",
+                Runner.run(file, "echo", "{\"body\":\"b\",\"tag\":\"t\"}").trim());
+
+        RuntimeException e = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "echo", "{\"body\":\"b\",\"tag\":42}"));
+        assertFalse(e.getMessage().contains("is required"), e.getMessage());
+    }
+}

--- a/souther-runtime/src/main/java/souther/runtime/Option.java
+++ b/souther-runtime/src/main/java/souther/runtime/Option.java
@@ -40,10 +40,12 @@ public sealed interface Option<T> permits Option.Some, Option.None {
         return (Option<T>) NONE;
     }
 
-    /** Bridges a {@code java.util.Optional} (as produced by a Raoh optional-field decoder) to
-     * the Souther {@code Option}. Called by generated decode bodies for {@code ?} fields. */
-    static <T> Option<T> ofOptional(java.util.Optional<T> o) {
-        return o.isPresent() ? new Some<>(o.get()) : none();
+    /** Bridges the value a Raoh nullable-field decoder lands on to the Souther {@code Option}.
+     * Called by generated decode bodies for {@code ?} fields. A {@code ?} field is {@code None} for
+     * an absent key and for a written {@code null} alike, and that decoder answers both with a
+     * null. */
+    static <T> Option<T> ofNullable(T value) {
+        return value == null ? none() : new Some<>(value);
     }
 
     default boolean isPresent() {

--- a/souther-runtime/src/main/java/souther/runtime/Option.java
+++ b/souther-runtime/src/main/java/souther/runtime/Option.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * The optional type from spec section 7.3: {@code Some(T)} or {@code None}.
  *
@@ -43,8 +45,8 @@ public sealed interface Option<T> permits Option.Some, Option.None {
     /** Bridges the value a Raoh nullable-field decoder lands on to the Souther {@code Option}.
      * Called by generated decode bodies for {@code ?} fields. A {@code ?} field is {@code None} for
      * an absent key and for a written {@code null} alike, and that decoder answers both with a
-     * null. */
-    static <T> Option<T> ofNullable(T value) {
+     * null — so this is one of the places the package says admit a null, and it says so. */
+    static <T> Option<T> ofNullable(@Nullable T value) {
         return value == null ? none() : new Some<>(value);
     }
 


### PR DESCRIPTION
Fixes #362. The specification is what holds: `T?` is `None` for an absent key **and** for a written `null`.

## What was wrong

`CodecGen.emitObjectDecode` emitted Raoh's `optionalField` for a `T?` field. That combinator answers *is the key there* — absent gives `Optional.empty()`, present hands the value to the element decoder:

```java
// raoh-json JsonDecoders.java:283-294
var node = in.get(name);
if (node == null || node.isMissingNode()) return Result.ok(Optional.empty());
return dec.decode(node, fieldPath).map(Optional::of);   // a NullNode arrives here
```

A JSON `null` is present, so it reached `string()`, which has no `None` to answer with and failed `required`. The `is required` text the report calls out is Raoh's, from the element decoder that should never have been handed the value; only the `/tag: ` prefix is ours.

Raoh separates the three readings deliberately — `optionalField` → `Optional` (about the key), `optionalNullableField` → `Presence` (keeps absent apart from present-null), `nullableField` → collapses both to a null. The third is what the specification describes, and `Option` has no third state to lose by it. The one that was picked is the one whose name matches the concept's name.

## The change

Emit `nullableField` and bridge with a new `Option.ofNullable` instead of `Option.ofOptional`. All three sources are affected the same way and all three are changed: a JSON `null`, a map entry holding a null, and a NULL column. The now-dead `ofOptional` / `MTD_ofOptional` / `CD_JavaOptional` go, and the descriptors are renamed to the combinator that is emitted.

Nothing says `is required` about an optional field any more. A value of another shape still fails and still says what it wanted (`expected string`), and a *required* field written `null` still gets `is required`.

## Tests

`OptionalFieldReadsAWrittenNullTest` — one row per generated decoder, because the bug was per decoder, plus the end-to-end `souther run` case as reported. Reverting the codegen change fails four of the six; the two that survive are the guards on what did **not** change.

The rule was already written in `specification.adoc:1252`, in two comments in `FixtureReader`, and in the javadoc of `CompileOptionalFieldTest` ("An absent (or null) key decodes to `None`") — and asserted nowhere. `DecoderPathAgreementTest`, which exists to catch exactly this drift, has no `Option` row: it is keyed by type and `T?` is only a field. That is why the new rows are their own class rather than a row there.

`mvn clean test` is green across all modules (2894 in the compiler).