### PR TITLE
The library listing takes its order from the library, not from two passes

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
@@ -96,18 +96,26 @@ public final class ApiCommand {
      * what the specification tells a reader to call, so it is listed under its own name and with
      * only the arguments its caller writes. Leaving it out would have this command contradict the
      * specification about what exists.
+     *
+     * <p>Which names those are and what order they come in are both {@link Prelude#published()}'s
+     * answer, walked here rather than rebuilt: a listing assembled from the declarations and then
+     * the rewrites puts every sugar after every module, whichever module it reads as. What each
+     * name's signature comes from is this command's own question, and the only one it decides.
      */
     static Map<String, Signature> surface() {
         Map<String, Signature> surface = new LinkedHashMap<>();
-        for (Map.Entry<String, Prelude.PreludeEntry> e : Prelude.entries().entrySet()) {
-            if (Prelude.published().contains(e.getKey())) {
-                surface.put(e.getKey(), declared(e.getValue(), e.getValue().signature().params().size()));
+        for (String name : Prelude.published()) {
+            Prelude.Rewrite rewrite = Prelude.rewriteOf(name);
+            if (rewrite != null) {
+                Prelude.PreludeEntry target = Prelude.entry(rewrite.target().qualified());
+                if (target != null) {
+                    surface.put(name, declared(target, rewrite.keptArgs()));
+                }
+                continue;
             }
-        }
-        for (Map.Entry<String, Prelude.Rewrite> e : Prelude.rewrites().entrySet()) {
-            Prelude.PreludeEntry target = Prelude.entry(e.getValue().target().qualified());
-            if (target != null) {
-                surface.put(e.getKey(), declared(target, e.getValue().keptArgs()));
+            Prelude.PreludeEntry entry = Prelude.entry(name);
+            if (entry != null) {
+                surface.put(name, declared(entry, entry.signature().params().size()));
             }
         }
         return surface;

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheApiCommandAnswersTheStdlibSurfaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheApiCommandAnswersTheStdlibSurfaceTest.java
@@ -1,6 +1,7 @@
 package souther.compiler.doc;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.Prelude;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -36,6 +37,23 @@ class TheApiCommandAnswersTheStdlibSurfaceTest {
         List<String> lines = answer.out().lines().toList();
         assertTrue(lines.stream().anyMatch(l -> l.startsWith("List.map(")), "List.map is listed:\n" + answer.out());
         assertTrue(lines.stream().anyMatch(l -> l.startsWith("String.length(")), "String.length is listed");
+    }
+
+    @Test
+    void withNoArgumentNamesFollowThePublishedModuleOrder() {
+        Answer answer = run();
+
+        assertEquals(0, answer.code());
+        List<String> listed = answer.out().lines()
+                .map(line -> line.substring(0, line.indexOf('(')))
+                .toList();
+
+        assertEquals(List.copyOf(Prelude.published()), listed,
+                "the listing is one module's vocabulary at a time, and the library is what says"
+                        + " which module a name reads as:\n" + answer.out());
+        assertTrue(listed.indexOf("List.fold") < listed.indexOf("Set.empty"),
+                "a name callable only through its sugar stays in the block of the module it is"
+                        + " called through:\n" + answer.out());
     }
 
     @Test


### PR DESCRIPTION
`souther api` with no argument printed `List.fold` as the last line of the listing, after `Option`, instead of in the `List` block. Refs #408.

## Root cause

`ApiCommand.surface()` built the listing in two passes — `Prelude.entries()` (declarations, in load order) and then `Prelude.rewrites()` — into a `LinkedHashMap`, so a sugar, having no declaration for the first pass to find, was appended after every module. `Prelude.published()` was consulted in the first pass only as a membership predicate, though it is the thing that answers the ordering question: it walks the qualifiers and places a sugar at the end of the module it belongs to.

So this is not a misplaced name. The order had one source of truth and this command rebuilt it.

## Change

`surface()` walks `Prelude.published()`. Where each name's signature comes from — the rewrite target or the declaration — is decided by `rewriteOf(name)` / `entry(name)`, which is the only question this command still answers. Behaviour for a name the library cannot resolve is unchanged: it is dropped, not thrown on.

`--search` filters the same order, so it follows without a change of its own.

## Test

`withNoArgumentNamesFollowThePublishedModuleOrder` asserts the listing's whole name sequence against `Prelude.published()`, so adding a function to a module does not require editing an expected value. One further assertion places `List.fold` before `Set.empty`, so the reported case is legible when it fails.

Before the change the sequence assertion fails with `List.fold` as the only difference.

## Verification

`mvn clean test` — BUILD SUCCESS across all modules.