### PR TITLE
Warnings can fail a build, and a size that only grows is a size the check knows

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -65,6 +65,7 @@ public final class Main {
               --strict                  exit non-zero while rows are waiting for a `let`
             options (compile):
               --adequacy off|witness|all  warn about what the `example`s do not cover (default off)
+              --warnings report|error   refuse a compile that warns (default report)
             options (compile/examples/japi):
               -cp, --class-path <path>  where to find modules another project compiled
 
@@ -93,6 +94,7 @@ public final class Main {
             Map.entry("--class-path", "compile/examples/japi"),
             Map.entry("-d", "compile"),
             Map.entry("--adequacy", "compile"),
+            Map.entry("--warnings", "compile"),
             Map.entry("--behavior", "run/examples"),
             Map.entry("--input", "run"),
             Map.entry("-w", "fmt"),
@@ -232,6 +234,7 @@ public final class Main {
         List<Path> classPath = new ArrayList<>();
         Path outDir = Path.of(".");
         Adequacy.Asked measure = Adequacy.Asked.NOTHING;
+        boolean refuseWarnings = false;
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
                 case "--adequacy" -> {
@@ -240,6 +243,14 @@ public final class Main {
                         return 2;
                     }
                     measure = Adequacy.Asked.warningsAt(adequacyLevel(args[i]));
+                }
+                case "--warnings" -> {
+                    if (++i >= args.length
+                            || !(args[i].equals("report") || args[i].equals("error"))) {
+                        System.err.println("`--warnings` takes report or error");
+                        return 2;
+                    }
+                    refuseWarnings = args[i].equals("error");
                 }
                 case "-d" -> {
                     if (++i >= args.length) {
@@ -276,11 +287,14 @@ public final class Main {
         }
         List<Located> warnings = new ArrayList<>();
         try {
-            List<Path> written = compileToDir(sources, outDir, classPath, warnings, measure);
+            Map<String, byte[]> classes = compiledClasses(sources, classPath, warnings, measure);
             // Before the written files: the warnings are about the source, and a long list of paths
             // between them and the command would bury them.
             report(warnings, sources, render);
-            for (Path file : written) {
+            if (refuseWarnings && !warnings.isEmpty()) {
+                return refused(render);
+            }
+            for (Path file : writeClasses(classes, outDir)) {
                 System.out.println("wrote " + file);
             }
             return 0;
@@ -610,6 +624,23 @@ public final class Main {
         report(e.locatedDiagnostics(), sources, render);
     }
 
+    /**
+     * Says that the warnings just printed are what stopped this build, and answers with the exit code
+     * for it.
+     *
+     * <p>Not under {@code --format json}. What that format writes is one object per diagnostic with
+     * nothing around them, so a reader takes the output a line at a time; a sentence among them is a
+     * line that parses as nothing, and a reader given it cannot tell that from output it should have
+     * understood. There the exit code is what says it, which is what a tool reads anyway.
+     */
+    private static int refused(RenderOptions render) {
+        if (!render.json()) {
+            System.err.println(Messages.get("cli.warnings.refused",
+                    Messages.resolveLocale(render.lang)));
+        }
+        return 1;
+    }
+
     /** Prints each diagnostic to stderr as the chosen renderer renders it, quoting the file it
      * belongs to. Errors and warnings take the same path; only where they come from differs. */
     private static void report(List<Located> located, List<Path> sources, RenderOptions render) {
@@ -714,6 +745,21 @@ public final class Main {
     static List<Path> compileToDir(List<Path> sources, Path outDir, List<Path> classPath,
                                    List<Located> warningsOut, Adequacy.Asked measure)
             throws IOException {
+        return writeClasses(compiledClasses(sources, classPath, warningsOut, measure), outDir);
+    }
+
+    /**
+     * The classes the sources compile to, by binary name, with the compile's warnings collected into
+     * {@code warningsOut}.
+     *
+     * <p>Held apart from writing them because a command may read the warnings before deciding whether
+     * this build is one it accepts, and a build it does not accept writes nothing: the exit code says
+     * the classes are not the output of an accepted compile, and a directory holding them anyway is
+     * what a later step would read as if they were.
+     */
+    static Map<String, byte[]> compiledClasses(List<Path> sources, List<Path> classPath,
+                                               List<Located> warningsOut, Adequacy.Asked measure)
+            throws IOException {
         List<String> texts = new ArrayList<>();
         for (Path source : sources) {
             texts.add(Files.readString(source));
@@ -728,7 +774,11 @@ public final class Main {
                         compileWarnings, measure)
                 : Compiler.compiledModules(texts, path, compileWarnings, measure);
         warningsOut.addAll(compileWarnings);
-        Map<String, byte[]> classes = compilation.classes();
+        return compilation.classes();
+    }
+
+    /** Writes each class under {@code outDir}, and answers with the paths written, in order. */
+    static List<Path> writeClasses(Map<String, byte[]> classes, Path outDir) throws IOException {
         List<Path> written = new ArrayList<>();
         for (Map.Entry<String, byte[]> entry : classes.entrySet()) {
             Path file = outDir.resolve(entry.getKey().replace('.', '/') + ".class");

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -196,11 +196,13 @@ final class DischargeRules {
     /**
      * The containers a construction's result is never smaller than.
      *
-     * <p>Written on its own and not as a {@link Shape}, because these keep nothing of the elements:
-     * {@code List.append(a, b)} holds neither {@code a}'s elements alone nor {@code b}'s, and an
-     * insert puts in one that was in neither. How many there are survives that, and a rule that had
-     * to be spelled as a rule about the elements could not say so — which is why these sat among the
-     * constructions nothing is known of, their count discarded along with the rest.
+     * <p>Written on its own and not as a {@link Shape}, because none of these establishes an element
+     * relation to a single source that a shape states. It is not that they keep nothing:
+     * {@code List.append(a, b)} keeps every element of both, and holds neither {@code a}'s alone nor
+     * {@code b}'s; an insert or a union answers one entry for a key that was already there, so what
+     * the result holds may have been in neither. The cardinality is a separate fact and survives
+     * either way — which is why these sat among the constructions nothing is known of, their bound
+     * discarded with an element rule that was never the same statement.
      *
      * <p>No more than the bound. A union makes one entry of a key both sides have and an insert of
      * something already there adds nothing, so neither answers the sum of what it read; appending
@@ -226,7 +228,8 @@ final class DischargeRules {
      *
      * <p>They put in what the container they read did not hold. Nothing that held of every element
      * still does, which is what a shape would have had to say. How many there are is said instead by
-     * {@link #NO_SMALLER_THAN}, which those of them that only add are in.
+     * {@link #NO_SMALLER_THAN}, which those of them whose result is never smaller than a source it
+     * names are in.
      *
      * <p>They answer the same elements in a container of another kind. That is true and unsayable:
      * every statement the check makes names the kind it is about — {@code List.length} and

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -199,12 +199,12 @@ final class DischargeRules {
      * <p>Written on its own and not as a {@link Shape}, because none of these establishes an element
      * relation to a single source that a shape states. It is not that they keep nothing:
      * {@code List.append(a, b)} keeps every element of both, and holds neither {@code a}'s alone nor
-     * {@code b}'s; an insert or a union answers one entry for a key that was already there, so what
-     * the result holds may have been in neither. The cardinality is a separate fact and survives
+     * {@code b}'s, so neither of the two is what it was built from; an insert puts in an element or
+     * an entry the container it read did not hold. The cardinality is a separate fact and survives
      * either way — which is why these sat among the constructions nothing is known of, their bound
      * discarded with an element rule that was never the same statement.
      *
-     * <p>No more than the bound. A union makes one entry of a key both sides have and an insert of
+     * <p>No more than the bound. A union answers one of what both sides hold and an insert of
      * something already there adds nothing, so neither answers the sum of what it read; appending
      * does, and stating it for that one alone would be a second rule for one operation. The bound is
      * what they share, and it is what a lower-bound invariant asks for.

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -49,24 +49,39 @@ final class DischargeRules {
             op("List.length"), op("String.length"), op("Set.size"), op("Map.size"));
 
     /**
-     * What a construction of a container keeps of the container it was built from.
+     * What a construction of a container keeps of the elements of the container it was built from.
      *
      * <ul>
      * <li>{@code PERMUTES} — the same elements in another order. Everything survives.
      * <li>{@code SUBSET} — some of the same elements. Nothing new is there, so a property of every
-     *     element survives and the size can only fall.
-     * <li>{@code MAPS} — one new element for each. As many as before, and nothing is known of what
-     *     they are.
-     * <li>{@code COLLAPSES} — at most one new element for each. Neither the elements nor the count.
+     *     element survives.
+     * <li>{@code MAPS} — one new element for each. Nothing is known of what they are.
+     * <li>{@code COLLAPSES} — at most one new element for each. Neither the elements nor what a
+     *     closure that answers about them said.
      * </ul>
+     *
+     * <p>How many there are is {@link Cardinality} and is stated beside this, not read off it. The
+     * two agree for every construction here — the same elements in another order is as many, some of
+     * them is no more — and that agreement is what made one enum look like enough. It ends at a
+     * construction given two containers: {@code List.append(a, b)} holds neither {@code a}'s elements
+     * alone nor {@code b}'s, and its size is still no less than either. A statement about the count
+     * that has to be spelled as a statement about the elements cannot be made there.
      */
     enum Shape {
-        PERMUTES, SUBSET, MAPS, COLLAPSES;
+        PERMUTES, SUBSET, MAPS, COLLAPSES
+    }
 
-        /** Whether the result has exactly as many as the container it was built from. */
-        boolean keepsSize() {
-            return this == PERMUTES || this == MAPS;
-        }
+    /**
+     * How the size of a construction's result relates to the size of the container it was built from.
+     *
+     * <ul>
+     * <li>{@code SAME} — exactly as many. Not stated as a fact: both are one atom, since
+     *     {@link #sizeSource} answers the size of the result with the size of its source.
+     * <li>{@code AT_MOST} — no more, and possibly fewer.
+     * </ul>
+     */
+    enum Cardinality {
+        SAME, AT_MOST
     }
 
     /**
@@ -145,35 +160,59 @@ final class DischargeRules {
         return new Reads.At(position);
     }
 
-    /** Which argument a container was built from, and what the building keeps of it. */
-    record Built(Reads from, Shape shape) {}
+    /** Which argument a container was built from, what the building keeps of its elements, and how
+     * many of them the result has. */
+    record Built(Reads from, Shape shape, Cardinality size) {}
 
     /** The container {@code call} built its result from, and what the building kept of it. */
-    record Source(Core container, Shape shape) {}
+    record Source(Core container, Shape shape, Cardinality size) {}
 
     private static final Map<ValueName, Built> BUILT_FROM = Map.ofEntries(
-            Map.entry(op("List.reverse"), new Built(at(0), Shape.PERMUTES)),
-            Map.entry(op("List.sort"), new Built(at(0), Shape.PERMUTES)),
-            Map.entry(op("List.sortBy"), new Built(CONTAINER, Shape.PERMUTES)),
-            Map.entry(op("List.map"), new Built(CONTAINER, Shape.MAPS)),
-            Map.entry(op("List.mapIndexed"), new Built(CONTAINER, Shape.MAPS)),
-            Map.entry(op("Map.mapValues"), new Built(CONTAINER, Shape.MAPS)),
-            Map.entry(op("List.filter"), new Built(CONTAINER, Shape.SUBSET)),
-            Map.entry(op("List.distinct"), new Built(at(0), Shape.SUBSET)),
-            Map.entry(op("List.take"), new Built(at(1), Shape.SUBSET)),
-            Map.entry(op("List.drop"), new Built(at(1), Shape.SUBSET)),
-            Map.entry(op("Set.filter"), new Built(CONTAINER, Shape.SUBSET)),
-            Map.entry(op("Map.filterEntries"), new Built(CONTAINER, Shape.SUBSET)),
-            Map.entry(op("List.distinctBy"), new Built(CONTAINER, Shape.SUBSET)),
-            Map.entry(op("Map.remove"), new Built(at(1), Shape.SUBSET)),
-            Map.entry(op("Set.remove"), new Built(at(1), Shape.SUBSET)),
-            Map.entry(op("Map.intersection"), new Built(at(0), Shape.SUBSET)),
-            Map.entry(op("Map.difference"), new Built(at(0), Shape.SUBSET)),
-            Map.entry(op("Set.intersection"), new Built(at(0), Shape.SUBSET)),
-            Map.entry(op("Set.difference"), new Built(at(0), Shape.SUBSET)),
-            Map.entry(op("Map.updateIfPresent"), new Built(CONTAINER, Shape.MAPS)),
-            Map.entry(op("List.filterMap"), new Built(CONTAINER, Shape.COLLAPSES)),
-            Map.entry(op("Set.map"), new Built(CONTAINER, Shape.COLLAPSES)));
+            Map.entry(op("List.reverse"), new Built(at(0), Shape.PERMUTES, Cardinality.SAME)),
+            Map.entry(op("List.sort"), new Built(at(0), Shape.PERMUTES, Cardinality.SAME)),
+            Map.entry(op("List.sortBy"), new Built(CONTAINER, Shape.PERMUTES, Cardinality.SAME)),
+            Map.entry(op("List.map"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
+            Map.entry(op("List.mapIndexed"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
+            Map.entry(op("Map.mapValues"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
+            Map.entry(op("List.filter"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("List.distinct"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("List.take"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("List.drop"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Set.filter"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map.filterEntries"),
+                    new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("List.distinctBy"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map.remove"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Set.remove"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map.intersection"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map.difference"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Set.intersection"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Set.difference"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map.updateIfPresent"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
+            Map.entry(op("List.filterMap"),
+                    new Built(CONTAINER, Shape.COLLAPSES, Cardinality.AT_MOST)),
+            Map.entry(op("Set.map"), new Built(CONTAINER, Shape.COLLAPSES, Cardinality.AT_MOST)));
+
+    /**
+     * The containers a construction's result is never smaller than.
+     *
+     * <p>Written on its own and not as a {@link Shape}, because these keep nothing of the elements:
+     * {@code List.append(a, b)} holds neither {@code a}'s elements alone nor {@code b}'s, and an
+     * insert puts in one that was in neither. How many there are survives that, and a rule that had
+     * to be spelled as a rule about the elements could not say so — which is why these sat among the
+     * constructions nothing is known of, their count discarded along with the rest.
+     *
+     * <p>No more than the bound. A union makes one entry of a key both sides have and an insert of
+     * something already there adds nothing, so neither answers the sum of what it read; appending
+     * does, and stating it for that one alone would be a second rule for one operation. The bound is
+     * what they share, and it is what a lower-bound invariant asks for.
+     */
+    private static final Map<ValueName, List<Reads>> NO_SMALLER_THAN = Map.of(
+            op("List.append"), List.of(at(0), at(1)),
+            op("Set.union"), List.of(at(0), at(1)),
+            op("Map.union"), List.of(at(0), at(1)),
+            op("Set.insert"), List.of(at(1)),
+            op("Map.insert"), List.of(at(2)));
 
     /**
      * The constructions this says nothing of, in three groups. Each reason is about what a shape can
@@ -186,7 +225,8 @@ final class DischargeRules {
      * elements from each — which is neither the elements nor a count.
      *
      * <p>They put in what the container they read did not hold. Nothing that held of every element
-     * still does, and the size can rise; a shape says neither of those.
+     * still does, which is what a shape would have had to say. How many there are is said instead by
+     * {@link #NO_SMALLER_THAN}, which those of them that only add are in.
      *
      * <p>They answer the same elements in a container of another kind. That is true and unsayable:
      * every statement the check makes names the kind it is about — {@code List.length} and
@@ -416,6 +456,18 @@ final class DischargeRules {
         private static final Map<ValueName, Reads> PROJECTIONS =
                 bind(PROJECTION_OF, Function.identity(), CLOSURE, t -> t instanceof Type.FnOf,
                         "the projection a predicate is stated over");
+        private static final Map<ValueName, List<Reads>> LOWER_BOUNDS =
+                bindEach(NO_SMALLER_THAN, CONTAINER, Question::holdsElements,
+                        "a container the result is no smaller than");
+    }
+
+    /** As {@link #bind}, for a rule that names more than one argument: each is held to the
+     * declaration on its own, since each is a separate claim about a separate argument. */
+    static Map<ValueName, List<Reads>> bindEach(Map<ValueName, List<Reads>> rules, Reads derived,
+                                                Predicate<Type> required, String what) {
+        rules.forEach((operation, reads) -> reads.forEach(one ->
+                bind(Map.of(operation, one), Function.identity(), derived, required, what)));
+        return rules;
     }
 
     /**
@@ -459,7 +511,35 @@ final class DischargeRules {
      * what the operation keeps. */
     static Source builtFrom(Core.PreservedCall call) {
         Built built = Bound.BUILDINGS.get(call.operation());
-        return built == null ? null : new Source(built.from().of(call), built.shape());
+        return built == null ? null
+                : new Source(built.from().of(call), built.shape(), built.size());
+    }
+
+    /**
+     * The containers {@code e}'s result is no smaller than, in the order the rule names them.
+     *
+     * <p>{@code a ++ b} is here beside the table rather than in it. The library declares
+     * {@code List.append} as {@code a ++ b}, so the two spellings are one operation and a rule about
+     * one is a rule about the other; and a {@code String} has no {@code append} at all, so the
+     * operator is the only spelling its concatenation has. A rule keyed by operation reaches neither,
+     * both being written as an operator and not as a call.
+     */
+    static List<Core> noSmallerThan(Core e) {
+        if (e instanceof Core.Binary b && b.op() == Ast.BinOp.CONCAT) {
+            return List.of(b.left(), b.right());
+        }
+        if (!(e instanceof Core.PreservedCall call)) {
+            return List.of();
+        }
+        List<Reads> reads = Bound.LOWER_BOUNDS.get(call.operation());
+        if (reads == null) {
+            return List.of();
+        }
+        List<Core> containers = new ArrayList<>(reads.size());
+        for (Reads one : reads) {
+            containers.add(one.of(call));
+        }
+        return containers;
     }
 
     /** Where {@code call} reads the container it states its predicate of, or null where it is not a
@@ -520,7 +600,7 @@ final class DischargeRules {
     static Core sizeSource(Core e) {
         if (e instanceof Core.PreservedCall call) {
             Source built = builtFrom(call);
-            if (built != null && built.shape().keepsSize()) {
+            if (built != null && built.size() == Cardinality.SAME) {
                 return sizeSource(built.container());
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -2,6 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Combinators.Handed;
+import souther.compiler.check.DischargeRules.Cardinality;
 import souther.compiler.check.DischargeRules.Carrying;
 import souther.compiler.check.DischargeRules.Projection;
 import souther.compiler.check.DischargeRules.Shape;
@@ -426,17 +427,32 @@ final class Predicates {
         }
     }
 
-    /** {@code size(c) <= size(what c was built from)}, down the chain, wherever the building can only
-     * drop elements. */
+    /** How the size of a container relates to the size of what it was built from, down the chain.
+     * Which way it is stated is what the construction's {@link Cardinality} says. */
     void bounds(ValueName sizeCall, Core container, Denotations at, List<Constraint> out) {
+        // A construction that only adds is no smaller than each container it read. It names more than
+        // one of them, so this is a loop where the building below is a single answer — and it is
+        // asked of the expression rather than of a call, since `a ++ b` is one of these and is
+        // written as an operator.
+        for (Core added : DischargeRules.noSmallerThan(container)) {
+            stated(sizeCall, container, DischargeRules.sizeSource(added), Rel.GE, at, out);
+        }
         if (!(container instanceof Core.PreservedCall call)) {
             return;
         }
         Source built = DischargeRules.builtFrom(call);
-        if (built == null || built.shape().keepsSize()) {
+        Rel rel = built == null ? null : relationOf(built.size());
+        if (rel == null) {
             return;
         }
-        Core source = DischargeRules.sizeSource(built.container());
+        stated(sizeCall, container, DischargeRules.sizeSource(built.container()), rel, at, out);
+    }
+
+    /** States how the size of {@code container} relates to the size of {@code source}, and goes on
+     * down whatever that one was built from. A container neither of them has a key for is one
+     * nothing can be said of, and stops the walk. */
+    private void stated(ValueName sizeCall, Core container, Core source, Rel rel, Denotations at,
+                        List<Constraint> out) {
         String here = terms.bodyKey(container, at);
         String there = terms.bodyKey(source, at);
         if (here == null || there == null) {
@@ -445,8 +461,18 @@ final class Predicates {
         out.add(new Constraint(
                 LinearForm.atom(Terms.sizeKey(sizeCall, here))
                         .minus(LinearForm.atom(Terms.sizeKey(sizeCall, there))),
-                Rel.LE));
+                rel));
         bounds(sizeCall, source, at, out);
+    }
+
+    /** How {@code size} is stated of the two sizes, or null where there is nothing to state: a
+     * construction of the same size answers both with one atom ({@code DischargeRules.sizeSource}),
+     * so a constraint between them would say a name is itself. */
+    private static Rel relationOf(Cardinality size) {
+        return switch (size) {
+            case AT_MOST -> Rel.LE;
+            case SAME -> null;
+        };
     }
 
     /** The keys a guard could have settled to establish this clause: the predicate as written, and

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -430,8 +430,8 @@ final class Predicates {
     /** How the size of a container relates to the size of what it was built from, down the chain.
      * Which way it is stated is what the construction's {@link Cardinality} says. */
     void bounds(ValueName sizeCall, Core container, Denotations at, List<Constraint> out) {
-        // A construction that only adds is no smaller than each container it read. It names more than
-        // one of them, so this is a loop where the building below is a single answer — and it is
+        // A construction's result is never smaller than each source named for it. A rule may name
+        // more than one, so this is a loop where the building below is a single answer — and it is
         // asked of the expression rather than of a call, since `a ++ b` is one of these and is
         // written as an operator.
         for (Core added : DischargeRules.noSmallerThan(container)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -149,16 +149,34 @@ final class Terms {
         });
     }
 
-    /** How many elements a size call over a value written out counts, or {@code null} where its
-     * argument is not one. */
+    /**
+     * How many elements a size call over a list written out counts, or {@code null} where its
+     * argument is not one.
+     *
+     * <p>What the elements are is not asked. Whether a value is <em>written</em>
+     * ({@link #isWritten}) is a question about the whole of it, down to every part, and it is the
+     * right question where a construction is read as the value it builds — there a computed part is
+     * a value the source does not hold. Counting reads the line the list is written on, and three
+     * elements written there are three however each was arrived at. Asking the stronger question
+     * left a list of parameters with a length nothing knew, and an invariant over it with no guard
+     * an author could write: the length is not a value any condition could settle.
+     */
     BigDecimal writtenSize(Core e, Denotations at) {
         Core container = DischargeRules.sizeArgOf(e);
         if (container == null) {
             return null;
         }
-        Core written = writtenValue(container, at);
-        return written instanceof Core.ListLit list
+        return listedOut(container, at) instanceof Core.ListLit list
                 ? BigDecimal.valueOf(list.elements().size()) : null;
+    }
+
+    /** The list {@code e} is, written where it is or written where the name it is was given one. */
+    private Core listedOut(Core e, Denotations at) {
+        if (!(e instanceof Core.Read r)) {
+            return e;
+        }
+        Core given = at.valueOf(r.binding());
+        return given == null || given == e ? e : listedOut(given, at);
     }
 
     static LinearForm negate(LinearForm f) {

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -11,6 +11,9 @@ diag.diff.found=It is:
 diag.diff.expected=But it needs to be:
 diag.suggestion=did you mean `{0}`?
 
+# --- what the command line says about the build, rather than about the source ---
+cli.warnings.refused=No classes were written: warnings are treated as errors.
+
 # --- error titles (spec section 22) ---
 e1001.title=DIRECT CONSTRUCTION
 e1002.title=INSUFFICIENT CONSTRUCTION AUTHORITY

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -10,6 +10,9 @@ diag.diff.found=実際:
 diag.diff.expected=期待:
 diag.suggestion=`{0}` の間違いではありませんか？
 
+# --- ソースではなくビルドについてコマンドラインが言うこと ---
+cli.warnings.refused=警告をエラーとして扱う設定のため、クラスを出力しませんでした。
+
 # --- エラー見出し（仕様 22 章） ---
 e1001.title=データの直接構築
 e1002.title=構築権限の不足

--- a/souther-compiler/src/test/java/souther/compiler/ABuildThatWarnsCanBeRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABuildThatWarnsCanBeRefusedTest.java
@@ -130,9 +130,12 @@ class ABuildThatWarnsCanBeRefusedTest {
     }
 
     /**
-     * A refused build leaves nothing behind. The exit code says the build was not accepted, and a
-     * directory of classes from a build in that state is what a later step would pick up as the
-     * output of one that was.
+     * A refused build writes no classes. The exit code says the build was not accepted, and classes
+     * this run had written are what a later step would pick up as the output of one that was.
+     *
+     * <p>What it does not say is that the output directory is empty afterwards: classes an earlier
+     * run left there stay, as they do when a compile fails. Removing those is a separate question
+     * about who owns that directory, and the same one for both.
      */
     @Test
     void aRefusedCompileWritesNoClasses() throws Exception {

--- a/souther-compiler/src/test/java/souther/compiler/ABuildThatWarnsCanBeRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABuildThatWarnsCanBeRefusedTest.java
@@ -1,0 +1,218 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * A warning says the run-time check stands, which is a fact about the construction and not about
+ * whether the build should go on. Those are two questions, and only the first one was being asked:
+ * a compile that warned wrote its classes and exited 0, so a project that wanted the warnings gone
+ * had no way to hold itself to it and they accumulated while the build stayed green.
+ *
+ * <p>The answer is an acceptance rule and not a severity: {@code --warnings error} decides whether a
+ * compile carrying warnings is accepted, and the diagnostics it prints are the same warnings they
+ * were. Rewriting them to errors would say the construction is refused, which is not what the check
+ * found.
+ */
+class ABuildThatWarnsCanBeRefusedTest {
+
+    @TempDir
+    Path dir;
+
+    /** One unproven construction: nothing is known of the Int the name was given. */
+    private static final String WARNS = """
+            module m
+
+            data Eaches = Int
+                invariant value >= 0
+
+            behavior wrap : (n: Int) -> Eaches
+                constructs Eaches
+            let wrap (n) = {
+                let m = n
+                Eaches(m)
+            }
+            """;
+
+    private static final String CLEAN = """
+            module m
+
+            data Note = { body: String }
+            """;
+
+    private record Said(int code, String err, String out) {}
+
+    private Said run(String... args) {
+        PrintStream originalErr = System.err;
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            int code = Main.dispatch(args);
+            return new Said(code, err.toString(StandardCharsets.UTF_8),
+                    out.toString(StandardCharsets.UTF_8));
+        } finally {
+            System.setErr(originalErr);
+            System.setOut(originalOut);
+        }
+    }
+
+    private Path source(String text) throws Exception {
+        Path file = dir.resolve("m.sou");
+        Files.writeString(file, text);
+        return file;
+    }
+
+    private Path outDir() {
+        return dir.resolve("out");
+    }
+
+    private List<Path> written() throws Exception {
+        if (!Files.isDirectory(outDir())) {
+            return List.of();
+        }
+        try (var walk = Files.walk(outDir())) {
+            return walk.filter(Files::isRegularFile).toList();
+        }
+    }
+
+    // --- what the rule decides ------------------------------------------------------------------
+
+    @Test
+    void aCompileThatWarnsIsRefusedWhenWarningsAreErrors() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings", "error", "--lang", "en");
+
+        assertEquals(1, said.code(), said.err());
+    }
+
+    @Test
+    void aCompileThatWarnsIsAcceptedWhenTheyAreOnlyReported() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings", "report", "--lang", "en");
+
+        assertEquals(0, said.code(), said.err());
+        assertTrue(said.err().contains("E2011"), "the warning is still reported: " + said.err());
+    }
+
+    /** The default is what the command did before there was an option to write. */
+    @Test
+    void reportingIsWhatAnUnaskedCompileDoes() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--lang", "en");
+
+        assertEquals(0, said.code(), said.err());
+        assertTrue(said.err().contains("E2011"), said.err());
+    }
+
+    @Test
+    void aCompileThatDoesNotWarnIsAcceptedWhenWarningsAreErrors() throws Exception {
+        Said said = run("compile", source(CLEAN).toString(), "-d", outDir().toString(),
+                "--warnings", "error", "--lang", "en");
+
+        assertEquals(0, said.code(), said.err());
+        assertFalse(written().isEmpty(), "a clean compile still writes its classes");
+    }
+
+    /**
+     * A refused build leaves nothing behind. The exit code says the build was not accepted, and a
+     * directory of classes from a build in that state is what a later step would pick up as the
+     * output of one that was.
+     */
+    @Test
+    void aRefusedCompileWritesNoClasses() throws Exception {
+        run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings", "error", "--lang", "en");
+
+        assertEquals(List.of(), written(), "the refused build wrote classes");
+    }
+
+    // --- what it prints -------------------------------------------------------------------------
+
+    /** The diagnostic is about the construction; the rule is about the build. Only the second one
+     * changed, so the first says what it said. */
+    @Test
+    void theDiagnosticIsStillAWarning() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings", "error", "--lang", "en");
+
+        assertTrue(said.err().contains("INVARIANT (WARNING)"), said.err());
+        assertTrue(said.err().contains("E2011"), said.err());
+        assertFalse(said.err().contains("INVARIANT  E2011"),
+                "the warning was not re-titled as an error: " + said.err());
+    }
+
+    @Test
+    void theRefusalSaysWhyTheBuildStopped() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings", "error", "--lang", "en");
+
+        assertTrue(said.err().contains("warnings are treated as errors"),
+                "an exit code alone does not say which flag decided it: " + said.err());
+    }
+
+    @Test
+    void theRefusalFollowsTheChosenLanguage() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings", "error", "--lang", "ja");
+
+        assertTrue(said.err().contains("警告"), said.err());
+        assertFalse(said.err().contains("warnings are treated as errors"), said.err());
+    }
+
+    /**
+     * The JSON renderer writes one object per diagnostic and no envelope around them, so what a tool
+     * reads is JSON lines. A sentence appended there is a line that does not parse, and the reader
+     * that was given it has no way to skip what it cannot name. Under this format the exit code is
+     * what says the build was refused.
+     */
+    @Test
+    void underJsonEveryLineIsStillOneDiagnostic() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings", "error", "--format", "json", "--lang", "en");
+
+        assertEquals(1, said.code(), said.err());
+        JsonMapper json = JsonMapper.builder().build();
+        for (String line : said.err().split("\\R")) {
+            if (line.isBlank()) {
+                continue;
+            }
+            assertDoesNotThrow(() -> json.readTree(line), "not a JSON line: " + line);
+        }
+        assertTrue(said.err().contains("\"severity\":\"warning\""), said.err());
+    }
+
+    // --- what the option accepts ----------------------------------------------------------------
+
+    @Test
+    void warningsTakesReportOrError() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings", "nope");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("`--warnings` takes report or error"), said.err());
+    }
+
+    @Test
+    void warningsNeedsAValue() throws Exception {
+        Said said = run("compile", source(WARNS).toString(), "-d", outDir().toString(),
+                "--warnings");
+
+        assertEquals(2, said.code(), said.err());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileSizeNeverSmallerThanItsSourceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSizeNeverSmallerThanItsSourceTest.java
@@ -14,10 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>What the check could say about a size was how much of it a construction dropped: the same count
  * or fewer. An operation given two containers, or given one and an element to put in it, was left
  * saying nothing, because saying anything meant saying it about the elements — and there is no
- * element relation to a single source to state, {@code List.append(a, b)} holding neither
- * {@code a}'s elements alone nor {@code b}'s, and an insert or a union answering one entry for a key
- * that was already there. The bound on the count is not that statement and survived it, and was
- * discarded with it anyway.
+ * element relation to a single source to state: {@code List.append(a, b)} holds {@code a}'s elements
+ * and {@code b}'s and neither of them alone, and an insert puts in an element or an entry the
+ * container it read did not hold. The bound on the count is not that statement and survived it, and
+ * was discarded with it anyway.
  *
  * <p>So a non-empty list appended to a non-empty list was possibly empty, and the warning could not
  * be cleared: there is no relation between the two operands to reify, and guarding would ask the

--- a/souther-compiler/src/test/java/souther/compiler/CompileSizeNeverSmallerThanItsSourceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSizeNeverSmallerThanItsSourceTest.java
@@ -8,20 +8,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A construction that adds to a container answers something no smaller than what it added to, and a
- * lower-bound invariant is discharged by that alone.
+ * A construction's result is no smaller than a source it reads, and a lower-bound invariant is
+ * discharged by that alone.
  *
  * <p>What the check could say about a size was how much of it a construction dropped: the same count
- * or fewer. An operation that puts elements in was left saying nothing, because saying it meant
- * saying something about the elements too — and of {@code List.append(a, b)} there is nothing to say
- * there, the result holding neither {@code a}'s elements alone nor {@code b}'s. The count survived
- * that and was discarded with the rest.
+ * or fewer. An operation given two containers, or given one and an element to put in it, was left
+ * saying nothing, because saying anything meant saying it about the elements — and there is no
+ * element relation to a single source to state, {@code List.append(a, b)} holding neither
+ * {@code a}'s elements alone nor {@code b}'s, and an insert or a union answering one entry for a key
+ * that was already there. The bound on the count is not that statement and survived it, and was
+ * discarded with it anyway.
  *
  * <p>So a non-empty list appended to a non-empty list was possibly empty, and the warning could not
  * be cleared: there is no relation between the two operands to reify, and guarding would ask the
  * author for a departure case for a failure that cannot happen.
  */
-class CompileSizeThatOnlyGrowsTest {
+class CompileSizeNeverSmallerThanItsSourceTest {
 
     private static long warnings(Compiler.Compiled c) {
         return c.warnings().stream().filter(d -> d.severity() == Severity.WARNING).count();

--- a/souther-compiler/src/test/java/souther/compiler/CompileSizeThatOnlyGrowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileSizeThatOnlyGrowsTest.java
@@ -1,0 +1,216 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A construction that adds to a container answers something no smaller than what it added to, and a
+ * lower-bound invariant is discharged by that alone.
+ *
+ * <p>What the check could say about a size was how much of it a construction dropped: the same count
+ * or fewer. An operation that puts elements in was left saying nothing, because saying it meant
+ * saying something about the elements too — and of {@code List.append(a, b)} there is nothing to say
+ * there, the result holding neither {@code a}'s elements alone nor {@code b}'s. The count survived
+ * that and was discarded with the rest.
+ *
+ * <p>So a non-empty list appended to a non-empty list was possibly empty, and the warning could not
+ * be cleared: there is no relation between the two operands to reify, and guarding would ask the
+ * author for a departure case for a failure that cannot happen.
+ */
+class CompileSizeThatOnlyGrowsTest {
+
+    private static long warnings(Compiler.Compiled c) {
+        return c.warnings().stream().filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    private static boolean hasWarning(Compiler.Compiled c, String code) {
+        return c.warnings().stream()
+                .anyMatch(d -> d.severity() == Severity.WARNING && code.equals(d.code()));
+    }
+
+    private static final String NON_EMPTY = """
+            data NEL = List<Int>
+                invariant List.length(value) >= 1
+            data NES = Set<Int>
+                invariant Set.size(value) >= 1
+            data NEM = Map<String, Int>
+                invariant Map.size(value) >= 1
+            """;
+
+    private static String model(String body) {
+        return "module demo\n" + NON_EMPTY + body;
+    }
+
+    // --- what the lower bound discharges ---------------------------------------------------------
+
+    @Test
+    void appendingToANonEmptyListStaysNonEmpty() {
+        String m = model("""
+                behavior both : (a: NEL, b: NEL) -> NEL
+                let both (a, b) = NEL(List.append(a.value, b.value))
+                """);
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "length(a) >= 1 and the result is no shorter than a");
+    }
+
+    /** The second operand is as much a lower bound as the first: what is appended to what is the
+     * author's order, not the check's. */
+    @Test
+    void appendingANonEmptyListOnTheRightStaysNonEmpty() {
+        String m = model("""
+                behavior right : (a: List<Int>, b: NEL) -> NEL
+                let right (a, b) = NEL(List.append(a, b.value))
+                """);
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    @Test
+    void insertingIntoANonEmptySetKeepsItNonEmpty() {
+        String m = model("""
+                behavior add : (s: NES, x: Int) -> NES
+                let add (s, x) = NES(Set.insert(x, s.value))
+                """);
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    @Test
+    void insertingIntoANonEmptyMapKeepsItNonEmpty() {
+        String m = model("""
+                behavior put : (m: NEM, k: String, v: Int) -> NEM
+                let put (m, k, v) = NEM(Map.insert(k, v, m.value))
+                """);
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    @Test
+    void aUnionWithANonEmptySetIsNonEmpty() {
+        String m = model("""
+                behavior joined : (a: NES, b: Set<Int>) -> NES
+                let joined (a, b) = NES(Set.union(a.value, b))
+                """);
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    @Test
+    void aUnionWithANonEmptyMapIsNonEmpty() {
+        String m = model("""
+                behavior merged : (a: Map<String, Int>, b: NEM) -> NEM
+                let merged (a, b) = NEM(Map.union(a, b.value))
+                """);
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    // --- the operator spelling ---------------------------------------------------------------------
+
+    /** {@code List.append} is written {@code a ++ b} in the library it is declared in, so the two are
+     * one operation and the rule is about both. */
+    @Test
+    void concatenatingNonEmptyListsStaysNonEmpty() {
+        String m = model("""
+                behavior joined : (a: NEL, b: NEL) -> NEL
+                let joined (a, b) = NEL(a.value ++ b.value)
+                """);
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    /** A string has no {@code append} to be the other spelling of, so the operator is the only way
+     * this is written and the only place the rule can reach it. */
+    @Test
+    void concatenatingNonEmptyStringsStaysNonEmpty() {
+        String m = """
+                module demo
+                data S = String
+                    invariant String.length(value) >= 1
+                behavior joined : (a: S, b: S) -> S
+                let joined (a, b) = S(a.value ++ b.value)
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    @Test
+    void concatenatingWithANonEmptyStringOnEitherSideIsEnough() {
+        String m = """
+                module demo
+                data S = String
+                    invariant String.length(value) >= 1
+                behavior prefixed : (a: String, b: S) -> S
+                let prefixed (a, b) = S(a ++ b.value)
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    // --- what it must not discharge ---------------------------------------------------------------
+
+    @Test
+    void concatenatingTwoStringsThatMayBeEmptyIsStillUnproven() {
+        String m = """
+                module demo
+                data S = String
+                    invariant String.length(value) >= 1
+                behavior joined : (a: String, b: String) -> S
+                let joined (a, b) = S(a ++ b)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"));
+    }
+
+    @Test
+    void anUpperBoundIsNotDischargedByAConcatenation() {
+        String m = """
+                module demo
+                data Short = String
+                    invariant String.length(value) <= 10
+                behavior joined : (a: Short, b: Short) -> Short
+                let joined (a, b) = Short(a.value ++ b.value)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "two short strings concatenate to a long one");
+    }
+
+
+    /** Nothing here is known to hold anything, so the result is not known to either. */
+    @Test
+    void appendingTwoListsThatMayBeEmptyIsStillUnproven() {
+        String m = model("""
+                behavior maybe : (a: List<Int>, b: List<Int>) -> NEL
+                let maybe (a, b) = NEL(List.append(a, b))
+                """);
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "two possibly-empty lists append to a possibly-empty list");
+    }
+
+    /**
+     * The direction is the whole of the rule. A bound from below says nothing about a bound from
+     * above, and appending is where the two part company: two lists of at most ten make a list of up
+     * to twenty. A rule written the other way round would discharge this and admit an abort.
+     */
+    @Test
+    void anUpperBoundIsNotDischargedByALowerBound() {
+        String m = """
+                module demo
+                data Small = List<Int>
+                    invariant List.length(value) <= 10
+                behavior grow : (a: Small, b: Small) -> Small
+                let grow (a, b) = Small(List.append(a.value, b.value))
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"),
+                "appending two short lists can make a long one");
+    }
+
+    /** Inserting adds at most one, so what an upper bound allowed before it is not what it allows
+     * after. */
+    @Test
+    void anUpperBoundIsNotDischargedByAnInsert() {
+        String m = """
+                module demo
+                data Small = Set<Int>
+                    invariant Set.size(value) <= 10
+                behavior add : (s: Small, x: Int) -> Small
+                let add (s, x) = Small(Set.insert(x, s.value))
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileWrittenListLengthTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileWrittenListLengthTest.java
@@ -1,0 +1,113 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A list written out has as many elements as it is written with, whatever they are.
+ *
+ * <p>The count was asked through the question of whether the whole value was written — every element
+ * a literal, and so on down — which is what naming a written value at a construction site needs and
+ * is not what counting needs. So a three-element list built from three parameters was a list of
+ * unknown length, and an invariant asking for two of them was left to the run-time check with no
+ * guard an author could write to discharge it: the elements are the arguments, and the length is on
+ * the line.
+ */
+class CompileWrittenListLengthTest {
+
+    private static long warnings(Compiler.Compiled c) {
+        return c.warnings().stream().filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    private static boolean hasWarning(Compiler.Compiled c, String code) {
+        return c.warnings().stream()
+                .anyMatch(d -> d.severity() == Severity.WARNING && code.equals(d.code()));
+    }
+
+    @Test
+    void aNewtypeOverAWrittenListIsAsLongAsItIsWritten() {
+        String m = """
+                module demo
+                data P = { n: Int }
+                data Entry = List<P>
+                    invariant List.length(value) >= 2
+                behavior make : (a: Int, b: Int, c: Int) -> Entry
+                    constructs Entry, P
+                let make (a, b, c) = Entry([ P { n = a }, P { n = b }, P { n = c } ])
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)),
+                "three elements are written on the line, whatever they hold");
+    }
+
+    @Test
+    void aRecordFieldGivenAWrittenListIsAsLongAsItIsWritten() {
+        String m = """
+                module demo
+                data P = { n: Int }
+                data Entry = { ps: List<P> }
+                    invariant List.length(ps) >= 2
+                behavior make : (a: Int, b: Int, c: Int) -> Entry
+                    constructs Entry, P
+                let make (a, b, c) = Entry { ps = [ P { n = a }, P { n = b }, P { n = c } ] }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    /** The list is written where the name is, so naming it changes nothing about how long it is. */
+    @Test
+    void aNameGivenAWrittenListIsAsLongAsTheListItWasGiven() {
+        String m = """
+                module demo
+                data P = { n: Int }
+                data Entry = List<P>
+                    invariant List.length(value) >= 2
+                behavior make : (a: Int, b: Int) -> Entry
+                    constructs Entry, P
+                let make (a, b) = {
+                    let ps = [ P { n = a }, P { n = b } ]
+                    Entry(ps)
+                }
+                """;
+        assertEquals(0, warnings(Compiler.compileWithWarnings(m)));
+    }
+
+    // --- what it must not discharge ---------------------------------------------------------------
+
+    /** A count read is a count the check decides with. Written too short, the invariant is refuted
+     * rather than left unproven. */
+    @Test
+    void aListWrittenShorterThanTheInvariantNeedsIsAViolation() {
+        String m = """
+                module demo
+                data P = { n: Int }
+                data Entry = List<P>
+                    invariant List.length(value) >= 2
+                behavior make : (a: Int) -> Entry
+                    constructs Entry, P
+                let make (a) = Entry([ P { n = a } ])
+                """;
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(m));
+        assertEquals("E2010", e.diagnostic().code(), e.getMessage());
+    }
+
+    /** A list handed in was not written here, and how long it is is not on any line. */
+    @Test
+    void aListGivenAsAnInputIsStillUnproven() {
+        String m = """
+                module demo
+                data P = { n: Int }
+                data Entry = List<P>
+                    invariant List.length(value) >= 2
+                behavior make : (ps: List<P>) -> Entry
+                    constructs Entry
+                let make (ps) = Entry(ps)
+                """;
+        assertTrue(hasWarning(Compiler.compileWithWarnings(m), "E2011"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.check.DischargeRules.Built;
+import souther.compiler.check.DischargeRules.Cardinality;
 import souther.compiler.check.DischargeRules.Carried;
 import souther.compiler.check.DischargeRules.Reads;
 import souther.compiler.check.DischargeRules.Shape;
@@ -41,7 +42,7 @@ class ARuleIsHeldToTheDeclarationItIsAboutTest {
 
     private static void bindBuilt(String operation, Reads from) {
         DischargeRules.bind(
-                Map.of(op(operation), new Built(from, Shape.SUBSET)),
+                Map.of(op(operation), new Built(from, Shape.SUBSET, Cardinality.AT_MOST)),
                 Built::from, new Reads.TheContainer(), Question::holdsElements,
                 "the container something is built from");
     }

--- a/specification.adoc
+++ b/specification.adoc
@@ -1135,7 +1135,7 @@ An operation not in the table keeps nothing that can be relied on, and a clause 
 
 ===== A construction whose result is no smaller than what it read
 
-An operation given two containers, or given a container and an element to put in it, establishes no element relation to a single source that any of the four shapes states. `+List.append(a, b)+` holds `+a+`'s elements and `+b+`'s and neither of them alone; an insert or a union answers one entry for a key that was already there, so what the result holds may have been in neither. A property of every element does not survive either way. How many there are is bounded from below all the same, and that bound is a fact of its own.
+An operation given two containers, or given a container and something to put in it, establishes no element relation to a single source that any of the four shapes states. Appending and union read two sources, so neither of them alone is what the result was built from; an insert puts in an element or an entry the container it read did not hold. A property of every element does not survive either way. How many there are is bounded from below all the same, and that bound is a fact of its own.
 
 [cols="2,3"]
 |===
@@ -1157,7 +1157,7 @@ behavior joined : (a: Lines, b: List<Line>) -> Lines
 let joined (a, b) = Lines(a.value ++ b)   // discharged: no shorter than `a`
 ----
 
-Nothing is said the other way. A union answers one entry for a key both sides hold and an insert of an element already there adds none, so the result is not the sum of what was read; an upper bound on the sources does not bound it.
+Nothing is said the other way. A union answers one of what both sides hold, and an insert of something already there adds none, so the result is not the sum of what was read; an upper bound on the sources does not bound it.
 
 [#invariant-discharge-projection]
 ===== A projection the closure copied

--- a/specification.adoc
+++ b/specification.adoc
@@ -1047,7 +1047,7 @@ let build (rows) = {
 }
 ----
 
-A size taken of a container built by an operation is read through that operation, by the rules in <<invariant-discharge-preservation>>. A size taken of anything else — of what a `+let+` returned, of a string joined from parts — is not a term, and a clause needing it is left to the run-time check.
+A size taken of a container built by an operation is read through that operation, by the rules in <<invariant-discharge-preservation>>. A size taken of anything else — of what a behavior answered — is not a term, and a clause needing it is left to the run-time check.
 
 [,text]
 ----
@@ -1132,6 +1132,32 @@ let build (rows) = {
 "A property of every element" is a clause like `+List.all(p, value)+` or `+List.allDistinctBy(f, value)+`: nothing new is in a sublist, so what held of every element still holds. "A particular element" is `+List.contains(x, value)+` or `+Set.contains(x, value)+`, which a selection may drop.
 
 An operation not in the table keeps nothing that can be relied on, and a clause over what it built is left to the run-time check.
+
+===== A construction that only adds
+
+An operation given two containers, or given a container and an element to put in it, answers one holding what it read and possibly more. None of the four shapes describes it: what is in the result was in one of the containers read and not the other, so neither "the same elements" nor "some of the same elements" is true of it, and a property of every element does not survive. How many there are does.
+
+[cols="2,3"]
+|===
+| what holds of the result | the operations
+
+| no smaller than either container it was given | `+List.append+`, `+Set.union+`, `+Map.union+`
+| no smaller than the container it was given | `+Set.insert+`, `+Map.insert+`
+|===
+
+`+List.append+` is written `+a ++ b+`, and a `+String+` is joined with the same operator and read the same way: `+String.length(a ++ b)+` is no less than `+String.length(a)+` and no less than `+String.length(b)+`.
+
+So a lower bound on either part is a lower bound on the result, and a non-empty list appended to any list is non-empty.
+
+[,text]
+----
+data Lines = List<Line> invariant List.length(value) >= 1
+
+behavior joined : (a: Lines, b: List<Line>) -> Lines
+let joined (a, b) = Lines(a.value ++ b)   // discharged: no shorter than `a`
+----
+
+Nothing is said the other way. A union answers one entry for a key both sides hold and an insert of an element already there adds none, so the result is not the sum of what was read; an upper bound on the parts does not bound it.
 
 [#invariant-discharge-projection]
 ===== A projection the closure copied

--- a/specification.adoc
+++ b/specification.adoc
@@ -1133,9 +1133,9 @@ let build (rows) = {
 
 An operation not in the table keeps nothing that can be relied on, and a clause over what it built is left to the run-time check.
 
-===== A construction that only adds
+===== A construction whose result is no smaller than what it read
 
-An operation given two containers, or given a container and an element to put in it, answers one holding what it read and possibly more. None of the four shapes describes it: what is in the result was in one of the containers read and not the other, so neither "the same elements" nor "some of the same elements" is true of it, and a property of every element does not survive. How many there are does.
+An operation given two containers, or given a container and an element to put in it, establishes no element relation to a single source that any of the four shapes states. `+List.append(a, b)+` holds `+a+`'s elements and `+b+`'s and neither of them alone; an insert or a union answers one entry for a key that was already there, so what the result holds may have been in neither. A property of every element does not survive either way. How many there are is bounded from below all the same, and that bound is a fact of its own.
 
 [cols="2,3"]
 |===
@@ -1147,7 +1147,7 @@ An operation given two containers, or given a container and an element to put in
 
 `+List.append+` is written `+a ++ b+`, and a `+String+` is joined with the same operator and read the same way: `+String.length(a ++ b)+` is no less than `+String.length(a)+` and no less than `+String.length(b)+`.
 
-So a lower bound on either part is a lower bound on the result, and a non-empty list appended to any list is non-empty.
+So a lower bound on any source named above is a lower bound on the result, and a non-empty list appended to any list is non-empty.
 
 [,text]
 ----
@@ -1157,7 +1157,7 @@ behavior joined : (a: Lines, b: List<Line>) -> Lines
 let joined (a, b) = Lines(a.value ++ b)   // discharged: no shorter than `a`
 ----
 
-Nothing is said the other way. A union answers one entry for a key both sides hold and an insert of an element already there adds none, so the result is not the sum of what was read; an upper bound on the parts does not bound it.
+Nothing is said the other way. A union answers one entry for a key both sides hold and an insert of an element already there adds none, so the result is not the sum of what was read; an upper bound on the sources does not bound it.
 
 [#invariant-discharge-projection]
 ===== A projection the closure copied


### PR DESCRIPTION
Refs #375. A build-acceptance rule, and two repairs to what the discharge check can prove.

## `souther compile --warnings error`

A compile that warned wrote its classes and exited 0, so a project that wanted its warnings gone had no way to hold itself to it.

This is an acceptance rule and not a severity. Errors and warnings already travel on separate channels — an error is thrown as a `CompileException`, a warning is returned in a list — and nothing reads `severity` to decide whether a compile failed, so no policy abstraction was added. `compile` decides its exit status from the list it already holds, as `examples --strict` does from `report.pendingRows()`.

The diagnostics printed stay warnings. Rewriting them to errors would say the construction is refused, which is not what the check found.

A refused build writes no classes: the exit code says its classes are not the output of an accepted compile, and classes this run had written are what a later step would read as if they were. `compileToDir` is now the composition of `compiledClasses` and `writeClasses`. It does not empty the output directory — classes an earlier run left there stay, as they do when a compile fails, and who owns that directory is the same question for both.

Not under `--format json` — that format writes one object per diagnostic with no envelope, so a reader takes the output a line at a time and a sentence among them is a line that parses as nothing. There the exit code says it.

`compile` alone. `examples` has `--strict`, and the annotation processor reports through `Messager`, which `javac -Werror` already fails on.

## Cardinality is not a statement about elements

`DischargeRules.Shape` answered two questions with one enum: what a construction keeps of the elements it read, and how the size of its result relates to its source's. For every construction in the table the two agree, which is what made one enum look like enough. They part company at a construction given two containers — `List.append(a, b)` holds neither `a`'s elements alone nor `b`'s, and its size is still no less than either.

All five such operations sat in `NOTHING_KEPT`, whose comment recorded that the size can rise and then discarded it, because a shape could not say so. The point is not that they keep nothing — `List.append` keeps every element of both operands. It is that none of them establishes an element relation to a *single* source, which is the only kind a `Shape` states.

Cardinality is now stated beside the shape rather than read off it, and the lower bound is a table of its own, element provenance not being what it is about. `Predicates.bounds` reads which way to state a size from that, where it read `keepsSize()` and assumed the other direction.

| operation | what actually holds | what is stated |
| --- | --- | --- |
| `List.append(a, b)` | `size = size(a) + size(b)` | `>= size(a)`, `>= size(b)` |
| `Set.union`, `Map.union` | `max(size(a), size(b)) <= size <= size(a) + size(b)` | `>= size(a)`, `>= size(b)` |
| `Set.insert`, `Map.insert` | `size(s) <= size <= size(s) + 1` | `>= size(s)` |

Only the bound they share. A union answers one of what both sides hold and an insert of something already there adds none, so neither is a sum; appending is, and one operation is not given two rules.

`a ++ b` is asked as the expression it is rather than looked up by operation: the library declares `List.append` as `a ++ b`, so the two spellings are one operation, and a `String` has no `append` to be the other spelling of.

## How long a written list is

`List.length([a, b, c]) >= 2` was left to the run-time check. The count was asked through `writtenValue`, which answers whether the *whole value* is written — every element a literal, and so on down. That is the right question where a construction is read as the value it builds; it is not what counting asks. Three elements written on a line are three however each was arrived at.

The comment above `writtenSize` already said "whatever they are". The implementation was the stronger question borrowed from beside it.

## What this measures

The 14 models in `souther-lang/examples`, counted with the lower-bound rule disabled and enabled:

```
before 7  →  after 7
```

**The lower-bound rule fires nowhere in the example corpus.** It is tested and correct, but no model there carries a lower-bound invariant over `append` / `union` / `insert` / `++` today. The written-list repair does not move the count either — the two `JournalEntry` warnings it reaches are held by that type's *other* clause, which compares the two sides' totals.

Of the 7 that remain, 4 are warnings doing their job (a `String.split` piece that can be empty, an input `Int` with no declared lower bound) and 3 cannot be cleared by anything an author can write:

- `Eaches(Int.floorMod(e, pack))` where `PackSize` declares `value >= 1`, so the remainder is necessarily non-negative — `Int.floorMod` is outside the fragment
- two `JournalEntry` constructions whose `balanced` clause compares `sideTotal(Debit, postings)` with `sideTotal(Credit, postings)`

## What is deliberately not here

**Per-site suppression.** Souther has no attribute syntax, so `@Suppress(E2011)` would decide whether the language gets a declaration/expression metadata mechanism at all — one that `@deprecated`, `@inline`, `@extern` would follow into. On the measurement above the case is three warnings in two of fourteen models. That is not enough to take on a new syntactic category permanently, and `--warnings error` plus a wider fragment is what those three would be weighed against. If a case survives that, it is the evidence the ADR would need.

**Any change to ADR-0070.** Its claim — that an attempt is the only way to silence E2011 for an invariant the checked fragment cannot express — is still true. What changed is the size of that set, and ADR-0070 never fixed the boundary. Narrowing `attempt` to constructions that can really fail would mean an author's attempt breaking whenever the prover improves, which nothing here asks for.

## Tests

30 new, across three files (11 + 14 + 5). Each was watched to fail first.

The guards that make them non-vacuous:

- reordering the write and the refusal makes `aRefusedCompileWritesNoClasses` the only test that fails
- an upper-bound invariant (`<= 10`) is not discharged by a lower-bound fact — asserted for `append`, `insert` and `++` separately, since a rule written the other way round would admit an abort
- appending or concatenating two possibly-empty containers still warns
- a list written *shorter* than its invariant needs is `E2010`, not a warning — the count is read, not merely absent
- naming `Map.insert`'s key as its container fails the build at table-binding time (`argument 1 of Map.insert is not a container the result is no smaller than`)

`bounds()` was disabled before the refactor to find what held it: `aSelectionBoundsTheLengthFromAbove` and `eachRuleCarriesWhatItsProgramNeeds`.

`mvn clean test` — 3078 + 166 + 109 + 1, all green.

## Specification

`invariant-discharge-preservation` gains a section for a construction whose result is no smaller than what it read. The sentence claiming a size taken "of a string joined from parts" is not a term was removed, being no longer true. The example added there was compiled under `--warnings error` before it was written down.

## Review

`ac86653` and `b22506b` are review fixes, both to prose rather than to behaviour: the rule this branch adds is about cardinality alone, and the wording around it had gone on describing it as an element relation — `Map.insert` replacing an entry does not hold what it read, and `List.append` keeps everything, so neither "holds what it read and possibly more" nor "keeps nothing of the elements" was true. The vocabulary is now "never smaller than a source it names" throughout, `Map`'s entries and keys no longer stand in for `Set`'s members, and the refused-build contract says what is tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
