### PR TITLE
A module's section names the operations the module publishes

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/CompileListLibTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileListLibTest.java
@@ -522,11 +522,11 @@ class CompileListLibTest {
         assertEquals("", empty.get("rightward"));
     }
 
-    /** {@code zip} pairs two lists and truncates to the shorter one (Elm's {@code map2}); {@code
-     *  unzip} takes the pairs apart again. The tuples stay inside the behavior — a tuple has no
-     *  external form — so the boundary sees the two lists and a rendering of the pairs. */
+    /** {@code zipShortest} pairs two lists and truncates to the shorter one (Elm's {@code map2});
+     *  {@code unzip} takes the pairs apart again. The tuples stay inside the behavior — a tuple has
+     *  no external form — so the boundary sees the two lists and a rendering of the pairs. */
     @Test
-    void zipPairsTwoListsAndUnzipTakesThemApart() throws Exception {
+    void zipShortestPairsTwoListsAndUnzipTakesThemApart() throws Exception {
         BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
                 module demo
 

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryOperationAModulePublishesIsListedInItsSectionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryOperationAModulePublishesIsListedInItsSectionTest.java
@@ -47,28 +47,42 @@ class EveryOperationAModulePublishesIsListedInItsSectionTest {
      *  inside a longer one is content rather than the end of it. */
     private static final Pattern LISTING = Pattern.compile("^-{4,}$");
 
+    /**
+     * The modules walked are the reserved namespace, not the ones the surface happens to have a
+     * name under. Taking them from the surface would drop a module whose last published operation
+     * went away, and the section left naming what it used to publish would be the one thing not
+     * read — the gap this check exists to close, one level up.
+     */
     @Test
     void eachModuleSectionNamesTheOperationsItsModulePublishes() {
         SpecDocument spec = SpecDocument.bundled();
+        Map<String, Set<String>> published = publishedByModule();
+        Map<String, Set<String>> publishes = new LinkedHashMap<>();
         Map<String, Set<String>> listed = new LinkedHashMap<>();
-        for (String module : publishedByModule().keySet()) {
+        for (String module : new TreeSet<>(Prelude.qualifiers())) {
             String anchor = "stdlib-" + module.toLowerCase(Locale.ROOT);
             SpecDocument.Section section = spec.section(anchor);
-            assertNotNull(section, "`" + module + "` publishes names and has no `" + anchor
-                    + "` section for a reader to find them in");
+            assertNotNull(section, "`" + module + "` has no `" + anchor
+                    + "` section for a reader to find its operations in");
+            publishes.put(module, published.getOrDefault(module, Set.of()));
             listed.put(module, namesListedIn(section.body()));
         }
 
-        assertEquals(render(publishedByModule()), render(listed),
+        assertEquals(render(publishes), render(listed),
                 "the specification's list of a module's operations and the module's published"
                         + " surface disagree. The left side is what the library publishes.");
     }
 
-    /** Both sides being empty would compare equal and say nothing. How many modules there are is
-     *  not written down here: a module arrives with a section or fails the check above. */
+    /**
+     * Both sides being empty would compare equal and say nothing, and the walk is over the reserved
+     * namespace. That it covers what is published is what makes it the wider of the two to walk;
+     * how many modules there are is not written down here.
+     */
     @Test
     void thereIsSomethingToCompareSoTheAgreementIsNotBetweenTwoEmptyThings() {
-        assertFalse(publishedByModule().isEmpty(), "the library publishes nothing to compare against");
+        assertFalse(Prelude.qualifiers().isEmpty(), "no module to compare a section against");
+        assertTrue(Prelude.qualifiers().containsAll(publishedByModule().keySet()),
+                "a module the library publishes under is a module the walk reaches");
     }
 
     /** One line per module: its name, then the names it publishes in a fixed order. */

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryOperationAModulePublishesIsListedInItsSectionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryOperationAModulePublishesIsListedInItsSectionTest.java
@@ -15,6 +15,7 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -41,7 +42,9 @@ class EveryOperationAModulePublishesIsListedInItsSectionTest {
     /** A row of the block: bare names separated by spaces, with nothing else on the line. */
     private static final Pattern NAME_ROW = Pattern.compile("[a-z][a-zA-Z0-9]*( +[a-z][a-zA-Z0-9]*)*");
 
-    /** The listing delimiter, as the document writes it. */
+    /** A listing delimiter: four or more dashes. The block runs to the line that repeats it
+     *  exactly, which is AsciiDoc's rule and the one the document reader follows — a shorter run
+     *  inside a longer one is content rather than the end of it. */
     private static final Pattern LISTING = Pattern.compile("^-{4,}$");
 
     @Test
@@ -61,17 +64,11 @@ class EveryOperationAModulePublishesIsListedInItsSectionTest {
                         + " surface disagree. The left side is what the library publishes.");
     }
 
-    /**
-     * Both sides being empty would compare equal and say nothing. The count is the ten modules the
-     * document has a section for; a new one arrives with a section or fails the check above.
-     */
+    /** Both sides being empty would compare equal and say nothing. How many modules there are is
+     *  not written down here: a module arrives with a section or fails the check above. */
     @Test
-    void everyModuleIsComparedSoTheAgreementIsNotBetweenTwoEmptyThings() {
-        Map<String, Set<String>> published = publishedByModule();
-
-        assertEquals(10, published.size(), "every published module is compared: " + published.keySet());
-        assertTrue(published.get("List").contains("zipShortest"),
-                "the library publishes the name the block is checked against");
+    void thereIsSomethingToCompareSoTheAgreementIsNotBetweenTwoEmptyThings() {
+        assertFalse(publishedByModule().isEmpty(), "the library publishes nothing to compare against");
     }
 
     /** One line per module: its name, then the names it publishes in a fixed order. */
@@ -97,27 +94,32 @@ class EveryOperationAModulePublishesIsListedInItsSectionTest {
     /**
      * The names in the section's one block of bare names. A trailing {@code //} comment labels a
      * row — which of them read, which build — and is not part of a name.
+     *
+     * <p>A name written twice is refused rather than counted once. The comparison that follows is
+     * between sets, so a repeat would fold into the name already there and the block would list an
+     * operation twice and still agree with the library.
      */
     private static Set<String> namesListedIn(String body) {
-        List<Set<String>> blocks = new ArrayList<>();
-        Set<String> current = null;
-        boolean inside = false;
+        List<List<String>> blocks = new ArrayList<>();
+        List<String> current = null;
+        String opening = null;
         boolean bare = true;
         for (String line : body.split("\n", -1)) {
-            if (LISTING.matcher(line.strip()).matches()) {
-                if (inside) {
-                    if (bare && current != null && !current.isEmpty()) {
-                        blocks.add(current);
-                    }
-                    inside = false;
-                } else {
-                    inside = true;
-                    bare = true;
-                    current = new TreeSet<>();
-                }
+            String delimiter = line.strip();
+            if (opening == null && LISTING.matcher(delimiter).matches()) {
+                opening = delimiter;
+                current = new ArrayList<>();
+                bare = true;
                 continue;
             }
-            if (!inside) {
+            if (opening != null && delimiter.equals(opening)) {
+                if (bare && !current.isEmpty()) {
+                    blocks.add(current);
+                }
+                opening = null;
+                continue;
+            }
+            if (opening == null) {
                 continue;
             }
             String written = line.split("//", 2)[0].strip();
@@ -134,7 +136,13 @@ class EveryOperationAModulePublishesIsListedInItsSectionTest {
             throw new IllegalStateException("a module section lists its operations in one block of"
                     + " bare names; found " + blocks.size());
         }
-        return blocks.get(0);
+        Set<String> names = new TreeSet<>();
+        for (String name : blocks.get(0)) {
+            if (!names.add(name)) {
+                throw new IllegalStateException("a module section lists `" + name + "` more than once");
+            }
+        }
+        return names;
     }
 
     @Test
@@ -183,5 +191,43 @@ class EveryOperationAModulePublishesIsListedInItsSectionTest {
                         """));
 
         assertTrue(refused.getMessage().contains("found 2"), refused.getMessage());
+    }
+
+    /**
+     * Folded into the name already there, a repeat would leave the block naming an operation twice
+     * and still agreeing with the library — the set it compares as would be the same set.
+     */
+    @Test
+    void anOperationNamedTwiceIsRefusedRatherThanCountedOnce() {
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> namesListedIn("""
+                        [,text]
+                        ----
+                        map  filter  fold
+                        fold  all
+                        ----
+                        """));
+
+        assertTrue(refused.getMessage().contains("`fold` more than once"), refused.getMessage());
+    }
+
+    /** A block runs to the line that repeats its delimiter exactly. Closing it on a shorter run
+     *  would end the block where AsciiDoc reads content, and what follows the false end would be
+     *  read as the section around it. */
+    @Test
+    void aShorterRunInsideALongerDelimiterIsContent() {
+        assertEquals(new TreeSet<>(Set.of("map", "filter")), namesListedIn("""
+                [,text]
+                -----
+                [e1, e2, ...]
+                ----
+                not a row of names either
+                -----
+
+                [,text]
+                ----
+                map  filter
+                ----
+                """));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryOperationAModulePublishesIsListedInItsSectionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryOperationAModulePublishesIsListedInItsSectionTest.java
@@ -1,0 +1,187 @@
+package souther.compiler.doc;
+
+import souther.compiler.Prelude;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The published surface is written down twice: once as the library's own declarations, and once as
+ * the block of names each module's specification section opens with. The second is what a reader
+ * reads and what `souther doc` prints, and nothing held the two together — a rename could land on
+ * the declarations, on the snapshot of them, and on the prose that explains the new name, and leave
+ * the block naming a function that no longer exists.
+ *
+ * <p>What is checked is membership, not layout. The rows are the document's own grouping and the
+ * prose points at them by position, so generating the block from the declarations would have to
+ * invent that grouping or lose it. Which names are in the block is the part that can silently
+ * disagree with the library, and it is the part fixed here; how they are spread over rows stays the
+ * document's to decide.
+ *
+ * <p>The block is found by its shape rather than by a marker written beside it, and exactly one per
+ * section is required. A second block of bare names is a failure that says so, rather than a union
+ * that quietly admits whatever else was written in the section.
+ */
+class EveryOperationAModulePublishesIsListedInItsSectionTest {
+
+    /** A row of the block: bare names separated by spaces, with nothing else on the line. */
+    private static final Pattern NAME_ROW = Pattern.compile("[a-z][a-zA-Z0-9]*( +[a-z][a-zA-Z0-9]*)*");
+
+    /** The listing delimiter, as the document writes it. */
+    private static final Pattern LISTING = Pattern.compile("^-{4,}$");
+
+    @Test
+    void eachModuleSectionNamesTheOperationsItsModulePublishes() {
+        SpecDocument spec = SpecDocument.bundled();
+        Map<String, Set<String>> listed = new LinkedHashMap<>();
+        for (String module : publishedByModule().keySet()) {
+            String anchor = "stdlib-" + module.toLowerCase(Locale.ROOT);
+            SpecDocument.Section section = spec.section(anchor);
+            assertNotNull(section, "`" + module + "` publishes names and has no `" + anchor
+                    + "` section for a reader to find them in");
+            listed.put(module, namesListedIn(section.body()));
+        }
+
+        assertEquals(render(publishedByModule()), render(listed),
+                "the specification's list of a module's operations and the module's published"
+                        + " surface disagree. The left side is what the library publishes.");
+    }
+
+    /**
+     * Both sides being empty would compare equal and say nothing. The count is the ten modules the
+     * document has a section for; a new one arrives with a section or fails the check above.
+     */
+    @Test
+    void everyModuleIsComparedSoTheAgreementIsNotBetweenTwoEmptyThings() {
+        Map<String, Set<String>> published = publishedByModule();
+
+        assertEquals(10, published.size(), "every published module is compared: " + published.keySet());
+        assertTrue(published.get("List").contains("zipShortest"),
+                "the library publishes the name the block is checked against");
+    }
+
+    /** One line per module: its name, then the names it publishes in a fixed order. */
+    private static String render(Map<String, Set<String>> byModule) {
+        StringJoiner lines = new StringJoiner("\n");
+        for (Map.Entry<String, Set<String>> module : byModule.entrySet()) {
+            lines.add(module.getKey() + ": " + String.join(" ", module.getValue()));
+        }
+        return lines.toString();
+    }
+
+    /** The published surface, split by the qualifier a caller writes it under. */
+    private static Map<String, Set<String>> publishedByModule() {
+        Map<String, Set<String>> byModule = new LinkedHashMap<>();
+        for (String qualified : Prelude.published()) {
+            int dot = qualified.indexOf('.');
+            byModule.computeIfAbsent(qualified.substring(0, dot), m -> new TreeSet<>())
+                    .add(qualified.substring(dot + 1));
+        }
+        return byModule;
+    }
+
+    /**
+     * The names in the section's one block of bare names. A trailing {@code //} comment labels a
+     * row — which of them read, which build — and is not part of a name.
+     */
+    private static Set<String> namesListedIn(String body) {
+        List<Set<String>> blocks = new ArrayList<>();
+        Set<String> current = null;
+        boolean inside = false;
+        boolean bare = true;
+        for (String line : body.split("\n", -1)) {
+            if (LISTING.matcher(line.strip()).matches()) {
+                if (inside) {
+                    if (bare && current != null && !current.isEmpty()) {
+                        blocks.add(current);
+                    }
+                    inside = false;
+                } else {
+                    inside = true;
+                    bare = true;
+                    current = new TreeSet<>();
+                }
+                continue;
+            }
+            if (!inside) {
+                continue;
+            }
+            String written = line.split("//", 2)[0].strip();
+            if (written.isEmpty()) {
+                continue;
+            }
+            if (!NAME_ROW.matcher(written).matches()) {
+                bare = false;
+                continue;
+            }
+            current.addAll(List.of(written.split(" +")));
+        }
+        if (blocks.size() != 1) {
+            throw new IllegalStateException("a module section lists its operations in one block of"
+                    + " bare names; found " + blocks.size());
+        }
+        return blocks.get(0);
+    }
+
+    @Test
+    void theNamesAreTakenFromTheBlockAndTheLabelOnARowIsNot() {
+        assertEquals(new TreeSet<>(Set.of("get", "insert", "remove", "size")), namesListedIn("""
+                A `+Map+` is immutable.
+
+                [,text]
+                ----
+                get                      // read
+                insert  remove  size     // build
+                ----
+
+                `+get+` answers an optional.
+                """));
+    }
+
+    @Test
+    void aBlockThatIsNotARowOfNamesIsNotTheList() {
+        assertEquals(new TreeSet<>(Set.of("map", "filter")), namesListedIn("""
+                [,text]
+                ----
+                [e1, e2, ...]
+                ----
+
+                [,text]
+                ----
+                map  filter
+                ----
+                """));
+    }
+
+    @Test
+    void aSecondBlockOfBareNamesIsRefusedRatherThanFoldedIntoTheFirst() {
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> namesListedIn("""
+                        [,text]
+                        ----
+                        map  filter
+                        ----
+
+                        [,text]
+                        ----
+                        take  drop
+                        ----
+                        """));
+
+        assertTrue(refused.getMessage().contains("found 2"), refused.getMessage());
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -2963,7 +2963,7 @@ Note that `+applicant.rank == Staff+` cannot be written as a condition. `+==+` w
 map  filter  fold  foldRight  all  any  length  get  mapIndexed
 reverse  contains  sum  product  append  concat  flatMap  isEmpty  sort  rangeInclusive
 distinct  distinctBy  allDistinctBy  partition  groupBy  indexBy  filterMap  max  min  find  sortBy
-take  drop  zip  unzip
+take  drop  zipShortest  unzip
 ----
 
 All are called through the qualifier `+List+` (<<stdlib>>). `+List.get+` returns `+Option<T>+`. `+List.map+` / `+List.filter+` / `+List.fold+` / `+List.all+` / `+List.any+` / `+List.mapIndexed+` take a block (<<blocks>>). Import them as `+import List (map, all )+` to write unqualified thereafter.


### PR DESCRIPTION
`souther doc stdlib-list` named `zip`, which no module publishes. This is not a
typo fix: the published surface is enumerated twice, and only one of the two
copies was checked.

## What diverged

```
documented but unpublished: List.zip
published but undocumented: List.zipShortest
```

The paragraph a few lines below the block already explained why the name
carries the behaviour, so the block and the prose under it disagreed, and the
block sent a reader to a function that does not exist.

## How it got there

`git log -L` on the block puts it in the rename that introduced the naming
grammar. The rename touched the other three rows of the block, each of which
held more than one renamed operation, while this row — where `zip` was the only
renamed operation — was left unchanged.

## Why nothing caught it

`ThePublishedSurfaceIsFixedTest` compares `Prelude.published()` against a
recorded copy of it and never reads `specification.adoc`.

```
compiler surface ──checked── published-surface.txt
       │
       └──────────── specification.adoc
                      ↑ unchecked duplicate
```

## Scope

All ten module sections were compared with the published surface in both
directions. `List`'s `zip` is the only divergence in the document, and the ten
blocks match the surface name for name and count for count:

| module | in the block | published | extra | missing |
|---|---|---|---|---|
| String | 27 | 27 | — | — |
| Int | 11 | 11 | — | — |
| Decimal | 12 | 12 | — | — |
| List | 34 | 34 | `zip` | `zipShortest` |
| Map | 20 | 20 | — | — |
| Option | 2 | 2 | — | — |
| Set | 16 | 16 | — | — |
| Bool | 1 | 1 | — | — |
| Date | 7 | 7 | — | — |
| DateTime | 5 | 5 | — | — |

So the specification had not drifted generally. The mechanism allowed drift and
one rename had used it. The exact agreement across ten sections is also what
settles what the block means: it is the module's whole published surface, not a
selection from it, and the check writes down a contract that already held
everywhere.

## The check

`EveryOperationAModulePublishesIsListedInItsSectionTest` reads the block back
out of the bundled specification and compares its names with
`Prelude.published()`, module by module. The property it holds:

> For every module in the reserved namespace, the specification names each
> published operation exactly once, with the grouping and the order left to the
> document.

The modules walked are `Prelude.qualifiers()` — the namespace itself — and not
the qualifiers the published surface happens to carry a name under. A module
whose last published operation went away would drop out of a walk taken from
the surface, and its section, still naming what it used to publish, would be
the one section not read.

Exactly once and not merely present: compared as sets, an operation named twice
would fold into the one already there and the block would still agree with the
library, which is the same shape of gap the check exists for. The names are
collected as written and a repeat is refused when the block closes.

It fixes membership and not layout. The rows are the document's own grouping and
the prose points at them by position ("in the lower row", "the third row"), and
`Map` and `Set` label theirs (`// read`, `// build`, `// key algebra`).
Generating the block from the declarations would have to carry that grouping
somewhere else, which moves the hand-written part rather than removing it.
Membership is the part that can silently disagree with the library.

The block is found by its shape rather than by a marker beside it, since
`souther doc` prints the section body as it stands and a marker would be in the
reader's way. Exactly one block of bare names per section is required — true of
all ten today — so a second one fails and says so instead of being folded in.

## Changes

- `specification.adoc`: `zip` → `zipShortest`
- `CompileListLibTest`: the test name and javadoc said `zip` while the program
  they compile imports `zipShortest`
- the conformance check above

ADR-0084 writes `zip` and `indexedMap` and is left alone: an ADR records a
decision at the time it was made, and applying a later rename to it would
rewrite what the record says happened.

## Verification

`mvn clean test` passes across every module.

Put `zip` back and the check fails:

```
[ERROR] Tests run: 5, Failures: 1
the specification's list of a module's operations and the module's published
surface disagree. The left side is what the library publishes.
```

Empty `Option` of its two operations and it fails against a section that still
names them; on the first version of the check it passed, the module having
dropped out of the comparison altogether.

Write `fold` a second time into a block and it fails too:

```
[ERROR] Tests run: 7, Failures: 0, Errors: 1
java.lang.IllegalStateException: a module section lists `fold` more than once
```

The extractor is held to hand-written sections of its own rather than to the
document it reads: a trailing `//` label is not a name, a block that is not a
row of names is not the list, two blocks of bare names are refused, a repeat is
refused, and a shorter run of dashes inside a longer delimiter is content — a
block runs to the line that repeats its delimiter exactly, as it does for the
document reader. That there is something to compare at all is asserted
separately, so an agreement between two empty sides is not one.

How many modules there are is deliberately not written down: eleven of them,
added to the library and to the document alike, would fail a count of ten while
nothing had diverged. That a module has a section is checked where the section
is asked for.

Refs #369.
