### PR TITLE
A fixture reads a value from the settled table and from nothing else

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -633,21 +633,22 @@ public final class FixtureReader {
      * What a name stands for: a binding in force, or the body a value — a {@code let} with no parameter
      * list — was defined as. Null where the name is neither.
      *
+     * <p>Read from the table {@link #helperDef} reads, and from nothing else. That table is the
+     * settled representation this whole reading is written against, and what it does not hold is not
+     * a value a fixture may read. The written module is not a second way to the same answer: it
+     * holds every definition, a behavior's implementation among them, and a behavior taking nothing
+     * is written the way a value is — so a spread, which asks here for any name it does not bind,
+     * used to copy the fields of one.
+     *
      * <p>Whether a fixture may name it is not a property of this one body: a value stands for a
      * fixture when it is a literal, a construction, a spread, a {@code fromList} over one, or a name
      * of another such value. So the body is read the same way the row's own text is, and a chain of
      * values holds.
      */
     private Ast.Expr valueBody(String name) {
-        for (Ast.FnDef fn : module.fns()) {
-            if (fn.name().equals(name) && fn.params().isEmpty()
-                    && fn.body() instanceof Ast.FnBody.Written w) {
-                return w.expr();
-            }
-        }
-        Ast.FnDef imported = values.get(name);
-        return imported != null && imported.params().isEmpty()
-                && imported.body() instanceof Ast.FnBody.Written w ? w.expr() : null;
+        Ast.FnDef value = values.get(name);
+        return value != null && value.params().isEmpty()
+                && value.body() instanceof Ast.FnBody.Written w ? w.expr() : null;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/ABehaviorIsNotAValueAFixtureCanNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABehaviorIsNotAValueAFixtureCanNameTest.java
@@ -1,0 +1,96 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A behavior taking nothing is implemented the way a value is. {@code behavior base : () -> Note} is
+ * satisfied by {@code let base = Note { … }} — {@code let base ()} is not a parameter list a
+ * definition may write (E2301) — so the definition behind a behavior and the definition behind a
+ * value have the same shape, and nothing about the shape tells a fixture which it has.
+ *
+ * <p>What tells them apart is the table a fixture reads values from, which holds the module's
+ * helpers and not its behaviors' implementations. Both positions a fixture may write a name in are
+ * here: named where a value goes, and spread into a construction. The two used to disagree — the
+ * name was refused by what it denotes and the spread was answered from the written module, which
+ * holds the implementation the table leaves out.
+ *
+ * <p>A value of the same shape stands beside each, because a reading that refused by shape rather
+ * than by what the table holds would refuse both.
+ */
+class ABehaviorIsNotAValueAFixtureCanNameTest {
+
+    private static final String MODEL = """
+            module demo
+
+            data Note = { t: String }
+
+            behavior base : () -> Note
+                constructs Note
+
+            let base = Note { t = "T" }
+
+            let plain = Note { t = "T" }
+
+            behavior echo : (n: Note) -> Note
+
+            let echo (n) = n
+            """;
+
+    private static CompileException only(String rows) {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compile(MODEL + rows));
+        assertEquals(1, e.diagnostics().size(), "one row, one diagnostic: " + e.getMessage());
+        return e;
+    }
+
+    @Test
+    void aBehaviorNamedWhereAValueGoesIsRefused() {
+        CompileException e = only("""
+                example echo
+                  | (base) -> Note { t = "T" }
+                """);
+        Diagnostic d = e.diagnostics().get(0);
+
+        assertEquals("E1903", d.code());
+        assertTrue(e.getMessage().contains("`base` is not a value a fixture can name"),
+                "the row is told the name is not a value, not that it built the wrong one: "
+                        + e.getMessage());
+    }
+
+    @Test
+    void aBehaviorSpreadIntoAConstructionIsRefused() {
+        CompileException e = only("""
+                example echo
+                  | (Note { ...base }) -> Note { t = "T" }
+                """);
+        Diagnostic d = e.diagnostics().get(0);
+
+        assertEquals("E1903", d.code());
+        assertTrue(e.getMessage().contains("`base` is not a value a fixture can spread"),
+                "a spread reads the table the same way a name does: " + e.getMessage());
+    }
+
+    @Test
+    void aValueOfTheSameShapeIsNamed() {
+        assertDoesNotThrow(() -> Compiler.compile(MODEL + """
+                example echo
+                  | (plain) -> Note { t = "T" }
+                """));
+    }
+
+    @Test
+    void aValueOfTheSameShapeIsSpread() {
+        assertDoesNotThrow(() -> Compiler.compile(MODEL + """
+                example echo
+                  | (Note { ...plain }) -> Note { t = "T" }
+                """));
+    }
+}


### PR DESCRIPTION
Closes #400.

`valueBody` answered one question from two sources: it searched the written module (`Shapes.Prepared`) first and the settled table (`Bodies.Helpers`) second. The two do not agree everywhere, and where they disagree the written module is the wrong authority.

## Where a fixture writes a bare name, the two agreed

A name reaches `valueBody` from `named` and `helperAnswer` only where it denotes a `ValueName.Helper`; `HelperInliner.helpersOf(Settled)` records every fn of the module whose name is not a behavior's; and `HelperParams.settle` is the identity on a definition with no parameters — the per-definition `settle` returns null when no parameter is open, and `settleOnce` rebuilds the list as `settled.getOrDefault(fn.name(), fn)`. So the search of the written module returned the object the table already held.

## Where a fixture spreads, they did not

The spread site asks `valueBody` for any name it does not bind locally:

```java
Ast.Expr value = ref.denotes() instanceof ValueName.Local local
        ? bindings.get(local.id()) : valueBody(spread);
```

There is no `ValueName.Helper` guard there, so a behavior's name reaches `valueBody`. The written module holds the implementation behind a behavior and the table leaves it out — `helpersOf` drops a fn whose name is a behavior's.

A behavior taking nothing is written the way a value is (`let base = Note { t = "T" }`; `let base ()` is refused with E2301), so nothing about the shape tells the two apart:

```souther
behavior base : () -> Note
    constructs Note

let base = Note { t = "T" }

example echo
  | (Note { ...base }) -> Note { t = "T" }
```

On `develop` that row compiles: the spread copies the fields of the behavior's implementation. With this change it is refused — `` `base` is not a value a fixture can spread ``.

So this is not a pure cleanup. The second source was already reading past a semantic boundary in one reachable position, and removing it closes that.

## Test

`ABehaviorIsNotAValueAFixtureCanNameTest` covers both positions a fixture may write a name in, each with a value of the same shape beside it so the refusal is by what the table holds rather than by shape:

- `aBehaviorSpreadIntoAConstructionIsRefused` — **fails on `develop`** (nothing is thrown; the row compiles) and passes here. This is the regression witness.
- `aBehaviorNamedWhereAValueGoesIsRefused` — passes on either side. A bare name is refused in `named` by what it denotes and never reaches `valueBody`; the test pins the rule, which nothing asserted before.
- `aValueOfTheSameShapeIsNamed` / `aValueOfTheSameShapeIsSpread`.

Reading a module's own value and reading an imported one are already covered by `ExampleFileValuesTest` and `ExampleSpreadFixtureTest`.

## Verification

Before the change, `valueBody` was instrumented to compute both answers over the compiler suite: 175 hits, 139 where both sides answered with the identical object, 36 answered only by the table (imported values under qualified keys), none disagreeing. That sample contains no spread of a behavior, which is why it showed no difference — the difference is reachable but not exercised by the suite until the test above.

`mvn clean test` passes across all modules (3486 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
