### PR TITLE
A tool publishes what the command can do, not one way of calling it

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,10 @@ same way from 0.7.1 on, so `souther doc raoh/composition-patterns` reads raoh's 
 version this build depends on.
 
 The same answers are served over the Model Context Protocol: `souther mcp` speaks MCP on stdio,
-exposing `doc_search`, `doc_read`, `stdlib_api`, and `jar_api`, so agent harnesses that prefer
-tools over shell commands register one command. It answers under protocol revisions `2025-11-25`
+exposing `doc_search`, `doc_read`, `stdlib_api`, `stdlib_api_search` and `jar_api`, so agent
+harnesses that prefer tools over shell commands register one command. `doc_read` with no argument
+lists every section and topic, which is where a client with nothing else starts. It answers under
+protocol revisions `2025-11-25`
 and `2025-06-18` — the ones whose opening exchange is `initialize` — echoing the client's own when
 it is one of them:
 

--- a/README.md
+++ b/README.md
@@ -161,10 +161,10 @@ same way from 0.7.1 on, so `souther doc raoh/composition-patterns` reads raoh's 
 version this build depends on.
 
 The same answers are served over the Model Context Protocol: `souther mcp` speaks MCP on stdio,
-exposing `doc_search`, `doc_read`, `stdlib_api`, `stdlib_api_search` and `jar_api`, so agent
-harnesses that prefer tools over shell commands register one command. `doc_read` with no argument
-lists every section and topic, which is where a client with nothing else starts. It answers under
-protocol revisions `2025-11-25`
+exposing `doc_search`, `doc_read`, `stdlib_api`, `stdlib_api_search`, `stdlib_api_source` and
+`jar_api`, so agent harnesses that prefer tools over shell commands register one command.
+`doc_read` with no argument lists every section and topic, which is where a client with nothing
+else starts. It answers under protocol revisions `2025-11-25`
 and `2025-06-18` — the ones whose opening exchange is `initialize` — echoing the client's own when
 it is one of them:
 

--- a/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
@@ -25,6 +25,10 @@ public final class ApiCommand {
     private ApiCommand() {}
 
     public static int run(String[] args, PrintStream out, PrintStream err) {
+        return run(args, out, err, Caller.CLI);
+    }
+
+    static int run(String[] args, PrintStream out, PrintStream err, Caller caller) {
         if (args.length == 0) {
             listPublished(out, null);
             return 0;
@@ -64,8 +68,7 @@ public final class ApiCommand {
             out.println(line(asked, signature));
             // A signature says what to pass, not what it means — whether a span counts both ends,
             // whether a division aborts or answers a case. That is in the module's own source.
-            err.println("`souther api --source " + asked.substring(0, asked.indexOf('.'))
-                    + "` for what it means");
+            err.println(caller.stdlibSource(asked.substring(0, asked.indexOf('.'))));
             return 0;
         }
         if (!Prelude.isQualifier(asked)) {

--- a/souther-compiler/src/main/java/souther/compiler/doc/Caller.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/Caller.java
@@ -1,0 +1,49 @@
+package souther.compiler.doc;
+
+/**
+ * Who a command is answering, so that what an answer offers next is something that caller can do.
+ *
+ * <p>The doc and api answers are written once and reached over two wires. A line that says how to
+ * see more has to name a way of asking, and the two callers ask differently: a reader at a prompt
+ * has subcommands and flags, an MCP client has tools and their arguments. Naming the other one's
+ * spelling sends the reader somewhere they cannot go.
+ *
+ * <p>Every such offer lives here rather than at the place that prints it, so that adding a caller
+ * is answering these questions once instead of finding every message that asks them.
+ */
+enum Caller {
+
+    CLI, MCP;
+
+    /** How to see every specification section and every shipped doc topic. */
+    String everySectionAndTopic() {
+        return switch (this) {
+            case CLI -> "`souther doc` lists every section and topic";
+            case MCP -> "`doc_read` with no `name` lists every section and topic";
+        };
+    }
+
+    /** How to see every specification section. */
+    String everySection() {
+        return switch (this) {
+            case CLI -> "`souther doc` lists every section";
+            case MCP -> "`doc_read` with no `name` lists every section";
+        };
+    }
+
+    /** How to ask a search for the hits it held back. */
+    String everyHit() {
+        return switch (this) {
+            case CLI -> "`--limit 0` for all of them";
+            case MCP -> "`limit: 0` for all of them";
+        };
+    }
+
+    /** How to read a stdlib module's own source, where what a signature means is written. */
+    String stdlibSource(String module) {
+        return switch (this) {
+            case CLI -> "`souther api --source " + module + "` for what it means";
+            case MCP -> "`stdlib_api {name: \"" + module + "\", source: true}` for what it means";
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/doc/Caller.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/Caller.java
@@ -43,7 +43,7 @@ enum Caller {
     String stdlibSource(String module) {
         return switch (this) {
             case CLI -> "`souther api --source " + module + "` for what it means";
-            case MCP -> "`stdlib_api {name: \"" + module + "\", source: true}` for what it means";
+            case MCP -> "`stdlib_api_source {name: \"" + module + "\"}` for what it means";
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -21,10 +21,18 @@ public final class DocCommand {
     private DocCommand() {}
 
     public static int run(String[] args, PrintStream out, PrintStream err) {
-        return run(args, out, err, DocCommand.class.getClassLoader());
+        return run(args, out, err, Caller.CLI);
+    }
+
+    static int run(String[] args, PrintStream out, PrintStream err, Caller caller) {
+        return run(args, out, err, caller, DocCommand.class.getClassLoader());
     }
 
     static int run(String[] args, PrintStream out, PrintStream err, ClassLoader loader) {
+        return run(args, out, err, Caller.CLI, loader);
+    }
+
+    static int run(String[] args, PrintStream out, PrintStream err, Caller caller, ClassLoader loader) {
         SpecDocument spec = SpecDocument.bundled();
         LibraryDocs shipped = LibraryDocs.on(loader);
         if (args.length == 0) {
@@ -69,13 +77,13 @@ public final class DocCommand {
             }
             if (lines.isEmpty()) {
                 err.println("nothing says `" + term + "`");
-                err.println("`souther doc` lists every section and topic");
+                err.println(caller.everySectionAndTopic());
                 return 0;
             }
             int shown = limit <= 0 ? lines.size() : Math.min(limit, lines.size());
             lines.subList(0, shown).forEach(out::println);
             if (shown < lines.size()) {
-                out.println("… " + (lines.size() - shown) + " more; `--limit 0` for all of them");
+                out.println("… " + (lines.size() - shown) + " more; " + caller.everyHit());
             }
             return 0;
         }
@@ -88,7 +96,7 @@ public final class DocCommand {
             String text = shipped.read(anchor);
             if (text == null) {
                 err.println("no doc topic `" + anchor + "`");
-                err.println("`souther doc` lists every section and topic");
+                err.println(caller.everySectionAndTopic());
                 return 2;
             }
             out.print(text);
@@ -107,7 +115,7 @@ public final class DocCommand {
             if (!near.isEmpty()) {
                 err.println("did you mean: " + String.join(", ", near));
             }
-            err.println("`souther doc` lists every section");
+            err.println(caller.everySection());
             return 2;
         }
         if (!DocName.canonical(section.anchor()).equals(DocName.canonical(anchor))) {

--- a/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
@@ -1,5 +1,6 @@
 package souther.compiler.doc;
 
+import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ObjectNode;
@@ -34,7 +35,19 @@ import java.util.regex.Pattern;
  */
 public final class McpServer {
 
-    private static final JsonMapper JSON = JsonMapper.builder().build();
+    /**
+     * The reader for requests and the writer for responses.
+     *
+     * <p>Numbers with a point or an exponent are kept as decimals rather than taken to {@code
+     * double}, because a request's number is a value and {@code double} is a box that not every
+     * value fits. {@code 1.0000000000000000001} rounds to {@code 1} on the way in, and a count no
+     * schema admits would then be honoured as one that it does; {@code 1e-324} falls to zero, which
+     * is this server's spelling for every hit there is. What is checked further down has to be the
+     * number that was sent.
+     */
+    private static final JsonMapper JSON = JsonMapper.builder()
+            .enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS)
+            .build();
 
     /**
      * One character that is not a space — written so that a client's regular expressions and this

--- a/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
@@ -15,6 +15,7 @@ import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * {@code souther mcp}: the doc/api/japi answers, served over the Model Context Protocol's stdio
@@ -34,6 +35,21 @@ import java.util.List;
 public final class McpServer {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /**
+     * One character that is not a space — written so that a client's regular expressions and this
+     * server's read it as the same set.
+     *
+     * <p>It is spelled in code points rather than with {@code \s}, because that shorthand does not
+     * mean the same thing on both sides: a schema's patterns are ECMA-262, where {@code \s} takes
+     * in the no-break space and the byte order mark, and Java's takes in neither. The set below is
+     * ECMA-262's, and the same literal is what gets published and what gets matched, so there is
+     * no second definition to fall out of step with the first.
+     */
+    private static final String NON_BLANK = "[^\\u0009-\\u000d\\u0020\\u00a0\\u1680"
+            + "\\u2000-\\u200a\\u2028\\u2029\\u202f\\u205f\\u3000\\ufeff]";
+
+    private static final Pattern SAYS_SOMETHING = Pattern.compile(NON_BLANK);
 
     /**
      * The protocol revisions this server answers under, newest first.
@@ -105,7 +121,7 @@ public final class McpServer {
                 schema.put("type", "string");
                 // Somewhere in it, a character that is not a space: the empty term is the one a
                 // search cannot walk, and saying so here is cheaper than a call spent finding out.
-                schema.put("pattern", "\\S");
+                schema.put("pattern", NON_BLANK);
             }
 
             @Override
@@ -113,7 +129,8 @@ public final class McpServer {
                 if (!value.isString()) {
                     return "`" + name + "` must be a string";
                 }
-                return value.asString().isBlank() ? "`" + name + "` must not be empty" : null;
+                return SAYS_SOMETHING.matcher(value.asString()).find()
+                        ? null : "`" + name + "` must not be empty";
             }
         },
 
@@ -127,11 +144,15 @@ public final class McpServer {
 
             @Override
             String malformed(String name, JsonNode value) {
-                // A count written as a string is the shape a client falls into when it is guessing,
-                // and answering the default would look like the count had been honoured. One past
-                // what a count can hold is refused here rather than thrown from the conversion.
-                if (!value.isIntegralNumber() || !value.canConvertToInt()) {
-                    return "`" + name + "` must be an integer no larger than " + Integer.MAX_VALUE;
+                // A schema's `integer` is a value that is whole, not a way of writing one down:
+                // 1, 1.0 and 1e0 are the same number and all three are integers. Asking Jackson
+                // whether the node is integral would answer about the notation instead, and refuse
+                // two spellings of a count this server is published as taking.
+                if (!value.isNumber() || !value.canConvertToExactIntegral()) {
+                    return "`" + name + "` must be a whole number";
+                }
+                if (!value.canConvertToInt()) {
+                    return "`" + name + "` must be no larger than " + Integer.MAX_VALUE;
                 }
                 return value.intValue() < 0
                         ? "`" + name + "` must not be negative; 0 is all of them" : null;

--- a/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
@@ -15,7 +15,6 @@ import java.io.PrintWriter;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
 
 /**
  * {@code souther mcp}: the doc/api/japi answers, served over the Model Context Protocol's stdio
@@ -23,6 +22,12 @@ import java.util.Map;
  * and hands its text back as the tool result; a failed lookup is the tool's error
  * ({@code isError}), not a protocol error, which is reserved for requests the server cannot read
  * at all.
+ *
+ * <p>What the tools publish is what the commands can do, not the shapes their argument vectors
+ * happen to take. A client here has no shell to fall back to and no listing of the commands it is
+ * reaching, so a capability with no spelling in this table is one it can only arrive at by
+ * guessing. Where the two do differ — {@code stdlib_api_search} takes no count because the stdlib
+ * surface is answered whole — the tool's own description says so.
  *
  * <p>Stdout carries protocol lines only; everything a command would say lands inside a response.
  */
@@ -44,29 +49,65 @@ public final class McpServer {
      */
     private static final List<String> PROTOCOL_VERSIONS = List.of("2025-11-25", "2025-06-18");
 
-    /** name → its description and input schema; order is the order tools/list answers with. */
+    /** The tools this server publishes, in the order {@code tools/list} answers with. */
     private static final List<Tool> TOOLS = List.of(
             new Tool("doc_search",
-                    "Search the Souther language specification and every bundled library doc for a term.",
-                    Map.of("term", "the word or phrase to look for"), List.of("term")),
+                    "Search the Souther language specification and every bundled library doc for a term."
+                            + " Answers the 20 best hits unless `limit` says otherwise.",
+                    List.of(new Param("term", Kind.STRING, true, "the word or phrase to look for"),
+                            new Param("limit", Kind.INTEGER, false,
+                                    "how many hits to answer with; 0 for all of them (default 20)"))),
             new Tool("doc_read",
-                    "Read one specification section by its anchor (e.g. `newtype`) or one bundled library"
-                            + " doc topic by its set-qualified name (e.g. `raoh/tutorial`)."
-                            + " `doc_search` and the no-argument `souther doc` listing name them.",
-                    Map.of("name", "a section anchor or a set/topic name"), List.of("name")),
+                    "Read the Souther specification and the docs bundled libraries ship. With no `name`"
+                            + " it lists every section anchor and every shipped topic as `name<TAB>title`,"
+                            + " one per line — start there. With a `name` it reads that one specification"
+                            + " section by its anchor (e.g. `newtype`) or that one library topic by its"
+                            + " set-qualified name (e.g. `raoh/tutorial`).",
+                    List.of(new Param("name", Kind.STRING, false,
+                            "a section anchor or a set/topic name; omit to list every one of them"))),
             new Tool("stdlib_api",
-                    "The Souther standard library's published surface with resolved signatures."
-                            + " No name lists everything; a module qualifier (`List`) or a qualified name"
-                            + " (`List.map`) narrows the answer.",
-                    Map.of("name", "a stdlib module or Module.name, omit for all"), List.of()),
+                    "The Souther standard library's published surface with resolved signatures. No name"
+                            + " lists everything; a module qualifier (`List`) or a qualified name"
+                            + " (`List.map`) narrows the answer. With `source` and a module name it reads"
+                            + " that module's own source instead, whose comments say what each"
+                            + " declaration means.",
+                    List.of(new Param("name", Kind.STRING, false,
+                                    "a stdlib module or Module.name, omit for all"),
+                            new Param("source", Kind.BOOLEAN, false,
+                                    "read the named module's own source rather than its signatures"))),
+            new Tool("stdlib_api_search",
+                    "Find published stdlib names containing a term. Answers every match — the surface is"
+                            + " small enough that nothing is ever held back.",
+                    List.of(new Param("term", Kind.STRING, true,
+                            "a piece of the name to look for, matched without regard to case"))),
             new Tool("jar_api",
                     "A dependency jar's public API read from its class files, with javadoc from the"
                             + " -sources.jar beside it. Give a fully qualified class or package name.",
-                    Map.of("name", "a fully qualified class or package name",
-                            "classpath", "jars or class directories to search, path-separated;"
-                                    + " omit to search the CLI's own class path"), List.of("name")));
+                    List.of(new Param("name", Kind.STRING, true,
+                                    "a fully qualified class or package name"),
+                            new Param("classpath", Kind.STRING, false,
+                                    "jars or class directories to search, path-separated;"
+                                            + " omit to search the CLI's own class path"))));
 
-    private record Tool(String name, String description, Map<String, String> params, List<String> required) {}
+    /** What a declared argument may hold, and the JSON Schema type that says so. */
+    private enum Kind {
+        STRING("string"), INTEGER("integer"), BOOLEAN("boolean");
+
+        private final String schemaType;
+
+        Kind(String schemaType) {
+            this.schemaType = schemaType;
+        }
+    }
+
+    private record Param(String name, Kind kind, boolean required, String description) {}
+
+    private record Tool(String name, String description, List<Param> params) {
+
+        Param param(String name) {
+            return params.stream().filter(p -> p.name().equals(name)).findFirst().orElse(null);
+        }
+    }
 
     private McpServer() {}
 
@@ -147,13 +188,16 @@ public final class McpServer {
             ObjectNode schema = t.putObject("inputSchema");
             schema.put("type", "object");
             ObjectNode properties = schema.putObject("properties");
-            tool.params().forEach((name, description) -> {
-                ObjectNode p = properties.putObject(name);
-                p.put("type", "string");
-                p.put("description", description);
-            });
+            for (Param param : tool.params()) {
+                ObjectNode p = properties.putObject(param.name());
+                p.put("type", param.kind().schemaType);
+                p.put("description", param.description());
+            }
             var required = schema.putArray("required");
-            tool.required().forEach(required::add);
+            tool.params().stream().filter(Param::required).map(Param::name).forEach(required::add);
+            // An argument this server would drop is one a client can spend a call learning about,
+            // so the schema says up front that there are no others to guess at.
+            schema.put("additionalProperties", false);
         }
         return result;
     }
@@ -166,6 +210,11 @@ public final class McpServer {
      * not a value to be worked with — the search term this matters most for matches everything and
      * at every position, and the walk over its occurrences would not advance. Reporting it as an
      * invalid parameter says the tool was never entered, which a tool error would not.
+     *
+     * <p>An argument the schema does not declare is refused for the same reason rather than
+     * dropped. A client that guesses a name — and one that has only these tools to work with will
+     * guess — would otherwise be handed an answer computed without it, with nothing in the answer
+     * saying the argument had no effect.
      */
     private static String invalidArguments(JsonNode params) {
         String name = params == null || params.get("name") == null ? "" : params.get("name").asString();
@@ -179,42 +228,87 @@ public final class McpServer {
         if (arguments != null && !arguments.isNull() && !arguments.isObject()) {
             return "`arguments` must be an object";
         }
-        for (String required : tool.required()) {
-            JsonNode value = arguments == null ? null : arguments.get(required);
-            if (value == null || value.isNull()) {
-                return "`" + name + "` needs `" + required + "`";
-            }
-            if (!value.isString()) {
-                return "`" + required + "` must be a string";
-            }
-            if (value.asString().isBlank()) {
-                return "`" + required + "` must not be empty";
-            }
-        }
-        if (arguments != null) {
-            for (String given : tool.params().keySet()) {
-                JsonNode value = arguments.get(given);
-                if (value != null && !value.isNull() && !value.isString()) {
-                    return "`" + given + "` must be a string";
+        if (arguments != null && arguments.isObject()) {
+            for (String given : arguments.propertyNames()) {
+                if (tool.param(given) == null) {
+                    return "`" + name + "` has no argument `" + given + "`; it takes "
+                            + String.join(", ", tool.params().stream()
+                                    .map(p -> "`" + p.name() + "`").toList());
                 }
             }
+        }
+        for (Param param : tool.params()) {
+            JsonNode value = arguments == null ? null : arguments.get(param.name());
+            if (value == null || value.isNull()) {
+                if (param.required()) {
+                    return "`" + name + "` needs `" + param.name() + "`";
+                }
+                continue;
+            }
+            String wrong = malformed(param, value);
+            if (wrong != null) {
+                return wrong;
+            }
+        }
+        // `--source` names a module, and the command it reaches has no listing to fall back on.
+        if (flag(arguments, "source") && argument(arguments, "name").isEmpty()) {
+            return "`source` needs `name` — the module whose source to read";
         }
         return null;
     }
 
+    /** Why this value does not fit the argument it was given for, or null when it does. */
+    private static String malformed(Param param, JsonNode value) {
+        return switch (param.kind()) {
+            case STRING -> !value.isString()
+                    ? "`" + param.name() + "` must be a string"
+                    : value.asString().isBlank() ? "`" + param.name() + "` must not be empty" : null;
+            // A count written as a string is the shape a client falls into when it is guessing,
+            // and answering it with the default count would look like the count was honoured.
+            case INTEGER -> value.isIntegralNumber() ? null : "`" + param.name() + "` must be an integer";
+            case BOOLEAN -> value.isBoolean() ? null : "`" + param.name() + "` must be true or false";
+        };
+    }
+
+    /**
+     * Runs the call and answers with what the command said.
+     *
+     * <p>Each tool names a capability, and the arguments it was given decide which of the
+     * underlying command's forms carries it out. A tool is not a fixed way of spelling one
+     * invocation: {@code doc_read} with no name is the listing that command prints for no
+     * arguments, and it is reachable here for the same reason it is reachable at a prompt.
+     *
+     * <p>The command is told it is answering an MCP client, so that what it offers next is a tool
+     * call rather than a shell command the caller has no way to run.
+     */
     private static ObjectNode call(JsonNode params) {
         String tool = params == null || params.get("name") == null ? "" : params.get("name").asString();
-        JsonNode arguments = params == null ? null : params.get("params") != null
-                ? params.get("params") : params.get("arguments");
+        JsonNode arguments = params == null ? null : params.get("arguments");
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
         PrintStream stream = new PrintStream(captured, true, StandardCharsets.UTF_8);
         int code = switch (tool) {
-            case "doc_search" -> DocCommand.run(new String[]{"--search", argument(arguments, "term")}, stream, stream);
-            case "doc_read" -> DocCommand.run(new String[]{argument(arguments, "name")}, stream, stream);
+            case "doc_search" -> {
+                JsonNode limit = arguments == null ? null : arguments.get("limit");
+                String[] args = limit == null || limit.isNull()
+                        ? new String[]{"--search", argument(arguments, "term")}
+                        : new String[]{"--search", argument(arguments, "term"),
+                                "--limit", String.valueOf(limit.asInt())};
+                yield DocCommand.run(args, stream, stream, Caller.MCP);
+            }
+            case "doc_read" -> {
+                String name = argument(arguments, "name");
+                yield DocCommand.run(name.isEmpty() ? new String[]{} : new String[]{name},
+                        stream, stream, Caller.MCP);
+            }
             case "stdlib_api" -> {
                 String name = argument(arguments, "name");
-                yield ApiCommand.run(name.isEmpty() ? new String[]{} : new String[]{name}, stream, stream);
+                String[] args = flag(arguments, "source")
+                        ? new String[]{"--source", name}
+                        : name.isEmpty() ? new String[]{} : new String[]{name};
+                yield ApiCommand.run(args, stream, stream, Caller.MCP);
             }
+            case "stdlib_api_search" -> ApiCommand.run(
+                    new String[]{"--search", argument(arguments, "term")}, stream, stream, Caller.MCP);
             case "jar_api" -> {
                 String classpath = argument(arguments, "classpath");
                 String[] args = classpath.isEmpty()
@@ -245,7 +339,13 @@ public final class McpServer {
     }
 
     private static String argument(JsonNode arguments, String name) {
-        return arguments == null || arguments.get(name) == null ? "" : arguments.get(name).asString();
+        return arguments == null || arguments.get(name) == null || !arguments.get(name).isString()
+                ? "" : arguments.get(name).asString();
+    }
+
+    private static boolean flag(JsonNode arguments, String name) {
+        JsonNode value = arguments == null ? null : arguments.get(name);
+        return value != null && value.isBoolean() && value.asBoolean();
     }
 
     private static ObjectNode result(JsonNode id, ObjectNode result) {

--- a/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
@@ -55,7 +55,7 @@ public final class McpServer {
                     "Search the Souther language specification and every bundled library doc for a term."
                             + " Answers the 20 best hits unless `limit` says otherwise.",
                     List.of(new Param("term", Kind.STRING, true, "the word or phrase to look for"),
-                            new Param("limit", Kind.INTEGER, false,
+                            new Param("limit", Kind.COUNT, false,
                                     "how many hits to answer with; 0 for all of them (default 20)"))),
             new Tool("doc_read",
                     "Read the Souther specification and the docs bundled libraries ship. With no `name`"
@@ -68,18 +68,19 @@ public final class McpServer {
             new Tool("stdlib_api",
                     "The Souther standard library's published surface with resolved signatures. No name"
                             + " lists everything; a module qualifier (`List`) or a qualified name"
-                            + " (`List.map`) narrows the answer. With `source` and a module name it reads"
-                            + " that module's own source instead, whose comments say what each"
-                            + " declaration means.",
+                            + " (`List.map`) narrows the answer.",
                     List.of(new Param("name", Kind.STRING, false,
-                                    "a stdlib module or Module.name, omit for all"),
-                            new Param("source", Kind.BOOLEAN, false,
-                                    "read the named module's own source rather than its signatures"))),
+                            "a stdlib module or Module.name, omit for all"))),
             new Tool("stdlib_api_search",
                     "Find published stdlib names containing a term. Answers every match — the surface is"
                             + " small enough that nothing is ever held back.",
                     List.of(new Param("term", Kind.STRING, true,
                             "a piece of the name to look for, matched without regard to case"))),
+            new Tool("stdlib_api_source",
+                    "A stdlib module's own source, whose comments say what each declaration means —"
+                            + " which end a span counts, whether a division aborts or answers a case."
+                            + " A signature says how to call something; this says what it does.",
+                    List.of(new Param("name", Kind.STRING, true, "a stdlib module, e.g. `String`"))),
             new Tool("jar_api",
                     "A dependency jar's public API read from its class files, with javadoc from the"
                             + " -sources.jar beside it. Give a fully qualified class or package name.",
@@ -89,15 +90,59 @@ public final class McpServer {
                                     "jars or class directories to search, path-separated;"
                                             + " omit to search the CLI's own class path"))));
 
-    /** What a declared argument may hold, and the JSON Schema type that says so. */
+    /**
+     * What a declared argument may hold.
+     *
+     * <p>Each kind both publishes its domain and decides whether a value is in it, because the two
+     * being written apart is how a server comes to refuse what its own schema invites. A client
+     * that reads the schema and is then told no has learnt nothing it can act on.
+     */
     private enum Kind {
-        STRING("string"), INTEGER("integer"), BOOLEAN("boolean");
 
-        private final String schemaType;
+        STRING {
+            @Override
+            void publish(ObjectNode schema) {
+                schema.put("type", "string");
+                // Somewhere in it, a character that is not a space: the empty term is the one a
+                // search cannot walk, and saying so here is cheaper than a call spent finding out.
+                schema.put("pattern", "\\S");
+            }
 
-        Kind(String schemaType) {
-            this.schemaType = schemaType;
-        }
+            @Override
+            String malformed(String name, JsonNode value) {
+                if (!value.isString()) {
+                    return "`" + name + "` must be a string";
+                }
+                return value.asString().isBlank() ? "`" + name + "` must not be empty" : null;
+            }
+        },
+
+        COUNT {
+            @Override
+            void publish(ObjectNode schema) {
+                schema.put("type", "integer");
+                schema.put("minimum", 0);
+                schema.put("maximum", Integer.MAX_VALUE);
+            }
+
+            @Override
+            String malformed(String name, JsonNode value) {
+                // A count written as a string is the shape a client falls into when it is guessing,
+                // and answering the default would look like the count had been honoured. One past
+                // what a count can hold is refused here rather than thrown from the conversion.
+                if (!value.isIntegralNumber() || !value.canConvertToInt()) {
+                    return "`" + name + "` must be an integer no larger than " + Integer.MAX_VALUE;
+                }
+                return value.intValue() < 0
+                        ? "`" + name + "` must not be negative; 0 is all of them" : null;
+            }
+        };
+
+        /** Writes this kind's domain into the property schema a client reads. */
+        abstract void publish(ObjectNode schema);
+
+        /** Why this value is outside that domain, or null when it is in it. */
+        abstract String malformed(String name, JsonNode value);
     }
 
     private record Param(String name, Kind kind, boolean required, String description) {}
@@ -190,7 +235,7 @@ public final class McpServer {
             ObjectNode properties = schema.putObject("properties");
             for (Param param : tool.params()) {
                 ObjectNode p = properties.putObject(param.name());
-                p.put("type", param.kind().schemaType);
+                param.kind().publish(p);
                 p.put("description", param.description());
             }
             var required = schema.putArray("required");
@@ -223,12 +268,13 @@ public final class McpServer {
             return "no tool `" + name + "`";
         }
         JsonNode arguments = params.get("arguments");
-        // The schema says arguments are an object. A tool that requires none of them would
-        // otherwise take anything at all and answer as though it had been called properly.
-        if (arguments != null && !arguments.isNull() && !arguments.isObject()) {
-            return "`arguments` must be an object";
+        // The schema says arguments are an object, and the protocol says the field is either an
+        // object or not there. A null is neither, and reading it as "not there" would have a tool
+        // whose arguments are all optional answer a request nobody wrote.
+        if (arguments != null && !arguments.isObject()) {
+            return "`arguments` must be an object, or left out entirely";
         }
-        if (arguments != null && arguments.isObject()) {
+        if (arguments != null) {
             for (String given : arguments.propertyNames()) {
                 if (tool.param(given) == null) {
                     return "`" + name + "` has no argument `" + given + "`; it takes "
@@ -239,35 +285,20 @@ public final class McpServer {
         }
         for (Param param : tool.params()) {
             JsonNode value = arguments == null ? null : arguments.get(param.name());
-            if (value == null || value.isNull()) {
+            if (value == null) {
                 if (param.required()) {
                     return "`" + name + "` needs `" + param.name() + "`";
                 }
                 continue;
             }
-            String wrong = malformed(param, value);
+            // A null written for an argument is not the argument left out — the schema gives it a
+            // type and null is not of it. Reading it as absent is the same slip one level down.
+            String wrong = param.kind().malformed(param.name(), value);
             if (wrong != null) {
                 return wrong;
             }
         }
-        // `--source` names a module, and the command it reaches has no listing to fall back on.
-        if (flag(arguments, "source") && argument(arguments, "name").isEmpty()) {
-            return "`source` needs `name` — the module whose source to read";
-        }
         return null;
-    }
-
-    /** Why this value does not fit the argument it was given for, or null when it does. */
-    private static String malformed(Param param, JsonNode value) {
-        return switch (param.kind()) {
-            case STRING -> !value.isString()
-                    ? "`" + param.name() + "` must be a string"
-                    : value.asString().isBlank() ? "`" + param.name() + "` must not be empty" : null;
-            // A count written as a string is the shape a client falls into when it is guessing,
-            // and answering it with the default count would look like the count was honoured.
-            case INTEGER -> value.isIntegralNumber() ? null : "`" + param.name() + "` must be an integer";
-            case BOOLEAN -> value.isBoolean() ? null : "`" + param.name() + "` must be true or false";
-        };
     }
 
     /**
@@ -289,7 +320,7 @@ public final class McpServer {
         int code = switch (tool) {
             case "doc_search" -> {
                 JsonNode limit = arguments == null ? null : arguments.get("limit");
-                String[] args = limit == null || limit.isNull()
+                String[] args = limit == null
                         ? new String[]{"--search", argument(arguments, "term")}
                         : new String[]{"--search", argument(arguments, "term"),
                                 "--limit", String.valueOf(limit.asInt())};
@@ -302,13 +333,13 @@ public final class McpServer {
             }
             case "stdlib_api" -> {
                 String name = argument(arguments, "name");
-                String[] args = flag(arguments, "source")
-                        ? new String[]{"--source", name}
-                        : name.isEmpty() ? new String[]{} : new String[]{name};
-                yield ApiCommand.run(args, stream, stream, Caller.MCP);
+                yield ApiCommand.run(name.isEmpty() ? new String[]{} : new String[]{name},
+                        stream, stream, Caller.MCP);
             }
             case "stdlib_api_search" -> ApiCommand.run(
                     new String[]{"--search", argument(arguments, "term")}, stream, stream, Caller.MCP);
+            case "stdlib_api_source" -> ApiCommand.run(
+                    new String[]{"--source", argument(arguments, "name")}, stream, stream, Caller.MCP);
             case "jar_api" -> {
                 String classpath = argument(arguments, "classpath");
                 String[] args = classpath.isEmpty()
@@ -341,11 +372,6 @@ public final class McpServer {
     private static String argument(JsonNode arguments, String name) {
         return arguments == null || arguments.get(name) == null || !arguments.get(name).isString()
                 ? "" : arguments.get(name).asString();
-    }
-
-    private static boolean flag(JsonNode arguments, String name) {
-        JsonNode value = arguments == null ? null : arguments.get(name);
-        return value != null && value.isBoolean() && value.asBoolean();
     }
 
     private static ObjectNode result(JsonNode id, ObjectNode result) {

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -85,7 +85,13 @@ souther mcp
 
 Serves the `doc`, `api` and `japi` answers over the Model Context Protocol on stdio, for agent
 harnesses that take tools rather than shell commands. The tools are `doc_search`, `doc_read`,
-`stdlib_api` and `jar_api`.
+`stdlib_api`, `stdlib_api_search` and `jar_api`.
+
+Each tool publishes a capability rather than one spelling of an argument vector, because a client
+here has no prompt to fall back to. `doc_read` with no `name` is the listing `souther doc` prints
+for no argument; `doc_search` takes the `limit` the flag takes; `stdlib_api` takes a `source` flag
+for what `--source` reads. `stdlib_api_search` answers every match, so it takes no count. An
+argument no tool declares is refused rather than dropped.
 
 ## Options every command shares
 

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -85,13 +85,16 @@ souther mcp
 
 Serves the `doc`, `api` and `japi` answers over the Model Context Protocol on stdio, for agent
 harnesses that take tools rather than shell commands. The tools are `doc_search`, `doc_read`,
-`stdlib_api`, `stdlib_api_search` and `jar_api`.
+`stdlib_api`, `stdlib_api_search`, `stdlib_api_source` and `jar_api`.
 
 Each tool publishes a capability rather than one spelling of an argument vector, because a client
 here has no prompt to fall back to. `doc_read` with no `name` is the listing `souther doc` prints
-for no argument; `doc_search` takes the `limit` the flag takes; `stdlib_api` takes a `source` flag
-for what `--source` reads. `stdlib_api_search` answers every match, so it takes no count. An
-argument no tool declares is refused rather than dropped.
+for no argument, and `doc_search` takes the `limit` the flag takes. What `souther api` selects with
+`--search` and `--source` is a tool each. `stdlib_api_search` answers every match, so it takes no
+count.
+
+The schema a client reads is the one the server enforces: every argument publishes its domain, and
+one no tool declares is refused rather than dropped.
 
 ## Options every command shares
 

--- a/souther-compiler/src/test/java/souther/compiler/doc/AnAnswerOffersOnlyWhatItsOwnCallerCanDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/AnAnswerOffersOnlyWhatItsOwnCallerCanDoTest.java
@@ -1,0 +1,111 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * When an answer runs out of what it was asked for, it says what to ask next. That line is only
+ * worth printing if the reader it reaches can act on it, and the two readers act differently: one
+ * is at a prompt with subcommands and flags, the other holds tools and their arguments. An MCP
+ * client told to run `souther doc` is being sent to a shell it does not have.
+ *
+ * <p>Documents that describe the CLI still describe it — that is their subject. What is checked
+ * here is what an answer offers as the next thing to do.
+ */
+class AnAnswerOffersOnlyWhatItsOwnCallerCanDoTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    @Test
+    void aSectionThatIsNotThereOffersTheListingAsAToolCall() {
+        String said = text(call("doc_read", "{\"name\":\"no-such-section\"}"));
+
+        assertTrue(said.contains("`doc_read` with no `name` lists every section"), said);
+        assertTrue(!said.contains("souther doc"), said);
+    }
+
+    @Test
+    void aTopicThatIsNotThereOffersItTheSameWay() {
+        String said = text(call("doc_read", "{\"name\":\"nosuchlib/nothing\"}"));
+
+        assertTrue(said.contains("`doc_read` with no `name` lists every section and topic"), said);
+        assertTrue(!said.contains("souther doc"), said);
+    }
+
+    @Test
+    void aSearchThatFindsNothingOffersItTheSameWay() {
+        String said = text(call("doc_search", "{\"term\":\"zzzznothingsaysthis\"}"));
+
+        assertTrue(said.contains("`doc_read` with no `name` lists"), said);
+        assertTrue(!said.contains("souther doc"), said);
+    }
+
+    @Test
+    void aTruncatedSearchOffersACountTheClientCanPass() {
+        String said = text(call("doc_search", "{\"term\":\"type\"}"));
+
+        assertTrue(said.contains("`limit: 0` for all of them"), said);
+        assertTrue(!said.contains("--limit"), "`--limit` is a flag no MCP client can write: " + said);
+    }
+
+    @Test
+    void aSignatureDefersToItsModulesSourceAsAToolCall() {
+        String said = text(call("stdlib_api", "{\"name\":\"String.length\"}"));
+
+        assertTrue(said.contains("`stdlib_api {name: \"String\", source: true}` for what it means"), said);
+        assertTrue(!said.contains("souther api"), said);
+    }
+
+    @Test
+    void andWhatTheOfferNamesIsACallThatAnswers() {
+        String offered = text(call("stdlib_api", "{\"name\":\"String.length\"}"));
+        assertTrue(offered.contains("{name: \"String\", source: true}"), offered);
+
+        JsonNode answer = call("stdlib_api", "{\"name\":\"String\",\"source\":true}");
+
+        assertTrue(!answer.get("isError").asBoolean(), "the call the answer named is one that works");
+    }
+
+    @Test
+    void aReaderAtAPromptIsStillOfferedTheSpellingsThatPromptHas() {
+        ByteArrayOutputStream doc = new ByteArrayOutputStream();
+        DocCommand.run(new String[]{"no-such-section"},
+                new PrintStream(doc, true, StandardCharsets.UTF_8),
+                new PrintStream(doc, true, StandardCharsets.UTF_8));
+        ByteArrayOutputStream api = new ByteArrayOutputStream();
+        ApiCommand.run(new String[]{"String.length"},
+                new PrintStream(api, true, StandardCharsets.UTF_8),
+                new PrintStream(api, true, StandardCharsets.UTF_8));
+
+        assertTrue(doc.toString(StandardCharsets.UTF_8).contains("`souther doc` lists every section"),
+                "the CLI text was adapted for the other caller, not taken away from this one");
+        assertTrue(api.toString(StandardCharsets.UTF_8).contains("`souther api --source String`"),
+                api.toString(StandardCharsets.UTF_8));
+    }
+
+    private String text(JsonNode result) {
+        return result.get("content").get(0).get("text").asString();
+    }
+
+    private JsonNode call(String tool, String arguments) {
+        return serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\""
+                + tool + "\",\"arguments\":" + arguments + "}}").getFirst().get("result");
+    }
+
+    private List<JsonNode> serve(String... requests) {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                (String.join("\n", requests) + "\n").getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        McpServer.serve(in, out);
+        return out.toString(StandardCharsets.UTF_8).lines().map(JSON::readTree).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/AnAnswerOffersOnlyWhatItsOwnCallerCanDoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/AnAnswerOffersOnlyWhatItsOwnCallerCanDoTest.java
@@ -61,16 +61,16 @@ class AnAnswerOffersOnlyWhatItsOwnCallerCanDoTest {
     void aSignatureDefersToItsModulesSourceAsAToolCall() {
         String said = text(call("stdlib_api", "{\"name\":\"String.length\"}"));
 
-        assertTrue(said.contains("`stdlib_api {name: \"String\", source: true}` for what it means"), said);
+        assertTrue(said.contains("`stdlib_api_source {name: \"String\"}` for what it means"), said);
         assertTrue(!said.contains("souther api"), said);
     }
 
     @Test
     void andWhatTheOfferNamesIsACallThatAnswers() {
         String offered = text(call("stdlib_api", "{\"name\":\"String.length\"}"));
-        assertTrue(offered.contains("{name: \"String\", source: true}"), offered);
+        assertTrue(offered.contains("stdlib_api_source {name: \"String\"}"), offered);
 
-        JsonNode answer = call("stdlib_api", "{\"name\":\"String\",\"source\":true}");
+        JsonNode answer = call("stdlib_api_source", "{\"name\":\"String\"}");
 
         assertTrue(!answer.get("isError").asBoolean(), "the call the answer named is one that works");
     }

--- a/souther-compiler/src/test/java/souther/compiler/doc/AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest.java
@@ -1,0 +1,94 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An argument that is dropped costs a client more than one that is refused. The call comes back
+ * with an answer, the answer is well formed, and nothing in it says the argument had no effect —
+ * so a client reads the answer as the one it asked for and carries the wrong belief forward. A
+ * client that has only these tools is the one most likely to guess a name, and the least able to
+ * find out it guessed wrong.
+ */
+class AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    @Test
+    void anArgumentNoToolDeclaresIsRefusedAndTheOnesItDoesAreNamed() {
+        JsonNode answer = call("doc_search", "{\"term\":\"newtype\",\"page\":2}");
+
+        assertEquals(-32602, answer.get("error").get("code").asInt());
+        String said = answer.get("error").get("message").asString();
+        assertTrue(said.contains("`page`"), said);
+        assertTrue(said.contains("`term`") && said.contains("`limit`"),
+                "and the refusal says what there is instead: " + said);
+    }
+
+    @Test
+    void aCountWrittenAsAStringIsRefusedRatherThanQuietlyIgnored() {
+        JsonNode answer = call("doc_search", "{\"term\":\"/\",\"limit\":\"0\"}");
+
+        assertEquals(-32602, answer.get("error").get("code").asInt(),
+                "answering the default 20 here would look like the count was honoured");
+        assertTrue(answer.get("error").get("message").asString().contains("must be an integer"));
+    }
+
+    @Test
+    void aFlagWrittenAsAStringIsRefusedTheSameWay() {
+        JsonNode answer = call("stdlib_api", "{\"name\":\"String\",\"source\":\"true\"}");
+
+        assertEquals(-32602, answer.get("error").get("code").asInt());
+        assertTrue(answer.get("error").get("message").asString().contains("must be true or false"));
+    }
+
+    @Test
+    void aFlagThatNeedsANameIsRefusedRatherThanRunWithout() {
+        JsonNode answer = call("stdlib_api", "{\"source\":true}");
+
+        assertEquals(-32602, answer.get("error").get("code").asInt());
+        assertTrue(answer.get("error").get("message").asString().contains("`source` needs `name`"),
+                answer.get("error").get("message").asString());
+    }
+
+    @Test
+    void anOptionalArgumentLeftOutIsNotAnErrorAtAll() {
+        JsonNode answer = call("doc_read", "{}");
+
+        assertTrue(answer.has("result"), "absent is how a client says it wants the whole listing");
+    }
+
+    @Test
+    void theSessionGoesOnAfterEachRefusal() {
+        List<JsonNode> answers = serve(
+                "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"doc_read\","
+                        + "\"arguments\":{\"offset\":1}}}",
+                "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"ping\"}");
+
+        assertEquals(2, answers.size());
+        assertEquals(-32602, answers.getFirst().get("error").get("code").asInt());
+        assertTrue(answers.get(1).has("result"));
+    }
+
+    private JsonNode call(String tool, String arguments) {
+        return serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\""
+                + tool + "\",\"arguments\":" + arguments + "}}").getFirst();
+    }
+
+    private List<JsonNode> serve(String... requests) {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                (String.join("\n", requests) + "\n").getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        McpServer.serve(in, out);
+        return out.toString(StandardCharsets.UTF_8).lines().map(JSON::readTree).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest.java
@@ -44,20 +44,21 @@ class AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest {
     }
 
     @Test
-    void aFlagWrittenAsAStringIsRefusedTheSameWay() {
-        JsonNode answer = call("stdlib_api", "{\"name\":\"String\",\"source\":\"true\"}");
+    void aCountBeyondWhatACountHoldsIsRefusedRatherThanThrown() {
+        JsonNode answer = call("doc_search", "{\"term\":\"newtype\",\"limit\":2147483648}");
 
-        assertEquals(-32602, answer.get("error").get("code").asInt());
-        assertTrue(answer.get("error").get("message").asString().contains("must be true or false"));
+        assertEquals(-32602, answer.get("error").get("code").asInt(),
+                "the conversion would have thrown, and the client would have been shown the throw");
+        assertTrue(answer.get("error").get("message").asString().contains("2147483647"),
+                answer.get("error").get("message").asString());
     }
 
     @Test
-    void aFlagThatNeedsANameIsRefusedRatherThanRunWithout() {
-        JsonNode answer = call("stdlib_api", "{\"source\":true}");
+    void aCountBelowZeroIsRefusedRatherThanQuietlyMeaningEverything() {
+        JsonNode answer = call("doc_search", "{\"term\":\"newtype\",\"limit\":-1}");
 
-        assertEquals(-32602, answer.get("error").get("code").asInt());
-        assertTrue(answer.get("error").get("message").asString().contains("`source` needs `name`"),
-                answer.get("error").get("message").asString());
+        assertEquals(-32602, answer.get("error").get("code").asInt(),
+                "0 is the spelling for all of them, and it is the only one published");
     }
 
     @Test
@@ -65,6 +66,28 @@ class AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest {
         JsonNode answer = call("doc_read", "{}");
 
         assertTrue(answer.has("result"), "absent is how a client says it wants the whole listing");
+    }
+
+    @Test
+    void argumentsWrittenAsNullAreNotTheSameAsArgumentsLeftOut() {
+        JsonNode written = serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                + "\"params\":{\"name\":\"doc_read\",\"arguments\":null}}").getFirst();
+        JsonNode omitted = serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                + "\"params\":{\"name\":\"doc_read\"}}").getFirst();
+
+        assertEquals(-32602, written.get("error").get("code").asInt(),
+                "the protocol has the field present as an object or absent; null is neither");
+        assertTrue(omitted.has("result"), "and leaving it out is how a client asks for the listing");
+    }
+
+    @Test
+    void anArgumentWrittenAsNullIsNotTheSameAsTheArgumentLeftOut() {
+        JsonNode written = call("doc_read", "{\"name\":null}");
+        JsonNode omitted = call("doc_read", "{}");
+
+        assertEquals(-32602, written.get("error").get("code").asInt(),
+                "the schema gives `name` a type, and null is not of it");
+        assertTrue(omitted.has("result"));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/doc/AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest.java
@@ -40,7 +40,7 @@ class AnArgumentTheSchemaDoesNotDeclareIsRefusedNotDroppedTest {
 
         assertEquals(-32602, answer.get("error").get("code").asInt(),
                 "answering the default 20 here would look like the count was honoured");
-        assertTrue(answer.get("error").get("message").asString().contains("must be an integer"));
+        assertTrue(answer.get("error").get("message").asString().contains("must be a whole number"));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
@@ -1,0 +1,124 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A client with these tools and nothing else has no shell, no repository and no listing of what
+ * the tools reach. So every answer the commands can give has to have a spelling here: a capability
+ * the table leaves out is one such a client can only arrive at by guessing a name, and a name it
+ * cannot guess is content that does not exist for it.
+ *
+ * <p>These tests ask for each answer the way a client would have to, over the protocol, and hold
+ * it against what the same command prints at a prompt.
+ */
+class EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    @Test
+    void aClientThatKnowsNoNameIsGivenEveryNameThereIs() {
+        String listing = text(call("doc_read", "{}"));
+
+        assertEquals(printed(new String[]{}), listing,
+                "the listing a reader gets for no argument is the listing a client gets for no name");
+        assertTrue(listing.lines().count() > 300, "every section and every shipped topic, not a page of them");
+        assertTrue(listing.contains("cli/start-here"),
+                "including the topic written for a reader who has never written Souther");
+    }
+
+    @Test
+    void everyNameTheListingGivesCanBeReadBack() {
+        List<String> names = text(call("doc_read", "{}")).lines()
+                .map(line -> line.substring(0, line.indexOf('\t'))).toList();
+
+        for (int at : List.of(0, names.size() / 2, names.size() - 1)) {
+            JsonNode answer = call("doc_read", "{\"name\":\"" + names.get(at) + "\"}");
+            assertFalse(answer.get("isError").asBoolean(),
+                    "`" + names.get(at) + "` was named by the listing, so it can be asked for");
+        }
+    }
+
+    @Test
+    void aSearchHoldsNothingBackWhenTheClientSaysNotTo() {
+        String capped = text(call("doc_search", "{\"term\":\"/\"}"));
+        String all = text(call("doc_search", "{\"term\":\"/\",\"limit\":0}"));
+
+        assertTrue(capped.contains("more; "), "the default answer says it held some back");
+        assertFalse(all.contains("more; "), "and the client can ask for those too");
+        assertTrue(all.lines().count() > capped.lines().count(), all.lines().count() + " vs " + capped.lines().count());
+    }
+
+    @Test
+    void aSearchAnswersTheCountItWasAskedFor() {
+        String three = text(call("doc_search", "{\"term\":\"newtype\",\"limit\":3}"));
+
+        assertEquals(3, three.lines().filter(line -> line.contains("\t")).count(),
+                "three hits, whatever the default would have been");
+    }
+
+    @Test
+    void aModulesOwnSourceIsAToolCallAway() {
+        String source = text(call("stdlib_api", "{\"name\":\"String\",\"source\":true}"));
+
+        assertEquals(printed(new String[]{"--source", "String"}), source);
+        assertTrue(source.contains("String."), "the module's own declarations, not its signatures alone");
+    }
+
+    @Test
+    void theStdlibCanBeSearchedAndNotOnlyListedOrNamed() {
+        JsonNode answer = call("stdlib_api_search", "{\"term\":\"map\"}");
+
+        assertFalse(answer.get("isError").asBoolean());
+        assertTrue(text(answer).contains("List.map"), text(answer));
+    }
+
+    @Test
+    void everyToolSaysWhatArgumentsItHasSoNoneHaveToBeGuessed() {
+        JsonNode tools = serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}")
+                .getFirst().get("result").get("tools");
+
+        assertTrue(tools.valueStream().allMatch(
+                        t -> !t.get("inputSchema").get("additionalProperties").asBoolean()),
+                "the schema closes the set, so a client learns the arguments rather than trying them");
+    }
+
+    private String printed(String[] args) {
+        ByteArrayOutputStream captured = new ByteArrayOutputStream();
+        PrintStream stream = new PrintStream(captured, true, StandardCharsets.UTF_8);
+        if (args.length > 0 && args[0].startsWith("--source")) {
+            ApiCommand.run(args, stream, stream);
+        } else {
+            DocCommand.run(args, stream, stream);
+        }
+        return captured.toString(StandardCharsets.UTF_8);
+    }
+
+    private String text(JsonNode result) {
+        return result.get("content").get(0).get("text").asString();
+    }
+
+    private JsonNode call(String tool, String arguments) {
+        return serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\""
+                + tool + "\",\"arguments\":" + arguments + "}}").getFirst().get("result");
+    }
+
+    private List<JsonNode> serve(String... requests) {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                (String.join("\n", requests) + "\n").getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        McpServer.serve(in, out);
+        return out.toString(StandardCharsets.UTF_8).lines().map(JSON::readTree).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
@@ -70,7 +70,7 @@ class EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest {
 
     @Test
     void aModulesOwnSourceIsAToolCallAway() {
-        String source = text(call("stdlib_api", "{\"name\":\"String\",\"source\":true}"));
+        String source = text(call("stdlib_api_source", "{\"name\":\"String\"}"));
 
         assertEquals(printed(new String[]{"--source", "String"}), source);
         assertTrue(source.contains("String."), "the module's own declarations, not its signatures alone");
@@ -82,16 +82,6 @@ class EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest {
 
         assertFalse(answer.get("isError").asBoolean());
         assertTrue(text(answer).contains("List.map"), text(answer));
-    }
-
-    @Test
-    void everyToolSaysWhatArgumentsItHasSoNoneHaveToBeGuessed() {
-        JsonNode tools = serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}")
-                .getFirst().get("result").get("tools");
-
-        assertTrue(tools.valueStream().allMatch(
-                        t -> !t.get("inputSchema").get("additionalProperties").asBoolean()),
-                "the schema closes the set, so a client learns the arguments rather than trying them");
     }
 
     private String printed(String[] args) {

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheMcpServerSpeaksTheProtocolOverStdioTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheMcpServerSpeaksTheProtocolOverStdioTest.java
@@ -84,7 +84,8 @@ class TheMcpServerSpeaksTheProtocolOverStdioTest {
 
         JsonNode tools = answers.getFirst().get("result").get("tools");
         List<String> names = tools.valueStream().map(t -> t.get("name").asString()).toList();
-        assertEquals(List.of("doc_search", "doc_read", "stdlib_api", "stdlib_api_search", "jar_api"), names);
+        assertEquals(List.of("doc_search", "doc_read", "stdlib_api", "stdlib_api_search",
+                "stdlib_api_source", "jar_api"), names);
         assertTrue(tools.valueStream().allMatch(t -> t.has("inputSchema")), "every tool declares its input");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheMcpServerSpeaksTheProtocolOverStdioTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheMcpServerSpeaksTheProtocolOverStdioTest.java
@@ -79,12 +79,12 @@ class TheMcpServerSpeaksTheProtocolOverStdioTest {
     }
 
     @Test
-    void toolsListNamesTheFourAnswersAndTheirSchemas() {
+    void toolsListNamesEveryAnswerAndTheirSchemas() {
         List<JsonNode> answers = serve("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}");
 
         JsonNode tools = answers.getFirst().get("result").get("tools");
         List<String> names = tools.valueStream().map(t -> t.get("name").asString()).toList();
-        assertEquals(List.of("doc_search", "doc_read", "stdlib_api", "jar_api"), names);
+        assertEquals(List.of("doc_search", "doc_read", "stdlib_api", "stdlib_api_search", "jar_api"), names);
         assertTrue(tools.valueStream().allMatch(t -> t.has("inputSchema")), "every tool declares its input");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheSchemaAClientReadsIsTheOneTheServerEnforcesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheSchemaAClientReadsIsTheOneTheServerEnforcesTest.java
@@ -1,0 +1,123 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What {@code tools/list} publishes is the only account of these tools a client will ever get, so
+ * it is a product of this server and not a description of one. Two ways it can be wrong: it can
+ * invite a call the server then refuses, and it can hold back a form the server would have
+ * answered. Both cost a client the same thing — a call spent learning what it was told.
+ *
+ * <p>So the schema is asserted as published text, and every domain it names is then sent.
+ */
+class TheSchemaAClientReadsIsTheOneTheServerEnforcesTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    @Test
+    void aCountIsPublishedAsACountAndNotMerelyAsANumber() {
+        JsonNode limit = argument("doc_search", "limit");
+
+        assertEquals("integer", limit.get("type").asString());
+        assertEquals(0, limit.get("minimum").asInt(), "0 is all of them; below it means nothing");
+        assertEquals(Integer.MAX_VALUE, limit.get("maximum").asInt(),
+                "and above this the conversion the server performs cannot hold the value");
+    }
+
+    @Test
+    void aStringArgumentPublishesThatEmptyIsNotOneOfItsValues() {
+        JsonNode term = argument("doc_search", "term");
+
+        assertEquals("string", term.get("type").asString());
+        assertEquals("\\S", term.get("pattern").asString(),
+                "the empty term is what the server refuses, so the schema says so before the call");
+    }
+
+    @Test
+    void anArgumentTheServerCanDoWithoutIsNotPublishedAsRequired() {
+        assertEquals(List.of("term"), required("doc_search"));
+        assertEquals(List.of(), required("doc_read"), "no name is how the listing is asked for");
+        assertEquals(List.of(), required("stdlib_api"));
+        assertEquals(List.of("name"), required("stdlib_api_source"),
+                "a module's source is read by naming the module, and there is nothing else to read");
+        assertEquals(List.of("name"), required("jar_api"));
+    }
+
+    @Test
+    void everyToolClosesTheSetOfArgumentsItTakes() {
+        assertTrue(tools().valueStream().allMatch(
+                        t -> !t.get("inputSchema").get("additionalProperties").asBoolean()),
+                "so a client learns the arguments rather than trying them");
+    }
+
+    @Test
+    void noToolLeavesAnArgumentsDomainToBeDiscoveredByCalling() {
+        for (JsonNode tool : tools()) {
+            JsonNode properties = tool.get("inputSchema").get("properties");
+            for (String name : properties.propertyNames()) {
+                assertTrue(properties.get(name).has("type"),
+                        tool.get("name").asString() + "." + name + " says what it holds");
+                assertTrue(properties.get(name).has("description"),
+                        tool.get("name").asString() + "." + name + " says what it is for");
+            }
+        }
+    }
+
+    @Test
+    void everyCallTheSchemaAdmitsIsOneTheServerAnswers() {
+        List<String> admitted = List.of(
+                "{\"name\":\"doc_read\"}",
+                "{\"name\":\"doc_read\",\"arguments\":{}}",
+                "{\"name\":\"doc_read\",\"arguments\":{\"name\":\"purpose\"}}",
+                "{\"name\":\"doc_search\",\"arguments\":{\"term\":\"newtype\"}}",
+                "{\"name\":\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":0}}",
+                "{\"name\":\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":2147483647}}",
+                "{\"name\":\"stdlib_api\",\"arguments\":{}}",
+                "{\"name\":\"stdlib_api\",\"arguments\":{\"name\":\"List\"}}",
+                "{\"name\":\"stdlib_api_search\",\"arguments\":{\"term\":\"map\"}}",
+                "{\"name\":\"stdlib_api_source\",\"arguments\":{\"name\":\"String\"}}");
+
+        for (String call : admitted) {
+            JsonNode answer = serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                    + "\"params\":" + call + "}").getFirst();
+
+            assertTrue(answer.has("result"), call + " fits the published schema: " + answer);
+            assertFalse(answer.get("result").get("isError").asBoolean(), call + " -> " + answer);
+        }
+    }
+
+    private List<String> required(String tool) {
+        return tools().valueStream().filter(t -> t.get("name").asString().equals(tool)).findFirst()
+                .orElseThrow().get("inputSchema").get("required")
+                .valueStream().map(JsonNode::asString).toList();
+    }
+
+    private JsonNode argument(String tool, String name) {
+        return tools().valueStream().filter(t -> t.get("name").asString().equals(tool)).findFirst()
+                .orElseThrow().get("inputSchema").get("properties").get(name);
+    }
+
+    private JsonNode tools() {
+        return serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}")
+                .getFirst().get("result").get("tools");
+    }
+
+    private List<JsonNode> serve(String... requests) {
+        ByteArrayInputStream in = new ByteArrayInputStream(
+                (String.join("\n", requests) + "\n").getBytes(StandardCharsets.UTF_8));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        McpServer.serve(in, out);
+        return out.toString(StandardCharsets.UTF_8).lines().map(JSON::readTree).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheSchemaAClientReadsIsTheOneTheServerEnforcesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheSchemaAClientReadsIsTheOneTheServerEnforcesTest.java
@@ -55,6 +55,19 @@ class TheSchemaAClientReadsIsTheOneTheServerEnforcesTest {
     }
 
     /**
+     * A number that no `double` holds is still the number that was sent. Rounding it on the way in
+     * decides the question before anything gets to ask it: `1.0000000000000000001` becomes a count
+     * the schema does not admit and would be honoured as `1`, and `1e-324` becomes zero, which is
+     * this server's spelling for every hit there is.
+     */
+    @Test
+    void aCountIsJudgedAsTheNumberSentAndNotAsWhatADoubleCanHold() {
+        assertCount("1.0000000000000000001", false);
+        assertCount("1e-324", false);
+        assertCount("1e400", false);
+    }
+
+    /**
      * Both edges of the domain refuse, and a client that cannot tell which one it fell off does
      * not know whether to round the number or to make it smaller.
      */
@@ -64,6 +77,8 @@ class TheSchemaAClientReadsIsTheOneTheServerEnforcesTest {
         assertTrue(refusal("2147483648").contains("2147483647"), refusal("2147483648"));
         assertFalse(refusal("2147483648").contains("whole number"),
                 "2147483648 is whole; what it is not is small enough");
+        assertTrue(refusal("1e400").contains("2147483647"),
+                "1e400 is whole too, and taking it to a double would have called it otherwise");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheSchemaAClientReadsIsTheOneTheServerEnforcesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheSchemaAClientReadsIsTheOneTheServerEnforcesTest.java
@@ -35,13 +35,94 @@ class TheSchemaAClientReadsIsTheOneTheServerEnforcesTest {
                 "and above this the conversion the server performs cannot hold the value");
     }
 
+    /**
+     * A schema's `integer` is a value that is whole, not a way of writing one down: 1, 1.0 and 1e0
+     * are one number and all three are integers under it. So the boundary is fixed here as values
+     * rather than as notations, and each is sent as well as read.
+     */
+    @Test
+    void everyWayOfWritingACountIsAnsweredByWhetherTheCountIsInTheDomain() {
+        assertCount("0", true);
+        assertCount("1", true);
+        assertCount("1.0", true);
+        assertCount("1e0", true);
+        assertCount("2147483647", true);
+        assertCount("1.5", false);
+        assertCount("-1", false);
+        assertCount("2147483648", false);
+        assertCount("\"1\"", false);
+        assertCount("null", false);
+    }
+
+    /**
+     * Both edges of the domain refuse, and a client that cannot tell which one it fell off does
+     * not know whether to round the number or to make it smaller.
+     */
+    @Test
+    void aCountOutsideTheDomainIsToldWhichEdgeItFellOff() {
+        assertTrue(refusal("1.5").contains("whole number"), refusal("1.5"));
+        assertTrue(refusal("2147483648").contains("2147483647"), refusal("2147483648"));
+        assertFalse(refusal("2147483648").contains("whole number"),
+                "2147483648 is whole; what it is not is small enough");
+    }
+
+    @Test
+    void aCountWrittenWithAPointIsReadAsTheCountAndNotMerelyAllowed() {
+        String one = serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":"
+                + "\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":1.0}}}")
+                .getFirst().get("result").get("content").get(0).get("text").asString();
+
+        assertEquals(1, one.lines().filter(line -> line.contains("\t")).count(), one);
+    }
+
     @Test
     void aStringArgumentPublishesThatEmptyIsNotOneOfItsValues() {
         JsonNode term = argument("doc_search", "term");
 
         assertEquals("string", term.get("type").asString());
-        assertEquals("\\S", term.get("pattern").asString(),
+        assertTrue(term.get("pattern").asString().startsWith("[^"),
                 "the empty term is what the server refuses, so the schema says so before the call");
+    }
+
+    /**
+     * `\s` is not one set. A schema's patterns are ECMA-262, where it takes in the no-break space;
+     * Java's does not. Written either way, the same argument has to be answered the same way.
+     */
+    @Test
+    void aSpaceIsASpaceOnBothSidesOfTheSchema() {
+        String published = argument("doc_read", "name").get("pattern").asString();
+
+        for (String space : List.of("\\u0020", "\\u00a0", "\\u2003", "\\ufeff")) {
+            assertFalse(java.util.regex.Pattern.compile(published)
+                            .matcher(unescape(space)).find(),
+                    space + " is a space, so a string of only it says nothing");
+
+            JsonNode answer = serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":"
+                    + "{\"name\":\"doc_read\",\"arguments\":{\"name\":\"" + space + "\"}}}").getFirst();
+
+            assertEquals(-32602, answer.get("error").get("code").asInt(),
+                    space + " is refused by the server too, not only by the schema: " + answer);
+        }
+    }
+
+    private String unescape(String escaped) {
+        return String.valueOf((char) Integer.parseInt(escaped.substring(2), 16));
+    }
+
+    private String refusal(String written) {
+        return count(written).get("error").get("message").asString();
+    }
+
+    private JsonNode count(String written) {
+        return serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":"
+                + "\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":" + written + "}}}")
+                .getFirst();
+    }
+
+    private void assertCount(String written, boolean inDomain) {
+        JsonNode answer = count(written);
+
+        assertEquals(inDomain, answer.has("result"), "limit: " + written + " -> " + answer);
     }
 
     @Test
@@ -82,6 +163,8 @@ class TheSchemaAClientReadsIsTheOneTheServerEnforcesTest {
                 "{\"name\":\"doc_read\",\"arguments\":{\"name\":\"purpose\"}}",
                 "{\"name\":\"doc_search\",\"arguments\":{\"term\":\"newtype\"}}",
                 "{\"name\":\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":0}}",
+                "{\"name\":\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":1.0}}",
+                "{\"name\":\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":1e0}}",
                 "{\"name\":\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":2147483647}}",
                 "{\"name\":\"stdlib_api\",\"arguments\":{}}",
                 "{\"name\":\"stdlib_api\",\"arguments\":{\"name\":\"List\"}}",


### PR DESCRIPTION
`souther doc` decides among three answers by the shape of its argument vector: none is the listing,
`--search` is the search, anything else is one section. The MCP layer bound `doc_read` to exactly
one of those shapes — always one argument — and declared `name` required, so the listing had no
spelling a client could write. The code that builds it runs at a prompt and was unreachable over
the wire.

That is why the error text and the tool's own description both named `souther doc`: an escape hatch
the schema forbids. `stdlib_api` said the same thing about `souther api --source`.

## What changed

The tools publish capabilities rather than the argv forms they happened to take.

| tool | arguments |
| --- | --- |
| `doc_search` | `term`, `limit` (count, optional) |
| `doc_read` | `name` (optional) |
| `stdlib_api` | `name` (optional) |
| `stdlib_api_search` | `term` |
| `stdlib_api_source` | `name` |
| `jar_api` | `name`, `classpath` (optional) |

`doc_read` with no name is the listing. `doc_search` takes the `limit` the flag takes. What `souther
api` selects with `--search` and `--source` is a tool each. Where MCP and the CLI still differ — the
stdlib search answers every match, so it takes no count — the tool description says so.

The schema a client reads is the one the server enforces. Each argument kind both publishes its
domain and decides membership in it, so the two cannot drift, and the domain is a set of values
rather than of ways to write them down:

- a count publishes `minimum: 0` and `maximum: 2147483647`, and is judged whole-or-not and
  small-enough-or-not, which are those two edges. `1`, `1.0` and `1e0` are one number and all three
  are counts;
- requests are read keeping decimals, so what the checks see is the number that was sent —
  `1.0000000000000000001` is not silently a `1`;
- a string publishes the negation of ECMA-262's whitespace, written in code points. The same
  literal is what gets published and what gets matched, so `\s` — which does not mean one thing on
  both sides — appears on neither.

An argument no tool declares is refused rather than dropped, and `additionalProperties: false` says
up front that there are none to guess at. Absent, `{}` and `null` are three different things at both
the `arguments` object and each argument in it. `params` as an alias for `arguments` is gone — it is
not in the protocol and reached the tool without validation.

What an answer offers next is chosen by who is asking. `Caller` holds both spellings of each offer,
so an MCP client is pointed at a tool call and a reader at a prompt keeps the flags and subcommands
they have.

## Measured, over a real session against the packaged jar

```
doc_read {}                             -> 307 lines, identical to what `souther doc` prints
doc_read {name:"nope"}                  -> no section `nope`
                                           `doc_read` with no `name` lists every section
doc_search {term:"/"}                   -> 20 hits + "... 87 more; `limit: 0` for all of them"
doc_search {term:"/", limit:0}          -> 107 hits, no truncation line
doc_search {term:"newtype", limit:1.0}  -> 1 hit
doc_search {term:"/", limit:"0"}        -> -32602 "`limit` must be a whole number"
doc_search {term:"/", limit:-1}         -> -32602 "`limit` must not be negative; 0 is all of them"
doc_search {term:"/", limit:1e-324}     -> -32602 "`limit` must be a whole number"
doc_search {term:"/", limit:1e400}      -> -32602 "`limit` must be no larger than 2147483647"
stdlib_api {name:"String.length"}       -> `stdlib_api_source {name: "String"}` for what it means
stdlib_api_source {name:"String"}       -> module souther.string ...
stdlib_api {source:true}                -> -32602 "`stdlib_api` has no argument `source`; it takes `name`"
doc_read {page:2}                       -> -32602 "`doc_read` has no argument `page`; it takes `name`"
doc_read arguments:null                 -> -32602 "`arguments` must be an object, or left out entirely"
doc_read {name:null}                    -> -32602 "`name` must be a string"
doc_read {name:"<U+00A0>"}              -> -32602 "`name` must not be empty"
```

Four test classes. `TheSchemaAClientReadsIsTheOneTheServerEnforcesTest` holds the published schema
as text and then sends every call that schema admits, closing both directions — a schema that
invites a call the server refuses, and a schema that hides a form the server would have answered.
The count's domain is fixed as a boundary table of values, each of which is sent, not as a handful
of representative calls.

Every assertion was checked against a mutant: `name` required again, the MCP wording reverted to the
CLI's, the unknown-argument check removed, the range check dropped, the null bypass restored, the
`\S` shorthand restored, decimals not kept on the way in. Each fails only the matching case. A
further case holds the CLI's own text in place, so adapting it for the other caller is not the same
as taking it away from this one.

`mvn clean test` is green across every module.

## Left out on purpose

Reading a large topic in pieces — `doc_read {name:"raoh/tutorial"}` is 55 KB in one result — is a
capability the commands do not have either, so it stays in #405 rather than becoming a projection
fix. So does the missing tool for `souther examples`. Documents that describe the CLI still
describe it; that is their subject. What changed is the line that says what to do next.

Extracting `DocService`/`ApiService` so the CLI and MCP share a capability instead of an argv and a
stdout is the follow-up refactor. `Caller` is the interim seam.

Refs #404, and the three MCP answers of #405 that named a CLI command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
