### PR TITLE
What a module reaches is not what it has as fns of its own

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -181,7 +181,7 @@ public final class HelperInliner {
     public static HelperInliner forModule(Ast.Module module, Map<String, Ast.FnDef> imported) {
         HelperTable table = HelperTable.of(module, imported, InliningPolicy.FULL);
         HelperInliner inliner = new HelperInliner(table, HelperGraph.of(table));
-        inliner.computeReferencedPreludeRecursive(module);
+        inliner.computeTakenOnRecursive(module);
         return inliner;
     }
 
@@ -262,11 +262,17 @@ public final class HelperInliner {
         return own;
     }
 
-    /** Prelude recursive helpers this module reaches, by qualified name (`List.foldFrom`). A prelude
-     * recursive helper is not inlined (it would expand forever); instead it is emitted as one of this
-     * module's own methods, exactly like a module-own recursive helper (see {@link
-     * #injectedRecursiveHelpers}). Only the ones actually reached are emitted. */
-    private final Set<String> referencedPreludeRecursive = new java.util.LinkedHashSet<>();
+    /**
+     * The recursive helpers this module reaches and does not declare, by the qualified name it
+     * reaches each of them by ({@code List.foldFrom}, {@code pricing.sumDown}).
+     *
+     * <p>A recursive helper is not inlined — it would expand forever — so it is emitted as one of
+     * this module's own methods, exactly like a recursive helper the module declared (see {@link
+     * #injectedRecursiveHelpers}). That holds whoever declared it: the standard library, or a module
+     * that published one, or published something that calls one. Only the ones actually reached are
+     * emitted.
+     */
+    private final Set<String> takenOnRecursive = new java.util.LinkedHashSet<>();
 
     /** The helpers this module's example rows apply, which need a method for that reason alone. */
     private final Set<String> exampleHelpers = new java.util.LinkedHashSet<>();
@@ -281,7 +287,7 @@ public final class HelperInliner {
      * publish into what it has as fns of its own: that join answered yes for every published helper
      * whether this module reached it or not, and so covered what this walk was not finding.
      */
-    private void computeReferencedPreludeRecursive(Ast.Module module) {
+    private void computeTakenOnRecursive(Ast.Module module) {
         Set<String> named = new LinkedHashSet<>();
         Deque<Ast.Expr> work = new ArrayDeque<>();
         for (Ast.FnDef fn : module.fns()) {
@@ -299,11 +305,11 @@ public final class HelperInliner {
                 e -> helpersNamedIn(e, table.reachable(), named));
         for (String name : graph.reachedFrom(named)) {
             if (graph.recurses(name) && !table.holds(name)) {
-                referencedPreludeRecursive.add(name);
+                takenOnRecursive.add(name);
             }
         }
         exampleHelpers.addAll(exampleHelpers(module, table.reachable()));
-        exampleHelpers.removeAll(referencedPreludeRecursive);
+        exampleHelpers.removeAll(takenOnRecursive);
         exampleHelpers.removeIf(graph::recurses);   // already emitted as a recursive helper
     }
 
@@ -381,10 +387,11 @@ public final class HelperInliner {
         return out;
     }
 
-    /** The recursive helpers this module emits as methods: its own recursive helpers plus the prelude
-     * recursive helpers it reaches (spec 13.1). A call to any of them is left standing by {@link
-     * #inline}. The internal {@code recursive} set additionally holds prelude recursive helpers the
-     * module does not reach, so {@code inline} never expands one that slips in through a nested body. */
+    /** The recursive helpers this module emits as methods: the ones it declares, plus the ones it
+     * reaches and took on to emit — a library one, or one another module published (spec 13.1). A
+     * call to any of them is left standing by {@link #inline}. The graph's own {@code recursive} set
+     * additionally holds recursive helpers the module does not reach at all, so {@code inline} never
+     * expands one that slips in through a nested body. */
     public Set<String> recursiveHelpers() {
         Set<String> result = new java.util.LinkedHashSet<>();
         for (String name : graph.recursive()) {
@@ -392,16 +399,18 @@ public final class HelperInliner {
                 result.add(name);
             }
         }
-        result.addAll(referencedPreludeRecursive);
+        result.addAll(takenOnRecursive);
         return result;
     }
 
-    /** The prelude recursive helpers this module reaches, renamed to their qualified names so they are
-     * emitted as the module's own methods — a prelude {@code let foldFrom} is reached as {@code
-     * List.foldFrom}, and its self-call already reads {@code List.foldFrom}. */
+    /** The recursive helpers this module reaches and does not declare, renamed to the qualified names
+     * it reaches them by so they are emitted as the module's own methods — a library {@code let
+     * foldFrom} is reached as {@code List.foldFrom}, and its self-call already reads {@code
+     * List.foldFrom}. Which module declared one is not in that name and is read off the declaration
+     * ({@link Ast.FnDef#declaredIn}). */
     public Map<String, Ast.FnDef> injectedRecursiveHelpers() {
         Map<String, Ast.FnDef> out = new java.util.LinkedHashMap<>();
-        for (String qualified : referencedPreludeRecursive) {
+        for (String qualified : takenOnRecursive) {
             Ast.FnDef def = table.reached(qualified);
             out.put(qualified, def.reachedAs(qualified));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -271,21 +271,32 @@ public final class HelperInliner {
     /** The helpers this module's example rows apply, which need a method for that reason alone. */
     private final Set<String> exampleHelpers = new java.util.LinkedHashSet<>();
 
-    /** Walks the module's fn bodies and data invariants, collecting the prelude recursive helpers they
-     * reach transitively — those must be emitted as this module's own methods. */
+    /**
+     * Walks everything the module writes — its fn bodies, its data invariants, its rows — collecting
+     * the recursive helpers it reaches and does not declare. Those it must emit as methods of its own.
+     *
+     * <p>Reached, which is wider than called. A helper written where a value goes is eta-expanded into
+     * a call, and a value's body stands wherever the value is named, so a helper is reached through
+     * either. Both were once left to a caller that joined the definitions this module's imports
+     * publish into what it has as fns of its own: that join answered yes for every published helper
+     * whether this module reached it or not, and so covered what this walk was not finding.
+     */
     private void computeReferencedPreludeRecursive(Ast.Module module) {
         Set<String> named = new LinkedHashSet<>();
+        Deque<Ast.Expr> work = new ArrayDeque<>();
         for (Ast.FnDef fn : module.fns()) {
-            collectHelperCalls(fn.writtenBody(), named);
+            work.add(fn.writtenBody());
         }
         for (Ast.Def d : module.defs()) {
             if (d instanceof Ast.Data data) {
                 for (Ast.InvariantClause clause : data.invariants()) {
-                    collectHelperCalls(clause.expr(), named);
+                    work.add(clause.expr());
                 }
             }
         }
-        forEachExampleExpr(module, e -> collectHelperCalls(e, named));
+        forEachExampleExpr(module, work::add);
+        followingValues(work, table.reachable(),
+                e -> helpersNamedIn(e, table.reachable(), named));
         for (String name : graph.reachedFrom(named)) {
             if (graph.recurses(name) && !table.holds(name)) {
                 referencedPreludeRecursive.add(name);
@@ -333,27 +344,11 @@ public final class HelperInliner {
      */
     public static Set<String> exampleHelpers(Ast.Module module, Map<String, Ast.FnDef> table) {
         Set<String> called = new LinkedHashSet<>();
-        // A row may name a value rather than write the input again (ADR-0072), and that value's body
-        // is read the way the row's own text is — so a helper it applies is applied when the row is
-        // evaluated. The bodies are followed as far as they name each other, which is how a chain of
-        // values holds.
-        Set<String> valuesRead = new LinkedHashSet<>();
         Deque<Ast.Expr> work = new ArrayDeque<>();
         forEachExampleExpr(module, work::add);
-        while (!work.isEmpty()) {
-            Ast.Expr e = work.poll();
-            helperCallsIn(e, table, called);
-            Set<String> named = new LinkedHashSet<>();
-            ValueCycles.valuesRead(e, table, named);
-            for (String value : named) {
-                Ast.FnDef def = table.get(value);
-                if (def != null && def.params().isEmpty()
-                        && def.body() instanceof Ast.FnBody.Written w
-                        && valuesRead.add(value)) {
-                    work.add(w.expr());
-                }
-            }
-        }
+        // What a row applies, so a helper it merely names is not one: a row is a fixture and holds no
+        // function, and the reason a method is emitted here is that the row runs the helper.
+        followingValues(work, table, e -> helperCallsIn(e, table, called));
         Set<String> out = new LinkedHashSet<>();
         for (String name : called) {
             Ast.FnDef helper = table.get(name);
@@ -1676,9 +1671,12 @@ public final class HelperInliner {
         if (!(spread.denotes() instanceof ValueName.Helper)) {
             return null;
         }
-        // by the name it is reached by here, which for another module's value is the qualified one
+        // by the name it is reached by here, which for another module's value is the qualified one.
+        // Asked of what the name reaches and not of what this module has as its own fns: a published
+        // value is substituted where it is spread exactly as one declared here is, and it is not one
+        // of this module's fns — nothing emits a value.
         String reached = spread.reaches();
-        Ast.FnDef value = table.fns().get(reached);
+        Ast.FnDef value = table.reached(reached);
         return value == null || !value.params().isEmpty() || value.body() == null
                 || graph.recurses(reached) ? null : value;
     }
@@ -1704,8 +1702,64 @@ public final class HelperInliner {
         return found[0];
     }
 
-    private void collectHelperCalls(Ast.Expr e, Set<String> out) {
-        helperCallsIn(e, table.reachable(), out);
+    /**
+     * Runs {@code collect} over everything {@code work} reaches, following the values it reads.
+     *
+     * <p>An expression alone stops at the reference. A value is substituted where it is named
+     * (ADR-0072), so the body of a value a body reads stands in that body — what that body names is
+     * named there, and a declaration reached only through a value is reached. The bodies are followed
+     * as far as they name each other, which is how a chain of values holds.
+     *
+     * <p>What is collected is the caller's question and not this walk's: which helpers a row applies
+     * is one question, which declarations a module reaches at all is another. {@code work} is drained,
+     * and what is seeded into it is the caller's too.
+     */
+    static void followingValues(Deque<Ast.Expr> work, Map<String, Ast.FnDef> table,
+                                java.util.function.Consumer<Ast.Expr> collect) {
+        Set<String> read = new LinkedHashSet<>();
+        while (!work.isEmpty()) {
+            Ast.Expr e = work.poll();
+            collect.accept(e);
+            Set<String> named = new LinkedHashSet<>();
+            ValueCycles.valuesRead(e, table, named);
+            for (String value : named) {
+                Ast.FnDef def = table.get(value);
+                if (def != null && def.params().isEmpty()
+                        && def.body() instanceof Ast.FnBody.Written w && read.add(value)) {
+                    work.add(w.expr());
+                }
+            }
+        }
+    }
+
+    /**
+     * The declarations {@code e} names, applied or not.
+     *
+     * <p>Which declarations a module reaches, which is what decides the methods it has to emit. A
+     * recursive helper written where a value goes — {@code apply1(spin, n)} — is reached as surely as
+     * one that is called: the expansion eta-expands it, and what stands there afterwards is a call to
+     * a method that has to be somewhere. Asked of what a name denotes, so a parameter spelled like a
+     * helper is the parameter.
+     */
+    private static void helpersNamedIn(Ast.Expr e, Map<String, Ast.FnDef> table, Set<String> out) {
+        switch (e) {
+            // `List.fold` desugars to `List.foldFrom` before inlining, so a body that folds reaches
+            // the recursive `foldFrom` and not the wrapper it wrote.
+            case Ast.Apply call when !(call.denotes() instanceof ValueName.Local) -> {
+                String fn = "List.fold".equals(call.reaches()) ? "List.foldFrom" : call.reaches();
+                if (table.containsKey(fn)) {
+                    out.add(fn);
+                }
+            }
+            case Ast.Var v when v.denotes() instanceof ValueName.Helper
+                    || v.denotes() instanceof ValueName.Stdlib -> {
+                if (table.containsKey(v.reaches())) {
+                    out.add(v.reaches());
+                }
+            }
+            default -> { }
+        }
+        forEachChild(e, c -> helpersNamedIn(c, table, out));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -62,7 +62,8 @@ public final class ValueCycles {
      * Refuses the first value of {@code own} that reaches itself, naming the path it goes round.
      *
      * <p>{@code callsOf} is the call graph over the same table: a cycle may be closed by calling a
-     * helper that names the value, so the two kinds of edge are followed together.
+     * helper that names the value, so the two kinds of edge are followed together — which is why both
+     * are keyed by the name a reference reaches its target by, and neither by a spelling.
      */
     static void reject(Map<String, Ast.FnDef> own, Map<String, Set<String>> callsOf) {
         Map<String, Set<String>> edges = new LinkedHashMap<>();
@@ -102,19 +103,29 @@ public final class ValueCycles {
         }
     }
 
-    /** The names of {@code own}'s values that {@code e} reads. A value is written bare, so a
-     * reference to one is a {@code Var} and never reaches the call graph. */
-    static void valuesRead(Ast.Expr e, Map<String, Ast.FnDef> own, Set<String> out) {
+    /**
+     * The values of {@code reachable} that {@code e} reads, by the name it reaches each of them by. A
+     * value is written bare, so a reference to one is a {@code Var} and never reaches the call graph.
+     *
+     * <p>Asked with the reach name the reference carries, which is what {@link
+     * HelperInliner#helperCallsIn} asks a call with. The two are the two kinds of edge in one graph
+     * and are followed together, so a table answering one of them under a key the other does not use
+     * is a graph with edges missing — and missing silently, because a miss is what a table does with
+     * a key it has not got. Reading {@link Ast.Var#name()} here asked with the spelling instead, and
+     * an import may let a name go without its qualifier: it agreed with the key only where a pass had
+     * already written the spelling out qualified.
+     */
+    static void valuesRead(Ast.Expr e, Map<String, Ast.FnDef> reachable, Set<String> out) {
         if (e == null) {
             return;
         }
         if (e instanceof Ast.Var v && v.denotes() instanceof ValueName.Helper) {
-            Ast.FnDef d = own.get(v.name());
+            Ast.FnDef d = reachable.get(v.reaches());
             if (d != null && d.params().isEmpty()) {
-                out.add(v.name());
+                out.add(v.reaches());
             }
         }
-        Ast.forEachChild(e, c -> valuesRead(c, own, out));
+        Ast.forEachChild(e, c -> valuesRead(c, reachable, out));
     }
 
     /** Records into {@code path} a route from {@code from} back to {@code target}, or answers false. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -555,7 +555,7 @@ public final class Adequacy {
             if (classes == null || requirements == null) {
                 return null;
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.Helpers(module)).value();
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.Reachable(module)).value();
             // `requirements` is asked above as a readiness condition, not as an input: whether a
             // value builds at this module's boundary is the decoder's answer, and nothing here runs.
             return FixtureReader.constructing(written, symbols, classes,

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -555,7 +555,7 @@ public final class Adequacy {
             if (classes == null || requirements == null) {
                 return null;
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.Reachable(module)).value();
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.ModuleDefinitions(module)).value();
             // `requirements` is asked above as a readiness condition, not as an input: whether a
             // value builds at this module's boundary is the decoder's answer, and nothing here runs.
             return FixtureReader.constructing(written, symbols, classes,

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -490,14 +490,20 @@ public final class Bodies {
     }
 
     /**
-     * The module's helpers, settled — what every body in it expands its calls against.
+     * Every declaration a body of this module can reach by name, settled, keyed by the name it is
+     * reached by here: what the module has as fns of its own, and what its imports publish to it.
+     *
+     * <p>Reachable and not owned. A definition another module publishes is one this module expands at
+     * the call and not one it declares or emits, so a reader asking what the module holds is asking
+     * something else and must not read this. The table a body is expanded against is handed the two
+     * apart, and {@link Expanding} is where that is done.
      *
      * <p>Its own question, and a map of definitions rather than an inliner, because that is what makes
      * it an answer two bodies can share: a helper says what it says whatever the behavior beside it
      * was edited to, so a body that reads this is left alone. An inliner cannot do that job — nothing
      * says when two of them are the same, so every reader of one would run again whatever changed.
      */
-    public record Helpers(String name) implements Key<Map<String, Ast.FnDef>> {
+    public record Reachable(String name) implements Key<Map<String, Ast.FnDef>> {
         @Override
         public String module() {
             return name;
@@ -565,7 +571,7 @@ public final class Bodies {
                 // Closed against everything the declaring module can name, not only what it declares:
                 // a published body may call a helper that module imported in turn, and a chain of
                 // three is where a table of its own definitions leaves the middle one unexpanded.
-                Answer<Map<String, Ast.FnDef>> table = db.ask(new Helpers(imp.module()));
+                Answer<Map<String, Ast.FnDef>> table = db.ask(new Reachable(imp.module()));
                 if (!from.present() || !table.present()) {
                     continue;
                 }
@@ -718,11 +724,17 @@ public final class Bodies {
 
         @Override
         public Answer<Of> compute(Db db) {
-            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(name));
-            if (!helpers.present()) {
+            Answer<Ast.Module> settled = db.ask(new Settled(name));
+            Answer<Map<String, Ast.FnDef>> imported = db.ask(new ImportedDefinitions(name));
+            if (!settled.present() || !imported.present()) {
                 return Answer.absent();
             }
-            HelperTable table = HelperTable.of(name, helpers.value(), Map.of(), policy);
+            // The two are handed over apart, which is what {@link Reachable} has already joined: a
+            // definition another module publishes is one this module expands and not one it has as a
+            // fn of its own. Joined here, a table built for this module would answer that it holds a
+            // published helper, and the table the check builds — which is handed the same two apart —
+            // would answer that it does not.
+            HelperTable table = HelperTable.of(settled.value(), imported.value(), policy);
             return Answer.of(new Of(table, HelperGraph.of(table)));
         }
     }
@@ -750,7 +762,7 @@ public final class Bodies {
         @Override
         public Answer<Set<String>> compute(Db db) {
             Answer<Ast.Module> settled = db.ask(new Settled(name));
-            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Helpers(name));
+            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Reachable(name));
             if (!settled.present() || !helpers.present()) {
                 return Answer.absent();
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -490,20 +490,25 @@ public final class Bodies {
     }
 
     /**
-     * Every declaration a body of this module can reach by name, settled, keyed by the name it is
-     * reached by here: what the module has as fns of its own, and what its imports publish to it.
+     * The definitions some module wrote that a body of this one can name, settled, keyed by the name
+     * it reaches each of them by: what this module has as fns of its own, and what its imports publish
+     * to it.
      *
-     * <p>Reachable and not owned. A definition another module publishes is one this module expands at
-     * the call and not one it declares or emits, so a reader asking what the module holds is asking
+     * <p>Not what the module owns. A definition another module publishes is one this module expands
+     * at the call and not one it declares or emits, so a reader asking what the module holds is asking
      * something else and must not read this. The table a body is expanded against is handed the two
      * apart, and {@link Expanding} is where that is done.
+     *
+     * <p>Not everything a name reaches, either. The standard library is under every module and is
+     * written nowhere here; it joins where a table is built, under {@link InliningPolicy#FULL}, so
+     * {@link HelperTable#reachable()} is the wider set and is what "reachable" means.
      *
      * <p>Its own question, and a map of definitions rather than an inliner, because that is what makes
      * it an answer two bodies can share: a helper says what it says whatever the behavior beside it
      * was edited to, so a body that reads this is left alone. An inliner cannot do that job — nothing
      * says when two of them are the same, so every reader of one would run again whatever changed.
      */
-    public record Reachable(String name) implements Key<Map<String, Ast.FnDef>> {
+    public record ModuleDefinitions(String name) implements Key<Map<String, Ast.FnDef>> {
         @Override
         public String module() {
             return name;
@@ -571,7 +576,7 @@ public final class Bodies {
                 // Closed against everything the declaring module can name, not only what it declares:
                 // a published body may call a helper that module imported in turn, and a chain of
                 // three is where a table of its own definitions leaves the middle one unexpanded.
-                Answer<Map<String, Ast.FnDef>> table = db.ask(new Reachable(imp.module()));
+                Answer<Map<String, Ast.FnDef>> table = db.ask(new ModuleDefinitions(imp.module()));
                 if (!from.present() || !table.present()) {
                     continue;
                 }
@@ -729,7 +734,7 @@ public final class Bodies {
             if (!settled.present() || !imported.present()) {
                 return Answer.absent();
             }
-            // The two are handed over apart, which is what {@link Reachable} has already joined: a
+            // The two are handed over apart, which is what {@link ModuleDefinitions} has already joined: a
             // definition another module publishes is one this module expands and not one it has as a
             // fn of its own. Joined here, a table built for this module would answer that it holds a
             // published helper, and the table the check builds — which is handed the same two apart —
@@ -762,7 +767,7 @@ public final class Bodies {
         @Override
         public Answer<Set<String>> compute(Db db) {
             Answer<Ast.Module> settled = db.ask(new Settled(name));
-            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new Reachable(name));
+            Answer<Map<String, Ast.FnDef>> helpers = db.ask(new ModuleDefinitions(name));
             if (!settled.present() || !helpers.present()) {
                 return Answer.absent();
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -612,7 +612,7 @@ public final class Output {
                     || exampleOrigins == null || fakeOrigins == null) {
                 return Answer.absent();
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.Reachable(name)).value();
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.ModuleDefinitions(name)).value();
             // `requirements` is asked for above as a readiness condition — a module whose
             // requirements are not settled is not one to read statements off yet — rather than
             // because reading them needs it. Nothing here applies a behavior.
@@ -831,7 +831,7 @@ public final class Output {
             if (classes == null || requirements == null || fakeOrigins == null) {
                 return List.of();
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.Reachable(name)).value();
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.ModuleDefinitions(name)).value();
             // As above: `requirements` says this module is ready to be read, not what to read.
             return souther.compiler.ExampleStatements.fakeTables(prepared.value(), scope.value(),
                     sigs.value(), classes, evaluationLoader(db),
@@ -882,7 +882,7 @@ public final class Output {
             if (!reports.isEmpty()) {
                 return Answer.absent(reports);   // a row naming one would read the other declaration
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.Reachable(name)).value();
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.ModuleDefinitions(name)).value();
             souther.compiler.ExampleVerifier.Observations observed =
                     souther.compiler.ExampleVerifier.check(rows, scope.value(), sigs.value(), classes,
                             requirements, evaluationLoader(db),

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -612,7 +612,7 @@ public final class Output {
                     || exampleOrigins == null || fakeOrigins == null) {
                 return Answer.absent();
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.Helpers(name)).value();
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.Reachable(name)).value();
             // `requirements` is asked for above as a readiness condition — a module whose
             // requirements are not settled is not one to read statements off yet — rather than
             // because reading them needs it. Nothing here applies a behavior.
@@ -831,7 +831,7 @@ public final class Output {
             if (classes == null || requirements == null || fakeOrigins == null) {
                 return List.of();
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.Helpers(name)).value();
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.Reachable(name)).value();
             // As above: `requirements` says this module is ready to be read, not what to read.
             return souther.compiler.ExampleStatements.fakeTables(prepared.value(), scope.value(),
                     sigs.value(), classes, evaluationLoader(db),
@@ -882,7 +882,7 @@ public final class Output {
             if (!reports.isEmpty()) {
                 return Answer.absent(reports);   // a row naming one would read the other declaration
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.Helpers(name)).value();
+            Map<String, Ast.FnDef> values = db.ask(new Bodies.Reachable(name)).value();
             souther.compiler.ExampleVerifier.Observations observed =
                     souther.compiler.ExampleVerifier.check(rows, scope.value(), sigs.value(), classes,
                             requirements, evaluationLoader(db),

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -446,7 +446,7 @@ class CompileFakeExampleDisagreementTest {
                 c.db().ask(new souther.compiler.query.Output.EvaluationLinked(
                         name, souther.compiler.query.Output.CoverageMode.NONE)).value(),
                 parent,
-                c.db().ask(new souther.compiler.query.Bodies.Helpers(name)).value(),
+                c.db().ask(new souther.compiler.query.Bodies.Reachable(name)).value(),
                 c.db().ask(new souther.compiler.query.Front.ExampleOrigins(name)).value(),
                 c.db().ask(new souther.compiler.query.Front.FakeOrigins(name)).value(),
                 Deadline.ofMillis(EvaluationPolicy.DEFAULT.outerTimeout().toMillis()),

--- a/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFakeExampleDisagreementTest.java
@@ -446,7 +446,7 @@ class CompileFakeExampleDisagreementTest {
                 c.db().ask(new souther.compiler.query.Output.EvaluationLinked(
                         name, souther.compiler.query.Output.CoverageMode.NONE)).value(),
                 parent,
-                c.db().ask(new souther.compiler.query.Bodies.Reachable(name)).value(),
+                c.db().ask(new souther.compiler.query.Bodies.ModuleDefinitions(name)).value(),
                 c.db().ask(new souther.compiler.query.Front.ExampleOrigins(name)).value(),
                 c.db().ask(new souther.compiler.query.Front.FakeOrigins(name)).value(),
                 Deadline.ofMillis(EvaluationPolicy.DEFAULT.outerTimeout().toMillis()),

--- a/souther-compiler/src/test/java/souther/compiler/check/AValueIsReadUnderTheNameItIsReachedByTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AValueIsReadUnderTheNameItIsReachedByTest.java
@@ -1,0 +1,110 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A value a body reads is looked up by the name that body reaches it by, never by how it is spelled.
+ *
+ * <p>The value edges and the call edges are the two kinds of edge in one graph and are followed
+ * together, so they have to be keyed alike. The call side has asked what a call reaches since
+ * resolution began settling it; the value side asked {@link Ast.Var#name()}, which is the spelling —
+ * and an import lets a name be written without its qualifier while the table keys it under the
+ * module that declares it.
+ *
+ * <p>Nothing failed for it. {@code HelperNames.qualifyImports} writes an imported name out qualified
+ * before any of the callers run, so the spelling had already been made into the key and the two
+ * agreed. That is a pass covering for a lookup rather than a lookup that holds, so the shape is built
+ * here rather than compiled from a file: a resolved body, which is what that pass is handed, reading a
+ * published value under the bare name its author wrote.
+ */
+class AValueIsReadUnderTheNameItIsReachedByTest {
+
+    /** {@code source} resolved with {@code imported} (bare name -> declaring module) reachable, which
+     * is the tree {@code HelperNames.qualifyImports} is given — the author's spellings still on it. */
+    private static Ast.Module resolved(String source, Map<String, String> imported) {
+        Ast.Module parsed = CstFrontend.parse(source);
+        Map<String, ValueName.Helper> helpers =
+                new LinkedHashMap<>(Resolve.Values.of(parsed).helpers());
+        imported.forEach((bare, module) -> helpers.put(bare, new ValueName.Helper(module, bare)));
+        Resolve.Resolved answered = Resolve.resolving(parsed, Symbols.of(parsed),
+                new Resolve.Values(parsed.name(), helpers, Map.of(), Map.of()));
+        if (!answered.unresolved().isEmpty()) {
+            throw answered.unresolved().get(0);
+        }
+        return answered.module();
+    }
+
+    /** The value {@code up} publishes, under the name a reader reaches it by — which is how it
+     * arrives in a reader's table. */
+    private static Ast.FnDef published() {
+        Ast.Module up = resolved("""
+                module up exposing ( standard )
+
+                let standard = 100
+                """, Map.of());
+        return HelperInliner.helpersOf(up).get("standard").reachedAs("up.standard");
+    }
+
+    private static Set<String> read(Ast.Module m, String fn, Map<String, Ast.FnDef> table) {
+        Set<String> out = new LinkedHashSet<>();
+        ValueCycles.valuesRead(HelperInliner.helpersOf(m).get(fn).writtenBody(), table, out);
+        return out;
+    }
+
+    /**
+     * The author wrote {@code standard}; the table holds {@code up.standard}. The reference carries
+     * which of the two it reaches, and reading its spelling instead answers with a miss — silently,
+     * because that is what a table does with a key it has not got.
+     */
+    @Test
+    void aPublishedValueWrittenBareIsFoundUnderTheNameItIsReachedBy() {
+        Ast.Module down = resolved("""
+                module down
+
+                let doubled = standard + standard
+                """, Map.of("standard", "up"));
+
+        assertEquals(Set.of("up.standard"),
+                read(down, "doubled", Map.of("up.standard", published())));
+    }
+
+    /** And a value of the module's own is reached bare, so it is still found under that. A reader
+     * moved onto the reach name answers both, which is the point of there being one key. */
+    @Test
+    void aValueTheModuleDeclaresIsFoundUnderItsBareName() {
+        Ast.Module solo = resolved("""
+                module solo
+
+                let base = 1
+                let doubled = base + base
+                """, Map.of());
+
+        assertEquals(Set.of("base"),
+                read(solo, "doubled", HelperInliner.helpersOf(solo)));
+    }
+
+    /** A helper is not a value, whatever it is keyed under: what closes a value cycle is a value, and
+     * a call is the other kind of edge. So neither reading answers with one. */
+    @Test
+    void aHelperReachedByTheSameRouteIsStillNotAValue() {
+        Ast.Module down = resolved("""
+                module down
+
+                let twice (n: Int) : Int = n + n
+                let four = twice(2)
+                """, Map.of());
+
+        assertEquals(Set.of(), read(down, "four", HelperInliner.helpersOf(down)));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/OneModuleIsExpandedAgainstOneTableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneModuleIsExpandedAgainstOneTableTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>Two callers build it. The check builds it from the settled module and the definitions its
  * imports publish, held apart ({@link HelperInliner#forModule}); {@link Bodies.Expanding} builds it
- * from {@link Bodies.Helpers}, which is those two already joined, and hands the join over as what the
+ * from {@link Bodies.ModuleDefinitions}, which is those two already joined, and hands the join over as what the
  * module has as fns of its own. So a definition another module publishes was one of this module's own
  * fns on one path and not on the other — and what a call expands to was decided by which caller was
  * asking.

--- a/souther-compiler/src/test/java/souther/compiler/query/OneModuleIsExpandedAgainstOneTableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/OneModuleIsExpandedAgainstOneTableTest.java
@@ -1,0 +1,118 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.HelperGraph;
+import souther.compiler.check.HelperInliner;
+import souther.compiler.check.HelperTable;
+import souther.compiler.check.InliningPolicy;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.types.BindingOwner;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One module's bodies are expanded against one table, whoever asked for it.
+ *
+ * <p>Two callers build it. The check builds it from the settled module and the definitions its
+ * imports publish, held apart ({@link HelperInliner#forModule}); {@link Bodies.Expanding} builds it
+ * from {@link Bodies.Helpers}, which is those two already joined, and hands the join over as what the
+ * module has as fns of its own. So a definition another module publishes was one of this module's own
+ * fns on one path and not on the other — and what a call expands to was decided by which caller was
+ * asking.
+ *
+ * <p>What that decided is below: a spread of a published value is looked up among the module's own
+ * fns, so the path that had it there substituted the value and the path that did not left the spread
+ * standing. The check reads the second and the backend the first, which is one body under two
+ * representations.
+ */
+class OneModuleIsExpandedAgainstOneTableTest {
+
+    private static final String UP = """
+            module up exposing ( Deal, standard )
+
+            data Deal = { n: Int, amount: Int }
+
+            let standard = Deal { n = 1, amount = 100 }
+            """;
+
+    private static final String DOWN = """
+            module down
+
+            import up ( Deal, standard )
+
+            let raised (k: Int) : Deal = Deal { ...standard, amount = k }
+            """;
+
+    private static Db db() {
+        return Compilation.ofDocuments(
+                Map.of("up.sou", UP, "down.sou", DOWN), Set.of(), ModulePath.EMPTY).db();
+    }
+
+    /** The table the check expands against: the settled module, and what its imports publish beside
+     * it — which is how {@link HelperInliner#forModule} is handed the two. */
+    private static HelperTable asTheCheckBuildsIt(Db db, String module) {
+        return HelperTable.of(db.ask(new Bodies.Settled(module)).value(),
+                db.ask(new Bodies.ImportedDefinitions(module)).value(), InliningPolicy.FULL);
+    }
+
+    /** The table every query expands against, which the backend reads through. */
+    private static HelperTable asTheQueryLayerBuildsIt(Db db, String module) {
+        return db.ask(new Bodies.Expanding(module, InliningPolicy.FULL)).value().table();
+    }
+
+    @Test
+    void theTableTheCheckExpandsAgainstIsTheTableTheQueryLayerExpandsAgainst() {
+        Db db = db();
+        assertEquals(asTheCheckBuildsIt(db, "down"), asTheQueryLayerBuildsIt(db, "down"));
+    }
+
+    @Test
+    void aSpreadOfAPublishedValueIsSubstitutedWhicheverTableExpandsIt() {
+        Db db = db();
+        Ast.FnDef raised =
+                HelperInliner.helpersOf(db.ask(new Bodies.Settled("down")).value()).get("raised");
+
+        assertEquals(Set.of(), spreadsLeftBy(asTheCheckBuildsIt(db, "down"), raised),
+                "the check left a published value standing as a spread");
+        assertEquals(Set.of(), spreadsLeftBy(asTheQueryLayerBuildsIt(db, "down"), raised),
+                "the query layer left a published value standing as a spread");
+    }
+
+    /** The names still written as spreads after {@code table} expands {@code fn}'s body. A value is
+     * substituted where it is spread, so a name left here is one the expansion did not reach. */
+    private static Set<String> spreadsLeftBy(HelperTable table, Ast.FnDef fn) {
+        HelperInliner inliner = HelperInliner.over(table, HelperGraph.of(table));
+        Ast.Expr expanded = inliner.inline(fn.writtenBody(),
+                new BindingOwner.OfValue(table.module(), fn.name()));
+        Set<String> left = new LinkedHashSet<>();
+        namedSpreads(expanded, table, left);
+        return left;
+    }
+
+    private static void namedSpreads(Ast.Expr e, HelperTable table, Set<String> out) {
+        if (e instanceof Ast.NewData nd) {
+            for (Ast.Var spread : nd.spreads()) {
+                if (table.reaches(spread.reaches())) {
+                    out.add(spread.reaches());
+                }
+            }
+        }
+        Ast.forEachChild(e, c -> namedSpreads(c, table, out));
+    }
+
+    /** And the module the two tables are built for is one the expansion has something to say about,
+     * so neither passes by having nothing in it. */
+    @Test
+    void thePublishedValueIsThereToBeReached() {
+        Db db = db();
+        assertTrue(asTheCheckBuildsIt(db, "down").reaches("up.standard"));
+        assertTrue(asTheQueryLayerBuildsIt(db, "down").reaches("up.standard"));
+    }
+}


### PR DESCRIPTION
The first of two for #398. This one separates what a module reaches from what it
has as fns of its own; the second separates what it declared from what it took on
to emit, and closes the issue.

## What was wrong

Two callers build the table a body of one module is expanded against, and they
disagreed about what that module holds.

| | how `own` was built |
|---|---|
| the check (`HelperInliner.forModule`) | the settled module, with what its imports publish handed over apart |
| `Bodies.Expanding` | `Bodies.Helpers`, which is those two already joined |

Both tables answer that they reach a published definition. Only one answers that
the module has it as a fn of its own, and which one you got depended on who was
asking.

`valueSpread` is what read the difference. It looked a published value up among
the module's own fns, so on one path a spread of `up.standard` was substituted
and on the other it was left standing — the check reads the second
representation of the body and the backend the first. It is also the one lookup
in `HelperInliner` that asked `fns()` a reach name; `valueOf` asks `reached()`
for the same relation, and nothing emits a value.

## What is here

- `Bodies.Expanding` asks `Settled` and `ImportedDefinitions` and passes them apart
- `valueSpread` asks `reached()`
- `Bodies.Helpers` is renamed `Bodies.Reachable` — what it answers, and what its
  other five readers want of it

## What the join was covering

`computeReferencedPreludeRecursive` follows call edges. A module reaches a
recursive helper two further ways: through the body of a published value it
reads, which stands wherever the value is named, and through a helper written
where a value goes, which is eta-expanded into a call. Neither was found.
`recursiveHelpers()` answered with them anyway, because the join put every
published definition into `own` whether this module reached it or not — so the
method was emitted for a reason unrelated to reaching it.

Three existing tests went to `neither expanded nor bound` the moment the join
came out. The walk now follows values, and what it collects at each expression is
the caller's question: which helpers a row applies is calls, which declarations a
module reaches is names.

## Witness

`OneModuleIsExpandedAgainstOneTableTest`. Before this change the two tables are
unequal (`reached` matches at 48 entries, `own` does not) and the check leaves
`up.standard` standing as a spread while the query layer substitutes it. The
third case asserts both tables reach `up.standard`, so neither passes by having
nothing to say.

`mvn -o clean test`: 3485 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
