### PR TITLE
A conditional is read in the scope it stands in

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -198,18 +198,28 @@ public final class InvariantChecker {
     // --- the walk ------------------------------------------------------------------------------
 
     private void walk(Core e, Known k, Denotations at, int depth) {
-        Core.If value = conditionalValueIn(e);
-        if (value != null && depth < BRANCHES_OPENED) {
+        ConditionalSite site = conditionalValueIn(e);
+        if (site != null && depth < BRANCHES_OPENED) {
             // A conditional in a value position is one of its two branches, and which one is decided
             // by its condition. So this is read once with each standing there, under that condition,
             // and what the two readings find is said once. Every place a conditional can be given —
             // to a field, to a name, to a guard — is this one place.
+            Core.If value = site.conditional();
             walk(value.cond(), k, at, depth);
-            Set<Core> alike = sameConditional(e, value, at);
+            // The condition is read where it stands, which is inside every binding on the way down to
+            // it, and not at the outer place the reading is decided on. Read at the outer place it
+            // names bindings nothing has entered, and a condition over those settles nothing — the
+            // two readings would come out alike and the conditional would decide nothing.
+            Entered inside = scopeOf(site, k, at);
+            Known within = inside.known();
+            Denotations there = inside.at();
+            Set<Core> alike = sameConditional(e, value, there);
+            // The readings take the outer environment, not this one: the tree each is given still
+            // holds those bindings, and walking it enters them again on the way in.
             say(reading(without(e, alike, value.then()),
-                            predicates.assumeCond(value.cond(), k, at, true), at, depth),
+                            predicates.assumeCond(value.cond(), within, there, true), at, depth),
                     reading(without(e, alike, value.els()),
-                            predicates.assumeCond(value.cond(), k, at, false), at, depth));
+                            predicates.assumeCond(value.cond(), within, there, false), at, depth));
             return;
         }
         checkIfConstruction(e, k, at, false);
@@ -244,24 +254,8 @@ public final class InvariantChecker {
                 if (!(li.value() instanceof Core.Block)) {
                     walk(li.value(), k, at, depth);
                 }
-                // The name is an alias for what its initializer denotes, so what is recorded about it
-                // is recorded under that denotation and not under the binding. Recording it under the
-                // binding is what made a named subexpression a term of its own, answering differently
-                // from the very expression it was given.
-                Denotes what = terms.denotationOf(li.value(), at, k);
-                Known k2 = k;
-                // A binding that denotes what it was given is an alias and introduces no value, so
-                // there is nothing to record of it: what holds of what it names already holds.
-                // Recording it anyway assigns that name its own form, and an assignment drops what
-                // was known of what it assigns to — the bound on it would be lost to the copy. A
-                // location is always this; a term is where the form is that term's own atom.
-                if (what instanceof Denotes.Term term && terms.isNumeric(li.value().type())) {
-                    LinearForm vf = terms.affineOf(li.value(), at, k);
-                    if (vf != null && !vf.equals(LinearForm.atom(term.key()))) {
-                        k2 = k2.assigning(term.key(), vf);
-                    }
-                }
-                walk(li.body(), k2, at.binding(li.binder().id(), li.value(), what), depth);
+                Entered in = bindLet(li, k, at);
+                walk(li.body(), in.known(), in.at(), depth);
             }
             case Core.Match m -> {
                 walk(m.scrutinee(), k, at, depth);
@@ -600,12 +594,36 @@ public final class InvariantChecker {
     }
 
     /**
+     * A conditional a value is handed, and the bindings in scope where it stands. The two go
+     * together: a node is found by searching down from the outside, and what it means is settled by
+     * where it was found, so a search that answered with the node alone would leave the reading to
+     * work the scope out again — which is what it got wrong.
+     *
+     * <p>Only the bindings a {@code let} writes are carried. A value a {@code match} arm or an
+     * attempted construction binds is not one a construction site can be read against, so a
+     * construction over one says nothing whatever is in scope for it; those binders are on no path
+     * this can reach. That is a fact about which construction sites are representable, not about
+     * which binders exist — should that boundary move, this has to widen with it.
+     */
+    private record ConditionalSite(Core.If conditional, List<Core.LetIn> scope) {
+
+        /** The same site, read from outside {@code li} — so {@code li} is the outermost of what it is
+         * inside. */
+        ConditionalSite under(Core.LetIn li) {
+            List<Core.LetIn> outer = new ArrayList<>();
+            outer.add(li);
+            outer.addAll(scope);
+            return new ConditionalSite(conditional, List.copyOf(outer));
+        }
+    }
+
+    /**
      * The first conditional {@code e} gives a value to, or {@code null} where it gives none. A
      * conditional in tail position — an {@code if}'s own branches, a {@code let}'s body, a case's
      * body — is where the walk goes next rather than a value it is handed, and a closure's body is
      * read where the closure is applied.
      */
-    private static Core.If conditionalValueIn(Core e) {
+    private static ConditionalSite conditionalValueIn(Core e) {
         return switch (e) {
             // Where the walk goes next is not a value it is handed: an `if`'s own branches, a `let`'s
             // body and a case's body are read after this, each with what is known there.
@@ -617,17 +635,27 @@ public final class InvariantChecker {
         };
     }
 
-    /** The first conditional inside a value. Everything under one is part of it, including the body
-     * of a binding an expansion introduced — {@code let $0 = r in if $0.a > b then ...} is a helper
-     * called on an argument, which is one value however many bindings writing it took. */
-    private static Core.If conditionalIn(Core e) {
+    /** The first conditional inside a value, with what it is inside. Everything under one is part of
+     * it, including the body of a binding an expansion introduced — {@code let $0 = r in if $0.a > b
+     * then ...} is a helper called on an argument, which is one value however many bindings writing
+     * it took. Those bindings are what the conditional is read in the scope of; a binding is not in
+     * scope for the value it is itself given, so a conditional found there is inside nothing. */
+    private static ConditionalSite conditionalIn(Core e) {
         if (e instanceof Core.If iff) {
-            return iff;
+            return new ConditionalSite(iff, List.of());
         }
         if (e instanceof Core.Block) {
             return null;   // read where the closure is applied
         }
-        Core.If[] found = {null};
+        if (e instanceof Core.LetIn li) {
+            ConditionalSite given = conditionalIn(li.value());
+            if (given != null) {
+                return given;
+            }
+            ConditionalSite inside = conditionalIn(li.body());
+            return inside == null ? null : inside.under(li);
+        }
+        ConditionalSite[] found = {null};
         Core.forEachChild(e, child -> {
             if (found[0] == null) {
                 found[0] = conditionalIn(child);
@@ -664,9 +692,16 @@ public final class InvariantChecker {
         return made;
     }
 
-    /** Every conditional in {@code e} that computes what {@code value} computes, {@code value}
+    /**
+     * Every conditional in {@code e} that computes what {@code value} computes, {@code value}
      * included. Asked once for the two readings, since which nodes those are does not depend on which
-     * branch is being read. */
+     * branch is being read.
+     *
+     * <p>{@code at} is where {@code value} stands, which is what keying it needs. A candidate
+     * elsewhere in {@code e} is keyed there too rather than in its own scope, so two conditionals
+     * that compute the same value under different bindings are read as two — which is the thing this
+     * exists to prevent, still unanswered for that shape.
+     */
     private Set<Core> sameConditional(Core e, Core.If value, Denotations at) {
         Set<Core> alike = Collections.newSetFromMap(new IdentityHashMap<>());
         alike.add(value);
@@ -728,6 +763,46 @@ public final class InvariantChecker {
      * be named without being seeded.
      */
     private record Entered(Known known, Denotations at) {}
+
+    /**
+     * The environment a binding's body is read in. Both places a body is read reach it through here:
+     * the walk on its way into one, and a conditional hoisted out of one. The bug this answers came
+     * from those two working the scope rule out separately, so there is one of it.
+     *
+     * <p>The initializer is not read here. The walk reads it before it gets here, and a hoisted
+     * conditional was found past it.
+     *
+     * <p>The name is an alias for what its initializer denotes, so what is recorded about it is
+     * recorded under that denotation and not under the binding. Recording it under the binding is
+     * what made a named subexpression a term of its own, answering differently from the very
+     * expression it was given.
+     */
+    private Entered bindLet(Core.LetIn li, Known k, Denotations at) {
+        Denotes what = terms.denotationOf(li.value(), at, k);
+        Known out = k;
+        // A binding that denotes what it was given is an alias and introduces no value, so there is
+        // nothing to record of it: what holds of what it names already holds. Recording it anyway
+        // assigns that name its own form, and an assignment drops what was known of what it assigns
+        // to — the bound on it would be lost to the copy. A location is always this; a term is where
+        // the form is that term's own atom.
+        if (what instanceof Denotes.Term term && terms.isNumeric(li.value().type())) {
+            LinearForm vf = terms.affineOf(li.value(), at, k);
+            if (vf != null && !vf.equals(LinearForm.atom(term.key()))) {
+                out = out.assigning(term.key(), vf);
+            }
+        }
+        return new Entered(out, at.binding(li.binder().id(), li.value(), what));
+    }
+
+    /** Where {@code site}'s conditional stands: {@code k} and {@code at} with every binding it is
+     * inside entered, outermost first. */
+    private Entered scopeOf(ConditionalSite site, Known k, Denotations at) {
+        Entered in = new Entered(k, at);
+        for (Core.LetIn li : site.scope()) {
+            in = bindLet(li, in.known(), in.at());
+        }
+        return in;
+    }
 
     /**
      * Introduces {@code root} as a location: somewhere nothing else names, holding a value of its

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -66,6 +66,19 @@ public final class InvariantChecker {
 
     record Findings(List<CompileException> errors, List<Diagnostic> warnings) {}
 
+    /** One construction and how this check came out on it. */
+    record Said(String type, SourcePos pos, Verdict verdict) {}
+
+    /**
+     * Where a test in this package reads the verdicts a check reached, and null everywhere else.
+     *
+     * <p>What the check <em>says</em> is its findings, and a verdict is not one of them: two of the
+     * four are silent, and which of those two a construction came out as is exactly what no
+     * diagnostic reports. A test holding that difference has nowhere else to read it, and a
+     * distinction nothing can read is one that stops being true without anything failing.
+     */
+    static List<Said> WATCHING;
+
     /**
      * What this check reads: one behavior's body and the invariants of the types around it, both in
      * the representation the rules are written at ({@link InliningPolicy#DISCHARGE}) rather than the
@@ -121,17 +134,20 @@ public final class InvariantChecker {
         // assuming it.
         Core stated = c.clauses.typed(clause, data);
         Denotations fields = Denotations.none().locations(c.clauses.bindingsOf(data).values());
-        List<Predicates.Clause> owed;
+        Predicates.Owed owed;
         try {
-            owed = stated == null ? null
+            owed = stated == null ? Predicates.Owed.UNREADABLE
                     : c.predicates.obligations(stated, Known.top(), fields, false);
         } catch (RuntimeException _) {
-            owed = null;   // fail-open, as the walk is
+            owed = Predicates.Owed.UNREADABLE;   // fail-open, as the walk is
         }
-        if (owed == null || owed.isEmpty()) {
+        // A clause owing nothing is answered here as one nothing can be asked of. What it is instead
+        // — a clause that holds wherever it is built — is a fourth answer this classification does
+        // not have, and giving it one is a change to what the language states about a clause.
+        if (owed.clauses().isEmpty()) {
             return ClauseDischarge.runtimeOnly(at, c.whyUnreadable(stated, fields));
         }
-        for (Predicates.Clause owe : owed) {
+        for (Predicates.Clause owe : owed.clauses()) {
             if (owe.numeric() != null) {
                 return ClauseDischarge.derivable(at);
             }
@@ -205,21 +221,23 @@ public final class InvariantChecker {
             // and what the two readings find is said once. Every place a conditional can be given —
             // to a field, to a name, to a guard — is this one place.
             Core.If value = site.conditional();
-            walk(value.cond(), k, at, depth);
-            // The condition is read where it stands, which is inside every binding on the way down to
-            // it, and not at the outer place the reading is decided on. Read at the outer place it
-            // names bindings nothing has entered, and a condition over those settles nothing — the
-            // two readings would come out alike and the conditional would decide nothing.
+            // Everything about the conditional is read where it stands, which is inside every binder
+            // on the way down to it and not at the outer place the reading is decided on: what its
+            // condition settles, and what the condition's own subtree is. Read at the outer place the
+            // condition names binders nothing has entered, which denote nothing — it would settle
+            // nothing, and a construction written inside it would be one nothing can be said of.
             Entered inside = scopeOf(site, k, at);
             Known within = inside.known();
             Denotations there = inside.at();
+            walk(value.cond(), within, there, depth);
             Set<Core> alike = sameConditional(e, value, there);
-            // The readings take the outer environment, not this one: the tree each is given still
-            // holds those bindings, and walking it enters them again on the way in.
+            // The readings start from where the conditional stood, not from outside it. The tree each
+            // is given still holds those binders and walks into them again, which is why entering one
+            // already entered is nothing: a second transition would forget what the branch settled.
             say(reading(without(e, alike, value.then()),
-                            predicates.assumeCond(value.cond(), within, there, true), at, depth),
+                            predicates.assumeCond(value.cond(), within, there, true), there, depth),
                     reading(without(e, alike, value.els()),
-                            predicates.assumeCond(value.cond(), within, there, false), at, depth));
+                            predicates.assumeCond(value.cond(), within, there, false), there, depth));
             return;
         }
         checkIfConstruction(e, k, at, false);
@@ -398,7 +416,7 @@ public final class InvariantChecker {
      * written over a conditional can be checked on each branch and answered once — which of the two
      * values it is is not decided here, so what holds of the construction is what holds of both.
      */
-    private enum Verdict {
+    enum Verdict {
         /** Every clause is discharged. */
         PROVED,
         /** A clause names something the check cannot read at this construction, and no clause is
@@ -420,8 +438,11 @@ public final class InvariantChecker {
             return this == REFUTED_ALONE || this == REFUTED_NOT_ALONE;
         }
 
-        /** Whether nothing is said of a construction that came out this way. */
-        boolean silent() {
+        /** Whether the reading found nothing that may fail: every clause it could read is
+         * discharged. Not the same question as whether anything is reported — what is reported is
+         * settled at {@link #report}, and this is what the two readings of one construction are
+         * combined by. */
+        boolean holds() {
             return this == PROVED || this == UNREPRESENTABLE;
         }
 
@@ -445,9 +466,10 @@ public final class InvariantChecker {
             if (a.refuted() && b.refuted()) {
                 return REFUTED_NOT_ALONE;
             }
-            // One branch discharged the invariant and the other could not read it. Neither says the
-            // construction may abort, so neither does this; what it is not is proven of both.
-            return a.silent() && b.silent() ? UNREPRESENTABLE : UNKNOWN;
+            // Neither reading found anything that may fail, and they are not the same reading: one
+            // discharged the invariant and the other could not read it. So neither does this, and
+            // what it is not is the invariant proven of both.
+            return a.holds() && b.holds() ? UNREPRESENTABLE : UNKNOWN;
         }
     }
 
@@ -469,12 +491,9 @@ public final class InvariantChecker {
         // the clause that failed. It reads the construction as written, so a name given the value is
         // not one it sees, and this check says it instead — which is what `decidesFalse` carries.
         for (Core stated : clauses.statedAt(named, type, given)) {
-            List<Predicates.Clause> o = predicates.obligations(stated, k, at, unnamed, decidesFalse);
-            if (o == null) {
-                unreadable = true;
-            } else {
-                owed.addAll(o);
-            }
+            Predicates.Owed o = predicates.obligations(stated, k, at, unnamed, decidesFalse);
+            unreadable |= o.unreadable();
+            owed.addAll(o.clauses());
         }
         if (owed.isEmpty()) {
             return unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED;
@@ -532,6 +551,10 @@ public final class InvariantChecker {
      * construction raises no warning: what the warning reports is a possible abort, and an attempt
      * takes its else branch instead. */
     private void report(Core at, Ast.Data type, SourcePos pos, boolean attempted, Verdict verdict) {
+        List<Said> watching = WATCHING;
+        if (watching != null && capturing == null) {
+            watching.add(new Said(type.name(), pos, verdict));
+        }
         if (capturing != null) {
             capturing.found().put(new Occurrence(asWritten(at)),
                     new Reported(type, pos, verdict, attempted));
@@ -630,21 +653,44 @@ public final class InvariantChecker {
      * where it was found, so a search that answered with the node alone would leave the reading to
      * work the scope out again — which is what it got wrong.
      *
-     * <p>Only the bindings a {@code let} writes are carried. A value a {@code match} arm or an
-     * attempted construction binds is not one a construction site can be read against, so a
-     * construction over one says nothing whatever is in scope for it; those binders are on no path
-     * this can reach. That is a fact about which construction sites are representable, not about
-     * which binders exist — should that boundary move, this has to widen with it.
+     * <p>Every binder the search descends through is carried, and not only the ones a construction
+     * outside could have been read against. What stands in scope decides two things: what the
+     * condition settles about the value being built, and what the condition's own subtree means —
+     * a construction written inside a condition is a construction like any other, and reading it
+     * where its binders are not entered is reading it as something nothing can be said of.
      */
-    private record ConditionalSite(Core.If conditional, List<Core.LetIn> scope) {
+    private record ConditionalSite(Core.If conditional, List<Binder> scope) {
 
-        /** The same site, read from outside {@code li} — so {@code li} is the outermost of what it is
-         * inside. */
-        ConditionalSite under(Core.LetIn li) {
-            List<Core.LetIn> outer = new ArrayList<>();
-            outer.add(li);
+        /** One binder the conditional stands inside, as the environment its body is read in. */
+        private interface Binder {
+            Entered entering(InvariantChecker c, Known k, Denotations at);
+        }
+
+        /** The same site, read from outside {@code binder} — so {@code binder} is the outermost of
+         * what it is inside. */
+        ConditionalSite under(Binder binder) {
+            List<Binder> outer = new ArrayList<>();
+            outer.add(binder);
             outer.addAll(scope);
             return new ConditionalSite(conditional, List.copyOf(outer));
+        }
+
+        /** A {@code let}'s body, read with the name standing for what it was given. */
+        static Binder of(Core.LetIn li) {
+            return (c, k, at) -> c.bindLet(li, k, at);
+        }
+
+        /** A {@code match} arm's body, read with what the arm binds standing for a value of the
+         * case's type — a location this arm introduces, carrying what that type guarantees. */
+        static Binder of(Core.Case arm) {
+            return (c, k, at) -> c.enter(Terms.read(arm.binding(), arm.bindType(), arm.pos()), k, at);
+        }
+
+        /** An attempted construction's success branch, read with the binding carrying the invariant
+         * the attempt established. */
+        static Binder of(Core.IfConstructed ic) {
+            return (c, k, at) ->
+                    c.enter(Terms.read(ic.binder(), ic.construct().type(), ic.pos()), k, at);
         }
     }
 
@@ -684,7 +730,42 @@ public final class InvariantChecker {
                 return given;
             }
             ConditionalSite inside = conditionalIn(li.body());
-            return inside == null ? null : inside.under(li);
+            return inside == null ? null : inside.under(ConditionalSite.of(li));
+        }
+        if (e instanceof Core.Match m) {
+            ConditionalSite asked = conditionalIn(m.scrutinee());
+            if (asked != null) {
+                return asked;
+            }
+            for (Core.Case arm : m.cases()) {
+                ConditionalSite inside = conditionalIn(arm.body());
+                if (inside == null) {
+                    continue;
+                }
+                // A case that binds nothing introduces nothing: its body is read as the arm's own.
+                return arm.binding() == null || arm.bindType() == null
+                        ? inside : inside.under(ConditionalSite.of(arm));
+            }
+            return null;
+        }
+        if (e instanceof Core.IfConstructed ic) {
+            ConditionalSite tried = conditionalIn(ic.construct());
+            if (tried != null) {
+                return tried;
+            }
+            ConditionalSite held = conditionalIn(ic.then());
+            if (held != null) {
+                return held.under(ConditionalSite.of(ic));
+            }
+            // A departure stands where the invariant did not hold and nothing was built, so it is
+            // inside nothing the attempt would have guaranteed.
+            for (Core.ElseArm arm : ic.els()) {
+                ConditionalSite departed = conditionalIn(arm.body());
+                if (departed != null) {
+                    return departed;
+                }
+            }
+            return null;
         }
         ConditionalSite[] found = {null};
         Core.forEachChild(e, child -> {
@@ -809,6 +890,14 @@ public final class InvariantChecker {
      * expression it was given.
      */
     private Entered bindLet(Core.LetIn li, Known k, Denotations at) {
+        // Entering a binding the walk is already inside is not a second binding of it. A branch is
+        // read from where its conditional stood, which is inside these, over a tree that still holds
+        // them; running the transition again would assign the name its form a second time, and an
+        // assignment forgets what was known of what it assigns to — including what the branch had
+        // just established.
+        if (at.valueOf(li.binder().id()) == li.value()) {
+            return new Entered(k, at);
+        }
         Denotes what = terms.denotationOf(li.value(), at, k);
         Known out = k;
         // A binding that denotes what it was given is an alias and introduces no value, so there is
@@ -825,12 +914,12 @@ public final class InvariantChecker {
         return new Entered(out, at.binding(li.binder().id(), li.value(), what));
     }
 
-    /** Where {@code site}'s conditional stands: {@code k} and {@code at} with every binding it is
+    /** Where {@code site}'s conditional stands: {@code k} and {@code at} with every binder it is
      * inside entered, outermost first. */
     private Entered scopeOf(ConditionalSite site, Known k, Denotations at) {
         Entered in = new Entered(k, at);
-        for (Core.LetIn li : site.scope()) {
-            in = bindLet(li, in.known(), in.at());
+        for (ConditionalSite.Binder binder : site.scope()) {
+            in = binder.entering(this, in.known(), in.at());
         }
         return in;
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -399,8 +399,13 @@ public final class InvariantChecker {
      * values it is is not decided here, so what holds of the construction is what holds of both.
      */
     private enum Verdict {
-        /** Every clause is discharged, or none of them is expressible. */
+        /** Every clause is discharged. */
         PROVED,
+        /** A clause names something the check cannot read at this construction, and no clause is
+         * unproven: nothing is owed here because nothing could be asked. Silent, as a discharge is,
+         * and not the same thing — the run-time check is what stands for the clause, and an author
+         * who reads the silence as a proof is reading something that was never attempted. */
+        UNREPRESENTABLE,
         /** A clause is expressible and unproven: the construction may abort. */
         UNKNOWN,
         /** A clause the reading without the path's assumptions already refutes, so the invariant
@@ -413,6 +418,11 @@ public final class InvariantChecker {
 
         boolean refuted() {
             return this == REFUTED_ALONE || this == REFUTED_NOT_ALONE;
+        }
+
+        /** Whether nothing is said of a construction that came out this way. */
+        boolean silent() {
+            return this == PROVED || this == UNREPRESENTABLE;
         }
 
         /**
@@ -432,7 +442,12 @@ public final class InvariantChecker {
             if (a == b) {
                 return a;
             }
-            return a.refuted() && b.refuted() ? REFUTED_NOT_ALONE : UNKNOWN;
+            if (a.refuted() && b.refuted()) {
+                return REFUTED_NOT_ALONE;
+            }
+            // One branch discharged the invariant and the other could not read it. Neither says the
+            // construction may abort, so neither does this; what it is not is proven of both.
+            return a.silent() && b.silent() ? UNREPRESENTABLE : UNKNOWN;
         }
     }
 
@@ -445,17 +460,24 @@ public final class InvariantChecker {
         // cannot be guarded is not the same as what cannot be computed.
         Set<Core> unnamed = unnamed(given.values(), k, at);
         List<Predicates.Clause> owed = new ArrayList<>();
+        // A clause the check cannot read here owes nothing and proves nothing, and the two are not
+        // the same answer. Kept apart: a clause that owes nothing because it folded to what it is read
+        // with is discharged, and one that owes nothing because nothing here could be asked of it is
+        // left to the run-time check.
+        boolean unreadable = false;
         // A newtype construction from a value written out is the constant check's to report: it names
         // the clause that failed. It reads the construction as written, so a name given the value is
         // not one it sees, and this check says it instead — which is what `decidesFalse` carries.
         for (Core stated : clauses.statedAt(named, type, given)) {
             List<Predicates.Clause> o = predicates.obligations(stated, k, at, unnamed, decidesFalse);
-            if (o != null) {
+            if (o == null) {
+                unreadable = true;
+            } else {
                 owed.addAll(o);
             }
         }
         if (owed.isEmpty()) {
-            return Verdict.PROVED;   // nothing here is expressible — the run-time check stands for it
+            return unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED;
         }
         NumericDomain dom = k.numbers();
         // The same clauses read against the same site, under what would be known here had no
@@ -490,7 +512,12 @@ public final class InvariantChecker {
         if (alongside) {
             return Verdict.REFUTED_NOT_ALONE;
         }
-        return unknown ? Verdict.UNKNOWN : Verdict.PROVED;
+        if (unknown) {
+            return Verdict.UNKNOWN;
+        }
+        // Every clause that could be read is discharged. One that could not be read still stands, so
+        // this is not the whole invariant proven.
+        return unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED;
     }
 
     /** Whether the constant check reads this construction: a newtype's, over a value written where
@@ -520,6 +547,10 @@ public final class InvariantChecker {
                             .hint("check.invariant.reify", type.name()).warning().build());
                 }
             }
+            // Nothing was asked here, so nothing is said. Whether that is the right thing to say of a
+            // construction the check could not read is a question about what E2011 reports, and this
+            // answers it the way it has always been answered.
+            case UNREPRESENTABLE -> { }
             case PROVED -> { }
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -182,35 +182,60 @@ final class Predicates {
         }
     }
 
+    /**
+     * What a clause owes, and whether any part of it was outside what the check can read.
+     *
+     * <p>The two are apart because a clause owing nothing has two reasons: it folded to what it is
+     * read with, or nothing in it could be asked here. A conjunction can be both at once — one
+     * conjunct discharged and the next unreadable — and reporting only the obligations would say the
+     * invariant was proven when half of it was never read.
+     *
+     * @param clauses what is owed, which the reading discharges or refutes
+     * @param unreadable whether a conjunct of it names something the check cannot read here, whose
+     *                   run-time check stands whatever the rest comes out as
+     */
+    record Owed(List<Clause> clauses, boolean unreadable) {
+
+        static final Owed NOTHING = new Owed(List.of(), false);
+        static final Owed UNREADABLE = new Owed(List.of(), true);
+
+        static Owed of(Clause clause) {
+            return new Owed(List.of(clause), false);
+        }
+
+        /** Both conjuncts of one clause: everything either owes, unreadable if either was. */
+        Owed and(Owed other) {
+            List<Clause> both = new ArrayList<>(clauses);
+            both.addAll(other.clauses);
+            return new Owed(List.copyOf(both), unreadable || other.unreadable);
+        }
+    }
+
     /** What {@code inv} owes, where {@code decidesFalse} says a clause folding to the other answer
      * than it is read with is this check's to report. A newtype's constant construction is checked
      * elsewhere, and that check names the clause that failed rather than only saying one did, so it
      * is left to say it. */
-    List<Clause> obligations(Core inv, Known k, Denotations at, boolean decidesFalse) {
+    Owed obligations(Core inv, Known k, Denotations at, boolean decidesFalse) {
         return obligations(inv, k, at, Set.of(), true, decidesFalse);
     }
 
     /** The same, where {@code unnamed} holds the values the site hands over that no clause may be
      * read against. */
-    List<Clause> obligations(Core inv, Known k, Denotations at, Set<Core> unnamed,
-                             boolean decidesFalse) {
+    Owed obligations(Core inv, Known k, Denotations at, Set<Core> unnamed,
+                     boolean decidesFalse) {
         return obligations(inv, k, at, unnamed, true, decidesFalse);
     }
 
-    private List<Clause> obligations(Core rawInv, Known k, Denotations at, Set<Core> unnamed,
-                                     boolean positive, boolean decidesFalse) {
+    private Owed obligations(Core rawInv, Known k, Denotations at, Set<Core> unnamed,
+                             boolean positive, boolean decidesFalse) {
         Core inv = asSizeComparison(rawInv);
         if (inv instanceof Core.Binary b && b.op() == Ast.BinOp.AND && positive) {
             // Each conjunct on its own: an invariant is a set of things that hold, and one the check
             // cannot read leaves its own run-time check standing without costing the others theirs.
-            List<Clause> l = obligations(b.left(), k, at, unnamed, true, decidesFalse);
-            List<Clause> r = obligations(b.right(), k, at, unnamed, true, decidesFalse);
-            if (l == null && r == null) {
-                return null;
-            }
-            List<Clause> both = new ArrayList<>(l == null ? List.of() : l);
-            both.addAll(r == null ? List.of() : r);
-            return both;
+            // That it stands is carried rather than dropped — the other conjunct being discharged is
+            // not the invariant proven.
+            return obligations(b.left(), k, at, unnamed, true, decidesFalse)
+                    .and(obligations(b.right(), k, at, unnamed, true, decidesFalse));
         }
         Core under = negated(inv);
         if (under != null) {
@@ -223,10 +248,10 @@ final class Predicates {
             // saying so needs no term to be named. Read under a denial it is the other answer that
             // discharges, which is why the polarity is asked.
             if (folded == positive) {
-                return List.of();
+                return Owed.NOTHING;
             }
             if (decidesFalse) {
-                return List.of(VIOLATED);
+                return Owed.of(VIOLATED);
             }
         }
         Constraint numeric = null;
@@ -247,11 +272,11 @@ final class Predicates {
         boolean stated = polar.positive();
         Fact fact = keys.isEmpty() ? null : new Fact(stated ? keys : firstOnly(keys), stated);
         if (numeric == null && fact == null) {
-            return null;
+            return Owed.UNREADABLE;
         }
         List<Constraint> known = new ArrayList<>();
         sizeFacts(inv, at, known);
-        return List.of(new Clause(numeric, fact, known));
+        return Owed.of(new Clause(numeric, fact, known));
     }
 
     /** Whether {@code inv} is decided outright: the clause, with the construction's own values
@@ -376,12 +401,11 @@ final class Predicates {
      * reaches. What a clause owes at a construction is what it guarantees where it is already
      * established, so the two read the same clauses through the same rule and differ only in
      * direction. */
-    Known assume(List<Clause> owed, Known k, Known.Held held) {
-        if (owed == null) {
-            return k;
-        }
+    Known assume(Owed owed, Known k, Known.Held held) {
         Known out = k;
-        for (Clause c : owed) {
+        // What could not be read says nothing here: a clause left to the run-time check is not one
+        // the seeding may assume, and the flag saying so is the construction site's to act on.
+        for (Clause c : owed.clauses()) {
             for (Constraint known : c.known()) {
                 // What is known of a size holds of the container itself, whatever established the
                 // clause it was read out of.

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -145,9 +145,31 @@ final class Terms {
             if (counted != null) {
                 return LinearForm.constant(counted);
             }
+            // A name given arithmetic over terms the check names is related to that arithmetic (spec
+            // §invariant-discharge-terms). Read through it, as the `let` node above is read through:
+            // the name and the expression it was given are one value, and reading one as an atom of
+            // its own leaves a guard on the name saying nothing about the value it was built from.
+            LinearForm given = givenForm(n, at, k);
+            if (given != null) {
+                return given;
+            }
             String atom = atomOf(n, at, k);
             return atom == null ? null : LinearForm.atom(atom);
         });
+    }
+
+    /**
+     * The form of what a name was given, where the name stands for a term of its own and what it was
+     * given is arithmetic this can read. A name given a location is not this — {@link #atomOf}
+     * answers that with the location, which is what the seeding wrote about.
+     */
+    private LinearForm givenForm(Core e, Denotations at, Known k) {
+        if (!(e instanceof Core.Read r) || !(at.of(r.binding()) instanceof Denotes.Term)
+                || !isNumeric(e.type())) {
+            return null;
+        }
+        Core given = at.valueOf(r.binding());
+        return given == null || given == e ? null : affineOf(given, at, k);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AConditionalIsReadInTheScopeItStandsInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AConditionalIsReadInTheScopeItStandsInTest.java
@@ -1,0 +1,115 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A conditional a construction is given is read in the scope it stands in.
+ *
+ * <p>The discharge walk reads a conditional in a value position by reading the whole value twice,
+ * once with each branch standing there and each under what the condition settles. The conditional is
+ * found inside the value and the value is read from the outside, so the two are at different places
+ * in the body: everything a binding between them introduced is in scope for the conditional and not
+ * yet in scope where the reading is decided on. A condition read at the outer place names bindings
+ * nothing has entered, {@link Denotations} answers those with nothing, and the condition settles
+ * nothing — so both readings run with the same knowledge and the conditional stops deciding anything.
+ *
+ * <p>What that costs is a warning on a construction the author cannot answer. The value is still
+ * nameable through the binding once the reading walks into it, so the clause is owed and unproven,
+ * and the remedies the warning names — a guard, a reified relation — are not what the body needs.
+ *
+ * <p>The bindings are the ones a call's expansion writes, so the shapes below are helpers; what is
+ * held here is not about helpers but about the scope a conditional is read in, and the last two hold
+ * the other direction — a binding is not in scope for its own initializer, and a condition that
+ * settles nothing about what is built is still reported.
+ */
+class AConditionalIsReadInTheScopeItStandsInTest {
+
+    private static final String YEN = """
+            module demo
+            data Yen = Int
+                invariant nonNegative = value >= 0
+            """;
+
+    private static long warnings(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    @Test
+    void aConditionalUnderABindingReadsThatBinding() {
+        // `atLeastZero(n)` is `let $n = n in if $n < 0 then 0 else $n`, so the condition names a
+        // binding the walk enters only on its way into the body.
+        assertEquals(0, warnings(YEN + """
+                let atLeastZero (n: Int) = if n < 0 then 0 else n
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(atLeastZero(n))
+                """),
+                "both branches are non-negative under the condition, as they are written inline");
+    }
+
+    @Test
+    void aConditionalUnderABindingReadsItWhereverTheConstructionStands() {
+        assertEquals(0, warnings(YEN + """
+                let atLeastZero (n: Int) = if n < 0 then 0 else n
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = {
+                    let k = atLeastZero(n)
+                    Yen(k)
+                }
+                """),
+                "naming the value does not change what the conditional settles");
+    }
+
+    @Test
+    void aConditionalUnderSeveralBindingsReadsThemAll() {
+        assertEquals(0, warnings(YEN + """
+                let atLeast (n: Int, floor: Int) = if n < floor then floor else n
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(atLeast(n, 0))
+                """),
+                "the condition names both bindings the expansion wrote");
+    }
+
+    @Test
+    void aConditionalUnderNestedExpansionsReadsEachScope() {
+        assertEquals(0, warnings(YEN + """
+                let atLeastZero (n: Int) = if n < 0 then 0 else n
+                let clamped (n: Int) = atLeastZero(n)
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(clamped(n))
+                """),
+                "one expansion inside another is two bindings on the way in, entered outermost first");
+    }
+
+    @Test
+    void aBindingIsNotInScopeForItsOwnInitializer() {
+        assertEquals(0, warnings(YEN + """
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = {
+                    let k = if n < 0 then 0 else n
+                    Yen(k)
+                }
+                """),
+                "the conditional is what `k` is given, and is read before `k` stands for anything");
+    }
+
+    @Test
+    void aConditionThatSettlesNothingAboutTheValueIsStillReported() {
+        assertEquals(1, warnings(YEN + """
+                let same (n: Int) = n
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(same(n))
+                """),
+                "nothing said `n` is non-negative, and reading the binding does not say it");
+        assertEquals(1, warnings(YEN + """
+                behavior f : (n: Int, m: Int) -> Yen constructs Yen
+                let f (n, m) = Yen(if m < 0 then 0 else n)
+                """),
+                "the condition is about `m` and the value built is `n`");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AConditionalIsReadInTheScopeItStandsInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AConditionalIsReadInTheScopeItStandsInTest.java
@@ -87,6 +87,42 @@ class AConditionalIsReadInTheScopeItStandsInTest {
     }
 
     @Test
+    void aBindingGivenArithmeticIsReadAsThatArithmetic() {
+        // `$n` is given `n + 1`, so what the condition settles of `$n` and what the construction is
+        // given are one value. Read as a term of its own, the branch says nothing about what is built.
+        assertEquals(0, warnings(YEN + """
+                let atLeastOne (n: Int) = if n < 1 then 1 else n
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(atLeastOne(n + 1))
+                """),
+                "the else branch is at least one, and one is not negative");
+        assertEquals(0, warnings(YEN + """
+                let atLeastOne (n: Int) = if n < 1 then 1 else n
+                let shifted (n: Int) = atLeastOne(n + 1)
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(shifted(n))
+                """),
+                "and again through a second expansion");
+    }
+
+    @Test
+    void aConstructionInsideAConditionIsReadInThatScopeToo() {
+        // The condition is read where it stands, and a construction written in one is a construction
+        // like any other: `Yen(n)` here is unguarded, whichever spelling reached it.
+        assertEquals(1, warnings(YEN + """
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(if Yen(n).value >= 0 then 0 else 0)
+                """),
+                "written inline, the construction in the condition is reported");
+        assertEquals(1, warnings(YEN + """
+                let h (n: Int) = if Yen(n).value >= 0 then 0 else 0
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(h(n))
+                """),
+                "and under a binding it is the same construction, not one nothing can be said of");
+    }
+
+    @Test
     void aBindingIsNotInScopeForItsOwnInitializer() {
         assertEquals(0, warnings(YEN + """
                 behavior f : (n: Int) -> Yen constructs Yen

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckCouldNotReadIsNotWhatItProvedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckCouldNotReadIsNotWhatItProvedTest.java
@@ -1,11 +1,18 @@
 package souther.compiler.check;
 
 import souther.compiler.Compiler;
+import souther.compiler.check.InvariantChecker.Said;
+import souther.compiler.check.InvariantChecker.Verdict;
 import souther.compiler.diag.Severity;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * A construction the check could not read and one it discharged are both silent, and they are not the
@@ -13,16 +20,33 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  *
  * <p>Held together they read as one: an author who writes a construction over something outside the
  * fragment sees the same nothing as one whose guards discharged it, and takes the silence for a proof
- * that was never attempted. Nothing reports the difference today and this does not change that. What
- * is held here is where the two answers meet — a construction over a conditional is read once per
- * branch and the two readings are answered together, and a discharge on one branch beside an unread
- * value on the other is still nothing to report.
+ * that was never attempted. Nothing reports the difference and this does not change that, so it is
+ * read off the verdicts rather than off the diagnostics — a difference no test can reach is one that
+ * stops being true without anything failing.
  *
- * <p>The stdlib shapes are the ones that made this worth telling apart: {@code Int.max} keeps its call
- * where the check reads the body, and a call is not a term any clause can be read against, so a
- * construction over one is silent however plainly it violates.
+ * <p>What made it worth telling apart is {@code Int.max}: it keeps its call where the check reads the
+ * body, a call is not a term any clause is read against, and a construction over one is silent
+ * however plainly it violates. That silence read as a discharge is what {@code #409} reported.
  */
 class WhatTheCheckCouldNotReadIsNotWhatItProvedTest {
+
+    /** How the check came out on each construction of {@code source}. */
+    private static List<Said> verdictsIn(String source) {
+        List<Said> said = Collections.synchronizedList(new ArrayList<>());
+        InvariantChecker.WATCHING = said;
+        try {
+            Compiler.compileWithWarnings(source);
+        } finally {
+            InvariantChecker.WATCHING = null;
+        }
+        assertFalse(said.isEmpty(), "nothing was checked, so nothing here is being held to anything");
+        return said;
+    }
+
+    private static Verdict verdictOn(String type, String source) {
+        return verdictsIn(source).stream()
+                .filter(s -> s.type().equals(type)).findFirst().orElseThrow().verdict();
+    }
 
     private static long warnings(String source) {
         return Compiler.compileWithWarnings(source).warnings().stream()
@@ -30,41 +54,74 @@ class WhatTheCheckCouldNotReadIsNotWhatItProvedTest {
     }
 
     @Test
-    void oneBranchDischargedBesideOneUnreadIsStillSilent() {
-        // `0` discharges the clause; `Int.max(0, n)` is a call, and no clause is read against it.
-        assertEquals(0, warnings("""
-                module demo
-                data Yen = Int
-                    invariant nonNegative = value >= 0
-                behavior f : (n: Int, flag: Bool) -> Yen constructs Yen
-                let f (n, flag) = Yen(if flag then 0 else Int.max(0, n))
-                """),
-                "neither reading says the construction may abort, so neither does the answer");
-    }
-
-    @Test
-    void aConstructionOverAnUnreadValueIsSilentWhateverItsClauseSays() {
-        // `value >= 1` does not hold of `Int.max(0, n)` at n <= 0. The check says nothing because it
-        // cannot read the value, not because it settled the clause.
-        assertEquals(0, warnings("""
+    void aValueTheCheckCannotReadIsNotADischarge() {
+        // `value >= 1` does not hold of `Int.max(0, n)` at n <= 0, and nothing here says otherwise.
+        String source = """
                 module demo
                 data Pos = Int
                     invariant positive = value >= 1
                 behavior f : (n: Int) -> Pos constructs Pos
                 let f (n) = Pos(Int.max(0, n))
+                """;
+        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Pos", source),
+                "the clause was never asked, so it was not answered");
+        assertEquals(0, warnings(source), "and nothing is reported of it");
+    }
+
+    @Test
+    void aClauseDischargedBesideOneUnreadIsNotTheInvariantProved() {
+        // `0 <= 1` folds to true and owes nothing; `value >= 1` cannot be read at this value. An
+        // invariant is the conjunction of its clauses, so one of them holding is not the invariant.
+        String source = """
+                module demo
+                data Pos = Int
+                    invariant mixed = 0 <= 1 && value >= 1
+                behavior f : (n: Int) -> Pos constructs Pos
+                let f (n) = Pos(Int.max(0, n))
+                """;
+        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Pos", source),
+                "the conjunct left to the run-time check is still left to it");
+        assertEquals(0, warnings(source), "and nothing is reported of it");
+    }
+
+    @Test
+    void oneBranchDischargedBesideOneUnreadIsNotProvedEither() {
+        String source = """
+                module demo
+                data Yen = Int
+                    invariant nonNegative = value >= 0
+                behavior f : (n: Int, flag: Bool) -> Yen constructs Yen
+                let f (n, flag) = Yen(if flag then 0 else Int.max(0, n))
+                """;
+        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Yen", source),
+                "`0` discharges the clause and `Int.max(0, n)` is not read; together they are the"
+                        + " weaker of the two");
+        assertEquals(0, warnings(source), "neither reading says the construction may abort");
+    }
+
+    @Test
+    void aDischargeIsStillADischarge() {
+        assertEquals(Verdict.PROVED, verdictOn("Yen", """
+                module demo
+                data Yen = Int
+                    invariant nonNegative = value >= 0
+                behavior f : (n: Int) -> Yen constructs Yen
+                let f (n) = Yen(if n < 0 then 0 else n)
                 """),
-                "the run-time check is the whole of the enforcement here");
+                "both branches are non-negative under the condition");
     }
 
     @Test
     void aValueTheCheckCanReadAndCannotProveIsStillReported() {
-        assertEquals(1, warnings("""
+        String source = """
                 module demo
                 data Pos = Int
                     invariant positive = value >= 1
                 behavior f : (n: Int) -> Pos constructs Pos
                 let f (n) = Pos(n)
-                """),
+                """;
+        assertEquals(Verdict.UNKNOWN, verdictOn("Pos", source),
                 "`n` is a term, and nothing said it is at least one");
+        assertEquals(1, warnings(source), "which is what E2011 reports");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckCouldNotReadIsNotWhatItProvedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckCouldNotReadIsNotWhatItProvedTest.java
@@ -1,0 +1,70 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A construction the check could not read and one it discharged are both silent, and they are not the
+ * same answer.
+ *
+ * <p>Held together they read as one: an author who writes a construction over something outside the
+ * fragment sees the same nothing as one whose guards discharged it, and takes the silence for a proof
+ * that was never attempted. Nothing reports the difference today and this does not change that. What
+ * is held here is where the two answers meet — a construction over a conditional is read once per
+ * branch and the two readings are answered together, and a discharge on one branch beside an unread
+ * value on the other is still nothing to report.
+ *
+ * <p>The stdlib shapes are the ones that made this worth telling apart: {@code Int.max} keeps its call
+ * where the check reads the body, and a call is not a term any clause can be read against, so a
+ * construction over one is silent however plainly it violates.
+ */
+class WhatTheCheckCouldNotReadIsNotWhatItProvedTest {
+
+    private static long warnings(String source) {
+        return Compiler.compileWithWarnings(source).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    @Test
+    void oneBranchDischargedBesideOneUnreadIsStillSilent() {
+        // `0` discharges the clause; `Int.max(0, n)` is a call, and no clause is read against it.
+        assertEquals(0, warnings("""
+                module demo
+                data Yen = Int
+                    invariant nonNegative = value >= 0
+                behavior f : (n: Int, flag: Bool) -> Yen constructs Yen
+                let f (n, flag) = Yen(if flag then 0 else Int.max(0, n))
+                """),
+                "neither reading says the construction may abort, so neither does the answer");
+    }
+
+    @Test
+    void aConstructionOverAnUnreadValueIsSilentWhateverItsClauseSays() {
+        // `value >= 1` does not hold of `Int.max(0, n)` at n <= 0. The check says nothing because it
+        // cannot read the value, not because it settled the clause.
+        assertEquals(0, warnings("""
+                module demo
+                data Pos = Int
+                    invariant positive = value >= 1
+                behavior f : (n: Int) -> Pos constructs Pos
+                let f (n) = Pos(Int.max(0, n))
+                """),
+                "the run-time check is the whole of the enforcement here");
+    }
+
+    @Test
+    void aValueTheCheckCanReadAndCannotProveIsStillReported() {
+        assertEquals(1, warnings("""
+                module demo
+                data Pos = Int
+                    invariant positive = value >= 1
+                behavior f : (n: Int) -> Pos constructs Pos
+                let f (n) = Pos(n)
+                """),
+                "`n` is a term, and nothing said it is at least one");
+    }
+}


### PR DESCRIPTION
Closes #409.

## What was wrong

The invariant-discharge walk reads a construction over a conditional by reading it twice, once with each branch standing there and each under what the condition settles. The conditional is found by searching down into the value; the reading is decided on from the outside. Those are different places in the body, and everything about the conditional was read at the outer one.

A call's expansion binds each argument, so `Yen(atLeastZero(n))` is `Yen(let $n = n in if $n < 0 then 0 else $n)`. Read at the outer place, `$n < 0` names a binding nothing has entered. `Denotations` answers that with nothing, `Predicates.assumeCond` records no constraint, and both readings run with the same knowledge — the conditional stops deciding anything. The else branch is still nameable once the reading walks into the binding, so the clause is owed and unproven, and E2011 fires on a construction the author cannot answer.

The same expression written inline is silent, because its condition names a parameter that is entered.

## The apparent stdlib exception

The issue reads `Yen(Int.max(0, n))` as a call the procedure reads through. It is not. `Int.max` has no rule giving its result a bound; the construction is silent because the check cannot name the value at all. With the clause changed to `value >= 1`, `Pos(Int.max(0, n))` is still silent though it plainly violates at `n <= 0`, and `Pos(Int.abs(n))` with it. The run-time check is what enforces those: a generated `Pos(Int.max(0, 0))` throws `ConstraintViolation: invariant violated on demo.Pos: positive`.

So the two calls were not answered differently for the reason the issue gives. One says nothing because nothing could be asked; the other said something wrong.

`<<invariant-discharge-terms>>` needs no change: a function result is not a term, and `Int.max` does not participate.

## A node and the environment it means something in are one thing

Four places kept them apart, each the same mistake as the one before.

**The conditional.** The search answers with the conditional and the binders it stands inside, and everything about it is read there: what its condition settles, and the condition's own subtree. A binder is collected on the way into a body and not on the way into the value a `let` is given — a binding is not in scope for its own initializer. The environment transition is one function the walk and the hoist both call.

Every binder the search descends through is carried, not only the ones a construction outside could have been read against. A `match` arm and an attempted construction bind values a condition can name whatever the site can, and a construction written inside a condition is a construction like any other: `Yen(if Yen(n).value >= 0 then 0 else 0)` reports the inner one, and so does the same condition reached through a helper.

**A name given arithmetic.** `Terms.affine` reads through a `let` node to the form its initializer has, but a name read on its own inside that `let` was a term of its own. So a branch settled something about the name while the construction asked about the initializer, and the two never met: `Yen(atLeastOne(n + 1))` was reported though the same expression written inline discharges. A name is read through to what it was given, which is what `<<invariant-discharge-terms>>` says relates the two.

**Re-entering a binding.** A branch is read from where its conditional stood, over a tree that still holds those binders. Running the transition a second time would assign the name its form again, and an assignment forgets what was known of what it assigns to — including what the branch had just established.

**A conjunction.** It carried its obligations but not whether a conjunct was left to the run-time check, so an invariant with one clause discharged and one unreadable came out proven. `Predicates.Owed` carries both, and a conjunction concatenates the one and takes the disjunction of the other.

## What the check could not read is not what it proved

`PROVED` meant "every clause is discharged, or none of them is expressible". `Predicates.obligations` answers those separately, and the caller collapsed them. The verdicts are now REFUTED over UNKNOWN over UNREPRESENTABLE over PROVED, and two readings of one construction combine by whether each found anything that may fail rather than by what is reported of it.

Nothing is reported differently. Whether a construction the check could not read should say so is a question about what E2011 reports, and it is not answered here.

## Tests

`AConditionalIsReadInTheScopeItStandsInTest` holds the rule as scope and not as helpers: a conditional under one binder, under two, under nested expansions, and reached wherever the construction stands; a name given arithmetic read as that arithmetic; a construction inside a condition read in that scope; a binding out of scope for its own initializer; and a condition that settles nothing about what is built still reported.

`WhatTheCheckCouldNotReadIsNotWhatItProvedTest` reads the verdicts rather than the diagnostics, because the difference it holds is the one no diagnostic reports. Two of the four verdicts are silent, and a distinction nothing can read is one that stops being true without anything failing.

Each fix was put back one at a time to see its test fail.

`mvn clean test`: 3567 tests, 0 failures, with `origin/develop` merged in.

## Left alone

`capabilityOf` collapses the same two answers, and there it is observable: `invariant trivial = 0 <= 1` compiles, and the editor is told `RUNTIME_ONLY`, "it names a term the check cannot name", of a clause that folded to true. Separating it needs a fourth `ClauseDischarge.Kind`, which is a classification the specification states, so it is not done here.

`sameConditional` keys every candidate in the site's environment rather than each in its own, so two conditionals computing one value under different binders are read as two. Noted where it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
