### PR TITLE
A call the specification writes is resolved against the signature it is written for

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
@@ -78,7 +78,7 @@ public final class ApiCommand {
     }
 
     /** One callable name's parameters, as written, and the type its call answers with. */
-    private record Signature(List<String> paramNames, List<Type> paramTypes, Type result) {}
+    record Signature(List<String> paramNames, List<Type> paramTypes, Type result) {}
 
     private static void listPublished(PrintStream out, String prefix) {
         surface().forEach((name, signature) -> {
@@ -97,7 +97,7 @@ public final class ApiCommand {
      * only the arguments its caller writes. Leaving it out would have this command contradict the
      * specification about what exists.
      */
-    private static Map<String, Signature> surface() {
+    static Map<String, Signature> surface() {
         Map<String, Signature> surface = new LinkedHashMap<>();
         for (Map.Entry<String, Prelude.PreludeEntry> e : Prelude.entries().entrySet()) {
             if (Prelude.published().contains(e.getKey())) {

--- a/souther-compiler/src/test/java/souther/compiler/CompileLibraryFunctionByNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLibraryFunctionByNameTest.java
@@ -12,8 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * A named function may be handed over rather than applied, and that is one rule for every named
- * function ([#blocks]): {@code List.all(reasons, isValid)} and {@code List.all(reasons, r ->
- * isValid(r))} are the same thing. It held for a module's own {@code let} and not for the library's,
+ * function ([#blocks]): {@code List.all(isValid, reasons)} and {@code List.all(r -> isValid(r),
+ * reasons)} are the same thing. It held for a module's own {@code let} and not for the library's,
  * whose names could not be written without an argument list at all.
  *
  * <p>What a name is on the other side of — a Souther body, a shipped kernel — is not the name's

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest.java
@@ -1,0 +1,322 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.Prelude;
+import souther.compiler.types.Type;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A call the specification writes in its prose or in an example is what a reader copies. The
+ * checker resolves that call against a signature the standard library declares, so a call the
+ * document writes one way and the library declares another is the document teaching code that does
+ * not compile.
+ *
+ * <p>The calls are read out of the specification's own text and the signatures come from the
+ * resolver `souther api` prints. Neither side is written for the other: what is checked is that the
+ * side a reader reads and the side the compiler enforces say the same thing.
+ */
+class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
+
+    /** A qualified standard-library call, wherever the specification writes one. */
+    private static final Pattern CALL =
+            Pattern.compile("(?<![\\w.])([A-Z][A-Za-z0-9]*)\\.([a-z][A-Za-z0-9]*)\\(");
+
+    /** A function the specification declares, so a bare name it writes elsewhere is known to be one. */
+    private static final Pattern DECLARED_FUNCTION = Pattern.compile(
+            "(?m)^\\s*(?:partial\\s+)?let\\s+([a-z][A-Za-z0-9]*)\\s*\\("
+                    + "|^\\s*behavior\\s+([a-z][A-Za-z0-9]*)\\s*:");
+
+    /** An argument written as an ellipsis rather than as a value — the call is quoted, not made. */
+    private static final Pattern ELIDED = Pattern.compile("\\.\\.\\.|…");
+
+    /** A bare name, qualified or not, with nothing applied to it. */
+    private static final Pattern NAME = Pattern.compile("[A-Za-z][A-Za-z0-9]*(\\.[A-Za-z][A-Za-z0-9]*)?");
+
+    /** A getter block: {@code .field} desugars to {@code (x) -> x.field}. */
+    private static final Pattern GETTER = Pattern.compile("\\.[a-z][A-Za-z0-9]*");
+
+    /**
+     * A call the specification writes in order to say that it is refused. The document is right
+     * about each of these and the checker is right to resolve them otherwise; what is checked here
+     * is the calls a reader is meant to copy.
+     */
+    private static final Set<String> WRITTEN_TO_BE_REFUSED = Set.of(
+            "Decimal.divide(dividend, divisor)");
+
+    @Test
+    void theSpecificationCallsTheStandardLibraryTheWayTheLibraryDeclaresItself() {
+        assertEquals(Set.of(), disagreements(text()),
+                "the specification writes these calls, and the checker resolves them otherwise");
+    }
+
+    @Test
+    void aCallIsFoundAtAllSoTheScanIsNotLookingAtAnEmptyDocument() {
+        assertFalse(callsIn(text()).isEmpty(), "found no standard-library call at all — the scan missed the document");
+    }
+
+    /**
+     * The two lines this check was written for. Both pass a function where {@code List.all} declares
+     * the list: the first writes it as a block, the second by the name the same listing declares it
+     * under.
+     */
+    @Test
+    void aFunctionPassedWhereTheSignatureDeclaresTheCollectionIsCaught() {
+        Set<String> found = disagreements("""
+                [,text]
+                ----
+                let isValid (r: PreApprovalReason) = ...
+
+                List.all(reasons, r -> isValid(r))
+                List.all(reasons, isValid)
+                ----
+                """);
+
+        assertEquals(2, found.size(), found.toString());
+        assertTrue(found.stream().allMatch(f -> f.contains("List.all") && f.contains("argument 2")), found.toString());
+        assertEquals(Set.of(), disagreements("""
+                [,text]
+                ----
+                let isValid (r: PreApprovalReason) = ...
+
+                List.all(r -> isValid(r), reasons)
+                List.all(isValid, reasons)
+                ----
+                """), "and the same two lines written the other way round are what the signature declares");
+    }
+
+    @Test
+    void aCallPassingTooFewOrTooManyArgumentsIsCaught() {
+        assertEquals(1, disagreements("`+List.map(xs)+`").size());
+        assertEquals(1, disagreements("`+List.map(f, xs, more)+`").size());
+        assertEquals(Set.of(), disagreements("`+List.map(f, xs)+`"));
+    }
+
+    /** A pipe supplies the last argument, so the call is written with one fewer. */
+    @Test
+    void aPipedCallIsReadWithTheArgumentThePipeSupplies() {
+        assertEquals(Set.of(), disagreements("`+xs |> List.map(.value)+`"));
+        assertEquals(1, disagreements("`+xs |> List.map(f, xs)+`").size());
+    }
+
+    @Test
+    void aNameTheLibraryDoesNotPublishIsCaught() {
+        assertEquals(1, disagreements("`+List.mapish(f, xs)+`").size());
+    }
+
+    /** An ellipsis stands for arguments rather than being one, so the count says nothing. */
+    @Test
+    void aCallQuotedWithAnEllipsisIsNotCountedAgainstItsArity() {
+        assertEquals(Set.of(), disagreements("`+String.length(...)+`"));
+    }
+
+    /** Every way the specification disagrees with a resolved signature, one line each. */
+    private static Set<String> disagreements(String adoc) {
+        Set<String> declaredHere = declaredFunctionsIn(adoc);
+        Map<String, ApiCommand.Signature> surface = ApiCommand.surface();
+        Set<String> found = new TreeSet<>();
+        for (Call call : callsIn(adoc)) {
+            if (WRITTEN_TO_BE_REFUSED.contains(call.written())) {
+                continue;
+            }
+            ApiCommand.Signature signature = surface.get(call.name());
+            if (signature == null) {
+                found.add(call.where() + call.name() + " names nothing the standard library publishes");
+                continue;
+            }
+            int declared = signature.paramNames().size();
+            int written = call.args().size() + (call.piped() ? 1 : 0);
+            if (written != declared && call.args().stream().noneMatch(a -> ELIDED.matcher(a).find())) {
+                found.add(call.where() + call.name() + " is written with " + written
+                        + " argument(s) and declares " + declared);
+            }
+            for (int i = 0; i < call.args().size() && i < declared; i++) {
+                if (isFunction(call.args().get(i), declaredHere, surface)
+                        && !(signature.paramTypes().get(i) instanceof Type.FnOf)) {
+                    found.add(call.where() + call.name() + " is passed a function as argument " + (i + 1)
+                            + ", where it declares " + signature.paramNames().get(i) + ": "
+                            + Type.show(signature.paramTypes().get(i)));
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Whether the argument is a function on its face: an anonymous block, a getter block, or a name
+     * declared as a function — by the standard library, or by the document that writes the call.
+     * A name nothing here declares says nothing either way, so it is left alone. A library name
+     * declaring no parameter is a value rather than a function — {@code Map.empty}, which is written
+     * without an argument list for that reason.
+     */
+    private static boolean isFunction(String argument, Set<String> declaredHere,
+                                      Map<String, ApiCommand.Signature> surface) {
+        String written = argument.strip();
+        if (arrowAt(written) >= 0 || GETTER.matcher(written).matches()) {
+            return true;
+        }
+        if (!NAME.matcher(written).matches()) {
+            return false;
+        }
+        ApiCommand.Signature published = surface.get(written);
+        return declaredHere.contains(written) || (published != null && !published.paramNames().isEmpty());
+    }
+
+    /** One call as the document writes it, with the arguments split as the parser would. */
+    private record Call(String name, List<String> args, boolean piped, int line) {
+        String where() {
+            return "specification.adoc:" + line + ": ";
+        }
+
+        String written() {
+            return name + "(" + String.join(", ", args) + ")";
+        }
+    }
+
+    private static List<Call> callsIn(String adoc) {
+        List<Call> calls = new ArrayList<>();
+        Matcher m = CALL.matcher(adoc);
+        while (m.find()) {
+            if (!Prelude.isQualifier(m.group(1))) {
+                continue;
+            }
+            int open = m.end() - 1;
+            int close = closing(adoc, open);
+            if (close < 0) {
+                continue;
+            }
+            calls.add(new Call(m.group(1) + "." + m.group(2),
+                    argumentsOf(adoc.substring(open + 1, close)),
+                    piped(adoc, m.start()),
+                    lineOf(adoc, m.start())));
+        }
+        return calls;
+    }
+
+    /**
+     * The {@code )} that closes the argument list, or -1 where the paragraph ends first — an
+     * unbalanced {@code (} is prose about a call rather than a call, and reading on would take a
+     * {@code )} from somewhere else in the document.
+     */
+    private static int closing(String text, int open) {
+        int depth = 0;
+        for (int i = open; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '"') {
+                i = endOfString(text, i);
+            } else if (c == '(') {
+                depth++;
+            } else if (c == ')' && --depth == 0) {
+                return i;
+            } else if (c == '\n' && i + 1 < text.length() && text.charAt(i + 1) == '\n') {
+                return -1;
+            }
+        }
+        return -1;
+    }
+
+    private static List<String> argumentsOf(String inside) {
+        if (inside.isBlank()) {
+            return List.of();
+        }
+        List<String> args = new ArrayList<>();
+        int depth = 0;
+        int start = 0;
+        for (int i = 0; i < inside.length(); i++) {
+            char c = inside.charAt(i);
+            if (c == '"') {
+                i = endOfString(inside, i);
+            } else if (c == '(' || c == '[' || c == '{') {
+                depth++;
+            } else if (c == ')' || c == ']' || c == '}') {
+                depth--;
+            } else if (c == ',' && depth == 0) {
+                args.add(inside.substring(start, i).strip());
+                start = i + 1;
+            }
+        }
+        args.add(inside.substring(start).strip());
+        return args;
+    }
+
+    /** The index of a top-level {@code ->}, which makes what is written an anonymous block. */
+    private static int arrowAt(String written) {
+        int depth = 0;
+        for (int i = 0; i < written.length() - 1; i++) {
+            char c = written.charAt(i);
+            if (c == '"') {
+                i = endOfString(written, i);
+            } else if (c == '(' || c == '[' || c == '{') {
+                depth++;
+            } else if (c == ')' || c == ']' || c == '}') {
+                depth--;
+            } else if (c == '-' && written.charAt(i + 1) == '>' && depth == 0) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static int endOfString(String text, int quote) {
+        for (int i = quote + 1; i < text.length(); i++) {
+            if (text.charAt(i) == '\\') {
+                i++;
+            } else if (text.charAt(i) == '"') {
+                return i;
+            }
+        }
+        return text.length();
+    }
+
+    /** Whether the call stands on the right of a {@code |>}, which supplies its last argument. */
+    private static boolean piped(String text, int callStart) {
+        int i = callStart - 1;
+        while (i >= 0 && (text.charAt(i) == ' ' || text.charAt(i) == '\t' || text.charAt(i) == '\n')) {
+            i--;
+        }
+        return i >= 1 && text.charAt(i) == '>' && text.charAt(i - 1) == '|';
+    }
+
+    private static Set<String> declaredFunctionsIn(String adoc) {
+        Set<String> declared = new TreeSet<>();
+        Matcher m = DECLARED_FUNCTION.matcher(adoc);
+        while (m.find()) {
+            declared.add(m.group(1) != null ? m.group(1) : m.group(2));
+        }
+        return declared;
+    }
+
+    private static int lineOf(String text, int at) {
+        int line = 1;
+        for (int i = 0; i < at; i++) {
+            if (text.charAt(i) == '\n') {
+                line++;
+            }
+        }
+        return line;
+    }
+
+    private static String text() {
+        try (InputStream in = SpecDocument.class.getResourceAsStream("/META-INF/souther/specification.adoc")) {
+            assertNotNull(in, "the specification travels in the jar");
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest.java
@@ -36,9 +36,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>It refutes rather than verifies, and the name says so. Deciding that a call is right needs the
  * types of every argument, which is the checker's job over a program and not this scan's over a
  * document. What it decides is the argument count, whether the name is published, and — for an
- * argument whose being a function or not is settled by how it is written — whether it stands at a
- * parameter declared to take one. An argument neither settles is left alone, so
- * {@code List.map(xs, ys)} passes here and is caught only by the compiler (E1804).
+ * argument whose being a function or not is settled by how it is written, at a call site where no
+ * other binding of that name is in the way — whether it stands at a parameter declared to take one.
+ * Anything else is left alone, so {@code List.map(xs, ys)} passes here and is caught only by the
+ * compiler (E1804).
  */
 class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
 
@@ -49,15 +50,30 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
     /**
      * A function declared beside the call, so a bare name written as an argument is known to be one.
      * A behavior counts: its name handed over is the behavior, and passing one to {@code List.map}
-     * and calling it by name reach the same place (<<blocks>>, specification.adoc:1818).
+     * and calling it by name reach the same place (specification.adoc:1818).
      */
     private static final Pattern DECLARED_FUNCTION = Pattern.compile(
             "(?m)^\\s*(?:partial\\s+)?let\\s+([a-z][A-Za-z0-9]*)\\s*\\("
                     + "|^\\s*behavior\\s+([a-z][A-Za-z0-9]*)\\s*:");
 
+    /** A parameter list — a helper's, or an anonymous block's. Its binders stand for values. */
+    private static final Pattern PARAMETERS = Pattern.compile(
+            "(?:let\\s+[a-z][A-Za-z0-9]*\\s*)?\\(([^()]*)\\)\\s*(?:->|=|:)");
+
+    /** A block taking one parameter without parentheses: {@code r -> …}. */
+    private static final Pattern BARE_PARAMETER = Pattern.compile("(?<![\\w.])([a-z][A-Za-z0-9]*)\\s*->");
+
+    /** A {@code let} binding a value rather than declaring a function. */
+    private static final Pattern VALUE_BINDING =
+            Pattern.compile("(?m)^\\s*let\\s+([a-z][A-Za-z0-9]*)\\s*(?::[^=(]*)?=");
+
     /** The delimiter of a block AsciiDoc takes as it stands. A listing is one region a name is
      *  declared over; outside one, a paragraph is. */
     private static final Pattern BLOCK_DELIMITER = Pattern.compile("^([-.+/])\\1{3,}$");
+
+    /** The anchor attribute a section carries, which is how a finding says where it is without
+     *  naming a line number every edit above it would move. */
+    private static final Pattern ANCHOR = Pattern.compile("^\\[#([A-Za-z0-9_-]+)]$");
 
     /** An argument written as an ellipsis rather than as a value — the call is quoted, not made. */
     private static final Pattern ELIDED = Pattern.compile("\\.\\.\\.|…");
@@ -73,21 +89,26 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
             "-?\\d[\\d_]*(\\.\\d+)?m?|\"[^\"]*\"|true|false|\\[.*]|[A-Z][A-Za-z0-9]*\\s*\\{.*}");
 
     /**
-     * A call the specification writes in order to say that it is refused. The document is right
-     * about each of these and the checker is right to resolve them otherwise; what is checked here
-     * is the calls a reader is meant to copy.
+     * The calls the specification writes in order to say that they are refused, each with the
+     * contradiction it is written to carry. Expected rather than skipped: a negative example that
+     * stops contradicting the library — because the library came to accept it — is as much a
+     * document out of step as a positive one that starts. A second occurrence of the same spelling
+     * under another anchor is an extra entry and fails too.
      */
-    private static final Set<String> WRITTEN_TO_BE_REFUSED = Set.of(
+    private static final List<String> WRITTEN_TO_BE_REFUSED = List.of(
             // "`Decimal.divide(dividend, divisor)` without scale and mode cannot be written"
-            "Decimal.divide(dividend, divisor)",
+            "stdlib-decimal: Decimal.divide(dividend, divisor) is written with 2 argument(s) and declares 4",
             // "a *value* and not a function — written `Map.empty`, never `Map.empty()`"
-            "Map.empty()",
-            "Set.empty()");
+            "stdlib-map: Map.empty() is a value and takes no argument list",
+            // "so it is a *value* and not a function — written `Set.empty`, never `Set.empty()`"
+            "stdlib-set: Set.empty() is a value and takes no argument list");
 
     @Test
-    void theSpecificationCallsTheStandardLibraryTheWayTheLibraryDeclaresItself() {
-        assertEquals(Set.of(), disagreements(text()),
-                "the specification writes these calls, and the checker resolves them otherwise");
+    void theOnlyCallsContradictingTheLibraryAreTheOnesWrittenToBeRefused() {
+        List<Finding> found = findings(text());
+
+        assertEquals(WRITTEN_TO_BE_REFUSED, keysOf(found), "the specification writes these calls, "
+                + "and the checker resolves them otherwise: " + found);
     }
 
     @Test
@@ -103,7 +124,7 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
      */
     @Test
     void aFunctionPassedWhereTheSignatureDeclaresTheCollectionIsCaught() {
-        Set<String> found = disagreements("""
+        List<String> found = disagreements("""
                 [,text]
                 ----
                 let isValid (r: PreApprovalReason) = ...
@@ -116,7 +137,7 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
         assertEquals(2, found.size(), found.toString());
         assertTrue(found.stream().allMatch(f -> f.contains("List.all") && f.contains("argument 2")),
                 found.toString());
-        assertEquals(Set.of(), disagreements("""
+        assertEquals(List.of(), disagreements("""
                 [,text]
                 ----
                 let isValid (r: PreApprovalReason) = ...
@@ -145,7 +166,7 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
      */
     @Test
     void aBehaviorNameStandsWhereTheSignatureDeclaresAFunction() {
-        assertEquals(Set.of(), disagreements("""
+        assertEquals(List.of(), disagreements("""
                 [,text]
                 ----
                 behavior norm : (s: String) -> String
@@ -170,7 +191,7 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
      */
     @Test
     void aFunctionDeclaredInOneListingDoesNotNameAnotherListingsValue() {
-        assertEquals(Set.of(), disagreements("""
+        assertEquals(List.of(), disagreements("""
                 [,text]
                 ----
                 let n (x: Int) = x + 1
@@ -185,17 +206,48 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
                 """));
     }
 
+    /**
+     * Nor does a name a binding in the same listing has taken over. The scan does not resolve names,
+     * so where one spelling stands for a function in one place and a parameter in another it settles
+     * nothing and says nothing — a shadowing is harmless in the language and must be here too.
+     */
+    @Test
+    void aParameterShadowingAFunctionOfTheSameListingSettlesNothing() {
+        assertEquals(List.of(), disagreements("""
+                [,text]
+                ----
+                let index (x: Int) = x + 1
+
+                let nth (index: Int, xs: List<String>) =
+                    List.get(index, xs)
+                ----
+                """));
+    }
+
+    /** A block's own parameter is a binding like any other. */
+    @Test
+    void aBlockParameterShadowingAFunctionOfTheSameListingSettlesNothing() {
+        assertEquals(List.of(), disagreements("""
+                [,text]
+                ----
+                let p (x: Int) = x > 0
+
+                List.map(p -> List.get(p, xs), ys)
+                ----
+                """));
+    }
+
     @Test
     void aCallPassingTooFewOrTooManyArgumentsIsCaught() {
         assertEquals(1, disagreements("`+List.map(xs)+`").size());
         assertEquals(1, disagreements("`+List.map(f, xs, more)+`").size());
-        assertEquals(Set.of(), disagreements("`+List.map(f, xs)+`"));
+        assertEquals(List.of(), disagreements("`+List.map(f, xs)+`"));
     }
 
     /** A pipe supplies the last argument, so the call is written with one fewer. */
     @Test
     void aPipedCallIsReadWithTheArgumentThePipeSupplies() {
-        assertEquals(Set.of(), disagreements("`+xs |> List.map(.value)+`"));
+        assertEquals(List.of(), disagreements("`+xs |> List.map(.value)+`"));
         assertEquals(1, disagreements("`+xs |> List.map(f, xs)+`").size());
     }
 
@@ -213,34 +265,56 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
     /** An ellipsis stands for arguments rather than being one, so the count says nothing. */
     @Test
     void aCallQuotedWithAnEllipsisIsNotCountedAgainstItsArity() {
-        assertEquals(Set.of(), disagreements("`+String.length(...)+`"));
+        assertEquals(List.of(), disagreements("`+String.length(...)+`"));
     }
 
-    /** Every way the specification contradicts a resolved signature, one line each. */
-    private static Set<String> disagreements(String adoc) {
-        NavigableMap<Integer, Set<String>> declared = declarationsByRegion(adoc);
+    /**
+     * One way the specification contradicts a resolved signature. Identified by the anchor it stands
+     * under rather than by its line, which every edit above it moves.
+     */
+    private record Finding(String anchor, String written, String says, int line) {
+        String key() {
+            return anchor + ": " + written + " " + says;
+        }
+
+        @Override
+        public String toString() {
+            return "specification.adoc:" + line + " [" + anchor + "] " + written + " " + says;
+        }
+    }
+
+    private static List<String> keysOf(List<Finding> found) {
+        return found.stream().map(Finding::key).sorted().toList();
+    }
+
+    private static List<String> disagreements(String adoc) {
+        return keysOf(findings(adoc));
+    }
+
+    private static List<Finding> findings(String adoc) {
+        NavigableMap<Integer, Declared> declared = declarationsByRegion(adoc);
+        NavigableMap<Integer, String> anchors = anchorsByOffset(adoc);
         Map<String, ApiCommand.Signature> surface = ApiCommand.surface();
-        Set<String> found = new TreeSet<>();
+        List<Finding> found = new ArrayList<>();
         for (Call call : callsIn(adoc)) {
-            if (WRITTEN_TO_BE_REFUSED.contains(call.written())) {
-                continue;
-            }
+            String anchor = anchors.floorEntry(call.at()) == null ? ""
+                    : anchors.floorEntry(call.at()).getValue();
             ApiCommand.Signature signature = surface.get(call.name());
             if (signature == null) {
-                found.add(call.where() + call.name() + " names nothing the standard library publishes");
+                found.add(call.saying(anchor, "names nothing the standard library publishes"));
                 continue;
             }
             if (Prelude.isEmptyCollectionValue(call.name())) {
-                found.add(call.where() + call.name() + " is a value and takes no argument list");
+                found.add(call.saying(anchor, "is a value and takes no argument list"));
                 continue;
             }
             int declares = signature.paramNames().size();
             int written = call.args().size() + (call.piped() ? 1 : 0);
             if (written != declares && call.args().stream().noneMatch(a -> ELIDED.matcher(a).find())) {
-                found.add(call.where() + call.name() + " is written with " + written
-                        + " argument(s) and declares " + declares);
+                found.add(call.saying(anchor, "is written with " + written
+                        + " argument(s) and declares " + declares));
             }
-            Set<String> here = declared.floorEntry(call.at()).getValue();
+            Declared here = declared.floorEntry(call.at()).getValue();
             for (int i = 0; i < call.args().size() && i < declares; i++) {
                 boolean takesAFunction = signature.paramTypes().get(i) instanceof Type.FnOf;
                 String at = " as argument " + (i + 1) + ", where it declares "
@@ -248,13 +322,12 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
                 switch (kindOf(call.args().get(i), here, surface)) {
                     case FUNCTION -> {
                         if (!takesAFunction) {
-                            found.add(call.where() + call.name() + " is passed a function" + at);
+                            found.add(call.saying(anchor, "is passed a function" + at));
                         }
                     }
                     case NOT_A_FUNCTION -> {
                         if (takesAFunction) {
-                            found.add(call.where() + call.name()
-                                    + " is passed something that is not a function" + at);
+                            found.add(call.saying(anchor, "is passed something that is not a function" + at));
                         }
                     }
                     case UNDECIDED -> { }
@@ -270,10 +343,9 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
     /**
      * An anonymous block, a getter block and a name declared as a function are functions; a literal,
      * a list literal, a construction and a library name declaring no parameter list are not. A name
-     * nothing here declares settles nothing either way.
+     * nothing here declares — or one a binding of the same region has also taken — settles nothing.
      */
-    private static Kind kindOf(String argument, Set<String> declaredHere,
-                               Map<String, ApiCommand.Signature> surface) {
+    private static Kind kindOf(String argument, Declared here, Map<String, ApiCommand.Signature> surface) {
         String written = argument.strip();
         if (arrowAt(written) >= 0 || GETTER.matcher(written).matches()) {
             return Kind.FUNCTION;
@@ -282,8 +354,8 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
             return Kind.NOT_A_FUNCTION;
         }
         if (NAME.matcher(written).matches()) {
-            if (declaredHere.contains(written)) {
-                return Kind.FUNCTION;
+            if (here.functions().contains(written)) {
+                return here.bindings().contains(written) ? Kind.UNDECIDED : Kind.FUNCTION;
             }
             ApiCommand.Signature published = surface.get(written);
             if (published != null) {
@@ -295,12 +367,12 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
 
     /** One call as the document writes it, with the arguments split as the parser would. */
     private record Call(String name, List<String> args, boolean piped, int at, int line) {
-        String where() {
-            return "specification.adoc:" + line + ": ";
-        }
-
         String written() {
             return name + "(" + String.join(", ", args) + ")";
+        }
+
+        Finding saying(String anchor, String says) {
+            return new Finding(anchor, written(), says, line);
         }
     }
 
@@ -409,13 +481,17 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
         return i >= 1 && text.charAt(i) == '>' && text.charAt(i - 1) == '|';
     }
 
+    /** What a region of the document declares: the names it declares as functions, and the names it
+     *  also binds as something else, which leaves a bare occurrence of one undecided. */
+    private record Declared(Set<String> functions, Set<String> bindings) {}
+
     /**
-     * The functions declared in each region of the document, keyed by where the region starts. A
-     * listing block is one region and a paragraph outside one is another, so a name is a function
-     * where it was declared rather than everywhere the document goes on to write it.
+     * What each region of the document declares, keyed by where the region starts. A listing block
+     * is one region and a paragraph outside one is another, so a name is a function where it was
+     * declared rather than everywhere the document goes on to write it.
      */
-    private static NavigableMap<Integer, Set<String>> declarationsByRegion(String adoc) {
-        NavigableMap<Integer, Set<String>> byStart = new TreeMap<>();
+    private static NavigableMap<Integer, Declared> declarationsByRegion(String adoc) {
+        NavigableMap<Integer, Declared> byStart = new TreeMap<>();
         boolean listing = false;
         int start = 0;
         int at = 0;
@@ -426,22 +502,54 @@ class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
                 listing = !listing;
             }
             if (boundary || (!listing && delimiter.isEmpty())) {
-                byStart.put(start, declaredFunctionsIn(adoc.substring(start, at)));
+                byStart.put(start, declaredIn(adoc.substring(start, at)));
                 start = at;
             }
             at += line.length() + 1;
         }
-        byStart.put(start, declaredFunctionsIn(adoc.substring(Math.min(start, adoc.length()))));
+        byStart.put(start, declaredIn(adoc.substring(Math.min(start, adoc.length()))));
         return byStart;
     }
 
-    private static Set<String> declaredFunctionsIn(String region) {
-        Set<String> declared = new TreeSet<>();
+    private static Declared declaredIn(String region) {
+        Set<String> functions = new TreeSet<>();
         Matcher m = DECLARED_FUNCTION.matcher(region);
         while (m.find()) {
-            declared.add(m.group(1) != null ? m.group(1) : m.group(2));
+            functions.add(m.group(1) != null ? m.group(1) : m.group(2));
         }
-        return declared;
+        Set<String> bindings = new TreeSet<>();
+        Matcher params = PARAMETERS.matcher(region);
+        while (params.find()) {
+            for (String parameter : params.group(1).split(",")) {
+                String binder = parameter.strip().split("[:\\s]", 2)[0];
+                if (!binder.isEmpty()) {
+                    bindings.add(binder);
+                }
+            }
+        }
+        Matcher bare = BARE_PARAMETER.matcher(region);
+        while (bare.find()) {
+            bindings.add(bare.group(1));
+        }
+        Matcher value = VALUE_BINDING.matcher(region);
+        while (value.find()) {
+            bindings.add(value.group(1));
+        }
+        return new Declared(functions, bindings);
+    }
+
+    /** The section anchor in force at each offset, so a finding says where it is by name. */
+    private static NavigableMap<Integer, String> anchorsByOffset(String adoc) {
+        NavigableMap<Integer, String> byOffset = new TreeMap<>();
+        int at = 0;
+        for (String line : adoc.split("\n", -1)) {
+            Matcher m = ANCHOR.matcher(line.strip());
+            if (m.matches()) {
+                byOffset.put(at, m.group(1));
+            }
+            at += line.length() + 1;
+        }
+        return byOffset;
     }
 
     private static int lineOf(String text, int at) {

--- a/souther-compiler/src/test/java/souther/compiler/doc/NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest.java
@@ -11,7 +11,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -28,19 +30,34 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * not compile.
  *
  * <p>The calls are read out of the specification's own text and the signatures come from the
- * resolver `souther api` prints. Neither side is written for the other: what is checked is that the
- * side a reader reads and the side the compiler enforces say the same thing.
+ * resolver {@code souther api} prints. Neither side is written for the other: what is checked is
+ * that the side a reader reads and the side the compiler enforces do not say different things.
+ *
+ * <p>It refutes rather than verifies, and the name says so. Deciding that a call is right needs the
+ * types of every argument, which is the checker's job over a program and not this scan's over a
+ * document. What it decides is the argument count, whether the name is published, and — for an
+ * argument whose being a function or not is settled by how it is written — whether it stands at a
+ * parameter declared to take one. An argument neither settles is left alone, so
+ * {@code List.map(xs, ys)} passes here and is caught only by the compiler (E1804).
  */
-class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
+class NoStandardLibraryCallTheSpecificationWritesContradictsItsSignatureTest {
 
     /** A qualified standard-library call, wherever the specification writes one. */
     private static final Pattern CALL =
             Pattern.compile("(?<![\\w.])([A-Z][A-Za-z0-9]*)\\.([a-z][A-Za-z0-9]*)\\(");
 
-    /** A function the specification declares, so a bare name it writes elsewhere is known to be one. */
+    /**
+     * A function declared beside the call, so a bare name written as an argument is known to be one.
+     * A behavior counts: its name handed over is the behavior, and passing one to {@code List.map}
+     * and calling it by name reach the same place (<<blocks>>, specification.adoc:1818).
+     */
     private static final Pattern DECLARED_FUNCTION = Pattern.compile(
             "(?m)^\\s*(?:partial\\s+)?let\\s+([a-z][A-Za-z0-9]*)\\s*\\("
                     + "|^\\s*behavior\\s+([a-z][A-Za-z0-9]*)\\s*:");
+
+    /** The delimiter of a block AsciiDoc takes as it stands. A listing is one region a name is
+     *  declared over; outside one, a paragraph is. */
+    private static final Pattern BLOCK_DELIMITER = Pattern.compile("^([-.+/])\\1{3,}$");
 
     /** An argument written as an ellipsis rather than as a value — the call is quoted, not made. */
     private static final Pattern ELIDED = Pattern.compile("\\.\\.\\.|…");
@@ -51,13 +68,21 @@ class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
     /** A getter block: {@code .field} desugars to {@code (x) -> x.field}. */
     private static final Pattern GETTER = Pattern.compile("\\.[a-z][A-Za-z0-9]*");
 
+    /** What is not a function whatever it holds: a literal, a list literal, or a construction. */
+    private static final Pattern NOT_A_FUNCTION = Pattern.compile(
+            "-?\\d[\\d_]*(\\.\\d+)?m?|\"[^\"]*\"|true|false|\\[.*]|[A-Z][A-Za-z0-9]*\\s*\\{.*}");
+
     /**
      * A call the specification writes in order to say that it is refused. The document is right
      * about each of these and the checker is right to resolve them otherwise; what is checked here
      * is the calls a reader is meant to copy.
      */
     private static final Set<String> WRITTEN_TO_BE_REFUSED = Set.of(
-            "Decimal.divide(dividend, divisor)");
+            // "`Decimal.divide(dividend, divisor)` without scale and mode cannot be written"
+            "Decimal.divide(dividend, divisor)",
+            // "a *value* and not a function — written `Map.empty`, never `Map.empty()`"
+            "Map.empty()",
+            "Set.empty()");
 
     @Test
     void theSpecificationCallsTheStandardLibraryTheWayTheLibraryDeclaresItself() {
@@ -67,7 +92,8 @@ class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
 
     @Test
     void aCallIsFoundAtAllSoTheScanIsNotLookingAtAnEmptyDocument() {
-        assertFalse(callsIn(text()).isEmpty(), "found no standard-library call at all — the scan missed the document");
+        assertFalse(callsIn(text()).isEmpty(),
+                "found no standard-library call at all — the scan missed the document");
     }
 
     /**
@@ -88,7 +114,8 @@ class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
                 """);
 
         assertEquals(2, found.size(), found.toString());
-        assertTrue(found.stream().allMatch(f -> f.contains("List.all") && f.contains("argument 2")), found.toString());
+        assertTrue(found.stream().allMatch(f -> f.contains("List.all") && f.contains("argument 2")),
+                found.toString());
         assertEquals(Set.of(), disagreements("""
                 [,text]
                 ----
@@ -98,6 +125,64 @@ class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
                 List.all(isValid, reasons)
                 ----
                 """), "and the same two lines written the other way round are what the signature declares");
+    }
+
+    /**
+     * The other half of the same disagreement. An argument order is wrong in both directions at
+     * once, and the collection is the half a reader is likelier to write as something that could
+     * not be a function whatever it holds.
+     */
+    @Test
+    void somethingThatIsNotAFunctionPassedWhereTheSignatureDeclaresOneIsCaught() {
+        assertEquals(1, disagreements("`+List.map([1, 2], xs)+`").size());
+        assertEquals(1, disagreements("`+List.fold(0, step, xs)+`").size());
+        assertEquals(1, disagreements("`+List.filter(\"a\", xs)+`").size());
+    }
+
+    /**
+     * A behavior's name is a function value: the specification says so at {@code <<blocks>>} and the
+     * compiler accepts it, so the scan must not read one as a disagreement.
+     */
+    @Test
+    void aBehaviorNameStandsWhereTheSignatureDeclaresAFunction() {
+        assertEquals(Set.of(), disagreements("""
+                [,text]
+                ----
+                behavior norm : (s: String) -> String
+
+                List.map(norm, xs)
+                ----
+                """));
+        assertEquals(1, disagreements("""
+                [,text]
+                ----
+                behavior norm : (s: String) -> String
+
+                List.map(xs, norm)
+                ----
+                """).size());
+    }
+
+    /**
+     * A name is a function over the listing that declares it and nowhere else. Reading declarations
+     * from the whole document would have one listing's {@code let n (x)} make another listing's
+     * {@code n} a function, which is a coarser scope than the language's own.
+     */
+    @Test
+    void aFunctionDeclaredInOneListingDoesNotNameAnotherListingsValue() {
+        assertEquals(Set.of(), disagreements("""
+                [,text]
+                ----
+                let n (x: Int) = x + 1
+                ----
+
+                [,text]
+                ----
+                let n = 3
+
+                List.get(n, xs)
+                ----
+                """));
     }
 
     @Test
@@ -119,15 +204,21 @@ class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
         assertEquals(1, disagreements("`+List.mapish(f, xs)+`").size());
     }
 
+    /** {@code Map.empty} declares no parameter list, so applying it is refused (E1803). */
+    @Test
+    void aLibraryValueWrittenWithAnArgumentListIsCaught() {
+        assertEquals(1, disagreements("`+Map.empty(k)+`").size());
+    }
+
     /** An ellipsis stands for arguments rather than being one, so the count says nothing. */
     @Test
     void aCallQuotedWithAnEllipsisIsNotCountedAgainstItsArity() {
         assertEquals(Set.of(), disagreements("`+String.length(...)+`"));
     }
 
-    /** Every way the specification disagrees with a resolved signature, one line each. */
+    /** Every way the specification contradicts a resolved signature, one line each. */
     private static Set<String> disagreements(String adoc) {
-        Set<String> declaredHere = declaredFunctionsIn(adoc);
+        NavigableMap<Integer, Set<String>> declared = declarationsByRegion(adoc);
         Map<String, ApiCommand.Signature> surface = ApiCommand.surface();
         Set<String> found = new TreeSet<>();
         for (Call call : callsIn(adoc)) {
@@ -139,46 +230,71 @@ class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
                 found.add(call.where() + call.name() + " names nothing the standard library publishes");
                 continue;
             }
-            int declared = signature.paramNames().size();
-            int written = call.args().size() + (call.piped() ? 1 : 0);
-            if (written != declared && call.args().stream().noneMatch(a -> ELIDED.matcher(a).find())) {
-                found.add(call.where() + call.name() + " is written with " + written
-                        + " argument(s) and declares " + declared);
+            if (Prelude.isEmptyCollectionValue(call.name())) {
+                found.add(call.where() + call.name() + " is a value and takes no argument list");
+                continue;
             }
-            for (int i = 0; i < call.args().size() && i < declared; i++) {
-                if (isFunction(call.args().get(i), declaredHere, surface)
-                        && !(signature.paramTypes().get(i) instanceof Type.FnOf)) {
-                    found.add(call.where() + call.name() + " is passed a function as argument " + (i + 1)
-                            + ", where it declares " + signature.paramNames().get(i) + ": "
-                            + Type.show(signature.paramTypes().get(i)));
+            int declares = signature.paramNames().size();
+            int written = call.args().size() + (call.piped() ? 1 : 0);
+            if (written != declares && call.args().stream().noneMatch(a -> ELIDED.matcher(a).find())) {
+                found.add(call.where() + call.name() + " is written with " + written
+                        + " argument(s) and declares " + declares);
+            }
+            Set<String> here = declared.floorEntry(call.at()).getValue();
+            for (int i = 0; i < call.args().size() && i < declares; i++) {
+                boolean takesAFunction = signature.paramTypes().get(i) instanceof Type.FnOf;
+                String at = " as argument " + (i + 1) + ", where it declares "
+                        + signature.paramNames().get(i) + ": " + Type.show(signature.paramTypes().get(i));
+                switch (kindOf(call.args().get(i), here, surface)) {
+                    case FUNCTION -> {
+                        if (!takesAFunction) {
+                            found.add(call.where() + call.name() + " is passed a function" + at);
+                        }
+                    }
+                    case NOT_A_FUNCTION -> {
+                        if (takesAFunction) {
+                            found.add(call.where() + call.name()
+                                    + " is passed something that is not a function" + at);
+                        }
+                    }
+                    case UNDECIDED -> { }
                 }
             }
         }
         return found;
     }
 
+    /** What an argument is, where how it is written settles it. */
+    private enum Kind { FUNCTION, NOT_A_FUNCTION, UNDECIDED }
+
     /**
-     * Whether the argument is a function on its face: an anonymous block, a getter block, or a name
-     * declared as a function — by the standard library, or by the document that writes the call.
-     * A name nothing here declares says nothing either way, so it is left alone. A library name
-     * declaring no parameter is a value rather than a function — {@code Map.empty}, which is written
-     * without an argument list for that reason.
+     * An anonymous block, a getter block and a name declared as a function are functions; a literal,
+     * a list literal, a construction and a library name declaring no parameter list are not. A name
+     * nothing here declares settles nothing either way.
      */
-    private static boolean isFunction(String argument, Set<String> declaredHere,
-                                      Map<String, ApiCommand.Signature> surface) {
+    private static Kind kindOf(String argument, Set<String> declaredHere,
+                               Map<String, ApiCommand.Signature> surface) {
         String written = argument.strip();
         if (arrowAt(written) >= 0 || GETTER.matcher(written).matches()) {
-            return true;
+            return Kind.FUNCTION;
         }
-        if (!NAME.matcher(written).matches()) {
-            return false;
+        if (NOT_A_FUNCTION.matcher(written).matches()) {
+            return Kind.NOT_A_FUNCTION;
         }
-        ApiCommand.Signature published = surface.get(written);
-        return declaredHere.contains(written) || (published != null && !published.paramNames().isEmpty());
+        if (NAME.matcher(written).matches()) {
+            if (declaredHere.contains(written)) {
+                return Kind.FUNCTION;
+            }
+            ApiCommand.Signature published = surface.get(written);
+            if (published != null) {
+                return published.paramNames().isEmpty() ? Kind.NOT_A_FUNCTION : Kind.FUNCTION;
+            }
+        }
+        return Kind.UNDECIDED;
     }
 
     /** One call as the document writes it, with the arguments split as the parser would. */
-    private record Call(String name, List<String> args, boolean piped, int line) {
+    private record Call(String name, List<String> args, boolean piped, int at, int line) {
         String where() {
             return "specification.adoc:" + line + ": ";
         }
@@ -203,6 +319,7 @@ class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
             calls.add(new Call(m.group(1) + "." + m.group(2),
                     argumentsOf(adoc.substring(open + 1, close)),
                     piped(adoc, m.start()),
+                    m.start(),
                     lineOf(adoc, m.start())));
         }
         return calls;
@@ -292,9 +409,35 @@ class EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest {
         return i >= 1 && text.charAt(i) == '>' && text.charAt(i - 1) == '|';
     }
 
-    private static Set<String> declaredFunctionsIn(String adoc) {
+    /**
+     * The functions declared in each region of the document, keyed by where the region starts. A
+     * listing block is one region and a paragraph outside one is another, so a name is a function
+     * where it was declared rather than everywhere the document goes on to write it.
+     */
+    private static NavigableMap<Integer, Set<String>> declarationsByRegion(String adoc) {
+        NavigableMap<Integer, Set<String>> byStart = new TreeMap<>();
+        boolean listing = false;
+        int start = 0;
+        int at = 0;
+        for (String line : adoc.split("\n", -1)) {
+            String delimiter = line.strip();
+            boolean boundary = BLOCK_DELIMITER.matcher(delimiter).matches();
+            if (boundary) {
+                listing = !listing;
+            }
+            if (boundary || (!listing && delimiter.isEmpty())) {
+                byStart.put(start, declaredFunctionsIn(adoc.substring(start, at)));
+                start = at;
+            }
+            at += line.length() + 1;
+        }
+        byStart.put(start, declaredFunctionsIn(adoc.substring(Math.min(start, adoc.length()))));
+        return byStart;
+    }
+
+    private static Set<String> declaredFunctionsIn(String region) {
         Set<String> declared = new TreeSet<>();
-        Matcher m = DECLARED_FUNCTION.matcher(adoc);
+        Matcher m = DECLARED_FUNCTION.matcher(region);
         while (m.find()) {
             declared.add(m.group(1) != null ? m.group(1) : m.group(2));
         }

--- a/specification.adoc
+++ b/specification.adoc
@@ -1801,8 +1801,8 @@ A block is an anonymous `+let+`. It is the same as a `+let+` (<<fn>>), only unna
 ----
 let isValid (r: PreApprovalReason) = ...
 
-List.all(reasons, r -> isValid(r))   // wrap in an anonymous block
-List.all(reasons, isValid)           // pass by name directly. Same thing
+List.all(r -> isValid(r), reasons)   // wrap in an anonymous block
+List.all(isValid, reasons)           // pass by name directly. Same thing
 ----
 
 A name that names a function *is* that function where a value goes, whoever declared it: a `+let+` of this module, a `+let+` another module published, and a standard-library function alike. `+String.trim+` written where a value goes is a `+(String) -> String+`, and `+String.trim(s)+` is that function applied to `+s+`. So the two lines above are one rule rather than two, and a function reaches every position a block reaches — an argument, a binding, a branch of an `+if+`, an element of a list a `+fold+` walks.


### PR DESCRIPTION
Closes #406.

The section that teaches passing a function wrote `List.all`'s arguments in the order the convention forbids:

```
List.all(reasons, r -> isValid(r))   // wrap in an anonymous block
List.all(reasons, isValid)           // pass by name directly. Same thing
```

The signature is `List.all(p: ('a) -> Bool, xs: List<'a>) : Bool`, and `<<pipe>>` states the rule outright — the primary subject last, functions first. So the one example whose point is "these two lines are the same thing" had both lines resolving to nothing the checker would accept, and a reader who reaches `<<blocks>>` before `<<pipe>>` writes code that does not compile.

## The check

Nothing tied a call written in prose to the signature the checker resolves. `EveryStandardLibraryCallTheSpecificationWritesAgreesWithItsSignatureTest` reads every `Module.name(...)` out of the specification's own text — 148 of them, in prose and in listings alike — and asks `ApiCommand.surface()`, which is what `souther api` prints, what it declares. Neither side is written for the other: what is checked is that the side a reader reads and the side the compiler enforces say the same thing.

Three ways they can disagree:

- the name is not one the standard library publishes
- the argument count differs. A `|>` supplies the last argument, so a piped call is read with one more than it writes; a call quoted with an ellipsis (`String.length(...)`) stands outside the count
- a function is written where the signature declares something else. An argument is a function on its face when it is an anonymous block, a getter block, or a name declared as a function — by the library, or by the document that writes the call. A name nothing declares says nothing either way, so it is left alone

That last one is what catches both halves of the example. `r -> isValid(r)` is a block; `isValid` is a bare name the same listing declares as `let isValid (r: PreApprovalReason)`.

## It is not passing on an empty scan

Reverting the two lines makes the check name them:

```
specification.adoc:1804: List.all is passed a function as argument 2, where it declares xs: List<'a>
specification.adoc:1805: List.all is passed a function as argument 2, where it declares xs: List<'a>
```

Each kind of finding also has its own test over inline text, and one test asserts a call is found at all.

## What it does not cover

`Decimal.divide(dividend, divisor)` (specification.adoc:3154) is written in order to say that it is refused. The document is right and the checker is right to resolve it otherwise, so it is listed in `WRITTEN_TO_BE_REFUSED` with the reason rather than checked. It is the only entry.

Calls written without a qualifier — `singleton(k, v)`, `insert(k, v, m)` and the rest of the `<<stdlib-map>>`-style sections, which are where each module's argument order is described — are not read. Resolving those needs the section to say which module the bare name belongs to, which is a different scan.

## Visibility

`ApiCommand.Signature` and `surface()` widen from private to package-private for the test beside them. Reading the resolved surface any other way would be a second copy of what `souther api` answers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)