### PR TITLE
The guards are not the reason for a violation they took no part in

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -24,7 +24,7 @@ import java.util.Set;
 
 /**
  * The intraprocedural invariant-discharge check (spec §invariant-discharge). It walks a behavior's
- * body threading what the guards have settled ({@link Known}), seeded from the input types'
+ * body threading what holds where it stands ({@link Known}), seeded from the input types'
  * invariants and refined along each {@code guard}/{@code if} guard (a {@code guard} is already an
  * {@code if} here). At every construction whose invariant it can carry, it asks whether the guards
  * <em>discharge</em> it. A construction proven to violate its invariant on a reachable path is a
@@ -32,6 +32,11 @@ import java.util.Set;
  * cannot prove is a warning (a possible abort — guard it, or reify the relation into a type
  * invariant). An invariant naming something it cannot name is left opaque (no diagnostic; the
  * run-time check stays), so every flagged construction has a guard that discharges it.
+ *
+ * <p>A violation is reported in the terms it was reached in: {@link Known} carries beside itself what
+ * would hold had no condition on the path settled anything, and a clause that reading already refutes
+ * is one the construction fails wherever it is written. Which assumption a violation needs, where it
+ * needs one, is not asked — nothing here records what a refutation used.
  *
  * <p>What it reads is Core: the body in the representation the rules are written at
  * ({@link InliningPolicy#DISCHARGE}), typed by the checker like any other, and each declaration's
@@ -250,7 +255,7 @@ public final class InvariantChecker {
                 if (what instanceof Denotes.Term term && terms.isNumeric(li.value().type())) {
                     LinearForm vf = terms.affineOf(li.value(), at, k);
                     if (vf != null && !vf.equals(LinearForm.atom(term.key()))) {
-                        k2 = k2.with(k2.numbers().assign(term.key(), vf));
+                        k2 = k2.assigning(term.key(), vf);
                     }
                 }
                 walk(li.body(), k2, at.binding(li.binder().id(), li.value(), what), depth);
@@ -401,19 +406,33 @@ public final class InvariantChecker {
         PROVED,
         /** A clause is expressible and unproven: the construction may abort. */
         UNKNOWN,
-        /** A clause is proven to fail on a path that is reached. */
-        REFUTED;
+        /** A clause is proven to fail from what the construction is handed, with nothing a condition
+         * on the path settled taking part. It fails wherever the construction is written. */
+        REFUTED_ALONE,
+        /** A clause is proven to fail, and proving it takes what a condition on the path settled. */
+        REFUTED_UNDER_ASSUMPTIONS;
+
+        boolean refuted() {
+            return this == REFUTED_ALONE || this == REFUTED_UNDER_ASSUMPTIONS;
+        }
 
         /**
          * What holds of a value that is one of two. It is discharged where both are, and it is proven
          * to fail only where both fail — a construction one branch satisfies does not definitely
          * violate, whichever branch is taken. Everything else is possible and unproven.
          *
+         * <p>Where both fail and only one of them needed the path to, the two together are said to
+         * need it: what is claimed of the construction is what the weaker of the two readings
+         * supports.
+         *
          * <p>A branch nothing reaches finds nothing to combine: {@link #reading} answers it with no
          * findings at all, and a position only one branch found is read as discharged on the other.
          */
         static Verdict of(Verdict a, Verdict b) {
-            return a == b ? a : UNKNOWN;
+            if (a == b) {
+                return a;
+            }
+            return a.refuted() && b.refuted() ? REFUTED_UNDER_ASSUMPTIONS : UNKNOWN;
         }
     }
 
@@ -439,9 +458,14 @@ public final class InvariantChecker {
             return Verdict.PROVED;   // nothing here is expressible — the run-time check stands for it
         }
         NumericDomain dom = k.numbers();
+        // The same clauses read against the same site, under what would be known here had no
+        // condition on the path settled anything. What each clause states of the sizes it names holds
+        // either way, so both readings take it.
+        NumericDomain alone = k.unguarded().numbers();
         for (Predicates.Clause c : owed) {
             for (Predicates.Constraint known : c.known()) {
                 dom = dom.assume(known.form(), known.rel());
+                alone = alone.assume(known.form(), known.rel());
             }
         }
         Verdict out = Verdict.PROVED;
@@ -450,7 +474,8 @@ public final class InvariantChecker {
                 continue;
             }
             if (c.refutedBy(dom, k.facts())) {
-                return Verdict.REFUTED;
+                return c.refutedBy(alone, k.unguarded().facts())
+                        ? Verdict.REFUTED_ALONE : Verdict.REFUTED_UNDER_ASSUMPTIONS;
             }
             out = Verdict.UNKNOWN;
         }
@@ -475,7 +500,9 @@ public final class InvariantChecker {
             return;
         }
         switch (verdict) {
-            case REFUTED -> reportViolation(type, pos);
+            case REFUTED_ALONE -> reportViolation(type, pos, "check.invariant.violation.alone");
+            case REFUTED_UNDER_ASSUMPTIONS ->
+                    reportViolation(type, pos, "check.invariant.violation.assumed");
             case UNKNOWN -> {
                 if (!attempted) {
                     warnings.add(Diagnostic.of("E2011", "check.invariant.unproven")
@@ -665,11 +692,14 @@ public final class InvariantChecker {
         }
     }
 
-    private void reportViolation(Ast.Data type, SourcePos pos) {
+    /** Reports the violation, saying it in the terms {@code reason} was reached in: the value alone
+     * fails the invariant, or it fails under what the path assumed. The check knows which of the two
+     * decided it and does not know which assumption did, so neither message names one. */
+    private void reportViolation(Ast.Data type, SourcePos pos, String reason) {
         errors.add(CompileException.of(
-                Diagnostic.of("E2010", "check.invariant.violation").title("check.invariant.title")
+                Diagnostic.of("E2010", reason).title("check.invariant.title")
                         .at(pos).args(type.name()).build(),
-                "constructing `" + type.name() + "` here violates its invariant on a reachable path"));
+                "constructing `" + type.name() + "` here violates its invariant"));
     }
 
     // --- introducing a binding -----------------------------------------------------------------
@@ -728,7 +758,8 @@ public final class InvariantChecker {
         List<Quantified> quantified = new ArrayList<>();
         for (Core stated : clauses.statedAt(ref.name(), data, given)) {
             predicates.quantifiedBy(stated, at, true, quantified);
-            out = predicates.assume(predicates.obligations(stated, out, at, false), out);
+            out = predicates.assume(predicates.obligations(stated, out, at, false), out,
+                    Known.Held.OF_THE_VALUE);
         }
         out = out.and(quantified);
         if (data.newtype()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -26,17 +26,19 @@ import java.util.Set;
  * The intraprocedural invariant-discharge check (spec §invariant-discharge). It walks a behavior's
  * body threading what holds where it stands ({@link Known}), seeded from the input types'
  * invariants and refined along each {@code guard}/{@code if} guard (a {@code guard} is already an
- * {@code if} here). At every construction whose invariant it can carry, it asks whether the guards
- * <em>discharge</em> it. A construction proven to violate its invariant on a reachable path is a
- * compile error (the path-sensitive generalization of the constant check {@code Amount(-5)}); one it
- * cannot prove is a warning (a possible abort — guard it, or reify the relation into a type
- * invariant). An invariant naming something it cannot name is left opaque (no diagnostic; the
- * run-time check stays), so every flagged construction has a guard that discharges it.
+ * {@code if} here). At every construction whose invariant it can carry, it asks whether what is known
+ * there <em>discharges</em> it, or refutes it. A construction proven to violate its invariant on a
+ * reachable path is a compile error (the path-sensitive generalization of the constant check
+ * {@code Amount(-5)}); one it cannot prove is a warning (a possible abort — guard it, or reify the
+ * relation into a type invariant). An invariant naming something it cannot name is left opaque (no
+ * diagnostic; the run-time check stays), so every flagged construction is one whose clauses could be
+ * read at the values it is being given.
  *
- * <p>A violation is reported in the terms it was reached in: {@link Known} carries beside itself what
- * would hold had no condition on the path settled anything, and a clause that reading already refutes
- * is one the construction fails wherever it is written. Which assumption a violation needs, where it
- * needs one, is not asked — nothing here records what a refutation used.
+ * <p>A violation is reported in the terms it was reached in, and no stronger: {@link Known} carries
+ * beside itself the reading with nothing a condition on the path settled, and a clause that reading
+ * already refutes is one the construction fails wherever it is written. Which of the things known
+ * here settled the rest is not asked — nothing records what a refutation used, so a violation the
+ * values alone do not settle is said that way and not blamed on a guard.
  *
  * <p>What it reads is Core: the body in the representation the rules are written at
  * ({@link InliningPolicy#DISCHARGE}), typed by the checker like any other, and each declaration's
@@ -406,14 +408,16 @@ public final class InvariantChecker {
         PROVED,
         /** A clause is expressible and unproven: the construction may abort. */
         UNKNOWN,
-        /** A clause is proven to fail from what the construction is handed, with nothing a condition
-         * on the path settled taking part. It fails wherever the construction is written. */
+        /** A clause the reading without the path's assumptions already refutes, so the invariant
+         * fails wherever the construction is written. */
         REFUTED_ALONE,
-        /** A clause is proven to fail, and proving it takes what a condition on the path settled. */
-        REFUTED_UNDER_ASSUMPTIONS;
+        /** A clause the full reading refutes and that reading does not. Something known here beyond
+         * the values themselves settled it; which of the things known here is not asked, so this
+         * does not say a condition on the path was one of them. */
+        REFUTED_NOT_ALONE;
 
         boolean refuted() {
-            return this == REFUTED_ALONE || this == REFUTED_UNDER_ASSUMPTIONS;
+            return this == REFUTED_ALONE || this == REFUTED_NOT_ALONE;
         }
 
         /**
@@ -421,9 +425,10 @@ public final class InvariantChecker {
          * to fail only where both fail — a construction one branch satisfies does not definitely
          * violate, whichever branch is taken. Everything else is possible and unproven.
          *
-         * <p>Where both fail and only one of them needed the path to, the two together are said to
-         * need it: what is claimed of the construction is what the weaker of the two readings
-         * supports.
+         * <p>Where both fail and only one of them fails on the values alone, the two together are
+         * said not to: what is claimed of the construction is what the weaker of the two readings
+         * supports. The other direction is the clauses of one invariant, which are conjoined rather
+         * than alternative and are combined at {@link #verdictOf} the other way round.
          *
          * <p>A branch nothing reaches finds nothing to combine: {@link #reading} answers it with no
          * findings at all, and a position only one branch found is read as discharged on the other.
@@ -432,7 +437,7 @@ public final class InvariantChecker {
             if (a == b) {
                 return a;
             }
-            return a.refuted() && b.refuted() ? REFUTED_UNDER_ASSUMPTIONS : UNKNOWN;
+            return a.refuted() && b.refuted() ? REFUTED_NOT_ALONE : UNKNOWN;
         }
     }
 
@@ -468,18 +473,29 @@ public final class InvariantChecker {
                 alone = alone.assume(known.form(), known.rel());
             }
         }
-        Verdict out = Verdict.PROVED;
+        // An invariant is the conjunction of its clauses, so every one of them is read before what
+        // the invariant came out as is decided. A clause the values alone refute is the whole
+        // invariant refuted on the values alone, whatever another clause needed to be refuted —
+        // stopping at the first refutation would answer with whichever clause was declared first.
+        boolean alongside = false;
+        boolean unknown = false;
         for (Predicates.Clause c : owed) {
             if (c.dischargedBy(dom, k.facts())) {
                 continue;
             }
-            if (c.refutedBy(dom, k.facts())) {
-                return c.refutedBy(alone, k.unguarded().facts())
-                        ? Verdict.REFUTED_ALONE : Verdict.REFUTED_UNDER_ASSUMPTIONS;
+            if (!c.refutedBy(dom, k.facts())) {
+                unknown = true;
+                continue;
             }
-            out = Verdict.UNKNOWN;
+            if (c.refutedBy(alone, k.unguarded().facts())) {
+                return Verdict.REFUTED_ALONE;
+            }
+            alongside = true;
         }
-        return out;
+        if (alongside) {
+            return Verdict.REFUTED_NOT_ALONE;
+        }
+        return unknown ? Verdict.UNKNOWN : Verdict.PROVED;
     }
 
     /** Whether the constant check reads this construction: a newtype's, over a value written where
@@ -501,7 +517,7 @@ public final class InvariantChecker {
         }
         switch (verdict) {
             case REFUTED_ALONE -> reportViolation(type, pos, "check.invariant.violation.alone");
-            case REFUTED_UNDER_ASSUMPTIONS ->
+            case REFUTED_NOT_ALONE ->
                     reportViolation(type, pos, "check.invariant.violation.assumed");
             case UNKNOWN -> {
                 if (!attempted) {
@@ -693,8 +709,9 @@ public final class InvariantChecker {
     }
 
     /** Reports the violation, saying it in the terms {@code reason} was reached in: the value alone
-     * fails the invariant, or it fails under what the path assumed. The check knows which of the two
-     * decided it and does not know which assumption did, so neither message names one. */
+     * fails the invariant on its own, or it fails under what else is known where it stands. The check
+     * knows which of the two decided it and not what within the second did, so neither message names
+     * a guard. */
     private void reportViolation(Ast.Data type, SourcePos pos, String reason) {
         errors.add(CompileException.of(
                 Diagnostic.of("E2010", reason).title("check.invariant.title")

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -1,28 +1,74 @@
 package souther.compiler.check;
 
+import souther.compiler.check.NumericDomain.LinearForm;
+import souther.compiler.check.NumericDomain.Rel;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-/** What the guards have settled on the current path: numeric relations, predicates known to hold or
- * to fail, relations known of every element of a container, and the terms an assumption named — which
- * is what makes a computed value one a clause may be read against. Threaded functionally through the
- * walk, as the domain alone once was. */
+/**
+ * What holds where the walk stands: numeric relations, predicates known to hold or to fail, relations
+ * known of every element of a container, and the terms an assumption named — which is what makes a
+ * computed value one a clause may be read against. Threaded functionally through the walk, as the
+ * domain alone once was.
+ *
+ * <p>Beside it is {@link Unguarded}, the same reading with nothing a condition on the path settled.
+ * Both are refined by the same acts and differ only in which acts reach both, so a clause that comes
+ * out refuted can be asked which of the two refuted it. That is what a violation is explained by: one
+ * the unguarded reading already refutes holds wherever the construction stands, and one only the full
+ * reading refutes needs the path to be the path it is on.
+ */
 record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified,
-                     Set<String> spoken) {
+                     Set<String> spoken, Unguarded unguarded) {
+
+    /** What holds of the values here whatever the path did — what a type guarantees of a value and
+     * what a name was given. It carries no quantifiers and no spoken terms: those decide which
+     * clauses are read at all, and both readings are asked about the same clauses. */
+    record Unguarded(NumericDomain numbers, PredicateFacts facts) {
+
+        Unguarded taking(LinearForm f, Rel rel) {
+            return new Unguarded(numbers.assume(f, rel), facts);
+        }
+
+        Unguarded taking(String key, boolean positive) {
+            return new Unguarded(numbers, facts.assume(key, positive));
+        }
+
+        Unguarded assigning(String atom, LinearForm f) {
+            return new Unguarded(numbers.assign(atom, f), facts);
+        }
+    }
+
+    /** How far a fact reaches: a value's type and a name's binding say something wherever that value
+     * is named, and a condition says it only on the path it guards. */
+    enum Held { OF_THE_VALUE, ON_THE_PATH }
 
     static Known top() {
-        return new Known(NumericDomain.top(), PredicateFacts.none(), List.of(), Set.of());
+        return new Known(NumericDomain.top(), PredicateFacts.none(), List.of(), Set.of(),
+                new Unguarded(NumericDomain.top(), PredicateFacts.none()));
     }
 
-    Known with(NumericDomain n) {
-        return new Known(n, facts, quantified, spoken);
+    /** This, with {@code f rel 0} taken as holding as far as {@code held} reaches. */
+    Known taking(LinearForm f, Rel rel, Held held) {
+        return new Known(numbers.assume(f, rel), facts, quantified, spoken,
+                held == Held.OF_THE_VALUE ? unguarded.taking(f, rel) : unguarded);
     }
 
-    Known with(PredicateFacts f) {
-        return new Known(numbers, f, quantified, spoken);
+    /** This, with the predicate {@code key} taken as holding — or as failing, where {@code positive}
+     * is false — as far as {@code held} reaches. */
+    Known taking(String key, boolean positive, Held held) {
+        return new Known(numbers, facts.assume(key, positive), quantified, spoken,
+                held == Held.OF_THE_VALUE ? unguarded.taking(key, positive) : unguarded);
+    }
+
+    /** This, with {@code atom} standing for {@code f}. A name is an alias for what it was given
+     * wherever it is named, so this reaches both readings. */
+    Known assigning(String atom, LinearForm f) {
+        return new Known(numbers.assign(atom, f), facts, quantified, spoken,
+                unguarded.assigning(atom, f));
     }
 
     /**
@@ -37,7 +83,7 @@ record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quant
         }
         Set<String> all = new HashSet<>(spoken);
         all.addAll(terms);
-        return new Known(numbers, facts, quantified, all);
+        return new Known(numbers, facts, quantified, all, unguarded);
     }
 
     /** Whether an assumption on this path named {@code term}. */
@@ -51,6 +97,6 @@ record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quant
         }
         List<Quantified> all = new ArrayList<>(quantified);
         all.addAll(more);
-        return new Known(numbers, facts, List.copyOf(all), spoken);
+        return new Known(numbers, facts, List.copyOf(all), spoken, unguarded);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Known.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Known.java
@@ -19,7 +19,8 @@ import java.util.Set;
  * Both are refined by the same acts and differ only in which acts reach both, so a clause that comes
  * out refuted can be asked which of the two refuted it. That is what a violation is explained by: one
  * the unguarded reading already refutes holds wherever the construction stands, and one only the full
- * reading refutes needs the path to be the path it is on.
+ * reading refutes took something more than the values to settle. Which something is not recorded, so
+ * it is not claimed either.
  */
 record Known(NumericDomain numbers, PredicateFacts facts, List<Quantified> quantified,
                      Set<String> spoken, Unguarded unguarded) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -83,8 +83,8 @@ final class Predicates {
         quantifiedBy(stated, at, true, nested);
         // A quantifier is recorded by a guard and by a type's invariant alike, and carries no record
         // of which recorded it, so what it gives an element is taken as the path's. That is the
-        // weaker of the two readings: a violation it decides is reported as one the path decides,
-        // which holds either way.
+        // weaker of the two readings: a violation it decides is reported as one the values alone did
+        // not decide, which holds either way. It is why nothing downstream says a guard decided it.
         return assume(obligations(stated, k, at, false), k, Known.Held.ON_THE_PATH).and(nested);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -81,7 +81,11 @@ final class Predicates {
                 Map.of(q.predicate().params().get(0).id(), element));
         List<Quantified> nested = new ArrayList<>();
         quantifiedBy(stated, at, true, nested);
-        return assume(obligations(stated, k, at, false), k).and(nested);
+        // A quantifier is recorded by a guard and by a type's invariant alike, and carries no record
+        // of which recorded it, so what it gives an element is taken as the path's. That is the
+        // weaker of the two readings: a violation it decides is reported as one the path decides,
+        // which holds either way.
+        return assume(obligations(stated, k, at, false), k, Known.Held.ON_THE_PATH).and(nested);
     }
 
     /** What {@code e}, asserted with polarity {@code positive}, says of every element of a container.
@@ -280,7 +284,9 @@ final class Predicates {
         List<Constraint> known = new ArrayList<>();
         sizeFacts(cond, at, known);
         for (Constraint c : known) {
-            out = out.with(out.numbers().assume(c.form(), c.rel()));
+            // A size is never negative whether or not the condition holds, so this holds of the value
+            // and not of the path — the condition is only where the container got named.
+            out = out.taking(c.form(), c.rel(), Known.Held.OF_THE_VALUE);
         }
         if (cond instanceof Core.Binary b) {
             Rel rel = relOf(b.op());
@@ -288,7 +294,7 @@ final class Predicates {
             LinearForm la = eff == null ? null : terms.affineOf(b.left(), at, out);
             LinearForm ra = eff == null ? null : terms.affineOf(b.right(), at, out);
             if (la != null && ra != null) {
-                out = out.with(out.numbers().assume(la.minus(ra), eff));
+                out = out.taking(la.minus(ra), eff, Known.Held.ON_THE_PATH);
             }
             // What the comparison named, recorded as spoken about: a construction from one of these
             // is one the author has said something about, whichever route ends up carrying it.
@@ -303,7 +309,7 @@ final class Predicates {
         // guard does not know which that will be.
         Polar polar = polar(cond, positive);
         String key = terms.bodyKey(polar.expr(), at);
-        return key == null ? out : out.with(out.facts().assume(key, polar.positive()));
+        return key == null ? out : out.taking(key, polar.positive(), Known.Held.ON_THE_PATH);
     }
 
     /** The terms one side of a compared pair names: the expression itself, and each atom of the form it
@@ -365,25 +371,28 @@ final class Predicates {
     }
 
 
-    /** {@code k} with everything {@code owed} states taken as holding. What a clause owes at a
-     * construction is what it guarantees where it is already established, so the two read the same
-     * clauses through the same rule and differ only in direction. */
-    Known assume(List<Clause> owed, Known k) {
+    /** {@code k} with everything {@code owed} states taken as holding, as far as {@code held}
+     * reaches. What a clause owes at a construction is what it guarantees where it is already
+     * established, so the two read the same clauses through the same rule and differ only in
+     * direction. */
+    Known assume(List<Clause> owed, Known k, Known.Held held) {
         if (owed == null) {
             return k;
         }
         Known out = k;
         for (Clause c : owed) {
             for (Constraint known : c.known()) {
-                out = out.with(out.numbers().assume(known.form(), known.rel()));
+                // What is known of a size holds of the container itself, whatever established the
+                // clause it was read out of.
+                out = out.taking(known.form(), known.rel(), Known.Held.OF_THE_VALUE);
             }
             if (c.numeric() != null) {
-                out = out.with(out.numbers().assume(c.numeric().form(), c.numeric().rel()));
+                out = out.taking(c.numeric().form(), c.numeric().rel(), held);
             }
             if (c.fact() != null) {
                 // What is guaranteed is guaranteed of the term as written; a container built from it
                 // is another term, and reads the rules where it is constructed rather than here.
-                out = out.with(out.facts().assume(c.fact().keys().get(0), c.fact().positive()));
+                out = out.taking(c.fact().keys().get(0), c.fact().positive(), held);
             }
         }
         return out;

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -510,7 +510,8 @@ check.totality.partialasvalue=The `partial` helper `{0}` is written where a valu
 
 # --- invariant discharge (E2010 error, E2011 warning) ---
 check.invariant.title=INVARIANT
-check.invariant.violation=Constructing `{0}` here violates its invariant on a reachable path: the guards force a value the invariant rejects. Fix the value, or guard the path so the violating case cannot reach here.
+check.invariant.violation.alone=Constructing `{0}` here violates its invariant: the value being built is one the invariant rejects. Fix the value.
+check.invariant.violation.assumed=Constructing `{0}` here violates its invariant on a reachable path: under what is assumed where it stands, the value being built is one the invariant rejects. Fix the value, or guard the path so the violating case cannot reach here.
 check.invariant.unproven=Constructing `{0}` here may violate its invariant: the guards do not establish it. Guard it with `guard`, or reify the relation into `{0}`''s (or an input''s) invariant so it is assumed here.
 check.invariant.reify=If a relation between inputs guarantees this, declare it as an `invariant` on the input data so it is checked once at its boundary and assumed here.
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -509,7 +509,8 @@ check.totality.partialasvalue=`partial` ヘルパ `{0}` が値の位置に書か
 
 # --- invariant discharge (E2010 error, E2011 warning) ---
 check.invariant.title=INVARIANT
-check.invariant.violation=ここでの `{0}` の構築は、到達可能な経路で不変条件に違反します。ガードが不変条件の拒む値を強制しています。値を直すか、違反ケースがここに届かないよう経路をガードしてください。
+check.invariant.violation.alone=ここでの `{0}` の構築は不変条件に違反します。組み立てている値を不変条件が拒みます。値を直してください。
+check.invariant.violation.assumed=ここでの `{0}` の構築は、到達可能な経路で不変条件に違反します。ここで仮定されていることの下では、組み立てている値を不変条件が拒みます。値を直すか、違反ケースがここに届かないよう経路をガードしてください。
 check.invariant.unproven=ここでの `{0}` の構築は不変条件に違反する可能性があります。ガードが不変条件を確立していません。`guard` でガードするか、関係を `{0}`（または入力）の `invariant` に宣言してここで仮定させてください。
 check.invariant.reify=入力間の関係がこれを保証するなら、入力データの `invariant` として宣言してください。境界で一度検査され、ここでは仮定されます。
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantViolationReasonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantViolationReasonTest.java
@@ -1,0 +1,130 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * What E2010 says a construction was refuted <em>by</em>. The check decides a violation from two
+ * kinds of fact: what the values it is handed carry on their own — a literal, an arithmetic result, a
+ * name given a written value, an input's own type invariant — and what a condition on the path
+ * assumed. Only the second is something a guard settled, so only the second is said that way; a
+ * construction refuted without any of it is said without mentioning the path at all.
+ */
+class CompileInvariantViolationReasonTest {
+
+    /** The message key E2010 was raised with, which is what the reason is chosen by. */
+    private static String reasonOf(String module) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(module));
+        assertEquals("E2010", e.diagnostic().code(), e.getMessage());
+        return e.diagnostic().messageKey();
+    }
+
+    @Test
+    void aConstructionOverWrittenValuesIsRefutedWithoutAnyPath() {
+        String m = """
+                module demo
+                data Range = { lo: Int, hi: Int }
+                    invariant lo <= hi
+                behavior mk : () -> Range constructs Range
+                let mk = Range { lo = 5, hi = 1 }
+                """;
+        assertEquals("check.invariant.violation.alone", reasonOf(m),
+                "nothing is guarded here — the values written decide it");
+    }
+
+    @Test
+    void arithmeticOverWrittenValuesIsRefutedWithoutAnyPath() {
+        String m = """
+                module demo
+                data Money = Decimal
+                    invariant value >= 0m
+                behavior calc : (m: Money) -> Money constructs Money
+                let calc (m) = Money(0m) - Money(1m)
+                """;
+        assertEquals("check.invariant.violation.alone", reasonOf(m),
+                "0 - 1 is negative wherever it stands");
+    }
+
+    @Test
+    void anInputsOwnInvariantRefutesWithoutAnyPath() {
+        // `p.value > 0` is what Pos guarantees of its value, not what a guard settled
+        String m = """
+                module demo
+                data Pos = Int
+                    invariant value > 0
+                data Neg = Int
+                    invariant value < 0
+                behavior conv : (p: Pos) -> Neg constructs Neg
+                let conv (p) = Neg(p.value)
+                """;
+        assertEquals("check.invariant.violation.alone", reasonOf(m),
+                "an input's type carries its invariant everywhere the input does");
+    }
+
+    @Test
+    void aNameGivenAWrittenValueIsRefutedWithoutAnyPath() {
+        String m = """
+                module demo
+                data Amount = Int
+                    invariant value >= 0
+                behavior mk : (n: Int) -> Amount constructs Amount
+                let mk (n) = {
+                    let bad = 0 - 5
+                    Amount(bad)
+                }
+                """;
+        assertEquals("check.invariant.violation.alone", reasonOf(m),
+                "a name is an alias for what it was given, and no guard was written");
+    }
+
+    @Test
+    void aGuardThatForcesTheViolationIsSaidAsAnAssumption() {
+        String m = """
+                module demo
+                data Amount = Int
+                    invariant value >= 0
+                behavior mk : (n: Int) -> Amount constructs Amount
+                let mk (n) =
+                    if n < 0 then Amount(n)
+                    else Amount(0)
+                """;
+        assertEquals("check.invariant.violation.assumed", reasonOf(m),
+                "without `n < 0` nothing here refutes the invariant");
+    }
+
+    @Test
+    void aGuardBesideAViolationIsNotItsReason() {
+        String m = """
+                module demo
+                data Money = Decimal
+                    invariant value >= 0m
+                data Pair = { a: Money, b: Money }
+                behavior pick : (p: Pair) -> Money constructs Money
+                let pick (p) =
+                    if p.a < p.b then Money(0m) - Money(1m)
+                    else p.a
+                """;
+        assertEquals("check.invariant.violation.alone", reasonOf(m),
+                "the guard settles something, and the violation does not need it");
+    }
+
+    @Test
+    void twoReadingsRefutedDifferentlyStayAnErrorAndAreSaidAsTheWeakerOne() {
+        // read with `n`, the guard decides it; read with `0 - 1`, the value does. Either way the
+        // construction violates, so it stays an error — and what is claimed of the two together is
+        // what the reading that needed the path supports.
+        String m = """
+                module demo
+                data Amount = Int
+                    invariant value >= 0
+                behavior mk : (n: Int) -> Amount constructs Amount
+                let mk (n) = Amount(if n < 0 then n else 0 - 1)
+                """;
+        assertEquals("check.invariant.violation.assumed", reasonOf(m),
+                "one reading needed the path, so the two together are said to");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantViolationReasonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantViolationReasonTest.java
@@ -127,4 +127,31 @@ class CompileInvariantViolationReasonTest {
         assertEquals("check.invariant.violation.assumed", reasonOf(m),
                 "one reading needed the path, so the two together are said to");
     }
+
+    /** An invariant is the conjunction of its clauses, so one clause failing on the values alone is
+     * the whole invariant failing on them — whatever the other clauses needed to fail. */
+    private static final String TWO_CLAUSES = """
+            module demo
+            data Pair = { x: Int, y: Int }
+            %s
+            behavior mk : (x: Int) -> Pair constructs Pair
+            let mk (x) =
+                if x < 0 then Pair { x = x, y = 0 - 1 }
+                else Pair { x = 0, y = 0 }
+            """;
+
+    @Test
+    void aClauseRefutedOnTheValuesAloneDecidesTheReasonForTheWholeInvariant() {
+        // `x >= 0` fails only under the guard; `y >= 0` fails on `y = -1` wherever it is written
+        assertEquals("check.invariant.violation.alone",
+                reasonOf(TWO_CLAUSES.formatted("    invariant x >= 0\n    invariant y >= 0")),
+                "the invariant is already false without the guard, by its second clause");
+    }
+
+    @Test
+    void whichClauseIsWrittenFirstIsNotTheReason() {
+        assertEquals("check.invariant.violation.alone",
+                reasonOf(TWO_CLAUSES.formatted("    invariant y >= 0\n    invariant x >= 0")),
+                "the same two clauses in the other order are the same invariant");
+    }
 }

--- a/specification.adoc
+++ b/specification.adoc
@@ -3873,16 +3873,24 @@ termination guarantee, so a `partial` helper may be applied but not handed over.
 ----
 
 [#e2010]
-=== A construction violates its invariant on a reachable path
+=== A construction violates its invariant
 
 [,text]
 ----
-Constructing `Amount` here violates its invariant on a reachable path: the guards force a
-value the invariant rejects. Fix the value, or guard the path so the violating case cannot
-reach here.
+Constructing `Amount` here violates its invariant: the value being built is one the
+invariant rejects. Fix the value.
 ----
 
-Emitted when the guards on the path to a construction prove the invariant false (<<invariant-discharge>>). The companion E2011 is a warning, not an error: it says the guards do not establish the invariant, so the check remains at run time.
+Emitted when the check proves the invariant false at a construction (<<invariant-discharge>>). What is said of it depends on what proved it. The message above is for a violation the values reach on their own — a value written out, an arithmetic result, a name given one of those, or what an input's own type guarantees of it — which fails wherever the construction is written. Where proving it takes a condition on the path as well, the message says that instead:
+
+[,text]
+----
+Constructing `Amount` here violates its invariant on a reachable path: under what is
+assumed where it stands, the value being built is one the invariant rejects. Fix the
+value, or guard the path so the violating case cannot reach here.
+----
+
+Neither names the condition that decided it: the check knows the violation needs the path to be the path it is on, and not which assumption on that path it needs. The companion E2011 is a warning, not an error: it says the guards do not establish the invariant, so the check remains at run time.
 
 [#e2012]
 === `as` names what a construction builds

--- a/specification.adoc
+++ b/specification.adoc
@@ -3881,7 +3881,7 @@ Constructing `Amount` here violates its invariant: the value being built is one 
 invariant rejects. Fix the value.
 ----
 
-Emitted when the check proves the invariant false at a construction (<<invariant-discharge>>). What is said of it depends on what proved it. The message above is for a violation the values reach on their own — a value written out, an arithmetic result, a name given one of those, or what an input's own type guarantees of it — which fails wherever the construction is written. Where proving it takes a condition on the path as well, the message says that instead:
+Emitted when the check proves the invariant false at a construction (<<invariant-discharge>>). What is said of it depends on what proved it. The message above is for a violation the values reach on their own — a value written out, an arithmetic result, a name given one of those, or what an input's own type guarantees of it — which fails wherever the construction is written. An invariant is the conjunction of its clauses, so one clause failing that way is the whole invariant failing that way. Where the values alone do not settle it and what else is known where it stands does, the message says that instead:
 
 [,text]
 ----
@@ -3890,7 +3890,7 @@ assumed where it stands, the value being built is one the invariant rejects. Fix
 value, or guard the path so the violating case cannot reach here.
 ----
 
-Neither names the condition that decided it: the check knows the violation needs the path to be the path it is on, and not which assumption on that path it needs. The companion E2011 is a warning, not an error: it says the guards do not establish the invariant, so the check remains at run time.
+Neither names what decided it: the check knows the values alone did not, and not which of the things known there did. The companion E2011 is a warning, not an error: it says the guards do not establish the invariant, so the check remains at run time.
 
 [#e2012]
 === `as` names what a construction builds


### PR DESCRIPTION
Closes #373.

```
-- INVARIANT  E2010 -------------------------
7| let mk = Range { lo = 5, hi = 1 }
Constructing `Range` here violates its invariant on a reachable path:
the guards force a value the invariant rejects.
```

There are no guards here. The sentence is the wording for one case, emitted for every one.

## What the check knew and threw away

`reportViolation` took a type and a position. The refutation is decided one frame above it, in `verdictOf`, where a clause is asked `refutedBy(dom, facts)` — and everything about *what* refuted it was collapsed into `Verdict.REFUTED` before anything was said. The message then supplied a cause the check had never computed.

Six programs, all of them E2010, all of them given the same sentence:

| source | what decided the violation | "the guards force" |
| --- | --- | --- |
| `let mk = Range { lo = 5, hi = 1 }` | the written values | false — no guards |
| `let calc (m) = Money(0m) - Money(1m)` | the written values | false — no guards |
| `let conv (p: Pos) = Neg(p.value)` | `Pos`'s own invariant | false — no guards |
| `{ let bad = 0 - 5  Amount(bad) }` | what the name was given | false — no guards |
| `if n < 0 then Amount(n)` | the guard | true |
| `if p.a < p.b then Money(0m) - Money(1m)` | the written values | false — the guard took no part |

## The distinction the check can actually draw

`Known` now carries beside itself `Known.Unguarded`: the same reading with nothing a condition on the path settled. Both are refined by the same acts, and `Known.Held` names how far each act reaches.

- `OF_THE_VALUE` — what a type guarantees of a value, what a name was bound to, what is structurally known of a size. Reaches both readings.
- `ON_THE_PATH` — what a condition settled. Reaches the guarded reading only.

`verdictOf` asks the refuted clause again against the unguarded reading, and `REFUTED` becomes `REFUTED_ALONE` or `REFUTED_NOT_ALONE`. `reportViolation` takes the message key that decision produced.

```
Constructing `Range` here violates its invariant: the value being built is one the
invariant rejects. Fix the value.

Constructing `Amount` here violates its invariant on a reachable path: under what is
assumed where it stands, the value being built is one the invariant rejects. Fix the
value, or guard the path so the violating case cannot reach here.
```

Neither says `guard`, and neither claims a condition on the path was needed. `REFUTED_NOT_ALONE` is named for exactly what was established: the full reading refuted the clause and the unguarded one did not. It does not follow that a guard is what made the difference — a `Quantified`, what is known of every element of a container, is recorded by a guard and by a type's invariant alike and keeps no record of which, so `instantiate` takes it as the path's. Going further would take a minimal refutation set. Assumption provenance is worth its own issue; this change is what can be said without it.

## Two aggregations, opposite ways

Both directions turn up here, and getting one of them backwards is order dependence in the diagnostic.

The readings of a conditional are **alternatives**. A construction written over `if` is read once with each branch standing there, and `Verdict.of` combines the two. Where both are refuted and only one of them alone, the pair is said not to be alone: the weaker claim is the one that holds of the construction either way.

The clauses of an invariant are **conjoined**. `verdictOf` first answered with the first clause it found refuted, so for

```souther
data Pair = { x: Int, y: Int }
    invariant x >= 0
    invariant y >= 0

let mk (x) =
    if x < 0 then Pair { x = x, y = 0 - 1 }
    else Pair { x = 0, y = 0 }
```

`x >= 0` fails only under the guard and `y >= 0` fails on `y = -1` wherever it is written — and swapping the two `invariant` lines changed the message. Every clause is now read, and one refuted on the values alone answers for the whole invariant however the others came out.

## Splitting the verdict exposed a third defect

Two readings of a construction written over a conditional were combined by equality:

```java
static Verdict of(Verdict a, Verdict b) {
    return a == b ? a : UNKNOWN;
}
```

With one `REFUTED` there was nothing to notice. With two, a construction whose one reading is refuted by the value and whose other is refuted by the guard combines to `UNKNOWN` — the error becomes an E2011 warning, and the run-time check is left to catch what the compiler had proven. `Amount(if n < 0 then n else 0 - 1)` is that program. Both readings refuting now stays a refutation, said as the weaker of the two, and a test pins it.

## What the tests witness

`CompileInvariantViolationReasonTest` asserts message keys, not rendered prose, over the six programs above plus the two-reading case and both orders of the two-clause one. Each was checked against a mutant to show it is not passing for free:

| mutant | tests that fail |
| --- | --- |
| the classification inverted | 6 of 9 |
| `Verdict.of` back to equality | the two-reading one — no exception is thrown at all |
| `verdictOf` back to answering with the first refuted clause | the two-clause one |
| an input's invariant seeded as `ON_THE_PATH` | the `Pos` → `Neg` one |
| `assigning` reaching the guarded reading only | the `let bad = 0 - 5` one |

`mvn clean test` is green across every module.

## Also corrected

The class javadoc said the check asks whether *the guards* discharge a construction, and that every flagged construction has a guard that discharges it. `Range { lo = 5, hi = 1 }` has none. Describing the check that way is what made its diagnostic guard-centric to begin with, so it is worth not leaving in place.

## Not touched

E2011 says "the guards do not establish it" for a construction with no guards anywhere near it — the same defect in the warning. It is outside what was agreed for this change and wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
