### PR TITLE
How --input is cut into arguments is answered by the parameter types

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -185,12 +185,8 @@ public final class Runner {
         Sig sig = sigs.get(spec.name());
         List<Type> ins = sig.ins();
 
-        JsonNode[] rawArgs = splitInput(spec.name(), ins.size(), inputJson);
         MemoryClassLoader loader = new MemoryClassLoader(classes, Runner.class.getClassLoader());
-        Object[] args = new Object[ins.size()];
-        for (int i = 0; i < ins.size(); i++) {
-            args[i] = decode(loader, module.name(), ins.get(i), rawArgs[i], i);
-        }
+        Object[] args = decodeInputs(loader, module.name(), spec.name(), ins, inputJson);
 
         Object result = invoke(loader, module.name(), spec.name(), args);
         Object encoded = encodeOutput(loader, module.name(), spec.name(), sig.out(), result);
@@ -364,9 +360,22 @@ public final class Runner {
 
     // --- input --------------------------------------------------------------------------------
 
-    private static JsonNode[] splitInput(String name, int arity, String inputJson) {
+    /**
+     * The behavior's arguments, read from {@code --input}.
+     *
+     * <p>How the text is cut into arguments is not a question the syntax answers. From two inputs up
+     * it is: the text is a JSON array of that length, positionally, and an array of another length or
+     * no array at all is refused by arity alone. A single input is written as it stands, and there the
+     * same text has two readings — for {@code (xs: List<Int>)}, {@code [1,2,3]} is the argument, and
+     * {@code [[1,2,3]]} is the argument written inside the argument array the two-input form takes.
+     * Arity cannot tell them apart; only decoding against the parameter type can. So the split and the
+     * decode are one step, taken with the types in hand.
+     */
+    private static Object[] decodeInputs(MemoryClassLoader loader, String pkg, String name,
+                                         List<Type> ins, String inputJson) {
+        int arity = ins.size();
         if (arity == 0) {
-            return new JsonNode[0];
+            return new Object[0];
         }
         if (inputJson == null) {
             throw usage("run.input.missing", "`" + name + "` takes " + arity + " input"
@@ -374,7 +383,7 @@ public final class Runner {
         }
         JsonNode tree = parseJson(inputJson);
         if (arity == 1) {
-            return new JsonNode[] {tree};
+            return new Object[] {decodeSoleInput(loader, pkg, ins.get(0), tree)};
         }
         if (!tree.isArray()) {
             throw fail("run.input.notarray", "`" + name + "` takes " + arity
@@ -384,11 +393,42 @@ public final class Runner {
             throw fail("run.input.count", "`" + name + "` takes " + arity + " inputs, but --input has "
                     + tree.size(), name, arity, tree.size());
         }
-        JsonNode[] args = new JsonNode[arity];
+        Object[] args = new Object[arity];
         for (int i = 0; i < arity; i++) {
-            args[i] = tree.get(i);
+            args[i] = decode(loader, pkg, ins.get(i), tree.get(i), i);
         }
         return args;
+    }
+
+    /**
+     * The sole input, read as it stands — and only when that fails, read again as the value a
+     * one-element array wraps.
+     *
+     * <p>The order is what makes the second reading safe: an input that is an array in its own right
+     * decodes on the first attempt and never reaches it. Being an array is not the mistake; failing as
+     * the value while succeeding as the array's sole element is. When the element fails too, the input
+     * is wrong for some other reason and the decoder's own report is what says so.
+     */
+    private static Object decodeSoleInput(MemoryClassLoader loader, String pkg, Type type, JsonNode tree) {
+        try {
+            return decode(loader, pkg, type, tree, 0);
+        } catch (RunException asWritten) {
+            if (tree.isArray() && tree.size() == 1 && decodes(loader, pkg, type, tree.get(0))) {
+                throw fail("run.input.wrapped", "This behavior has one parameter. Pass its value"
+                        + " directly to --input; remove the outer array.");
+            }
+            throw asWritten;
+        }
+    }
+
+    /** Whether {@code raw} decodes as {@code type}, asked without reporting anything. */
+    private static boolean decodes(MemoryClassLoader loader, String pkg, Type type, JsonNode raw) {
+        try {
+            decode(loader, pkg, type, raw, 0);
+            return true;
+        } catch (RunException _) {
+            return false;
+        }
     }
 
     // --- decode / encode ----------------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -1032,8 +1032,72 @@ final class CodecGen {
         emitConstructCall(code, gen, cdName, dec.result(), fields);
     }
 
+    /**
+     * Emits the JSON decoder's shape check: the node this decoder was handed either holds an object
+     * or it does not, and that is one fact about one node, reported at that node.
+     *
+     * <p>Without it the fields answer it one at a time. {@code JsonDecoders.field} reads its name out
+     * of the node it is given and rejects a node that is not an object — at the field's own path, once
+     * per field — so a node of the wrong shape becomes one report per declared field, each naming a
+     * field the author wrote correctly, and a nested one lands on the record's first field instead of
+     * the record. A data whose fields are all optional went the other way and decoded, since an absent
+     * field is what {@code nullableField} makes of a node it cannot read.
+     *
+     * <p>Only the JSON source needs it. The neutral decoder is handed a {@code Map} by its own
+     * signature, and a nested one is bridged through {@code MapDecoders.nested}, which asks the same
+     * question at the same place; a jOOQ {@code Record} is a row and has no other shape to be.
+     */
+    private void emitObjectGuard(CodeBuilder code, BodyGen gen, Src src) {
+        if (src != Src.JSON) {
+            return;
+        }
+        int node = gen.slot(Type.STRING);
+        Label required = code.newLabel();
+        Label ok = code.newLabel();
+        code.aload(1);
+        code.ifnull(required);
+        code.aload(1);
+        code.checkcast(CD_JsonNode);
+        code.astore(node);
+        code.aload(node);
+        code.invokevirtual(CD_JsonNode, "isNull", MTD_nodePredicate);
+        code.ifne(required);
+        code.aload(node);
+        code.invokevirtual(CD_JsonNode, "isMissingNode", MTD_nodePredicate);
+        code.ifne(required);
+        code.aload(node);
+        code.invokevirtual(CD_JsonNode, "isObject", MTD_nodePredicate);
+        code.ifne(ok);
+
+        code.aload(2);                                            // path
+        code.loadConstant("type_mismatch");
+        code.loadConstant("expected object");
+        code.loadConstant("expected");
+        code.loadConstant("object");
+        code.loadConstant("actual");
+        code.aload(node);
+        code.invokevirtual(CD_JsonNode, "getNodeType", MTD_getNodeType);
+        code.invokevirtual(CD_JsonNodeType, "name", MTD_enumName);
+        code.getstatic(CD_Locale, "ROOT", CD_Locale);
+        code.invokevirtual(CD_String, "toLowerCase", MTD_toLowerCase);
+        code.invokestatic(CD_Map, "of",
+                MethodTypeDesc.of(CD_Map, CD_Object, CD_Object, CD_Object, CD_Object), true);
+        code.invokestatic(CD_RResult, "fail", MTD_Rfail4, true);
+        code.areturn();
+
+        code.labelBinding(required);
+        code.aload(2);
+        code.loadConstant("required");
+        code.loadConstant("is required");
+        code.invokestatic(CD_RResult, "fail", MTD_Rfail, true);
+        code.areturn();
+
+        code.labelBinding(ok);
+    }
+
     private void emitObjectDecode(CodeBuilder code, BodyGen gen, ClassDesc cdName, Ast.ObjectDecoder obj,
                                   Map<String, Type> fields, Src src) {
+        emitObjectGuard(code, gen, src);
         List<Ast.Bind> binds = obj.binds();
         int[] resultSlots = new int[binds.size()];
         for (int i = 0; i < binds.size(); i++) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -287,6 +287,8 @@ final class CodecGen {
             // discriminator key of the source, each case dispatches to that case's decoder for the
             // same source (spec 10.3). discriminate/variant are the core (input-generic) combinators.
             cb.withMethodBody("decode", MTD_Rdecode, ClassFile.ACC_PUBLIC, code -> {
+                // this=0, in=1, path=2, so 3 is the first free slot for the guard to hold the node in.
+                emitObjectGuard(code, src, 3);
                 code.loadConstant(disc.key());
                 code.loadConstant(disc.key());
                 emitStringLeaf(code, srcLeafOwner(src));
@@ -1043,15 +1045,20 @@ final class CodecGen {
      * the record. A data whose fields are all optional went the other way and decoded, since an absent
      * field is what {@code nullableField} makes of a node it cannot read.
      *
+     * <p>A sum is read as an object too — its discriminator is a field — so it asks the same question
+     * in the same place. Left to the discriminator, the mismatch is blamed on the discriminator key,
+     * the one field of the object the author never writes.
+     *
      * <p>Only the JSON source needs it. The neutral decoder is handed a {@code Map} by its own
      * signature, and a nested one is bridged through {@code MapDecoders.nested}, which asks the same
      * question at the same place; a jOOQ {@code Record} is a row and has no other shape to be.
+     *
+     * @param node a free local slot, which the guard holds the cast node in
      */
-    private void emitObjectGuard(CodeBuilder code, BodyGen gen, Src src) {
+    private void emitObjectGuard(CodeBuilder code, Src src, int node) {
         if (src != Src.JSON) {
             return;
         }
-        int node = gen.slot(Type.STRING);
         Label required = code.newLabel();
         Label ok = code.newLabel();
         code.aload(1);
@@ -1097,7 +1104,7 @@ final class CodecGen {
 
     private void emitObjectDecode(CodeBuilder code, BodyGen gen, ClassDesc cdName, Ast.ObjectDecoder obj,
                                   Map<String, Type> fields, Src src) {
-        emitObjectGuard(code, gen, src);
+        emitObjectGuard(code, src, gen.slot(Type.STRING));
         List<Ast.Bind> binds = obj.binds();
         int[] resultSlots = new int[binds.size()];
         for (int i = 0; i < binds.size(); i++) {

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Descriptors.java
@@ -240,6 +240,14 @@ final class Descriptors {
     static final ClassDesc CD_ObjectDecoders = ClassDesc.of("net.unit8.raoh.decode.ObjectDecoders");
     static final ClassDesc CD_MapDecoders = ClassDesc.of("net.unit8.raoh.decode.map.MapDecoders");
     static final ClassDesc CD_JsonDecoders = ClassDesc.of("net.unit8.raoh.json.JsonDecoders");
+    /** Jackson's node, which a JSON decoder reads: the shape it holds is asked of the node itself. */
+    static final ClassDesc CD_JsonNode = ClassDesc.of("tools.jackson.databind.JsonNode");
+    static final ClassDesc CD_JsonNodeType = ClassDesc.of("tools.jackson.databind.node.JsonNodeType");
+    static final ClassDesc CD_Locale = ClassDesc.of("java.util.Locale");
+    static final MethodTypeDesc MTD_nodePredicate = MethodTypeDesc.of(ConstantDescs.CD_boolean);
+    static final MethodTypeDesc MTD_getNodeType = MethodTypeDesc.of(CD_JsonNodeType);
+    static final MethodTypeDesc MTD_enumName = MethodTypeDesc.of(CD_String);
+    static final MethodTypeDesc MTD_toLowerCase = MethodTypeDesc.of(CD_String, CD_Locale);
     static final ClassDesc CD_JooqDecoders = ClassDesc.of("net.unit8.raoh.jooq.JooqRecordDecoders");
     static final ClassDesc CD_RDecoders = ClassDesc.of("net.unit8.raoh.decode.Decoders");
     static final ClassDesc CD_RVariant = CD_RDecoders.nested("Variant");

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/run.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/run.md
@@ -42,6 +42,12 @@ So a one-parameter behavior over a `String` newtype takes `--input '"world"'`, n
 Passing an array of the wrong length, or a non-array where several parameters are expected, stops
 the run and says the arity it wanted.
 
+A one-parameter behavior over a collection takes an array as its argument, so an array is not a
+mistake by itself: `(xs: List<Int>)` takes `--input '[1,2,3]'`. Wrapping it — `--input '[[1,2,3]]'`
+— is read as the argument array of the two-or-more form and stops the run, saying to remove the
+outer array. What decides it is the decode: the text is read as the argument first, and only a text
+that fails there while its sole element succeeds is the wrapped one.
+
 Each element is decoded through the parameter type's own derived decoder, so it is written the way
 that type's external form is written: a newtype is bare (`"world"`, `1200` — not `{"value": …}`), a
 record is an object with its field names, a date is the string form `"2026-07-25"`.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -548,6 +548,7 @@ run.pipeline.depends=`{0}` is a pipeline whose stage `{1}` depends on injected d
 run.input.missing=`{0}` takes {1} input(s) — pass --input
 run.input.notarray=`{0}` takes {1} inputs — --input must be a JSON array of that length
 run.input.count=`{0}` takes {1} inputs, but --input has {2}
+run.input.wrapped=This behavior has one parameter. Pass its value directly to --input; remove the outer array.
 run.input.badjson=--input is not valid JSON: {0}
 run.input.toodeep=--input nests deeper than this boundary accepts: {0} and below (JSON nesting past {1} levels). One level of a data can spend more than one level of JSON.
 run.decode.failed=input #{0} could not be decoded — {1}

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -547,6 +547,7 @@ run.pipeline.depends=`{0}` はパイプラインで、ステージ `{1}` が注�
 run.input.missing=`{0}` は入力を {1} 個取ります。--input を渡してください。
 run.input.notarray=`{0}` は入力を {1} 個取ります。--input はその長さの JSON 配列にしてください。
 run.input.count=`{0}` は入力を {1} 個取りますが、--input には {2} 個あります。
+run.input.wrapped=この behavior のパラメータは1つです。--input には値を直接指定し、外側の配列を取り除いてください。
 run.input.badjson=--input が正しい JSON ではありません: {0}
 run.input.toodeep=--input はこの境界が受け取れる深さを超えています: {0} 以下（JSON の入れ子が {1} レベルを超えました）。data の1レベルが JSON の複数レベルを使うことがあります。
 run.decode.failed=入力 #{0} をデコードできませんでした — {1}

--- a/souther-compiler/src/test/java/souther/compiler/CompileJsonSourceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileJsonSourceTest.java
@@ -167,6 +167,54 @@ class CompileJsonSourceTest {
         assertEquals("required", issues.get(0).code());
     }
 
+    /**
+     * A sum is read as an object too — its discriminator is a field — so the same rule holds for it.
+     * Read through the discriminator alone, the shape mismatch is blamed on the discriminator key,
+     * which is the one field the author had no chance to write.
+     */
+    @Test
+    void jsonDecoderReportsANonObjectSumAtTheSumItself() throws Exception {
+        Result<?> r = Codecs.decode(compile(), "demo.Application", "jsonDecoder",
+                mapper.readTree("5"));
+
+        assertInstanceOf(Err.class, r);
+        List<Issue> issues = ((Err<?>) r).issues().asList();
+        assertEquals(1, issues.size(), "one node, one issue: " + issues);
+        assertEquals("", issues.get(0).path().toString(), "reported at the sum, not at its tag");
+        assertEquals("type_mismatch", issues.get(0).code());
+    }
+
+    @Test
+    void jsonDecoderReportsANestedNonObjectSumAtTheFieldNotItsTag() throws Exception {
+        String src = """
+                module demo
+                data Submitted = { note: String }
+                data Rejected = { reason: String }
+                data Application = Submitted | Rejected
+                data Envelope = { content: Application }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Result<?> r = Codecs.decode(loader, "demo.Envelope", "jsonDecoder",
+                mapper.readTree("{\"content\":5}"));
+
+        assertInstanceOf(Err.class, r);
+        List<Issue> issues = ((Err<?>) r).issues().asList();
+        assertEquals(1, issues.size(), "one node, one issue: " + issues);
+        assertEquals("/content", issues.get(0).path().toString());
+    }
+
+    @Test
+    void jsonDecoderCallsANullSumRequired() throws Exception {
+        Result<?> r = Codecs.decode(compile(), "demo.Application", "jsonDecoder",
+                mapper.readTree("null"));
+
+        assertInstanceOf(Err.class, r);
+        List<Issue> issues = ((Err<?>) r).issues().asList();
+        assertEquals(1, issues.size(), issues.toString());
+        assertEquals("", issues.get(0).path().toString());
+        assertEquals("required", issues.get(0).code());
+    }
+
     /** An object still accumulates every field's error, which is what makes the guard a guard. */
     @Test
     void jsonDecoderStillAccumulatesEveryFieldErrorOfAnObject() throws Exception {

--- a/souther-compiler/src/test/java/souther/compiler/CompileJsonSourceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileJsonSourceTest.java
@@ -138,6 +138,35 @@ class CompileJsonSourceTest {
         assertEquals("/note", issues.get(0).path().toString());
     }
 
+    /**
+     * A data whose fields are all optional read a non-object as a record of absent fields and
+     * succeeded: an optional field makes nothing of a node it cannot read, so no field objected.
+     */
+    @Test
+    void jsonDecoderDoesNotReadANonObjectAsARecordOfAbsentFields() throws Exception {
+        String src = """
+                module demo
+                data Draft = { body: String?, tag: String? }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+
+        assertInstanceOf(Ok.class,
+                Codecs.decode(loader, "demo.Draft", "jsonDecoder", mapper.readTree("{}")));
+        assertInstanceOf(Err.class,
+                Codecs.decode(loader, "demo.Draft", "jsonDecoder", mapper.readTree("5")));
+    }
+
+    /** A JSON null is the absent value every other decoder calls required, not a shape mismatch. */
+    @Test
+    void jsonDecoderCallsANullNodeRequired() throws Exception {
+        Result<?> r = Codecs.decode(compile(), "demo.Account", "jsonDecoder", mapper.readTree("null"));
+
+        assertInstanceOf(Err.class, r);
+        List<Issue> issues = ((Err<?>) r).issues().asList();
+        assertEquals(1, issues.size(), issues.toString());
+        assertEquals("required", issues.get(0).code());
+    }
+
     /** An object still accumulates every field's error, which is what makes the guard a guard. */
     @Test
     void jsonDecoderStillAccumulatesEveryFieldErrorOfAnObject() throws Exception {

--- a/souther-compiler/src/test/java/souther/compiler/CompileJsonSourceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileJsonSourceTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import net.unit8.raoh.Err;
+import net.unit8.raoh.Issue;
 import net.unit8.raoh.Ok;
 import net.unit8.raoh.Result;
 import net.unit8.raoh.decode.Decoder;
@@ -9,6 +10,8 @@ import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -99,6 +102,50 @@ class CompileJsonSourceTest {
         Result<?> r = Codecs.decode(loader, "demo.Person", "jsonDecoder",
                 mapper.readTree("{\"name\":\"amy\",\"born\":\"1990-05-01\"}"));
         assertInstanceOf(Ok.class, r);
+    }
+
+    /**
+     * A node that is not an object is one fact about the node, so it is reported once, where the node
+     * is. Read field by field it becomes one issue per declared field, each blaming a field the
+     * author wrote correctly — a four-field data turns one mistake into four reports.
+     */
+    @Test
+    void jsonDecoderReportsANonObjectOnceAtTheNodeItself() throws Exception {
+        Result<?> r = Codecs.decode(compile(), "demo.Account", "jsonDecoder", mapper.readTree("5"));
+
+        assertInstanceOf(Err.class, r);
+        List<Issue> issues = ((Err<?>) r).issues().asList();
+        assertEquals(1, issues.size(), "one node, one issue: " + issues);
+        assertEquals("", issues.get(0).path().toString(), "reported at the node, not at a field");
+        assertEquals("type_mismatch", issues.get(0).code());
+    }
+
+    /** The same for a nested one: the record's own path, not its first field's. */
+    @Test
+    void jsonDecoderReportsANestedNonObjectAtTheRecordNotItsField() throws Exception {
+        String src = """
+                module demo
+                data Note = { body: String, tag: String }
+                data Envelope = { note: Note }
+                """;
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compile(src), getClass().getClassLoader());
+        Result<?> r = Codecs.decode(loader, "demo.Envelope", "jsonDecoder",
+                mapper.readTree("{\"note\":5}"));
+
+        assertInstanceOf(Err.class, r);
+        List<Issue> issues = ((Err<?>) r).issues().asList();
+        assertEquals(1, issues.size(), "one node, one issue: " + issues);
+        assertEquals("/note", issues.get(0).path().toString());
+    }
+
+    /** An object still accumulates every field's error, which is what makes the guard a guard. */
+    @Test
+    void jsonDecoderStillAccumulatesEveryFieldErrorOfAnObject() throws Exception {
+        Result<?> r = Codecs.decode(compile(), "demo.Account", "jsonDecoder",
+                mapper.readTree("{\"id\":5,\"balance\":\"nope\"}"));
+
+        assertInstanceOf(Err.class, r);
+        assertEquals(3, ((Err<?>) r).issues().asList().size());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
@@ -632,6 +632,118 @@ class RunnerTest {
                 e.localized(java.util.Locale.JAPANESE));
     }
 
+    // --- one input, written bare or wrapped in an array -----------------------------------------
+
+    private static final String ONE_STRING = """
+            behavior echo : (name: String) -> String
+            let echo (name) = name
+            """;
+
+    private static final String ONE_LIST = """
+            behavior echo : (xs: List<Int>) -> List<Int>
+            let echo (xs) = xs
+            """;
+
+    private static final String ONE_NESTED_LIST = """
+            behavior echo : (xs: List<List<Int>>) -> List<List<Int>>
+            let echo (xs) = xs
+            """;
+
+    private static final String ONE_RECORD = """
+            data Note = { body: String, tag: String? }
+            behavior echo : (n: Note) -> Note
+            let echo (n) = n
+            """;
+
+    /** The wrapper diagnosis, in both the language a Java caller reads and the one the CLI selects. */
+    private void assertNamesTheOuterArray(Runner.RunException e) {
+        assertEquals(1, e.exitCode);
+        assertTrue(e.getMessage().contains("remove the outer array"), e.getMessage());
+        assertFalse(e.getMessage().contains("could not be decoded"), e.getMessage());
+        assertTrue(e.localized(java.util.Locale.JAPANESE).contains("外側の配列"),
+                e.localized(java.util.Locale.JAPANESE));
+    }
+
+    @Test
+    void readsASinglePrimitiveInputWrittenBare() throws Exception {
+        assertEquals("\"world\"", Runner.run(write("one.sou", ONE_STRING), "echo", "\"world\""));
+    }
+
+    @Test
+    void namesTheOuterArrayWhenASinglePrimitiveInputIsWrappedInOne() throws Exception {
+        Path file = write("one.sou", ONE_STRING);
+        assertNamesTheOuterArray(assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "echo", "[\"world\"]")));
+    }
+
+    /**
+     * A collection input is written as its own array, so an array is not a wrapper by itself. What
+     * makes the wrapper case decidable is that the whole input fails to decode and its sole element
+     * succeeds — which is why the value is tried as it stands first.
+     */
+    @Test
+    void readsAListInputWrittenAsItsOwnArray() throws Exception {
+        assertEquals("[1,2,3]", Runner.run(write("one.sou", ONE_LIST), "echo", "[1,2,3]"));
+    }
+
+    @Test
+    void namesTheOuterArrayWhenAListInputIsWrappedInOne() throws Exception {
+        Path file = write("one.sou", ONE_LIST);
+        assertNamesTheOuterArray(assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "echo", "[[1,2,3]]")));
+    }
+
+    /** The same text is the input itself when the parameter is a list of lists. */
+    @Test
+    void readsANestedListInputWrittenAsItself() throws Exception {
+        assertEquals("[[1,2,3]]",
+                Runner.run(write("one.sou", ONE_NESTED_LIST), "echo", "[[1,2,3]]"));
+    }
+
+    @Test
+    void readsASingleRecordInputWrittenBare() throws Exception {
+        assertEquals("{\"body\":\"b\"}",
+                Runner.run(write("one.sou", ONE_RECORD), "echo", "{\"body\":\"b\"}"));
+    }
+
+    @Test
+    void namesTheOuterArrayWhenASingleRecordInputIsWrappedInOne() throws Exception {
+        Path file = write("one.sou", ONE_RECORD);
+        assertNamesTheOuterArray(assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "echo", "[{\"body\":\"b\"}]")));
+    }
+
+    /**
+     * The element has to decode for the wrapper to be the mistake. When it does not, the input is
+     * wrong for some other reason and the decoder's own report is what says so.
+     */
+    @Test
+    void keepsTheDecodeFailureWhenTheSoleElementDoesNotDecodeEither() throws Exception {
+        Path file = write("one.sou", ONE_RECORD);
+        Runner.RunException e = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "echo", "[{\"unknown\":1}]"));
+        assertEquals(1, e.exitCode);
+        assertTrue(e.getMessage().contains("could not be decoded"), e.getMessage());
+        assertFalse(e.getMessage().contains("remove the outer array"), e.getMessage());
+    }
+
+    /** Two inputs still take an array, and the arity failures they get keep saying what they said. */
+    @Test
+    void keepsTheArityFailuresOfABehaviorThatTakesSeveralInputs() throws Exception {
+        Path file = write("pair.sou", """
+                data Pair = { left: Int, right: Int }
+                behavior mkPair : (a: Int, b: Int) -> Pair constructs Pair
+                let mkPair (a, b) = Pair { left = a, right = b }
+                """);
+        Runner.RunException notArray = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "mkPair", "3"));
+        assertTrue(notArray.getMessage().contains("must be a JSON array"), notArray.getMessage());
+
+        Runner.RunException count = assertThrows(Runner.RunException.class,
+                () -> Runner.run(file, "mkPair", "[3]"));
+        assertTrue(count.getMessage().contains("but --input has 1"), count.getMessage());
+    }
+
     /**
      * Deeper still, the encoder runs out of stack before the writer ever counts a level. That is not
      * a {@code RuntimeException}, so left alone it reaches the caller as a stack trace.


### PR DESCRIPTION
Closes #367.

A behavior of one input given `--input '[{"body":"b"}]'` said `/body: expected object`. The record's fields are not where the mistake is, and with a wider record there was one such line per field, so the report read as though every field the author wrote was wrong.

Two defects meet there, and each is a commit.

## The split is a type-directed reading, not a syntactic one

From two inputs up, `--input` is a JSON array of that length and arity alone refuses anything else. A single input is written as it stands, and there the same text has two readings: for `(xs: List<Int>)`, `[1,2,3]` is the argument and `[[1,2,3]]` is that argument written inside the array the two-input form takes. Arity cannot tell them apart, so `splitInput` passed the text through untouched, and the mistake surfaced as whatever the decoder made of the outer array — one level below where it was made.

The split and the decode become one step taken with the types in hand. The sole input is read as it stands first, which is what keeps a collection argument from being called a wrapper; only a text that fails there while its sole element succeeds is the wrapped one.

| Parameter | `--input` | Result |
| --- | --- | --- |
| `String` | `"world"` | decodes |
| `String` | `["world"]` | remove the outer array |
| `List<Int>` | `[1,2,3]` | decodes |
| `List<Int>` | `[[1,2,3]]` | remove the outer array |
| `List<List<Int>>` | `[[1,2,3]]` | decodes |
| `Note` | `[{"body":"b"}]` | remove the outer array |
| `Note` | `[{"unknown":1}]` | the decoder's own report |

## A node's shape is one fact, reported where the node is

The generated JSON decoder never asked whether it held an object. Each field asked instead: `JsonDecoders.field` rejects a node it cannot read a name out of, at the field's own path, so one wrong shape came back as one report per declared field, and a nested one landed on the record's first field rather than on the record. A data whose fields are all optional went the other way and decoded, since an absent field is what `nullableField` makes of a node it cannot read.

The decoder now asks once, before the fields. An object still accumulates every field's error; a null or missing node is `required`, which is what every other decoder calls it. Only the JSON source needs the check — the neutral decoder is handed a `Map` by its own signature and a nested one goes through `MapDecoders.nested`, and a jOOQ `Record` is a row.

Fixing this second one alone would not have explained the wrapper; fixing the first alone would leave every other non-object input still blaming the fields. The wording is `souther doc cli/run`'s rule, and `run.md` now states what decides it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
