### PR TITLE
The last of the decodes: an alias is asked of the name that holds it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -855,14 +855,19 @@ public final class Names {
 
     /**
      * One name written in a module and the declaration it turned out to mean: the spelling, and the
-     * module and name that spelling resolved to — for a library name, the alias an import line names
-     * it under, since that is what such a line writes.
+     * qualifier and name a reference would have reached that declaration by written out in full.
+     *
+     * <p>The qualifier and not the declaring module, because that is what an import line writes and
+     * an import line is what these are compared against. For a user module the two are the same
+     * name; for the standard library they are not — {@code souther.list} declares {@code foldFrom}
+     * and a line writes {@code import List ( foldFrom )} — and it is the alias every side of this
+     * comparison holds.
      *
      * <p>The spelling is half of it because an import list entry is a claim about a spelling. Two
      * uses of one declaration — {@code Sku} and {@code Stock.Sku} — are the same declaration and
      * different claims, and only the first is what an import list entry buys.
      */
-    private record Use(String written, String module, String name) {}
+    private record Use(String written, String qualifier, String name) {}
 
     /** Every name {@code module} writes, paired with what it denotes, or null when the module could
      * not be read. */
@@ -886,9 +891,9 @@ public final class Names {
                 case ValueName.Helper h ->
                         used.add(new Use(v.written().canonical(), h.module(), h.name()));
                 // `List.map` and a bare `map` an import brought in both denote the same library
-                // function. What an import line names is the alias, which is what the library
-                // publishes the operation under and not the module that declares it — asked of the
-                // name, which holds both, rather than taken back out of the two rendered together.
+                // function. Its qualifier is the alias the library publishes it under, asked of the
+                // name — which holds it — rather than taken back out of the two rendered together.
+                // A namespace applied is not a member of anything and no list entry names one.
                 case ValueName.Stdlib s when !s.isNamespace() ->
                         used.add(new Use(v.written().canonical(), s.alias(), s.operation()));
                 default -> { }   // a local, a builtin, a type used as a value (recorded as a type)

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -855,7 +855,8 @@ public final class Names {
 
     /**
      * One name written in a module and the declaration it turned out to mean: the spelling, and the
-     * module and name that spelling resolved to.
+     * module and name that spelling resolved to — for a library name, the alias an import line names
+     * it under, since that is what such a line writes.
      *
      * <p>The spelling is half of it because an import list entry is a claim about a spelling. Two
      * uses of one declaration — {@code Sku} and {@code Stock.Sku} — are the same declaration and
@@ -885,14 +886,11 @@ public final class Names {
                 case ValueName.Helper h ->
                         used.add(new Use(v.written().canonical(), h.module(), h.name()));
                 // `List.map` and a bare `map` an import brought in both denote the same library
-                // function, and the qualified name it is known by carries the module.
-                case ValueName.Stdlib s -> {
-                    int dot = s.qualified().lastIndexOf('.');
-                    if (dot > 0) {
-                        used.add(new Use(v.written().canonical(), s.qualified().substring(0, dot),
-                                s.qualified().substring(dot + 1)));
-                    }
-                }
+                // function. What an import line names is the alias, which is what the library
+                // publishes the operation under and not the module that declares it — asked of the
+                // name, which holds both, rather than taken back out of the two rendered together.
+                case ValueName.Stdlib s when !s.isNamespace() ->
+                        used.add(new Use(v.written().canonical(), s.alias(), s.operation()));
                 default -> { }   // a local, a builtin, a type used as a value (recorded as a type)
             }
         }


### PR DESCRIPTION
Closes the last item of #378 (2c): the audit of what still reads a name back out
of a rendering.

## What was left

One site. The unused-import check split a library name to find the alias an
import line names it under:

```java
int dot = s.qualified().lastIndexOf('.');
if (dot > 0) {
    used.add(new Use(v.written().canonical(), s.qualified().substring(0, dot),
            s.qualified().substring(dot + 1)));
}
```

`ValueName.Stdlib` has held the alias and the operation apart since #396, so it
is asked for them. `dot > 0` was standing in for "this is an operation of a
module rather than the module applied", which `isNamespace()` says.

Nothing changes. `CompileUnusedImportWarningTest` covers both prelude cases —
a bare use of an imported name, and a name only ever written qualified — and
fails when the two halves are swapped.

## And the record says what it holds

`Use`'s second component held the declaring module for a type, a behavior and a
helper, and the library's alias for a library name. The first version of this PR
absorbed that into a javadoc saying "for a library, the alias", which is the
kind of note that goes on explaining a mismatch instead of removing it.

It was never the declaring module. What every side of the comparison holds is
the qualifier a reference would have reached the declaration by — `limits.V`,
`List.foldFrom` — and, on the other side, `imp.module()`, which is what an
import line writes. For a user module the qualifier and the module are the same
name, which is why one name looked like it covered both cases.

So the component says `qualifier`, and the library stops being an exception to
it.

## The audit

Everything else matching `indexOf('.')`, `lastIndexOf('.')` or
`startsWith(alias + ".")` in the compiler falls into three groups, and none of
them is reading a value this compiler had joined:

**A spelling the author wrote, parsed into structure.** `Resolve` (a library
qualifier), `Symbols`, `Names` (a qualified reference), `AstBuilder`,
`ImplicitUnits`, `Front`. These run at or before resolution, where there is no
denotation to ask and the text is the input.

**A report quoting what was written.** `CallElaborator` (twice), `TypeOps`,
`TypeChecker`, `ApiCommand`. Each takes the author's own spelling apart to say
something about it in a sentence.

**A JVM binary name or a file name.** `Runner`, `SoutherProcessor`,
`Descriptors`, `JapiCommand`, `SourceDoc`, `PublishedModule`, `NeutralForm`.
Not Souther names at all.

Two of the first group are worth naming because they read a dot the way the ones
#396 removed did. `ImplicitUnits` reads it as "qualified, so another module
declares it" and `Front` as "the part before it is a qualifier". Both run in the
frontend, before anything has been resolved, so the spelling is all there is —
they are parses and not decodes. Left as they are.

## What #378 leaves behind

Nothing in the issue. The two things this work turned up have issues of their
own: #397 (the example layer keys by the source spelling) and #398 (one helper
table answers two questions, and which one depends on the pass that ran).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
