### PR TITLE
An expansion handed a value that reaches itself should stop, not run out of stack

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ExpansionCycle.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ExpansionCycle.java
@@ -1,0 +1,29 @@
+package souther.compiler.check;
+
+/**
+ * The expansion was asked to substitute a value it is already substituting.
+ *
+ * <p>It carries no diagnostic and is not an author's mistake to read. A value defined in terms of
+ * itself is one, and it is {@link ValueCycles} that says so — of the module, before anything expands
+ * a body of it, at the declaration, once, naming the path the value goes round. That is a statement
+ * about the program.
+ *
+ * <p>This is a statement about the expansion. It is an algorithm with a precondition, and an
+ * algorithm handed an input its precondition rules out should fail within a bound rather than descend
+ * until the stack runs out — what comes back from that is a report about an expression nesting too
+ * deeply, caught at the compiler's outer boundary, by which point which question was being answered
+ * is gone. Reaching here means a caller expanded a module nothing had refused, which is the
+ * compiler's mistake and not the author's, and it says which value it was standing in.
+ *
+ * <p>The two do not answer the same question, so neither replaces the other: what recurses under
+ * expansion is not what is well founded as a value. A value that reaches itself only through a
+ * recursive helper is expanded to the end — the helper is a method and its call is left standing —
+ * and evaluating the value still does not terminate. {@link ValueCycles} refuses it; nothing here
+ * would notice it.
+ */
+public final class ExpansionCycle extends RuntimeException {
+
+    ExpansionCycle(String message) {
+        super(message);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -82,6 +82,16 @@ public final class HelperInliner {
      * with each would give two of them the same binding.
      */
     private final Map<BindingOwner, Integer> written = new HashMap<>();
+    /**
+     * The values this expansion is inside, from the body being written down to here.
+     *
+     * <p>On the pass rather than in a {@link Writing}, because it is neither: a value's body is
+     * substituted within the writing that names it, and the substitution of one value can carry the
+     * expansion into another. It is a path through the tree being written, pushed and popped around
+     * each substitution, and it is empty again whenever a body is finished with — including a body
+     * that was refused partway through.
+     */
+    private final Set<String> substituting = new LinkedHashSet<>();
 
     /**
      * One writing of one body, and everything that is true only while it runs.
@@ -1271,7 +1281,35 @@ public final class HelperInliner {
         if (value == null || value.body() == null || graph.recurses(v.name())) {
             return v;
         }
-        return HelperNames.carriedByValue(inline(value.writtenBody()));
+        return substituted(v.reaches(), value.writtenBody());
+    }
+
+    /**
+     * The body of the value {@code reached} stands for, expanded here — and a refusal where this
+     * expansion is already substituting that value.
+     *
+     * <p>Substituting a value into itself has no end, so an expansion that reached one would descend
+     * until the stack ran out. Which modules that can happen to is answered before anything expands a
+     * body of one, and it is {@link ValueCycles} that answers it and says so to the author. This is
+     * not that rule said twice: it is about this algorithm rather than about the module, and what it
+     * gives is that expanding is bounded whatever it is handed. A caller that reached here with a
+     * module the answer above would have refused gets a failure naming the value, rather than a stack
+     * that ran out and a report about an expression nesting too deeply.
+     *
+     * <p>What it holds is the path and not what it has seen: a value named twice in one body is
+     * substituted twice, side by side, and only one inside the other is re-entry.
+     */
+    private Ast.Expr substituted(String reached, Ast.Expr body) {
+        if (!substituting.add(reached)) {
+            throw new ExpansionCycle("`" + reached + "` is substituted into itself ("
+                    + String.join(" -> ", substituting) + " -> " + reached + "), and a module whose"
+                    + " values are not well founded is refused before a body of it is expanded");
+        }
+        try {
+            return HelperNames.carriedByValue(inline(body));
+        } finally {
+            substituting.remove(reached);
+        }
     }
 
     /**
@@ -1294,7 +1332,7 @@ public final class HelperInliner {
             }
             Ast.Binder name = writing.binders().binder("$s" + next() + "_" + spread.bare(), spread.pos());
             bound.add(name);
-            values.add(HelperNames.carriedByValue(inline(value.writtenBody())));
+            values.add(substituted(spread.name(), value.writtenBody()));
             spreads.add(Ast.Var.local(name, spread.pos()));
         }
         Ast.Expr built = new Ast.NewData(nd.typeName(), inlineInits(nd.inits()), spreads,

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -15,10 +15,15 @@ import java.util.Set;
 /**
  * A value defined in terms of itself, refused before anything is expanded.
  *
- * <p>A value is substituted at each of its references (ADR-0072), so one that reaches itself is
- * substituted into itself and there is no body to reach the end of. It has to be refused before the
- * first expansion rather than caught by whatever depth guard the expansion runs into, which reports
- * a nesting the author did not write.
+ * <p>A value is substituted at each of its references, so one that reaches itself is substituted into
+ * itself and there is no body to reach the end of. It is refused here, of the module, before anything
+ * expands a body of it: the report belongs at the declaration, said once, naming the path the value
+ * goes round.
+ *
+ * <p>The expansion refuses to substitute a value into itself as well ({@link ExpansionCycle}), and
+ * that is a different statement. It bounds an algorithm handed an input this refusal rules out; it is
+ * not an answer about the program, and it does not see a value that reaches itself through a helper
+ * whose call it leaves standing. Neither stands in for the other.
  *
  * <p>The value graph is not the call graph. A helper on a call cycle is lowered to a method and
  * recurses at run time (ADR-0038); a value has no such form, so a cycle that passes through one is an

--- a/souther-compiler/src/test/java/souther/compiler/check/AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest.java
@@ -1,0 +1,93 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Located;
+import souther.compiler.frontend.CstFrontend;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A value that reaches itself through a helper that terminates is still a value that reaches itself.
+ *
+ * <p>{@code depth} recurses on a strictly smaller part of its argument, so it terminates and the
+ * totality check certifies it. It is therefore lowered to a method and its call is left standing
+ * rather than expanded, which means the expansion of a body that reads {@code seed} finishes: the
+ * substitution stops at the call. Evaluating {@code seed} does not stop —
+ * {@code seed -> depth(...) -> seed} — because what {@code depth} answers where it bottoms out is
+ * {@code seed} again.
+ *
+ * <p>So the two graphs are two graphs. What the expansion follows is which calls it keeps unfolding,
+ * and what {@link ValueCycles} follows is what a value's definition rests on, which is every call it
+ * reaches whether or not the expansion unfolds it. Narrowing the second to match the first would let
+ * this module through, and nothing below would catch it: the emitted program is well typed and total
+ * helper by helper, and only diverges when the value is asked for.
+ */
+class AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest {
+
+    /** {@code seed} calls a total recursive helper whose base case reads {@code seed}. */
+    private static final String CYCLE = """
+            module demo
+
+            data T = { c: T?, n: Int }
+            data Out = Int
+
+            behavior run : (t: T) -> Out
+                constructs Out
+
+            let seed = depth(T { c = None, n = 1 })
+
+            let depth (t: T) : Int = match t.c with | Some x -> depth(x) | None -> seed
+
+            let run (t) = Out(depth(t))
+            """;
+
+    /** The same module with the base case answering a number, so nothing reaches back to the value. */
+    private static final String WELL_FOUNDED = CYCLE.replace("| None -> seed", "| None -> t.n");
+
+    private static List<Diagnostic> diagnose(String source) {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("a.sou", source);
+        return Located.diagnosticsOf(Compiler.diagnoseModules(byId, Set.of())).get("a.sou");
+    }
+
+    @Test
+    void theValueIsRefused() {
+        List<Diagnostic> found = diagnose(CYCLE);
+
+        assertEquals(1, found.size(), "one mistake, one report: " + found);
+        assertEquals("check.value.cycle", found.get(0).messageKey());
+    }
+
+    /** And the helper it goes round is not what is wrong with it: on its own it compiles. */
+    @Test
+    void theSameHelperWithoutTheValueOnItIsFine() {
+        assertEquals(List.of(), diagnose(WELL_FOUNDED));
+    }
+
+    /**
+     * The refusal is not the expansion running out of room. Handed the module the check refuses, the
+     * expansion finishes — the call to the recursive helper is left standing, so the substitution
+     * has an end.
+     */
+    @Test
+    void theExpansionOfThatModuleFinishes() {
+        Ast.Module parsed = CstFrontend.parse(CYCLE);
+        HelperInliner inliner = HelperInliner.forModule(Resolve.module(parsed, Symbols.of(parsed)));
+
+        Ast.Expr expanded = assertDoesNotThrow(() -> inliner.inline(
+                inliner.helpers().get("depth").writtenBody(), inliner.bodyOf("depth")));
+
+        assertTrue(expanded != null, "a body the expansion finished with");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/NoExpansionSubstitutesAValueIntoItselfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NoExpansionSubstitutesAValueIntoItselfTest.java
@@ -1,0 +1,159 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
+import souther.compiler.frontend.CstFrontend;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The expansion refuses to substitute a value it is already substituting, whoever asked it to.
+ *
+ * <p>Which modules are well founded is {@link ValueCycles}' answer and it is asked of the module,
+ * before anything expands a body of it — that is the rule the author is told about. This is a
+ * different statement about a different thing: the expansion is an algorithm, and an algorithm handed
+ * an input its precondition rules out should answer wrongly and say so rather than descend until the
+ * stack runs out. What comes back from a stack that ran out is a report about an expression nesting
+ * too deeply, which is about nothing the author wrote, and it is caught only at the compiler's outer
+ * boundary — by which point which question was being answered is gone.
+ *
+ * <p>So this asks for the failure directly, with an inliner built the way a caller outside the query
+ * layer builds one: nothing here goes through {@code Shapes.Expandable}, which is the point.
+ */
+class NoExpansionSubstitutesAValueIntoItselfTest {
+
+    private static final String HEAD = """
+            module demo
+
+            data In = { n: Int }
+            data Out = { n: Int }
+
+            """;
+
+    private static final String TAIL = """
+
+            let use (n: Int) : Int = n + seed
+
+            behavior go : (i: In) -> Out
+                constructs Out
+            let go (i) = Out { n = use(i.n) }
+            """;
+
+    private static HelperInliner inlinerFor(String source) {
+        Ast.Module parsed = CstFrontend.parse(source);
+        return HelperInliner.forModule(Resolve.module(parsed, Symbols.of(parsed)));
+    }
+
+    private static Ast.Expr expand(HelperInliner inliner, String helper) {
+        return inliner.inline(inliner.helpers().get(helper).writtenBody(), inliner.bodyOf(helper));
+    }
+
+    private static Ast.Expr expand(String source, String helper) {
+        return expand(inlinerFor(source), helper);
+    }
+
+    @Test
+    void aValueDefinedAsItselfIsRefusedRatherThanSubstitutedForever() {
+        ExpansionCycle refused = assertThrows(ExpansionCycle.class,
+                () -> expand(HEAD + "let seed = seed" + TAIL, "use"));
+
+        assertTrue(refused.getMessage().contains("seed"),
+                "the failure names the value it was substituting: " + refused.getMessage());
+    }
+
+    @Test
+    void aValueReachingItselfThroughAHelperIsRefusedToo() {
+        String source = HEAD + """
+                let seed = twice(1)
+
+                let twice (n: Int) : Int = n * seed
+                """ + TAIL;
+
+        assertThrows(ExpansionCycle.class, () -> expand(source, "use"));
+    }
+
+    /**
+     * A spread names a value where an expression cannot stand, so the substitution happens at the
+     * construction rather than at the name — a second place to reach a value's body, and the same
+     * failure when it is the body being reached from.
+     */
+    @Test
+    void aValueSpreadIntoItsOwnConstructionIsRefusedToo() {
+        String source = """
+                module demo
+
+                data In = { n: Int }
+                data Out = { n: Int }
+                data D = { n: Int }
+
+                let seed = D { ...seed }
+
+                let use (d: D) : D = seed
+
+                behavior go : (i: In) -> Out
+                    constructs Out
+                let go (i) = Out { n = i.n }
+                """;
+
+        assertThrows(ExpansionCycle.class, () -> expand(source, "use"));
+    }
+
+    /**
+     * One value substituted twice is not a value substituted into itself. The two substitutions are
+     * beside each other rather than one inside the other, and an expansion that recorded every value
+     * it had ever substituted would refuse the second.
+     */
+    @Test
+    void theSameValueTwiceInOneBodyIsNotReEntry() {
+        String source = HEAD + """
+                let seed = 1
+                """ + """
+
+                let use (n: Int) : Int = n + seed + seed
+
+                behavior go : (i: In) -> Out
+                    constructs Out
+                let go (i) = Out { n = use(i.n) }
+                """;
+
+        assertDoesNotThrow(() -> expand(source, "use"));
+    }
+
+    /**
+     * A caller records a refusal and hands the next body to the same pass, so what a substitution
+     * that did not finish left behind is read by the body after it. A value it was standing in when
+     * it was refused is not a value it is still standing in: left there, the next body to name that
+     * value would be told it reaches itself, which is a report about the wrong thing entirely and
+     * about a module with nothing of the kind wrong with it.
+     */
+    @Test
+    void aSubstitutionRefusedPartwayIsNotStillStandingForTheNextBody() {
+        HelperInliner inliner = inlinerFor("""
+                module demo
+
+                data In = { n: Int }
+                data Out = { n: Int }
+
+                let applyTwice (f: (Int) -> Int, n: Int) : Int = f(n, n)
+
+                let bad = applyTwice((x) -> x + 1, 1)
+
+                let use (n: Int) : Int = n + bad
+                let again (n: Int) : Int = n + bad
+
+                behavior go : (i: In) -> Out
+                    constructs Out
+                let go (i) = Out { n = use(i.n) + again(i.n) }
+                """);
+        assertThrows(CompileException.class, () -> expand(inliner, "use"),
+                "the lambda takes one argument and is handed two");
+
+        assertThrows(CompileException.class, () -> expand(inliner, "again"),
+                "the second body is refused for what is wrong with it, not for reaching a value the"
+                        + " expansion was left standing in");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/EveryTreeAnExpansionIsGivenIsStillWellFoundedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/EveryTreeAnExpansionIsGivenIsStillWellFoundedTest.java
@@ -1,0 +1,161 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.HelperInliner;
+import souther.compiler.check.ValueCycles;
+import souther.compiler.diag.CompileException;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The tree that is expanded is not the tree that was checked, and it is well founded too.
+ *
+ * <p>{@code Shapes.Expandable} answers of the module as resolution left it, and hands that tree over.
+ * Every reader then makes another tree of it — derived, desugared, prepared, settled — and expands
+ * that one. So what the refusal establishes is carried across four rewrites by nothing: each of them
+ * could give a value a definition it did not have, and the answer that said the module was well
+ * founded was about a tree none of them expanded.
+ *
+ * <p>What is pinned here is the observation and not the reason. Over a module written to give each
+ * rewrite something to do, and one downstream of it, the values are still well founded in every tree
+ * a compile makes. A rewrite that closed a cycle between two stages is caught here; one that added a
+ * definition or an edge without closing a cycle is not. Whether the rewrites can do that at all is a
+ * property of the rewrites, and nothing here says they cannot.
+ *
+ * <p>{@code ValueCycles.rejectIn} is what asks, because it is what the expansion relies on and there
+ * is no second reading of well-foundedness to compare against. It is a check on a module as it was
+ * written and it says more than this — a zero-parameter {@code let} whose body is a block is refused
+ * by it too — so a tree failing it here is a report about that tree, and not on its own a statement
+ * that every tree between the stages is a thing this check was meant to be handed.
+ */
+class EveryTreeAnExpansionIsGivenIsStillWellFoundedTest {
+
+    /** Values read from a helper, from an invariant and from an example row, in a module with enough
+     * declarations for every rewrite to have something to do. */
+    private static final String UPSTREAM = """
+            module m.a exposing ( Amount, base )
+
+            data Amount = Int
+                invariant value >= floor
+
+            data Tag = Small | Large
+
+            data In = { n: Int }
+            data Out = { amount: Amount, tag: Tag }
+
+            let floor = 0
+            let base = 10
+            let step = twice(2)
+            let twice (n: Int) : Int = n * 2
+
+            behavior go : (i: In) -> Out
+                constructs Out, Amount
+            let go (i) = Out { amount = Amount(i.n + step), tag = Small }
+
+            example go
+              | "a row" : (In { n = 1 }) -> Out { amount = Amount(5), tag = Small }
+            """;
+
+    /** And a module downstream, so a published value is one of the definitions in the table. */
+    private static final String DOWNSTREAM = """
+            module m.b
+            import m.a ( Amount, base )
+
+            data Req = { n: Int }
+            data Quote = { amount: Amount }
+
+            let markup = base + 5
+
+            behavior quote : (r: Req) -> Quote
+                constructs Quote, Amount
+            let quote (r) = Quote { amount = Amount(r.n + markup) }
+            """;
+
+    private static Db dbOf() {
+        return Compilation.ofDocuments(
+                Map.of("a.sou", UPSTREAM, "b.sou", DOWNSTREAM), Set.of(), ModulePath.EMPTY).db();
+    }
+
+    /** Each tree a compile of {@code name} makes, by the stage that makes it. */
+    private static Map<String, Ast.Module> treesOf(Db db, String name) {
+        Map<String, Key<Ast.Module>> stages = new LinkedHashMap<>();
+        stages.put("resolved", new Names.Resolved(name));
+        stages.put("derived", new Shapes.Derived(name));
+        stages.put("desugared", new Shapes.Desugared(name));
+        stages.put("prepared", new Shapes.Prepared(name));
+        stages.put("settled", new Bodies.Settled(name));
+        Map<String, Ast.Module> out = new LinkedHashMap<>();
+        stages.forEach((stage, key) -> {
+            Answer<Ast.Module> answer = db.ask(key);
+            assertTrue(answer.present(), stage + " of " + name + ": " + answer.reports());
+            out.put(stage, answer.value());
+        });
+        return out;
+    }
+
+    private static Map<String, Ast.FnDef> publishedTo(Db db, String name) {
+        Answer<Map<String, Ast.FnDef>> imported = db.ask(new Bodies.ImportedDefinitions(name));
+        return imported.present() ? imported.value() : Map.of();
+    }
+
+    @Test
+    void valueWellFoundednessSurvivesTheRewritesBeforeAnExpansion() {
+        Db db = dbOf();
+        Map<String, String> aValueOf = Map.of("m.a", "step", "m.b", "markup");
+        aValueOf.forEach((name, value) -> {
+            Map<String, Ast.FnDef> published = publishedTo(db, name);
+            treesOf(db, name).forEach((stage, tree) -> {
+                // a value is still there to be asked about, so a stage that dropped the ones this
+                // module was written around is not passing by having nothing left to walk
+                assertTrue(HelperInliner.helpersOf(tree).containsKey(value),
+                        "the " + stage + " tree of " + name + " no longer declares `" + value + "`");
+                assertDoesNotThrow(() -> ValueCycles.rejectIn(tree, published),
+                        "the " + stage + " tree of " + name + " is expanded, and its values reach"
+                                + " themselves");
+            });
+        });
+    }
+
+    /** And the stages are not one tree asked for five times. */
+    @Test
+    void theTreesAreDifferentTrees() {
+        Map<String, Ast.Module> trees = treesOf(dbOf(), "m.a");
+
+        assertNotEquals(trees.get("resolved"), trees.get("settled"),
+                "nothing was rewritten between the tree that was checked and the tree expanded");
+    }
+
+    /**
+     * And the check said something about those trees. Asked of a tree with a value that does reach
+     * itself, it refuses — so a stage that passes above passed on its own account.
+     */
+    @Test
+    void theSameQuestionAskedOfATreeWithACycleRefusesIt() {
+        Db db = Compilation.ofDocuments(Map.of("a.sou", """
+                module m.a
+
+                data In = { n: Int }
+                data Out = { n: Int }
+
+                let step = step
+
+                behavior go : (i: In) -> Out
+                    constructs Out
+                let go (i) = Out { n = i.n + step }
+                """), Set.of(), ModulePath.EMPTY).db();
+        Answer<Ast.Module> resolved = db.ask(new Names.Resolved("m.a"));
+        assertTrue(resolved.present(), "resolution answers; the refusal comes later");
+
+        assertThrows(CompileException.class, () -> ValueCycles.rejectIn(resolved.value(), Map.of()));
+    }
+}


### PR DESCRIPTION
Expanding a value substituted its body wherever it was named, and nothing on that path noticed it was substituting a value into itself. It descended until the stack ran out — caught at the compiler's outer boundary and reported as `check.expr.toodeep`, an expression nesting too deeply, about nothing the author wrote. That it never happened is `Shapes.Expandable`'s doing, and that guard is only in front of the doors that are known about: `forModule`, `forHelpers` and `over` take a module or a table from anywhere.

The expansion now refuses re-entry, through `ExpansionCycle`. It holds the values it is inside as a path rather than as what it has seen, so a value named twice in one body is still substituted twice, and both places that reach a value's body go through it — the name and the spread. A substitution refused partway is not one the pass is still standing in; left there, the next body to name that value would be told it reaches itself.

## The two rules are not one rule

The issue weighed this as a defensive second statement of `ValueCycles` against `unify-duplication-not-meaning`. It is not one.

`ValueCycles` follows every call a value's definition reaches. The expansion stops at a call it leaves standing, because a recursive helper is lowered to a method. Where they differ the wide one is right:

```
let seed = depth(T { c = None, n = 1 })
let depth (t: T) : Int = match t.c with | Some x -> depth(x) | None -> seed
```

`depth` recurses on a strictly smaller part of its argument, so the totality check certifies it and it is emitted as a method. Expanding a body that reads `seed` therefore finishes; evaluating `seed` does not. Narrowed to the edges the expansion unfolds, the check accepts this module and nothing below refuses it — with that narrowing applied the module compiles with no diagnostics at all, which is what the new test pins.

So `ValueCycles` answers whether the program is well founded and keeps owning the report, at the declaration, once. `ExpansionCycle` carries no diagnostic: reaching it means a caller expanded a module nothing had refused, which is the compiler's mistake and not the author's.

## And the tree that was checked is not the tree that is expanded

`Shapes.Expandable` answers of the module as resolution left it and hands that tree over; every reader then derives, desugars, prepares and settles it and expands the result. What the refusal established is about a tree none of them expanded.

The second commit pins the observation and not the reason: over a module written to give each rewrite something to do, and one downstream of it, the values are still well founded in every tree a compile makes. A rewrite that closed a cycle between two stages is caught there; one that added a definition or an edge without closing a cycle is not. Whether the rewrites can do that at all is a property of the rewrites, and nothing in this PR states it.

## Tests

`NoExpansionSubstitutesAValueIntoItselfTest` builds an inliner the way a caller outside the query layer does, which is the point — nothing in it goes through `Shapes.Expandable`. Each case was watched failing first: the direct and helper cycles with `StackOverflowError`, the spread one by putting the old line back, and the one about a refusal partway by dropping the `finally`, which turns the second body's report into a value reaching itself.

`AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest` is the module above: refused, its helper fine on its own, and its expansion finishing. It was watched going red under a `ValueCycles` narrowed to the expansion's edges.

`EveryTreeAnExpansionIsGivenIsStillWellFoundedTest` asks the check of every tree a compile makes, and reads the stages for being different trees and the values for still being in them.

`mvn clean test` is green across the eight modules; 3077 in `souther-compiler`.

Refs #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)
