### PR TITLE
What a module declared and what it took on to emit are two components

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -768,9 +768,11 @@ public final class FixtureReader {
         if (Prelude.isLibraryFunction(reached)) {
             return true;   // a standard-library function: an intrinsic, or one nothing emitted here
         }
-        for (Ast.FnDef fn : module.fns()) {
-            if (fn.name().equals(reached) && !fn.params().isEmpty()) {
-                return true;
+        for (List<Ast.FnDef> component : List.of(module.fns(), module.takenOn())) {
+            for (Ast.FnDef fn : component) {
+                if (fn.name().equals(reached) && !fn.params().isEmpty()) {
+                    return true;
+                }
             }
         }
         return false;

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -213,6 +213,23 @@ public interface Ast {
      * written in the {@code exposing} list ({@code exposing ( name : A | B )}, spec 14.5). An exposed
      * {@code >->} composition must have one, checked to match its inferred output (ADR-0024); other
      * exposed names carry no signature (their type is at the definition).
+     *
+     * <p>{@code fns} is what the source wrote, and it stays that at every stage. {@code takenOn} is
+     * what the module emits as methods of its own without having declared them: a recursive helper it
+     * reaches, whether the standard library declares it or another module published it, has to be
+     * lowered to a method somewhere and the module compiling is where it goes. Both are emitted; only
+     * the first is declared here, and no rule reads a name to tell them apart — {@code List.foldFrom}
+     * is reached under the library's alias and declared in {@code souther.list}.
+     *
+     * <p>Two components rather than one list a later pass appends to. Appended, every reader asking
+     * what the module declared got what it declared before {@link
+     * souther.compiler.query.Shapes.Prepared} and that plus these after — the {@code exposing} check,
+     * the value namespace a body is resolved against, and what the module publishes among them.
+     *
+     * <p>Whoever rebuilds a module carries {@code takenOn} across, and there is no constructor that
+     * defaults it: a rebuild that quietly dropped it would put a module through codegen with the
+     * methods its bodies call missing, which is the failure this separation is here to make
+     * impossible.
      */
     record Module(String name,
                   List<String> exposing,
@@ -221,6 +238,7 @@ public interface Ast {
                   List<Def> defs,
                   List<BehaviorDef> behaviors,
                   List<FnDef> fns,
+                  List<FnDef> takenOn,
                   List<Example> examples,
                   List<Fake> fakes,
                   String exampleFileTarget,

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -215,11 +215,13 @@ public interface Ast {
      * exposed names carry no signature (their type is at the definition).
      *
      * <p>{@code fns} is what the source wrote, and it stays that at every stage. {@code takenOn} is
-     * what the module emits as methods of its own without having declared them: a recursive helper it
-     * reaches, whether the standard library declares it or another module published it, has to be
-     * lowered to a method somewhere and the module compiling is where it goes. Both are emitted; only
-     * the first is declared here, and no rule reads a name to tell them apart — {@code List.foldFrom}
-     * is reached under the library's alias and declared in {@code souther.list}.
+     * what the module took on to emit as methods of its own without having declared them, which is
+     * two kinds of helper: a recursive one it reaches, which cannot be inlined and has to be lowered
+     * somewhere, and a non-recursive one an {@code example} row applies, which a row runs rather than
+     * expands (ADR-0077). Either may be declared by the standard library or by a module that
+     * published it. Only {@code fns} is declared here, and no rule reads a name to tell the two apart
+     * — {@code List.foldFrom} is reached under the library's alias and declared in
+     * {@code souther.list}.
      *
      * <p>Two components rather than one list a later pass appends to. Appended, every reader asking
      * what the module declared got what it declared before {@link
@@ -229,7 +231,8 @@ public interface Ast {
      * <p>Whoever rebuilds a module carries {@code takenOn} across, and there is no constructor that
      * defaults it: a rebuild that quietly dropped it would put a module through codegen with the
      * methods its bodies call missing, which is the failure this separation is here to make
-     * impossible.
+     * impossible. The arity says something has to be passed; that it is this module's own is what a
+     * reader of the rebuild has to see, which is why every one of them names it.
      */
     record Module(String name,
                   List<String> exposing,

--- a/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Exposing.java
@@ -131,7 +131,7 @@ public final class Exposing {
             return module;
         }
         return new Ast.Module(module.name(), module.exposing(), module.exposedOutputs(),
-                kept, module.defs(), module.behaviors(), module.fns(),
+                kept, module.defs(), module.behaviors(), module.fns(), module.takenOn(),
                 module.examples(), module.fakes(), module.exampleFileTarget(), module.pos());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -316,7 +316,7 @@ public final class HelperInliner {
         followingValues(work, table.reachable(),
                 e -> helpersNamedIn(e, table.reachable(), named));
         for (String name : graph.reachedFrom(named)) {
-            if (graph.recurses(name) && !table.emits().containsKey(name)) {
+            if (graph.recurses(name) && !table.held().containsKey(name)) {
                 takenOnRecursive.add(name);
             }
         }
@@ -390,7 +390,7 @@ public final class HelperInliner {
     public Map<String, Ast.FnDef> injectedExampleHelpers() {
         Map<String, Ast.FnDef> out = new java.util.LinkedHashMap<>();
         for (String name : exampleHelpers) {
-            if (table.emits().containsKey(name)) {
+            if (table.held().containsKey(name)) {
                 continue;
             }
             Ast.FnDef def = table.reached(name);
@@ -407,7 +407,7 @@ public final class HelperInliner {
     public Set<String> recursiveHelpers() {
         Set<String> result = new java.util.LinkedHashSet<>();
         for (String name : graph.recursive()) {
-            if (table.emits().containsKey(name)) {
+            if (table.held().containsKey(name)) {
                 result.add(name);
             }
         }
@@ -438,8 +438,8 @@ public final class HelperInliner {
      * ({@link Ast.FnDef#declaredBy}), and a check whose rule is about the declaring module — what
      * may be walked, what must be proven total — asks it there.
      */
-    public Map<String, Ast.FnDef> emits() {
-        return table.emits();
+    public Map<String, Ast.FnDef> held() {
+        return table.held();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -217,9 +217,9 @@ public final class HelperInliner {
      * <p>They are in the table and not in {@code own}, as they are for {@link #forModule}: an imported
      * definition is one this module expands and not one it declares.
      */
-    public static HelperInliner forHelpers(String module, Map<String, Ast.FnDef> own,
+    public static HelperInliner forHelpers(String module, Map<String, Ast.FnDef> declared,
                                            Map<String, Ast.FnDef> imported, InliningPolicy policy) {
-        HelperTable table = HelperTable.of(module, own, imported, policy);
+        HelperTable table = HelperTable.of(module, declared, Map.of(), imported, policy);
         return over(table, HelperGraph.of(table));
     }
 
@@ -247,19 +247,31 @@ public final class HelperInliner {
         return this;
     }
 
-    /** A module's helpers: the fns that implement no behavior, keyed by name. */
+    /** The helpers a module declares: the fns its source wrote that implement no behavior, keyed by
+     * the name it declared each under. Not what it took on to emit — that is {@link #takenOnBy}, and
+     * the two are separate components of the module so that this answer is the same at every stage. */
     public static Map<String, Ast.FnDef> helpersOf(Ast.Module module) {
+        return keyed(module, module.fns());
+    }
+
+    /** The helpers a module emits without having declared them, keyed by the name it reaches each by.
+     * Empty until the pass that works out what the module reaches has run. */
+    public static Map<String, Ast.FnDef> takenOnBy(Ast.Module module) {
+        return keyed(module, module.takenOn());
+    }
+
+    private static Map<String, Ast.FnDef> keyed(Ast.Module module, List<Ast.FnDef> fns) {
         Set<String> behaviorNames = new HashSet<>();
         for (Ast.BehaviorDef b : module.behaviors()) {
             behaviorNames.add(b.name());
         }
-        Map<String, Ast.FnDef> own = new LinkedHashMap<>();
-        for (Ast.FnDef fn : module.fns()) {
+        Map<String, Ast.FnDef> out = new LinkedHashMap<>();
+        for (Ast.FnDef fn : fns) {
             if (!behaviorNames.contains(fn.name())) {
-                own.put(fn.name(), fn);
+                out.put(fn.name(), fn);
             }
         }
-        return own;
+        return out;
     }
 
     /**
@@ -304,7 +316,7 @@ public final class HelperInliner {
         followingValues(work, table.reachable(),
                 e -> helpersNamedIn(e, table.reachable(), named));
         for (String name : graph.reachedFrom(named)) {
-            if (graph.recurses(name) && !table.holds(name)) {
+            if (graph.recurses(name) && !table.emits().containsKey(name)) {
                 takenOnRecursive.add(name);
             }
         }
@@ -378,7 +390,7 @@ public final class HelperInliner {
     public Map<String, Ast.FnDef> injectedExampleHelpers() {
         Map<String, Ast.FnDef> out = new java.util.LinkedHashMap<>();
         for (String name : exampleHelpers) {
-            if (table.holds(name)) {
+            if (table.emits().containsKey(name)) {
                 continue;
             }
             Ast.FnDef def = table.reached(name);
@@ -395,7 +407,7 @@ public final class HelperInliner {
     public Set<String> recursiveHelpers() {
         Set<String> result = new java.util.LinkedHashSet<>();
         for (String name : graph.recursive()) {
-            if (table.holds(name)) {
+            if (table.emits().containsKey(name)) {
                 result.add(name);
             }
         }
@@ -426,8 +438,8 @@ public final class HelperInliner {
      * ({@link Ast.FnDef#declaredBy}), and a check whose rule is about the declaring module — what
      * may be walked, what must be proven total — asks it there.
      */
-    public Map<String, Ast.FnDef> helpers() {
-        return table.fns();
+    public Map<String, Ast.FnDef> emits() {
+        return table.emits();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInvariants.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInvariants.java
@@ -103,7 +103,8 @@ public final class HelperInvariants {
             }
         }
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
-                defs, m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
+                defs, m.behaviors(), m.fns(), m.takenOn(), m.examples(), m.fakes(),
+                m.exampleFileTarget(), m.pos());
     }
 
     /** The conjuncts of an invariant expression, flattened, in the order they are written — what a

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -91,8 +91,11 @@ public final class HelperNames {
             }
             fakes.add(new Ast.Fake(fake.target(), rows, fake.pos()));
         }
+        // Nothing is taken on until the pass below this one works out what the module reaches, so
+        // there is none here to qualify — and what does arrive there is named by the module that
+        // declares it already.
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
-                m.behaviors(), fns, examples, fakes, m.exampleFileTarget(), m.pos());
+                m.behaviors(), fns, m.takenOn(), examples, fakes, m.exampleFileTarget(), m.pos());
     }
 
     /** {@code m} with the foreign names in its invariants written qualified, and nothing else
@@ -102,8 +105,8 @@ public final class HelperNames {
         List<Ast.Def> defs = qualifiedInvariants(m);
         return defs.equals(m.defs()) ? m
                 : new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
-                        m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(),
-                        m.pos());
+                        m.behaviors(), m.fns(), m.takenOn(), m.examples(), m.fakes(),
+                        m.exampleFileTarget(), m.pos());
     }
 
     /** {@code m}'s declarations with every name in an invariant that denotes another module's

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperNames.java
@@ -92,8 +92,8 @@ public final class HelperNames {
             fakes.add(new Ast.Fake(fake.target(), rows, fake.pos()));
         }
         // Nothing is taken on until the pass below this one works out what the module reaches, so
-        // there is none here to qualify — and what does arrive there is named by the module that
-        // declares it already.
+        // there is none here to qualify — and what arrives there is already named by the name this
+        // module reaches it by, which is what it will be emitted under.
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), defs,
                 m.behaviors(), fns, m.takenOn(), examples, fakes, m.exampleFileTarget(), m.pos());
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -74,7 +74,7 @@ final class HelperParams {
             recursiveHelperFns = Map.of();
         }
         Map<String, Ast.FnDef> settled = new LinkedHashMap<>();
-        for (Ast.FnDef h : inliner.emits().values()) {
+        for (Ast.FnDef h : inliner.held().values()) {
             if (recursive.contains(h.name())) {
                 continue;   // a recursive helper is not inlined and declares its parameters (spec 13.1)
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -74,7 +74,7 @@ final class HelperParams {
             recursiveHelperFns = Map.of();
         }
         Map<String, Ast.FnDef> settled = new LinkedHashMap<>();
-        for (Ast.FnDef h : inliner.helpers().values()) {
+        for (Ast.FnDef h : inliner.emits().values()) {
             if (recursive.contains(h.name())) {
                 continue;   // a recursive helper is not inlined and declares its parameters (spec 13.1)
             }
@@ -86,12 +86,21 @@ final class HelperParams {
         if (settled.isEmpty()) {
             return m;
         }
-        List<Ast.FnDef> fns = new ArrayList<>();
-        for (Ast.FnDef fn : m.fns()) {
-            fns.add(settled.getOrDefault(fn.name(), fn));
-        }
+        // Both, and each back where it was. A helper the module took on to emit has parameters to
+        // settle like any other, and one written back into the wrong component would be a
+        // declaration this module never wrote.
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), m.defs(),
-                m.behaviors(), fns, m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
+                m.behaviors(), written(m.fns(), settled), written(m.takenOn(), settled),
+                m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
+    }
+
+    /** {@code fns} with each one that {@code settled} answered for replaced by what it settled to. */
+    private static List<Ast.FnDef> written(List<Ast.FnDef> fns, Map<String, Ast.FnDef> settled) {
+        List<Ast.FnDef> out = new ArrayList<>();
+        for (Ast.FnDef fn : fns) {
+            out.add(settled.getOrDefault(fn.name(), fn));
+        }
+        return out;
     }
 
     /**
@@ -105,13 +114,15 @@ final class HelperParams {
         for (Ast.BehaviorDef b : m.behaviors()) {
             behaviors.add(b.name());
         }
-        for (Ast.FnDef fn : m.fns()) {
-            if (behaviors.contains(fn.name())) {
-                continue;
-            }
-            for (Ast.FnParam p : fn.params()) {
-                if (p.type() == null) {
-                    return true;
+        for (List<Ast.FnDef> fns : List.of(m.fns(), m.takenOn())) {
+            for (Ast.FnDef fn : fns) {
+                if (behaviors.contains(fn.name())) {
+                    continue;
+                }
+                for (Ast.FnParam p : fn.params()) {
+                    if (p.type() == null) {
+                        return true;
+                    }
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
@@ -21,17 +21,24 @@ import java.util.Map;
  * it is reached by here. A qualified call resolves to whichever of the two declared it, a bare call
  * to the module's own — the standard library has no bare names (spec §stdlib).
  *
- * <p>{@link #fns} keeps the order the module wrote its helpers in, and that is load-bearing: the
+ * <p>Three questions are asked of what is here, and each has a surface of its own, so a caller
+ * cannot ask one and be answered by another:
+ *
+ * <ul>
+ *   <li>{@link #reached} — which declaration a call expands to. A call edge, asked with a reach name.
+ *   <li>{@link #declarations} — what this module's source wrote. Declarations, keyed by the names it
+ *       declared them under.
+ *   <li>{@link #emits} — what becomes a method of this module: what it declared, and what it took on
+ *       to emit because it reaches a recursive helper it did not write.
+ * </ul>
+ *
+ * <p>{@link #emits} keeps the order the module wrote its helpers in, and that is load-bearing: the
  * checks walk it and stop at the first helper they find wrong, so the order decides which one the
  * author is told about. An author reads their file from the top.
  *
- * <p>What is in {@link #fns} is what the module <em>has as a fn</em>, which is not the same as what
- * it declared. A module emits the recursive helpers it reaches as its own methods, so from
- * {@code Shapes.Prepared} on, a prelude {@code List.foldFrom} and a helper another module published
- * sit there beside the module's own {@code let}s. Nothing here answers which module declared one:
- * the declaration answers that ({@link Ast.FnDef#declaredBy}), because the name it is reached by
- * cannot — {@code List.foldFrom} is reached under the library's alias and declared in
- * {@code souther.list}.
+ * <p>Nothing here answers which module declared a taken-on helper: the declaration answers that
+ * ({@link Ast.FnDef#declaredBy}), because the name it is reached by cannot — {@code List.foldFrom}
+ * is reached under the library's alias and declared in {@code souther.list}.
  *
  * <p>What is in the table depends on {@link InliningPolicy}, which is what an expanded tree is a
  * representation <em>of</em>. Two policies are two tables and not one table read two ways.
@@ -41,27 +48,37 @@ public final class HelperTable {
     private final String module;
     private final InliningPolicy policy;
     private final Map<String, Ast.FnDef> reached;
-    private final Map<String, Ast.FnDef> own;
+    private final Map<String, Ast.FnDef> declared;
+    private final Map<String, Ast.FnDef> emits;
 
-    private HelperTable(String module, InliningPolicy policy,
-                        Map<String, Ast.FnDef> reached, Map<String, Ast.FnDef> own) {
+    private HelperTable(String module, InliningPolicy policy, Map<String, Ast.FnDef> reached,
+                        Map<String, Ast.FnDef> declared, Map<String, Ast.FnDef> emits) {
         this.module = module;
         this.policy = policy;
         this.reached = reached;
-        this.own = own;
+        this.declared = declared;
+        this.emits = emits;
     }
 
     /**
-     * The table a body of {@code module} is expanded against: what it declares itself, what the
-     * modules it imports publish to it, and — under {@link InliningPolicy#FULL} — the standard
-     * library underneath both.
+     * The table a body of {@code module} is expanded against, built from the three sources apart:
+     * what the module declared, what it took on to emit, what the modules it imports publish to it —
+     * and, under {@link InliningPolicy#FULL}, the standard library underneath all three.
+     *
+     * <p>Apart, because what a name reaches and what this module holds are two relations and one of
+     * them cannot be recovered from the other. Handed a single joined map, a table answered that the
+     * module has every published definition as a fn of its own, and the caller that held the three
+     * apart answered that it has none of them.
      */
-    public static HelperTable of(String module, Map<String, Ast.FnDef> own,
+    public static HelperTable of(String module, Map<String, Ast.FnDef> declared,
+                                 Map<String, Ast.FnDef> takenOn,
                                  Map<String, Ast.FnDef> imported, InliningPolicy policy) {
         // In the order they are written, so a module with two helpers to complain about complains
         // about the earlier one first.
+        Map<String, Ast.FnDef> emits = new LinkedHashMap<>(declared);
+        emits.putAll(takenOn);
         Map<String, Ast.FnDef> joined = new LinkedHashMap<>(imported);
-        joined.putAll(own);
+        joined.putAll(emits);
         Map<String, Ast.FnDef> reached;
         if (policy == InliningPolicy.FULL) {
             reached = new LinkedHashMap<>(Prelude.helpers());
@@ -69,13 +86,14 @@ public final class HelperTable {
         } else {
             reached = joined;
         }
-        return new HelperTable(module, policy, reached, new LinkedHashMap<>(own));
+        return new HelperTable(module, policy, reached, new LinkedHashMap<>(declared), emits);
     }
 
-    /** The same, for a module whose own helpers are read off its declarations. */
+    /** The same, reading the two components off the module rather than being handed them. */
     public static HelperTable of(Ast.Module module, Map<String, Ast.FnDef> imported,
                                  InliningPolicy policy) {
-        return of(module.name(), HelperInliner.helpersOf(module), imported, policy);
+        return of(module.name(), HelperInliner.helpersOf(module),
+                HelperInliner.takenOnBy(module), imported, policy);
     }
 
     /**
@@ -95,7 +113,7 @@ public final class HelperTable {
         for (String name : names) {
             any |= narrowed.remove(name) != null;
         }
-        return any ? new HelperTable(module, policy, narrowed, own) : this;
+        return any ? new HelperTable(module, policy, narrowed, declared, emits) : this;
     }
 
     /** The module whose body this expands into. */
@@ -123,16 +141,19 @@ public final class HelperTable {
         return Collections.unmodifiableMap(reached);
     }
 
-    /** The module's helpers, in the order it wrote them — what it declared, and what it took on as
-     * its own fns to emit. Which of the two one is, the declaration says. */
-    public Map<String, Ast.FnDef> fns() {
-        return Collections.unmodifiableMap(own);
+    /** What this module's source wrote, in the order it wrote it. A helper the module only took on to
+     * emit is not among these, however it is reached — and which of the two one is, the declaration
+     * says ({@link Ast.FnDef#declaredBy}); a rule about the declaring module asks it there rather
+     * than reading which component a fn arrived in. */
+    public Map<String, Ast.FnDef> declarations() {
+        return Collections.unmodifiableMap(declared);
     }
 
-    /** Whether the module has {@code name} as a fn of its own — one it declared, or one it took on
-     * to emit. Not whether it declared it: for that, ask the declaration. */
-    public boolean holds(String name) {
-        return own.containsKey(name);
+    /** What becomes a method of this module, in the order it wrote its own: what it declared, and
+     * what it took on to emit. Which of the two one is, the declaration says
+     * ({@link Ast.FnDef#declaredBy}). */
+    public Map<String, Ast.FnDef> emits() {
+        return Collections.unmodifiableMap(emits);
     }
 
     /**
@@ -146,12 +167,13 @@ public final class HelperTable {
     public boolean equals(Object other) {
         return other instanceof HelperTable t
                 && module.equals(t.module) && policy == t.policy
-                && reached.equals(t.reached) && own.equals(t.own);
+                && reached.equals(t.reached) && declared.equals(t.declared)
+                && emits.equals(t.emits);
     }
 
     @Override
     public int hashCode() {
-        return java.util.Objects.hash(module, policy, reached, own);
+        return java.util.Objects.hash(module, policy, reached, declared, emits);
     }
 
     @Override

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTable.java
@@ -28,11 +28,16 @@ import java.util.Map;
  *   <li>{@link #reached} — which declaration a call expands to. A call edge, asked with a reach name.
  *   <li>{@link #declarations} — what this module's source wrote. Declarations, keyed by the names it
  *       declared them under.
- *   <li>{@link #emits} — what becomes a method of this module: what it declared, and what it took on
- *       to emit because it reaches a recursive helper it did not write.
+ *   <li>{@link #held} — what this module has as fns of its own: what it declared, and what it took
+ *       on to emit for lack of anywhere else to put it.
  * </ul>
  *
- * <p>{@link #emits} keeps the order the module wrote its helpers in, and that is load-bearing: the
+ * <p>{@link #held} is not what becomes a method. Most of what a module declares is expanded into its
+ * callers and emitted nowhere, and a value has no method form at all; which of these survive is
+ * decided at lowering, over this and the answers about recursion and rows. What is held here is the
+ * question of whose fn it is, which is the one every check needs.
+ *
+ * <p>{@link #held} keeps the order the module wrote its helpers in, and that is load-bearing: the
  * checks walk it and stop at the first helper they find wrong, so the order decides which one the
  * author is told about. An author reads their file from the top.
  *
@@ -149,10 +154,10 @@ public final class HelperTable {
         return Collections.unmodifiableMap(declared);
     }
 
-    /** What becomes a method of this module, in the order it wrote its own: what it declared, and
-     * what it took on to emit. Which of the two one is, the declaration says
-     * ({@link Ast.FnDef#declaredBy}). */
-    public Map<String, Ast.FnDef> emits() {
+    /** What this module has as fns of its own, in the order it wrote its own: what it declared, and
+     * what it took on to emit. Not what becomes a method — that is decided at lowering. Which of the
+     * two one is, the declaration says ({@link Ast.FnDef#declaredBy}). */
+    public Map<String, Ast.FnDef> held() {
         return Collections.unmodifiableMap(emits);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -42,7 +42,7 @@ public final class HelperTyping {
                                      Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns,
                                      Map<String, Ast.Expr> loweredBodies,
                                      TypeChecker.Elaborated elaborated) {
-        for (Ast.FnDef h : inliner.emits().values()) {
+        for (Ast.FnDef h : inliner.held().values()) {
             boolean recursive = recursiveHelperFns.containsKey(h.name());
             Scope env = Scope.NONE;
             List<Integer> inferred = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -42,7 +42,7 @@ public final class HelperTyping {
                                      Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns,
                                      Map<String, Ast.Expr> loweredBodies,
                                      TypeChecker.Elaborated elaborated) {
-        for (Ast.FnDef h : inliner.helpers().values()) {
+        for (Ast.FnDef h : inliner.emits().values()) {
             boolean recursive = recursiveHelperFns.containsKey(h.name());
             Scope env = Scope.NONE;
             List<Integer> inferred = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/Lower.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Lower.java
@@ -86,9 +86,11 @@ public final class Lower {
         return bindings;
     }
 
-    /** {@code module} with {@code fns} as its fns and every data invariant desugared — the tree the
-     * backend emits from. */
-    public static Ast.Module lowered(Ast.Module module, List<Ast.FnDef> fns) {
+    /** {@code module} with {@code fns} as its declarations, {@code takenOn} as what it emits without
+     * having declared, and every data invariant desugared — the tree the backend emits from. The two
+     * stay apart down here: both become methods, and only the first is this module's to answer for. */
+    public static Ast.Module lowered(Ast.Module module, List<Ast.FnDef> fns,
+                                     List<Ast.FnDef> takenOn) {
         List<Ast.Def> defs = new ArrayList<>();
         for (Ast.Def def : module.defs()) {
             if (def instanceof Ast.Data d && !d.invariants().isEmpty()) {
@@ -100,7 +102,7 @@ public final class Lower {
             }
         }
         return new Ast.Module(module.name(), module.exposing(), module.exposedOutputs(),
-                module.imports(), defs, module.behaviors(), fns,
+                module.imports(), defs, module.behaviors(), fns, takenOn,
                 module.examples(), module.fakes(), module.exampleFileTarget(), module.pos());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/NewtypeDesugar.java
@@ -39,7 +39,8 @@ public final class NewtypeDesugar {
             fns.add(fn.withBody(body));
         }
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
-                m.defs(), m.behaviors(), fns, m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
+                m.defs(), m.behaviors(), fns, m.takenOn(), m.examples(), m.fakes(),
+                m.exampleFileTarget(), m.pos());
     }
 
     /**
@@ -60,7 +61,8 @@ public final class NewtypeDesugar {
             }
         }
         return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
-                defs, m.behaviors(), m.fns(), m.examples(), m.fakes(), m.exampleFileTarget(), m.pos());
+                defs, m.behaviors(), m.fns(), m.takenOn(), m.examples(), m.fakes(),
+                m.exampleFileTarget(), m.pos());
     }
 
     private static Ast.Expr go(Ast.Expr e, Symbols symbols) {

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -67,7 +67,7 @@ final class PartialReachability {
 
     static PartialReachability of(HelperInliner inliner) {
         Map<String, List<String>> calls = new LinkedHashMap<>();
-        for (Map.Entry<String, Ast.FnDef> entry : inliner.emits().entrySet()) {
+        for (Map.Entry<String, Ast.FnDef> entry : inliner.held().entrySet()) {
             // Only what this module declared is a node. What it took on to emit — a prelude helper,
             // one another module published — is a terminal, because its declaration already answers
             // for its whole closure (ADR-0098). It is in the same map and under a name of the same

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -67,7 +67,7 @@ final class PartialReachability {
 
     static PartialReachability of(HelperInliner inliner) {
         Map<String, List<String>> calls = new LinkedHashMap<>();
-        for (Map.Entry<String, Ast.FnDef> entry : inliner.helpers().entrySet()) {
+        for (Map.Entry<String, Ast.FnDef> entry : inliner.emits().entrySet()) {
             // Only what this module declared is a node. What it took on to emit — a prelude helper,
             // one another module published — is a terminal, because its declaration already answers
             // for its whole closure (ADR-0098). It is in the same map and under a name of the same

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -276,7 +276,8 @@ public final class Resolve {
         }
         return new Resolved(
                 new Ast.Module(m.name(), m.exposing(), exposedOutputs, m.imports(), defs,
-                        behaviors, fns, examples, fakes, m.exampleFileTarget(), m.pos()),
+                        behaviors, fns, m.takenOn(), examples, fakes, m.exampleFileTarget(),
+                        m.pos()),
                 List.copyOf(r.denotations), List.copyOf(r.values0), List.copyOf(r.unresolved),
                 Map.copyOf(r.binders));
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -51,7 +51,7 @@ final class TotalityChecker {
     /** Checks every non-{@code partial}, module-own recursive helper (or group) for size-change
      * termination. */
     static void check(HelperInliner inliner) {
-        Map<String, Ast.FnDef> own = inliner.emits();
+        Map<String, Ast.FnDef> own = inliner.held();
         Map<String, Set<String>> ownEdges = ownCallGraph(own);
         Set<String> handled = new HashSet<>();
         for (String name : inliner.recursiveHelpers()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TotalityChecker.java
@@ -51,7 +51,7 @@ final class TotalityChecker {
     /** Checks every non-{@code partial}, module-own recursive helper (or group) for size-change
      * termination. */
     static void check(HelperInliner inliner) {
-        Map<String, Ast.FnDef> own = inliner.helpers();
+        Map<String, Ast.FnDef> own = inliner.emits();
         Map<String, Set<String>> ownEdges = ownCallGraph(own);
         Set<String> handled = new HashSet<>();
         for (String name : inliner.recursiveHelpers()) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -381,7 +381,7 @@ public final class TypeChecker {
         // per declaration, so a module needing the word in several places says so in one build. Which
         // declarations each rule is about is the rule's own to say (see PartialHelperUse): the fns here
         // hold what this module took on to emit as well as what it wrote.
-        for (Ast.FnDef helper : inliner.emits().values()) {
+        for (Ast.FnDef helper : inliner.held().values()) {
             collect(errors, abandoned,
                     () -> PartialHelperUse.rejectReachingPartial(helper, module.name(), reachability));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -186,8 +186,14 @@ public final class TypeChecker {
                                         Map<String, ReqSig> reqSigs,
                                         Map<String, Type> recursiveHelperFns,
                                         Map<String, Ast.FnDef> publishedToHere) {
+        // Both components, because what reads this walks both: a helper is checked whether the module
+        // declared it or took it on to emit, and one missing here is a helper checked against a body
+        // it does not have.
         Map<String, Ast.Expr> loweredBodies = new HashMap<>();
         for (Ast.FnDef fn : lowered.fns()) {
+            loweredBodies.put(fn.name(), fn.writtenBody());
+        }
+        for (Ast.FnDef fn : lowered.takenOn()) {
             loweredBodies.put(fn.name(), fn.writtenBody());
         }
         // The imported definitions join the table this module's bodies are expanded against: a
@@ -375,7 +381,7 @@ public final class TypeChecker {
         // per declaration, so a module needing the word in several places says so in one build. Which
         // declarations each rule is about is the rule's own to say (see PartialHelperUse): the fns here
         // hold what this module took on to emit as well as what it wrote.
-        for (Ast.FnDef helper : inliner.helpers().values()) {
+        for (Ast.FnDef helper : inliner.emits().values()) {
             collect(errors, abandoned,
                     () -> PartialHelperUse.rejectReachingPartial(helper, module.name(), reachability));
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -49,13 +49,17 @@ public final class ValueCycles {
      */
     public static void rejectIn(Ast.Module m, Map<String, Ast.FnDef> published) {
         HelperTable table = HelperTable.of(m, published, InliningPolicy.FULL);
+        // What the module declared, which is what a value cycle is about: a value written in terms of
+        // itself is a defect in what the author wrote, and a helper the module only took on to emit
+        // was written by somebody else and answered for there.
+        Map<String, Ast.FnDef> declared = table.declarations();
         Map<String, Set<String>> callsOf = new LinkedHashMap<>();
-        for (Map.Entry<String, Ast.FnDef> e : table.fns().entrySet()) {
+        for (Map.Entry<String, Ast.FnDef> e : declared.entrySet()) {
             Set<String> called = new LinkedHashSet<>();
             HelperInliner.helperCallsIn(e.getValue().writtenBody(), table.reachable(), called);
             callsOf.put(e.getKey(), called);
         }
-        reject(table.fns(), callsOf);
+        reject(declared, callsOf);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -61,6 +61,21 @@ public final class Backend {
     /** The checker's elaborated bodies: what this emits from (issue #81). */
     private final TypeChecker.Checked checked;
 
+    /**
+     * Every fn {@code module} emits a method for: what its source declared, and what it took on to
+     * emit because it reaches a recursive helper it did not write.
+     *
+     * <p>The two are one question down here and two everywhere above. What may be walked, what must
+     * be proven total, what the module publishes — each of those is about the declaring module and
+     * reads the component the fn is in; a class being written is about neither, because a method is a
+     * method.
+     */
+    private static List<Ast.FnDef> emitted(Ast.Module module) {
+        List<Ast.FnDef> all = new ArrayList<>(module.fns());
+        all.addAll(module.takenOn());
+        return all;
+    }
+
     private Backend(CodegenContext ctx, TypeChecker.Checked checked) {
         this.ctx = ctx;
         this.pkg = ctx.pkg;
@@ -174,8 +189,10 @@ public final class Backend {
         for (Ast.BehaviorDef bd : module.behaviors()) {
             behaviorNames.add(bd.name());
         }
+        // Both components: a method is emitted for what the module declared and for what it took on
+        // to emit, and by the time a class is written there is no difference between them.
         Map<String, Ast.FnDef> recHelpers = new LinkedHashMap<>();
-        for (Ast.FnDef fn : module.fns()) {
+        for (Ast.FnDef fn : emitted(module)) {
             if (!behaviorNames.contains(fn.name())) {
                 recHelpers.put(fn.name(), fn);
             }
@@ -273,7 +290,7 @@ public final class Backend {
         // Behavior fn bodies arrive with their helper calls already inlined (the Lower stage,
         // ADR-0021); the backend emits them as-is and never lowers a helper on its own.
         Map<String, Ast.FnDef> fns = new HashMap<>();
-        for (Ast.FnDef fn : module.fns()) {
+        for (Ast.FnDef fn : emitted(module)) {
             fns.put(fn.name(), fn);
         }
         // Injection targets (spec 13.2): a SpecBehavior with no matching fn. Each becomes an

--- a/souther-compiler/src/main/java/souther/compiler/codegen/JvmLimits.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/JvmLimits.java
@@ -90,8 +90,13 @@ final class JvmLimits {
                 }
             }
         }
+        // What a class is written for, which is both components: the limit is the JVM's and does not
+        // ask who declared the fn.
         Set<String> implemented = new HashSet<>();
         for (Ast.FnDef fn : module.fns()) {
+            implemented.add(fn.name());
+        }
+        for (Ast.FnDef fn : module.takenOn()) {
             implemented.add(fn.name());
         }
         for (Ast.BehaviorDef bd : module.behaviors()) {

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -51,7 +51,7 @@ public final class Deriver {
             });
         }
         return new Ast.Module(module.name(), module.exposing(), module.exposedOutputs(),
-                module.imports(), defs, module.behaviors(), module.fns(),
+                module.imports(), defs, module.behaviors(), module.fns(), module.takenOn(),
                 module.examples(), module.fakes(), module.exampleFileTarget(), module.pos());
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -107,8 +107,10 @@ public final class AstBuilder {
                 default -> { /* MODULE_HEADER handled above; ERROR nodes are reported already */ }
             }
         }
+        // A source file declares; what the module takes on to emit follows from what its bodies reach
+        // and is worked out where that is known, which is not here.
         return new Ast.Module(name, exposing, exposedOutputs, imports, defs, behaviors, fns,
-                examples, fakes, null, pos);
+                List.of(), examples, fakes, null, pos);
     }
 
     /**
@@ -147,7 +149,7 @@ public final class AstBuilder {
             }
         }
         return new Ast.Module(target, List.of(), new HashMap<>(), List.of(), List.of(), List.of(),
-                values, examples, fakes, target, pos);
+                values, List.of(), examples, fakes, target, pos);
     }
 
     private CompileException onlyExamples(SyntaxNode n) {

--- a/souther-compiler/src/main/java/souther/compiler/frontend/ImplicitUnits.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/ImplicitUnits.java
@@ -83,8 +83,8 @@ public final class ImplicitUnits {
         List<Ast.Def> defs = new ArrayList<>(module.defs());
         defs.addAll(added.values());
         return new Ast.Module(module.name(), module.exposing(), module.exposedOutputs(),
-                module.imports(), defs, module.behaviors(), module.fns(), module.examples(),
-                module.fakes(), module.exampleFileTarget(), module.pos());
+                module.imports(), defs, module.behaviors(), module.fns(), module.takenOn(),
+                module.examples(), module.fakes(), module.exampleFileTarget(), module.pos());
     }
 
     private static void introduceAll(Ast.RetType output, Set<String> declared,

--- a/souther-compiler/src/main/java/souther/compiler/meta/PublishedModule.java
+++ b/souther-compiler/src/main/java/souther/compiler/meta/PublishedModule.java
@@ -135,8 +135,8 @@ public record PublishedModule(Ast.Module module, Set<String> injectedBehaviors) 
             return module;
         }
         return new Ast.Module(module.name(), module.exposing(), module.exposedOutputs(), needed,
-                module.defs(), module.behaviors(), module.fns(), module.examples(), module.fakes(),
-                module.exampleFileTarget(), module.pos());
+                module.defs(), module.behaviors(), module.fns(), module.takenOn(),
+                module.examples(), module.fakes(), module.exampleFileTarget(), module.pos());
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -576,17 +576,25 @@ public final class Bodies {
             Map<String, Ast.FnDef> out = new LinkedHashMap<>();
             for (Ast.Import imp : resolved.value().imports()) {
                 Answer<Ast.Module> from = db.ask(new Settled(imp.module()));
-                // Closed against everything the declaring module can name, not only what it declares:
-                // a published body may call a helper that module imported in turn, and a chain of
-                // three is where a table of its own definitions leaves the middle one unexpanded.
-                Answer<Map<String, Ast.FnDef>> table = db.ask(new ModuleDefinitions(imp.module()));
-                if (!from.present() || !table.present()) {
+                // Closed against the table that module's own bodies are expanded against, which is
+                // everything it can name and not only what it declares: a published body may call a
+                // helper that module imported in turn, and a chain of three is where a table of its
+                // own definitions leaves the middle one unexpanded.
+                //
+                // Its table and not a map of the same entries. A map says which declarations are
+                // there and nothing about which relation each is in, so handing one over is handing
+                // over the question of what it means — and the answer taken here would be this
+                // module's guess about another module's declarations.
+                Answer<Expanding.Of> against =
+                        db.ask(new Expanding(imp.module(), InliningPolicy.FULL));
+                if (!from.present() || !against.present()) {
                     continue;
                 }
                 // Two imports reaching one definition reach one definition: the name it is keyed by
                 // is the module that declares it and its own name, so the second arrival is the same
                 // entry rather than a second copy of the method.
-                publishedClosure(from.value(), imp.names(), table.value()).forEach(out::putIfAbsent);
+                publishedClosure(from.value(), imp.names(), against.value())
+                        .forEach(out::putIfAbsent);
             }
             return Answer.of(out);
         }
@@ -610,12 +618,12 @@ public final class Bodies {
      * named, one with parameters is expanded where it is called.
      */
     public static Map<String, Ast.FnDef> publishedDefinitions(Ast.Module from, List<String> wanted,
-                                                              Map<String, Ast.FnDef> table) {
+                                                              Expanding.Of against) {
         Map<String, Ast.FnDef> out = new LinkedHashMap<>();
         HelperInliner inliner = null;
         for (Ast.FnDef fn : publishable(from, wanted)) {
             if (inliner == null) {
-                inliner = HelperInliner.forHelpers(from.name(), table);
+                inliner = HelperInliner.over(against.table(), against.graph());
             }
             Ast.FnDef closed = inliner.closeAcross(fn, from.name());
             out.put(closed.name(), closed);
@@ -634,12 +642,12 @@ public final class Bodies {
      * from the others, so following the calls collects all of them.
      */
     public static Map<String, Ast.FnDef> publishedClosure(Ast.Module from, List<String> wanted,
-                                                          Map<String, Ast.FnDef> table) {
-        Map<String, Ast.FnDef> out = publishedDefinitions(from, wanted, table);
+                                                          Expanding.Of against) {
+        Map<String, Ast.FnDef> out = publishedDefinitions(from, wanted, against);
         if (out.isEmpty()) {
             return out;
         }
-        HelperInliner inliner = HelperInliner.forHelpers(from.name(), table);
+        HelperInliner inliner = HelperInliner.over(against.table(), against.graph());
         Deque<String> work = new ArrayDeque<>(out.keySet());
         while (!work.isEmpty()) {
             for (ValueName.Helper reached : HelperNames.helpersReached(out.get(work.poll()).writtenBody())) {
@@ -652,7 +660,10 @@ public final class Bodies {
                 // there and closed here, one that reached `from` from further up is already keyed and
                 // closed by the module that declares it, and is passed along as it stands.
                 boolean ownHelper = reached.module().equals(from.name());
-                Ast.FnDef def = table.get(ownHelper ? reached.name() : qualified);
+                // Asked of what the name reaches there, which is the one relation this module has any
+                // business asking of another module's table.
+                Ast.FnDef def =
+                        against.table().reached(ownHelper ? reached.name() : qualified);
                 if (def == null) {
                     continue;   // a prelude helper, which every module emits for itself
                 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Bodies.java
@@ -525,7 +525,10 @@ public final class Bodies {
                 return Answer.absent();
             }
             Map<String, Ast.FnDef> helpers = new LinkedHashMap<>(imported.value());
+            // What this module has, both components of it: a body may name a helper it took on to
+            // emit exactly as it names one it declared, and a row may apply either.
             helpers.putAll(HelperInliner.helpersOf(settled.value()));
+            helpers.putAll(HelperInliner.takenOnBy(settled.value()));
             return Answer.of(helpers);
         }
     }
@@ -792,9 +795,14 @@ public final class Bodies {
             if (!settled.present()) {
                 return Answer.absent();
             }
-            for (Ast.FnDef candidate : settled.value().fns()) {
-                if (candidate.name().equals(fn)) {
-                    return Answer.of(candidate);
+            // Either component: a body is asked for by name, and a helper the module took on to emit
+            // has one to expand exactly as one it declared does.
+            for (List<Ast.FnDef> component : List.of(
+                    settled.value().fns(), settled.value().takenOn())) {
+                for (Ast.FnDef candidate : component) {
+                    if (candidate.name().equals(fn)) {
+                        return Answer.of(candidate);
+                    }
                 }
             }
             return Answer.absent();
@@ -883,32 +891,42 @@ public final class Bodies {
                 return Answer.absent();
             }
             Set<String> behaviors = Names.behaviorNames(settled.value());
+            // A name is one question, so a name written twice is asked once and answered by the
+            // first. The check reports the duplicate and this module is not emitted; what it must
+            // not do is carry the same body twice. Shared across both components because a module
+            // that took on a helper it also declares would otherwise emit two of it.
             Set<String> taken = new LinkedHashSet<>();
-            List<Ast.FnDef> fns = new ArrayList<>();
-            for (Ast.FnDef fn : settled.value().fns()) {
-                // A non-recursive helper is fully inlined at its call sites and never emitted — it has
-                // no body of its own down here, so nothing asks for one. Unless an example row applies
-                // it (ADR-0077): a row runs a helper rather than expanding it, so that one is emitted.
-                if (!behaviors.contains(fn.name()) && !recursive.value().contains(fn.name())
-                        && !examples.value().contains(fn.name())) {
-                    continue;
+            List<List<Ast.FnDef>> lowered = new ArrayList<>();
+            // Both, and each stays where it was: what becomes a method is one question and what this
+            // module declared is another, and the backend reads the first while every rule about the
+            // declaring module reads the second.
+            for (List<Ast.FnDef> component : List.of(
+                    settled.value().fns(), settled.value().takenOn())) {
+                List<Ast.FnDef> fns = new ArrayList<>();
+                for (Ast.FnDef fn : component) {
+                    // A non-recursive helper is fully inlined at its call sites and never emitted —
+                    // it has no body of its own down here, so nothing asks for one. Unless an example
+                    // row applies it (ADR-0077): a row runs a helper rather than expanding it, so
+                    // that one is emitted.
+                    if (!behaviors.contains(fn.name()) && !recursive.value().contains(fn.name())
+                            && !examples.value().contains(fn.name())) {
+                        continue;
+                    }
+                    if (!taken.add(fn.name())) {
+                        continue;
+                    }
+                    Answer<Ast.FnDef> body = db.ask(new LoweredBody(name, fn.name()));
+                    if (!body.present()) {
+                        // Why is the body's to say, and it said it. A module with a body that does
+                        // not expand has none to emit.
+                        return Answer.absent();
+                    }
+                    fns.add(body.value());
                 }
-                // A name is one question, so a name written twice is asked once and answered by the
-                // first. The check reports the duplicate and this module is not emitted; what it must
-                // not do is carry the same body twice.
-                if (!taken.add(fn.name())) {
-                    continue;
-                }
-                Answer<Ast.FnDef> body = db.ask(new LoweredBody(name, fn.name()));
-                if (!body.present()) {
-                    // Why is the body's to say, and it said it. A module with a body that does not
-                    // expand has none to emit.
-                    return Answer.absent();
-                }
-                fns.add(body.value());
+                lowered.add(fns);
             }
             return Answer.of(new Lower.Lowered(settled.value(),
-                    Lower.lowered(settled.value(), fns)));
+                    Lower.lowered(settled.value(), lowered.get(0), lowered.get(1))));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Front.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Front.java
@@ -280,8 +280,12 @@ public final class Front {
                     }
                 }
             }
+            // An attached file writes rows and the values they name, which are declarations of the
+            // target module. What that module takes on to emit is worked out further down and is
+            // nothing an attached file adds to.
             return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), m.defs(),
-                    m.behaviors(), fns, examples, fakes, m.exampleFileTarget(), m.pos());
+                    m.behaviors(), fns, m.takenOn(), examples, fakes, m.exampleFileTarget(),
+                    m.pos());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Names.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Names.java
@@ -138,8 +138,8 @@ public final class Names {
                 }
             }
             Ast.Module bound = new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(),
-                    binding.imports(), m.defs(), behaviors, m.fns(), m.examples(), m.fakes(),
-                    m.exampleFileTarget(), m.pos());
+                    binding.imports(), m.defs(), behaviors, m.fns(), m.takenOn(), m.examples(),
+                    m.fakes(), m.exampleFileTarget(), m.pos());
             return Answer.of(bound, binding.reports());
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Output.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Output.java
@@ -956,7 +956,8 @@ public final class Output {
                 }
             }
             return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(), m.defs(),
-                    m.behaviors(), m.fns(), mine, m.fakes(), m.exampleFileTarget(), m.pos());
+                    m.behaviors(), m.fns(), m.takenOn(), mine, m.fakes(), m.exampleFileTarget(),
+                    m.pos());
         }
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -104,7 +104,7 @@ public final class Shapes {
                 return m;
             }
             return new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(), m.imports(),
-                    List.copyOf(kept), m.behaviors(), m.fns(), m.examples(), m.fakes(),
+                    List.copyOf(kept), m.behaviors(), m.fns(), m.takenOn(), m.examples(), m.fakes(),
                     m.exampleFileTarget(), m.pos());
         }
     }
@@ -269,10 +269,12 @@ public final class Shapes {
                 if (injected.isEmpty()) {
                     return Answer.of(m);
                 }
-                List<Ast.FnDef> fns = new ArrayList<>(m.fns());
-                fns.addAll(injected.values());
+                // Beside what the module declared, not among it. Both are emitted and only the first
+                // was written here, and a reader asking which is which asks the component it is in
+                // rather than the shape of a name.
                 return Answer.of(new Ast.Module(m.name(), m.exposing(), m.exposedOutputs(),
-                        m.imports(), m.defs(), m.behaviors(), fns, m.examples(), m.fakes(),
+                        m.imports(), m.defs(), m.behaviors(), m.fns(),
+                        List.copyOf(injected.values()), m.examples(), m.fakes(),
                         m.exampleFileTarget(), m.pos()));
             } catch (CompileException e) {
                 return Answer.absent(e);

--- a/souther-compiler/src/test/java/souther/compiler/check/AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest.java
@@ -86,7 +86,7 @@ class AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest {
         HelperInliner inliner = HelperInliner.forModule(Resolve.module(parsed, Symbols.of(parsed)));
 
         Ast.Expr expanded = assertDoesNotThrow(() -> inliner.inline(
-                inliner.helpers().get("depth").writtenBody(), inliner.bodyOf("depth")));
+                inliner.emits().get("depth").writtenBody(), inliner.bodyOf("depth")));
 
         assertTrue(expanded != null, "a body the expansion finished with");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest.java
@@ -86,7 +86,7 @@ class AValueOnACallCycleIsRefusedThoughTheExpansionFinishesTest {
         HelperInliner inliner = HelperInliner.forModule(Resolve.module(parsed, Symbols.of(parsed)));
 
         Ast.Expr expanded = assertDoesNotThrow(() -> inliner.inline(
-                inliner.emits().get("depth").writtenBody(), inliner.bodyOf("depth")));
+                inliner.held().get("depth").writtenBody(), inliner.bodyOf("depth")));
 
         assertTrue(expanded != null, "a body the expansion finished with");
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest.java
@@ -58,7 +58,7 @@ class AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest {
     }
 
     private static Ast.Expr expand(HelperInliner inliner, String helper) {
-        return inliner.inline(inliner.emits().get(helper).writtenBody(), inliner.bodyOf(helper));
+        return inliner.inline(inliner.held().get(helper).writtenBody(), inliner.bodyOf(helper));
     }
 
     @Test
@@ -87,7 +87,7 @@ class AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest {
     void twoWritingsIntoOneBodyDoNotWriteTheSameBinding() {
         HelperInliner inliner = inliner();
         BindingOwner body = new BindingOwner.OfData(new TypeName("demo", "X"));
-        Ast.Expr clause = inliner.emits().get("right").writtenBody();
+        Ast.Expr clause = inliner.held().get("right").writtenBody();
 
         Set<BindingId> first = bindingsOf(inliner.inline(clause, body));
         Set<BindingId> second = bindingsOf(inliner.inline(clause, body));

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest.java
@@ -58,7 +58,7 @@ class AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest {
     }
 
     private static Ast.Expr expand(HelperInliner inliner, String helper) {
-        return inliner.inline(inliner.helpers().get(helper).writtenBody(), inliner.bodyOf(helper));
+        return inliner.inline(inliner.emits().get(helper).writtenBody(), inliner.bodyOf(helper));
     }
 
     @Test
@@ -87,7 +87,7 @@ class AnExpansionAfterARefusalIsWhatItWouldHaveBeenTest {
     void twoWritingsIntoOneBodyDoNotWriteTheSameBinding() {
         HelperInliner inliner = inliner();
         BindingOwner body = new BindingOwner.OfData(new TypeName("demo", "X"));
-        Ast.Expr clause = inliner.helpers().get("right").writtenBody();
+        Ast.Expr clause = inliner.emits().get("right").writtenBody();
 
         Set<BindingId> first = bindingsOf(inliner.inline(clause, body));
         Set<BindingId> second = bindingsOf(inliner.inline(clause, body));

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
@@ -72,7 +72,7 @@ class AnExpansionOwnsWhatItWritesTest {
                 let f (x) = x
                 """.formatted(defs));
         HelperInliner inliner = HelperInliner.forModule(m);
-        return inliner.inline(inliner.emits().get(of).writtenBody(), inliner.bodyOf(of));
+        return inliner.inline(inliner.held().get(of).writtenBody(), inliner.bodyOf(of));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionOwnsWhatItWritesTest.java
@@ -72,7 +72,7 @@ class AnExpansionOwnsWhatItWritesTest {
                 let f (x) = x
                 """.formatted(defs));
         HelperInliner inliner = HelperInliner.forModule(m);
-        return inliner.inline(inliner.helpers().get(of).writtenBody(), inliner.bodyOf(of));
+        return inliner.inline(inliner.emits().get(of).writtenBody(), inliner.bodyOf(of));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/NoExpansionSubstitutesAValueIntoItselfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NoExpansionSubstitutesAValueIntoItselfTest.java
@@ -49,7 +49,7 @@ class NoExpansionSubstitutesAValueIntoItselfTest {
     }
 
     private static Ast.Expr expand(HelperInliner inliner, String helper) {
-        return inliner.inline(inliner.emits().get(helper).writtenBody(), inliner.bodyOf(helper));
+        return inliner.inline(inliner.held().get(helper).writtenBody(), inliner.bodyOf(helper));
     }
 
     private static Ast.Expr expand(String source, String helper) {

--- a/souther-compiler/src/test/java/souther/compiler/check/NoExpansionSubstitutesAValueIntoItselfTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/NoExpansionSubstitutesAValueIntoItselfTest.java
@@ -49,7 +49,7 @@ class NoExpansionSubstitutesAValueIntoItselfTest {
     }
 
     private static Ast.Expr expand(HelperInliner inliner, String helper) {
-        return inliner.inline(inliner.helpers().get(helper).writtenBody(), inliner.bodyOf(helper));
+        return inliner.inline(inliner.emits().get(helper).writtenBody(), inliner.bodyOf(helper));
     }
 
     private static Ast.Expr expand(String source, String helper) {

--- a/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest.java
@@ -61,8 +61,12 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
         return HelperInliner.helpersOf(m).get("spin");
     }
 
-    private static void check(String module, Map<String, Ast.FnDef> fns) {
-        HelperTable table = HelperTable.of(module, fns, Map.of(), InliningPolicy.FULL);
+    /** The totality check over a module that declared {@code declared} and took {@code takenOn} on to
+     * emit. Both are walked; only the first is this module's to prove. */
+    private static void check(String module, Map<String, Ast.FnDef> declared,
+                              Map<String, Ast.FnDef> takenOn) {
+        HelperTable table =
+                HelperTable.of(module, declared, takenOn, Map.of(), InliningPolicy.FULL);
         TotalityChecker.check(HelperInliner.over(table, HelperGraph.of(table)));
     }
 
@@ -82,7 +86,7 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
         assertEquals("maths", closed.declaredIn());
 
         CompileException refused = assertThrows(CompileException.class,
-                () -> check("maths", Map.of(closed.name(), closed)));
+                () -> check("maths", Map.of(closed.name(), closed), Map.of()));
         assertEquals("E2001", refused.code());
     }
 
@@ -101,7 +105,7 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
         assertEquals("spin", foreign.name());
         assertEquals("maths", foreign.declaredIn());
 
-        assertDoesNotThrow(() -> check("order", Map.of(foreign.name(), foreign)));
+        assertDoesNotThrow(() -> check("order", Map.of(), Map.of(foreign.name(), foreign)));
     }
 
     /**
@@ -136,10 +140,11 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
                 let throughWrapped (n: Int) : Int = wrapped(n)
                 let straightToSpin (n: Int) : Int = spin(n)
                 """, Map.of("wrapped", "maths", "spin", "maths"));
-        Map<String, Ast.FnDef> fns = new LinkedHashMap<>(HelperInliner.helpersOf(order));
-        fns.put(spin.name(), spin);
-        fns.put(wrapped.name(), wrapped);
-        HelperTable table = HelperTable.of("order", fns, Map.of(), InliningPolicy.FULL);
+        Map<String, Ast.FnDef> takenOn = new LinkedHashMap<>();
+        takenOn.put(spin.name(), spin);
+        takenOn.put(wrapped.name(), wrapped);
+        HelperTable table = HelperTable.of("order", HelperInliner.helpersOf(order), takenOn,
+                Map.of(), InliningPolicy.FULL);
         PartialReachability reachability =
                 PartialReachability.of(HelperInliner.over(table, HelperGraph.of(table)));
 
@@ -191,10 +196,11 @@ class WhichModuleDeclaredAHelperIsAskedOfTheDeclarationTest {
 
                 let ownWork (n: Int) : Int = n + 1
                 """);
-        Map<String, Ast.FnDef> fns = new LinkedHashMap<>(HelperInliner.helpersOf(order));
-        fns.put(spin.name(), spin);
-        fns.put(hands.name(), hands);
-        HelperTable table = HelperTable.of("order", fns, Map.of(), InliningPolicy.FULL);
+        Map<String, Ast.FnDef> takenOn = new LinkedHashMap<>();
+        takenOn.put(spin.name(), spin);
+        takenOn.put(hands.name(), hands);
+        HelperTable table = HelperTable.of("order", HelperInliner.helpersOf(order), takenOn,
+                Map.of(), InliningPolicy.FULL);
         PartialReachability reachability =
                 PartialReachability.of(HelperInliner.over(table, HelperGraph.of(table)));
 

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
@@ -1,0 +1,126 @@
+package souther.compiler.query;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.HelperInliner;
+import souther.compiler.meta.ModulePath;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a module declares is what its source wrote, whichever stage is asked.
+ *
+ * <p>A module emits the recursive helpers it reaches as methods of its own, and {@link
+ * Shapes.Prepared} put them into the same list its declarations are in. From there on one question
+ * had two answers: before that pass {@code helpersOf} said what the module declared, and after it,
+ * that plus what the module took on to emit. Every reader that wanted the first — which is the
+ * {@code exposing} check, the value namespace a body is resolved against, what the module publishes
+ * — got whichever the caller above it happened to hold.
+ *
+ * <p>The two are separate components of the module now, so a stage that adds to one does not answer
+ * for the other.
+ */
+class WhatAModuleDeclaresDoesNotChangeWithTheStageTest {
+
+    /** `flatten` recurses, so a reader has to emit it as a method of its own; `own` folds, which
+     * reaches the library's recursive `List.foldFrom` and is taken on the same way. */
+    private static final String LIB = """
+            module lib exposing ( flatten )
+
+            let flatten (xs: List<List<Int>>) : List<Int> =
+                if List.isEmpty(xs) then []
+                else List.head(xs, []) ++ flatten(List.drop(1, xs))
+            """;
+
+    private static final String APP = """
+            module app exposing ( own )
+
+            import lib ( flatten )
+
+            let own (xs: List<Int>) : List<Int> = List.map({ (x) -> x + 1 }, xs)
+            let both (xs: List<List<Int>>) : List<Int> = own(flatten(xs))
+            """;
+
+    private static Db db() {
+        return Compilation.ofDocuments(
+                Map.of("lib.sou", LIB, "app.sou", APP), Set.of(), ModulePath.EMPTY).db();
+    }
+
+    /** Every stage that hands a module over, by the name of the stage. */
+    private static Map<String, Ast.Module> stagesOf(Db db, String name) {
+        Map<String, Key<Ast.Module>> keys = new LinkedHashMap<>();
+        keys.put("resolved", new Names.Resolved(name));
+        keys.put("derived", new Shapes.Derived(name));
+        keys.put("desugared", new Shapes.Desugared(name));
+        keys.put("prepared", new Shapes.Prepared(name));
+        keys.put("settled", new Bodies.Settled(name));
+        Map<String, Ast.Module> out = new LinkedHashMap<>();
+        keys.forEach((stage, key) -> {
+            Answer<Ast.Module> answer = db.ask(key);
+            assertTrue(answer.present(), stage + " of " + name + ": " + answer.reports());
+            out.put(stage, answer.value());
+        });
+        return out;
+    }
+
+    @Test
+    void everyStageSaysTheModuleDeclaresWhatItsSourceWrote() {
+        Db db = db();
+        stagesOf(db, "app").forEach((stage, module) ->
+                assertEquals(Set.of("own", "both"), HelperInliner.helpersOf(module).keySet(),
+                        "the " + stage + " tree of `app` disagrees about what it declares"));
+    }
+
+    /**
+     * And this module does take helpers on, so no stage passes by having none to confuse a
+     * declaration with. Asked of what the module emits, which is a different question and a different
+     * answer.
+     */
+    @Test
+    void theModuleTakesOnHelpersItDidNotDeclare() {
+        Db db = db();
+        assertEquals(Set.of("List.foldFrom", "lib.flatten"),
+                db.ask(new Bodies.RecursiveHelpers("app")).value());
+    }
+
+    /**
+     * Which of the two a fn is in is what the declaration says of it, at every stage.
+     *
+     * <p>Asked of {@link Ast.FnDef#declaredBy} and not of the names. A reach name carries a dot and a
+     * source identifier cannot, so the two key sets never meet whatever the components hold — a test
+     * written over the names would pass however wrongly a pass filed one.
+     */
+    @Test
+    void eachComponentHoldsWhatItsNameSays() {
+        Db db = db();
+        stagesOf(db, "app").forEach((stage, module) -> {
+            module.fns().forEach(fn -> assertTrue(fn.declaredBy("app"),
+                    "the " + stage + " tree of `app` has `" + fn.name() + "` among its declarations,"
+                            + " and " + fn.declaredIn() + " declared it"));
+            module.takenOn().forEach(fn -> assertFalse(fn.declaredBy("app"),
+                    "the " + stage + " tree of `app` took on `" + fn.name() + "`, which it declared"));
+        });
+    }
+
+    /** And the lowered tree the backend emits from keeps them apart, which is the last place a pass
+     * could put a taken-on helper where a declaration goes. */
+    @Test
+    void theTreeTheBackendEmitsFromKeepsThemApart() {
+        Db db = db();
+        Ast.Module lowered = db.ask(new Bodies.Lowering("app")).value().lowered();
+
+        lowered.fns().forEach(fn -> assertTrue(fn.declaredBy("app"),
+                "`" + fn.name() + "` is emitted as a declaration of `app`, and "
+                        + fn.declaredIn() + " declared it"));
+        assertEquals(Set.of("List.foldFrom", "lib.flatten"),
+                lowered.takenOn().stream().map(Ast.FnDef::name)
+                        .collect(java.util.stream.Collectors.toSet()));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/WhatAModuleDeclaresDoesNotChangeWithTheStageTest.java
@@ -1,5 +1,6 @@
 package souther.compiler.query;
 
+import souther.compiler.Compiler;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.HelperInliner;
 import souther.compiler.meta.ModulePath;
@@ -7,9 +8,11 @@ import souther.compiler.meta.ModulePath;
 import org.junit.jupiter.api.Test;
 
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -107,6 +110,73 @@ class WhatAModuleDeclaresDoesNotChangeWithTheStageTest {
             module.takenOn().forEach(fn -> assertFalse(fn.declaredBy("app"),
                     "the " + stage + " tree of `app` took on `" + fn.name() + "`, which it declared"));
         });
+    }
+
+    /**
+     * A row applies a published helper that does not recurse. It is taken on for that reason alone —
+     * a row runs a helper rather than expanding it (ADR-0077) — so what a module takes on is not only
+     * what it reaches recursively, and a component holding only the recursive ones would drop it.
+     */
+    @Test
+    void aHelperOnlyARowAppliesIsTakenOnToo() {
+        Db db = Compilation.ofDocuments(Map.of("rules.sou", """
+                module rules exposing ( doubled )
+
+                let doubled (n: Int) : Int = n * 2
+                """, "app.sou", """
+                module app exposing ( In, Out, run )
+
+                import rules ( doubled )
+
+                data In  = { n: Int }
+                data Out = { m: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = Out { m = i.n }
+
+                example run
+                    | "a row applies a published helper" : (In { n = doubled(3) }) -> Out { m = 6 }
+                """), Set.of(), ModulePath.EMPTY).db();
+
+        Ast.Module prepared = db.ask(new Shapes.Prepared("app")).value();
+        // `run` implements a behavior, which is not a helper and is lowered on its own.
+        assertEquals(Set.of(), HelperInliner.helpersOf(prepared).keySet());
+        assertEquals(Set.of("rules.doubled"), HelperInliner.takenOnBy(prepared).keySet());
+        assertEquals(Set.of(), db.ask(new Bodies.RecursiveHelpers("app")).value(),
+                "nothing here recurses, so this is the row's doing and not a recursion's");
+        assertEquals(Set.of("rules.doubled"),
+                db.ask(new Bodies.Lowering("app")).value().lowered().takenOn().stream()
+                        .map(Ast.FnDef::name).collect(java.util.stream.Collectors.toSet()));
+    }
+
+    /**
+     * The same, with the row in an attached {@code examples for} file. That is the shape the two
+     * rebuilds that run either side of the pass filling {@code takenOn} are on — the one that gathers
+     * an attached file's rows into the module, and the one that keeps only the rows of one file to
+     * report against it — and the row still finds the method.
+     */
+    @Test
+    void anAttachedFilesRowStillReachesWhatTheModuleTookOn() {
+        assertDoesNotThrow(() -> Compiler.compileModules(List.of("""
+                module rules exposing ( doubled )
+
+                let doubled (n: Int) : Int = n * 2
+                """, """
+                module app exposing ( In, Out, run )
+
+                import rules ( doubled )
+
+                data In  = { n: Int }
+                data Out = { m: Int }
+
+                behavior run : (i: In) -> Out constructs Out
+                let run (i) = Out { m = i.n }
+                """, """
+                examples for app
+
+                example run
+                    | "written beside the model" : (In { n = doubled(3) }) -> Out { m = 6 }
+                """)));
     }
 
     /** And the lowered tree the backend emits from keeps them apart, which is the last place a pass


### PR DESCRIPTION
The second of two for #398, on top of #414. That one separated what a module
reaches from what it has as fns of its own; this one separates what it declared
from what it took on to emit, and closes the issue.

## What was wrong

`Shapes.Prepared` appended the recursive helpers a module reaches to the list its
declarations are in, so from that pass on `helpersOf` answered a different
question than it did before it:

```
Names.Resolved    helpersOf(app) = [own, both]
Shapes.Desugared  helpersOf(app) = [own, both]
Shapes.Prepared   helpersOf(app) = [own, both, lib.flatten, List.foldFrom]
```

Which answer a reader got was decided by the caller above it holding a tree from
before the pass or after. The `exposing` check, the value namespace a body is
resolved against, and what a module publishes all read it, and none of them
wanted the second.

## What is here

`Ast.Module` carries the two apart:

| | |
|---|---|
| `fns` | what the source wrote, at every stage |
| `takenOn` | what the module emits without having declared — a recursive helper it reaches, whoever declared it |

There is no constructor that defaults `takenOn`, so all nineteen places that
build a module had to say what they mean by it. That is the point of not writing
one: a rebuild that quietly dropped it would hand codegen a module missing the
methods its own bodies call, and three of the nineteen are rebuilds that run
after the pass that fills it (`HelperParams.settle`, `Lower.lowered`,
`Output.Examples`).

`HelperTable` takes the three sources apart and names its three questions:

```java
Ast.FnDef             reached(name)    // which declaration a call expands to — a call edge
Map<String, FnDef>    declarations()   // what this module's source wrote
Map<String, FnDef>    emits()          // what becomes a method here: both of the above
```

`fns()` and `holds()` are gone. They were the union under a name that did not say
which relation it stood for.

Where a walk has to follow both, it does so explicitly: `HelperParams` settles
both and writes each back where it was, `Bodies.Lowering` filters both,
`TypeChecker` collects lowered bodies from both, `Bodies.SettledFn` looks in
both, `Backend` and `JvmLimits` emit from both.

## What is deliberately not here

`declared(name)`. The issue proposed it beside `reached(name)` so that
`reached(String)` would stop compiling — that separation comes from retyping the
key to `ReachName`, which is a change to make once these surfaces exist. Today it
would be a second spelling of `reached(String)` with nothing reading it.

Which component a fn is in is also not read to decide anything. What may be
walked and what must be proven total are rules about the declaring module and ask
the declaration (ADR-0098): `List.foldFrom` is reached under the library's alias
and declared in `souther.list`, so no name and no list membership answers it.

## Witness

`WhatAModuleDeclaresDoesNotChangeWithTheStageTest` pins the invariant at every
stage and on the lowered tree the backend emits from, **by provenance and not by
names** — a reach name carries a dot and a source identifier cannot, so a test
over the key sets would pass however wrongly a pass filed one:

```
∀ fn ∈ module.fns()     : fn.declaredBy(module.name())
∀ fn ∈ module.takenOn() : !fn.declaredBy(module.name())
```

Restoring the append in `Shapes.Prepared` fails three of its four cases. Its
second case asserts the module does take helpers on, so none of the others passes
by having nothing to confuse a declaration with.

`mvn -o clean test`: 3557 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
