### PR TITLE
Which module declared a helper is the declaration's to say, not the name's

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -412,31 +412,72 @@ public interface Ast {
      * return type and names a primitive: {@code let trim (s: String): String = intrinsic
      * "string.trim"} — its body is {@link FnBody.Intrinsic}, written only in the {@code souther}
      * namespace. What the modifiers say is in {@link Modifiers}.
+     *
+     * <p>{@code declaredIn} is the module that wrote the {@code let}, and it is written once, where
+     * the source is parsed. Every pass after that copies it. It is here because a module emits the
+     * recursive helpers it reaches as its own methods, under the names it reaches them by, so from
+     * that point a module's fns are declarations of several modules under one set of names — and
+     * which module declared one decides what may be checked of it (ADR-0098). The name cannot answer
+     * that: {@code List.foldFrom} is reached under the library's alias and declared in
+     * {@code souther.list}.
+     *
+     * <p>Null says this is not a module-level declaration at all — a block standing where a function
+     * goes, which has parameters and a body so that applying it expands like a call. It does not say
+     * "from somewhere else": a helper this module took on to emit was written by some module and says
+     * which, and every rule here reads that rather than the absence. Anything a later pass mints that
+     * <em>is</em> a declaration says which module it belongs to, so that these stay one question.
      */
-    record FnDef(WrittenName written, List<FnParam> params, RetType declaredReturn, FnBody body,
-                 Modifiers modifiers, SourcePos pos) implements Ast {
+    record FnDef(WrittenName written, String declaredIn, List<FnParam> params,
+                 RetType declaredReturn, FnBody body, Modifiers modifiers, SourcePos pos)
+            implements Ast {
         /** A fn with no modifier (the common case; totality-checked if recursive, published). */
-        public FnDef(WrittenName written, List<FnParam> params, RetType declaredReturn, FnBody body,
-                     SourcePos pos) {
-            this(written, params, declaredReturn, body, Modifiers.NONE, pos);
+        public FnDef(WrittenName written, String declaredIn, List<FnParam> params,
+                     RetType declaredReturn, FnBody body, SourcePos pos) {
+            this(written, declaredIn, params, declaredReturn, body, Modifiers.NONE, pos);
         }
 
-        /** A fn a pass wrote — an expanded copy, a helper filed under its module's qualifier —
-         * named but written nowhere the author would recognise. */
-        public FnDef(String name, List<FnParam> params, RetType declaredReturn, FnBody body,
-                     Modifiers modifiers, SourcePos pos) {
-            this(WrittenName.synthetic(name, pos), params, declaredReturn, body, modifiers, pos);
+        /** A block standing where a function goes, which no module declares: a lambda a binding
+         * holds, one handed to a function parameter. It has parameters and a body like a
+         * declaration, which is what lets an application of it expand like a call, and it is
+         * declared by nobody, which is what {@link #declaredIn} says of it. */
+        public static FnDef lambda(String name, List<FnParam> params, RetType declaredReturn,
+                                   FnBody body, SourcePos pos) {
+            return new FnDef(WrittenName.synthetic(name, pos), null, params, declaredReturn, body,
+                    Modifiers.NONE, pos);
         }
 
-        /** The same, with no modifier. */
-        public FnDef(String name, List<FnParam> params, RetType declaredReturn, FnBody body,
-                     SourcePos pos) {
-            this(name, params, declaredReturn, body, Modifiers.NONE, pos);
+        /**
+         * The same declaration under the name a module reaches it by.
+         *
+         * <p>The one way a declaration is renamed. A module emits a recursive helper it reaches as
+         * one of its own methods, under the name it reaches it by ({@code List.foldFrom},
+         * {@code maths.spin}), and that name is not where the declaration came from:
+         * {@code List.foldFrom} is reached under the library's alias and declared in
+         * {@code souther.list}, so the module it came from cannot be read back out of it. Renaming
+         * here carries {@link #declaredIn} across rather than restating it, so no caller is in a
+         * position to pair a name with an origin that is not its own.
+         */
+        public FnDef reachedAs(String name) {
+            return new FnDef(WrittenName.synthetic(name, pos), declaredIn, params, declaredReturn,
+                    body, modifiers, pos);
+        }
+
+        /** The same declaration with {@code replacement} in place of its body. */
+        public FnDef withBody(FnBody replacement) {
+            return new FnDef(written, declaredIn, params, declaredReturn, replacement, modifiers,
+                    pos);
         }
 
         /** What the fn is called. */
         public String name() {
             return written.canonical();
+        }
+
+        /** Whether {@code module} is the module that declared this. Asked of the declaration, so a
+         * helper another module published answers for the module that wrote it however the module
+         * reading it happens to reach it. A lambda is declared by no module and answers no. */
+        public boolean declaredBy(String module) {
+            return declaredIn != null && declaredIn.equals(module);
         }
 
         /** Whether the definition opts out of the totality check. */

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -276,7 +276,7 @@ public final class HelperInliner {
         }
         forEachExampleExpr(module, e -> collectHelperCalls(e, named));
         for (String name : graph.reachedFrom(named)) {
-            if (graph.recurses(name) && !table.declares(name)) {
+            if (graph.recurses(name) && !table.holds(name)) {
                 referencedPreludeRecursive.add(name);
             }
         }
@@ -366,12 +366,11 @@ public final class HelperInliner {
     public Map<String, Ast.FnDef> injectedExampleHelpers() {
         Map<String, Ast.FnDef> out = new java.util.LinkedHashMap<>();
         for (String name : exampleHelpers) {
-            if (table.declares(name)) {
+            if (table.holds(name)) {
                 continue;
             }
             Ast.FnDef def = table.reached(name);
-            out.put(name, new Ast.FnDef(name, def.params(), def.declaredReturn(),
-                    def.body(), def.modifiers(), def.pos()));
+            out.put(name, def.reachedAs(name));
         }
         return out;
     }
@@ -383,7 +382,7 @@ public final class HelperInliner {
     public Set<String> recursiveHelpers() {
         Set<String> result = new java.util.LinkedHashSet<>();
         for (String name : graph.recursive()) {
-            if (table.declares(name)) {
+            if (table.holds(name)) {
                 result.add(name);
             }
         }
@@ -398,16 +397,22 @@ public final class HelperInliner {
         Map<String, Ast.FnDef> out = new java.util.LinkedHashMap<>();
         for (String qualified : referencedPreludeRecursive) {
             Ast.FnDef def = table.reached(qualified);
-            out.put(qualified, new Ast.FnDef(qualified, def.params(), def.declaredReturn(),
-                    def.body(), def.modifiers(), def.pos()));
+            out.put(qualified, def.reachedAs(qualified));
         }
         return out;
     }
 
-    /** The module's own helper fns, keyed by name (for the standalone signature check). The
-     * auto-imported prelude helpers are excluded — they are validated once, on their own. */
+    /**
+     * The module's helper fns, keyed by the name it reaches each of them by — what it declared, and
+     * what it took on to emit as a method of its own.
+     *
+     * <p>Both, because both are emitted here and both are checked here. Which module declared one is
+     * not read off this map or off the key: the declaration says it
+     * ({@link Ast.FnDef#declaredBy}), and a check whose rule is about the declaring module — what
+     * may be walked, what must be proven total — asks it there.
+     */
     public Map<String, Ast.FnDef> helpers() {
-        return table.own();
+        return table.fns();
     }
 
     /**
@@ -428,10 +433,9 @@ public final class HelperInliner {
     public Ast.FnDef closeAcross(Ast.FnDef fn, String module) {
         Ast.Expr closed = graph.recurses(fn.name())
                 ? inlineRecursiveBody(fn) : inline(fn.writtenBody(), bodyOf(fn.name()));
-        return new Ast.FnDef(HelperNames.qualified(module, fn.name()), fn.params(), fn.declaredReturn(),
-                new Ast.FnBody.Written(
-                        HelperNames.publishedBy(HelperNames.qualifyHelpersOf(closed, module), module)),
-                fn.modifiers(), fn.pos());
+        return fn.reachedAs(HelperNames.qualified(module, fn.name()))
+                .withBody(new Ast.FnBody.Written(
+                        HelperNames.publishedBy(HelperNames.qualifyHelpersOf(closed, module), module)));
     }
 
     /** The module these helpers belong to — what {@link HelperNames#keyIn} compares a name's
@@ -928,7 +932,7 @@ public final class HelperInliner {
                 }
                 BindingId bound = li.binder().id();
                 writing.scopedLambdas().put(bound, new ScopedLambda(
-                        new Ast.FnDef(li.name(), params, null,
+                        Ast.FnDef.lambda(li.name(), params, null,
                                 new Ast.FnBody.Written(lambda.body()), li.pos())));
                 Ast.Expr body = inline(li.body());
                 writing.scopedLambdas().remove(bound);
@@ -1129,7 +1133,7 @@ public final class HelperInliner {
                     // the lambda's body is caller code, so it is not renamed by this helper's
                     // substitution — only the enclosing helper body is.
                     writing.scopedLambdas().put(f.id(), new ScopedLambda(
-                            new Ast.FnDef(f.name(), lparams,
+                            Ast.FnDef.lambda(f.name(), lparams,
                                     declares == null ? null : declares.result(),
                                     new Ast.FnBody.Written(lambda.body()), lambda.pos()),
                             new LambdaOrigin(p.name(), helper.name(), lambda.pos())));
@@ -1628,7 +1632,7 @@ public final class HelperInliner {
         }
         // by the name it is reached by here, which for another module's value is the qualified one
         String reached = spread.name();
-        Ast.FnDef value = table.own().get(reached);
+        Ast.FnDef value = table.fns().get(reached);
         return value == null || !value.params().isEmpty() || value.body() == null
                 || graph.recurses(reached) ? null : value;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -47,9 +47,7 @@ public final class HelperNames {
         List<Ast.FnDef> fns = new ArrayList<>();
         for (Ast.FnDef fn : m.fns()) {
             fns.add(fn.body() instanceof Ast.FnBody.Written w
-                    ? new Ast.FnDef(fn.written(), fn.params(), fn.declaredReturn(),
-                            new Ast.FnBody.Written(qualifyForeign(w.expr(), m.name())),
-                            fn.modifiers(), fn.pos())
+                    ? fn.withBody(new Ast.FnBody.Written(qualifyForeign(w.expr(), m.name())))
                     : fn);
         }
         List<Ast.Def> defs = qualifiedInvariants(m);
@@ -265,6 +263,12 @@ public final class HelperNames {
      * that keyed by the spelling would answer differently on either side of that pass — silently,
      * because a miss is what a table does with a key it has not got. The pair (module, name) is what
      * the definition is (ADR-0072), so it is what a table of definitions is asked with.
+     *
+     * <p>What comes back is a key and not an identity. It names a definition only within the module it
+     * was asked for, and it does not hold the module the definition came from: a library helper is
+     * reached under the library's alias, so {@code List.foldFrom} is what {@code souther.list}'s
+     * {@code foldFrom} is keyed as here. A reader that needs the declaring module asks the declaration
+     * ({@link Ast.FnDef#declaredBy}) rather than reading this back.
      */
     public static String keyIn(String module, ValueName.Helper helper) {
         return helper.module().equals(module) ? helper.name() : qualified(helper.module(), helper.name());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -14,11 +14,17 @@ import java.util.function.Predicate;
  * module it was written in.
  *
  * <p>A reader writes an imported value or helper bare, and the pair (module, name) is what it
- * denotes. Writing the qualified spelling into the tree makes the two agree, so everything
- * downstream — the table a call is expanded against, the method a recursive helper is emitted as —
- * reads the identity by reading the name, and two modules publishing a {@code tally} stay two
- * definitions. Every rewrite here reads what a name denotes and never how it was spelled, so running
- * one twice says what running it once said.
+ * denotes. Writing the qualified spelling into the tree settles the name a reader reaches it by, so
+ * everything downstream — the table a call is expanded against, the method a recursive helper is
+ * emitted as — asks and answers with one name, and two modules publishing a {@code tally} stay two
+ * entries. Every rewrite here reads what a name denotes and never how it was spelled, so running one
+ * twice says what running it once said.
+ *
+ * <p>What that spelling settles is the reach name, and it is not the declaration's identity. The two
+ * coincide for a helper another module published and part ways for the standard library, which is
+ * reached under an alias: {@code List.foldFrom} is declared in {@code souther.list}, and no reader of
+ * the name can get there from it. Which module declared a definition is carried on the declaration
+ * ({@link Ast.FnDef#declaredIn}), and every rule about the declaring module reads it there.
  *
  * <p>The marks a construction carries belong here for the same reason. What a published body builds
  * is built where that body was written; expanding it puts the construction in the reader's body,
@@ -256,19 +262,22 @@ public final class HelperNames {
 
     /**
      * The key {@code helper} is filed under in the table of the module named {@code module} — bare for
-     * one that module declares, qualified for one it imported.
+     * one that module declares, declaring-module-qualified for one it imported.
      *
-     * <p>Read off what the name denotes and never off how it was written. A reader writes an imported
-     * definition bare, so the spelling is a key only after {@link #qualifyImports} has run, and a check
-     * that keyed by the spelling would answer differently on either side of that pass — silently,
-     * because a miss is what a table does with a key it has not got. The pair (module, name) is what
-     * the definition is (ADR-0072), so it is what a table of definitions is asked with.
+     * <p>This turns a helper's identity into the name that module reaches it by, and the two are
+     * different values. What comes back is a key: it names a declaration within one module's table and
+     * says nothing outside it, and it is not something to read a declaring module back out of. That is
+     * carried on the declaration ({@link Ast.FnDef#declaredBy}).
      *
-     * <p>What comes back is a key and not an identity. It names a definition only within the module it
-     * was asked for, and it does not hold the module the definition came from: a library helper is
-     * reached under the library's alias, so {@code List.foldFrom} is what {@code souther.list}'s
-     * {@code foldFrom} is keyed as here. A reader that needs the declaring module asks the declaration
-     * ({@link Ast.FnDef#declaredBy}) rather than reading this back.
+     * <p>Asked with the identity and never with a spelling, which is what {@link ValueName.Helper}
+     * holds (ADR-0072); a reader writes an imported definition bare, so a key taken off the spelling
+     * would be one key before {@link #qualifyImports} and another after — silently, because a miss is
+     * what a table does with a key it has not got.
+     *
+     * <p>The library does not come through here. A standard-library name is reached under an alias
+     * rather than under the module that declares it — {@code souther.list}'s {@code foldFrom} is
+     * reached as {@code List.foldFrom} — and denotes a {@link ValueName.Stdlib}, which already holds
+     * that reach name and is read as it stands.
      */
     public static String keyIn(String module, ValueName.Helper helper) {
         return helper.module().equals(module) ? helper.name() : qualified(helper.module(), helper.name());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -190,7 +190,7 @@ final class HelperParams {
                                     p.pos()),
                             p.typeFromPattern()));
         }
-        return new Ast.FnDef(h.written(), params, h.declaredReturn(), h.body(),
+        return new Ast.FnDef(h.written(), h.declaredIn(), params, h.declaredReturn(), h.body(),
                 h.modifiers(), h.pos());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
@@ -21,9 +21,17 @@ import java.util.Map;
  * it is reached by here. A qualified call resolves to whichever of the two declared it, a bare call
  * to the module's own — the standard library has no bare names (spec §stdlib).
  *
- * <p>{@link #own} keeps the order the module wrote its helpers in, and that is load-bearing: the
+ * <p>{@link #fns} keeps the order the module wrote its helpers in, and that is load-bearing: the
  * checks walk it and stop at the first helper they find wrong, so the order decides which one the
  * author is told about. An author reads their file from the top.
+ *
+ * <p>What is in {@link #fns} is what the module <em>has as a fn</em>, which is not the same as what
+ * it declared. A module emits the recursive helpers it reaches as its own methods, so from
+ * {@code Shapes.Prepared} on, a prelude {@code List.foldFrom} and a helper another module published
+ * sit there beside the module's own {@code let}s. Nothing here answers which module declared one:
+ * the declaration answers that ({@link Ast.FnDef#declaredBy}), because the name it is reached by
+ * cannot — {@code List.foldFrom} is reached under the library's alias and declared in
+ * {@code souther.list}.
  *
  * <p>What is in the table depends on {@link InliningPolicy}, which is what an expanded tree is a
  * representation <em>of</em>. Two policies are two tables and not one table read two ways.
@@ -115,13 +123,15 @@ public final class HelperTable {
         return Collections.unmodifiableMap(reached);
     }
 
-    /** The module's own helpers, in the order it wrote them. */
-    public Map<String, Ast.FnDef> own() {
+    /** The module's helpers, in the order it wrote them — what it declared, and what it took on as
+     * its own fns to emit. Which of the two one is, the declaration says. */
+    public Map<String, Ast.FnDef> fns() {
         return Collections.unmodifiableMap(own);
     }
 
-    /** Whether the module declares {@code name} itself. */
-    public boolean declares(String name) {
+    /** Whether the module has {@code name} as a fn of its own — one it declared, or one it took on
+     * to emit. Not whether it declared it: for that, ask the declaration. */
+    public boolean holds(String name) {
         return own.containsKey(name);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -71,8 +71,7 @@ public final class Lower {
         Ast.Expr expanded = recursive
                 ? inliner.inlineRecursiveBody(fn)
                 : inliner.inline(fn.writtenBody(), dependencies(fn, dependencies), inliner.bodyOf(fn.name()));
-        return new Ast.FnDef(fn.written(), fn.params(), fn.declaredReturn(),
-                new Ast.FnBody.Written(desugar(expanded)), fn.modifiers(), fn.pos());
+        return fn.withBody(new Ast.FnBody.Written(desugar(expanded)));
     }
 
     /** Which bindings the {@code depends on} names are: the trailing parameters that carry them. A

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -35,8 +35,7 @@ public final class NewtypeDesugar {
                 case Ast.FnBody.Written w -> new Ast.FnBody.Written(go(w.expr(), symbols));
                 case Ast.FnBody.Intrinsic i -> i;
             };
-            fns.add(new Ast.FnDef(fn.written(), fn.params(), fn.declaredReturn(), body, fn.modifiers(),
-                    fn.pos()));
+            fns.add(fn.withBody(body));
         }
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
                 m.defs(), m.behaviors(), fns, m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialHelperUse.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialHelperUse.java
@@ -31,15 +31,25 @@ import java.util.Optional;
  * may call a {@code partial} helper. That is not a boundary the walk stops at, it is a declaration the
  * walk is never asked about. A helper between the behavior and the {@code partial} one is still a
  * helper and still needs the word.
+ *
+ * <p>Both rules are about a declaration this module wrote, and each says so itself rather than leaving
+ * it to whoever loops. A module emits the recursive helpers it reaches as its own methods, so its fns
+ * hold declarations of other modules under names of the same shape; those were answered for where they
+ * were written (ADR-0098), and a report about one here would name a definition this module's author
+ * never wrote. The two rules are one guarantee seen twice — the first refuses a way around the call
+ * graph, the second refuses a way out of it — so a scope on one and not the other is the guarantee
+ * holding on one side only.
  */
 final class PartialHelperUse {
 
     private PartialHelperUse() {}
 
-    /** The first rule, for one helper: unmarked, it may reach no {@code partial} one. Asked per helper
-     * so that a module with several of them reports all of them in one build — the word goes on each. */
-    static void rejectReachingPartial(Ast.FnDef helper, PartialReachability reachability) {
-        if (helper.partial()) {
+    /** The first rule, for one helper of {@code module}: unmarked, it may reach no {@code partial} one.
+     * Asked per helper so that a module with several of them reports all of them in one build — the
+     * word goes on each. */
+    static void rejectReachingPartial(Ast.FnDef helper, String module,
+                                      PartialReachability reachability) {
+        if (!helper.declaredBy(module) || helper.partial()) {
             return;
         }
         Optional<List<String>> path = reachability.fromHelper(helper.name());
@@ -66,18 +76,33 @@ final class PartialHelperUse {
     }
 
     /**
+     * The second rule, for one fn of {@code module}: it may write no {@code partial} helper where a
+     * value goes.
+     *
+     * <p>Asked of every fn and not only of the helpers. A behavior's implementing {@code let} may call
+     * a {@code partial} helper and may not hand it over either — what the rule is about is the function
+     * value, which is the same thing wherever it is written.
+     */
+    static void rejectNamedAsValue(Ast.FnDef fn, String module, PartialReachability reachability) {
+        if (!fn.declaredBy(module) || !(fn.body() instanceof Ast.FnBody.Written written)) {
+            return;
+        }
+        walkForNamedAsValue(written.expr(), reachability);
+    }
+
+    /**
      * Walks {@code e} for a {@code partial} helper written where a value goes. The callee of an
      * application is not such a place — that is the call the rule allows — so it is skipped where it is
      * a name and walked where it is anything else.
      */
-    static void rejectNamedAsValue(Ast.Expr e, PartialReachability reachability) {
+    private static void walkForNamedAsValue(Ast.Expr e, PartialReachability reachability) {
         switch (e) {
             case Ast.Apply call -> {
                 if (!(call.function() instanceof Ast.Var)) {
-                    rejectNamedAsValue(call.function(), reachability);
+                    walkForNamedAsValue(call.function(), reachability);
                 }
                 for (Ast.Expr arg : call.args()) {
-                    rejectNamedAsValue(arg, reachability);
+                    walkForNamedAsValue(arg, reachability);
                 }
             }
             case Ast.Var v -> {
@@ -95,7 +120,7 @@ final class PartialHelperUse {
                                     + " `partial` helper may be applied but not handed over");
                 }
             }
-            default -> Ast.forEachChild(e, child -> rejectNamedAsValue(child, reachability));
+            default -> Ast.forEachChild(e, child -> walkForNamedAsValue(child, reachability));
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -33,20 +33,28 @@ import java.util.TreeSet;
  * {@link souther.compiler.codegen.Backend#BOUNDARY_VERSION} records — an unmarked published helper
  * summarises its whole call closure, so a reader never walks it.
  *
- * <p>Two things are asked of a declaration rather than of this graph, because a soundness rule may not
- * rest on what building the graph happened to visit. Whether a name is {@code partial} is read off the
- * declaration it reaches, not off a set collected on the way — a clause names what it names, whether
- * or not a helper of this module names it too. And which declaration a name reaches is read off what
- * the name denotes ({@link HelperNames#keyIn}), not off how it was spelled, so the answer is the same
- * before and after the pass that writes an imported name out qualified.
+ * <p>Which of the two a helper is comes from its declaration. A module emits the recursive helpers it
+ * reaches as its own methods, so an imported one sits in this module's fns under a name of the same
+ * shape as the module's own; the declaration is the only thing that still says who wrote it
+ * ({@link Ast.FnDef#declaredBy}). Deciding it any other way is deciding it by spelling, and this is a
+ * rule about which module carries the guarantee.
+ *
+ * <p>Three things are asked of a declaration rather than of this graph, because a soundness rule may
+ * not rest on what building the graph happened to visit. Whether a name is {@code partial} is read off
+ * the declaration it reaches, not off a set collected on the way — a clause names what it names,
+ * whether or not a helper of this module names it too. And which declaration a name reaches is read
+ * off what the name denotes ({@link HelperNames#keyIn}), not off how it was spelled, so the answer is
+ * the same before and after the pass that writes an imported name out qualified.
  *
  * <p>A path is the shortest one, found breadth-first with each node's callees taken in name order, so
  * the same module always reports the same path.
  */
 final class PartialReachability {
 
-    /** Module-own helper -> the helpers it reaches, in name order. A name absent as a key is a
-     * terminal: an imported or prelude helper, whose declaration answers for its own closure. */
+    /** A helper this module declared -> the helpers it reaches, in name order. A name absent as a
+     * key is a terminal: an imported or prelude helper, whose declaration answers for its own
+     * closure. Which of the two a name is comes from the declaration and not from the name, since a
+     * module's fns hold both under names of one shape. */
     private final Map<String, List<String>> calls;
 
     private final HelperInliner inliner;
@@ -59,6 +67,13 @@ final class PartialReachability {
     static PartialReachability of(HelperInliner inliner) {
         Map<String, List<String>> calls = new LinkedHashMap<>();
         for (Map.Entry<String, Ast.FnDef> entry : inliner.helpers().entrySet()) {
+            // Only what this module declared is a node. What it took on to emit — a prelude helper,
+            // one another module published — is a terminal, because its declaration already answers
+            // for its whole closure (ADR-0098). It is in the same map and under a name of the same
+            // shape, so the declaration is what tells the two apart.
+            if (!entry.getValue().declaredBy(inliner.moduleName())) {
+                continue;
+            }
             if (entry.getValue().body() instanceof Ast.FnBody.Written written) {
                 calls.put(entry.getKey(), reachedBy(written.expr(), inliner));
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -299,8 +299,8 @@ public final class Resolve {
             case Ast.FnBody.Written w -> new Ast.FnBody.Written(expr(w.expr(), bound));
             case Ast.FnBody.Intrinsic i -> i;
         };
-        return new Ast.FnDef(f.written(), params, retType(f.declaredReturn()), body, f.modifiers(),
-                f.pos());
+        return new Ast.FnDef(f.written(), f.declaredIn(), params, retType(f.declaredReturn()), body,
+                f.modifiers(), f.pos());
     }
 
     // --- written types ---

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -32,9 +32,10 @@ import java.util.Set;
  * lexicographic recursion. A {@code partial} helper opts out (it is not checked and may not terminate);
  * if any member of a mutually-recursive group is {@code partial} the whole group is skipped — a cycle
  * through an unchecked member cannot be certified, so its other members are not independently certified
- * either. The stdlib's {@code List.foldFrom} (index recursion) is trusted total and exempt — only
- * bare-named module-own helpers are checked. Numeric ({@code n - 1}) and index ({@code i + 1})
- * recursion are not structural (Souther has no inductive {@code Nat}) and must be {@code partial}.
+ * either. The stdlib's {@code List.foldFrom} (index recursion) is trusted total and exempt — only the
+ * helpers this module declared are checked, whatever else it emits beside them. Numeric
+ * ({@code n - 1}) and index ({@code i + 1}) recursion are not structural (Souther has no inductive
+ * {@code Nat}) and must be {@code partial}.
  */
 final class TotalityChecker {
 
@@ -54,9 +55,12 @@ final class TotalityChecker {
         Set<String> handled = new HashSet<>();
         for (String name : inliner.recursiveHelpers()) {
             Ast.FnDef h = own.get(name);
-            // A qualified name (`List.foldFrom`) is a prelude recursive helper injected into the module
-            // (trusted total); only bare-named user helpers are checked.
-            if (h == null || name.indexOf('.') >= 0) {
+            // Only what this module declared is checked. A recursive helper it took on to emit — a
+            // prelude `List.foldFrom`, one another module published — carries its declaring module's
+            // guarantee (ADR-0098), and its own module proved it. Asked of the declaration: the name
+            // it is reached by here says nothing about who wrote it, and `List.foldFrom` does not
+            // even hold the module it came from.
+            if (h == null || !h.declaredBy(inliner.moduleName())) {
                 continue;
             }
             Set<String> group = cycleMembers(name, ownEdges);   // the strongly-connected group (>= 1)

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -371,20 +371,18 @@ public final class TypeChecker {
         collect(errors, abandoned, () -> TotalityChecker.check(inliner));
         // And the guarantee covers what a helper reaches, not only its own descent: an unmarked helper
         // may reach no `partial` one, and a `partial` one may not be written where a value goes. Asked
-        // per declaration, so a module needing the word in several places says so in one build. Of the
-        // ones this module declared: a helper it took on to emit was answered for where it was
-        // written, and re-answering it here would put another module's mistake in this module's report.
+        // per declaration, so a module needing the word in several places says so in one build. Which
+        // declarations each rule is about is the rule's own to say (see PartialHelperUse): the fns here
+        // hold what this module took on to emit as well as what it wrote.
         for (Ast.FnDef helper : inliner.helpers().values()) {
-            if (!helper.declaredBy(module.name())) {
-                continue;
-            }
-            collect(errors, abandoned, () -> PartialHelperUse.rejectReachingPartial(helper, reachability));
+            collect(errors, abandoned,
+                    () -> PartialHelperUse.rejectReachingPartial(helper, module.name(), reachability));
         }
+        // Every fn and not only the helpers: a behavior's `let` may call a `partial` helper and may not
+        // hand it over either.
         for (Ast.FnDef fn : module.fns()) {
-            if (fn.body() instanceof Ast.FnBody.Written written) {
-                collect(errors, abandoned,
-                        () -> PartialHelperUse.rejectNamedAsValue(written.expr(), reachability));
-            }
+            collect(errors, abandoned,
+                    () -> PartialHelperUse.rejectNamedAsValue(fn, module.name(), reachability));
         }
         // A fn matching a pipeline is rejected (a pipeline is already its own implementation, so it
         // cannot also have a fn body — spec 13.1). A fn matching a SpecBehavior is that behavior's

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -371,8 +371,13 @@ public final class TypeChecker {
         collect(errors, abandoned, () -> TotalityChecker.check(inliner));
         // And the guarantee covers what a helper reaches, not only its own descent: an unmarked helper
         // may reach no `partial` one, and a `partial` one may not be written where a value goes. Asked
-        // per declaration, so a module needing the word in several places says so in one build.
+        // per declaration, so a module needing the word in several places says so in one build. Of the
+        // ones this module declared: a helper it took on to emit was answered for where it was
+        // written, and re-answering it here would put another module's mistake in this module's report.
         for (Ast.FnDef helper : inliner.helpers().values()) {
+            if (!helper.declaredBy(module.name())) {
+                continue;
+            }
             collect(errors, abandoned, () -> PartialHelperUse.rejectReachingPartial(helper, reachability));
         }
         for (Ast.FnDef fn : module.fns()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -44,12 +44,12 @@ public final class ValueCycles {
     public static void rejectIn(Ast.Module m, Map<String, Ast.FnDef> published) {
         HelperTable table = HelperTable.of(m, published, InliningPolicy.FULL);
         Map<String, Set<String>> callsOf = new LinkedHashMap<>();
-        for (Map.Entry<String, Ast.FnDef> e : table.own().entrySet()) {
+        for (Map.Entry<String, Ast.FnDef> e : table.fns().entrySet()) {
             Set<String> called = new LinkedHashSet<>();
             HelperInliner.helperCallsIn(e.getValue().writtenBody(), table.reachable(), called);
             callsOf.put(e.getKey(), called);
         }
-        reject(table.own(), callsOf);
+        reject(table.fns(), callsOf);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -435,7 +435,7 @@ public final class AstBuilder {
                                 + " namespace may declare one (ADR-0028)");
             }
             String key = stringValue(intrinsic.get().token(SyntaxKind.STRING_LIT).orElseThrow().text());
-            return new Ast.FnDef(declared, params, declaredReturn,
+            return new Ast.FnDef(declared, moduleName, params, declaredReturn,
                     new Ast.FnBody.Intrinsic(key), modifiers, pos);
         }
         SyntaxNode bodyNode = onlyExpr(n);
@@ -468,8 +468,8 @@ public final class AstBuilder {
                 body = bindPattern(pat, Ast.Var.desugared(params.get(i).name(), at), body, at);
             }
         }
-        return new Ast.FnDef(declared, params, declaredReturn, new Ast.FnBody.Written(body),
-                modifiers, pos);
+        return new Ast.FnDef(declared, moduleName, params, declaredReturn,
+                new Ast.FnBody.Written(body), modifiers, pos);
     }
 
     private Ast.FnParam fnParam(SyntaxNode p, SyntaxNode pat) {

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -253,9 +253,11 @@ public final class Shapes {
             // where it is found, and this module is not compiled either way.
             Map<String, Ast.FnDef> published = imported.present() ? imported.value() : Map.of();
             // An imported definition is written here bare and denotes the module that declares it.
-            // Spelling it that way, once, is what lets everything downstream — the table a call
-            // expands against, the method a recursive helper becomes — read the identity by reading
-            // the name.
+            // Spelling it out, once, settles the name this module reaches it by, which is what the
+            // table a call expands against is keyed by and what the method a recursive helper becomes
+            // is called. It settles nothing about where the definition came from: the fns below hold
+            // declarations of several modules under names of one shape, and which module wrote each is
+            // carried on the declaration (Ast.FnDef.declaredIn).
             Ast.Module m = HelperNames.qualifyImports(desugared.value());
             try {
                 HelperInliner inliner = HelperInliner.forModule(m, published);

--- a/souther-compiler/src/test/java/souther/compiler/PreludeValueDeclaresItsTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/PreludeValueDeclaresItsTypeTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.ast.WrittenName;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.SourcePos;
 
@@ -23,8 +24,8 @@ class PreludeValueDeclaresItsTypeTest {
     @Test
     void aValueWithoutAWrittenTypeIsRefusedAtLoad() {
         SourcePos at = new SourcePos(1, 1);
-        Ast.FnDef value = new Ast.FnDef("someValue", List.of(), null,
-                new Ast.FnBody.Written(new Ast.IntLit(0, at)), at);
+        Ast.FnDef value = new Ast.FnDef(WrittenName.synthetic("someValue", at), "souther.list",
+                List.of(), null, new Ast.FnBody.Written(new Ast.IntLit(0, at)), at);
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
                 () -> Prelude.signatureOf(value, "List.someValue", Symbols.none()));

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
@@ -1,0 +1,169 @@
+package souther.compiler.check;
+
+import souther.compiler.Prelude;
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which module declared a helper is read off the declaration, never off the name it is reached by.
+ *
+ * <p>The two used to be one question. A module emits the recursive helpers it reaches as its own
+ * methods, under the names it reaches them by, so from that point its fns hold declarations of
+ * several modules side by side — and the only thing left saying which was which was the dot the
+ * qualified name was joined with. Every rule about the declaring module was then a rule about the
+ * spelling: the totality check may only require a descent of what this module wrote (ADR-0098), and
+ * it asked whether the name had a dot in it.
+ *
+ * <p>No source can spell the two apart — an identifier holds no dot — so the tables below are built
+ * where a table is built rather than compiled from a file. Each is a shape the pipeline produces: a
+ * published closure is keyed and named qualified by the module that declares it, and an imported
+ * helper arrives under whatever name the reader reaches it by.
+ */
+class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
+
+    private static Ast.Module resolved(String source) {
+        Ast.Module parsed = CstFrontend.parse(source);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    /** {@code source} resolved with {@code imported} (bare name -> declaring module) reachable, which
+     * is what the query layer hands a module that writes an {@code import}. */
+    private static Ast.Module resolved(String source, Map<String, String> imported) {
+        Ast.Module parsed = CstFrontend.parse(source);
+        Map<String, ValueName.Helper> helpers =
+                new LinkedHashMap<>(Resolve.Values.of(parsed).helpers());
+        imported.forEach((bare, module) -> helpers.put(bare, new ValueName.Helper(module, bare)));
+        Resolve.Resolved answered = Resolve.resolving(parsed, Symbols.of(parsed),
+                new Resolve.Values(parsed.name(), helpers, Map.of(), Map.of()));
+        if (!answered.unresolved().isEmpty()) {
+            throw answered.unresolved().get(0);
+        }
+        return answered.module();
+    }
+
+    /** A module declaring one recursive helper that descends on nothing. */
+    private static Ast.FnDef spinOf(String module) {
+        Ast.Module m = resolved("module " + module + "\n\nlet spin (n: Int) : Int = spin(n)\n");
+        return HelperInliner.helpersOf(m).get("spin");
+    }
+
+    private static void check(String module, Map<String, Ast.FnDef> fns) {
+        HelperTable table = HelperTable.of(module, fns, Map.of(), InliningPolicy.FULL);
+        TotalityChecker.check(HelperInliner.over(table, HelperGraph.of(table)));
+    }
+
+    /**
+     * A helper the module declared, filed under a qualified name — the shape a published body is
+     * closed into, read back in the module that wrote it. Its descent is still required.
+     *
+     * <p>Reading the dot skips this, and skipping it is accepting a recursion nobody proved.
+     */
+    @Test
+    void aQualifiedNameIsNotAnExemption() {
+        Ast.FnDef own = spinOf("maths");
+        HelperInliner maths = HelperInliner.forHelpers("maths", Map.of("spin", own));
+        Ast.FnDef closed = maths.closeAcross(own, "maths");
+
+        assertEquals("maths.spin", closed.name());
+        assertEquals("maths", closed.declaredIn());
+
+        CompileException refused = assertThrows(CompileException.class,
+                () -> check("maths", Map.of(closed.name(), closed)));
+        assertEquals("E2001", refused.code());
+    }
+
+    /**
+     * A helper another module declared, reached here under a bare name. Its descent is not this
+     * module's to require: the module that wrote it required it there, and an unmarked published
+     * helper answers for its whole closure (ADR-0098).
+     *
+     * <p>Reading the dot checks this one, and a rejection here names a definition the author of this
+     * module never wrote.
+     */
+    @Test
+    void aBareNameIsNotADeclaration() {
+        Ast.FnDef foreign = spinOf("maths");
+
+        assertEquals("spin", foreign.name());
+        assertEquals("maths", foreign.declaredIn());
+
+        assertDoesNotThrow(() -> check("order", Map.of(foreign.name(), foreign)));
+    }
+
+    /**
+     * A helper this module took on to emit is a terminal in the {@code partial}-reachability graph:
+     * what it reaches is answered by the module that declared it (ADR-0098), so this one does not
+     * walk its body.
+     *
+     * <p>Trust is only visible against something it would otherwise have caught, so {@code wrapped}
+     * below is unmarked and reaches a {@code partial} helper — which the module declaring it rejects.
+     * That is what a module published under an older boundary version can look like
+     * ({@link souther.compiler.codegen.Backend#BOUNDARY_VERSION}), and where the rule says the reader
+     * does not re-derive it, the reader must not report it either.
+     */
+    @Test
+    void aHelperTakenOnToEmitIsATerminal() {
+        Ast.Module maths = resolved("""
+                module maths exposing ( wrapped )
+
+                partial let spin (n: Int) : Int = spin(n)
+                let wrapped (n: Int) : Int = spin(n)
+                """);
+        Map<String, Ast.FnDef> declared = HelperInliner.helpersOf(maths);
+        HelperInliner from = HelperInliner.forHelpers("maths", declared);
+        Ast.FnDef spin = from.closeAcross(declared.get("spin"), "maths");
+        Ast.FnDef wrapped = from.closeAcross(declared.get("wrapped"), "maths");
+
+        Ast.Module order = resolved("""
+                module order
+
+                import maths ( wrapped, spin )
+
+                let throughWrapped (n: Int) : Int = wrapped(n)
+                let straightToSpin (n: Int) : Int = spin(n)
+                """, Map.of("wrapped", "maths", "spin", "maths"));
+        Map<String, Ast.FnDef> fns = new LinkedHashMap<>(HelperInliner.helpersOf(order));
+        fns.put(spin.name(), spin);
+        fns.put(wrapped.name(), wrapped);
+        HelperTable table = HelperTable.of("order", fns, Map.of(), InliningPolicy.FULL);
+        PartialReachability reachability =
+                PartialReachability.of(HelperInliner.over(table, HelperGraph.of(table)));
+
+        // `wrapped` is unmarked, and what it reaches is the module that declared it to answer for.
+        assertEquals(Optional.empty(), reachability.fromHelper("maths.wrapped"));
+        assertEquals(Optional.empty(), reachability.fromHelper("throughWrapped"));
+        // The rule stops at the boundary rather than everywhere: a `partial` helper of another
+        // module is still one, and what this module wrote is still walked to find it.
+        assertEquals(Optional.of(List.of("straightToSpin", "maths.spin")),
+                reachability.fromHelper("straightToSpin"));
+    }
+
+    /**
+     * The library's own case, and the reason the name cannot be asked at all: a prelude helper is
+     * reached under the library's alias and declared in the module the source says. {@code List} is
+     * not {@code souther.list}, so the module a name came from is not in the name — the dot only ever
+     * said that there was one.
+     */
+    @Test
+    void theNameAHelperIsReachedByDoesNotHoldTheModuleThatWroteIt() {
+        Ast.FnDef foldFrom = Prelude.helpers().get("List.foldFrom");
+
+        assertEquals("souther.list", foldFrom.declaredIn());
+        assertTrue(foldFrom.declaredIn().startsWith("souther."));
+        assertEquals("souther.list", foldFrom.reachedAs("List.foldFrom").declaredIn());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
@@ -153,6 +153,58 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
     }
 
     /**
+     * The other half of the same guarantee. A {@code partial} helper may not be written where a value
+     * goes, which is what keeps it from leaving the call graph the rule above walks — and that rule is
+     * about a declaration this module wrote, for the reason the one above is.
+     *
+     * <p>Asked of every fn rather than of the helpers, since a behavior's own {@code let} may not hand
+     * one over either, so the fns of a module are exactly where a declaration it only took on to emit
+     * turns up.
+     *
+     * <p>The body below is the declaration as its own module wrote it, which is the shape
+     * {@link HelperInliner#injectedRecursiveHelpers} and {@link HelperInliner#injectedExampleHelpers}
+     * put into a reader's fns for a library helper: those read {@code Prelude.helpers()}, whose bodies
+     * were never closed. A body that <em>was</em> closed cannot carry this at all — the expansion
+     * eta-expands a helper named where a value goes — so this rule and the one above meet a foreign
+     * declaration by different routes and need the same scope either way.
+     */
+    @Test
+    void aHelperTakenOnToEmitIsNotReReadForAPartialHandedOver() {
+        Ast.Module maths = resolved("""
+                module maths exposing ( hands )
+
+                partial let spin (n: Int) : Int = spin(n)
+                partial let loop (f: (Int) -> Int, n: Int) : Int = loop(f, n)
+                let hands (n: Int) : Int = loop(spin, n)
+                """);
+        Map<String, Ast.FnDef> declared = HelperInliner.helpersOf(maths);
+        HelperInliner from = HelperInliner.forHelpers("maths", declared);
+        Ast.FnDef spin = from.closeAcross(declared.get("spin"), "maths");
+        Ast.FnDef hands = declared.get("hands").reachedAs("maths.hands");
+
+        Ast.Module order = resolved("""
+                module order
+
+                let ownWork (n: Int) : Int = n + 1
+                """);
+        Map<String, Ast.FnDef> fns = new LinkedHashMap<>(HelperInliner.helpersOf(order));
+        fns.put(spin.name(), spin);
+        fns.put(hands.name(), hands);
+        HelperTable table = HelperTable.of("order", fns, Map.of(), InliningPolicy.FULL);
+        PartialReachability reachability =
+                PartialReachability.of(HelperInliner.over(table, HelperGraph.of(table)));
+
+        // `maths` answered for its own body. Reading it again here reports `maths.spin` against a
+        // module whose author never wrote it.
+        assertDoesNotThrow(() ->
+                PartialHelperUse.rejectNamedAsValue(hands, "order", reachability));
+        // Where it was written, the same body is the module's own to answer for.
+        CompileException refused = assertThrows(CompileException.class,
+                () -> PartialHelperUse.rejectNamedAsValue(hands, "maths", reachability));
+        assertEquals("E2001", refused.code());
+    }
+
+    /**
      * The library's own case, and the reason the name cannot be asked at all: a prelude helper is
      * reached under the library's alias and declared in the module the source says. {@code List} is
      * not {@code souther.list}, so the module a name came from is not in the name — the dot only ever


### PR DESCRIPTION
The first half of #378: a helper's declaring module is recorded on the declaration, so the rules that are about it stop reading the name.

## What was wrong

A module emits the recursive helpers it reaches as its own methods, so `Shapes.Prepared` puts a prelude `List.foldFrom` and a helper another module published into `m.fns()` under the names this module reaches them by. `HelperInliner.helpersOf` reads `m.fns()` and nothing else, so from there a module's helpers are declarations of several modules under one set of names, with nothing recording which is which. What the totality check is handed:

```
module=demo   own=[firstOver, anyOver, List.foldFrom]  recursive=[List.foldFrom, firstOver]
module=order  own=[maths.spin]                         recursive=[maths.spin]
```

`HelperTable.own()` said "the module's own helpers" and answered "in this module's fn set". `TotalityChecker` needed the first and had only the dot to read:

```java
if (h == null || name.indexOf('.') >= 0) {
    continue;
}
```

`h == null` never fires there — the prelude helper is in the fn set — so the dot carried the whole rule. And the dot does not hold the answer anyway: `List.foldFrom` is reached under the library's alias and declared in `souther.list`, so the module a helper came from is not recoverable from the name it is reached by.

`PartialReachability` had the same shape. Its javadoc states ADR-0098 — an unmarked published helper summarises its whole call closure, so a reader never walks it — and builds its nodes from `inliner.helpers()`, where those helpers now are. The rule was written down and not run.

## What this does

`Ast.FnDef` carries `declaredIn`, written once in `AstBuilder` where the source is parsed and copied by every pass after. Renaming goes through `reachedAs` and a body swap through `withBody`, so no caller is in a position to pair a name with an origin that is not its own; a lambda is `FnDef.lambda`, which no module declares. `declaredIn == null` says "not a module-level declaration", never "from somewhere else".

With that recorded:

- `TotalityChecker` requires a descent of what this module declared, asked of the declaration
- `PartialReachability` makes a helper this module took on a terminal, which is what its javadoc and ADR-0098 say
- `TypeChecker` runs `rejectReachingPartial` over this module's own declarations, so another module's mistake is not reported here
- `HelperTable` stops claiming to answer provenance: `own()`/`declares()` became `fns()`/`holds()`, which is what its three callers were asking for

`HelperNames.keyIn`'s javadoc is corrected too. It blamed `qualifyImports`, but its one caller hands it a pair and it never reads a spelling; what it returns is a key within one module, and it does not hold the declaring module.

## What changes for a build

One thing. A module published under an older `Backend.BOUNDARY_VERSION` can hold an unmarked helper reaching a `partial` one. The reader used to walk into it and report, in its own module, what the declaring module was supposed to have answered for. It no longer does.

Nothing else: a module-own helper's reach name cannot contain a dot, since `CstLexer.identifier` takes `Character.isJavaIdentifierPart`, so the old test and the new rule agree on everything a source can spell.

## Witnesses

`WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest`. No source can spell the two apart, so the tables are built where a table is built. Each was checked against the old rule:

| | under the old rule |
|---|---|
| a qualified name is not an exemption | `Expected CompileException to be thrown, but nothing was thrown` |
| a bare name is not a declaration | `E2001` raised for a definition this module never wrote |
| a helper taken on to emit is a terminal | `Optional[[maths.wrapped, maths.spin]]` |

The fourth states why the name cannot be asked at all: `List.foldFrom` is declared in `souther.list`.

`mvn -o clean test` — 109 + 3043 + 166 + 1, no failures.

## What is left

The rest of #378, which the rewritten issue splits out: a reach name is still a `String`, and it is still decoded downstream. That is a representation change and reviews on its own.

Refs #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)
