### PR TITLE
Make every name the compiler and the specification write a name souther doc answers

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -111,6 +111,11 @@ public final class DocCommand {
             err.println("`souther doc` lists every section");
             return 2;
         }
+        if (!DocName.canonical(section.anchor()).equals(DocName.canonical(anchor))) {
+            // A name written inside a section is answered with that section, and a reader who is
+            // not told so cannot tell an answer to what they asked from the nearest thing to it.
+            err.println("`" + anchor + "` is written in `" + section.anchor() + "`, which is what follows");
+        }
         out.println("=".repeat(section.level()) + " " + section.title() + " [#" + section.anchor() + "]");
         out.println();
         out.println(section.body());

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -97,9 +97,13 @@ public final class DocCommand {
         SpecDocument.Section section = spec.section(anchor);
         if (section == null) {
             err.println("no section `" + anchor + "`");
+            // Through the same fold the lookup itself went through: a reader who typed the case the
+            // compiler prints would otherwise be told there is nothing near what they asked for.
+            String asked = DocName.canonical(anchor);
             List<String> near = spec.sections().stream()
                     .map(SpecDocument.Section::anchor)
-                    .filter(a -> a.contains(anchor) || anchor.contains(a))
+                    .filter(a -> DocName.canonical(a).contains(asked)
+                            || asked.contains(DocName.canonical(a)))
                     .toList();
             if (!near.isEmpty()) {
                 err.println("did you mean: " + String.join(", ", near));

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -100,8 +100,7 @@ public final class DocCommand {
             // Through the same fold the lookup itself went through: a reader who typed the case the
             // compiler prints would otherwise be told there is nothing near what they asked for.
             String asked = DocName.canonical(anchor);
-            List<String> near = spec.sections().stream()
-                    .map(SpecDocument.Section::anchor)
+            List<String> near = spec.names().stream()
                     .filter(a -> DocName.canonical(a).contains(asked)
                             || asked.contains(DocName.canonical(a)))
                     .toList();

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocName.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocName.java
@@ -1,0 +1,24 @@
+package souther.compiler.doc;
+
+import java.util.Locale;
+
+/**
+ * The one form a documentation name is looked up by.
+ *
+ * <p>A name is written in more than one case before it reaches a lookup: the specification anchors
+ * a diagnostic as {@code e2010} and the compiler prints the same diagnostic as {@code E2010}, which
+ * is the form a reader copies. Both name the same thing, so both have to arrive at the same key.
+ *
+ * <p>Only the key is folded. What a name is spelled as belongs to whoever wrote it — a section
+ * keeps its anchor as the specification writes it, and a shipped topic keeps a name that is also
+ * the path its text is read from, which the class path resolves by the spelling on the file.
+ */
+final class DocName {
+
+    private DocName() {}
+
+    /** The key {@code name} is registered and asked for under. */
+    static String canonical(String name) {
+        return name.toLowerCase(Locale.ROOT);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/doc/LibraryDocs.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/LibraryDocs.java
@@ -22,11 +22,13 @@ public final class LibraryDocs {
 
     private static final String ROOT = "META-INF/souther-docs/";
 
-    /** One shipped document: {@code set/topic} as it is asked for, the title of its first
-     *  markdown heading, and where its text is. */
+    /** One shipped document: {@code set/topic} as the jar that ships it spells the name, the title
+     *  of its first markdown heading, and where its text is. */
     public record Topic(String name, String title, String resource) {}
 
     private final ClassLoader loader;
+    /** Keyed by {@link DocName#canonical}, so a topic is found in whatever case it is asked for.
+     *  The topic keeps its own spelling: the name is also the path its text is read from. */
     private final Map<String, Topic> byName;
 
     private LibraryDocs(ClassLoader loader, Map<String, Topic> byName) {
@@ -49,7 +51,13 @@ public final class LibraryDocs {
                     for (String file : lines(indexUrl)) {
                         String topic = set + "/" + file.replaceFirst("\\.md$", "");
                         String resource = ROOT + set + "/" + file;
-                        byName.put(topic, new Topic(topic, titleOf(loader, resource, file), resource));
+                        Topic taken = byName.put(DocName.canonical(topic),
+                                new Topic(topic, titleOf(loader, resource, file), resource));
+                        if (taken != null) {
+                            throw new IllegalStateException(
+                                    "two shipped topics are asked for by the same name: `"
+                                            + taken.name() + "` and `" + topic + "`");
+                        }
                     }
                 }
             }
@@ -70,7 +78,7 @@ public final class LibraryDocs {
      * with nothing in it.
      */
     public String read(String name) {
-        Topic topic = byName.get(name);
+        Topic topic = byName.get(DocName.canonical(name));
         if (topic == null || loader.getResource(topic.resource()) == null) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
@@ -37,7 +37,11 @@ public final class SpecDocument {
         this.ownTexts = List.copyOf(ownTexts);
         this.byAnchor = new LinkedHashMap<>();
         for (Section s : sections) {
-            byAnchor.put(s.anchor(), s);
+            Section taken = byAnchor.put(DocName.canonical(s.anchor()), s);
+            if (taken != null) {
+                throw new IllegalStateException("two sections are asked for by the same name: `"
+                        + taken.anchor() + "` and `" + s.anchor() + "`");
+            }
         }
     }
 
@@ -103,9 +107,10 @@ public final class SpecDocument {
         return inOrder;
     }
 
-    /** The section named by {@code anchor}, or null when no section has that anchor. */
+    /** The section named by {@code anchor} in whatever case it was asked for, or null when no
+     *  section has that anchor. */
     public Section section(String anchor) {
-        return byAnchor.get(anchor);
+        return byAnchor.get(DocName.canonical(anchor));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
@@ -17,6 +17,12 @@ import java.util.regex.Pattern;
  * <p>Every heading in specification.adoc carries an explicit {@code [#anchor]} on the line above
  * it; the anchor is the name a section is asked for by, the same name cross-references inside the
  * document use.
+ *
+ * <p>Every other name the document writes resolves too, to the section it stands in. A heading may
+ * carry more than one anchor, which is how several diagnostics explained together are each asked
+ * for by their own code; and an anchor may sit on a paragraph, which is how the document points at
+ * a rule finer than a section. Neither is a section of its own — what comes back is the section the
+ * name is written in — but a name the document sends a reader to is a name a reader can ask for.
  */
 public final class SpecDocument {
 
@@ -25,24 +31,33 @@ public final class SpecDocument {
     private static final Pattern HEADING = Pattern.compile("^(={2,})\\s+(.*\\S)\\s*$");
     private static final String LISTING_DELIMITER = "----";
 
-    /** A section: its anchor, title, heading level (2 for {@code ==}), and body up to the next heading of the same or a higher level. */
+    /** A section: the first anchor written above its heading, its title, heading level (2 for
+     *  {@code ==}), and body up to the next heading of the same or a higher level. */
     public record Section(String anchor, String title, int level, String body) {}
 
+    /** Keyed by {@link DocName#canonical}: every name the document writes, and the section it
+     *  resolves to. Several names may resolve to one section. */
     private final Map<String, Section> byAnchor;
     private final List<Section> inOrder;
     private final List<String> ownTexts;
 
-    private SpecDocument(List<Section> sections, List<String> ownTexts) {
+    private SpecDocument(List<Section> sections, List<String> ownTexts, Map<String, Section> byAnchor) {
         this.inOrder = List.copyOf(sections);
         this.ownTexts = List.copyOf(ownTexts);
-        this.byAnchor = new LinkedHashMap<>();
-        for (Section s : sections) {
-            Section taken = byAnchor.put(DocName.canonical(s.anchor()), s);
-            if (taken != null) {
-                throw new IllegalStateException("two sections are asked for by the same name: `"
-                        + taken.anchor() + "` and `" + s.anchor() + "`");
-            }
+        this.byAnchor = Map.copyOf(byAnchor);
+    }
+
+    /** Registers {@code anchor} as a name for {@code section}, refusing a name already taken. Two
+     *  names that fold to one key would otherwise answer by whichever was read second. */
+    private static void register(Map<String, Section> byAnchor, Map<String, String> writtenAs,
+            String anchor, Section section) {
+        String key = DocName.canonical(anchor);
+        String taken = writtenAs.put(key, anchor);
+        if (taken != null) {
+            throw new IllegalStateException("two names to ask for fold together: `"
+                    + taken + "` and `" + anchor + "`");
         }
+        byAnchor.put(key, section);
     }
 
     /** The specification this compiler was built from, bundled in its jar. */
@@ -59,7 +74,7 @@ public final class SpecDocument {
 
     public static SpecDocument of(String adoc) {
         String[] lines = adoc.split("\n", -1);
-        record Heading(String anchor, String title, int level, int bodyFrom) {}
+        record Heading(List<String> anchors, String title, int level, int anchorFrom, int bodyFrom) {}
         List<Heading> headings = new ArrayList<>();
         boolean inListing = false;
         for (int i = 0; i < lines.length; i++) {
@@ -74,11 +89,24 @@ public final class SpecDocument {
             if (!heading.matches() || i == 0) {
                 continue;
             }
-            Matcher anchor = ANCHOR.matcher(lines[i - 1]);
-            if (!anchor.matches()) {
+            if (!ANCHOR.matcher(lines[i - 1]).matches()) {
                 continue;
             }
-            headings.add(new Heading(anchor.group(1), heading.group(2), heading.group(1).length(), i + 1));
+            // Every anchor written above the heading names it. The first one written is the
+            // section's own name — the one it is listed and printed under — and the rest are
+            // further names for the same section.
+            int anchorFrom = i - 1;
+            while (anchorFrom > 0 && ANCHOR.matcher(lines[anchorFrom - 1]).matches()) {
+                anchorFrom--;
+            }
+            List<String> anchors = new ArrayList<>();
+            for (int a = anchorFrom; a < i; a++) {
+                Matcher anchor = ANCHOR.matcher(lines[a]);
+                anchor.matches();
+                anchors.add(anchor.group(1));
+            }
+            headings.add(new Heading(List.copyOf(anchors), heading.group(2), heading.group(1).length(),
+                    anchorFrom, i + 1));
         }
         List<Section> sections = new ArrayList<>();
         List<String> ownTexts = new ArrayList<>();
@@ -87,19 +115,51 @@ public final class SpecDocument {
             int end = lines.length;
             for (int n = h + 1; n < headings.size(); n++) {
                 if (headings.get(n).level() <= here.level()) {
-                    // The anchor line belongs to the next section, not to this body.
-                    end = headings.get(n).bodyFrom() - 2;
+                    // The anchor lines belong to the next section, not to this body.
+                    end = headings.get(n).anchorFrom();
                     break;
                 }
             }
             // A subsection's words are its own: what this section itself says stops at the very
             // next heading, while the readable body runs on through its subsections.
-            int ownEnd = h + 1 < headings.size() ? Math.min(end, headings.get(h + 1).bodyFrom() - 2) : end;
+            int ownEnd = h + 1 < headings.size() ? Math.min(end, headings.get(h + 1).anchorFrom()) : end;
             String body = String.join("\n", List.of(lines).subList(here.bodyFrom(), end)).strip();
-            sections.add(new Section(here.anchor(), here.title(), here.level(), body));
+            sections.add(new Section(here.anchors().getFirst(), here.title(), here.level(), body));
             ownTexts.add(String.join("\n", List.of(lines).subList(here.bodyFrom(), ownEnd)).strip());
         }
-        return new SpecDocument(sections, ownTexts);
+        Map<String, Section> byAnchor = new LinkedHashMap<>();
+        Map<String, String> writtenAs = new LinkedHashMap<>();
+        for (int h = 0; h < headings.size(); h++) {
+            for (String anchor : headings.get(h).anchors()) {
+                register(byAnchor, writtenAs, anchor, sections.get(h));
+            }
+        }
+        // An anchor written anywhere else names a place inside a section rather than a section, and
+        // there is no text of its own to answer with: what a reader is sent to for it is the
+        // section it stands in. The heading runs are stepped over, having been registered above.
+        inListing = false;
+        Section standingIn = null;
+        int next = 0;
+        for (int i = 0; i < lines.length; i++) {
+            if (next < headings.size() && i == headings.get(next).anchorFrom()) {
+                standingIn = sections.get(next);
+                i = headings.get(next).bodyFrom() - 1;
+                next++;
+                continue;
+            }
+            if (lines[i].startsWith(LISTING_DELIMITER)) {
+                inListing = !inListing;
+                continue;
+            }
+            if (inListing || standingIn == null) {
+                continue;
+            }
+            Matcher anchor = ANCHOR.matcher(lines[i]);
+            if (anchor.matches()) {
+                register(byAnchor, writtenAs, anchor.group(1), standingIn);
+            }
+        }
+        return new SpecDocument(sections, ownTexts, byAnchor);
     }
 
     /** Every section, in document order. */

--- a/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
@@ -37,7 +37,13 @@ public final class SpecDocument {
     private static final Pattern ANCHOR = Pattern.compile("^\\[#([^\\]]+)]\\s*$");
     private static final Pattern ALSO_NAMED = Pattern.compile("^\\[also-named=\"([^\"]*)\"]\\s*$");
     private static final Pattern HEADING = Pattern.compile("^(={2,})\\s+(.*\\S)\\s*$");
-    private static final String LISTING_DELIMITER = "----";
+    /**
+     * The delimiter of a block AsciiDoc takes as it stands: listing {@code ----}, literal
+     * {@code ....}, passthrough {@code ++++}, and the comment block {@code ////}. Four or more of
+     * the character repeated, and the block runs to the line that repeats it exactly — a shorter
+     * run, or a different character, is content rather than the end of it.
+     */
+    private static final Pattern OPAQUE_DELIMITER = Pattern.compile("^([-.+/])\\1{3,}$");
 
     /** A section: the first anchor written above its heading, its title, heading level (2 for
      *  {@code ==}), and body up to the next heading of the same or a higher level. */
@@ -86,14 +92,10 @@ public final class SpecDocument {
     public static SpecDocument of(String adoc) {
         String[] lines = adoc.split("\n", -1);
         record Heading(List<String> anchors, String title, int level, int anchorFrom, int bodyFrom) {}
+        boolean[] takenAsItStands = opaqueLines(lines);
         List<Heading> headings = new ArrayList<>();
-        boolean inListing = false;
         for (int i = 0; i < lines.length; i++) {
-            if (lines[i].startsWith(LISTING_DELIMITER)) {
-                inListing = !inListing;
-                continue;
-            }
-            if (inListing) {
+            if (takenAsItStands[i]) {
                 continue;
             }
             Matcher heading = HEADING.matcher(lines[i]);
@@ -167,7 +169,6 @@ public final class SpecDocument {
         // An anchor written anywhere else names a place inside a section rather than a section, and
         // there is no text of its own to answer with: what a reader is sent to for it is the
         // section it stands in. The heading runs are stepped over, having been registered above.
-        inListing = false;
         Section standingIn = null;
         int next = 0;
         for (int i = 0; i < lines.length; i++) {
@@ -177,11 +178,7 @@ public final class SpecDocument {
                 next++;
                 continue;
             }
-            if (lines[i].startsWith(LISTING_DELIMITER)) {
-                inListing = !inListing;
-                continue;
-            }
-            if (inListing || standingIn == null) {
+            if (takenAsItStands[i] || standingIn == null) {
                 continue;
             }
             Matcher anchor = ANCHOR.matcher(lines[i]);
@@ -190,6 +187,38 @@ public final class SpecDocument {
             }
         }
         return new SpecDocument(sections, ownTexts, byAnchor, List.copyOf(writtenAs.values()));
+    }
+
+    /**
+     * Which lines are inside a block AsciiDoc takes as it stands, delimiters included.
+     *
+     * <p>Nothing there is document structure: a heading written in a listing is shown to a reader
+     * as the words of a heading, and one written in a comment block is not shown at all. Reading
+     * either as a section would not only answer for a name AsciiDoc never registered — it would cut
+     * the surrounding section short at a heading that is not there, so the two would disagree about
+     * where the sections are and not only about what they are called.
+     *
+     * <p>One walk answers for both what a heading is and what an anchor is, so the document has one
+     * account of where its structure is written and not two that can come apart.
+     */
+    private static boolean[] opaqueLines(String[] lines) {
+        boolean[] opaque = new boolean[lines.length];
+        String open = null;
+        for (int i = 0; i < lines.length; i++) {
+            String delimiter = lines[i].strip();
+            if (open != null) {
+                opaque[i] = true;
+                if (delimiter.equals(open)) {
+                    open = null;
+                }
+                continue;
+            }
+            if (OPAQUE_DELIMITER.matcher(delimiter).matches()) {
+                open = delimiter;
+                opaque[i] = true;
+            }
+        }
+        return opaque;
     }
 
     /** Every section, in document order. */

--- a/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
@@ -18,16 +18,24 @@ import java.util.regex.Pattern;
  * it; the anchor is the name a section is asked for by, the same name cross-references inside the
  * document use.
  *
- * <p>Every other name the document writes resolves too, to the section it stands in. A heading may
- * carry more than one anchor, which is how several diagnostics explained together are each asked
- * for by their own code; and an anchor may sit on a paragraph, which is how the document points at
- * a rule finer than a section. Neither is a section of its own — what comes back is the section the
- * name is written in — but a name the document sends a reader to is a name a reader can ask for.
+ * <p>Every other name the document writes resolves too, to the section it stands in. An anchor may
+ * sit on a paragraph, which is how the document points at a rule finer than a section; it is a
+ * cross-reference target to AsciiDoc as much as a heading's is, and what comes back for it is the
+ * section it stands in, that being the text there is to answer with.
+ *
+ * <p>A heading may also be asked for by names that are not anchors at all, written
+ * {@code [also-named="e2015,e2016"]} beside its anchor. That is how several diagnostics explained
+ * in one section are each asked for by their own code. It is a named attribute rather than a second
+ * {@code [#...]} line because a heading has exactly one AsciiDoc ID: stacking anchors would leave
+ * AsciiDoc reading the last one as the heading's ID and registering no target for the rest, while
+ * this document read the first — the same heading under two identities, one of them invisible to
+ * every renderer. A name Souther adds for its own lookup is therefore kept out of the ID.
  */
 public final class SpecDocument {
 
     private static final String RESOURCE = "/META-INF/souther/specification.adoc";
     private static final Pattern ANCHOR = Pattern.compile("^\\[#([^\\]]+)]\\s*$");
+    private static final Pattern ALSO_NAMED = Pattern.compile("^\\[also-named=\"([^\"]*)\"]\\s*$");
     private static final Pattern HEADING = Pattern.compile("^(={2,})\\s+(.*\\S)\\s*$");
     private static final String LISTING_DELIMITER = "----";
 
@@ -40,11 +48,14 @@ public final class SpecDocument {
     private final Map<String, Section> byAnchor;
     private final List<Section> inOrder;
     private final List<String> ownTexts;
+    private final List<String> names;
 
-    private SpecDocument(List<Section> sections, List<String> ownTexts, Map<String, Section> byAnchor) {
+    private SpecDocument(List<Section> sections, List<String> ownTexts,
+            Map<String, Section> byAnchor, List<String> names) {
         this.inOrder = List.copyOf(sections);
         this.ownTexts = List.copyOf(ownTexts);
         this.byAnchor = Map.copyOf(byAnchor);
+        this.names = List.copyOf(names);
     }
 
     /** Registers {@code anchor} as a name for {@code section}, refusing a name already taken. Two
@@ -89,22 +100,41 @@ public final class SpecDocument {
             if (!heading.matches() || i == 0) {
                 continue;
             }
-            if (!ANCHOR.matcher(lines[i - 1]).matches()) {
-                continue;
-            }
-            // Every anchor written above the heading names it. The first one written is the
-            // section's own name — the one it is listed and printed under — and the rest are
-            // further names for the same section.
-            int anchorFrom = i - 1;
-            while (anchorFrom > 0 && ANCHOR.matcher(lines[anchorFrom - 1]).matches()) {
+            // The attribute lines written above the heading belong to it: its anchor, which is the
+            // name it is listed and printed under, and any further names it answers to.
+            int anchorFrom = i;
+            while (anchorFrom > 0 && (ANCHOR.matcher(lines[anchorFrom - 1]).matches()
+                    || ALSO_NAMED.matcher(lines[anchorFrom - 1]).matches())) {
                 anchorFrom--;
             }
+            String own = null;
             List<String> anchors = new ArrayList<>();
             for (int a = anchorFrom; a < i; a++) {
                 Matcher anchor = ANCHOR.matcher(lines[a]);
-                anchor.matches();
-                anchors.add(anchor.group(1));
+                if (anchor.matches()) {
+                    if (own != null) {
+                        // AsciiDoc would read the last of them as the heading's ID and register no
+                        // target for the rest, leaving this document reading a name no renderer
+                        // knows the heading by. A further name goes in `also-named`.
+                        throw new IllegalStateException("a heading has one anchor, and `"
+                                + heading.group(2) + "` is written with two: `" + own + "` and `"
+                                + anchor.group(1) + "`");
+                    }
+                    own = anchor.group(1);
+                    continue;
+                }
+                Matcher alsoNamed = ALSO_NAMED.matcher(lines[a]);
+                alsoNamed.matches();
+                for (String name : alsoNamed.group(1).split(",")) {
+                    if (!name.isBlank()) {
+                        anchors.add(name.strip());
+                    }
+                }
             }
+            if (own == null) {
+                continue;
+            }
+            anchors.addFirst(own);
             headings.add(new Heading(List.copyOf(anchors), heading.group(2), heading.group(1).length(),
                     anchorFrom, i + 1));
         }
@@ -159,7 +189,7 @@ public final class SpecDocument {
                 register(byAnchor, writtenAs, anchor.group(1), standingIn);
             }
         }
-        return new SpecDocument(sections, ownTexts, byAnchor);
+        return new SpecDocument(sections, ownTexts, byAnchor, List.copyOf(writtenAs.values()));
     }
 
     /** Every section, in document order. */
@@ -171,6 +201,17 @@ public final class SpecDocument {
      *  section has that anchor. */
     public Section section(String anchor) {
         return byAnchor.get(DocName.canonical(anchor));
+    }
+
+    /**
+     * Every name that resolves, as the document spells it, in the order the document writes them.
+     *
+     * <p>The same names {@link #section} answers for, so a caller suggesting what a reader might
+     * have meant suggests from what they could have asked for. Suggesting from the sections alone
+     * would leave a name that resolves out of reach of a near miss on it.
+     */
+    public List<String> names() {
+        return names;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/doc/ANameIsFoundInWhateverCaseItIsAskedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ANameIsFoundInWhateverCaseItIsAskedForTest.java
@@ -1,0 +1,147 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name reaches the lookup in whatever case its writer used. The specification anchors a
+ * diagnostic {@code e2010} and the compiler prints that diagnostic {@code E2010}, so the form a
+ * reader copies out of an error is not the form the document registers — and answering `no section`
+ * to it tells the reader about the anchors' spelling, which is nothing they asked about.
+ *
+ * <p>Only the lookup key is folded. A shipped topic's name is also the path its text is read from,
+ * and the class path resolves that by the spelling on the file, so folding the name itself would
+ * answer for a topic and then fail to read it.
+ */
+class ANameIsFoundInWhateverCaseItIsAskedForTest {
+
+    private record Answer(int code, String out, String err) {}
+
+    private static Answer run(ClassLoader loader, String... args) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int code = DocCommand.run(args,
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8), loader);
+        return new Answer(code, out.toString(StandardCharsets.UTF_8), err.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void aSectionAnsweredForItsAnchorIsAnsweredForTheCaseTheCompilerPrints() {
+        SpecDocument spec = SpecDocument.bundled();
+
+        SpecDocument.Section written = spec.section("e2010");
+
+        assertNotNull(written, "the specification anchors this one");
+        assertSame(written, spec.section("E2010"), "the case an error is printed in");
+
+        SpecDocument.Section named = spec.section("newtype");
+
+        assertNotNull(named, "a section named by a word rather than by a code");
+        assertSame(named, spec.section("NewType"), "and any other case of it");
+    }
+
+    @Test
+    void theDocCommandReadsASectionAskedForInTheCaseTheCompilerPrints() {
+        Answer answer = run(DocCommand.class.getClassLoader(), "E2010");
+
+        assertEquals(0, answer.code(), answer.err());
+        assertTrue(answer.out().contains("[#e2010]"),
+                "the section is printed under the anchor the specification writes: " + answer.out());
+    }
+
+    @Test
+    void aNearMissIsSuggestedForTheCaseTheCompilerPrintsToo() {
+        Answer answer = run(DocCommand.class.getClassLoader(), "E1001");
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().contains("did you mean: e1001-removed"),
+                "the suggestion goes through the same fold as the lookup: " + answer.err());
+    }
+
+    @Test
+    void aShippedTopicKeepsItsSpellingAndIsStillFoundByAnyCase() throws Exception {
+        try (URLClassLoader loader = jarOf("MixedCase", List.of("Guide.md"))) {
+            LibraryDocs docs = LibraryDocs.on(loader);
+
+            assertEquals(List.of("MixedCase/Guide"),
+                    docs.topics().stream().map(LibraryDocs.Topic::name).toList(),
+                    "the name is the jar's, since it is also where the text is");
+            assertTrue(docs.read("mixedcase/guide").contains("Text of Guide."),
+                    "and it is read through a name folded to any case");
+            assertTrue(docs.read("MixedCase/Guide").contains("Text of Guide."));
+
+            Answer answer = run(loader, "MIXEDCASE/GUIDE");
+            assertEquals(0, answer.code(), answer.err());
+            assertTrue(answer.out().contains("Text of Guide."), answer.out());
+        }
+    }
+
+    @Test
+    void twoNamesThatFoldTogetherAreRefusedRatherThanOneWinningSilently() {
+        String adoc = """
+                = A specification
+
+                [#Alpha]
+                == Written one way
+
+                Something.
+
+                [#alpha]
+                == Written the other
+
+                Something else.
+                """;
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> SpecDocument.of(adoc));
+
+        assertTrue(refused.getMessage().contains("Alpha") && refused.getMessage().contains("alpha"),
+                "the refusal names both of them: " + refused.getMessage());
+    }
+
+    @Test
+    void twoShippedTopicsThatFoldTogetherAreRefusedTheSameWay() throws Exception {
+        try (URLClassLoader loader = jarOf("somelib", List.of("Guide.md", "guide.md"))) {
+            IllegalStateException refused =
+                    assertThrows(IllegalStateException.class, () -> LibraryDocs.on(loader));
+
+            assertTrue(refused.getMessage().contains("somelib/Guide")
+                            && refused.getMessage().contains("somelib/guide"),
+                    "the refusal names both of them: " + refused.getMessage());
+        }
+    }
+
+    /** A jar shipping one doc set, whose topics are the given files, each holding its own name. */
+    private static URLClassLoader jarOf(String set, List<String> files) throws Exception {
+        Path jar = Files.createTempDirectory("docset").resolve(set + "-1.0.jar");
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+            out.putNextEntry(new JarEntry("META-INF/souther-docs/sets"));
+            out.write((set + "\n").getBytes(StandardCharsets.UTF_8));
+            out.putNextEntry(new JarEntry("META-INF/souther-docs/" + set + "/index"));
+            out.write((String.join("\n", files) + "\n").getBytes(StandardCharsets.UTF_8));
+            for (String file : files) {
+                String topic = file.replaceFirst("\\.md$", "");
+                out.putNextEntry(new JarEntry("META-INF/souther-docs/" + set + "/" + file));
+                out.write(("# " + topic + "\n\nText of " + topic + ".\n").getBytes(StandardCharsets.UTF_8));
+            }
+        }
+        return new URLClassLoader(new URL[]{jar.toUri().toURL()}, null);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryDiagnosticTheCompilerEmitsCanBeLookedUpTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryDiagnosticTheCompilerEmitsCanBeLookedUpTest.java
@@ -1,0 +1,87 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A code is what a diagnostic hands the reader to go and look the thing up with. Every code the
+ * compiler prints therefore has to resolve, or the reader is handed a name and then told there is
+ * nothing under it — which is worse than printing no code at all, since they spend the lookup
+ * first.
+ *
+ * <p>What is checked is that the lookup answers, not that the codes and the sections are the same
+ * set. Several diagnostics coming out of one language feature are explained together, and a section
+ * carrying the codes of all of them is a section doing its job; what would be wrong is a code with
+ * no way to reach the section that explains it.
+ *
+ * <p>The codes are discovered from {@code E}-and-four-digits string literals in every module's main
+ * sources. That is the domain this quantifies over: a code assembled at run time out of pieces is
+ * outside it and would not be seen. Every code the compiler emits today is written as a literal at
+ * the site that emits it.
+ */
+class EveryDiagnosticTheCompilerEmitsCanBeLookedUpTest {
+
+    private static final Pattern CODE = Pattern.compile("\"(E[0-9]{4})\"");
+
+    @Test
+    void everyCodeTheCompilerPrintsResolvesToASection() throws IOException {
+        SpecDocument spec = SpecDocument.bundled();
+        Set<String> emitted = emittedCodes();
+        Set<String> unresolved = new TreeSet<>();
+        for (String code : emitted) {
+            if (spec.section(code) == null) {
+                unresolved.add(code);
+            }
+        }
+
+        assertFalse(emitted.isEmpty(), "found no diagnostic code at all — the source scan missed the tree");
+        assertEquals(Set.of(), unresolved,
+                "the compiler prints these and `souther doc` has nothing to answer them with");
+    }
+
+    /** Every {@code E}-and-four-digits literal in every module's main sources. */
+    private static Set<String> emittedCodes() throws IOException {
+        Set<String> codes = new TreeSet<>();
+        for (Path source : mainSources()) {
+            Matcher m = CODE.matcher(Files.readString(source, StandardCharsets.UTF_8));
+            while (m.find()) {
+                codes.add(m.group(1));
+            }
+        }
+        return codes;
+    }
+
+    /** Every module's main sources. The test runs in its own module directory, so the repo root is
+     *  that directory's parent, and any module may emit a diagnostic. */
+    private static List<Path> mainSources() throws IOException {
+        Path module = Path.of("").toAbsolutePath();
+        Path repo = Files.isDirectory(module.resolve(Path.of("src", "main", "java")))
+                ? module.getParent() : module;
+        List<Path> sources = new ArrayList<>();
+        try (Stream<Path> modules = Files.list(repo)) {
+            for (Path root : modules.map(m -> m.resolve(Path.of("src", "main", "java"))).toList()) {
+                if (!Files.isDirectory(root)) {
+                    continue;
+                }
+                try (Stream<Path> walk = Files.walk(root)) {
+                    walk.filter(p -> p.toString().endsWith(".java")).forEach(sources::add);
+                }
+            }
+        }
+        return sources;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest.java
@@ -1,0 +1,155 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A cross-reference is the specification telling a reader where to go. `souther doc` is how a
+ * reader gets there without the document in front of them, so a name the text sends them to and a
+ * name the command refuses is the document promising something the tool does not keep.
+ *
+ * <p>The names are read out of the specification's own text rather than listed from the resolver.
+ * Asking the resolver which names it knows and then asking it about those names would pass whatever
+ * the resolver did — the point is that the side that writes the references and the side that
+ * answers them agree.
+ */
+class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
+
+    /** An AsciiDoc cross-reference: {@code <<anchor>>} or {@code <<anchor,the words shown>>}. */
+    private static final Pattern XREF = Pattern.compile("<<([^,>]+)[^>]*>>");
+
+    @Test
+    void everyCrossReferenceInTheSpecificationResolvesToASection() {
+        SpecDocument spec = SpecDocument.bundled();
+        Set<String> unresolved = new TreeSet<>();
+        Matcher m = XREF.matcher(text());
+        while (m.find()) {
+            if (spec.section(m.group(1)) == null) {
+                unresolved.add(m.group(1));
+            }
+        }
+
+        assertEquals(Set.of(), unresolved,
+                "the specification sends a reader to these and `souther doc` has no answer for them");
+    }
+
+    @Test
+    void aReferenceIsFoundAtAllSoTheScanIsNotLookingAtAnEmptyDocument() {
+        assertFalse(XREF.matcher(text()).results().findAny().isEmpty(),
+                "found no cross-reference at all — the scan missed the document");
+    }
+
+    @Test
+    void aHeadingCarryingSeveralAnchorsIsAskedForByEachOfThem() {
+        SpecDocument spec = SpecDocument.of("""
+                = A specification
+
+                [#first]
+                [#second]
+                == One heading, two names
+
+                What both names answer with.
+
+                [#other]
+                == Another
+
+                Something else.
+                """);
+
+        SpecDocument.Section section = spec.section("first");
+
+        assertNotNull(section);
+        assertSame(section, spec.section("second"), "the second name answers with the same section");
+        assertEquals("first", section.anchor(), "and the section is listed under the first written");
+        assertEquals(2, spec.sections().size(), "a further name is not a section of its own");
+        assertEquals("What both names answer with.", section.body(),
+                "the body starts after the heading, not inside the anchors");
+    }
+
+    @Test
+    void anAnchorOnAParagraphIsAnsweredWithTheSectionItStandsIn() {
+        SpecDocument spec = SpecDocument.of("""
+                = A specification
+
+                [#surrounding]
+                == The section it stands in
+
+                Opening words.
+
+                [#a-rule]
+                A rule finer than a section.
+
+                [#later]
+                == A later section
+
+                Something else.
+                """);
+
+        SpecDocument.Section section = spec.section("a-rule");
+
+        assertNotNull(section, "a name the document points at is a name a reader can ask for");
+        assertSame(spec.section("surrounding"), section);
+        assertEquals(2, spec.sections().size(), "and it is not a section of its own");
+    }
+
+    @Test
+    void theBodyOfASectionStopsBeforeTheAnchorsOfTheNextOne() {
+        SpecDocument spec = SpecDocument.of("""
+                = A specification
+
+                [#one]
+                == One
+
+                The body of one.
+
+                [#two-first]
+                [#two-second]
+                == Two
+
+                The body of two.
+                """);
+
+        assertEquals("The body of one.", spec.section("one").body());
+    }
+
+    @Test
+    void aNameAnsweredWithTheSectionAroundItSaysThatIsWhatHappened() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+        int code = DocCommand.run(new String[]{"union-member"},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+        String said = err.toString(StandardCharsets.UTF_8);
+
+        assertEquals(0, code, said);
+        assertTrue(said.contains("`union-member` is written in"),
+                "the reader is told which section answered: " + said);
+        assertFalse(out.toString(StandardCharsets.UTF_8).isBlank(), "and the section itself is printed");
+    }
+
+    private static String text() {
+        try (InputStream in = SpecDocument.class.getResourceAsStream("/META-INF/souther/specification.adoc")) {
+            assertNotNull(in, "the specification travels in the jar");
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest.java
@@ -35,9 +35,10 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
     /** An AsciiDoc cross-reference: {@code <<anchor>>} or {@code <<anchor,the words shown>>}. */
     private static final Pattern XREF = Pattern.compile("<<([^,>]+)[^>]*>>");
 
-    /** The delimiters of the blocks AsciiDoc takes verbatim: listing, literal, passthrough, and the
-     *  comment block. A macro is not expanded inside any of them, so nothing there is a reference. */
-    private static final Set<String> VERBATIM = Set.of("----", "....", "++++", "////");
+    /** The delimiter of a block AsciiDoc takes as it stands: listing, literal, passthrough, and the
+     *  comment block. A macro is not expanded inside any of them, so nothing there is a reference.
+     *  Four or more of the character, closed by the line that repeats it exactly. */
+    private static final Pattern OPAQUE_DELIMITER = Pattern.compile("^([-.+/])\\1{3,}$");
 
     @Test
     void everyCrossReferenceInTheSpecificationResolvesToASection() {
@@ -80,17 +81,17 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
     /** The names the document sends a reader to, where AsciiDoc expands a macro at all. */
     private static Set<String> referencesIn(String adoc) {
         Set<String> found = new TreeSet<>();
-        String verbatim = null;
+        String opaque = null;
         for (String line : adoc.split("\n", -1)) {
             String delimiter = line.strip();
-            if (verbatim != null) {
-                if (delimiter.equals(verbatim)) {
-                    verbatim = null;
+            if (opaque != null) {
+                if (delimiter.equals(opaque)) {
+                    opaque = null;
                 }
                 continue;
             }
-            if (VERBATIM.contains(delimiter)) {
-                verbatim = delimiter;
+            if (OPAQUE_DELIMITER.matcher(delimiter).matches()) {
+                opaque = delimiter;
                 continue;
             }
             if (line.startsWith("//")) {

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest.java
@@ -17,6 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -34,14 +35,17 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
     /** An AsciiDoc cross-reference: {@code <<anchor>>} or {@code <<anchor,the words shown>>}. */
     private static final Pattern XREF = Pattern.compile("<<([^,>]+)[^>]*>>");
 
+    /** The delimiters of the blocks AsciiDoc takes verbatim: listing, literal, passthrough, and the
+     *  comment block. A macro is not expanded inside any of them, so nothing there is a reference. */
+    private static final Set<String> VERBATIM = Set.of("----", "....", "++++", "////");
+
     @Test
     void everyCrossReferenceInTheSpecificationResolvesToASection() {
         SpecDocument spec = SpecDocument.bundled();
         Set<String> unresolved = new TreeSet<>();
-        Matcher m = XREF.matcher(text());
-        while (m.find()) {
-            if (spec.section(m.group(1)) == null) {
-                unresolved.add(m.group(1));
+        for (String reference : referencesIn(text())) {
+            if (spec.section(reference) == null) {
+                unresolved.add(reference);
             }
         }
 
@@ -51,20 +55,65 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
 
     @Test
     void aReferenceIsFoundAtAllSoTheScanIsNotLookingAtAnEmptyDocument() {
-        assertFalse(XREF.matcher(text()).results().findAny().isEmpty(),
+        assertFalse(referencesIn(text()).isEmpty(),
                 "found no cross-reference at all — the scan missed the document");
     }
 
     @Test
-    void aHeadingCarryingSeveralAnchorsIsAskedForByEachOfThem() {
+    void whatAListingOrACommentWritesIsNotAReference() {
+        assertEquals(Set.of("real"), referencesIn("""
+                A paragraph pointing at <<real>>.
+
+                [,text]
+                ----
+                A listing writing <<listed>>, which AsciiDoc leaves as it stands.
+                ----
+
+                // A line comment writing <<commented>>.
+
+                ////
+                A comment block writing <<blocked>>.
+                ////
+                """));
+    }
+
+    /** The names the document sends a reader to, where AsciiDoc expands a macro at all. */
+    private static Set<String> referencesIn(String adoc) {
+        Set<String> found = new TreeSet<>();
+        String verbatim = null;
+        for (String line : adoc.split("\n", -1)) {
+            String delimiter = line.strip();
+            if (verbatim != null) {
+                if (delimiter.equals(verbatim)) {
+                    verbatim = null;
+                }
+                continue;
+            }
+            if (VERBATIM.contains(delimiter)) {
+                verbatim = delimiter;
+                continue;
+            }
+            if (line.startsWith("//")) {
+                continue;
+            }
+            Matcher m = XREF.matcher(line);
+            while (m.find()) {
+                found.add(m.group(1));
+            }
+        }
+        return found;
+    }
+
+    @Test
+    void aHeadingIsAlsoAskedForByTheNamesWrittenBesideItsAnchor() {
         SpecDocument spec = SpecDocument.of("""
                 = A specification
 
                 [#first]
-                [#second]
-                == One heading, two names
+                [also-named="second,third"]
+                == One heading, three names
 
-                What both names answer with.
+                What all three names answer with.
 
                 [#other]
                 == Another
@@ -75,11 +124,35 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
         SpecDocument.Section section = spec.section("first");
 
         assertNotNull(section);
-        assertSame(section, spec.section("second"), "the second name answers with the same section");
-        assertEquals("first", section.anchor(), "and the section is listed under the first written");
+        assertSame(section, spec.section("second"), "a further name answers with the same section");
+        assertSame(section, spec.section("third"));
+        assertEquals("first", section.anchor(), "and the section is listed under its anchor");
         assertEquals(2, spec.sections().size(), "a further name is not a section of its own");
-        assertEquals("What both names answer with.", section.body(),
-                "the body starts after the heading, not inside the anchors");
+        assertEquals("What all three names answer with.", section.body(),
+                "the body starts after the heading, not inside the attributes");
+    }
+
+    /**
+     * AsciiDoc gives a heading exactly one ID: written twice, the last is the heading's ID and no
+     * target is registered for the first. Reading the first here would be this document knowing a
+     * heading by a name no renderer — and no deep link into the published specification — knows it
+     * by, which is the divergence a name added for `souther doc` has to stay out of.
+     */
+    @Test
+    void aHeadingWrittenWithTwoAnchorsIsRefusedRatherThanReadOneWayHereAndAnotherByAsciiDoc() {
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> SpecDocument.of("""
+                        = A specification
+
+                        [#first]
+                        [#second]
+                        == One heading under two identities
+
+                        Something.
+                        """));
+
+        assertTrue(refused.getMessage().contains("first") && refused.getMessage().contains("second"),
+                "the refusal names both of them: " + refused.getMessage());
     }
 
     @Test
@@ -109,7 +182,7 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
     }
 
     @Test
-    void theBodyOfASectionStopsBeforeTheAnchorsOfTheNextOne() {
+    void theBodyOfASectionStopsBeforeTheAttributesOfTheNextOne() {
         SpecDocument spec = SpecDocument.of("""
                 = A specification
 
@@ -118,8 +191,8 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
 
                 The body of one.
 
-                [#two-first]
-                [#two-second]
+                [#two]
+                [also-named="two-again"]
                 == Two
 
                 The body of two.
@@ -142,6 +215,33 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
         assertTrue(said.contains("`union-member` is written in"),
                 "the reader is told which section answered: " + said);
         assertFalse(out.toString(StandardCharsets.UTF_8).isBlank(), "and the section itself is printed");
+    }
+
+    /**
+     * A near miss is suggested from what a reader could have asked for, which is every name that
+     * resolves. Suggesting from the sections alone would answer `no section` to a typo on a name
+     * that does resolve, and say nothing about the name itself — the same shape of gap as answering
+     * nothing for the name in the first place, one keystroke further out.
+     */
+    @Test
+    void aNearMissOnANameThatIsNotASectionOfItsOwnIsSuggestedToo() {
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream discard = new PrintStream(ByteArrayOutputStream.nullOutputStream(), true,
+                StandardCharsets.UTF_8);
+
+        DocCommand.run(new String[]{"e2015x"}, discard,
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+        String forAName = err.toString(StandardCharsets.UTF_8);
+
+        err.reset();
+        DocCommand.run(new String[]{"union-membe"}, discard,
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+        String forAnAnchor = err.toString(StandardCharsets.UTF_8);
+
+        assertTrue(forAName.contains("did you mean: e2015"),
+                "a name a section answers to is a name to suggest: " + forAName);
+        assertTrue(forAnAnchor.contains("did you mean: union-member"),
+                "and so is an anchor written on a paragraph: " + forAnAnchor);
     }
 
     private static String text() {

--- a/souther-compiler/src/test/java/souther/compiler/doc/WhatAsciiDocTakesAsItStandsIsNotDocumentStructureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/WhatAsciiDocTakesAsItStandsIsNotDocumentStructureTest.java
@@ -1,0 +1,98 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A listing, a literal block, a passthrough and a comment block are shown as they stand or not
+ * shown at all, and AsciiDoc reads no structure out of any of them. What this document reads out of
+ * them has to be nothing too.
+ *
+ * <p>A name is the smaller half of it. A heading read where AsciiDoc reads none ends the section
+ * around it, so the two would disagree about where the sections are — the surrounding section would
+ * come back cut off at a heading no reader is shown, which is a wrong answer to a right question
+ * rather than an extra answer to a wrong one.
+ */
+class WhatAsciiDocTakesAsItStandsIsNotDocumentStructureTest {
+
+    private static String document(String delimiter) {
+        return """
+                = A specification
+
+                [#real]
+                == The section that is really there
+
+                What it says.
+
+                %s
+                [#hidden]
+                == A heading that is only shown, or not shown at all
+
+                [#also-hidden]
+                What that block says.
+                %s
+
+                The rest of what the real section says.
+                """.formatted(delimiter, delimiter);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"----", "....", "++++", "////"})
+    void aHeadingInsideAnOpaqueBlockIsNotASection(String delimiter) {
+        SpecDocument spec = SpecDocument.of(document(delimiter));
+
+        assertEquals(1, spec.sections().size(),
+                "only the heading outside the block is a section: "
+                        + spec.sections().stream().map(SpecDocument.Section::anchor).toList());
+        assertNull(spec.section("hidden"), "and it is not answered for by name either");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"----", "....", "++++", "////"})
+    void anAnchorInsideAnOpaqueBlockIsNotAName(String delimiter) {
+        SpecDocument spec = SpecDocument.of(document(delimiter));
+
+        assertNull(spec.section("also-hidden"),
+                "an anchor written where AsciiDoc registers no target is no name to ask for");
+        assertNotNull(spec.section("real"), "the section around it still answers");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"----", "....", "++++", "////"})
+    void aHeadingInsideAnOpaqueBlockDoesNotEndTheSectionAroundIt(String delimiter) {
+        SpecDocument spec = SpecDocument.of(document(delimiter));
+
+        assertTrue(spec.section("real").body().contains("The rest of what the real section says."),
+                "the section runs past the block, having never been ended by it: "
+                        + spec.section("real").body());
+    }
+
+    @Test
+    void aBlockIsEndedByTheDelimiterItWasOpenedWithAndNotByAShorterOne() {
+        SpecDocument spec = SpecDocument.of("""
+                = A specification
+
+                [#real]
+                == The section that is really there
+
+                -----
+                ----
+                [#hidden]
+                == Still inside the longer listing
+
+                ----
+                -----
+
+                The rest of it.
+                """);
+
+        assertEquals(1, spec.sections().size(), "the inner run is content, not the end of the block");
+        assertNull(spec.section("hidden"));
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -3924,7 +3924,7 @@ What to do about it is therefore a choice and not a repair. Guarding the constru
 An attempted construction raises no warning. What this reports is a possible abort, and an attempt takes its `+else+` value instead of aborting (<<attempted-construction>>).
 
 [#e2012]
-[#e2013]
+[also-named="e2013"]
 === An attempted construction that cannot be read
 
 Two codes, for the two ways the form does not read at all (<<attempted-construction>>). E2012 is `+as+` naming something that does not build a value:
@@ -3946,11 +3946,7 @@ Hint: Construct `Amount` directly, or give it the invariant that decides the bra
 ----
 
 [#e2014]
-[#e2015]
-[#e2016]
-[#e2017]
-[#e2018]
-[#e2019]
+[also-named="e2015,e2016,e2017,e2018,e2019"]
 === A per-clause departure and the clauses it answers for
 
 Six codes, for the ways a departure answering one invariant clause at a time does not line up with the clauses the type declares (<<attempt-departures>>, <<invariant-clause-name>>). E2014 answers a clause by a name the type does not declare:

--- a/specification.adoc
+++ b/specification.adoc
@@ -3816,6 +3816,19 @@ was checked.
 
 A warning, quoted where the `+fake+` names the behavior it stands in for. Emitted when building the table where it is written (<<example-fakes>>) does not come to a value, with the same three reasons <<e1920>> distinguishes. A warning rather than an error: what stopped the build says the table was not read, not that it is wrong.
 
+[#e1922]
+=== An import is never used under the name it was given
+
+[,text]
+----
+`Employee` is imported but never used under this name.
+Hint: Take it off the import list. What another module declares is reachable qualified
+whether or not it is imported, so an entry here earns its place only by being written bare
+somewhere below.
+----
+
+A warning, at the entry on the list rather than at the import as a whole. What an import list buys is the bare name; an entry no bare use reads buys nothing and still says the module depends on that name. A qualified reach does not keep an entry: it reads the same whether or not the name is listed (<<imports>>), so a name reached only that way is on the list for nothing. An editor is told the entry is unnecessary rather than merely told about it, since what to do with it is to delete it.
+
 [#e1923]
 === An example evaluation did not answer
 
@@ -3890,10 +3903,31 @@ assumed where it stands, the value being built is one the invariant rejects. Fix
 value, or guard the path so the violating case cannot reach here.
 ----
 
-Neither names what decided it: the check knows the values alone did not, and not which of the things known there did. The companion E2011 is a warning, not an error: it says the guards do not establish the invariant, so the check remains at run time.
+Neither names what decided it: the check knows the values alone did not, and not which of the things known there did.
+
+[#e2011]
+=== A construction is not shown to satisfy its invariant
+
+[,text]
+----
+Constructing `Amount` here may violate its invariant: the guards do not establish it. Guard
+it with `guard`, or reify the relation into `Amount`'s (or an input's) invariant so it is
+assumed here.
+Hint: If a relation between inputs guarantees this, declare it as an `invariant` on the
+input data so it is checked once at its boundary and assumed here.
+----
+
+A warning, and the one diagnostic in this chapter that says nothing about whether the model is wrong. E2010 is the check having proved the invariant false; this is the check having proved nothing either way, so what was always going to happen still happens — the invariant is tested when the value is built, and a violation aborts there (<<violation-destination>>). A model whose guards do establish the invariant by an argument the check cannot follow is told this too, and is not thereby wrong.
+
+What to do about it is therefore a choice and not a repair. Guarding the construction puts the reason where the check can read it. Reifying the relation — declaring it as an `+invariant+` on an input's own data — moves it to that data's boundary, where it is tested once and assumed everywhere the value reaches afterwards (<<invariant-discharge>>). Leaving it is the third: the run-time test is the guarantee, and the warning says it is still the thing doing the work.
+
+An attempted construction raises no warning. What this reports is a possible abort, and an attempt takes its `+else+` value instead of aborting (<<attempted-construction>>).
 
 [#e2012]
-=== `as` names what a construction builds
+[#e2013]
+=== An attempted construction that cannot be read
+
+Two codes, for the two ways the form does not read at all (<<attempted-construction>>). E2012 is `+as+` naming something that does not build a value:
 
 [,text]
 ----
@@ -3902,19 +3936,73 @@ Hint: Write the construction whose invariant decides the branch, or drop the `as
 a condition.
 ----
 
-Emitted for the forms of an attempted construction that cannot be read (<<attempted-construction>>). Attempting a type that declares no invariant is E2013, since the `+else+` value could never be reached.
+E2013 is the form reading and having nothing to decide, since a type declaring no invariant refuses no value:
+
+[,text]
+----
+`Amount` declares no invariant, so an attempted construction of it always succeeds and the
+`else` value is never reached.
+Hint: Construct `Amount` directly, or give it the invariant that decides the branch.
+----
 
 [#e2014]
-=== A clause answered by name does not exist
+[#e2015]
+[#e2016]
+[#e2017]
+[#e2018]
+[#e2019]
+=== A per-clause departure and the clauses it answers for
+
+Six codes, for the ways a departure answering one invariant clause at a time does not line up with the clauses the type declares (<<attempt-departures>>, <<invariant-clause-name>>). E2014 answers a clause by a name the type does not declare:
 
 [,text]
 ----
 `Amount` has no invariant clause named `nonNegative`.
 Hint: The clauses that can be answered by name are: inYen. A clause is named where it is
-declared (`invariant <name> = ...`); one declared without a name is answered by `| _`.
+declared (`invariant <name> = ...`); one declared without a name is answered by `| _ -> ...`.
 ----
 
-Emitted when a per-clause departure names a clause the type does not declare (<<attempt-departures>>, <<invariant-clause-name>>). The rest of that form is checked with its own codes: a clause that can fail and has no arm is E2015, unnamed clauses left unanswered E2016, a `+| _+` with nothing to answer E2017, arms with no attempted construction to answer for E2018, and a clause answered twice E2019.
+E2015 leaves a clause that can fail with no arm to reach. A failure reaches one arm, so a clause with none is a failure with nowhere to go:
+
+[,text]
+----
+These clauses of `Amount` have no arm: inYen. A failure reaches one arm, so every clause
+that can fail needs one.
+Hint: Answer each of them, or give the `else` one value, which answers any failure.
+----
+
+E2016 is the same for the clauses that have no name to be answered by:
+
+[,text]
+----
+`Amount` has invariant clauses declared without a name, and nothing here answers them.
+Hint: Add `| _ -> ...` for them, or name them where they are declared.
+----
+
+E2017 is the other direction — the arm that answers the unnamed clauses where there are none:
+
+[,text]
+----
+Every invariant clause of `Amount` is named and answered, so `| _ -> ...` answers nothing.
+Hint: Drop it. It would come back the moment `Amount` declares a clause without a name.
+----
+
+E2018 is arms with nothing to answer for, the departure having no attempted construction above it:
+
+[,text]
+----
+These arms answer one invariant clause each, and there is no attempted construction here
+for them to answer for.
+Hint: Attempt the construction (`guard T(v) as x else ...`), or give the `else` one value.
+----
+
+E2019 is one clause answered twice:
+
+[,text]
+----
+The clause `inYen` is answered twice. An arm is chosen by the clause that failed, so a
+second arm for it could never be reached.
+----
 
 [#e2101]
 === A generated method exceeds the JVM parameter-slot limit


### PR DESCRIPTION
`souther doc e2011` answered `no section` (#364). Walking the whole set first showed E2011 was one instance of three broken contracts rather than a missing paragraph, so this fixes the mechanism each one runs through and leaves a test behind for each.

| contract | how it was broken |
| --- | --- |
| diagnostic code → documentation | 8 emitted codes resolved to nothing |
| printed spelling → lookup spelling | `E2010` did not resolve, though `e2010` did |
| specification reference → `souther doc` | 7 anchors the document links to resolved to nothing |

### A name is asked for in the case it was printed

The compiler prints `E2010` and the specification anchors `e2010`, so the form a reader copies out of an error was the one form the lookup refused — for all 47 codes that had a section, not only the ones that did not. The lookup key is folded; the names are not, since a shipped topic's name is also the path its text is read from. Two names that fold together are refused where the index is built rather than resolved by whichever jar was read second.

### Every name the specification writes resolves

An anchor resolved only directly above a heading, so `<<union-member>>`, `<<bridge-case>>` and five more were names the document sent a reader to and the tool refused. An anchor now resolves wherever it is written: a heading may carry several, and one on a paragraph resolves to the section it stands in, with the reader told which section answered.

### Every emitted code is one a reader can look up

E2011 and E1922 get sections of their own — E2011 because it is the one diagnostic that says nothing about whether the model is wrong, so pointing at E2010's section would answer a question the reader did not ask. E2013 and E2015–E2019 are named on the section that already explains them, which now quotes each message the chapter says it lists.

### Tests

Three invariants, each committed with the change it guards:

- every emitted code resolves — the domain is codes written as literals at their emission sites, stated in the test
- every `<<x>>` the specification writes resolves — read out of the document's own text, not listed from the resolver, so the two sides have to agree
- a name resolves in any case, and a topic keeps the spelling its resource is read by

Both invariant tests were run against the state before these commits and fail there with exactly the populations found in the investigation: 8 codes and 7 anchors.

`mvn clean test`: 3355 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
