### PR TITLE
A fixture applies the helper its call reaches, not the one its spelling names

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -234,7 +234,7 @@ public final class FixtureReader {
      */
     private Object helperAnswer(Ast.Expr e, Set<String> followed) {
         return switch (e) {
-            case Ast.Apply c when appliedHelper(c) instanceof Ast.FnDef helper -> answered(c, helper);
+            case Ast.Apply c when appliedHelper(c) instanceof Applied helper -> answered(c, helper);
             case Ast.LetIn let -> helperAnswer(let.body(), followed);
             // a binding holds what it was bound to; a value stands for the body it was defined as.
             // A name that denotes a type is a case, and no helper answered it.
@@ -703,45 +703,83 @@ public final class FixtureReader {
             }
             return raw(c.args().get(0), expected);
         }
-        if (appliedHelper(c) instanceof Ast.FnDef helper) {
+        if (appliedHelper(c) instanceof Applied helper) {
             return applied(c, helper, expected);
         }
         return newtypeInner(c);
     }
 
+    /**
+     * A helper a fixture applies, and the name this module reached it by.
+     *
+     * <p>The two travel together because the declaration and the method have to be the same helper.
+     * Each was looked up on its own, and each looked up a spelling, so which declaration a fixture
+     * read and which method it ran were two answers that happened to agree.
+     */
+    private record Applied(String reached, Ast.FnDef def) {}
+
     /** The helper an application applies, or null where the call is not one: a {@code fromList} is the
      * fixture's own notation for a collection and a newtype application is a construction, so neither is
      * a helper however it is spelled. Asked wherever an application has to be told from a construction,
      * so the two readers of a call cannot come to different answers. */
-    private Ast.FnDef appliedHelper(Ast.Apply c) {
+    private Applied appliedHelper(Ast.Apply c) {
         if ("Set.fromList".equals(c.reaches()) || "Map.fromList".equals(c.reaches())
                 || neutral.isNewtype(c.written())) {
             return null;
         }
-        return helperDef(c.written());
+        String reached = helperKey(c);
+        Ast.FnDef helper = reached == null ? null : helperDef(reached);
+        return helper == null ? null : new Applied(reached, helper);
     }
 
     /**
-     * The helper a fixture may apply under {@code name}, or null where the name is not one: a
-     * definition written with a parameter list, read from the table that keys every helper this module
-     * reaches — its own, the ones its imports publish, and the prelude's — as the emitted method is
-     * keyed. The types come from there rather than from the written module because that table is
-     * settled (ADR-0066), and an argument is decoded against the parameter's settled type.
+     * The name this fixture looks {@code c}'s callee up by, or null where the call is not one a helper
+     * table may answer at all.
+     *
+     * <p>Two questions, and each is put to the thing that holds the answer. Whether this may be read as
+     * a helper is what the call denotes: a binding holds whatever it was given, a construction and a
+     * checker built-in stand for no declaration, and a behavior is not a helper — so a binding that
+     * shares a helper's spelling is still the binding. Under what name it is then looked up is the
+     * reach name the reference carries, settled at resolution and not worked out again here.
      */
-    private Ast.FnDef helperDef(String name) {
-        Ast.FnDef helper = values.get(name);
+    private String helperKey(Ast.Apply c) {
+        return switch (c.denotes()) {
+            case ValueName.Helper _, ValueName.Stdlib _ -> c.reaches();
+            case ValueName.Local _, ValueName.OfType _, ValueName.Builtin _, ValueName.Behavior _,
+                    ValueName.Unresolved _ -> null;
+            case null -> null;   // what applying something that is not a name leaves
+        };
+    }
+
+    /**
+     * The helper a fixture may apply under the reach name {@code reached}, or null where nothing there
+     * is one: a definition written with a parameter list, read from the table that keys every helper
+     * this module reaches — its own, the ones its imports publish, and the prelude's — as the emitted
+     * method is keyed. The types come from there rather than from the written module because that
+     * table is settled (ADR-0066), and an argument is decoded against the parameter's settled type.
+     *
+     * <p>Asked with what the call reaches and never with what it spells. An import lets a library name
+     * be written without its qualifier and nothing rewrites that spelling — the pass that writes
+     * imported names qualified reads what a name denotes, and a library name denotes something else —
+     * so a table keyed by reach names misses on it, silently, and the row is reported as having named
+     * a construction it cannot make.
+     */
+    private Ast.FnDef helperDef(String reached) {
+        Ast.FnDef helper = values.get(reached);
         return helper != null && !helper.params().isEmpty() ? helper : null;
     }
 
-    /** Whether {@code name} is a function this example cannot run: nothing emitted a method for it.
-     * A helper that has one is applied; the ones that never do are the standard library's intrinsics
-     * and a helper whose body produces a function, and both read as this. */
-    private boolean noMethod(String name) {
-        if (Prelude.isLibraryFunction(name)) {
+    /** Whether the helper {@code reached} names is a function this example cannot run: nothing emitted
+     * a method for it. A helper that has one is applied; the ones that never do are the standard
+     * library's intrinsics and a helper whose body produces a function, and both read as this. The
+     * reach name for the reason {@link #helperDef} takes one: the library is keyed under its alias, and
+     * this module's fns under the names it reaches them by. */
+    private boolean noMethod(String reached) {
+        if (Prelude.isLibraryFunction(reached)) {
             return true;   // a standard-library function: an intrinsic, or one nothing emitted here
         }
         for (Ast.FnDef fn : module.fns()) {
-            if (fn.name().equals(name) && !fn.params().isEmpty()) {
+            if (fn.name().equals(reached) && !fn.params().isEmpty()) {
                 return true;
             }
         }
@@ -754,21 +792,22 @@ public final class FixtureReader {
      * a field of a record and an element of a list alike. An application that encloses nothing is
      * {@link #helperAnswer}: there the value itself is what the row asserts.
      */
-    private Object applied(Ast.Apply c, Ast.FnDef helper, Type expected) {
+    private Object applied(Ast.Apply c, Applied helper, Type expected) {
         return neutral.of(answered(c, helper), expected, c.written());
     }
 
     /** The value a helper answers with, run as the method its module emits. Its arguments are fixtures
      * built against its parameter types, so an argument breaking one of those types' invariants is
      * reported as the fixture it is. */
-    private Object answered(Ast.Apply c, Ast.FnDef helper) {
-        if (c.args().size() != helper.params().size()) {
-            throw new FixtureException("`" + c.written() + "` takes " + helper.params().size()
+    private Object answered(Ast.Apply c, Applied helper) {
+        List<Ast.FnParam> params = helper.def().params();
+        if (c.args().size() != params.size()) {
+            throw new FixtureException("`" + c.written() + "` takes " + params.size()
                     + " argument(s) but is called with " + c.args().size());
         }
-        Object[] args = new Object[helper.params().size()];
+        Object[] args = new Object[params.size()];
         for (int i = 0; i < args.length; i++) {
-            Ast.FnParam p = helper.params().get(i);
+            Ast.FnParam p = params.get(i);
             if (p.type() == null) {
                 throw new FixtureException("`" + c.written() + "` parameter `" + p.name()
                         + "` has no type a fixture can be built against");
@@ -784,7 +823,7 @@ public final class FixtureReader {
             }
             args[i] = built(c.args().get(i), paramType);
         }
-        return helpers.invoke(c.written(), args);
+        return helpers.invoke(helper.reached(), args);
     }
 
     private Object newtypeInner(Ast.Apply c) {
@@ -797,7 +836,8 @@ public final class FixtureReader {
             return CallElaborator.parseTemporal(c.written(), lit.value(), c.pos());
         }
         if (!neutral.isNewtype(c.written())) {
-            if (noMethod(c.written())) {
+            String reached = helperKey(c);
+            if (reached != null && noMethod(reached)) {
                 // A function this module cannot run: an intrinsic implemented in Java, or a helper
                 // whose body produces a function. Said as that, so the rule that a fixture may apply a
                 // helper does not appear to have exceptions nothing explains (ADR-0077).

--- a/souther-compiler/src/test/java/souther/compiler/ARowAppliesTheHelperItsCallReachesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARowAppliesTheHelperItsCallReachesTest.java
@@ -1,0 +1,129 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.CompileException;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A fixture applies the helper its call reaches, not the one its spelling names.
+ *
+ * <p>An import lets a library name be written without its qualifier, and nothing rewrites that
+ * spelling into the name the table of reached helpers is keyed by — the rewrite that does it for an
+ * imported helper reads what the name denotes, and a library name denotes something else. So a row
+ * applying one was looked up under the spelling the author wrote, missed, and was reported as naming
+ * a construction it could not make (issue #397).
+ */
+class ARowAppliesTheHelperItsCallReachesTest {
+
+    private static final String MODULE = """
+            module demo
+            import Int ( abs )
+            data In  = { n: Int }
+            data Out = { m: Int }
+            behavior go : (i: In) -> Out constructs Out
+            let go (i) = Out { m = Int.abs(i.n) }
+            """;
+
+    @Test
+    void aRowMayApplyALibraryHelperWrittenBare() {
+        assertDoesNotThrow(() -> Compiler.compile(MODULE + """
+                example go
+                    | "bare" : (In { n = -3 }) -> Out { m = abs(-3) }
+                """));
+    }
+
+    @Test
+    void theSameHelperWrittenQualifiedIsTheSameHelper() {
+        assertDoesNotThrow(() -> Compiler.compile(MODULE + """
+                example go
+                    | "qualified" : (In { n = -3 }) -> Out { m = Int.abs(-3) }
+                """));
+    }
+
+    /** The row is run rather than passed over: a fixture that applies the helper and states the wrong
+     * answer fails as the mismatch it is. */
+    @Test
+    void aBareApplicationIsEvaluatedAndNotAssumed() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(MODULE + """
+                example go
+                    | "bare" : (In { n = -3 }) -> Out { m = abs(-4) }
+                """));
+        assertEquals("E1905", e.diagnostic().code(), e.getMessage());
+    }
+
+    /** Which library function a row applied decides what it is told about it, so that question is
+     * asked with the name the call reaches too: an intrinsic has no method for a fixture to run, and
+     * saying so is not the same as saying the call was not a construction. */
+    @Test
+    void aLibraryIntrinsicWrittenBareIsRefusedAsTheIntrinsicItIs() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                import String ( length )
+                data In  = { s: String }
+                data Out = { n: Int }
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { n = String.length(i.s) }
+                example go
+                    | "bare" : (In { s = "abc" }) -> Out { n = length("abc") }
+                """));
+        assertTrue(e.getMessage().contains("no executable helper method"), e.getMessage());
+    }
+
+    /**
+     * A helper another module publishes is applied the same way. It is reached under the module that
+     * declares it, which is what the row is looked up with — and the row writes it bare, because the
+     * import let it.
+     */
+    @Test
+    void aRowMayApplyAHelperAnotherModulePublishes() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
+                module up exposing ( twice )
+                let twice (n: Int) : Int = n * 2
+                """, """
+                module down
+                import up ( twice )
+                data In  = { n: Int }
+                data Out = { m: Int }
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { m = twice(i.n) }
+                example go
+                    | "imported" : (In { n = 3 }) -> Out { m = twice(3) }
+                """)));
+    }
+
+    /**
+     * Which name a fixture looks a call up by is one question and whether it may look it up as a helper
+     * at all is another. A binding that shares a helper's spelling is the binding, and a fixture cannot
+     * apply what a binding holds — so the row is refused rather than answered by the helper.
+     *
+     * <p>The first row is what makes this reachable: it applies the helper, so the method is emitted and
+     * a lookup by spelling would find one to run. Asked by spelling, the second row runs {@code twice}
+     * over 3, gets the 6 the behavior also returns, and holds — a row that states one thing and is
+     * passed by another.
+     */
+    @Test
+    void aBindingIsNotTheHelperThatSharesItsSpelling() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+                data In  = { n: Int }
+                data Out = { m: Int }
+                let twice (n: Int) : Int = n * 2
+                behavior go : (i: In) -> Out constructs Out
+                let go (i) = Out { m = twice(i.n) }
+                example go
+                    | "applies the helper" : (In { n = 1 }) -> Out { m = twice(1) }
+                    | "shadow"             : (In { n = 3 }) -> {
+                        let twice: (Int) -> Int = (k) -> k + 100
+                        Out { m = twice(3) }
+                      }
+                """));
+        assertEquals("E1903", e.diagnostic().code(), e.getMessage());
+    }
+}


### PR DESCRIPTION
`FixtureReader` looked a callee up by the spelling written at the call rather
than by the name it reaches. For a library name an import let be written bare
those are two different strings, so the row failed — and failed as though the
author had written something the compiler cannot build.

```souther
module demo
import Int ( abs )
…
example go
    | "bare" : (In { n = -3 }) -> Out { m = abs(-3) }
```

    E1903: `abs` is not a newtype; a fixture cannot call it

Written `Int.abs(-3)` the same row holds. Resolution had answered the call and
the method was emitted under `Int.abs` — `HelperInliner.helperCallsIn` collects
by `call.reaches()` — so only the reading side asked for it by another name.

The rewrite that would have hidden this does not run here:
`HelperNames.qualifyImports` reads what a name denotes and rewrites only a
`ValueName.Helper`, and a library name denotes a `ValueName.Stdlib`.

## What changed

Three readers on the Apply path each took the callee's spelling and then asked a
different question with it — which declaration (`helperDef`), which emitted
method (`HelperInvoker.invoke`), and which of two refusals the author is told
(`noMethod`). Fixing the first alone moves the failure to the second, which is
what says these are one defect and not three lines.

Two questions now, each put to what holds the answer:

```
may this be read as a helper at all?   ValueName
under what name is it looked up?       ReachName, carried on the reference
what does a report quote?              the written spelling
```

The reach name is settled at resolution and carried (#396, #399), so nothing here
works one out and nothing turns on which passes have run. `appliedHelper` puts
both questions and hands back the declaration together with the name it was
reached by, so the helper a fixture reads and the method it runs are one helper by
construction.

Keeping the first question is what stops a binding being answered by a helper of
the same spelling — see the test below.

Reports still quote the spelling: the arity and parameter-type refusals, the
value a helper returned, and E1903 all show what the source has.

## Tests

`ARowAppliesTheHelperItsCallReachesTest` — a bare-imported prelude helper applied
in a row, the qualified spelling as the control, a wrong expectation that must
still fail as E1905 so the row is known to have run, and a bare-imported intrinsic
that is refused as the intrinsic it is instead of as a failed construction. Three
of those four failed before the change; the control passed.

Two more pin what the shape is, not just what today's bug was:

- a helper another module publishes, applied bare in a row through the import —
  the same path with a `ValueName.Helper` rather than a `ValueName.Stdlib`
- a binding that shares a helper's spelling. An earlier row applies the helper, so
  the method is emitted and a lookup by spelling finds one to run: asked that way
  the shadowing row is answered by `twice`, gets the 6 the behavior also returns,
  and **holds**. It is refused here.

`mvn clean test` is green across the reactor.

## Left out

The four `Ast.Var` sites reading `v.name()` are untouched: each is reached only
where the name denotes a `ValueName.Helper`, which is reached bare or under the
module that declares it, and the pass that writes an imported name qualified has
already put that spelling there. The phase mixing in `valueBody` found beside
them is #400.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)
