### PR TITLE
japi is read by someone who cannot open the jar

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Suggest.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Suggest.java
@@ -1,16 +1,53 @@
 package souther.compiler.check;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
 
 /**
  * "Did you mean" hints for unknown names. When a name the checker cannot resolve is a near-miss of
  * one that is in scope, the error carries the likely intended name, so a typo reads as a typo. The
  * closeness bound is Levenshtein distance ≤ 2 and strictly less than the name's length, so a short
  * name does not match every candidate.
+ *
+ * <p>What "near" measures is one thing across the compiler and the documentation tools: an edit
+ * distance, not a containment. How near is near enough is not — a class identifier and a section
+ * anchor are not the same length — so {@link #nearest} takes its bound from the caller while the
+ * measure stays here.
  */
 public final class Suggest {
 
+    /** The bound an unknown identifier is matched under. */
+    private static final int NEAR_ENOUGH = 2;
+
     private Suggest() {
+    }
+
+    /**
+     * The candidates within {@code bound} edits of {@code name}, closest first, at most
+     * {@code limit} of them.
+     *
+     * <p>A candidate must also be further than its own length is short — a two-letter name would
+     * otherwise be within two edits of everything and suggest whatever came first.
+     */
+    public static List<String> nearest(String name, Collection<String> candidates, int bound, int limit) {
+        record Near(String candidate, int distance) {}
+        List<Near> near = new ArrayList<>();
+        for (String candidate : candidates) {
+            if (candidate.equals(name)) {
+                continue;
+            }
+            int d = distance(name, candidate);
+            if (d <= bound && d < name.length()) {
+                near.add(new Near(candidate, d));
+            }
+        }
+        return near.stream()
+                .sorted(Comparator.comparingInt(Near::distance).thenComparing(Near::candidate))
+                .limit(limit)
+                .map(Near::candidate)
+                .toList();
     }
 
     /** {@code " (did you mean `X`?)"} for the closest candidate within bound, or {@code ""}. */
@@ -34,7 +71,7 @@ public final class Suggest {
                 best = candidate;
             }
         }
-        if (best != null && bestDistance <= 2 && bestDistance < name.length()) {
+        if (best != null && bestDistance <= NEAR_ENOUGH && bestDistance < name.length()) {
             return best;
         }
         return null;

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -1,8 +1,12 @@
 package souther.compiler.doc;
 
+import souther.compiler.check.Suggest;
+
 import java.io.PrintStream;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * {@code souther doc}: the language specification and every doc set a bundled dependency ships,
@@ -97,13 +101,7 @@ public final class DocCommand {
         SpecDocument.Section section = spec.section(anchor);
         if (section == null) {
             err.println("no section `" + anchor + "`");
-            // Through the same fold the lookup itself went through: a reader who typed the case the
-            // compiler prints would otherwise be told there is nothing near what they asked for.
-            String asked = DocName.canonical(anchor);
-            List<String> near = spec.names().stream()
-                    .filter(a -> DocName.canonical(a).contains(asked)
-                            || asked.contains(DocName.canonical(a)))
-                    .toList();
+            List<String> near = near(anchor, spec.names());
             if (!near.isEmpty()) {
                 err.println("did you mean: " + String.join(", ", near));
             }
@@ -119,6 +117,55 @@ public final class DocCommand {
         out.println();
         out.println(section.body());
         return 0;
+    }
+
+    /** What separates one part of a documentation name from the next. */
+    private static final String SEGMENTS = "-/";
+
+    /** How far a name may be from a section's and still be offered as the one that was meant. */
+    private static final int NEAR_ENOUGH = 2;
+
+    /** How many names a miss is answered with. */
+    private static final int MOST_SUGGESTIONS = 5;
+
+    /**
+     * The names {@code asked} may have meant, likeliest first.
+     *
+     * <p>Both tests run through the same fold the lookup itself went through, so a reader who typed
+     * the case the compiler prints is not told there is nothing near what they asked for.
+     *
+     * <p>A name that opens a section's own name is the answer on its own: {@code e1001} names the
+     * diagnostic the section {@code e1001-removed} is about, and no count of edits would put the two
+     * near each other. It is also what settles the question, so the spellings one keystroke away are
+     * not listed beside it — {@code e1002} is a keystroke from {@code e1001} and is about something
+     * else entirely.
+     *
+     * <p>Failing that the name is a typo, which is what an edit distance measures. Whether one name
+     * occurs somewhere inside another measures neither — {@code cli} sits in the middle of
+     * {@code acyclic}.
+     */
+    private static List<String> near(String asked, List<String> names) {
+        String key = DocName.canonical(asked);
+        Map<String, String> spelled = new LinkedHashMap<>();
+        names.forEach(name -> spelled.putIfAbsent(DocName.canonical(name), name));
+
+        List<String> named = spelled.entrySet().stream()
+                .filter(e -> opensWith(e.getKey(), key) || opensWith(key, e.getKey()))
+                .map(Map.Entry::getValue)
+                .limit(MOST_SUGGESTIONS)
+                .toList();
+        if (!named.isEmpty()) {
+            return named;
+        }
+        return Suggest.nearest(key, spelled.keySet(), NEAR_ENOUGH, MOST_SUGGESTIONS).stream()
+                .map(spelled::get)
+                .toList();
+    }
+
+    /** Whether {@code opening} is the whole of a leading run of {@code name}'s segments. */
+    private static boolean opensWith(String name, String opening) {
+        return name.length() > opening.length() && name.startsWith(opening)
+                && SEGMENTS.indexOf(name.charAt(opening.length())) >= 0;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/doc/JapiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/JapiCommand.java
@@ -40,19 +40,31 @@ import java.util.zip.ZipEntry;
  */
 public final class JapiCommand {
 
-    private JapiCommand() {}
-
-    public static int run(String[] args, PrintStream out, PrintStream err) {
-        return run(args, out, err, JapiCommand.class.getClassLoader());
-    }
-
     /** How far a name may be from one on the class path and still be offered as the one that was meant. */
     private static final int NEAR_ENOUGH = 2;
 
     /** How many names a miss is answered with. */
     private static final int MOST_SUGGESTIONS = 3;
 
+    private JapiCommand() {}
+
+    public static int run(String[] args, PrintStream out, PrintStream err) {
+        return run(args, out, err, System.getProperty("java.class.path", ""));
+    }
+
+    /**
+     * The same run, with a class loader carrying whatever it carries.
+     *
+     * <p>It is not consulted: a class taken from one copy of a library is not described by another
+     * copy this tool happens to hold. The parameter is how a caller says which loader that would
+     * have been.
+     */
     static int run(String[] args, PrintStream out, PrintStream err, ClassLoader bundled) {
+        return run(args, out, err, System.getProperty("java.class.path", ""));
+    }
+
+    /** The same run, over the class path to fall back on when the caller names none. */
+    static int run(String[] args, PrintStream out, PrintStream err, String defaultClassPath) {
         String name = null;
         List<Entry> entries = new ArrayList<>();
         for (int i = 0; i < args.length; i++) {
@@ -74,7 +86,7 @@ public final class JapiCommand {
             return 2;
         }
         if (entries.isEmpty()) {
-            for (String p : System.getProperty("java.class.path", "").split(java.io.File.pathSeparator)) {
+            for (String p : defaultClassPath.split(java.io.File.pathSeparator)) {
                 if (!p.isEmpty()) {
                     entries.add(new Entry(Path.of(p), false));
                 }
@@ -90,21 +102,22 @@ public final class JapiCommand {
 
         String classPath = entries.stream().map(e -> e.path().toString())
                 .collect(java.util.stream.Collectors.joining(java.io.File.pathSeparator));
-        Found found = findClass(name, entries, err);
+        Skipped skipped = new Skipped(err, new java.util.HashSet<>());
+        Found found = findClass(name, entries, skipped);
         if (found != null) {
             return print(found, name, member, out, err, classPath);
         }
         if (member != null) {
             err.println("no class `" + name + "` on the class path:");
-            return missed(name, entries, err);
+            return missed(name, entries, err, skipped);
         }
-        List<String> classes = classesUnder(name, entries, err);
+        List<String> classes = classesUnder(name, entries, skipped);
         if (!classes.isEmpty()) {
             classes.forEach(out::println);
             return 0;
         }
         err.println("no class or package `" + name + "` on the class path:");
-        return missed(name, entries, err);
+        return missed(name, entries, err, skipped);
     }
 
     /**
@@ -122,6 +135,27 @@ public final class JapiCommand {
             Path file = path.getFileName();
             return given || file == null ? path.toString() : file.toString();
         }
+
+        /**
+         * Why this entry could not be read.
+         *
+         * <p>An {@link IOException} names the file it is about, so passing its message on would hand
+         * back by another route the path {@link #shown} keeps back. A message belongs to the caller
+         * who wrote the path it names; for an entry this command fell back on, the failure is said
+         * by what kind of failure it is.
+         */
+        String failure(IOException e) {
+            if (given) {
+                return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+            }
+            return switch (e) {
+                case java.nio.file.NoSuchFileException _ -> "no such file";
+                case java.nio.file.AccessDeniedException _ -> "permission denied";
+                case java.io.FileNotFoundException _ -> "cannot be opened";
+                case java.util.zip.ZipException _ -> "not a readable archive";
+                default -> "cannot be read";
+            };
+        }
     }
 
     /**
@@ -131,9 +165,9 @@ public final class JapiCommand {
      * the second for every identifier in a source file. A reader of a jar has less to go on than the
      * author of a source file, not more.
      */
-    private static int missed(String name, List<Entry> entries, PrintStream err) {
+    private static int missed(String name, List<Entry> entries, PrintStream err, Skipped skipped) {
         entries.forEach(e -> err.println("  " + e.shown()));
-        List<String> near = Suggest.nearest(name, namesOn(entries, err), NEAR_ENOUGH, MOST_SUGGESTIONS);
+        List<String> near = Suggest.nearest(name, namesOn(entries, skipped), NEAR_ENOUGH, MOST_SUGGESTIONS);
         if (!near.isEmpty()) {
             err.println("did you mean: " + String.join(", ", near));
         }
@@ -148,15 +182,14 @@ public final class JapiCommand {
      * settles by parsing it, and parsing every class on the class path to phrase one guess would
      * cost more than the guess is worth.
      */
-    private static List<String> namesOn(List<Entry> entries, PrintStream err) {
+    private static List<String> namesOn(List<Entry> entries, Skipped skipped) {
         List<String> names = new ArrayList<>();
         for (Entry entry : entries) {
             try {
                 if (Files.isDirectory(entry.path())) {
                     try (var files = Files.walk(entry.path())) {
-                        for (Path f : files.filter(Files::isRegularFile).toList()) {
-                            add(names, entry.path().relativize(f).toString().replace(java.io.File.separatorChar, '/'));
-                        }
+                        files.filter(Files::isRegularFile).forEach(f -> add(names,
+                                entry.path().relativize(f).toString().replace(java.io.File.separatorChar, '/')));
                     }
                 } else if (Files.isRegularFile(entry.path())) {
                     try (JarFile jar = versioned(entry.path())) {
@@ -164,7 +197,13 @@ public final class JapiCommand {
                     }
                 }
             } catch (IOException e) {
-                unreadable(entry, e, err);
+                skipped.report(entry, e);
+            } catch (UncheckedIOException e) {
+                // A walk opens the directory it was handed straight away and every directory under
+                // it only on reaching it, so a failure below the entry arrives here rather than
+                // above. What was walked before it is kept: a name to suggest may already be among
+                // them, and looking for one is not what may end the run.
+                skipped.report(entry, e.getCause());
             }
         }
         return names.stream().distinct().toList();
@@ -188,7 +227,7 @@ public final class JapiCommand {
      *  sources jar, and with it the javadoc, is found from the entry. */
     private record Found(byte[] bytes, Path entry) {}
 
-    private static Found findClass(String binaryName, List<Entry> entries, PrintStream err) {
+    private static Found findClass(String binaryName, List<Entry> entries, Skipped skipped) {
         String resource = binaryName.replace('.', '/') + ".class";
         for (Entry entry : entries) {
             Path path = entry.path();
@@ -207,16 +246,28 @@ public final class JapiCommand {
                     }
                 }
             } catch (IOException e) {
-                unreadable(entry, e, err);
+                skipped.report(entry, e);
             }
         }
         return null;
     }
 
-    /** A class path is given, not chosen: one entry that cannot be opened is said and stepped
-     *  over, so the entries beside it still answer. */
-    private static void unreadable(Entry entry, IOException e, PrintStream err) {
-        err.println("skipping `" + entry.shown() + "`: " + e.getMessage());
+    /**
+     * Where an entry that cannot be opened is reported.
+     *
+     * <p>A class path is given, not chosen: one entry that cannot be opened is said and stepped over,
+     * so the entries beside it still answer. A miss walks the class path once for the class, once for
+     * the package and once for a name to suggest, and the same entry fails all three — so what has
+     * been said is remembered, and a reader is told once.
+     */
+    private record Skipped(PrintStream err, Set<String> said) {
+
+        void report(Entry entry, IOException e) {
+            String line = "skipping `" + entry.shown() + "`: " + entry.failure(e);
+            if (said.add(line)) {
+                err.println(line);
+            }
+        }
     }
 
     /**
@@ -226,7 +277,7 @@ public final class JapiCommand {
      * type. This command answers a dependency's public API, so the class's own access flag decides,
      * and {@code package-info} — a descriptor rather than a type — is left out with it.
      */
-    private static List<String> classesUnder(String packageName, List<Entry> entries, PrintStream err) {
+    private static List<String> classesUnder(String packageName, List<Entry> entries, Skipped skipped) {
         String prefix = packageName.replace('.', '/') + "/";
         List<String> classes = new ArrayList<>();
         for (Entry entry : entries) {
@@ -264,7 +315,7 @@ public final class JapiCommand {
                     }
                 }
             } catch (IOException e) {
-                unreadable(entry, e, err);
+                skipped.report(entry, e);
             }
         }
         return classes.stream().distinct().sorted().toList();
@@ -424,11 +475,14 @@ public final class JapiCommand {
     }
 
     /**
-     * A constant as the source that declared it would write it.
+     * A constant written as Java writes it.
      *
-     * <p>What japi prints is Java, so the value is a Java literal: the pool stores {@code boolean}
-     * and {@code char} as an int and says nothing about the width of an integer, and the field's own
-     * descriptor is what tells them apart.
+     * <p>The pool stores {@code boolean} and {@code char} as an int and says nothing about the width
+     * of an integer, so the field's own descriptor is what tells them apart.
+     *
+     * <p>Three floating-point values have no literal that spells them, and Java names them on
+     * {@code Float} and {@code Double} instead. A name is what is printed for them: what japi prints
+     * is read as Java, and {@code NaNf} — which is what a disassembler says — is not.
      */
     private static String literal(ConstantDesc value, ClassDesc type) {
         if (value instanceof String s) {
@@ -442,9 +496,16 @@ public final class JapiCommand {
         }
         return switch (value) {
             case Long l -> l + "L";
-            case Float fl -> fl + "f";
+            case Float f when f.isNaN() || f.isInfinite() -> "Float." + named(f.isNaN(), f > 0);
+            case Double d when d.isNaN() || d.isInfinite() -> "Double." + named(d.isNaN(), d > 0);
+            case Float f -> f + "f";
             default -> String.valueOf(value);
         };
+    }
+
+    /** What Java calls a floating-point value no literal spells. */
+    private static String named(boolean notANumber, boolean above) {
+        return notANumber ? "NaN" : above ? "POSITIVE_INFINITY" : "NEGATIVE_INFINITY";
     }
 
     /** {@code text} between {@code quote}s, with what Java cannot write plainly escaped. */

--- a/souther-compiler/src/main/java/souther/compiler/doc/JapiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/JapiCommand.java
@@ -1,5 +1,7 @@
 package souther.compiler.doc;
 
+import souther.compiler.check.Suggest;
+
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UncheckedIOException;
@@ -13,6 +15,8 @@ import java.lang.classfile.MethodSignature;
 import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.MethodParameterInfo;
 import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDesc;
+import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.reflect.AccessFlag;
 import java.nio.charset.StandardCharsets;
@@ -42,9 +46,15 @@ public final class JapiCommand {
         return run(args, out, err, JapiCommand.class.getClassLoader());
     }
 
+    /** How far a name may be from one on the class path and still be offered as the one that was meant. */
+    private static final int NEAR_ENOUGH = 2;
+
+    /** How many names a miss is answered with. */
+    private static final int MOST_SUGGESTIONS = 3;
+
     static int run(String[] args, PrintStream out, PrintStream err, ClassLoader bundled) {
         String name = null;
-        List<Path> entries = new ArrayList<>();
+        List<Entry> entries = new ArrayList<>();
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
                 case "-cp", "--class-path" -> {
@@ -53,20 +63,20 @@ public final class JapiCommand {
                         return 2;
                     }
                     for (String p : args[++i].split(java.io.File.pathSeparator)) {
-                        entries.add(Path.of(p));
+                        entries.add(new Entry(Path.of(p), true));
                     }
                 }
                 default -> name = args[i];
             }
         }
         if (name == null) {
-            err.println("usage: souther japi <class-or-package> [-cp <path>]");
+            err.println("usage: souther japi <class-or-package>[#<member>] [-cp <path>]");
             return 2;
         }
         if (entries.isEmpty()) {
             for (String p : System.getProperty("java.class.path", "").split(java.io.File.pathSeparator)) {
                 if (!p.isEmpty()) {
-                    entries.add(Path.of(p));
+                    entries.add(new Entry(Path.of(p), false));
                 }
             }
         }
@@ -78,7 +88,7 @@ public final class JapiCommand {
             name = name.substring(0, hash);
         }
 
-        String classPath = entries.stream().map(Path::toString)
+        String classPath = entries.stream().map(e -> e.path().toString())
                 .collect(java.util.stream.Collectors.joining(java.io.File.pathSeparator));
         Found found = findClass(name, entries, err);
         if (found != null) {
@@ -86,8 +96,7 @@ public final class JapiCommand {
         }
         if (member != null) {
             err.println("no class `" + name + "` on the class path:");
-            entries.forEach(e -> err.println("  " + e));
-            return 2;
+            return missed(name, entries, err);
         }
         List<String> classes = classesUnder(name, entries, err);
         if (!classes.isEmpty()) {
@@ -95,28 +104,105 @@ public final class JapiCommand {
             return 0;
         }
         err.println("no class or package `" + name + "` on the class path:");
-        entries.forEach(e -> err.println("  " + e));
+        return missed(name, entries, err);
+    }
+
+    /**
+     * A class path entry, and whether the caller is the one who named it.
+     *
+     * <p>A path the caller wrote is theirs, and it is said back as they wrote it — it is what they
+     * need to see where the search went. A path this command fell back to is its own hosting, which
+     * says nothing a reader can act on and is not theirs to be handed, so it is named by the file it
+     * is.
+     */
+    private record Entry(Path path, boolean given) {
+
+        /** What this entry is called when a message names it. */
+        String shown() {
+            Path file = path.getFileName();
+            return given || file == null ? path.toString() : file.toString();
+        }
+    }
+
+    /**
+     * Where the search went, and the nearest names to the one that was not found.
+     *
+     * <p>A name out of the class path and a name misspelled read the same, and the compiler answers
+     * the second for every identifier in a source file. A reader of a jar has less to go on than the
+     * author of a source file, not more.
+     */
+    private static int missed(String name, List<Entry> entries, PrintStream err) {
+        entries.forEach(e -> err.println("  " + e.shown()));
+        List<String> near = Suggest.nearest(name, namesOn(entries, err), NEAR_ENOUGH, MOST_SUGGESTIONS);
+        if (!near.isEmpty()) {
+            err.println("did you mean: " + String.join(", ", near));
+        }
         return 2;
+    }
+
+    /**
+     * Every top-level class the class path holds, and the packages holding them — the names a miss
+     * could have meant.
+     *
+     * <p>Only entry names are read. Whether a class is published is what {@link #classesUnder}
+     * settles by parsing it, and parsing every class on the class path to phrase one guess would
+     * cost more than the guess is worth.
+     */
+    private static List<String> namesOn(List<Entry> entries, PrintStream err) {
+        List<String> names = new ArrayList<>();
+        for (Entry entry : entries) {
+            try {
+                if (Files.isDirectory(entry.path())) {
+                    try (var files = Files.walk(entry.path())) {
+                        for (Path f : files.filter(Files::isRegularFile).toList()) {
+                            add(names, entry.path().relativize(f).toString().replace(java.io.File.separatorChar, '/'));
+                        }
+                    }
+                } else if (Files.isRegularFile(entry.path())) {
+                    try (JarFile jar = versioned(entry.path())) {
+                        jar.versionedStream().forEach(e -> add(names, e.getName()));
+                    }
+                }
+            } catch (IOException e) {
+                unreadable(entry, e, err);
+            }
+        }
+        return names.stream().distinct().toList();
+    }
+
+    /** The binary name {@code resource} declares, and its package, when it declares a type. */
+    private static void add(List<String> names, String resource) {
+        int slash = resource.lastIndexOf('/');
+        String simple = topLevelName(resource.substring(slash + 1));
+        if (simple == null) {
+            return;
+        }
+        String pkg = slash < 0 ? "" : resource.substring(0, slash).replace('/', '.');
+        names.add(pkg.isEmpty() ? simple : pkg + "." + simple);
+        if (!pkg.isEmpty()) {
+            names.add(pkg);
+        }
     }
 
     /** A class's bytes and the classpath entry they came from — kept together because the
      *  sources jar, and with it the javadoc, is found from the entry. */
     private record Found(byte[] bytes, Path entry) {}
 
-    private static Found findClass(String binaryName, List<Path> entries, PrintStream err) {
+    private static Found findClass(String binaryName, List<Entry> entries, PrintStream err) {
         String resource = binaryName.replace('.', '/') + ".class";
-        for (Path entry : entries) {
+        for (Entry entry : entries) {
+            Path path = entry.path();
             try {
-                if (Files.isDirectory(entry)) {
-                    Path f = entry.resolve(resource);
+                if (Files.isDirectory(path)) {
+                    Path f = path.resolve(resource);
                     if (Files.isRegularFile(f)) {
-                        return new Found(Files.readAllBytes(f), entry);
+                        return new Found(Files.readAllBytes(f), path);
                     }
-                } else if (Files.isRegularFile(entry)) {
-                    try (JarFile jar = versioned(entry)) {
+                } else if (Files.isRegularFile(path)) {
+                    try (JarFile jar = versioned(path)) {
                         ZipEntry e = jar.getEntry(resource);
                         if (e != null) {
-                            return new Found(jar.getInputStream(e).readAllBytes(), entry);
+                            return new Found(jar.getInputStream(e).readAllBytes(), path);
                         }
                     }
                 }
@@ -129,8 +215,8 @@ public final class JapiCommand {
 
     /** A class path is given, not chosen: one entry that cannot be opened is said and stepped
      *  over, so the entries beside it still answer. */
-    private static void unreadable(Path entry, IOException e, PrintStream err) {
-        err.println("skipping `" + entry + "`: " + e.getMessage());
+    private static void unreadable(Entry entry, IOException e, PrintStream err) {
+        err.println("skipping `" + entry.shown() + "`: " + e.getMessage());
     }
 
     /**
@@ -140,13 +226,14 @@ public final class JapiCommand {
      * type. This command answers a dependency's public API, so the class's own access flag decides,
      * and {@code package-info} — a descriptor rather than a type — is left out with it.
      */
-    private static List<String> classesUnder(String packageName, List<Path> entries, PrintStream err) {
+    private static List<String> classesUnder(String packageName, List<Entry> entries, PrintStream err) {
         String prefix = packageName.replace('.', '/') + "/";
         List<String> classes = new ArrayList<>();
-        for (Path entry : entries) {
+        for (Entry entry : entries) {
+            Path path = entry.path();
             try {
-                if (Files.isDirectory(entry)) {
-                    Path dir = entry.resolve(packageName.replace('.', '/'));
+                if (Files.isDirectory(path)) {
+                    Path dir = path.resolve(packageName.replace('.', '/'));
                     if (Files.isDirectory(dir)) {
                         try (var files = Files.list(dir)) {
                             for (Path f : files.toList()) {
@@ -157,8 +244,8 @@ public final class JapiCommand {
                             }
                         }
                     }
-                } else if (Files.isRegularFile(entry)) {
-                    try (JarFile jar = versioned(entry)) {
+                } else if (Files.isRegularFile(path)) {
+                    try (JarFile jar = versioned(path)) {
                         for (JarEntry e : jar.versionedStream().toList()) {
                             String name = e.getName();
                             if (!name.startsWith(prefix)) {
@@ -318,7 +405,63 @@ public final class JapiCommand {
         String type = f.findAttribute(Attributes.signature())
                 .map(a -> show(Signature.parseFrom(a.signature().stringValue())))
                 .orElse(shortName(desc(f.fieldTypeSymbol())));
-        return memberFlags(f.flags().flags()) + type + " " + f.fieldName().stringValue();
+        return memberFlags(f.flags().flags()) + type + " " + f.fieldName().stringValue() + value(f);
+    }
+
+    /**
+     * {@code  = <literal>} for a field the class file carries the value of, and nothing for one it
+     * does not.
+     *
+     * <p>A constant's value is the whole of what its declaration says, and a reader comparing it
+     * against what some other code produces needs the value rather than the name. Only a compile-time
+     * constant has one in the class file; a field an initializer computes has none, and none is
+     * invented for it.
+     */
+    private static String value(FieldModel f) {
+        return f.findAttribute(Attributes.constantValue())
+                .map(a -> " = " + literal(a.constant().constantValue(), f.fieldTypeSymbol()))
+                .orElse("");
+    }
+
+    /**
+     * A constant as the source that declared it would write it.
+     *
+     * <p>What japi prints is Java, so the value is a Java literal: the pool stores {@code boolean}
+     * and {@code char} as an int and says nothing about the width of an integer, and the field's own
+     * descriptor is what tells them apart.
+     */
+    private static String literal(ConstantDesc value, ClassDesc type) {
+        if (value instanceof String s) {
+            return quoted(s, '"');
+        }
+        if (type.equals(ConstantDescs.CD_boolean)) {
+            return ((Integer) value) == 0 ? "false" : "true";
+        }
+        if (type.equals(ConstantDescs.CD_char)) {
+            return quoted(Character.toString((char) (int) (Integer) value), '\'');
+        }
+        return switch (value) {
+            case Long l -> l + "L";
+            case Float fl -> fl + "f";
+            default -> String.valueOf(value);
+        };
+    }
+
+    /** {@code text} between {@code quote}s, with what Java cannot write plainly escaped. */
+    private static String quoted(String text, char quote) {
+        StringBuilder sb = new StringBuilder().append(quote);
+        text.codePoints().forEach(c -> sb.append(switch (c) {
+            case '\\' -> "\\\\";
+            case '\b' -> "\\b";
+            case '\f' -> "\\f";
+            case '\n' -> "\\n";
+            case '\r' -> "\\r";
+            case '\t' -> "\\t";
+            default -> c == quote ? "\\" + quote
+                    : c < 0x20 || c == 0x7f ? String.format("\\u%04x", c)
+                    : new String(Character.toChars(c));
+        }));
+        return sb.append(quote).toString();
     }
 
     private static String methodLine(MethodModel m, String simpleName, SourceDoc doc) {

--- a/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
@@ -61,8 +61,11 @@ public final class McpServer {
                     Map.of("name", "a stdlib module or Module.name, omit for all"), List.of()),
             new Tool("jar_api",
                     "A dependency jar's public API read from its class files, with javadoc from the"
-                            + " -sources.jar beside it. Give a fully qualified class or package name.",
-                    Map.of("name", "a fully qualified class or package name",
+                            + " -sources.jar beside it. Give a fully qualified class or package name."
+                            + " To read one member of a class rather than all of them, write"
+                            + " `Class#member` — for example `net.unit8.raoh.Result#map2`.",
+                    Map.of("name", "a fully qualified class or package name, optionally followed by"
+                            + " `#member` to select one member of the class",
                             "classpath", "jars or class directories to search, path-separated;"
                                     + " omit to search the CLI's own class path"), List.of("name")));
 

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -70,12 +70,20 @@ argument it prints everything, which for a library this size is the fastest way 
 ## japi
 
 ```
-souther japi <class-or-package> [-cp <path>]
+souther japi <class-or-package>[#<member>] [-cp <path>]
 ```
 
 A dependency's public API, read from its class files without loading them, with javadoc taken from
 the `-sources.jar` beside the jar. This is the answer to "what does this library actually offer"
 without disassembling anything.
+
+A class name answers with every published member; `Class#member` answers with one of them, which is
+what a class carrying sixteen overloads of the same name is worth asking. A compile-time constant is
+printed with its value, since the value is what the declaration says.
+
+```
+souther japi net.unit8.raoh.Result#map2
+```
 
 ## mcp
 

--- a/souther-compiler/src/test/java/souther/compiler/doc/ANameIsFoundInWhateverCaseItIsAskedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ANameIsFoundInWhateverCaseItIsAskedForTest.java
@@ -75,6 +75,23 @@ class ANameIsFoundInWhateverCaseItIsAskedForTest {
                 "the suggestion goes through the same fold as the lookup: " + answer.err());
     }
 
+    /**
+     * `e1001` is the name of the diagnostic `e1001-removed` is about, so that section is what was
+     * asked for. `e1002` is one keystroke away and is about something else entirely — a diagnostic
+     * code is not a word, and its neighbours are not near it. When the name asked for opens a
+     * section's own name, that is the answer, and the near spellings are not worth listing beside it.
+     */
+    @Test
+    void aNameASectionIsNamedAfterIsAnsweredWithThatSectionAlone() {
+        Answer answer = run(DocCommand.class.getClassLoader(), "E1001");
+
+        assertEquals(2, answer.code());
+        String suggestion = answer.err().lines().filter(l -> l.startsWith("did you mean"))
+                .findFirst().orElseThrow();
+        assertEquals("did you mean: e1001-removed", suggestion,
+                "the section the name belongs to, and nothing that merely spells like it");
+    }
+
     @Test
     void aShippedTopicKeepsItsSpellingAndIsStillFoundByAnyCase() throws Exception {
         try (URLClassLoader loader = jarOf("MixedCase", List.of("Guide.md"))) {

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest.java
@@ -245,6 +245,24 @@ class EveryNameTheSpecificationSendsAReaderToCanBeAskedForTest {
                 "and so is an anchor written on a paragraph: " + forAnAnchor);
     }
 
+    /**
+     * A short name occurs inside longer words that have nothing to do with it — `cli` sits in the
+     * middle of `acyclic`. A suggestion is worth making only when the name asked for and the name
+     * offered are near each other, which containment does not measure.
+     */
+    @Test
+    void aNameThatMerelyOccursInsideAWordIsNotANearMiss() {
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        PrintStream discard = new PrintStream(ByteArrayOutputStream.nullOutputStream(), true,
+                StandardCharsets.UTF_8);
+
+        DocCommand.run(new String[]{"cli"}, discard, new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        String said = err.toString(StandardCharsets.UTF_8);
+        assertFalse(said.contains("module-dependencies-are-acyclic"),
+                "a word that happens to hold the letters is not a suggestion: " + said);
+    }
+
     private static String text() {
         try (InputStream in = SpecDocument.class.getResourceAsStream("/META-INF/souther/specification.adoc")) {
             assertNotNull(in, "the specification travels in the jar");

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheJapiCommandReadsAJarsPublicApiTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheJapiCommandReadsAJarsPublicApiTest.java
@@ -16,7 +16,9 @@ import java.util.jar.JarOutputStream;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * `souther japi` answers a dependency's public API from its class files — what javap is reached
@@ -100,6 +102,9 @@ class TheJapiCommandReadsAJarsPublicApiTest {
                     public static final int COUNT = 3;
                     public static final boolean ON = true;
                     public static final byte MASK = 7;
+                    public static final float NOT_A_NUMBER = 0.0f / 0.0f;
+                    public static final double UNBOUNDED = 1.0 / 0.0;
+                    public static final double BELOW = -1.0 / 0.0;
                     public static final Object OPEN = new Object();
                 }
                 """);
@@ -372,9 +377,8 @@ class TheJapiCommandReadsAJarsPublicApiTest {
         Answer answer = run("acme.Nobody");
 
         assertEquals(2, answer.code());
-        assertTrue(answer.err().lines().filter(l -> l.startsWith("  "))
-                        .noneMatch(l -> l.contains(java.io.File.separator)),
-                "no path into this machine is handed out: " + answer.err());
+        assertFalse(answer.err().contains(java.io.File.separator),
+                "nothing said about this run carries a path into this machine: " + answer.err());
     }
 
     /** A path the caller wrote is theirs, and it is what they need back to see where japi looked. */
@@ -385,6 +389,105 @@ class TheJapiCommandReadsAJarsPublicApiTest {
         assertEquals(2, answer.code());
         assertTrue(answer.err().contains(jar.toString()),
                 "the path they gave is the one they are told about: " + answer.err());
+    }
+
+    /**
+     * A floating-point value can be one no literal spells. Java has a name for each of them, and a
+     * name is what japi prints, since what it prints is Java.
+     */
+    @Test
+    void aFloatingPointValueNoLiteralSpellsIsPrintedUnderTheNameJavaGivesIt() {
+        Answer answer = run("acme.Constants", "-cp", jar.toString());
+
+        assertEquals(0, answer.code(), answer.err());
+        String out = answer.out();
+        assertTrue(out.contains("float NOT_A_NUMBER = Float.NaN"), out);
+        assertTrue(out.contains("double UNBOUNDED = Double.POSITIVE_INFINITY"), out);
+        assertTrue(out.contains("double BELOW = Double.NEGATIVE_INFINITY"), out);
+    }
+
+    /**
+     * A walk reports a directory it cannot descend into only once it reaches it, and reports it
+     * unchecked. Looking for a name to suggest must not be what ends the run — that is the miss the
+     * suggestion exists to answer.
+     */
+    @Test
+    void aDirectoryTheSearchCannotDescendIntoIsSteppedOverLikeAnyOtherEntry() throws Exception {
+        Path tree = Files.createTempDirectory("unwalkable");
+        Path shut = tree.resolve("shut");
+        Files.createDirectories(shut);
+        Files.writeString(shut.resolve("Something.class"), "not read");
+        assertTrue(shut.toFile().setReadable(false), "the fixture needs the directory closed");
+        assumeTrue(!readable(shut), "this process can read whatever it likes; nothing to step over");
+
+        Answer answer = run("acme.Greetr", "-cp", tree + java.io.File.pathSeparator + jar);
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().contains("acme.Greeter"),
+                "the entry beside it is still searched for a near name: " + answer.err());
+    }
+
+    /**
+     * An IOException names the file it is about. For an entry this command fell back on, that is
+     * the path {@link #theClassPathThisToolFellBackOnIsNamedByWhatItIsNotWhereItIs} keeps back,
+     * arriving by another route.
+     */
+    @Test
+    void aFailureOnTheClassPathThisToolFellBackOnCarriesNoPathEither() throws Exception {
+        Path shut = Files.createTempDirectory("shut-jar").resolve("shut.jar");
+        Files.writeString(shut, "not read");
+        assertTrue(shut.toFile().setReadable(false), "the fixture needs the file closed");
+        assumeTrue(!readable(shut), "this process can read whatever it likes; nothing to fail on");
+
+        Answer answer = fellBackOn(shut.toString(), "acme.Nobody");
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().contains("shut.jar"), "the entry is still named: " + answer.err());
+        assertFalse(answer.err().contains(shut.getParent().toString()),
+                "and no path into this machine rides along with the reason: " + answer.err());
+    }
+
+    /**
+     * A miss walks the class path more than once — for the class, for the package, and for a name to
+     * suggest. An entry that cannot be opened fails every one of them, and is worth saying once.
+     */
+    @Test
+    void anEntryThatCannotBeOpenedIsSaidOnceHoweverManyPassesMeetIt() throws Exception {
+        Path shut = Files.createTempDirectory("said-once").resolve("shut.jar");
+        Files.writeString(shut, "not read");
+        assertTrue(shut.toFile().setReadable(false), "the fixture needs the file closed");
+        assumeTrue(!readable(shut), "this process can read whatever it likes; nothing to fail on");
+
+        Answer answer = run("acme.Nobody", "-cp", shut + java.io.File.pathSeparator + jar);
+
+        assertEquals(2, answer.code());
+        assertEquals(1, answer.err().lines().filter(l -> l.startsWith("skipping")).count(),
+                "one entry, one report: " + answer.err());
+    }
+
+    private static boolean readable(Path path) {
+        try {
+            if (Files.isDirectory(path)) {
+                try (Stream<Path> entries = Files.list(path)) {
+                    entries.toList();
+                }
+            } else {
+                Files.readAllBytes(path);
+            }
+            return true;
+        } catch (java.io.IOException e) {
+            return false;
+        }
+    }
+
+    /** japi run over a class path it was not given but fell back on. */
+    private Answer fellBackOn(String classPath, String... args) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int code = JapiCommand.run(args,
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8), classPath);
+        return new Answer(code, out.toString(StandardCharsets.UTF_8), err.toString(StandardCharsets.UTF_8));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheJapiCommandReadsAJarsPublicApiTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheJapiCommandReadsAJarsPublicApiTest.java
@@ -84,12 +84,31 @@ class TheJapiCommandReadsAJarsPublicApiTest {
                 public record Pair<A, B>(A first, B second) {
                 }
                 """);
+        Path constants = dir.resolve("acme/Constants.java");
+        Files.writeString(constants, """
+                package acme;
+
+                /** Values settled at compile time, and one that is not. */
+                public final class Constants {
+                    public static final String GREETING = "hello";
+                    public static final String ESCAPED = "a\\"b\\\\c\\nd\\te";
+                    public static final char SEPARATOR = '\\n';
+                    public static final char QUOTED = '\\'';
+                    public static final long LIMIT = 10L;
+                    public static final float RATIO = 1.5f;
+                    public static final double SCALE = 2.5;
+                    public static final int COUNT = 3;
+                    public static final boolean ON = true;
+                    public static final byte MASK = 7;
+                    public static final Object OPEN = new Object();
+                }
+                """);
         JavaCompiler javac = ToolProvider.getSystemJavaCompiler();
         Path classes = dir.resolve("classes");
         Files.createDirectories(classes);
         assertEquals(0, javac.run(null, OutputStream.nullOutputStream(), OutputStream.nullOutputStream(),
                 "-d", classes.toString(), "-parameters", src.toString(), record.toString(),
-                hidden.toString(), packageInfo.toString()));
+                hidden.toString(), packageInfo.toString(), constants.toString()));
 
         jar = dir.resolve("greeter-1.0.jar");
         try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
@@ -269,5 +288,110 @@ class TheJapiCommandReadsAJarsPublicApiTest {
         assertEquals(2, answer.code());
         assertTrue(answer.err().contains("acme.Nobody"), answer.err());
         assertTrue(answer.err().contains("greeter-1.0.jar"), "the classpath it searched is named: " + answer.err());
+    }
+
+    /**
+     * A compile-time constant's value is the whole of what its declaration says, and the class file
+     * carries it. It is printed as the source would write it, so what is read back is a Java literal
+     * and not a JVM {@code toString}.
+     */
+    @Test
+    void aCompileTimeConstantIsPrintedWithTheLiteralItsSourceWrote() {
+        Answer answer = run("acme.Constants", "-cp", jar.toString());
+
+        assertEquals(0, answer.code(), answer.err());
+        String out = answer.out();
+        assertTrue(out.contains("String GREETING = \"hello\""), out);
+        assertTrue(out.contains("= \"a\\\"b\\\\c\\nd\\te\""),
+                "a quote, a backslash and a control character are escaped as Java writes them: " + out);
+        assertTrue(out.contains("char SEPARATOR = '\\n'"), out);
+        assertTrue(out.contains("char QUOTED = '\\''"), out);
+        assertTrue(out.contains("long LIMIT = 10L"), out);
+        assertTrue(out.contains("float RATIO = 1.5f"), out);
+        assertTrue(out.contains("double SCALE = 2.5"), out);
+        assertTrue(out.contains("int COUNT = 3"), out);
+        assertTrue(out.contains("boolean ON = true"), out);
+        assertTrue(out.contains("byte MASK = 7"), out);
+    }
+
+    /**
+     * Only a compile-time constant has a value in the class file. A field initialized by running
+     * code has none, and japi prints what the class file holds rather than guessing at the rest.
+     */
+    @Test
+    void aFieldWhoseValueIsNotInTheClassFileIsPrintedWithoutOne() {
+        Answer answer = run("acme.Constants", "-cp", jar.toString());
+
+        assertEquals(0, answer.code(), answer.err());
+        String declared = answer.out().lines().filter(l -> l.contains("OPEN")).findFirst().orElseThrow();
+        assertTrue(declared.strip().equals("public static final Object OPEN"),
+                "no value is invented for it: " + declared);
+    }
+
+    @Test
+    void aClassNameThatAlmostSpellsOneOnTheClassPathIsToldWhatItAlmostSpells() {
+        Answer answer = run("acme.Greetr", "-cp", jar.toString());
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().contains("did you mean"), answer.err());
+        assertTrue(answer.err().contains("acme.Greeter"), answer.err());
+    }
+
+    @Test
+    void aPackageNameThatAlmostSpellsOneOnTheClassPathIsToldSoToo() {
+        Answer answer = run("acmee", "-cp", jar.toString());
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().contains("did you mean"), answer.err());
+        assertTrue(answer.err().contains("acme"), answer.err());
+    }
+
+    @Test
+    void aNameNearNothingOnTheClassPathIsOfferedNothing() {
+        Answer answer = run("acme.Bewilderment", "-cp", jar.toString());
+
+        assertEquals(2, answer.code());
+        assertTrue(!answer.err().contains("did you mean"),
+                "a name that is not a near miss gets no guess: " + answer.err());
+    }
+
+    @Test
+    void aMissOnAMemberOfAClassThatIsNotThereNamesTheClassItAlmostSpells() {
+        Answer answer = run("acme.Greetr#greet", "-cp", jar.toString());
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().contains("acme.Greeter"), answer.err());
+    }
+
+    /**
+     * The class path the caller did not choose is the tool's own hosting, and naming it by where
+     * this machine keeps it tells a reader nothing they can act on.
+     */
+    @Test
+    void theClassPathThisToolFellBackOnIsNamedByWhatItIsNotWhereItIs() {
+        Answer answer = run("acme.Nobody");
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().lines().filter(l -> l.startsWith("  "))
+                        .noneMatch(l -> l.contains(java.io.File.separator)),
+                "no path into this machine is handed out: " + answer.err());
+    }
+
+    /** A path the caller wrote is theirs, and it is what they need back to see where japi looked. */
+    @Test
+    void aClassPathTheCallerGaveIsSaidBackAsTheyWroteIt() {
+        Answer answer = run("acme.Nobody", "-cp", jar.toString());
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().contains(jar.toString()),
+                "the path they gave is the one they are told about: " + answer.err());
+    }
+
+    @Test
+    void theUsageSaysAMemberCanBeSelected() {
+        Answer answer = run();
+
+        assertEquals(2, answer.code());
+        assertTrue(answer.err().contains("#"), "the `Class#member` form is in the usage: " + answer.err());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheMcpServerSpeaksTheProtocolOverStdioTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheMcpServerSpeaksTheProtocolOverStdioTest.java
@@ -123,6 +123,24 @@ class TheMcpServerSpeaksTheProtocolOverStdioTest {
         assertTrue(answers.get(1).get("result").has("tools"), "the next request is served as usual");
     }
 
+    /**
+     * A tool schema is the whole of what a client can find out about a tool. A form the tool accepts
+     * and the schema does not mention cannot be reached by a reader who only has the schema, so it
+     * is missing however well it works.
+     */
+    @Test
+    void theJarApiSchemaSaysThatAMemberCanBeSelected() {
+        List<JsonNode> answers = serve("{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\"}");
+
+        JsonNode jarApi = answers.getFirst().get("result").get("tools").valueStream()
+                .filter(t -> t.get("name").asString().equals("jar_api")).findFirst().orElseThrow();
+        assertTrue(jarApi.get("description").asString().contains("Class#member"),
+                "the description names the form: " + jarApi.get("description").asString());
+        String name = jarApi.get("inputSchema").get("properties").get("name")
+                .get("description").asString();
+        assertTrue(name.contains("#member"), "and so does the argument that takes it: " + name);
+    }
+
     @Test
     void anUnknownMethodIsAJsonRpcError() {
         List<JsonNode> answers = serve("{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"nothing/here\"}");


### PR DESCRIPTION
Fixes the four defects in #407. They are one thing four times: `japi` and the MCP tools over it are read by someone who cannot fall back on `javap` and a zip listing, and each defect is a place where that reader is left with less than the class file holds.

## A constant is printed with its value

`ConstantValue` is on the field and was never read. `fieldLine` now prints it as the source wrote it — the pool stores `boolean` and `char` as an int and says nothing about the width of an integer, so the field's descriptor tells them apart, and what Java cannot write plainly is escaped.

```
public static final String REQUIRED = "required"
public static final char SEPARATOR = '\n'
public static final long LIMIT = 10L
public static final float RATIO = 1.5f
public static final Object OPEN
```

A field an initializer computes has no value in the class file, and none is invented for it — the last line above.

## A near miss is answered with the name it almost spells

`Suggest.nearest` measures the edit distance the compiler already measures for every identifier in a source file, and takes its bound from the caller: a class identifier and a section anchor are not the same length, so the measure is shared and the threshold is not.

On a miss `japi` reads the entry names on the class path — names only, not the classes themselves — and offers the nearest.

```
$ souther japi net.unit8.raoh.decoder.Decoder
no class or package `net.unit8.raoh.decoder.Decoder` on the class path:
  souther.jar
did you mean: net.unit8.raoh.decode.Decoder, net.unit8.raoh.decode.Decoders
```

`souther doc` had a suggestion already, arrived at by asking whether one name occurred inside another. That is not a measure of nearness — `cli` sits in the middle of `acyclic` — and it now asks the same distance, with one case ahead of it: a name that is the whole of a section name's opening segment is what was asked for. `e1001` names the diagnostic `e1001-removed` is about, and no count of edits would put the two near each other. That case settles the question on its own, so `e1002` and its neighbours are not listed beside it.

```
$ souther doc E1001
did you mean: e1001-removed
$ souther doc cli
(nothing offered)
```

## The class path is named by what it is, not where this machine keeps it

A class path entry now carries whether the caller is the one who named it. A path they wrote is said back as they wrote it; a path the command fell back on is its own hosting and is named by the file it is.

```
$ souther japi net.unit8.raoh.decoder.Decoder        # fell back
  souther.jar
$ souther japi acme.Nobody -cp /tmp/nowhere.jar      # given
  /tmp/nowhere.jar
```

## `Class#member` is declared, not just implemented

The form worked and was written down nowhere. For a client whose whole knowledge of a tool is its schema, a form the schema does not mention does not exist. It is now in the `jar_api` description, in the description of the `name` argument that takes it, in the CLI usage line and in the command's doc.

```
souther japi <class-or-package>[#<member>] [-cp <path>]
```

## Tests

Every regression test was watched failing before its fix. Three assertions could not fail beforehand and are there to keep the new code from reaching further than it should: that a field without `ConstantValue` gets no value, that a name near nothing on the class path is offered nothing, and that an explicit `-cp` is not abbreviated.

The class path test asserts that no defaulted entry line contains a path separator, rather than that some expected filename appears — a positive assertion would not catch the leak coming back.

`mvn clean verify` is green across all modules.