### PR TITLE
A definition owns its identity; a resolved call owns the name it reaches

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Prelude.java
+++ b/souther-compiler/src/main/java/souther/compiler/Prelude.java
@@ -7,6 +7,7 @@ import souther.compiler.check.TypeChecker;
 import souther.compiler.ast.Ast;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
 import souther.compiler.check.TypeOps;
 import souther.compiler.frontend.CstFrontend;
 
@@ -94,6 +95,16 @@ public final class Prelude {
     private static final List<String> QUALIFIERS_IN_LOAD_ORDER = new ArrayList<>();
 
     /**
+     * Every library name as what a name reaching it denotes, keyed by the qualified spelling.
+     *
+     * <p>Written where the qualified spelling is made, out of the two values it is made of. A caller
+     * holding a qualified name asks here rather than splitting it: the alias and the operation are
+     * what the library knew when it loaded, and a name that has been joined and split again is a name
+     * that agrees with the original only as long as nobody writes one with a dot in it.
+     */
+    private static final Map<String, ValueName.Stdlib> OPERATIONS = new LinkedHashMap<>();
+
+    /**
      * The data declarations whose JVM implementation souther-runtime provides by hand rather than
      * the backend generating. The classification is made once, here: it anchors the declared names
      * to the runtime namespace ({@code souther.runtime.RoundingMode} is the class shipped there),
@@ -154,7 +165,7 @@ public final class Prelude {
      *  stand where they stood. A sugar supplies constants and nothing else, which is why they are
      *  numbers here; one that had to supply anything else could not be written down as this and
      *  would say so. */
-    public record Rewrite(String target, List<Integer> supplied) {
+    public record Rewrite(ValueName.Stdlib target, List<Integer> supplied) {
         public Rewrite {
             supplied = List.copyOf(supplied);
         }
@@ -162,15 +173,25 @@ public final class Prelude {
         /** How many of the arguments the sugar is written with stand where they stood — the target's
          *  own count, less what the rewrite adds. */
         public int keptArgs() {
-            PreludeEntry entry = ENTRIES.get(target);
+            PreludeEntry entry = ENTRIES.get(target.qualified());
             return entry == null ? 0 : entry.signature().params().size() - supplied.size();
         }
     }
 
     /** Names that are sugar for another standard-library call, recognised as library functions but
-     *  rewritten before inlining. */
-    private static final Map<String, Rewrite> SUGARED =
-            Map.of("List.fold", new Rewrite("List.foldFrom", List.of(0)));
+     *  rewritten before inlining. Written as the two values a library name is made of, so that the
+     *  sugar and what it becomes are named here the way every other library name is. */
+    private static final ValueName.Stdlib FOLD = new ValueName.Stdlib("List", "fold");
+
+    private static final Map<String, Rewrite> SUGARED = Map.of(FOLD.qualified(),
+            new Rewrite(new ValueName.Stdlib("List", "foldFrom"), List.of(0)));
+
+    /** A sugar has no declaration, so nothing above put it among the operations; it is a name a
+     * reader may write, so it belongs there. Placed after {@link #SUGARED} because a static
+     * initializer reads what the ones above it have already written. */
+    static {
+        OPERATIONS.put(FOLD.qualified(), FOLD);
+    }
 
     /** Whether {@code qualifiedName} is one of those — a name no tree holds after the rewrite. */
     public static boolean sugared(String qualifiedName) {
@@ -215,6 +236,18 @@ public final class Prelude {
         return Collections.unmodifiableMap(ENTRIES);
     }
 
+    /**
+     * What a name reaching {@code qualifiedName} denotes, or null where the library has no such name.
+     *
+     * <p>The alias and the operation as the library wrote them, so a caller holding a qualified
+     * spelling gets them back rather than splitting it. The library is the only thing that knows
+     * which part is which: {@code souther.list} declares {@code foldFrom} and publishes it under
+     * {@code List}, and the spelling says nothing about either.
+     */
+    public static ValueName.Stdlib operation(String qualifiedName) {
+        return OPERATIONS.get(qualifiedName);
+    }
+
     /** Whether {@code qualifiedName} names a declaration the library keeps to itself. Such a name
      *  may be written inside the reserved namespace and nowhere else, so everything outside it is
      *  told the library has no such member. */
@@ -238,7 +271,7 @@ public final class Prelude {
         Set<String> byModule = new LinkedHashSet<>();
         for (String qualifier : QUALIFIERS_IN_LOAD_ORDER) {
             for (String name : names) {
-                if (name.startsWith(qualifier + ".")) {
+                if (OPERATIONS.get(name).alias().equals(qualifier)) {
                     byModule.add(name);
                 }
             }
@@ -283,7 +316,8 @@ public final class Prelude {
                 RUNTIME_DEFS.put(def.name(), def);
             }
             for (Ast.FnDef fn : module.fns()) {
-                String qualified = alias + "." + fn.name();
+                ValueName.Stdlib operation = new ValueName.Stdlib(alias, fn.name());
+                String qualified = operation.qualified();
                 // One qualified name, one declaration. The library has no overloading: a name that
                 // reads two ways would have to be chosen between, and nothing at a value position
                 // could do the choosing. Put into a map, a second one would replace the first in
@@ -294,6 +328,7 @@ public final class Prelude {
                 }
                 Signature signature = signatureOf(fn, qualified, symbols);
                 ENTRIES.put(qualified, new PreludeEntry(fn, signature));
+                OPERATIONS.put(qualified, operation);
                 if (fn.body() instanceof Ast.FnBody.Intrinsic intrinsic) {
                     KERNELS.put(intrinsic.key(), signature);
                 }

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -1283,6 +1283,22 @@ public interface Ast {
      */
     record Var(WrittenName written, ValueName denotes, ReachName reachedAs) implements Expr {
 
+        /**
+         * A name that has been resolved has both answers or neither.
+         *
+         * <p>Refused rather than allowed to stand, because what a name reaches is asked of a table
+         * and a table answers a key it has not got with silence. A rewrite that carried the
+         * denotation across and dropped the reach name would leave a reference that resolves to a
+         * declaration and reaches nothing, and the first reader of it would read the spelling
+         * instead — which is what this pair was separated out to stop.
+         */
+        public Var {
+            if (denotes != null && reachedAs == null) {
+                throw new IllegalArgumentException("`" + written.canonical() + "` denotes " + denotes
+                        + " and says nothing about how this module reaches it");
+            }
+        }
+
         /** A name as the parser read it, before resolution has said what it denotes or how this
          * module reaches it. */
         public Var(String spelling, SourcePos pos) {
@@ -1321,7 +1337,8 @@ public interface Ast {
          */
         public String bare() {
             if (denotes == null) {
-                throw new IllegalStateException("`" + name() + "` was never resolved");
+                new Throwable("UNRESOLVED reaches() " + name()).printStackTrace();
+                return name();
             }
             return denotes.name();
         }
@@ -1351,9 +1368,14 @@ public interface Ast {
         }
 
         /**
-         * The name of the declaration this reference reaches, or the name written where it reaches
-         * none. The reading counterpart of {@link Apply#reaches()}: {@link #name()} is the name the
-         * source writes, which an import may have let go without its qualifier.
+         * The name of the declaration this reference reaches, or the name written where nothing has
+         * been resolved. The reading counterpart of {@link Apply#reaches()}: {@link #name()} is the
+         * name the source writes, which an import may have let go without its qualifier.
+         *
+         * <p>The spelling is answered only for a tree resolution never saw — one a pass built for
+         * itself, which {@code FixtureTemplate} does and the example reader asks this of. It is not
+         * what a rewrite that dropped the reach name would get: a name that denotes something and
+         * says nothing about how it is reached cannot be built at all (see the constructor).
          */
         public String reaches() {
             return reachedAs == null ? name() : reachedAs.rendered();

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -4,6 +4,7 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -1280,16 +1281,24 @@ public interface Ast {
      * {@link ValueName.Unresolved}, so a reader downstream never has a spelling to match and never
      * repeats the report.
      */
-    record Var(WrittenName written, ValueName denotes) implements Expr {
+    record Var(WrittenName written, ValueName denotes, ReachName reachedAs) implements Expr {
 
-        /** A name as the parser read it, before resolution has said what it denotes. */
+        /** A name as the parser read it, before resolution has said what it denotes or how this
+         * module reaches it. */
         public Var(String spelling, SourcePos pos) {
-            this(WrittenName.of(spelling, pos), null);
+            this(WrittenName.of(spelling, pos), null, null);
         }
 
-        /** A name a pass already knows the meaning of, written where the source writes it. */
-        public Var(String spelling, ValueName denotes, SourcePos pos) {
-            this(WrittenName.of(spelling, pos), denotes);
+        /**
+         * A name a pass already knows the meaning of, written where the source writes it.
+         *
+         * <p>The reach name is given rather than worked out here. A pass writing a name into a body
+         * either has one in hand — it is rewriting a name that already carried it — or knows which
+         * module's body it is writing into, and neither is something this constructor can see. Worked
+         * out from the spelling it would be the very derivation the carried value exists to remove.
+         */
+        public Var(String spelling, ValueName denotes, ReachName reachedAs, SourcePos pos) {
+            this(WrittenName.of(spelling, pos), denotes, reachedAs);
         }
 
         /** The bare name this reaches its declaration by, whatever the source spelled. */
@@ -1330,14 +1339,15 @@ public interface Ast {
          * binding. There is no way to write one of these without having the binding in hand.
          */
         public static Var local(Binder binder, SourcePos pos) {
-            return new Var(WrittenName.synthetic(binder.name(), pos),
-                    new ValueName.Local(binder.name(), binder.id()));
+            ValueName.Local local = new ValueName.Local(binder.name(), binder.id());
+            return new Var(WrittenName.synthetic(binder.name(), pos), local,
+                    new ReachName.Bare(binder.name()));
         }
 
         /** A read of a name a desugaring minted, at the form it is rewriting. Written nowhere: the
          * characters at {@code anchor} spell whatever the author put there, which is not this. */
         public static Var desugared(String name, SourcePos anchor) {
-            return new Var(WrittenName.synthetic(name, anchor), null);
+            return new Var(WrittenName.synthetic(name, anchor), null, null);
         }
 
         /**
@@ -1346,11 +1356,26 @@ public interface Ast {
          * source writes, which an import may have let go without its qualifier.
          */
         public String reaches() {
-            return denotes instanceof ValueName.Stdlib lib ? lib.qualified() : name();
+            return reachedAs == null ? name() : reachedAs.rendered();
         }
 
+        /**
+         * The same name, denoting {@code resolved} and reached as {@code reachedAs}.
+         *
+         * <p>The two answers together, because resolution gives them together and they are the two
+         * halves of one question: which declaration this reaches, and under what name it reaches it
+         * from here. Handed over separately, a caller could pair one name's denotation with another's
+         * reach name, and nothing would say so.
+         */
+        public Var denoting(ValueName resolved, ReachName reachedAs) {
+            return new Var(written, resolved, reachedAs);
+        }
+
+        /** The same name denoting {@code resolved}, reached as it already was — for a pass that
+         * changes what a name says about where its construction came from and not which declaration
+         * it reaches. */
         public Var denoting(ValueName resolved) {
-            return new Var(written, resolved);
+            return new Var(written, resolved, reachedAs);
         }
 
         @Override
@@ -1400,10 +1425,11 @@ public interface Ast {
             this(new Var(fn, pos), args, ConstructionOrigin.own(), pos);
         }
 
-        /** Applying a name a pass already knows the meaning of. */
-        public Apply(String fn, ValueName denotes, List<Expr> args, ConstructionOrigin origin,
-                     SourcePos pos) {
-            this(new Var(fn, denotes, pos), args, origin, pos);
+        /** Applying a name a pass already knows the meaning of, and knows how the body it is
+         * writing into reaches. */
+        public Apply(String fn, ValueName denotes, ReachName reachedAs, List<Expr> args,
+                     ConstructionOrigin origin, SourcePos pos) {
+            this(new Var(fn, denotes, reachedAs, pos), args, origin, pos);
         }
 
         /** Whether what this applies is a name. A reader that wants the name itself matches on
@@ -1458,13 +1484,14 @@ public interface Ast {
          * compiler looked up with it.
          */
         public String reaches() {
-            return denotes() instanceof ValueName.Stdlib lib ? lib.qualified() : nameApplied();
+            return function instanceof Var v ? v.reaches() : "";
         }
 
-        /** The name in the callee position, or the empty spelling where what is applied is not a
-         *  name. What both spellings above are built from, and what neither may skip past. */
-        private String nameApplied() {
-            return function instanceof Var v ? v.name() : "";
+        /** How this module reaches what the application applies, or null where what it applies is
+         * not a name. Settled at resolution and carried, so it says the same thing whichever passes
+         * have run. */
+        public ReachName reachedAs() {
+            return function instanceof Var v ? v.reachedAs() : null;
         }
 
         /** What the name this applies denotes, or null where what it applies is not a name. */

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -1337,8 +1337,7 @@ public interface Ast {
          */
         public String bare() {
             if (denotes == null) {
-                new Throwable("UNRESOLVED reaches() " + name()).printStackTrace();
-                return name();
+                throw new IllegalStateException("`" + name() + "` was never resolved");
             }
             return denotes.name();
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -7,6 +7,7 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Localizable;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
@@ -113,7 +114,7 @@ public final class CallElaborator {
         Map<String, Type> bindings = new HashMap<>();
         BottomInfer.pinResultTypeVars(declared, expected, bindings, ctx.symbols(),
                 v.pos(), "the type of " + lib.qualified());
-        return new Core.Call(lib.qualified(), List.of(),
+        return new Core.Call(new ReachName.OfLibrary(lib), List.of(),
                 TypeOps.toBottom(TypeOps.substitute(declared, bindings)), v.pos());
     }
 
@@ -137,7 +138,7 @@ public final class CallElaborator {
                     new Core.Read(call.written(), local.id(), env.typeOf(local.id()), call.pos()),
                     ca.cores(), result, call.pos());
         }
-        return new Core.Call(call.reaches(), ca.cores(), result, call.pos());
+        return new Core.Call(call.reachedAs(), ca.cores(), result, call.pos());
     }
 
     /**
@@ -556,16 +557,25 @@ public final class CallElaborator {
                     }
                     yield applySignature(call, fn, ca, expected, env, ctx).result();
                 }
-                // A library qualifier that matched no builtin or intrinsic above is a wrong stdlib
-                // call (spec §stdlib) — report it as such, not as a missing behavior. Asked of what
-                // this reaches rather than of what a report would quote: a field read applied
-                // (`deps.count(x)`) reaches a binding and is quoted with a dot in it, and what is
-                // wrong with it is that it is not a function, which is what the report below says.
-                if (library || call.reaches().indexOf('.') >= 0) {
+                // A library name that matched no builtin or intrinsic above is a wrong stdlib call
+                // (spec §stdlib) — reported as that, not as a missing behavior. Asked of which kind
+                // of name this reaches and not of whether the spelling holds a dot: a field read
+                // applied (`deps.count(x)`) is quoted with a dot in it and reaches a binding, and
+                // what is wrong with it is that it is not a function, which the report below says.
+                if (call.reachedAs() instanceof ReachName.OfLibrary) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.stdlib.notfunction").title("check.unknown.title")
                                     .at(call.name().region()).args(call.written()).build(),
                             "`" + call.written() + "` is not a standard-library function.");
+                }
+                // A helper another module declares is expanded where it is called, or — where it
+                // recurses — bound as a signature and answered above. Reaching here it is neither,
+                // which is this compiler having failed to do one of them rather than anything the
+                // author wrote. Said outright: reported as a wrong library call, it named a library
+                // the author never wrote.
+                if (call.reachedAs() instanceof ReachName.OfModule reached) {
+                    throw new IllegalStateException("`" + reached + "` was neither expanded nor"
+                            + " bound before the call to it at " + call.pos() + " was typed");
                 }
                 // a required behavior called inline (spec 12.2, 13), or one that requires nothing and
                 // is called by name (spec [#calling-a-behavior]). Both are typed against the callee's

--- a/souther-compiler/src/main/java/souther/compiler/check/Combinators.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Combinators.java
@@ -130,7 +130,7 @@ final class Combinators {
     /** The operations there is a rule for, for the tests that hold them to firing. */
     static Set<String> names() {
         Set<String> names = new LinkedHashSet<>();
-        Derived.RULES.keySet().forEach(operation -> names.add(operation.name()));
+        Derived.RULES.keySet().forEach(operation -> names.add(operation.toString()));
         return names;
     }
 
@@ -145,11 +145,11 @@ final class Combinators {
         Prelude.entries().forEach((qualified, entry) -> {
             Combinator rule = ruleFor(qualified, entry.signature().params());
             if (rule != null) {
-                rules.put(new ValueName.Stdlib(qualified), rule);
+                rules.put(Prelude.operation(qualified), rule);
             }
         });
         Prelude.rewrites().forEach((sugar, rewrite) -> {
-            Combinator target = rules.get(new ValueName.Stdlib(rewrite.target()));
+            Combinator target = rules.get(rewrite.target());
             if (target == null) {
                 return;   // what it becomes hands its closure nothing, so neither does it
             }
@@ -158,7 +158,7 @@ final class Combinators {
                         + ", whose closure or container is not among the arguments the rewrite keeps"
                         + " in place — what it hands its closure cannot be said of the sugar");
             }
-            rules.put(new ValueName.Stdlib(sugar), target);
+            rules.put(Prelude.operation(sugar), target);
         });
         return Collections.unmodifiableMap(rules);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -35,9 +35,11 @@ import java.util.function.Predicate;
  */
 final class DischargeRules {
 
-    /** The library operation written {@code qualified}, as what a name reaching it denotes. */
-    private static ValueName op(String qualified) {
-        return new ValueName.Stdlib(qualified);
+    /** The operation {@code name} of the library module published as {@code alias}, as what a name
+     * reaching it denotes. Written as the two values it is, so that a row here says which library it
+     * is about without a reader splitting a spelling to find out. */
+    private static ValueName op(String alias, String name) {
+        return new ValueName.Stdlib(alias, name);
     }
 
     /** The pure, total stdlib calls whose result is a number the domain can name: the size of a
@@ -46,7 +48,7 @@ final class DischargeRules {
      * name the same atom, and the guard discharges the clause. The argument must be a nameable path:
      * {@code List.length(List.map(f, xs))} is not this atom, and nothing relates the two. */
     private static final Set<ValueName> SIZE_CALLS = Set.of(
-            op("List.length"), op("String.length"), op("Set.size"), op("Map.size"));
+            op("List", "length"), op("String", "length"), op("Set", "size"), op("Map", "size"));
 
     /**
      * What a construction of a container keeps of the elements of the container it was built from.
@@ -139,7 +141,7 @@ final class DischargeRules {
         private static Combinators.Combinator handing(ValueName operation, String part) {
             Combinators.Combinator handed = Combinators.of(operation);
             if (handed == null) {
-                throw new IllegalStateException("a rule about " + operation.name() + " names " + part
+                throw new IllegalStateException("a rule about " + operation + " names " + part
                         + " of what it hands its closure, and its signature says it hands one nothing"
                         + " a container holds");
             }
@@ -168,30 +170,30 @@ final class DischargeRules {
     record Source(Core container, Shape shape, Cardinality size) {}
 
     private static final Map<ValueName, Built> BUILT_FROM = Map.ofEntries(
-            Map.entry(op("List.reverse"), new Built(at(0), Shape.PERMUTES, Cardinality.SAME)),
-            Map.entry(op("List.sort"), new Built(at(0), Shape.PERMUTES, Cardinality.SAME)),
-            Map.entry(op("List.sortBy"), new Built(CONTAINER, Shape.PERMUTES, Cardinality.SAME)),
-            Map.entry(op("List.map"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
-            Map.entry(op("List.mapIndexed"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
-            Map.entry(op("Map.mapValues"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
-            Map.entry(op("List.filter"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("List.distinct"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("List.take"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("List.drop"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Set.filter"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Map.filterEntries"),
+            Map.entry(op("List", "reverse"), new Built(at(0), Shape.PERMUTES, Cardinality.SAME)),
+            Map.entry(op("List", "sort"), new Built(at(0), Shape.PERMUTES, Cardinality.SAME)),
+            Map.entry(op("List", "sortBy"), new Built(CONTAINER, Shape.PERMUTES, Cardinality.SAME)),
+            Map.entry(op("List", "map"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
+            Map.entry(op("List", "mapIndexed"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
+            Map.entry(op("Map", "mapValues"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
+            Map.entry(op("List", "filter"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("List", "distinct"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("List", "take"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("List", "drop"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Set", "filter"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map", "filterEntries"),
                     new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("List.distinctBy"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Map.remove"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Set.remove"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Map.intersection"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Map.difference"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Set.intersection"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Set.difference"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
-            Map.entry(op("Map.updateIfPresent"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
-            Map.entry(op("List.filterMap"),
+            Map.entry(op("List", "distinctBy"), new Built(CONTAINER, Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map", "remove"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Set", "remove"), new Built(at(1), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map", "intersection"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map", "difference"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Set", "intersection"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Set", "difference"), new Built(at(0), Shape.SUBSET, Cardinality.AT_MOST)),
+            Map.entry(op("Map", "updateIfPresent"), new Built(CONTAINER, Shape.MAPS, Cardinality.SAME)),
+            Map.entry(op("List", "filterMap"),
                     new Built(CONTAINER, Shape.COLLAPSES, Cardinality.AT_MOST)),
-            Map.entry(op("Set.map"), new Built(CONTAINER, Shape.COLLAPSES, Cardinality.AT_MOST)));
+            Map.entry(op("Set", "map"), new Built(CONTAINER, Shape.COLLAPSES, Cardinality.AT_MOST)));
 
     /**
      * The containers a construction's result is never smaller than.
@@ -210,11 +212,11 @@ final class DischargeRules {
      * what they share, and it is what a lower-bound invariant asks for.
      */
     private static final Map<ValueName, List<Reads>> NO_SMALLER_THAN = Map.of(
-            op("List.append"), List.of(at(0), at(1)),
-            op("Set.union"), List.of(at(0), at(1)),
-            op("Map.union"), List.of(at(0), at(1)),
-            op("Set.insert"), List.of(at(1)),
-            op("Map.insert"), List.of(at(2)));
+            op("List", "append"), List.of(at(0), at(1)),
+            op("Set", "union"), List.of(at(0), at(1)),
+            op("Map", "union"), List.of(at(0), at(1)),
+            op("Set", "insert"), List.of(at(1)),
+            op("Map", "insert"), List.of(at(2)));
 
     /**
      * The constructions this says nothing of, in three groups. Each reason is about what a shape can
@@ -238,11 +240,11 @@ final class DischargeRules {
      * spans kinds is what would have to exist first.
      */
     static final Set<ValueName> NOTHING_KEPT = Set.of(
-            op("Map.keys"), op("Map.toList"), op("Map.fromList"), op("List.groupBy"),
-            op("List.concat"), op("List.zipShortest"), op("List.flatMap"),
-            op("Map.insert"), op("Set.insert"), op("Map.union"), op("Set.union"),
-            op("List.append"), op("Map.updateOrInsert"),
-            op("Map.values"), op("Set.toList"), op("Set.fromList"), op("List.indexBy"));
+            op("Map", "keys"), op("Map", "toList"), op("Map", "fromList"), op("List", "groupBy"),
+            op("List", "concat"), op("List", "zipShortest"), op("List", "flatMap"),
+            op("Map", "insert"), op("Set", "insert"), op("Map", "union"), op("Set", "union"),
+            op("List", "append"), op("Map", "updateOrInsert"),
+            op("Map", "values"), op("Set", "toList"), op("Set", "fromList"), op("List", "indexBy"));
 
     /** Where a predicate reads its container, and which shapes of construction carry it there.
      * {@code List.all} holds of any sublist of a list it holds of; {@code List.contains} does not, and
@@ -250,12 +252,12 @@ final class DischargeRules {
     record Carried(Reads container, Set<Shape> through) {}
 
     private static final Map<ValueName, Carried> CARRIED = Map.of(
-            op("List.all"), new Carried(CONTAINER, Set.of(Shape.PERMUTES, Shape.SUBSET)),
-            op("List.allDistinctBy"), new Carried(CONTAINER, Set.of(Shape.PERMUTES, Shape.SUBSET)),
-            op("List.any"), new Carried(CONTAINER, Set.of(Shape.PERMUTES)),
-            op("List.contains"), new Carried(at(1), Set.of(Shape.PERMUTES)),
-            op("Set.contains"), new Carried(at(1), Set.of(Shape.PERMUTES)),
-            op("Map.containsKey"), new Carried(at(1), Set.of(Shape.PERMUTES)));
+            op("List", "all"), new Carried(CONTAINER, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            op("List", "allDistinctBy"), new Carried(CONTAINER, Set.of(Shape.PERMUTES, Shape.SUBSET)),
+            op("List", "any"), new Carried(CONTAINER, Set.of(Shape.PERMUTES)),
+            op("List", "contains"), new Carried(at(1), Set.of(Shape.PERMUTES)),
+            op("Set", "contains"), new Carried(at(1), Set.of(Shape.PERMUTES)),
+            op("Map", "containsKey"), new Carried(at(1), Set.of(Shape.PERMUTES)));
 
     /** Where a predicate reads its container at a call, and how far its statement travels. */
     record Carrying(Core.PreservedCall stated, Reads at, Set<Shape> through) {
@@ -267,8 +269,8 @@ final class DischargeRules {
         /** {@code call} — a call to the same operation — with the container it reads replaced. */
         Core.PreservedCall over(Core.PreservedCall call, Core container) {
             if (!call.operation().equals(stated.operation())) {
-                throw new IllegalStateException("a rule read for " + stated.operation().name()
-                        + " was asked to rewrite a call to " + call.operation().name());
+                throw new IllegalStateException("a rule read for " + stated.operation()
+                        + " was asked to rewrite a call to " + call.operation());
             }
             return at.replacedIn(call, container);
         }
@@ -278,7 +280,7 @@ final class DischargeRules {
      * the closure copies that field from the element unchanged, so the predicate holds of the mapped
      * list exactly when it holds of what was mapped, over the field it came from. */
     private static final Map<ValueName, Reads> PROJECTION_OF =
-            Map.of(op("List.allDistinctBy"), CLOSURE);
+            Map.of(op("List", "allDistinctBy"), CLOSURE);
 
     /** The projection a predicate at a call is stated over, as the block it answers with. */
     record Projection(Core.PreservedCall stated, Reads at, Core.Block projection) {
@@ -294,7 +296,7 @@ final class DischargeRules {
      * and which the container is what {@link Combinators} already answers of any combinator, and how
      * far the statement travels is what {@link #carried} already answers of any predicate — so a
      * quantifier is the name and nothing else. {@code List.all} is the only one the library has. */
-    private static final Set<ValueName> QUANTIFIERS = Set.of(op("List.all"));
+    private static final Set<ValueName> QUANTIFIERS = Set.of(op("List", "all"));
 
     /** Emptiness, by the size call it means. This is not a rule about what an operation does to a
      * property but about what a predicate <em>says</em>: {@code List.isEmpty(xs)} and
@@ -302,10 +304,10 @@ final class DischargeRules {
      * writing the other. Without it the two would be unrelated, which is an accident of which one the
      * author reached for. */
     private static final Map<ValueName, ValueName> EMPTINESS = Map.of(
-            op("List.isEmpty"), op("List.length"),
-            op("Set.isEmpty"), op("Set.size"),
-            op("Map.isEmpty"), op("Map.size"),
-            op("String.isEmpty"), op("String.length"));
+            op("List", "isEmpty"), op("List", "length"),
+            op("Set", "isEmpty"), op("Set", "size"),
+            op("Map", "isEmpty"), op("Map", "size"),
+            op("String", "isEmpty"), op("String", "length"));
 
     /** The predicates whose statement this carries nowhere. A predicate over a string states
      * something of the characters it holds in the order it holds them, and what would carry such a
@@ -313,9 +315,9 @@ final class DischargeRules {
      * its length being all this names of it. An emptiness check states a size, which travels as a
      * size does ({@link #EMPTINESS}) and not as a property of elements. */
     static final Set<ValueName> NOTHING_CARRIED = Set.of(
-            op("String.contains"), op("String.startsWith"), op("String.endsWith"),
-            op("String.matches"),
-            op("List.isEmpty"), op("Set.isEmpty"), op("Map.isEmpty"), op("String.isEmpty"));
+            op("String", "contains"), op("String", "startsWith"), op("String", "endsWith"),
+            op("String", "matches"),
+            op("List", "isEmpty"), op("Set", "isEmpty"), op("Map", "isEmpty"), op("String", "isEmpty"));
 
     /** The predicates of a single container that are not emptiness checks. The library has none:
      * every one-argument predicate it declares over a container or a string is one, and one that was
@@ -325,7 +327,7 @@ final class DischargeRules {
     /** The predicates that apply a predicate to what a container holds without stating it of every
      * element. {@code List.any} states it of some, so what it says of the container says nothing
      * about the element a closure is handed. */
-    static final Set<ValueName> NOT_A_QUANTIFIER = Set.of(op("List.any"));
+    static final Set<ValueName> NOT_A_QUANTIFIER = Set.of(op("List", "any"));
 
     /** The predicates that compute something other than a truth value from each element and are not
      * stated over it. The library has none: {@code allDistinctBy} is the only such predicate and its
@@ -343,22 +345,22 @@ final class DischargeRules {
      * {@code divide} is absent: it answers a union rather than a number.
      */
     private static final Map<ValueName, Ast.BinOp> OPERATOR_CALLS = Map.of(
-            op("Int.add"), Ast.BinOp.ADD,
-            op("Int.subtract"), Ast.BinOp.SUB,
-            op("Int.multiply"), Ast.BinOp.MUL,
-            op("Decimal.add"), Ast.BinOp.ADD,
-            op("Decimal.subtract"), Ast.BinOp.SUB,
-            op("Decimal.multiply"), Ast.BinOp.MUL);
+            op("Int", "add"), Ast.BinOp.ADD,
+            op("Int", "subtract"), Ast.BinOp.SUB,
+            op("Int", "multiply"), Ast.BinOp.MUL,
+            op("Decimal", "add"), Ast.BinOp.ADD,
+            op("Decimal", "subtract"), Ast.BinOp.SUB,
+            op("Decimal", "multiply"), Ast.BinOp.MUL);
 
     /** The operations over two numbers that are the function form of no operator: the language
      * writes no {@code min}, {@code max}, {@code floorMod} or {@code compare}, so there is no second
      * spelling for a term to be read as one of. */
     static final Set<ValueName> NOT_AN_OPERATOR = Set.of(
-            op("Int.min"), op("Int.max"), op("Int.floorMod"), op("Int.compare"),
-            op("Decimal.min"), op("Decimal.max"));
+            op("Int", "min"), op("Int", "max"), op("Int", "floorMod"), op("Int", "compare"),
+            op("Decimal", "min"), op("Decimal", "max"));
 
     /** Denial, which the analysis representation keeps as the call it is. */
-    static final ValueName NOT = op("Bool.not");
+    static final ValueName NOT = op("Bool", "not");
 
     /** The operations each table has a rule for. What is asked of them is {@link Question}'s to
      * settle; these are so it can hold a rule to being one an operation is asked for. */
@@ -383,7 +385,8 @@ final class DischargeRules {
     static Set<String> constructionKinds() {
         Set<String> kinds = new LinkedHashSet<>();
         Bound.BUILDINGS.forEach((operation, built) -> {
-            Prelude.PreludeEntry entry = Prelude.entry(operation.name());
+            Prelude.PreludeEntry entry = operation instanceof ValueName.Stdlib library
+                    ? Prelude.entry(library.qualified()) : null;
             String kind = entry == null ? null : kindOf(entry.signature().result());
             if (kind != null) {
                 kinds.add(kind + "." + built.shape());
@@ -427,7 +430,7 @@ final class DischargeRules {
      * it discharges. */
     static Set<String> builtNames() {
         Set<String> names = new LinkedHashSet<>();
-        builtOperations().forEach(operation -> names.add(operation.name()));
+        builtOperations().forEach(operation -> names.add(operation.toString()));
         return names;
     }
 
@@ -483,26 +486,33 @@ final class DischargeRules {
     static <T> Map<ValueName, T> bind(Map<ValueName, T> rules, Function<T, Reads> reads,
                                       Reads derived, Predicate<Type> required, String what) {
         rules.forEach((operation, rule) -> {
-            Prelude.PreludeEntry entry = Prelude.entry(operation.name());
+            // Every row here is about an operation the library declares, so the key says which
+            // library and which operation rather than a spelling this would have to take apart.
+            if (!(operation instanceof ValueName.Stdlib library)) {
+                throw new IllegalStateException("a rule about " + what + " is written for "
+                        + operation + ", which is not a library operation");
+            }
+            Prelude.PreludeEntry entry = Prelude.entry(library.qualified());
             if (entry == null) {
                 throw new IllegalStateException("a rule about " + what + " is written for "
-                        + operation.name() + ", which the library does not declare");
+                        + library.qualified() + ", which the library does not declare");
             }
             List<Type> params = entry.signature().params();
             Reads at = reads.apply(rule);
             int position = at.positionIn(operation);
             if (position < 0 || position >= params.size()) {
-                throw new IllegalStateException(operation.name() + " takes " + params.size()
+                throw new IllegalStateException(library.qualified() + " takes " + params.size()
                         + " argument(s), and the rule about " + what + " reads argument "
                         + (position + 1));
             }
             if (!required.test(params.get(position))) {
                 throw new IllegalStateException("argument " + (position + 1) + " of "
-                        + operation.name() + " is not " + what);
+                        + library.qualified() + " is not " + what);
             }
             if (at instanceof Reads.At && Combinators.of(operation) != null
                     && derived.positionIn(operation) == position) {
-                throw new IllegalStateException("the rule about " + what + " for " + operation.name()
+                throw new IllegalStateException("the rule about " + what + " for "
+                        + library.qualified()
                         + " writes the argument its signature already answers — say which part it is"
                         + " rather than where, so the two cannot come apart");
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -4,6 +4,7 @@ import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -44,7 +45,7 @@ public final class Exposing {
      * reading this file" for the whole workspace while the author was part-way through writing a
      * {@code let}.
      */
-    public record Validated(Map<String, String> exposed, List<Ast.Import> kept,
+    public record Validated(Map<String, ValueName.Stdlib> exposed, List<Ast.Import> kept,
                             List<Diagnostic> conflicts) {}
 
     /** Both answers at once, for a reader that wants them both and should ask once. */
@@ -77,7 +78,7 @@ public final class Exposing {
             declaredData.add(def.name());
         }
 
-        Map<String, String> exposed = new HashMap<>();
+        Map<String, ValueName.Stdlib> exposed = new HashMap<>();
         List<Ast.Import> kept = new ArrayList<>();
         List<Diagnostic> conflicts = new ArrayList<>();
         for (Ast.Import imp : module.imports()) {
@@ -86,7 +87,11 @@ public final class Exposing {
                 continue;
             }
             for (String name : imp.names()) {
-                String qualified = imp.module() + "." + name;
+                // The import line writes both halves of a library name: the module it names is the
+                // alias, and each name in its list is the operation. What is brought in is that pair,
+                // so nothing downstream has to take a spelling apart to get at either.
+                ValueName.Stdlib operation = new ValueName.Stdlib(imp.module(), name);
+                String qualified = operation.qualified();
                 if (!Prelude.isLibraryFunction(qualified)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.import.notstdfn").title("check.module.title")
@@ -100,12 +105,13 @@ public final class Exposing {
                             .hint("check.import.conflict.hint").build());
                     continue;   // the name is refused; what it means until then is the declaration
                 }
-                String prior = exposed.putIfAbsent(name, qualified);
-                if (prior != null && !prior.equals(qualified)) {
+                ValueName.Stdlib prior = exposed.putIfAbsent(name, operation);
+                if (prior != null && !prior.equals(operation)) {
                     throw CompileException.of(
                             Diagnostic.of(null, "check.import.ambiguous").title("check.module.title")
-                                    .at(imp.pos()).args(name, prior, qualified).build(),
-                            "`" + name + "` is exposed from both `" + prior + "` and `" + qualified
+                                    .at(imp.pos()).args(name, prior.qualified(), qualified).build(),
+                            "`" + name + "` is exposed from both `" + prior.qualified() + "` and `"
+                                    + qualified
                                     + "` — call it qualified instead of importing both (spec §stdlib).");
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -8,6 +8,7 @@ import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
@@ -488,8 +489,8 @@ public final class HelperInliner {
         for (int supplied : rewrite.supplied()) {
             args.add(new Ast.IntLit(supplied, call.pos()));
         }
-        return new Ast.Apply(rewrite.target().qualified(), rewrite.target(), args,
-                ConstructionOrigin.own(),
+        return new Ast.Apply(rewrite.target().qualified(), rewrite.target(),
+                new ReachName.OfLibrary(rewrite.target()), args, ConstructionOrigin.own(),
                 call.pos());
     }
 
@@ -870,7 +871,7 @@ public final class HelperInliner {
                 // separate slots: the binding is in the callee position, the spelling beside it.
                 yield inline(new Ast.LetIn(f, raw.function(), null, false, null,
                         new Ast.Apply(new Ast.Var(f.name(), new ValueName.Local(f.name(), f.id()),
-                                raw.pos()),
+                                new ReachName.Bare(f.name()), raw.pos()),
                                 raw.args(), raw.origin(), spelling(raw.function()), raw.pos()),
                         raw.pos()));
             }
@@ -1206,8 +1207,8 @@ public final class HelperInliner {
             args.add(Ast.Var.local(p, function.pos()));
         }
         return new Ast.Block(params,
-                new Ast.Apply(function.name(), function.denotes(), args, ConstructionOrigin.own(),
-                        function.pos()),
+                new Ast.Apply(function.name(), function.denotes(), function.reachedAs(), args,
+                        ConstructionOrigin.own(), function.pos()),
                 function.pos());
     }
 
@@ -1442,6 +1443,11 @@ public final class HelperInliner {
         static Substituted of(Ast.Binder binder) {
             return new Substituted(binder.name(), new ValueName.Local(binder.name(), binder.id()));
         }
+
+        /** A binding is reached where it is bound, so its own name is the whole of it. */
+        ReachName reachedAs() {
+            return new ReachName.Bare(name);
+        }
     }
 
     /**
@@ -1643,8 +1649,10 @@ public final class HelperInliner {
     private Ast.Var renameVar(Ast.Var v, Renaming renaming) {
         Substituted stands = renaming.substituted(v.denotes());
         return stands != null
-                ? new Ast.Var(stands.name(), stands.denotes(), renaming.at(v.pos()))
-                : new Ast.Var(v.name(), renaming.copy().of(v.denotes()), renaming.at(v.pos()));
+                ? new Ast.Var(stands.name(), stands.denotes(), stands.reachedAs(),
+                        renaming.at(v.pos()))
+                : new Ast.Var(v.name(), renaming.copy().of(v.denotes()), v.reachedAs(),
+                        renaming.at(v.pos()));
     }
 
     private List<Ast.Expr> renameList(List<Ast.Expr> es, Renaming renaming) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -448,8 +448,7 @@ public final class HelperInliner {
                         HelperNames.publishedBy(HelperNames.qualifyHelpersOf(closed, module), module)));
     }
 
-    /** The module these helpers belong to — what {@link HelperNames#keyIn} compares a name's
-     * declaring module against. */
+    /** The module these helpers belong to — the one whose bodies this expands into. */
     public String moduleName() {
         return table.module();
     }
@@ -489,7 +488,7 @@ public final class HelperInliner {
         for (int supplied : rewrite.supplied()) {
             args.add(new Ast.IntLit(supplied, call.pos()));
         }
-        return new Ast.Apply(rewrite.target(), new ValueName.Stdlib(rewrite.target()), args,
+        return new Ast.Apply(rewrite.target().qualified(), rewrite.target(), args,
                 ConstructionOrigin.own(),
                 call.pos());
     }
@@ -655,7 +654,7 @@ public final class HelperInliner {
     private List<Ast.FnParam> declaredParams(Ast.Apply call) {
         Prelude.Rewrite rewrite = Prelude.rewriteOf(call.reaches());
         if (rewrite != null && call.args().size() == rewrite.keptArgs()) {
-            Ast.FnDef target = table.reached(rewrite.target());
+            Ast.FnDef target = table.reached(rewrite.target().qualified());
             return target == null ? null : target.params().subList(0, rewrite.keptArgs());
         }
         Ast.FnDef helper = table.reached(call.reaches());

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1278,7 +1278,9 @@ public final class HelperInliner {
             return v;
         }
         Ast.FnDef value = table.reached(v.reaches());
-        if (value == null || value.body() == null || graph.recurses(v.name())) {
+        // Asked with the name the table was asked with. The graph is keyed as the table is, and a
+        // spelling agrees with that key only where a pass has already written it out qualified.
+        if (value == null || value.body() == null || graph.recurses(v.reaches())) {
             return v;
         }
         return substituted(v.reaches(), value.writtenBody());
@@ -1676,7 +1678,7 @@ public final class HelperInliner {
             return null;
         }
         // by the name it is reached by here, which for another module's value is the qualified one
-        String reached = spread.name();
+        String reached = spread.reaches();
         Ast.FnDef value = table.fns().get(reached);
         return value == null || !value.params().isEmpty() || value.body() == null
                 || graph.recurses(reached) ? null : value;

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -142,12 +143,12 @@ public final class HelperNames {
     private static Ast.Expr qualifyHelpers(Ast.Expr e, Predicate<ValueName.Helper> which) {
         // a name slot takes the same rewrite as a name standing on its own: a spread names a value
         // the way any other position does
-        Ast.Expr rebuilt = Ast.mapChildren(e, c -> qualifyHelpers(c, which),
-                s -> qualified(s, which));
+        Ast.Expr rebuilt = alsoInGiven(Ast.mapChildren(e, c -> qualifyHelpers(c, which),
+                s -> qualified(s, which)), c -> qualifyHelpers(c, which));
         return switch (rebuilt) {
             case Ast.Apply call when foreign(call.denotes(), which) ->
-                    new Ast.Apply(qualifiedName(call.denotes()), call.denotes(), call.args(),
-                            call.origin(),
+                    new Ast.Apply(qualifiedName(call.denotes()), call.denotes(),
+                            ofModule(call.denotes()), call.args(), call.origin(),
                             call.pos());
             case Ast.Var v -> qualified(v, which);
             default -> rebuilt;
@@ -157,8 +158,37 @@ public final class HelperNames {
     /** {@code name} written qualified where it denotes a helper {@code which} accepts. */
     private static Ast.Var qualified(Ast.Var name, Predicate<ValueName.Helper> which) {
         return foreign(name.denotes(), which)
-                ? new Ast.Var(qualifiedName(name.denotes()), name.denotes(), name.pos())
+                ? new Ast.Var(qualifiedName(name.denotes()), name.denotes(),
+                        ofModule(name.denotes()), name.pos())
                 : name;
+    }
+
+    /**
+     * {@code e} with {@code rewrite} also applied to what a combinator was handed.
+     *
+     * <p>A function argument stands in {@link Ast.Expansion#given} and that is not a slot, so no
+     * generic walk reaches it: a callee that applies its argument holds the same lambda inside its
+     * body, and a walk taking both would read one lambda twice. What is written here is not a
+     * general walk. It is the rewrite a body takes when it leaves the module it was written in, and
+     * a body leaves whole — an argument the callee never applies stands in {@code given} and nowhere
+     * else, and one it does apply still says, there, what it said where it was written. Left alone,
+     * it goes on naming the declaring module's helpers by the names that module reached them by,
+     * inside a body being read against a reader's.
+     */
+    private static Ast.Expr alsoInGiven(Ast.Expr e, java.util.function.UnaryOperator<Ast.Expr> rewrite) {
+        if (!(e instanceof Ast.Expansion ex)) {
+            return e;
+        }
+        List<Ast.Given> given = new ArrayList<>();
+        boolean any = false;
+        for (Ast.Given g : ex.given()) {
+            Ast.Expr value = rewrite.apply(g.value());
+            any |= value != g.value();
+            given.add(value == g.value() ? g
+                    : new Ast.Given(g.declaredType(), value, g.applied(), g.arrivesAs()));
+        }
+        return any ? new Ast.Expansion(ex.callee(), ex.application(), ex.bound(), given,
+                ex.declaredReturn(), ex.body(), ex.pos()) : e;
     }
 
     /** Whether {@code denotes} is a helper {@code which} accepts. */
@@ -179,7 +209,8 @@ public final class HelperNames {
     static Ast.Expr publishedBy(Ast.Expr e, String module) {
         // a spread names a value, and a value is not a construction: what it built was built where it
         // was defined, so the mark is already on it
-        Ast.Expr rebuilt = Ast.mapChildren(e, c -> publishedBy(c, module), s -> s);
+        Ast.Expr rebuilt = alsoInGiven(Ast.mapChildren(e, c -> publishedBy(c, module), s -> s),
+                c -> publishedBy(c, module));
         return switch (rebuilt) {
             case Ast.NewData nd -> nd.publishedBy(module);
             // a unit data is constructed by being named, so the name is where it says where it came
@@ -214,7 +245,8 @@ public final class HelperNames {
      * showing through the rule again, in the one place expansion cannot reach.
      */
     static Ast.Expr carriedByValue(Ast.Expr e) {
-        Ast.Expr rebuilt = Ast.mapChildren(e, HelperNames::carriedByValue, s -> s);
+        Ast.Expr rebuilt = alsoInGiven(Ast.mapChildren(e, HelperNames::carriedByValue, s -> s),
+                HelperNames::carriedByValue);
         return switch (rebuilt) {
             case Ast.NewData nd -> nd.carriedByValue();
             case Ast.Var v when v.denotes() instanceof ValueName.OfType named ->
@@ -253,33 +285,17 @@ public final class HelperNames {
         Ast.forEachChild(e, c -> collectHelpersOf(c, out));
     }
 
+    /** How a helper written qualified is reached: under the module that declares it, which is what
+     * writing it qualified says. Read off what the name denotes, like the spelling beside it. */
+    private static ReachName ofModule(ValueName denotes) {
+        ValueName.Helper helper = (ValueName.Helper) denotes;
+        return new ReachName.OfModule(helper.module(), helper.name());
+    }
+
     /** The name a helper is reached by outside the module that declares it. Read off what the name
      * denotes, so applying it to a name already written this way answers the same thing. */
     private static String qualifiedName(ValueName denotes) {
         ValueName.Helper helper = (ValueName.Helper) denotes;
         return qualified(helper.module(), helper.name());
-    }
-
-    /**
-     * The key {@code helper} is filed under in the table of the module named {@code module} — bare for
-     * one that module declares, declaring-module-qualified for one it imported.
-     *
-     * <p>This turns a helper's identity into the name that module reaches it by, and the two are
-     * different values. What comes back is a key: it names a declaration within one module's table and
-     * says nothing outside it, and it is not something to read a declaring module back out of. That is
-     * carried on the declaration ({@link Ast.FnDef#declaredBy}).
-     *
-     * <p>Asked with the identity and never with a spelling, which is what {@link ValueName.Helper}
-     * holds (ADR-0072); a reader writes an imported definition bare, so a key taken off the spelling
-     * would be one key before {@link #qualifyImports} and another after — silently, because a miss is
-     * what a table does with a key it has not got.
-     *
-     * <p>The library does not come through here. A standard-library name is reached under an alias
-     * rather than under the module that declares it — {@code souther.list}'s {@code foldFrom} is
-     * reached as {@code List.foldFrom} — and denotes a {@link ValueName.Stdlib}, which already holds
-     * that reach name and is read as it stands.
-     */
-    public static String keyIn(String module, ValueName.Helper helper) {
-        return helper.module().equals(module) ? helper.name() : qualified(helper.module(), helper.name());
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -1,6 +1,7 @@
 package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayDeque;
@@ -43,7 +44,7 @@ import java.util.TreeSet;
  * not rest on what building the graph happened to visit. Whether a name is {@code partial} is read off
  * the declaration it reaches, not off a set collected on the way — a clause names what it names,
  * whether or not a helper of this module names it too. And which declaration a name reaches is read
- * off what the name denotes ({@link HelperNames#keyIn}), not off how it was spelled, so the answer is
+ * off the name the reference carries, not off how it was spelled, so the answer is
  * the same before and after the pass that writes an imported name out qualified.
  *
  * <p>A path is the shortest one, found breadth-first with each node's callees taken in name order, so
@@ -101,7 +102,7 @@ final class PartialReachability {
      * not be written where a value goes. A value takes none and is read rather than handed over.
      */
     boolean isPartialFunctionNamed(Ast.Var v) {
-        Ast.FnDef declared = declarationOf(v.denotes(), inliner);
+        Ast.FnDef declared = declarationOf(v.denotes(), v.reachedAs(), inliner);
         return declared != null && declared.partial() && !declared.params().isEmpty();
     }
 
@@ -195,15 +196,15 @@ final class PartialReachability {
     private static void collectReached(Ast.Expr e, HelperInliner inliner, Set<String> out) {
         switch (e) {
             case Ast.Apply call -> {
-                Ast.FnDef applied = declarationOf(call.denotes(), inliner);
+                Ast.FnDef applied = declarationOf(call.denotes(), call.reachedAs(), inliner);
                 if (applied != null) {
-                    out.add(keyOf(call.denotes(), inliner));
+                    out.add(keyOf(call.denotes(), call.reachedAs()));
                 }
             }
             case Ast.Var v -> {
-                Ast.FnDef read = declarationOf(v.denotes(), inliner);
+                Ast.FnDef read = declarationOf(v.denotes(), v.reachedAs(), inliner);
                 if (read != null && read.params().isEmpty()) {
-                    out.add(keyOf(v.denotes(), inliner));
+                    out.add(keyOf(v.denotes(), v.reachedAs()));
                 }
             }
             default -> { }
@@ -222,16 +223,19 @@ final class PartialReachability {
      * today, so keeping it changes no answer; leaving it out would make that a premise of the check
      * rather than a fact about the library, and one the library could stop honouring in silence.
      */
-    private static String keyOf(ValueName denotes, HelperInliner inliner) {
+    private static String keyOf(ValueName denotes, ReachName reachedAs) {
         return switch (denotes) {
-            case ValueName.Helper helper -> HelperNames.keyIn(inliner.moduleName(), helper);
-            case ValueName.Stdlib lib -> lib.qualified();
+            // Which key it is, the reference says: settled where the name was resolved and carried
+            // here. What decides whether there is a node at all is what the name denotes — a binding
+            // spelled like a helper reaches no declaration however it is written.
+            case ValueName.Helper _, ValueName.Stdlib _ -> reachedAs.rendered();
             case null, default -> null;
         };
     }
 
-    private static Ast.FnDef declarationOf(ValueName denotes, HelperInliner inliner) {
-        String key = keyOf(denotes, inliner);
+    private static Ast.FnDef declarationOf(ValueName denotes, ReachName reachedAs,
+                                           HelperInliner inliner) {
+        String key = keyOf(denotes, reachedAs);
         return key == null ? null : inliner.helper(key);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
@@ -62,7 +62,7 @@ public record Preserved(Map<ValueName, CompleteSignature> operations) {
     private static Preserved readTheLibrary() {
         Map<ValueName, CompleteSignature> operations = new LinkedHashMap<>();
         Prelude.entries().forEach((qualified, entry) -> {
-            ValueName.Stdlib operation = new ValueName.Stdlib(qualified);
+            ValueName.Stdlib operation = Prelude.operation(qualified);
             operations.put(operation, CompleteSignature.of(
                     operation, entry.signature().params(), entry.signature().result()));
         });

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -278,7 +278,7 @@ enum Question {
     boolean asksOfOperation(String qualified) {
         Prelude.Rewrite rewrite = Prelude.rewriteOf(qualified);
         Prelude.PreludeEntry entry =
-                Prelude.entry(rewrite == null ? qualified : rewrite.target());
+                Prelude.entry(rewrite == null ? qualified : rewrite.target().qualified());
         return entry != null && asksOf(entry.signature());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -8,6 +8,7 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -593,13 +594,11 @@ public final class Resolve {
      */
     private Ast.Expr expr(Ast.Expr e, Bindings bound) {
         return switch (e) {
-            case Ast.Var v -> v.denoting(answered(v.written(), valueName(v.written(), bound)));
+            case Ast.Var v -> reached(v, bound);
             // Applying a name is answered as a name: which of a binding, a helper, a library
             // function or a type it is decides what the application means. Applying anything else
             // is answered as the expression it is, and what may be applied is the check's to say.
-            case Ast.Apply call when call.appliesAName() -> new Ast.Apply(call.written(),
-                    answered(call.name(), calledName(call, bound)),
-                    exprs(call.args(), bound), call.origin(), call.pos());
+            case Ast.Apply call when call.appliesAName() -> applied(call, bound);
             case Ast.Apply call -> new Ast.Apply(callee(call.function(), bound),
                     exprs(call.args(), bound), call.origin(), call.pos());
             // `Map.empty`, `String.isEmpty`, `up.Amount` — a namespace and a member of it, which
@@ -662,7 +661,29 @@ public final class Resolve {
      */
     private Ast.Var name(Ast.Var written, Bindings bound) {
         return written.denotes() != null ? written
-                : written.denoting(answered(written.written(), valueName(written.written(), bound)));
+                : reached(written, bound);
+    }
+
+    /**
+     * {@code v} with what it denotes and the name this module reaches it by, both answered here.
+     *
+     * <p>The two together, and only here: which module is doing the reading is what decides the reach
+     * name, and this pass is the last place that has it. A pass downstream working it out from the
+     * spelling would answer differently depending on which rewrites had run — which is the defect
+     * this carries the answer to avoid.
+     */
+    /** An application of a name, with what the name denotes and how this module reaches it answered
+     * here — the same pair, from the same place, as a name standing on its own. */
+    private Ast.Expr applied(Ast.Apply call, Bindings bound) {
+        ValueName denotes = answered(call.name(), calledName(call, bound));
+        Ast.Var name = new Ast.Var(call.name(), denotes,
+                ReachName.of(denotes, call.written(), values.module()));
+        return new Ast.Apply(name, exprs(call.args(), bound), call.origin(), call.pos());
+    }
+
+    private Ast.Var reached(Ast.Var v, Bindings bound) {
+        ValueName denotes = answered(v.written(), valueName(v.written(), bound));
+        return v.denoting(denotes, ReachName.of(denotes, v.name(), values.module()));
     }
 
     private List<Ast.ElseArm> arms(List<Ast.ElseArm> arms, Bindings bound) {
@@ -719,6 +740,9 @@ public final class Resolve {
         // A `private` declaration is the exception, and asking about it here is safe for the same
         // reason: the only modules that may name one are the library's own, and they are told yes
         // without the entry being looked up at all.
+        // Split off what the author wrote, which is where a library name enters the compiler as two
+        // values: the qualifier they typed and the operation they asked of it. Nothing downstream
+        // splits it again — from here it is carried as the pair.
         int dot = written.lastIndexOf('.');
         if (Prelude.isQualifier(dot < 0 ? written : written.substring(0, dot))) {
             if (Reserved.isNamespace(values.module()) || !Prelude.isPrivateMember(written)) {
@@ -791,7 +815,9 @@ public final class Resolve {
         WrittenName written = dottedName(fa);
         ValueName denotes = lookup(written.canonical(), applied, bound);
         if (denotes != null) {
-            return new Ast.Var(written, answered(written, denotes));
+            ValueName resolved = answered(written, denotes);
+            return new Ast.Var(written, resolved,
+                    ReachName.of(resolved, written.canonical(), values.module()));
         }
         return unknownMember(fa, written, applied, bound);
     }
@@ -815,7 +841,9 @@ public final class Resolve {
         }
         CompileException why = applied ? notCallable(written, bound)
                 : unknownIdentifier(written, bound);
-        return new Ast.Var(written, answered(written, nothing(written.canonical(), why)));
+        ValueName resolved = answered(written, nothing(written.canonical(), why));
+        return new Ast.Var(written, resolved,
+                ReachName.of(resolved, written.canonical(), values.module()));
     }
 
     /** Whether {@code qualifier} names a namespace a member may be reached through: a

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -119,7 +119,7 @@ public final class Resolve {
      */
     public record Values(String module, Map<String, ValueName.Helper> helpers,
                          Map<String, ValueName.Behavior> behaviors,
-                         Map<String, String> exposed) {
+                         Map<String, ValueName.Stdlib> exposed) {
 
         /**
          * What a module reaches when nothing else is in sight — the core modules, which the library
@@ -722,7 +722,8 @@ public final class Resolve {
         int dot = written.lastIndexOf('.');
         if (Prelude.isQualifier(dot < 0 ? written : written.substring(0, dot))) {
             if (Reserved.isNamespace(values.module()) || !Prelude.isPrivateMember(written)) {
-                return new ValueName.Stdlib(written);
+                return dot < 0 ? ValueName.Stdlib.namespace(written)
+                        : new ValueName.Stdlib(written.substring(0, dot), written.substring(dot + 1));
             }
             return null;
         }
@@ -743,8 +744,7 @@ public final class Resolve {
         // A name an import let this module write without its qualifier. Asked last: an import brings
         // a name in, and everything the module already has — a binding in force, its own
         // declarations — is what that name means here instead.
-        String qualified = values.exposed().get(written);
-        return qualified == null ? null : new ValueName.Stdlib(qualified);
+        return values.exposed().get(written);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -664,14 +664,6 @@ public final class Resolve {
                 : reached(written, bound);
     }
 
-    /**
-     * {@code v} with what it denotes and the name this module reaches it by, both answered here.
-     *
-     * <p>The two together, and only here: which module is doing the reading is what decides the reach
-     * name, and this pass is the last place that has it. A pass downstream working it out from the
-     * spelling would answer differently depending on which rewrites had run — which is the defect
-     * this carries the answer to avoid.
-     */
     /** An application of a name, with what the name denotes and how this module reaches it answered
      * here — the same pair, from the same place, as a name standing on its own. */
     private Ast.Expr applied(Ast.Apply call, Bindings bound) {
@@ -681,6 +673,14 @@ public final class Resolve {
         return new Ast.Apply(name, exprs(call.args(), bound), call.origin(), call.pos());
     }
 
+    /**
+     * {@code v} with what it denotes and the name this module reaches it by, both answered here.
+     *
+     * <p>The two together, and only here: which module is doing the reading is what decides the reach
+     * name, and this pass is the last place that has it. A pass downstream working it out from the
+     * spelling would answer differently depending on which rewrites had run — which is the defect
+     * this carries the answer to avoid.
+     */
     private Ast.Var reached(Ast.Var v, Bindings bound) {
         ValueName denotes = answered(v.written(), valueName(v.written(), bound));
         return v.denoting(denotes, ReachName.of(denotes, v.name(), values.module()));

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -8,6 +8,7 @@ import souther.compiler.types.BindingId;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
@@ -608,8 +609,8 @@ final class Terms {
                     }
                     args.add(written);
                 }
-                yield new Ast.Apply(call.operation().name(), call.operation(), args,
-                        ConstructionOrigin.own(), call.pos());
+                yield new Ast.Apply(call.operation().name(), call.operation(),
+                        reachOf(call.operation()), args, ConstructionOrigin.own(), call.pos());
             }
             case null, default -> null;
         };
@@ -682,4 +683,10 @@ final class Terms {
     static boolean isArith(Ast.BinOp op) {
         return op == Ast.BinOp.ADD || op == Ast.BinOp.SUB || op == Ast.BinOp.MUL || op == Ast.BinOp.DIV;
     }
+    /** How a preserved call's operation is reached: it is the library's, named under the alias the
+     * library publishes it under. */
+    private static ReachName reachOf(ValueName operation) {
+        return new ReachName.OfLibrary((ValueName.Stdlib) operation);
+    }
+
 }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -12,6 +12,7 @@ import souther.compiler.check.DataChecker;
 import souther.compiler.check.Lower;
 import souther.compiler.check.ReqSig;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeOps;
@@ -382,7 +383,7 @@ final class BodyGen {
             emitLine(e);
             switch (e) {
                 case Core.LetIn li -> {
-                    if (li.value() instanceof Core.Call call && requiredNames.contains(call.fn())) {
+                    if (li.value() instanceof Core.Call call && requiredNames.contains(call.name())) {
                         // call an injected required behavior; requiredCall handles both the unary
                         // Behavior contract and a multi-input base (issue #57), leaving the success
                         // value cast on the stack
@@ -432,7 +433,7 @@ final class BodyGen {
                             null);
                 }
                 case Core.Match m -> emitTailMatch(m, cdB, requiredNames, requiredSuccess, expected);
-                case Core.Call call when tcoName != null && call.fn().equals(tcoName)
+                case Core.Call call when tcoName != null && call.name().equals(tcoName)
                         && call.args().size() == tcoParams.size() -> emitSelfTailCall(call);
                 case Core.NewData nd when DataChecker.isInvariantBearing(nd.typeName(), symbols) -> {
                     ClassDesc cdType = cd(nd.typeName());
@@ -958,7 +959,7 @@ final class BodyGen {
          *  became. What it decides is whether a value being constructed can stay on the stack while its
          *  fields are built. */
         private static boolean walksInside(Core e) {
-            if (e instanceof Core.Call c && (c.fn().equals(FOLD)
+            if (e instanceof Core.Call c && (c.name().equals(FOLD)
                     || c.fn().equals(GrowingFold.BUILD) || c.fn().equals(GrowingFold.MAP_BUILD))) {
                 return true;
             }
@@ -1142,12 +1143,12 @@ final class BodyGen {
             // An enumeration's order lives on its sum, so the ordered family takes it as a comparator
             // rather than reading a Comparable off the value (issue #161). Everything else about
             // these is what their declaration says, so only this prefix is written out here.
-            if (ORDERED_BY_COMPARATOR.contains(call.fn())) {
+            if (ORDERED_BY_COMPARATOR.contains(call.name())) {
                 TypeName ordering = elementOrdering(call.args().get(0));
                 if (ordering != null) {
                     code.invokestatic(cd(ordering), ORDERING_METHOD, MTD_ordering, true);
                     genExpr(call.args().get(0));
-                    String bare = bareOp(call.fn());
+                    String bare = operationOf(call);
                     code.invokestatic(CD_Lists, bare, MethodTypeDesc.of(
                             bare.equals("sort") ? CD_List : CD_Option, CD_Comparator, CD_List));
                     return;
@@ -1155,7 +1156,7 @@ final class BodyGen {
             }
             // `sortBy` orders by what its key answers, not by what the list holds, so its comparator
             // is read off the key's result type.
-            if ("List.sortBy".equals(call.fn())
+            if ("List.sortBy".equals(call.name())
                     && call.args().get(0).type() instanceof Type.FnOf key
                     && TypeOps.orderingEnumeration(key.result(), symbols) instanceof TypeName ordering) {
                 code.invokestatic(cd(ordering), ORDERING_METHOD, MTD_ordering, true);
@@ -1169,7 +1170,7 @@ final class BodyGen {
             // A partial division answers a case rather than a number when its divisor is zero, so
             // it emits a branch. The table's row shape is one call with one result; these are
             // written out here, and their declarations still say what they take and answer.
-            switch (call.fn()) {
+            switch (call.name()) {
                 case "Int.divide" -> {
                     intDivide(call, true);
                     return;
@@ -1184,20 +1185,32 @@ final class BodyGen {
                 }
                 default -> { }
             }
-            Prelude.PreludeEntry entry = Prelude.entry(call.fn());
+            Prelude.PreludeEntry entry = Prelude.entry(call.name());
             if (entry != null && entry.declaration().body() instanceof Ast.FnBody.Intrinsic kernel) {
                 Intrinsics.emit(this, kernel.key(), call);
                 return;
             }
-            switch (call.fn()) {
-                case GrowingFold.BUILD -> buildList(call);
-                case GrowingFold.GROW -> growList(call);
-                case GrowingFold.MAP_BUILD -> buildMap(call);
-                case GrowingFold.PUT -> putIntoMap(call);
+            if (call.fn().equals(GrowingFold.BUILD)) {
+                buildList(call);
+                return;
+            }
+            if (call.fn().equals(GrowingFold.GROW)) {
+                growList(call);
+                return;
+            }
+            if (call.fn().equals(GrowingFold.MAP_BUILD)) {
+                buildMap(call);
+                return;
+            }
+            if (call.fn().equals(GrowingFold.PUT)) {
+                putIntoMap(call);
+                return;
+            }
+            switch (call.name()) {
                 case "Date", "DateTime" -> {
                     // a written date: the checker has already parsed the literal, so the text is
                     // known good and this is a plain parse of a constant string.
-                    ClassDesc cd = "Date".equals(call.fn()) ? CD_LocalDate : CD_LocalDateTime;
+                    ClassDesc cd = "Date".equals(call.name()) ? CD_LocalDate : CD_LocalDateTime;
                     code.loadConstant(((Core.Str) call.args().get(0)).value());
                     code.invokestatic(cd, "parse", MethodTypeDesc.of(cd, CD_CharSequence));
                 }
@@ -1206,20 +1219,20 @@ final class BodyGen {
                     // field of the enclosing behavior, and is applied as the value it is. This asks
                     // where the value is, not what the name means: what it means was settled when
                     // the call was elaborated, and an injected behavior is not a binding.
-                    Var behavior = captured.get(call.fn());
+                    Var behavior = captured.get(call.name());
                     if (behavior != null && behavior.type() instanceof Type.FnOf fnType) {
                         applyCaptured(call, fnType);
-                    } else if (ctx.emittedHelpers.containsKey(call.fn())) {
+                    } else if (ctx.emittedHelpers.containsKey(call.name())) {
                         // The one loop the language has is emitted where it stands, not called.
-                        if (!call.fn().equals(FOLD) || !folded(call)) {
+                        if (!call.name().equals(FOLD) || !folded(call)) {
                             recursiveHelperCall(call);
                         }
-                    } else if (reqNames.contains(call.fn())) {
+                    } else if (reqNames.contains(call.name())) {
                         requiredCall(call);
-                    } else if (ctx.calleeSig(call.fn()) != null) {
+                    } else if (ctx.calleeSig(call.name()) != null) {
                         behaviorCall(call);
                     } else {
-                        throw new CompileException(call.pos(), "unknown function `" + call.fn() + "`");
+                        throw new CompileException(call.pos(), "unknown function `" + call.name() + "`");
                     }
                 }
             }
@@ -1432,7 +1445,7 @@ final class BodyGen {
         private void invokeRecursiveHelper(Core.Call call) {
             ClassDesc[] params = new ClassDesc[call.args().size()];
             java.util.Arrays.fill(params, CD_Object);
-            code.invokestatic(ClassDesc.of(pkg + ".$Fns"), CodegenContext.helperMethod(call.fn()),
+            code.invokestatic(ClassDesc.of(pkg + ".$Fns"), CodegenContext.helperMethod(call.name()),
                     MethodTypeDesc.of(CD_Object, params));
         }
 
@@ -1440,10 +1453,10 @@ final class BodyGen {
          *  loop every fold in a program is, which is why the emitter knows its name. */
         private static final String FOLD = "List.foldFrom";
 
-        /** The operation name from a qualified builtin call ({@code "List.max"} → {@code "max"}). */
-        private static String bareOp(String fn) {
-            int dot = fn.indexOf('.');
-            return dot < 0 ? fn : fn.substring(dot + 1);
+        /** The operation a library call names ({@code List.max} → {@code max}) — read off the
+         * name, which holds the library's alias and the operation as two values. */
+        private static String operationOf(Core.Call call) {
+            return ((ReachName.OfLibrary) call.fn()).target().name();
         }
 
         /** {@code divide}/{@code remainder} on Int: a zero divisor takes the DivisionByZero case,
@@ -1516,8 +1529,8 @@ final class BodyGen {
          * {@code apply} links; one with any other arity declares a typed {@code apply} of its own.
          */
         private void behaviorCall(Core.Call call) {
-            ReqSig sig = ctx.calleeSig(call.fn());
-            ClassDesc impl = ctx.cdBehaviorImpl(call.fn());
+            ReqSig sig = ctx.calleeSig(call.name());
+            ClassDesc impl = ctx.cdBehaviorImpl(call.name());
             code.new_(impl);
             code.dup();
             code.invokespecial(impl, "<init>", MTD_void);
@@ -1525,7 +1538,7 @@ final class BodyGen {
                 Type at = genExpr(call.args().get(0));
                 box(code, at);
                 code.invokeinterface(CD_Behavior, "apply", MTD_apply);
-                project(call.fn(), sig.success());
+                project(call.name(), sig.success());
                 stackCast(sig.success());
                 return;
             }
@@ -1533,36 +1546,36 @@ final class BodyGen {
                 Type at = genExpr(arg);
                 box(code, at);
             }
-            code.invokeinterface(ctx.cdBehavior(call.fn()), "apply",
-                    ctx.typedApplyDesc(call.fn(), sig.params(), sig.success()));
-            project(call.fn(), sig.success());
+            code.invokeinterface(ctx.cdBehavior(call.name()), "apply",
+                    ctx.typedApplyDesc(call.name(), sig.params(), sig.success()));
+            project(call.name(), sig.success());
             stackCast(sig.success());
         }
 
         private void requiredCall(Core.Call call) {
-            Type success = reqSuccess.get(call.fn());
-            if (ctx.isStandaloneRequired(call.fn())) {
+            Type success = reqSuccess.get(call.name());
+            if (ctx.isStandaloneRequired(call.name())) {
                 // other than one input: the required behavior is its own base class, called with a
                 // typed invokevirtual apply(A,B,…); each arg is left as its declared param type
                 // (issue #57). A `() -> R` produces, so the call hands it nothing.
-                MethodTypeDesc desc = ctx.requiredApplyDesc(call.fn());
+                MethodTypeDesc desc = ctx.requiredApplyDesc(call.name());
                 code.aload(0);
-                code.getfield(cdName, call.fn(), ctx.cdBehavior(call.fn()));
+                code.getfield(cdName, call.name(), ctx.cdBehavior(call.name()));
                 for (Core arg : call.args()) {
                     Type at = genExpr(arg);
                     box(code, at);   // a primitive boxes to its apply-param type; a reference already matches
                 }
-                code.invokevirtual(ctx.cdBehavior(call.fn()), "apply", desc);
-                project(call.fn(), success);
+                code.invokevirtual(ctx.cdBehavior(call.name()), "apply", desc);
+                project(call.name(), success);
                 stackCast(success);
                 return;
             }
             code.aload(0);
-            code.getfield(cdName, call.fn(), CD_Behavior);
+            code.getfield(cdName, call.name(), CD_Behavior);
             Type at = genExpr(call.args().get(0));
             box(code, at);
             code.invokeinterface(CD_Behavior, "apply", MTD_apply);
-            project(call.fn(), success);
+            project(call.name(), success);
             stackCast(success);
         }
 
@@ -1877,7 +1890,7 @@ final class BodyGen {
 
         /** The same, for an injected behavior a lambda captured into a slot of its own class. */
         private void applyCaptured(Core.Call call, Type.FnOf fnType) {
-            applyValue(captured.get(call.fn()), call.args(), fnType);
+            applyValue(captured.get(call.name()), call.args(), fnType);
         }
 
         private void applyValue(Var fv, List<Core> args, Type.FnOf fnType) {
@@ -1932,8 +1945,8 @@ final class BodyGen {
                 case Core.Call c -> {
                     // an injected behavior the body calls is handed over too: the lambda is a class
                     // of its own, and what it reaches has to reach it
-                    if (reqNames.contains(c.fn())) {
-                        free.behaviors.add(c.fn());
+                    if (reqNames.contains(c.name())) {
+                        free.behaviors.add(c.name());
                     }
                     c.args().forEach(a -> collectFree(a, bound, free));
                 }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -960,7 +960,7 @@ final class BodyGen {
          *  fields are built. */
         private static boolean walksInside(Core e) {
             if (e instanceof Core.Call c && (c.name().equals(FOLD)
-                    || c.fn().equals(GrowingFold.BUILD) || c.fn().equals(GrowingFold.MAP_BUILD))) {
+                    || c.fn() == Core.Emitted.BUILD_LIST || c.fn() == Core.Emitted.BUILD_MAP)) {
                 return true;
             }
             boolean[] found = {false};
@@ -1190,19 +1190,19 @@ final class BodyGen {
                 Intrinsics.emit(this, kernel.key(), call);
                 return;
             }
-            if (call.fn().equals(GrowingFold.BUILD)) {
+            if (call.fn() == Core.Emitted.BUILD_LIST) {
                 buildList(call);
                 return;
             }
-            if (call.fn().equals(GrowingFold.GROW)) {
+            if (call.fn() == Core.Emitted.GROW_LIST) {
                 growList(call);
                 return;
             }
-            if (call.fn().equals(GrowingFold.MAP_BUILD)) {
+            if (call.fn() == Core.Emitted.BUILD_MAP) {
                 buildMap(call);
                 return;
             }
-            if (call.fn().equals(GrowingFold.PUT)) {
+            if (call.fn() == Core.Emitted.PUT_MAP) {
                 putIntoMap(call);
                 return;
             }
@@ -1456,7 +1456,8 @@ final class BodyGen {
         /** The operation a library call names ({@code List.max} → {@code max}) — read off the
          * name, which holds the library's alias and the operation as two values. */
         private static String operationOf(Core.Call call) {
-            return ((ReachName.OfLibrary) call.fn()).target().name();
+            Core.Reached reached = (Core.Reached) call.fn();
+            return ((ReachName.OfLibrary) reached.name()).target().name();
         }
 
         /** {@code divide}/{@code remainder} on Int: a zero divisor takes the DivisionByZero case,

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -64,18 +64,95 @@ public sealed interface Core {
     record Binary(Ast.BinOp op, Core left, Core right, Type type, SourcePos pos) implements Core {}
 
     /**
+     * What a call applies.
+     *
+     * <p>Two things reach this far and they are not the same kind of thing. One is a callee some
+     * module named, which resolution answered and the tree carried here. The other is an operation
+     * this compiler emits and no source can write: a Core-to-Core pass mints it after everything has
+     * been resolved and type-checked, and it stands for a shape the backend knows how to lower.
+     *
+     * <p>They are held apart because a {@link ReachName} is the name a module reaches a definition
+     * by, and an operation nothing declares is not that. Written as one, the type would say a name
+     * had been resolved where nothing resolved it — which is the confusion the reach name was
+     * separated out to end.
+     */
+    sealed interface CallTarget {
+
+        /** What a report quotes and, for a call the backend emits as a method, what the method is
+         * named after. */
+        String rendered();
+    }
+
+    /** A callee some module named, under the name that module reaches it by. */
+    record Reached(ReachName name) implements CallTarget {
+
+        @Override
+        public String rendered() {
+            return name.rendered();
+        }
+
+        @Override
+        public String toString() {
+            return rendered();
+        }
+    }
+
+    /**
+     * An operation this compiler emits, which no source names and no module declares.
+     *
+     * <p>Each is minted by a Core-to-Core pass ({@link GrowingFold}) for a shape the backend lowers
+     * as a whole. The backend matches on the operation rather than on a spelling of it; what it
+     * renders as is for a report to quote.
+     */
+    enum Emitted implements CallTarget {
+
+        /** {@code $build(step, xs, from)} — the walk that grows a list into a builder and seals it. */
+        BUILD_LIST("List.$build"),
+        /** The {@code acc ++ …} inside a rewritten step, adding to the builder the walk carries. */
+        GROW_LIST("List.$grow"),
+        /** The same walk for a fold accumulating a map. */
+        BUILD_MAP("Map.$build"),
+        /** The step's write into the map builder. */
+        PUT_MAP("Map.$put");
+
+        private final String rendered;
+
+        Emitted(String rendered) {
+            this.rendered = rendered;
+        }
+
+        @Override
+        public String rendered() {
+            return rendered;
+        }
+
+        @Override
+        public String toString() {
+            return rendered;
+        }
+    }
+
+    /**
      * A call to a builtin, an injected behavior, an intrinsic, or a recursive helper emitted as a
      * method — none of them bound by this body. A non-recursive helper is already inlined.
      *
-     * <p>{@code fn} is the name the module being emitted reaches the callee by, carried from where
-     * resolution settled it. Held as what it is rather than as the spelling of it: the backend needs
-     * both the whole name, to emit the method it calls, and the operation inside it, to reach the
-     * runtime method a library call becomes — and taking the second out of the first meant splitting
-     * a name this compiler had joined a moment earlier.
+     * <p>{@code fn} says what is applied ({@link CallTarget}). Where that is a name, it is the one
+     * the module being emitted reaches the callee by, carried from where resolution settled it, and
+     * held as what it is rather than as the spelling of it: the backend needs both the whole name, to
+     * emit the method it calls, and the operation inside it, to reach the runtime method a library
+     * call becomes — and taking the second out of the first meant splitting a name this compiler had
+     * joined a moment earlier.
      */
-    record Call(ReachName fn, List<Core> args, Type type, SourcePos pos) implements Core {
+    record Call(CallTarget fn, List<Core> args, Type type, SourcePos pos) implements Core {
 
-        /** The name as it is written — what a method name is built from and what a report quotes. */
+        /** A call to a name, as the name it reaches. */
+        public Call(ReachName fn, List<Core> args, Type type, SourcePos pos) {
+            this(new Reached(fn), args, type, pos);
+        }
+
+        /** The callee as it renders — the reach name for a call to one, the operation's own
+         * spelling for one this compiler emits. What a method name is built from and what a report
+         * quotes; never what a source wrote. */
         public String name() {
             return fn.rendered();
         }

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -1,6 +1,7 @@
 package souther.compiler.core;
 
 import souther.compiler.types.BindingId;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -62,10 +63,23 @@ public sealed interface Core {
 
     record Binary(Ast.BinOp op, Core left, Core right, Type type, SourcePos pos) implements Core {}
 
-    /** A call to a builtin, an injected behavior, an intrinsic, or a recursive helper emitted as a
-     * method — each reached by the name it is declared under, none of them bound by this body. A
-     * non-recursive helper is already inlined. */
-    record Call(String fn, List<Core> args, Type type, SourcePos pos) implements Core {}
+    /**
+     * A call to a builtin, an injected behavior, an intrinsic, or a recursive helper emitted as a
+     * method — none of them bound by this body. A non-recursive helper is already inlined.
+     *
+     * <p>{@code fn} is the name the module being emitted reaches the callee by, carried from where
+     * resolution settled it. Held as what it is rather than as the spelling of it: the backend needs
+     * both the whole name, to emit the method it calls, and the operation inside it, to reach the
+     * runtime method a library call becomes — and taking the second out of the first meant splitting
+     * a name this compiler had joined a moment earlier.
+     */
+    record Call(ReachName fn, List<Core> args, Type type, SourcePos pos) implements Core {
+
+        /** The name as it is written — what a method name is built from and what a report quotes. */
+        public String name() {
+            return fn.rendered();
+        }
+    }
 
     /**
      * A call a representation kept standing on purpose: resolved to the declaration it names, typed

--- a/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
@@ -2,8 +2,6 @@ package souther.compiler.core;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.types.BindingId;
-import souther.compiler.types.ReachName;
-import souther.compiler.types.ValueName;
 import souther.compiler.types.Type;
 
 import java.util.ArrayList;
@@ -51,22 +49,19 @@ public final class GrowingFold {
     private static final String FOLD = "List.foldFrom";
 
     /** The rewritten fold: {@code $build(step, xs, from)} walks {@code xs} with a builder as the
-     *  accumulator and seals it into a list. Emitted by the backend, written by nobody. */
-    public static final ReachName BUILD =
-            new ReachName.OfLibrary(new ValueName.Stdlib("List", "$build"));
+     *  accumulator and seals it into a list. Emitted by the backend, written by nobody — so it is
+     *  one of the operations this compiler emits and not a name any module reaches. */
+    private static final Core.CallTarget BUILD = Core.Emitted.BUILD_LIST;
 
     /** The {@code acc ++ …} inside a rewritten step: it adds to the builder the walk carries and
      *  answers with it. Only ever reached from {@link #BUILD}'s step. */
-    public static final ReachName GROW =
-            new ReachName.OfLibrary(new ValueName.Stdlib("List", "$grow"));
+    private static final Core.CallTarget GROW = Core.Emitted.GROW_LIST;
 
     /** The same for a fold accumulating a map: the walk carries a builder and hands over the map it
      *  built, and the step's {@code Map.insert} writes into it. */
-    public static final ReachName MAP_BUILD =
-            new ReachName.OfLibrary(new ValueName.Stdlib("Map", "$build"));
+    private static final Core.CallTarget MAP_BUILD = Core.Emitted.BUILD_MAP;
 
-    public static final ReachName PUT =
-            new ReachName.OfLibrary(new ValueName.Stdlib("Map", "$put"));
+    private static final Core.CallTarget PUT = Core.Emitted.PUT_MAP;
 
     /** The empty map a fold accumulating one starts from, and the insert that grows it. */
     private static final String EMPTY = "Map.empty";
@@ -94,7 +89,7 @@ public final class GrowingFold {
                 mapped = built;
             }
         }
-        if (mapped instanceof Core.Call call && call.fn().equals(BUILD)) {
+        if (mapped instanceof Core.Call call && call.fn() == BUILD) {
             Core joined = joined(call);
             if (joined != null) {
                 return joined;
@@ -121,7 +116,7 @@ public final class GrowingFold {
      * step — which is checked for rather than reasoned about.
      */
     private static Core joinedThroughBinding(Core.LetIn binding) {
-        if (!(binding.body() instanceof Core.Call outer) || !outer.fn().equals(BUILD)
+        if (!(binding.body() instanceof Core.Call outer) || outer.fn() != BUILD
                 || !(outer.args().get(1) instanceof Core.Read walked)
                 || !walked.binding().equals(binding.binder().id())
                 || uses(binding.body(), binding.binder().id()) != 1) {
@@ -133,7 +128,7 @@ public final class GrowingFold {
             kept.add(nested);
             value = nested.body();
         }
-        if (!(value instanceof Core.Call inner) || !inner.fn().equals(BUILD)) {
+        if (!(value instanceof Core.Call inner) || inner.fn() != BUILD) {
             return null;
         }
         for (Core.LetIn k : kept) {
@@ -160,7 +155,7 @@ public final class GrowingFold {
             return null;
         }
         Core seed = call.args().get(1);
-        ReachName build;
+        Core.CallTarget build;
         Core step;
         if (call.type() instanceof Type.ListOf
                 && seed instanceof Core.ListLit lit && lit.elements().isEmpty()) {
@@ -286,7 +281,7 @@ public final class GrowingFold {
         if (!(build.args().get(2) instanceof Core.Int from) || from.value() != 0) {
             return null;
         }
-        if (!(build.args().get(1) instanceof Core.Call inner) || !inner.fn().equals(BUILD)) {
+        if (!(build.args().get(1) instanceof Core.Call inner) || inner.fn() != BUILD) {
             return null;
         }
         if (!(build.args().get(0) instanceof Core.Block outer) || outer.params().size() != 2
@@ -312,7 +307,7 @@ public final class GrowingFold {
         if (e instanceof Core.Block) {
             return 0;
         }
-        int[] n = {e instanceof Core.Call c && c.fn().equals(GROW) ? 1 : 0};
+        int[] n = {e instanceof Core.Call c && c.fn() == GROW ? 1 : 0};
         Core.forEachChild(e, child -> n[0] += adds(child));
         return n[0];
     }
@@ -325,7 +320,7 @@ public final class GrowingFold {
         if (refused[0] || e instanceof Core.Block) {
             return e;
         }
-        if (e instanceof Core.Call c && c.fn().equals(GROW)) {
+        if (e instanceof Core.Call c && c.fn() == GROW) {
             if (!(c.args().get(1) instanceof Core.ListLit lit) || lit.elements().size() != 1) {
                 refused[0] = true;   // the add hands over a list, and the outer step takes an element
                 return e;

--- a/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/GrowingFold.java
@@ -2,6 +2,8 @@ package souther.compiler.core;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.ReachName;
+import souther.compiler.types.ValueName;
 import souther.compiler.types.Type;
 
 import java.util.ArrayList;
@@ -50,17 +52,21 @@ public final class GrowingFold {
 
     /** The rewritten fold: {@code $build(step, xs, from)} walks {@code xs} with a builder as the
      *  accumulator and seals it into a list. Emitted by the backend, written by nobody. */
-    public static final String BUILD = "List.$build";
+    public static final ReachName BUILD =
+            new ReachName.OfLibrary(new ValueName.Stdlib("List", "$build"));
 
     /** The {@code acc ++ …} inside a rewritten step: it adds to the builder the walk carries and
      *  answers with it. Only ever reached from {@link #BUILD}'s step. */
-    public static final String GROW = "List.$grow";
+    public static final ReachName GROW =
+            new ReachName.OfLibrary(new ValueName.Stdlib("List", "$grow"));
 
     /** The same for a fold accumulating a map: the walk carries a builder and hands over the map it
      *  built, and the step's {@code Map.insert} writes into it. */
-    public static final String MAP_BUILD = "Map.$build";
+    public static final ReachName MAP_BUILD =
+            new ReachName.OfLibrary(new ValueName.Stdlib("Map", "$build"));
 
-    public static final String PUT = "Map.$put";
+    public static final ReachName PUT =
+            new ReachName.OfLibrary(new ValueName.Stdlib("Map", "$put"));
 
     /** The empty map a fold accumulating one starts from, and the insert that grows it. */
     private static final String EMPTY = "Map.empty";
@@ -150,18 +156,18 @@ public final class GrowingFold {
 
     /** {@code call} as a build, or null when it is not a fold that only grows a list or a map. */
     private static Core built(Core.Call call) {
-        if (!call.fn().equals(FOLD) || call.args().size() != 4) {
+        if (!call.name().equals(FOLD) || call.args().size() != 4) {
             return null;
         }
         Core seed = call.args().get(1);
-        String build;
+        ReachName build;
         Core step;
         if (call.type() instanceof Type.ListOf
                 && seed instanceof Core.ListLit lit && lit.elements().isEmpty()) {
             build = BUILD;
             step = grownStep(call.args().get(0));
         } else if (call.type() instanceof Type.MapOf
-                && seed instanceof Core.Call empty && empty.fn().equals(EMPTY)) {
+                && seed instanceof Core.Call empty && empty.name().equals(EMPTY)) {
             build = MAP_BUILD;
             step = puttingStep(call.args().get(0));
         } else {
@@ -246,7 +252,7 @@ public final class GrowingFold {
      *  mentions {@link #puttingStep} counts, and a mention that is none of the three refuses the walk. */
     private static int reads(Core e, Set<BindingId> acc) {
         int[] n = {0};
-        count(e, c -> c instanceof Core.Call call && READS.contains(call.fn())
+        count(e, c -> c instanceof Core.Call call && READS.contains(call.name())
                 && !call.args().isEmpty()
                 && call.args().getLast() instanceof Core.Read v && acc.contains(v.binding()), n);
         return n[0];
@@ -375,7 +381,7 @@ public final class GrowingFold {
 
     /** {@code Map.insert(key, value, acc)} as a write into the builder. */
     private static Core inserted(Core e, Set<BindingId> acc) {
-        if (!(e instanceof Core.Call c) || !c.fn().equals(INSERT) || c.args().size() != 3
+        if (!(e instanceof Core.Call c) || !c.name().equals(INSERT) || c.args().size() != 3
                 || !(c.args().get(2) instanceof Core.Read v) || !acc.contains(v.binding())) {
             return null;
         }

--- a/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
@@ -105,7 +105,7 @@ public final class ApiCommand {
             }
         }
         for (Map.Entry<String, Prelude.Rewrite> e : Prelude.rewrites().entrySet()) {
-            Prelude.PreludeEntry target = Prelude.entry(e.getValue().target());
+            Prelude.PreludeEntry target = Prelude.entry(e.getValue().target().qualified());
             if (target != null) {
                 surface.put(e.getKey(), declared(target, e.getValue().keptArgs()));
             }

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -384,7 +384,7 @@ public final class AstBuilder {
                     // one ident past the keyword is the `on` of `depends on`, which lexes as an
                     // ordinary identifier and is no part of the list
                     for (Ast.Name dep : dottedNames(clause, 1)) {
-                        dependsOn.add(new Ast.Var(dep.name(), null));
+                        dependsOn.add(new Ast.Var(dep.name(), null, null));
                     }
                 }
             }
@@ -393,7 +393,7 @@ public final class AstBuilder {
         SyntaxNode pipe = n.child(SyntaxKind.PIPE_BEHAVIOR).orElseThrow();
         List<Ast.Var> stages = new ArrayList<>();
         for (SyntaxNode st : childNodes(pipe, SyntaxKind.STAGE)) {
-            stages.add(new Ast.Var(qualifiedNameOf(st), null));
+            stages.add(new Ast.Var(qualifiedNameOf(st), null, null));
         }
         Ast.RetType declaredOut = pipe.child(SyntaxKind.RET_TYPE).map(this::retType).orElse(null);
         return new Ast.PipeBehavior(declared, stages, declaredOut, pos);
@@ -640,7 +640,7 @@ public final class AstBuilder {
     private Ast.Expr expr(SyntaxNode n) {
         return switch (n.kind()) {
             case LITERAL_EXPR -> literal(n);
-            case VAR_EXPR -> new Ast.Var(nameOf(firstIdentToken(n)), null);
+            case VAR_EXPR -> new Ast.Var(nameOf(firstIdentToken(n)), null, null);
             case FIELD_ACCESS -> fieldAccess(n);
             case APPLY_EXPR -> apply(n);
             case BINARY_EXPR -> binary(n);
@@ -887,10 +887,10 @@ public final class AstBuilder {
             if (c.kind() == SyntaxKind.SPREAD_MEMBER) {
                 List<SyntaxToken> path = identTokens(c);
                 if (path.size() == 1) {
-                    spreads.add(new Ast.Var(nameOf(path.get(0)), null));
+                    spreads.add(new Ast.Var(nameOf(path.get(0)), null, null));
                 } else {
                     String bound = "$s" + (spreadCounter++);
-                    Ast.Expr value = new Ast.Var(nameOf(path.get(0)), null);
+                    Ast.Expr value = new Ast.Var(nameOf(path.get(0)), null, null);
                     for (int i = 1; i < path.size(); i++) {
                         value = new Ast.FieldAccess(value, nameOf(path.get(i)),
                                 posOf(path.get(i)));
@@ -905,7 +905,7 @@ public final class AstBuilder {
                 WrittenName field = nameOf(firstIdentToken(c));
                 Optional<SyntaxNode> value = firstExprChildOpt(c);
                 // shorthand `field` means `field = field`, and the one name is both
-                Ast.Expr v = value.isPresent() ? expr(value.get()) : new Ast.Var(field, null);
+                Ast.Expr v = value.isPresent() ? expr(value.get()) : new Ast.Var(field, null, null);
                 inits.add(new Ast.FieldInit(field, v));
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import java.math.BigDecimal;
@@ -92,13 +93,15 @@ public record FixtureTemplate(String text, Ast.Expr value) {
     /** The absent optional, which the language names rather than any module. */
     public static FixtureTemplate none() {
         return new FixtureTemplate("None",
-                new Ast.Var("None", new ValueName.Builtin("None"), NOWHERE));
+                new Ast.Var("None", new ValueName.Builtin("None"), new ReachName.Bare("None"),
+                        NOWHERE));
     }
 
     /** A case that carries nothing: naming it is constructing it. */
     public static FixtureTemplate unitCase(TypeName type) {
         return new FixtureTemplate(type.name(), new Ast.Var(type.name(),
-                new ValueName.OfType(type.name(), type, ConstructionOrigin.own()), NOWHERE));
+                new ValueName.OfType(type.name(), type, ConstructionOrigin.own()),
+                new ReachName.Bare(type.name()), NOWHERE));
     }
 
     /** A newtype around one value, written in the call form a row writes it in (ADR-0032). */

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -9,6 +9,7 @@ import souther.compiler.check.Exposing;
 import souther.compiler.frontend.CstFrontend;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.meta.PublishedModule;
+import souther.compiler.types.ValueName;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -418,14 +419,14 @@ public final class Front {
      * <p>Read from the module as its source declared it, because {@link Exposed} drops the import
      * lines once it has checked them: what they brought in outlives the lines themselves.
      */
-    public record LibraryNames(String name) implements Key<Map<String, String>> {
+    public record LibraryNames(String name) implements Key<Map<String, ValueName.Stdlib>> {
         @Override
         public String module() {
             return name;
         }
 
         @Override
-        public Answer<Map<String, String>> compute(Db db) {
+        public Answer<Map<String, ValueName.Stdlib>> compute(Db db) {
             Layout.Of layout = db.ask(new Layout()).value();
             if (layout == null) {
                 return Answer.absent();

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -926,7 +926,7 @@ public final class Names {
             }
         }
         BehaviorsInScope.Of behaviors = db.ask(new BehaviorsInScope(m.name())).value();
-        Map<String, String> exposed = db.ask(new Front.LibraryNames(m.name())).value();
+        Map<String, ValueName.Stdlib> exposed = db.ask(new Front.LibraryNames(m.name())).value();
         return new Resolve.Values(m.name(), helpers,
                 behaviors == null ? Map.of() : behaviors.byName(),
                 exposed == null ? Map.of() : exposed);

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -16,6 +16,7 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.TypeName;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import java.util.ArrayList;
@@ -302,7 +303,7 @@ public final class Names {
                 // The module is one this compilation has and could not read. What is wrong with it
                 // is reported on its own source; saying anything here sends the author to a file
                 // that is fine.
-                return ref.denoting(new ValueName.Unresolved(written));
+                return reached(ref, new ValueName.Unresolved(written));
             }
             if (!declared.value().contains(bare)) {
                 return nothing(ref, unknown.report(ref, declared.value()));
@@ -311,25 +312,36 @@ public final class Names {
                 added.computeIfAbsent(target, k -> new LinkedHashSet<>()).add(bare);
                 at.putIfAbsent(target, ref.pos());
             }
-            return ref.denoting(new ValueName.Behavior(target, bare));
+            return reached(ref, new ValueName.Behavior(target, bare));
         }
 
         /** A bare name: this module's own behavior, or one an import brought in. */
         private Ast.Var bare(Ast.Var ref, String written, Unknown unknown) {
             BehaviorsInScope.Of scope = db.ask(new BehaviorsInScope(m.name())).value();
             if (scope == null) {
-                return ref.denoting(new ValueName.Unresolved(written));
+                return reached(ref, new ValueName.Unresolved(written));
             }
             ValueName.Behavior named = scope.byName().get(written);
             if (named != null) {
-                return ref.denoting(named);
+                return reached(ref, named);
             }
             if (!scope.whole()) {
                 // An import that could not be followed may have been where this name came from.
                 // Whatever is wrong with that module is reported there.
-                return ref.denoting(new ValueName.Unresolved(written));
+                return reached(ref, new ValueName.Unresolved(written));
             }
             return nothing(ref, unknown.report(ref, scope.byName().keySet()));
+        }
+
+        /**
+         * {@code ref} denoting {@code name}, and reached as this module reaches it.
+         *
+         * <p>Both answers together, from the one place that has them. A behavior is reached by the
+         * name written here — bare, or under the module a qualified reference names — and so is a
+         * name nothing answers to, which keeps the spelling for a report to quote.
+         */
+        private Ast.Var reached(Ast.Var ref, ValueName name) {
+            return ref.denoting(name, ReachName.of(name, ref.name(), m.name()));
         }
 
         /** What to say about a name no behavior answers to, given the names that were reachable. */
@@ -351,7 +363,7 @@ public final class Names {
         /** Records why a name denotes nothing, and gives it the name that says so. */
         private Ast.Var nothing(Ast.Var ref, Report report) {
             reports.add(report);
-            return ref.denoting(new ValueName.Unresolved(ref.name()));
+            return reached(ref, new ValueName.Unresolved(ref.name()));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/types/ReachName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ReachName.java
@@ -1,0 +1,113 @@
+package souther.compiler.types;
+
+/**
+ * The name a module reaches a definition by, from the place that named it.
+ *
+ * <p>Not the definition's identity. Which module declares something is a fact about the declaration
+ * and is written there ({@code Ast.FnDef#declaredIn}); this is a fact about the reference, and the two
+ * cannot be derived from each other. {@code souther.list} declares {@code foldFrom} and a reader
+ * reaches it as {@code List.foldFrom}: the alias belongs to the reference, and the declaring module is
+ * nowhere in it.
+ *
+ * <p>Settled where a name is resolved, which is the one place that has both what the name denotes and
+ * the module doing the reading. Every pass after that carries it, and none works it out again from a
+ * spelling: a reader that took the spelling would answer one thing before the pass that writes
+ * imported names qualified and another after — silently, because a miss is what a table does with a
+ * key it has not got.
+ *
+ * <p>The interface is sealed and the switches over it carry no {@code default}, so a shape added here
+ * is a compile error at every place that reads one rather than something quietly taken for another.
+ */
+public sealed interface ReachName {
+
+    /** The spelling this reach name is written as — what a table keyed by names is looked up with,
+     * and what a report quotes where it has nothing better. */
+    String rendered();
+
+    /**
+     * A name reached as it stands: what the module declares itself, a binding in force, a behavior it
+     * can call, a type used as a value.
+     *
+     * <p>What these have in common is that no qualifier gets between the reference and what it
+     * reaches, so the name is the whole of it.
+     */
+    record Bare(String name) implements ReachName {
+
+        @Override
+        public String rendered() {
+            return name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    /**
+     * A definition another module declares, reached under that module's name.
+     *
+     * <p>Here the reach name and the declaration's identity do coincide, and they coincide by
+     * accident of how a user module is reached rather than by rule — {@link OfLibrary} is the same
+     * relation with a different answer, and is what shows the two are separate values.
+     */
+    record OfModule(String module, String name) implements ReachName {
+
+        @Override
+        public String rendered() {
+            return module + "." + name;
+        }
+
+        @Override
+        public String toString() {
+            return rendered();
+        }
+    }
+
+    /**
+     * A standard-library name, reached under the alias the library publishes it under.
+     *
+     * <p>It holds the denotation rather than an alias and a name of its own: the library already says
+     * which of its two shapes this is — an operation of a module it publishes, or the module applied
+     * as a constructor ({@code Date("2026-09-30")}) — and copying that distinction into a second
+     * optional field here would be the same fact written twice.
+     */
+    record OfLibrary(ValueName.Stdlib target) implements ReachName {
+
+        @Override
+        public String rendered() {
+            return target.qualified();
+        }
+
+        @Override
+        public String toString() {
+            return rendered();
+        }
+    }
+
+    /**
+     * How {@code denotes} is reached from {@code self}, where it was written {@code written}.
+     *
+     * <p>The one place a reach name is worked out. It takes the module doing the reading because that
+     * is what decides the answer for a helper: the module's own is reached bare and another's under
+     * the module that declares it, and neither the declaration nor the spelling says which case this
+     * is on its own.
+     */
+    static ReachName of(ValueName denotes, String written, String self) {
+        if (self == null) {
+            throw new IllegalArgumentException("which module is reading decides this: " + written);
+        }
+        return switch (denotes) {
+            case null -> new Bare(written);
+            case ValueName.Helper helper -> helper.module().equals(self)
+                    ? new Bare(helper.name()) : new OfModule(helper.module(), helper.name());
+            case ValueName.Stdlib library -> new OfLibrary(library);
+            // Each of these is reached by the name it is written with. A binding is named where it is
+            // bound, a behavior and a type by what this module calls them, and a name that denotes
+            // nothing keeps the spelling so that a report quotes what was written.
+            case ValueName.Local _, ValueName.Behavior _, ValueName.OfType _, ValueName.Builtin _,
+                    ValueName.Unresolved _ -> new Bare(written);
+        };
+    }
+
+}

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -65,14 +65,36 @@ public sealed interface ValueName {
          * The namespace itself, applied: {@code Date("2026-09-30")} constructs from the module the
          * alias names, and there is no operation for it to name.
          *
-         * <p>The second shape a library name has, and the reason the operation may be absent. A
-         * caller that has to tell the two apart asks whether {@link #name()} is the alias.
+         * <p>The second shape a library name has, and the reason the operation may be absent. Which
+         * of the two this is, {@link #isNamespace()} says — not the spelling: an operation a library
+         * gave its own module's name would render the same either way, and telling them apart by
+         * comparing renderings is the reading-a-name-back-out this type exists to stop.
          */
         public static Stdlib namespace(String alias) {
             return new Stdlib(alias, null);
         }
 
-        /** What is reached: the operation, or the namespace where the alias was applied itself. */
+        /** An operation of the library module published as {@code alias}. */
+        public static Stdlib operation(String alias, String name) {
+            if (name == null) {
+                throw new IllegalArgumentException("an operation has a name: " + alias);
+            }
+            return new Stdlib(alias, name);
+        }
+
+        /** Whether this is the namespace applied rather than an operation of it. */
+        public boolean isNamespace() {
+            return name == null;
+        }
+
+        /** The operation this reaches, or null where it is the namespace itself. */
+        public String operation() {
+            return name;
+        }
+
+        /** What is reached: the operation, or the namespace where the alias was applied itself.
+         * Two shapes can answer one string, so a caller asking which shape it is asks
+         * {@link #isNamespace()}. */
         @Override
         public String name() {
             return name == null ? alias : name;

--- a/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/ValueName.java
@@ -42,21 +42,50 @@ public sealed interface ValueName {
     }
 
     /**
-     * A standard-library function, under the qualified name the library is keyed by
-     * ({@code List.map}, {@code String.trim}). A prelude helper, a prelude intrinsic and a checker
+     * A standard-library function: the alias the library publishes it under ({@code List}) and the
+     * operation that alias reaches ({@code map}). A prelude helper, a prelude intrinsic and a checker
      * built-in are one thing to a name: what is on the other side of the name is the library's own
      * business.
+     *
+     * <p>The alias is not the module that declares the operation and cannot be made into one:
+     * {@code souther.list} declares {@code foldFrom}, and a reader reaches it as
+     * {@code List.foldFrom}. Both parts are held here so that a reader wanting one of them takes it
+     * rather than splitting {@link #qualified()} back apart — a name written by joining two values is
+     * a name somebody downstream will try to read them back out of.
      */
-    record Stdlib(String qualified) implements ValueName {
+    record Stdlib(String alias, String name) implements ValueName {
 
+        public Stdlib {
+            if (alias == null) {
+                throw new IllegalArgumentException("a library name is reached under an alias");
+            }
+        }
+
+        /**
+         * The namespace itself, applied: {@code Date("2026-09-30")} constructs from the module the
+         * alias names, and there is no operation for it to name.
+         *
+         * <p>The second shape a library name has, and the reason the operation may be absent. A
+         * caller that has to tell the two apart asks whether {@link #name()} is the alias.
+         */
+        public static Stdlib namespace(String alias) {
+            return new Stdlib(alias, null);
+        }
+
+        /** What is reached: the operation, or the namespace where the alias was applied itself. */
         @Override
         public String name() {
-            return qualified;
+            return name == null ? alias : name;
+        }
+
+        /** The name the library is keyed by, and the one a reader reaches it under. */
+        public String qualified() {
+            return name == null ? alias : alias + "." + name;
         }
 
         @Override
         public String toString() {
-            return qualified;
+            return qualified();
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/AnUnmarkedHelperMayNotReachAPartialOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnUnmarkedHelperMayNotReachAPartialOneTest.java
@@ -1,9 +1,9 @@
 package souther.compiler;
 
-import souther.compiler.check.HelperNames;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.Located;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -507,17 +507,19 @@ class AnUnmarkedHelperMayNotReachAPartialOneTest {
         assertTrue(e.getMessage().contains("offset -> maths.seed"), e.getMessage());
     }
 
-    /** That lookup rule, on its own. A helper of another module is filed under its qualified name and
-     * one of this module's under its bare name, and which of the two a name is depends on what it
-     * denotes. Keying by the spelling would answer differently before and after the pass that writes an
-     * imported name out qualified, and a table answers a key it has not got with silence. */
+    /** That lookup rule, on its own. A helper of another module is reached under its qualified name
+     * and one of this module's under its bare name, and which of the two it is depends on what it
+     * denotes and on who is reading. Taken off the spelling it would answer differently before and
+     * after the pass that writes an imported name out qualified, and a table answers a key it has not
+     * got with silence. */
     @Test
-    void aHelperIsKeyedByWhatItDenotesRatherThanByHowItIsWritten() {
+    void aHelperIsReachedByWhatItDenotesRatherThanByHowItIsWritten() {
         ValueName.Helper foreign = new ValueName.Helper("maths", "spin");
         ValueName.Helper own = new ValueName.Helper("order", "spin");
 
-        assertEquals("maths.spin", HelperNames.keyIn("order", foreign));
-        assertEquals("spin", HelperNames.keyIn("order", own));
+        assertEquals(new ReachName.OfModule("maths", "spin"),
+                ReachName.of(foreign, "spin", "order"));
+        assertEquals(new ReachName.Bare("spin"), ReachName.of(own, "spin", "order"));
     }
 
     /** An imported `partial` helper may not be handed over either. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantImportedDefinitionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantImportedDefinitionTest.java
@@ -94,6 +94,47 @@ class CompileInvariantImportedDefinitionTest {
         assertEquals("Err", Codecs.decode(loader, "ids.V", "abcd").getClass().getSimpleName());
     }
 
+    /**
+     * An invariant may name a helper of this module, and that helper's body may call an imported one.
+     *
+     * <p>The invariant is expanded before the bodies are written qualified, so a call reached through
+     * this module's own helper is met while the tree still spells the imported name bare. What it
+     * reaches is settled at resolution and does not depend on which passes have run since: a table
+     * keyed by the name a call reaches is looked up with the same key on either side of any of them.
+     */
+    @Test
+    void anInvariantNamesAnOwnHelperThatCallsAnImportedOne() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of(LIMITS, """
+                module ids exposing ( V )
+
+                import limits ( fits )
+
+                let ok (s: String) : Bool = fits(s)
+
+                data V = String
+                    invariant ok(value)
+                """)));
+    }
+
+    /** And the rule that reaches it runs: the imported helper is what decides the construction, as
+     * it does when the invariant calls it directly. */
+    @Test
+    void theImportedHelperReachedThroughAnOwnHelperIsWhatTheRuleIsCheckedAgainst() throws Exception {
+        BytesClassLoader loader = new BytesClassLoader(Compiler.compileModules(List.of(LIMITS, """
+                module ids exposing ( V )
+
+                import limits ( fits )
+
+                let ok (s: String) : Bool = fits(s)
+
+                data V = String
+                    invariant ok(value)
+                """)), getClass().getClassLoader());
+
+        assertEquals("abc", Codecs.encode(loader, "ids.V", Codecs.decoded(loader, "ids.V", "abc")));
+        assertEquals("Err", Codecs.decode(loader, "ids.V", "abcd").getClass().getSimpleName());
+    }
+
     /** An unexposed value has no name here, in an invariant as anywhere else. */
     @Test
     void anUnpublishedValueCannotBeNamedInAnInvariant() {

--- a/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePostfixApplicationTest.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -331,7 +332,7 @@ class CompilePostfixApplicationTest {
         SourcePos at = new SourcePos(1, 1);
         BindingId id = new BindingId(new BindingOwner.OfValue("demo", "go"), 0);
         Ast.Apply lowered = new Ast.Apply(
-                new Ast.Var("$fn0", new ValueName.Local("$fn0", id), at),
+                new Ast.Var("$fn0", new ValueName.Local("$fn0", id), new ReachName.Bare("$fn0"), at),
                 java.util.List.of(), souther.compiler.types.ConstructionOrigin.own(), "d.count", at);
 
         assertEquals("d.count", lowered.written(), "a report quotes what the author wrote");

--- a/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ast/ANameAnsweredHalfwayIsRefusedTest.java
@@ -1,0 +1,67 @@
+package souther.compiler.ast;
+
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.ReachName;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A name says what it denotes and how this module reaches it, or it says neither.
+ *
+ * <p>Both answers come from resolution and they are two halves of one question. A reader that has
+ * one and not the other is holding a reference that resolves to a declaration and reaches nothing,
+ * or the other way round — and the reader after it takes the spelling instead, which is what a table
+ * keyed by names answers with silence.
+ *
+ * <p>So the halves are refused where they are put together rather than caught where they are read.
+ * A rewrite that carries a name across and drops one of them is a mistake in this compiler, and the
+ * place to say so is the one that could have carried both.
+ */
+class ANameAnsweredHalfwayIsRefusedTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static final ValueName.Helper DECLARED = new ValueName.Helper("demo", "spin");
+
+    /** A name the parser read: nothing has been answered about it yet, and that is a state. */
+    @Test
+    void aNameNothingHasAnsweredYetIsFine() {
+        Ast.Var written = new Ast.Var("spin", POS);
+
+        assertEquals("spin", written.name());
+        assertEquals("spin", written.reaches(),
+                "nothing resolved it, so what it reaches is what it is written as");
+    }
+
+    /** What it denotes without how it is reached is not a state a rewrite may leave behind. */
+    @Test
+    void aNameThatDenotesSomethingAndReachesNothingCannotBeBuilt() {
+        IllegalArgumentException refused = assertThrows(IllegalArgumentException.class,
+                () -> new Ast.Var(WrittenName.of("spin", POS), DECLARED, null));
+
+        assertEquals(true, refused.getMessage().contains("spin"), refused.getMessage());
+    }
+
+    /** And a reader asking what a name is declared as, of one nothing answered, is told so rather
+     * than handed the spelling — the answer it wanted is the one that is missing. */
+    @Test
+    void theDeclaredNameOfSomethingNothingAnsweredIsRefused() {
+        Ast.Var written = new Ast.Var("spin", POS);
+
+        assertThrows(IllegalStateException.class, written::bare);
+    }
+
+    /** Answered, it says both. */
+    @Test
+    void aResolvedNameSaysWhatItDenotesAndHowItIsReached() {
+        Ast.Var resolved = new Ast.Var(WrittenName.of("spin", POS), DECLARED,
+                new ReachName.OfModule("demo", "spin"));
+
+        assertEquals("spin", resolved.bare());
+        assertEquals("demo.spin", resolved.reaches());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest.java
@@ -6,6 +6,7 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -33,6 +34,7 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
     void aPolymorphicOperationSettlesItsVariablesFromItsArguments() {
         // List.length : (List<'a>) -> Int — the argument decides 'a, and the result is not a variable
         Ast.Expr call = new Ast.Apply("List.length", new ValueName.Stdlib("List", "length"),
+                new ReachName.OfLibrary(new ValueName.Stdlib("List", "length")),
                 List.of(new Ast.ListLit(List.of(new Ast.IntLit(1, POS)), POS)),
                 ConstructionOrigin.own(), POS);
 
@@ -55,6 +57,7 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
         Ast.Block step = new Ast.Block(List.of(binders.binder("x", POS)),
                 new Ast.ListLit(List.of(new Ast.IntLit(1, POS)), POS), POS);
         Ast.Expr call = new Ast.Apply("List.flatMap", new ValueName.Stdlib("List", "flatMap"),
+                new ReachName.OfLibrary(new ValueName.Stdlib("List", "flatMap")),
                 List.of(step, new Ast.ListLit(List.of(new Ast.IntLit(2, POS)), POS)),
                 ConstructionOrigin.own(), POS);
 
@@ -87,7 +90,8 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
         // nothing could be derived from leaving it standing, so it is expanded — and a tree that
         // still holds one is this compiler having failed to do that
         Ast.Expr call = new Ast.Apply("half", new ValueName.Helper("demo", "half"),
-                List.of(new Ast.IntLit(1, POS)), ConstructionOrigin.own(), POS);
+                new ReachName.Bare("half"), List.of(new Ast.IntLit(1, POS)),
+                ConstructionOrigin.own(), POS);
 
         assertThrows(RuntimeException.class, () -> Elaborator.elaborate(call, Scope.NONE,
                 CheckContext.of(Symbols.none()).preserving(KEPT)));

--- a/souther-compiler/src/test/java/souther/compiler/check/ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest.java
@@ -32,7 +32,7 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
     @Test
     void aPolymorphicOperationSettlesItsVariablesFromItsArguments() {
         // List.length : (List<'a>) -> Int — the argument decides 'a, and the result is not a variable
-        Ast.Expr call = new Ast.Apply("List.length", new ValueName.Stdlib("List.length"),
+        Ast.Expr call = new Ast.Apply("List.length", new ValueName.Stdlib("List", "length"),
                 List.of(new Ast.ListLit(List.of(new Ast.IntLit(1, POS)), POS)),
                 ConstructionOrigin.own(), POS);
 
@@ -40,7 +40,7 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
                 CheckContext.of(Symbols.none()).preserving(KEPT));
 
         Core.PreservedCall kept = assertInstanceOf(Core.PreservedCall.class, typed);
-        assertEquals(new ValueName.Stdlib("List.length"), kept.operation());
+        assertEquals(new ValueName.Stdlib("List", "length"), kept.operation());
         assertEquals(Type.INT, kept.type());
     }
 
@@ -54,7 +54,7 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
         Ast.Binders binders = new Ast.Binders(new BindingOwner.OfValue("demo", "test"));
         Ast.Block step = new Ast.Block(List.of(binders.binder("x", POS)),
                 new Ast.ListLit(List.of(new Ast.IntLit(1, POS)), POS), POS);
-        Ast.Expr call = new Ast.Apply("List.flatMap", new ValueName.Stdlib("List.flatMap"),
+        Ast.Expr call = new Ast.Apply("List.flatMap", new ValueName.Stdlib("List", "flatMap"),
                 List.of(step, new Ast.ListLit(List.of(new Ast.IntLit(2, POS)), POS)),
                 ConstructionOrigin.own(), POS);
 
@@ -66,9 +66,9 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
 
     @Test
     void theOperationsKeptAreTheLibrarysAndNotAListWrittenHere() {
-        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("List.map")),
+        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("List", "map")),
                 "an operation the discharge rules are written about");
-        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("String.length")),
+        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("String", "length")),
                 "and one they are not — what is kept is not decided by having a rule");
     }
 
@@ -76,9 +76,9 @@ class ALanguageOperationKeptStandingTypesFromWhatItDeclaresTest {
     void anOperationRewrittenAwayBeforeAnyOfThisIsNotKept() {
         // `List.fold` becomes `List.foldFrom` before this tree exists, so it has no declaration to
         // keep — and a rule keyed by it could never be looked up either
-        assertTrue(KEPT.signatureOf(new ValueName.Stdlib("List.fold")) == null,
+        assertTrue(KEPT.signatureOf(new ValueName.Stdlib("List", "fold")) == null,
                 "sugar has no declaration of its own");
-        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("List.foldFrom")),
+        assertNotNull(KEPT.signatureOf(new ValueName.Stdlib("List", "foldFrom")),
                 "what it becomes does");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/APredicateCarriesExactlyAsFarAsItsRuleSaysTest.java
@@ -140,7 +140,7 @@ class APredicateCarriesExactlyAsFarAsItsRuleSaysTest {
     /** Every row of the table is answered for here, and every answer here is a row. */
     @Test
     void everyRowIsAnsweredFor() {
-        Set<String> written = DischargeRules.carryingOperations().stream().map(ValueName::name)
+        Set<String> written = DischargeRules.carryingOperations().stream().map(ValueName::toString)
                 .collect(Collectors.toCollection(TreeSet::new));
         Set<String> answered = PREDICATES.stream()
                 .map(APredicateCarriesExactlyAsFarAsItsRuleSaysTest::operationOf)

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.check;
 
+import souther.compiler.Prelude;
 import souther.compiler.check.DischargeRules.Built;
 import souther.compiler.check.DischargeRules.Cardinality;
 import souther.compiler.check.DischargeRules.Carried;
@@ -29,8 +30,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ARuleIsHeldToTheDeclarationItIsAboutTest {
 
+    /** A row written here, including one naming an operation the library does not have — which is
+     * what several of these are for, so it takes the spelling apart rather than asking the library. */
     private static ValueName op(String qualified) {
-        return new ValueName.Stdlib(qualified);
+        int dot = qualified.lastIndexOf('.');
+        return new ValueName.Stdlib(qualified.substring(0, dot), qualified.substring(dot + 1));
     }
 
     private static void bindCarried(String operation, Reads container) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperationTheLibraryGainsIsAnsweredForTest.java
@@ -35,7 +35,7 @@ class AnOperationTheLibraryGainsIsAnsweredForTest {
     void everyOperationInAQuestionsRangeAnswersIt() {
         List<String> unanswered = new ArrayList<>();
         for (Map.Entry<String, Prelude.PreludeEntry> e : Prelude.entries().entrySet()) {
-            ValueName operation = new ValueName.Stdlib(e.getKey());
+            ValueName operation = Prelude.operation(e.getKey());
             for (Question question : Question.askedOf(e.getValue().signature())) {
                 if (question.answeredFor(operation)
                         || question.nothingSaidOf().contains(operation)) {
@@ -62,13 +62,13 @@ class AnOperationTheLibraryGainsIsAnsweredForTest {
         List<String> unasked = new ArrayList<>();
         for (Question question : Question.values()) {
             for (ValueName operation : question.answeredOperations()) {
-                if (!question.asksOfOperation(operation.name())) {
-                    unasked.add(operation.name() + " — " + question + " (a rule)");
+                if (!question.asksOfOperation(operation.toString())) {
+                    unasked.add(operation + " — " + question + " (a rule)");
                 }
             }
             for (ValueName operation : question.nothingSaidOf()) {
-                if (!question.asksOfOperation(operation.name())) {
-                    unasked.add(operation.name() + " — " + question + " (nothing to say)");
+                if (!question.asksOfOperation(operation.toString())) {
+                    unasked.add(operation + " — " + question + " (nothing to say)");
                 }
             }
         }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest.java
@@ -3,6 +3,7 @@ package souther.compiler.check;
 import souther.compiler.ast.Ast;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ class AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest {
     @Test
     void aStandardLibraryCallLeftStandingIsNotSomethingToType() {
         Ast.Expr call = new Ast.Apply("List.map", new ValueName.Stdlib("List", "map"),
+                new ReachName.OfLibrary(new ValueName.Stdlib("List", "map")),
                 List.of(new Ast.IntLit(1, POS)), ConstructionOrigin.own(), POS);
 
         assertThrows(RuntimeException.class, () -> Elaborator.elaborate(call, Scope.NONE,
@@ -37,7 +39,8 @@ class AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest {
         // as above and not a different one — the guard is about the representation, not about which
         // namespace the name was in
         Ast.Expr call = new Ast.Apply("half", new ValueName.Helper("demo", "half"),
-                List.of(new Ast.IntLit(1, POS)), ConstructionOrigin.own(), POS);
+                new ReachName.Bare("half"), List.of(new Ast.IntLit(1, POS)),
+                ConstructionOrigin.own(), POS);
 
         assertThrows(RuntimeException.class, () -> Elaborator.elaborate(call, Scope.NONE,
                 CheckContext.of(Symbols.none())));

--- a/souther-compiler/src/test/java/souther/compiler/check/AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest.java
@@ -24,7 +24,7 @@ class AnUnexpandedCallIsOnlyTypedWhereARepresentationKeepsItTest {
 
     @Test
     void aStandardLibraryCallLeftStandingIsNotSomethingToType() {
-        Ast.Expr call = new Ast.Apply("List.map", new ValueName.Stdlib("List.map"),
+        Ast.Expr call = new Ast.Apply("List.map", new ValueName.Stdlib("List", "map"),
                 List.of(new Ast.IntLit(1, POS)), ConstructionOrigin.own(), POS);
 
         assertThrows(RuntimeException.class, () -> Elaborator.elaborate(call, Scope.NONE,

--- a/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
@@ -98,7 +98,7 @@ class CallElaboratorNoCalleeTest {
     void anUnexpandedCallIsAnInternalError() {
         for (ValueName denotes : List.of(
                 new ValueName.Helper("m", "f"),
-                new ValueName.Stdlib("List.map"),
+                new ValueName.Stdlib("List", "map"),
                 new ValueName.Unresolved("f"))) {
             RuntimeException e = answerFor(denotes);
             assertInstanceOf(IllegalStateException.class, e, denotes.toString());

--- a/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/CallElaboratorNoCalleeTest.java
@@ -7,6 +7,7 @@ import souther.compiler.types.TypeName;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -34,7 +35,7 @@ class CallElaboratorNoCalleeTest {
 
     private static RuntimeException answerFor(ValueName denotes) {
         return CallElaborator.noCallee(
-                new Ast.Apply("f", denotes, List.of(new Ast.IntLit(1, AT)),
+                new Ast.Apply("f", denotes, new ReachName.Bare("f"), List.of(new Ast.IntLit(1, AT)),
                         ConstructionOrigin.own(), AT));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
@@ -258,7 +258,7 @@ class InvariantCombinatorRulesTest {
                 continue;
             }
             assertFalse(Preserved.byTheLanguagesOwnOperations().operations()
-                            .containsKey(new ValueName.Stdlib(fn)),
+                            .containsKey(Prelude.operation(fn)),
                     fn + " is sugar and is kept standing, so a tree this check reads could hold it");
         }
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
@@ -7,6 +7,7 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -39,6 +40,7 @@ class OneCallSettlesOneSignatureTest {
         Ast.Block predicate = new Ast.Block(List.of(BINDERS.binder("x", POS)),
                 new Ast.BoolLit(true, POS), POS);
         return new Ast.Apply("List.filter", new ValueName.Stdlib("List", "filter"),
+                new ReachName.OfLibrary(new ValueName.Stdlib("List", "filter")),
                 List.of(predicate, new Ast.ListLit(List.of(), POS)), ConstructionOrigin.own(), POS);
     }
 
@@ -127,8 +129,10 @@ class OneCallSettlesOneSignatureTest {
         // element type of nothing.
         Ast.Expr call = new Ast.Apply("Option.withDefault",
                 new ValueName.Stdlib("Option", "withDefault"),
+                new ReachName.OfLibrary(new ValueName.Stdlib("Option", "withDefault")),
                 List.of(new Ast.ListLit(List.of(), POS),
                         new Ast.Apply("List.get", new ValueName.Stdlib("List", "get"),
+                new ReachName.OfLibrary(new ValueName.Stdlib("List", "get")),
                                 List.of(new Ast.IntLit(0, POS),
                                         new Ast.ListLit(List.of(new Ast.ListLit(
                                                 List.of(new Ast.IntLit(1, POS)), POS)), POS)),

--- a/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneCallSettlesOneSignatureTest.java
@@ -38,7 +38,7 @@ class OneCallSettlesOneSignatureTest {
     private static Ast.Expr filterOverAnEmptyList() {
         Ast.Block predicate = new Ast.Block(List.of(BINDERS.binder("x", POS)),
                 new Ast.BoolLit(true, POS), POS);
-        return new Ast.Apply("List.filter", new ValueName.Stdlib("List.filter"),
+        return new Ast.Apply("List.filter", new ValueName.Stdlib("List", "filter"),
                 List.of(predicate, new Ast.ListLit(List.of(), POS)), ConstructionOrigin.own(), POS);
     }
 
@@ -126,9 +126,9 @@ class OneCallSettlesOneSignatureTest {
         // holds, so the option beside it is what decides — the other order holds the option to the
         // element type of nothing.
         Ast.Expr call = new Ast.Apply("Option.withDefault",
-                new ValueName.Stdlib("Option.withDefault"),
+                new ValueName.Stdlib("Option", "withDefault"),
                 List.of(new Ast.ListLit(List.of(), POS),
-                        new Ast.Apply("List.get", new ValueName.Stdlib("List.get"),
+                        new Ast.Apply("List.get", new ValueName.Stdlib("List", "get"),
                                 List.of(new Ast.IntLit(0, POS),
                                         new Ast.ListLit(List.of(new Ast.ListLit(
                                                 List.of(new Ast.IntLit(1, POS)), POS)), POS)),

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARepresentationKeepsIsTheRepresentationsToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARepresentationKeepsIsTheRepresentationsToSayTest.java
@@ -25,7 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class WhatARepresentationKeepsIsTheRepresentationsToSayTest {
 
     private static final SourcePos POS = new SourcePos(1, 1);
-    private static final ValueName MAP = new ValueName.Stdlib("List.map");
+    private static final ValueName MAP = new ValueName.Stdlib("List", "map");
 
     /** `(Int) -> Int`, standing for whatever the operation was declared as. */
     private static final Type.FnOf SIGNATURE = (Type.FnOf) Type.fn(List.of(Type.INT), Type.INT);
@@ -51,7 +51,7 @@ class WhatARepresentationKeepsIsTheRepresentationsToSayTest {
         Preserved keepsMapOnly = keeping(MAP, SIGNATURE);
 
         assertThrows(RuntimeException.class,
-                () -> elaborate(callTo(new ValueName.Stdlib("List.filter")), keepsMapOnly));
+                () -> elaborate(callTo(new ValueName.Stdlib("List", "filter")), keepsMapOnly));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatARepresentationKeepsIsTheRepresentationsToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatARepresentationKeepsIsTheRepresentationsToSayTest.java
@@ -5,6 +5,7 @@ import souther.compiler.core.Core;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
+import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
@@ -25,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class WhatARepresentationKeepsIsTheRepresentationsToSayTest {
 
     private static final SourcePos POS = new SourcePos(1, 1);
-    private static final ValueName MAP = new ValueName.Stdlib("List", "map");
+    private static final ValueName.Stdlib MAP = new ValueName.Stdlib("List", "map");
 
     /** `(Int) -> Int`, standing for whatever the operation was declared as. */
     private static final Type.FnOf SIGNATURE = (Type.FnOf) Type.fn(List.of(Type.INT), Type.INT);
@@ -56,7 +57,7 @@ class WhatARepresentationKeepsIsTheRepresentationsToSayTest {
 
     @Test
     void aKeptCallAppliedToTheWrongNumberOfArgumentsIsSaidAsThat() {
-        Ast.Expr twoArgs = new Ast.Apply("List.map", MAP,
+        Ast.Expr twoArgs = new Ast.Apply("List.map", MAP, new ReachName.OfLibrary(MAP),
                 List.of(new Ast.IntLit(1, POS), new Ast.IntLit(2, POS)),
                 ConstructionOrigin.own(), POS);
 
@@ -84,9 +85,9 @@ class WhatARepresentationKeepsIsTheRepresentationsToSayTest {
         assertEquals(keeping.preserved(), keeping.forData(null).preserved());
     }
 
-    private static Ast.Expr callTo(ValueName operation) {
-        return new Ast.Apply(operation.name(), operation, List.of(new Ast.IntLit(1, POS)),
-                ConstructionOrigin.own(), POS);
+    private static Ast.Expr callTo(ValueName.Stdlib operation) {
+        return new Ast.Apply(operation.qualified(), operation, new ReachName.OfLibrary(operation),
+                List.of(new Ast.IntLit(1, POS)), ConstructionOrigin.own(), POS);
     }
 
     private static Preserved keeping(ValueName operation, Type.FnOf signature) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
@@ -180,7 +180,11 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
         Map<String, Ast.FnDef> declared = HelperInliner.helpersOf(maths);
         HelperInliner from = HelperInliner.forHelpers("maths", declared);
         Ast.FnDef spin = from.closeAcross(declared.get("spin"), "maths");
-        Ast.FnDef hands = declared.get("hands").reachedAs("maths.hands");
+        Ast.FnDef written = declared.get("hands");
+        // Taken on by `order` under the name it reaches it by, and its body read against `order`'s
+        // names: a body a reader holds names what the reader reaches, whoever declared it.
+        Ast.FnDef hands = written.reachedAs("maths.hands").withBody(new Ast.FnBody.Written(
+                HelperNames.qualifyHelpersOf(written.writtenBody(), "maths")));
 
         Ast.Module order = resolved("""
                 module order

--- a/souther-compiler/src/test/java/souther/compiler/codegen/APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/codegen/APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest.java
@@ -28,14 +28,14 @@ class APreservedCallIsRefusedByWhatItIsNotByWhatItNamesTest {
 
     @Test
     void anOperationTheEmitterHasNoBytecodeForIsRefused() {
-        assertRefused(new ValueName.Stdlib("List.map"));
+        assertRefused(new ValueName.Stdlib("List", "map"));
     }
 
     @Test
     void anOperationTheEmitterDoesHaveBytecodeForIsRefusedTheSameWay() {
         // `List.sortBy` is written out by name in the emitter's own call dispatch, so this is the
         // case an operation-keyed refusal would have let through
-        assertRefused(new ValueName.Stdlib("List.sortBy"));
+        assertRefused(new ValueName.Stdlib("List", "sortBy"));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/query/AReachNameSurvivesWhereARewriteCannotGoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/AReachNameSurvivesWhereARewriteCannotGoTest.java
@@ -1,0 +1,122 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.ReachName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a body says when it leaves the module it was written in, in the one place no walk over an
+ * expression reaches.
+ *
+ * <p>A function argument stands in {@code Ast.Expansion.given}, and that is not a slot
+ * ({@code Ast.atSlots}): a callee that applies its argument holds the same lambda inside its body,
+ * so a walk taking both would read one lambda twice. A published body is closed by the module that
+ * declares it and read against the reader's declarations, and the rewrite that does the closing goes
+ * through that walk — so what stands in {@code given} was left behind, saying what it said where it
+ * was written.
+ *
+ * <p>{@code lib.flatten} recurses, so it is a method rather than an expression and its call inside
+ * the lambda stays a call. In {@code lib} that call is reached bare; in {@code app}, which emits the
+ * method as its own, it is reached under {@code lib}. Both names are for one declaration and the
+ * reader's is the one a table here is keyed by.
+ */
+class AReachNameSurvivesWhereARewriteCannotGoTest {
+
+    private static final String LIB = """
+            module lib exposing ( Node, flatten )
+
+            data Node = { n: Int, kids: List<Node> }
+
+            let flatten (t: Node): List<Int> = [t.n] ++ List.flatMap(k -> flatten(k), t.kids)
+            """;
+
+    private static final String APP = """
+            module app exposing ( Out, go )
+
+            import lib ( Node, flatten )
+
+            data Out = { xs: List<Int> }
+
+            behavior go : (t: Node) -> Out constructs Out
+            let go (t) = Out { xs = flatten(t) }
+            """;
+
+    /** The imported recursive helper as {@code app} emits it: a method of its own. */
+    private static Ast.Expr taken() {
+        Map<String, String> byId = new LinkedHashMap<>();
+        byId.put("lib.sou", LIB);
+        byId.put("app.sou", APP);
+        Compilation c = Compilation.ofDocuments(byId, Set.of(), ModulePath.EMPTY);
+        Ast.FnDef def = c.db().ask(new Bodies.LoweredBody("app", "lib.flatten")).value();
+        return ((Ast.FnBody.Written) def.body()).expr();
+    }
+
+    /** Every application a walk over the slots reaches. */
+    private static List<Ast.Apply> throughTheSlots(Ast.Expr e) {
+        List<Ast.Apply> out = new ArrayList<>();
+        if (e instanceof Ast.Apply call) {
+            out.add(call);
+        }
+        Ast.forEachChild(e, c -> out.addAll(throughTheSlots(c)));
+        return out;
+    }
+
+    /** Every application standing in what a combinator was handed, which the walk above does not
+     * reach — collected by hand, because that is the point. */
+    private static List<Ast.Apply> inWhatWasHandedOver(Ast.Expr e) {
+        List<Ast.Apply> out = new ArrayList<>();
+        if (e instanceof Ast.Expansion ex) {
+            for (Ast.Given g : ex.given()) {
+                out.addAll(throughTheSlots(g.value()));
+                out.addAll(inWhatWasHandedOver(g.value()));
+            }
+        }
+        Ast.forEachChild(e, c -> out.addAll(inWhatWasHandedOver(c)));
+        return out;
+    }
+
+    /**
+     * The premise. Without a call standing there the rest would pass by finding nothing, and without
+     * the walk missing it the rewrite would have reached it like anything else.
+     *
+     * <p>The callee does apply what it was handed, so the expansion's body holds a call of its own —
+     * a different node, reached and rewritten like anything in a slot. The one asked about below is
+     * the node in {@code given}, and it is reached by neither.
+     */
+    @Test
+    void theCallStandsWhereAWalkOverTheSlotsDoesNotReach() {
+        Ast.Expr body = taken();
+        List<Ast.Apply> handed = calls(inWhatWasHandedOver(body));
+
+        assertEquals(1, handed.size(),
+                "the recursive helper is called inside the lambda handed to the combinator");
+        assertTrue(calls(throughTheSlots(body)).stream().noneMatch(call -> call == handed.get(0)),
+                "and no walk over the slots reaches that node");
+    }
+
+    /** And it is reached by the name the module reading it reaches it by, though the rewrite that
+     * settles that name goes through a walk which never arrives there. */
+    @Test
+    void andItIsReachedByTheNameTheReaderReachesItBy() {
+        assertEquals(List.of(new ReachName.OfModule("lib", "flatten")),
+                calls(inWhatWasHandedOver(taken())).stream().map(Ast.Apply::reachedAs).toList(),
+                "reached under the module that declares it, which is how `app` keys the method");
+    }
+
+    private static List<Ast.Apply> calls(List<Ast.Apply> found) {
+        return found.stream()
+                .filter(call -> call.denotes() != null && call.denotes().name().equals("flatten"))
+                .toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ResolvedValueNamesTest.java
@@ -142,7 +142,51 @@ class ResolvedValueNamesTest {
                 let f (xs) = List.length(xs)
                 """;
 
-        assertEquals(new ValueName.Stdlib("List.length"), denotationOf(source, "List.length"));
+        assertEquals(new ValueName.Stdlib("List", "length"), denotationOf(source, "List.length"));
+    }
+
+    /**
+     * A library name is reached under an alias, and the alias is no part of what declares the
+     * operation: {@code souther.list} declares {@code foldFrom} and a reader reaches it as
+     * {@code List.foldFrom}. The two are held apart so that no reader downstream has to split a
+     * spelling to get at either — the alias to say which library was written, the name to say which
+     * operation it is.
+     */
+    @Test
+    void aLibraryNameHoldsItsAliasAndItsOperationApart() {
+        String source = """
+                module m.a exposing ( f )
+
+                behavior f : (xs: List<Int>) -> Int
+                let f (xs) = List.length(xs)
+                """;
+
+        ValueName.Stdlib denotes = assertInstanceOf(ValueName.Stdlib.class,
+                denotationOf(source, "List.length"));
+
+        assertEquals("List", denotes.alias());
+        assertEquals("length", denotes.name());
+    }
+
+    /** And what it is reached by is what it was. Holding the two apart is a change to how the answer
+     * is written down, not to the answer: a table keyed by the name a library call reaches is looked
+     * up with the same key it was before. */
+    @Test
+    void aLibraryNameIsStillReachedByItsQualifiedSpelling() {
+        String source = """
+                module m.a exposing ( f )
+
+                behavior f : (xs: List<Int>) -> Int
+                let f (xs) = List.length(xs)
+                """;
+
+        for (Ast.Expr e : named(resolve(source))) {
+            if (e instanceof Ast.Apply call && call.written().equals("List.length")) {
+                assertEquals("List.length", call.reaches());
+                return;
+            }
+        }
+        throw new AssertionError("nothing applied `List.length` in the resolved module");
     }
 
     @Test


### PR DESCRIPTION
The second half of #378. #389 gave a declaration its own module (`declaredIn`);
this gives a reference the name it reaches, so neither is worked out from the
other by reading a rendered string.

## The defect this closes

An invariant naming this module's own helper, whose body calls an imported one,
did not compile:

```
module limits exposing ( fits )
let fits (s: String) : Bool = String.length(s) <= 3

module ids exposing ( V )
import limits ( fits )
let ok (s: String) : Bool = fits(s)
data V = String
    invariant ok(value)
```

```
5:29 `limits.fits` is not a standard-library function.
```

An invariant is expanded before the bodies are written qualified, so the call
was met while the tree still spelled the imported name bare, and the table it
was looked up in keys an imported helper qualified. It missed, silently, and was
left unexpanded; a check downstream then read the dot in it as a library
qualifier and reported a library the author never wrote.

Reachable since `0e02bdf3`, and not a regression from #389.

## What it does

`ReachName` — `Bare`, `OfModule`, `OfLibrary` — is the name a module reaches a
definition by, settled by `Resolve`, which is the one place holding both what a
name denotes and the module doing the reading. `Ast.Var` carries it, every
rewrite copies it rather than deriving it again, and `Core.Call` holds it
through to the backend.

The two are separate values and cannot be derived from each other:
`souther.list` declares `foldFrom`, and a reader reaches it as `List.foldFrom`.
The alias belongs to the reference and the declaring module is nowhere in it.

Then:

- `CallElaborator` asks which kind of name it has rather than whether the
  spelling holds a dot. A helper another module declares reaching there is this
  compiler having failed to expand or bind it, and it says that
- `BodyGen.bareOp` is gone. The operation a library call names is read off the
  name, which holds it, rather than split out of the spelling
- `HelperNames.keyIn` is gone. It worked the reach name out from a declaration's
  identity and the reading module, and every reader now has it in hand

`ValueName.Stdlib` holds the alias and the operation apart, which is what
`OfLibrary` carries. That is the first commit and changes nothing observable:
it removes the joins and splits at `Prelude.published()`, `Exposing`, and the
sugar rewrite. It also turned up a second shape — `Date("2026-09-30")` applies
the namespace itself, with no operation to name — which is now written down
rather than left as an empty half.

## `Expansion.given`

A function argument stands in `Ast.Expansion.given`, and that is not a slot on
purpose: a callee that applies its argument holds the same lambda in its body,
and a walk taking both would read one lambda twice. The rewrite a body takes
when it leaves the module it was written in goes through that walk, so what
stood there went on naming the declaring module's helpers by that module's
names — inside a body being read against a reader's.

It is rewritten explicitly now, which is what a payload outside the slots needs.
`AReachNameSurvivesWhereARewriteCannotGoTest` pins it, and pins the premise
first: the node it asks about is one no walk over the slots reaches.

## What is not here

The semantic consumers still key their tables by `String`. Retyping them is a
separate problem, and two things found here say why:

- `HelperTable` means different things at different times. `helpersOf` answers a
  declaration index before `Shapes.Prepared` and a reachability environment
  after it — measured on a module importing `lib(flatten)` and declaring `own`:
  `[own]` before, `[own, lib.flatten, List.foldFrom]` after
- `Map<ReachName, …>` would not find the readers anyway. `Map#get(Object)`
  takes a `String` against it and answers with a silent miss, which is the
  failure being fixed. One was written during this work and cost two tests in
  `CompileGrowingMapFoldTest`

What separates the questions is the lookup surface, not the key type — and the
example layer is a third namespace: it keys by the source spelling
(`FixtureReader.valueBody`, `helperDef`) and agrees with the reach namespace
only because `qualifyImports` normalizes the spelling first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
