### PR TITLE
A name nothing reads is not carried, and a signature admits the null its body handles

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -322,12 +322,6 @@ public final class Compiler {
 
     private static Compilation linked(List<String> sources, ModulePath path,
                                       List<Located> warningsOut, Adequacy.Asked measure,
-                                      java.time.Duration exampleBudget) {
-        return linked(sources, path, warningsOut, measure, exampleBudget, null, null);
-    }
-
-    private static Compilation linked(List<String> sources, ModulePath path,
-                                      List<Located> warningsOut, Adequacy.Asked measure,
                                       java.time.Duration exampleBudget, Deadline deadline,
                                       EvaluationPolicy policy) {
         Compilation compilation = Compilation.ofSources(sources, path);

--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -279,17 +279,6 @@ public final class FixtureReader {
         return null;   // a literal expected (a primitive output)
     }
 
-    /** The concrete type a fixture stands for — the case it constructs — or {@code declared} where
-     * nothing in it names one (a literal, a collection). A sum-returning dependency's fake row names one
-     * case, so its output decodes against that case, not the declared sum (which, written inline, has no
-     * decoder at all). */
-    private Type fixtureType(Ast.Expr e, Type declared) {
-        TypeName named = constructedCase(e);
-        // a fixture naming nothing this target can produce is reported by the arm check; decoding it
-        // against the declared type is what turns it into that diagnostic rather than a crash
-        return named != null ? Type.ref(named) : declared;
-    }
-
     /**
      * The case a fixture stands for: the one a construction names, and for a name, the one the value it
      * denotes constructs.

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -497,7 +497,7 @@ public interface Ast {
         public Expr writtenBody() {
             return switch (body) {
                 case FnBody.Written w -> w.expr();
-                case FnBody.Intrinsic i -> throw new IllegalStateException(
+                case FnBody.Intrinsic _ -> throw new IllegalStateException(
                         "`" + name() + "` is an intrinsic and has no written body");
             };
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
@@ -9,7 +9,6 @@ import souther.compiler.diag.Region;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -89,7 +88,7 @@ public final class BinaryElaborator {
                 yield switch (answer) {
                     case ArithmeticCheck.Allowed allowed ->
                             new Core.Binary(bin.op(), left, right, allowed.resultType(), bin.pos());
-                    case ArithmeticCheck.DeferToPlainTypeCheck ignored -> {
+                    case ArithmeticCheck.DeferToPlainTypeCheck _ -> {
                         // One type against another: the found-versus-expected block says it better
                         // than a sentence would, and requireType raises or absorbs it.
                         Elaborator.requireType(bin.right(), rt, lt, ctx.symbols(), "operand of arithmetic");

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -7,7 +7,6 @@ import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.Type;
-import souther.compiler.types.TypeName;
 import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 import souther.compiler.diag.CompileException;
@@ -27,7 +26,6 @@ import java.util.Map;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.function.IntFunction;
-import java.util.function.Predicate;
 
 /**
  * Expands calls to helper {@code fn}s inline (spec 12.5: a named helper is the same as an inline block).

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -381,8 +381,6 @@ final class HelperParams {
         private Type pinned;
         /** Whether the position now being read is a field read off its child. */
         private boolean readingAField;
-        /** The parameter being settled: a variable standing for it is what is being worked out. */
-        private BindingId target;
         /** What every other parameter of this helper is known to be, for {@link #saysWhatAnotherHolds}. */
         private List<Type> otherParameters = List.of();
         /** Every reading of a parameter that leaves what it holds open, and what they settle. One
@@ -424,7 +422,6 @@ final class HelperParams {
 
         Type typeOf(Ast.Binder target, Ast.Expr body, Scope env, Type answers, List<Type> others) {
             this.otherParameters = others;
-            this.target = target.id();
             this.pinned = null;
             this.readings.forParameter();
             this.openUse = null;

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -11,7 +11,6 @@ import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -2,7 +2,6 @@ package souther.compiler.check;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.types.BindingId;
-import souther.compiler.diag.SourcePos;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/MatchElaborator.java
@@ -10,10 +10,8 @@ import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -19,10 +19,8 @@ import souther.compiler.Reserved;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * Says once, for a whole module, what every written type name denotes.
@@ -91,11 +89,6 @@ public final class Resolve {
         return new Answered(
                 new Ast.Binder.Bound(binder.written(), id, binder.pos()),
                 bound.and(binder.name(), new ValueName.Local(binder.name(), id)));
-    }
-
-    /** The bindings under {@code binder}, where the binder itself is not carried on. */
-    private Bindings binding(Bindings bound, Ast.Binder binder) {
-        return bind(bound, binder).bound();
     }
 
     /** Several binders answered, and the bindings that hold under all of them. */

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -17,7 +17,6 @@ import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.check.TypeOps;
 import souther.compiler.core.Core;
-import souther.compiler.coverage.CoverageSites;
 
 import java.lang.classfile.Annotation;
 import java.lang.classfile.ClassBuilder;

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -17,7 +17,6 @@ import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeOps;
-import souther.compiler.check.MatchElaborator;
 import souther.compiler.core.Core;
 import souther.compiler.core.GrowingFold;
 
@@ -744,7 +743,7 @@ final class BodyGen {
                     genExpr(li.body(), expected);
                 }
                 // a block has no value of its own; it is inlined by the call it is passed to
-                case Core.Block b -> throw new IllegalStateException("a block is not a value");
+                case Core.Block _ -> throw new IllegalStateException("a block is not a value");
             }
             // `unreachable` is typed Never, and what is on the stack is the shape the position asked
             // for, so that is what the caller is told is there.

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -2,7 +2,6 @@ package souther.compiler.codegen;
 
 import souther.compiler.check.MatchElaborator;
 import souther.compiler.check.Symbols;
-import souther.compiler.diag.CompileException;
 import souther.compiler.ast.Ast;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
@@ -706,7 +705,7 @@ final class CodecGen {
      * {@code flatMapWithPath}, which answers the plain {@link Decoder}. Its clauses are refined instead.
      */
     private static boolean leafStaysTyped(Ast.DecoderDef dec) {
-        if (!(dec instanceof Ast.NewtypeDecoder nt)) {
+        if (!(dec instanceof Ast.NewtypeDecoder)) {
             return true;   // a prim leaf is typed; an object decoder maps nothing either way
         }
         // A newtype over a map keeps its typed leaf: the key remap is appended *after* the
@@ -1213,7 +1212,7 @@ final class CodecGen {
                 code.invokedynamic(setFromListCallSite());                   // Function: List -> Set
                 code.invokeinterface(CD_RDecoder, "map", MTD_Rdecoder_map);  // Decoder<I, Set<T>> (dedup)
             }
-            case Ast.OptionDecRef o -> throw new IllegalStateException("optional is only supported as a direct object field");
+            case Ast.OptionDecRef _ -> throw new IllegalStateException("optional is only supported as a direct object field");
             case Ast.MapDecRef mp -> {
                 emitDecoderObject(code, mp.value(), src);
                 code.invokestatic(srcListOwner(src), "map", MTD_mapDec);   // Decoder<I, Map<String,V>>

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Intrinsics.java
@@ -1,7 +1,6 @@
 package souther.compiler.codegen;
 
 import souther.compiler.Prelude;
-import souther.compiler.diag.CompileException;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.core.Core;
@@ -255,7 +254,6 @@ final class Intrinsics {
     private static Map<String, Emit> buildTable() {
         ClassDesc bool = ConstantDescs.CD_boolean;
         ClassDesc lng = ConstantDescs.CD_long;
-        ClassDesc intCd = ConstantDescs.CD_int;
         Map<String, Emit> t = new java.util.LinkedHashMap<>();
 
         // String — JDK-native instance methods (explicit descriptor); receiver is the last Souther arg.

--- a/souther-compiler/src/main/java/souther/compiler/codegen/JvmLimits.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/JvmLimits.java
@@ -8,7 +8,6 @@ import souther.compiler.check.Sig;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.DiagnosticCode;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 
 import java.util.HashSet;

--- a/souther-compiler/src/main/java/souther/compiler/codegen/JvmTypes.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/JvmTypes.java
@@ -5,7 +5,6 @@ import java.lang.classfile.Annotation;
 import java.lang.classfile.ClassBuilder;
 import java.lang.classfile.ClassFile;
 import java.lang.classfile.CodeBuilder;
-import java.lang.classfile.Label;
 import java.lang.classfile.TypeAnnotation;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -348,7 +348,6 @@ public final class AstBuilder {
     }
 
     private Ast.Field field(SyntaxNode n) {
-        String name = firstIdentText(n);
         Ast.TypeTerm type = typeTerm(typeChild(n));
         if (n.token(SyntaxKind.QUESTION).isPresent()) {
             type = new Ast.TypeRef("Option", type, type.pos());   // `T?` → Option<T>

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -3,7 +3,6 @@ package souther.compiler.query;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Sig;
 import souther.compiler.diag.CompileException;
-import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.LabeledRegion;
 import souther.compiler.diag.Located;
 import souther.compiler.meta.ModulePath;

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -6,7 +6,6 @@ import souther.compiler.check.Symbols;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
 import souther.compiler.observe.Classification;
-import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.observe.RowOutcome;

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -27,7 +27,6 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 /**

--- a/souther-compiler/src/test/java/souther/compiler/AStringIsMeasuredInCodePointsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AStringIsMeasuredInCodePointsTest.java
@@ -31,10 +31,6 @@ class AStringIsMeasuredInCodePointsTest {
 
     /** A supplementary-plane kanji: one code point, two UTF-16 units. */
     private static final String YOSHI = "𠮷";
-    /** A base letter and a combining acute accent — two code points, and NFD, so a boundary
-     *  canonicalizes it to the one composed code point. Written as escapes because the difference
-     *  this test is about is invisible in the glyph. */
-    private static final String DECOMPOSED = "e\u0301";
     /** 葛 followed by a variation selector: two code points, one character to a reader, and stable
      *  under every normalization form — so it stays two after a boundary. */
     private static final String VARIANT = "\u845b\udb40\udd01";

--- a/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileAttemptedConstructionTest.java
@@ -3,7 +3,6 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.diag.CompileException;
-import souther.compiler.diag.Located;
 import souther.compiler.diag.Severity;
 
 import java.util.List;

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -602,18 +602,6 @@ class CompileFakeExampleDisagreementTest {
                 """));
     }
 
-    /** The E1919s of a compile that may also fail, read off the reports rather than the warnings —
-     * a compile that raises drops the warnings it had collected. */
-    private static List<String> codesOf(String model) {
-        List<String> codes = new ArrayList<>();
-        for (String code : allCodesOf(model)) {
-            if ("E1919".equals(code)) {
-                codes.add(code);
-            }
-        }
-        return codes;
-    }
-
     /** Every example-family code the compile reported, in order. Read off the reports so that the
      * error a case is really about is visible beside the E1919s, and a test cannot pass by the whole
      * comparison having stopped working. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeTableWhereWrittenTest.java
@@ -6,7 +6,6 @@ import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.HumanRenderer;
 import souther.compiler.diag.Located;
-import souther.compiler.meta.ModulePath;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
@@ -9,7 +9,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import souther.compiler.diag.Located;
 import souther.compiler.diag.Severity;
 
 /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -1,7 +1,6 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
-import souther.compiler.diag.Located;
 import souther.compiler.diag.Severity;
 
 import org.junit.jupiter.api.Test;

--- a/souther-compiler/src/test/java/souther/compiler/CompileLambdaLetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLambdaLetTest.java
@@ -8,7 +8,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A lambda is a value: it may be bound to a local with {@code let} and applied. When it does not

--- a/souther-compiler/src/test/java/souther/compiler/CompileLibraryFunctionByNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLibraryFunctionByNameTest.java
@@ -9,7 +9,6 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A named function may be handed over rather than applied, and that is one rule for every named

--- a/souther-compiler/src/test/java/souther/compiler/CompileModuleChainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileModuleChainTest.java
@@ -1,6 +1,5 @@
 package souther.compiler;
 
-import souther.compiler.diag.CompileException;
 
 import org.junit.jupiter.api.Test;
 
@@ -9,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileNestedCollectionCodecTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNestedCollectionCodecTest.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -112,12 +112,6 @@ class CompilePartialAdequacyTest {
         return measured(source, (Deadline) null);
     }
 
-    /** As {@link #measured(String)}, for a model whose rows do not come back: waiting out the default
-     * budget reaches the same answer, later. */
-    private static Compilation measured(String source, Duration budget) {
-        return compiled("report:", source, budget, Adequacy.Asked.reportOnly());
-    }
-
     private static Compilation warned(String source) {
         return warned(source, null);
     }

--- a/souther-compiler/src/test/java/souther/compiler/ImportChangesNoMeaningTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ImportChangesNoMeaningTest.java
@@ -1,7 +1,6 @@
 package souther.compiler;
 
 import souther.compiler.diag.Diagnostic;
-import souther.compiler.diag.Located;
 
 import org.junit.jupiter.api.Test;
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ARuleIsHeldToTheDeclarationItIsAboutTest.java
@@ -1,6 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.Prelude;
 import souther.compiler.check.DischargeRules.Built;
 import souther.compiler.check.DischargeRules.Cardinality;
 import souther.compiler.check.DischargeRules.Carried;

--- a/souther-compiler/src/test/java/souther/compiler/check/ASignatureIsNotInstantiatedPerUseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASignatureIsNotInstantiatedPerUseTest.java
@@ -7,7 +7,6 @@ import souther.compiler.types.Type;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/InvariantCombinatorRulesTest.java
@@ -2,9 +2,7 @@ package souther.compiler.check;
 
 import souther.compiler.Compiler;
 import souther.compiler.Prelude;
-import souther.compiler.diag.Located;
 import souther.compiler.diag.Severity;
-import souther.compiler.types.ValueName;
 
 import org.junit.jupiter.api.Test;
 

--- a/souther-compiler/src/test/java/souther/compiler/diag/DiagnosticRenderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/DiagnosticRenderTest.java
@@ -1,6 +1,5 @@
 package souther.compiler.diag;
 
-import souther.compiler.diag.DiagnosticCode;
 
 import souther.compiler.Compiler;
 import org.junit.jupiter.api.Test;

--- a/souther-lsp/src/test/java/souther/lsp/analysis/NavigationSurvivesAMistakeTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/NavigationSurvivesAMistakeTest.java
@@ -1,7 +1,6 @@
 package souther.lsp.analysis;
 
 import souther.lsp.protocol.Position;
-import souther.lsp.protocol.Range;
 import souther.lsp.protocol.TextEdit;
 
 import org.junit.jupiter.api.Test;

--- a/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/analysis/RenamingAValueAgreesWhereverItIsAskedTest.java
@@ -2,7 +2,6 @@ package souther.lsp.analysis;
 
 import org.junit.jupiter.api.Test;
 import souther.lsp.protocol.Position;
-import souther.lsp.protocol.Range;
 import souther.lsp.protocol.TextEdit;
 
 import java.util.LinkedHashMap;

--- a/souther-runtime/src/main/java/souther/runtime/CEILING.java
+++ b/souther-runtime/src/main/java/souther/runtime/CEILING.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
 public record CEILING() implements RoundingMode {
 
@@ -8,7 +10,7 @@ public record CEILING() implements RoundingMode {
     // The overrides pin the shape generated unit data has: equality by case, a stable hash,
     // and the record-style text form.
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof CEILING;
     }
 

--- a/souther-runtime/src/main/java/souther/runtime/DOWN.java
+++ b/souther-runtime/src/main/java/souther/runtime/DOWN.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
 public record DOWN() implements RoundingMode {
 
@@ -8,7 +10,7 @@ public record DOWN() implements RoundingMode {
     // The overrides pin the shape generated unit data has: equality by case, a stable hash,
     // and the record-style text form.
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof DOWN;
     }
 

--- a/souther-runtime/src/main/java/souther/runtime/FLOOR.java
+++ b/souther-runtime/src/main/java/souther/runtime/FLOOR.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
 public record FLOOR() implements RoundingMode {
 
@@ -8,7 +10,7 @@ public record FLOOR() implements RoundingMode {
     // The overrides pin the shape generated unit data has: equality by case, a stable hash,
     // and the record-style text form.
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof FLOOR;
     }
 

--- a/souther-runtime/src/main/java/souther/runtime/HALF_DOWN.java
+++ b/souther-runtime/src/main/java/souther/runtime/HALF_DOWN.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
 public record HALF_DOWN() implements RoundingMode {
 
@@ -8,7 +10,7 @@ public record HALF_DOWN() implements RoundingMode {
     // The overrides pin the shape generated unit data has: equality by case, a stable hash,
     // and the record-style text form.
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof HALF_DOWN;
     }
 

--- a/souther-runtime/src/main/java/souther/runtime/HALF_EVEN.java
+++ b/souther-runtime/src/main/java/souther/runtime/HALF_EVEN.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
 public record HALF_EVEN() implements RoundingMode {
 
@@ -8,7 +10,7 @@ public record HALF_EVEN() implements RoundingMode {
     // The overrides pin the shape generated unit data has: equality by case, a stable hash,
     // and the record-style text form.
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof HALF_EVEN;
     }
 

--- a/souther-runtime/src/main/java/souther/runtime/HALF_UP.java
+++ b/souther-runtime/src/main/java/souther/runtime/HALF_UP.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
 public record HALF_UP() implements RoundingMode {
 
@@ -8,7 +10,7 @@ public record HALF_UP() implements RoundingMode {
     // The overrides pin the shape generated unit data has: equality by case, a stable hash,
     // and the record-style text form.
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof HALF_UP;
     }
 

--- a/souther-runtime/src/main/java/souther/runtime/Option.java
+++ b/souther-runtime/src/main/java/souther/runtime/Option.java
@@ -16,7 +16,7 @@ public sealed interface Option<T> permits Option.Some, Option.None {
     record Some<T>(T value) implements Option<T> {
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             return o instanceof Some<?> other && Values.equal(value, other.value());
         }
 

--- a/souther-runtime/src/main/java/souther/runtime/PersistentHashMap.java
+++ b/souther-runtime/src/main/java/souther/runtime/PersistentHashMap.java
@@ -156,7 +156,7 @@ public final class PersistentHashMap<K, V> extends AbstractMap<K, V> implements 
      * foreign map meant is not a question the boundary can answer.
      */
     @Override
-    public boolean valueEquals(Object o) {
+    public boolean valueEquals(@Nullable Object o) {
         if (o == this) {
             return true;
         }

--- a/souther-runtime/src/main/java/souther/runtime/PersistentHashSet.java
+++ b/souther-runtime/src/main/java/souther/runtime/PersistentHashSet.java
@@ -131,7 +131,7 @@ public final class PersistentHashSet<E> extends AbstractSet<E> implements ValueS
      * when the set already is one, so a set Souther built pays nothing.
      */
     @Override
-    public boolean valueEquals(Object o) {
+    public boolean valueEquals(@Nullable Object o) {
         if (o == this) {
             return true;
         }

--- a/souther-runtime/src/main/java/souther/runtime/PersistentVector.java
+++ b/souther-runtime/src/main/java/souther/runtime/PersistentVector.java
@@ -373,7 +373,7 @@ public final class PersistentVector<E> extends AbstractList<E>
     /** Whether {@code o} is the same list the language means: the same elements in the same order,
      *  each compared through {@link Values}. */
     @Override
-    public boolean valueEquals(Object o) {
+    public boolean valueEquals(@Nullable Object o) {
         if (o == this) {
             return true;
         }

--- a/souther-runtime/src/main/java/souther/runtime/Representations.java
+++ b/souther-runtime/src/main/java/souther/runtime/Representations.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -132,7 +134,7 @@ public final class Representations {
     }
 
     /** The members of an encoded array, in ascending order of their own external representation. */
-    public static Object sortedArray(Object encoded) {
+    public static Object sortedArray(@Nullable Object encoded) {
         if (!(encoded instanceof List<?> members)) {
             throw notAnExternalForm(encoded);
         }
@@ -140,7 +142,7 @@ public final class Representations {
     }
 
     /** The members of an encoded object, in ascending order of their keys. */
-    public static Object sortedObject(Object encoded) {
+    public static Object sortedObject(@Nullable Object encoded) {
         if (!(encoded instanceof Map<?, ?> members)) {
             throw notAnExternalForm(encoded);
         }
@@ -153,15 +155,19 @@ public final class Representations {
      * form they are written in; strings by UTF-16 code unit; arrays element by element with the
      * shorter one first; objects as their members read in key order.
      */
-    public static int compareExternalForms(Object a, Object b) {
+    public static int compareExternalForms(@Nullable Object a, @Nullable Object b) {
         return compare(a, b, null);
     }
 
-    private static int compare(Object a, Object b, KeyOrders orders) {
+    private static int compare(@Nullable Object a, @Nullable Object b, @Nullable KeyOrders orders) {
         int form = rank(a);
         int other = rank(b);
         if (form != other) {
             return Integer.compare(form, other);
+        }
+        if (a == null || b == null) {
+            // the ranks agree, so both are null: the rank is the whole of what a null is
+            return 0;
         }
         return switch (form) {
             case NULL, FALSE, TRUE -> 0;
@@ -182,10 +188,14 @@ public final class Representations {
      * it holds is not — and stopping at the outside would accept, at one entry point, what the other
      * refuses.
      */
-    static boolean representationEquals(Object a, Object b) {
+    static boolean representationEquals(@Nullable Object a, @Nullable Object b) {
         int form = rank(a);
         if (form != rank(b)) {
             return false;
+        }
+        if (a == null || b == null) {
+            // the ranks agree, so both are null: the rank is the whole of what a null is
+            return true;
         }
         return switch (form) {
             case NULL, FALSE, TRUE -> true;
@@ -196,7 +206,7 @@ public final class Representations {
         };
     }
 
-    private static int rank(Object v) {
+    private static int rank(@Nullable Object v) {
         return switch (v) {
             case null -> NULL;
             case Boolean b -> b ? TRUE : FALSE;
@@ -231,7 +241,7 @@ public final class Representations {
         return number.toString();
     }
 
-    private static int compareArrays(List<?> a, List<?> b, KeyOrders orders) {
+    private static int compareArrays(List<?> a, List<?> b, @Nullable KeyOrders orders) {
         Iterator<?> xs = a.iterator();
         Iterator<?> ys = b.iterator();
         while (xs.hasNext() && ys.hasNext()) {
@@ -243,7 +253,7 @@ public final class Representations {
         return Integer.compare(a.size(), b.size());
     }
 
-    private static int compareObjects(Map<?, ?> a, Map<?, ?> b, KeyOrders orders) {
+    private static int compareObjects(Map<?, ?> a, Map<?, ?> b, @Nullable KeyOrders orders) {
         List<String> xs = keysOf(a, orders);
         List<String> ys = keysOf(b, orders);
         for (int i = 0; i < Math.min(xs.size(), ys.size()); i++) {
@@ -307,17 +317,19 @@ public final class Representations {
      */
     private static final class KeyOrders {
 
-        private Map<Object, List<String>> known;
+        private @Nullable Map<Object, List<String>> known;
 
         List<String> of(Map<?, ?> members) {
-            if (known == null) {
-                known = new IdentityHashMap<>();
+            Map<Object, List<String>> cache = known;
+            if (cache == null) {
+                cache = new IdentityHashMap<>();
+                known = cache;
             }
-            return known.computeIfAbsent(members, m -> sortedKeys((Map<?, ?>) m));
+            return cache.computeIfAbsent(members, m -> sortedKeys((Map<?, ?>) m));
         }
     }
 
-    private static List<String> keysOf(Map<?, ?> members, KeyOrders orders) {
+    private static List<String> keysOf(Map<?, ?> members, @Nullable KeyOrders orders) {
         return orders == null ? sortedKeys(members) : orders.of(members);
     }
 
@@ -348,7 +360,7 @@ public final class Representations {
     }
 
     /** One refusal, so a carrier the encoders do not emit is reported the same wherever it lands. */
-    private static IllegalStateException notAnExternalForm(Object v) {
+    private static IllegalStateException notAnExternalForm(@Nullable Object v) {
         return new IllegalStateException("not a Souther external representation: " + switch (v) {
             case null -> "nothing at all";     // null is a form, but it is not an array or an object
             case String said -> said;          // a phrase from the caller, not a value's own class

--- a/souther-runtime/src/main/java/souther/runtime/Tuple.java
+++ b/souther-runtime/src/main/java/souther/runtime/Tuple.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Several values carried together through a computation (ADR-0036). A tuple has no external form, so
  * it is never a data field or a behavior's input or output; within a computation it is a value like
@@ -60,7 +62,7 @@ public sealed interface Tuple {
     int size();
 
     /** Whether {@code a} and {@code b} are the same tuple; what each arm's {@code equals} answers. */
-    static boolean same(Tuple a, Object b) {
+    static boolean same(Tuple a, @Nullable Object b) {
         if (a == b) {
             return true;
         }
@@ -124,7 +126,7 @@ public sealed interface Tuple {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             return same(this, o);
         }
 
@@ -159,7 +161,7 @@ public sealed interface Tuple {
         }
 
         @Override
-        public boolean equals(Object o) {
+        public boolean equals(@Nullable Object o) {
             return same(this, o);
         }
 

--- a/souther-runtime/src/main/java/souther/runtime/UP.java
+++ b/souther-runtime/src/main/java/souther/runtime/UP.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /** A case of {@link RoundingMode}. A unit data: the only value is {@link #INSTANCE}. */
 public record UP() implements RoundingMode {
 
@@ -8,7 +10,7 @@ public record UP() implements RoundingMode {
     // The overrides pin the shape generated unit data has: equality by case, a stable hash,
     // and the record-style text form.
     @Override
-    public boolean equals(Object o) {
+    public boolean equals(@Nullable Object o) {
         return o instanceof UP;
     }
 

--- a/souther-runtime/src/main/java/souther/runtime/ValueSemantics.java
+++ b/souther-runtime/src/main/java/souther/runtime/ValueSemantics.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Souther's value semantics for a type whose Java {@code equals} and {@code hashCode} belong to a
  * JDK contract it cannot break.
@@ -18,7 +20,7 @@ package souther.runtime;
 public interface ValueSemantics {
 
     /** Whether {@code other} is the same Souther value as this one. */
-    boolean valueEquals(Object other);
+    boolean valueEquals(@Nullable Object other);
 
     /** A hash that agrees with {@link #valueEquals}. */
     int valueHash();

--- a/souther-runtime/src/main/java/souther/runtime/Values.java
+++ b/souther-runtime/src/main/java/souther/runtime/Values.java
@@ -1,5 +1,7 @@
 package souther.runtime;
 
+import org.jspecify.annotations.Nullable;
+
 import java.math.BigDecimal;
 import java.util.Iterator;
 import java.util.List;
@@ -40,7 +42,7 @@ public final class Values {
 
     private Values() {}
 
-    public static boolean equal(Object a, Object b) {
+    public static boolean equal(@Nullable Object a, @Nullable Object b) {
         if (a == b) {
             return true;
         }
@@ -67,11 +69,11 @@ public final class Values {
     }
 
     /** Two amounts are the same amount when they differ only in scale. */
-    public static boolean equal(BigDecimal a, BigDecimal b) {
+    public static boolean equal(@Nullable BigDecimal a, @Nullable BigDecimal b) {
         return a == null ? b == null : b != null && a.compareTo(b) == 0;
     }
 
-    public static int hash(Object v) {
+    public static int hash(@Nullable Object v) {
         return switch (v) {
             case null -> 0;
             case Long l -> l.hashCode();
@@ -94,7 +96,7 @@ public final class Values {
     }
 
     /** The hash of an amount, taken after dropping the scale its equality ignores. */
-    public static int hash(BigDecimal v) {
+    public static int hash(@Nullable BigDecimal v) {
         return v == null ? 0 : v.stripTrailingZeros().hashCode();
     }
 

--- a/souther-runtime/src/test/java/souther/runtime/RepresentationsTest.java
+++ b/souther-runtime/src/test/java/souther/runtime/RepresentationsTest.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,7 +31,7 @@ class RepresentationsTest {
      * against a BMP one that is the larger code unit and the smaller code point, and two objects
      * that differ only in the order their members were put.
      */
-    private static final List<Object> CORPUS = Arrays.asList(
+    private static final List<@Nullable Object> CORPUS = Arrays.asList(
             null,
             false,
             true,
@@ -180,7 +181,7 @@ class RepresentationsTest {
 
     @Test
     void theKindsAreOrderedNullFalseTrueNumberStringArrayObject() {
-        List<Object> ascending = Arrays.asList(null, false, true, 0L, "", List.of(), object());
+        List<@Nullable Object> ascending = Arrays.asList(null, false, true, 0L, "", List.of(), object());
         for (int i = 0; i < ascending.size() - 1; i++) {
             assertTrue(Representations.compareExternalForms(ascending.get(i), ascending.get(i + 1)) < 0,
                     ascending.get(i) + " must come before " + ascending.get(i + 1));
@@ -296,12 +297,12 @@ class RepresentationsTest {
 
     @Test
     void theOrderIsTransitive() {
-        for (Object a : CORPUS) {
-            for (Object b : CORPUS) {
+        for (@Nullable Object a : CORPUS) {
+            for (@Nullable Object b : CORPUS) {
                 if (Representations.compareExternalForms(a, b) > 0) {
                     continue;
                 }
-                for (Object c : CORPUS) {
+                for (@Nullable Object c : CORPUS) {
                     if (Representations.compareExternalForms(b, c) <= 0) {
                         assertTrue(Representations.compareExternalForms(a, c) <= 0,
                                 written(a) + " <= " + written(b) + " <= " + written(c)
@@ -315,10 +316,11 @@ class RepresentationsTest {
     // === sorting ===
 
     @Test
+    @SuppressWarnings("unchecked")   // sortedArray answers Object; over a list it is the list back
     void sortedArrayPutsTheMembersInOrderWhicheverOrderTheyArrivedIn() {
-        List<Object> members = new ArrayList<>(CORPUS);
-        List<Object> forwards = (List<Object>) Representations.sortedArray(members);
-        List<Object> reversed = new ArrayList<>(members);
+        List<@Nullable Object> members = new ArrayList<>(CORPUS);
+        List<@Nullable Object> forwards = (List<@Nullable Object>) Representations.sortedArray(members);
+        List<@Nullable Object> reversed = new ArrayList<>(members);
         java.util.Collections.reverse(reversed);
 
         assertEquals(written(forwards), written(Representations.sortedArray(reversed)));
@@ -413,18 +415,18 @@ class RepresentationsTest {
     // === helpers ===
 
     private interface Pair {
-        void check(Object a, Object b);
+        void check(@Nullable Object a, @Nullable Object b);
     }
 
     private static void forEachPair(Pair check) {
-        for (Object a : CORPUS) {
-            for (Object b : CORPUS) {
+        for (@Nullable Object a : CORPUS) {
+            for (@Nullable Object b : CORPUS) {
                 check.check(a, b);
             }
         }
     }
 
-    private static boolean isAscending(List<Object> xs) {
+    private static boolean isAscending(List<@Nullable Object> xs) {
         for (int i = 0; i < xs.size() - 1; i++) {
             if (Representations.compareExternalForms(xs.get(i), xs.get(i + 1)) > 0) {
                 return false;
@@ -446,7 +448,7 @@ class RepresentationsTest {
      * because their order is not part of what the object is. It is written here rather than asked of
      * {@link Representations} so that the law above is checked against something else.
      */
-    private static String written(Object v) {
+    private static String written(@Nullable Object v) {
         return switch (v) {
             case null -> "null";
             case Boolean b -> b.toString();


### PR DESCRIPTION
Clears the warnings the editor was reporting across the three modules.

## What was there

**Unused names.** 35 imports, 5 locals, 4 private methods, 2 fields, and 4 pattern variables a switch arm bound without reading. Two were not a bare deletion: `HelperParams.BodyTyping.target` was assigned once per call and never read, and `AstBuilder.field` worked a name out and then built its field from `nameOf` instead.

**Signatures narrower than their bodies.** `Values.equal` branched on `b == null` behind a parameter declared non-null, so the branch read as dead code. `Representations` says in its own comment that null is the first external form, while `compareExternalForms`, `sortedArray` and `sortedObject` refused to be handed one. Saying what the bodies do also cleared the eight mismatches those two were causing in `PersistentHashMap`, `PersistentHashSet` and `PersistentVector`.

`equals` takes `@Nullable Object` for the same reason: under `@NullMarked` a bare `Object` parameter is narrower than the `Object.equals` it overrides.

## Not changed

`CodecGen.leafStaysTyped` returns `true` from both arms of its `if`, so `refining` always starts false. Only the unused pattern variable was removed; the condition is left as it is.

The `pom.xml` warning about `copy-resources` reading `${project.basedir}/..` stays. It is m2e's, not Maven's, and `<?m2e ignore?>` is not available here because `EveryDiagnosticCodeIsReadableTest` reads the resource that execution produces.

The remaining "Unsafe null type conversion" reports are JSpecify read through JDT: under `@NullMarked`, `List<String>` already means `List<@NonNull String>`, and JDT calls the JDK's unannotated form a widening. They are settings, not code, and are keyed on `annotatedTypeArgumentToUnannotated` rather than the `nullUncheckedConversion` that was already set.

## Verification

`mvn -o clean install` — BUILD SUCCESS. compiler 3182, lsp 184, runtime 109, cli IT 7, bench 1, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
