### PR TITLE
Diagnostic rendering conflates reader locale with locale-invariant legacy text

### DIFF
--- a/docs/adr/0044-diagnostics-as-data-with-renderer-layer.md
+++ b/docs/adr/0044-diagnostics-as-data-with-renderer-layer.md
@@ -83,7 +83,7 @@ the adapter's own option, and a layer holding the list would know every adapter 
 question each of them can answer for itself. What the layer does hold is that each surface answers
 once — a surface picking a language twice has no policy, only two sites that happened to agree.
 
-The one-line text a `CompileException` carries for `getMessage()` is not one of them and takes no
+The one-line body a `CompileException` builds its `getMessage()` from is not one of them and takes no
 language at all. No adapter prints it while the exception carries a diagnostic, and the sites that
 build it always supply one, so it is read by callers holding the exception rather than by anyone it
 is written for. What it has to do is not change when the language a reader is answered in is decided
@@ -92,6 +92,13 @@ to *which language when nobody named one*, so a text that reads it moves wheneve
 again, and the text of a failing example was Japanese for that reason and no other. `legacyBody` now
 builds it and takes no locale, and `defaultLocale()` is private — the resolution's own last step,
 reachable only from the resolution.
+
+Which means no locale has to stop meaning the default one. A message lookup used to read a null
+locale as the default, which is the same reach spelled so that nothing looking for a locale being
+chosen would see it: a site with no reader to resolve for passes nothing and is answered out of the
+language chosen for readers who named none. So `Messages.get`, `Messages.has` and
+`DiagnosticRenderer.body` refuse a null locale. A caller has either resolved a language for a reader
+or is building a text that has no reader, and there is a way to say each.
 
 ## Context
 

--- a/docs/adr/0044-diagnostics-as-data-with-renderer-layer.md
+++ b/docs/adr/0044-diagnostics-as-data-with-renderer-layer.md
@@ -73,10 +73,25 @@ Amending in place rather than superseding: what changed is a default, the reason
 catalog has to be to ship — not the shape of the decision. Diagnostics are still data rendered by a
 locale-aware layer, and the code
 and type strings are still locale-independent, which is what makes a code a lookup that survives
-being answered in a language the reader does not read. Two surfaces still name a language of their
-own and are untouched here: the LSP renders in English because a language server is not told the
-editor's UI locale, and the annotation processor resolves from `souther.lang`. That the policy is
-written in each adapter rather than in one place is a separate problem from which language it names.
+being answered in a language the reader does not read.
+
+Three surfaces answer a reader, and each writes its own policy where the surface is. The CLI
+resolves from `--lang`, the annotation processor from `souther.lang`, and a language server names
+English outright, because an editor tells it which files the workspace holds and nothing about which
+language its user reads. Not one table in the diagnostics layer: an adapter's language comes from
+the adapter's own option, and a layer holding the list would know every adapter in order to answer a
+question each of them can answer for itself. What the layer does hold is that each surface answers
+once — a surface picking a language twice has no policy, only two sites that happened to agree.
+
+The one-line text a `CompileException` carries for `getMessage()` is not one of them and takes no
+language at all. No adapter prints it while the exception carries a diagnostic, and the sites that
+build it always supply one, so it is read by callers holding the exception rather than by anyone it
+is written for. What it has to do is not change when the language a reader is answered in is decided
+again, which is what `Messages.defaultLocale()` was the wrong way to say: the fallback is the answer
+to *which language when nobody named one*, so a text that reads it moves whenever that is settled
+again, and the text of a failing example was Japanese for that reason and no other. `legacyBody` now
+builds it and takes no locale, and `defaultLocale()` is private — the resolution's own last step,
+reachable only from the resolution.
 
 ## Context
 

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -146,8 +146,8 @@ public final class ExampleVerifier {
                 : failures.size() + " examples do not hold; " + legacyOf(first);
     }
 
-    /** A one-line message for a failing example: what {@code getMessage()} answers on the exception
-     * these are thrown in. No surface prints it — the CLI, the annotation processor and the LSP all
+    /** A one-line message for a failing example: the body {@code getMessage()} is built from on the
+     * exception these are thrown in. No surface prints it — the CLI, the annotation processor and the LSP all
      * render the diagnostics, which this exception carries — so what reads it is a caller holding
      * the exception, and it takes no language for the same reason
      * {@link DiagnosticRenderer#legacyBody} does not. */

--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -10,10 +10,10 @@ import souther.compiler.check.TypeOps;
 import souther.compiler.coverage.Probe;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.DiagnosticCode;
+import souther.compiler.diag.DiagnosticRenderer;
 import souther.compiler.evaluate.DepthLimitExceeded;
 import souther.compiler.evaluate.EvaluationContext;
 import souther.compiler.evaluate.StepLimitExceeded;
-import souther.compiler.diag.Messages;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.diag.SourceRef;
 import souther.compiler.observe.Disposition;
@@ -146,8 +146,11 @@ public final class ExampleVerifier {
                 : failures.size() + " examples do not hold; " + legacyOf(first);
     }
 
-    /** A one-line message for a failing example, used where only the legacy string is shown (the LSP
-     * surfaces this rather than the rendered catalog message). */
+    /** A one-line message for a failing example: what {@code getMessage()} answers on the exception
+     * these are thrown in. No surface prints it — the CLI, the annotation processor and the LSP all
+     * render the diagnostics, which this exception carries — so what reads it is a caller holding
+     * the exception, and it takes no language for the same reason
+     * {@link DiagnosticRenderer#legacyBody} does not. */
     private static String legacyOf(Diagnostic d) {
         if (d.diff() != null) {
             // JUnit order: the expected value (what the example asserts) first, then what the
@@ -159,7 +162,7 @@ public final class ExampleVerifier {
         // non-termination): render the diagnostic's own catalog message so the reason travels
         // through the annotation processor, rather than collapsing to a bare "example failed".
         if (d.messageKey() != null) {
-            return Messages.get(d.messageKey(), Messages.defaultLocale(), d.args());
+            return DiagnosticRenderer.legacyBody(d);
         }
         return "example failed";
     }

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -544,7 +544,7 @@ public final class Main {
             // run that aborted on an invariant is where a warning that the construction was unproven
             // is worth most. A usage error is raised before any of it and carries none.
             report(warnings, sources, render);
-            System.err.println(e.localized(Messages.resolveLocale(render.lang)));
+            System.err.println(e.localized(render.locale()));
             return e.exitCode;
         } catch (CompileException e) {
             reportCompileError(e, sources, render);
@@ -636,8 +636,7 @@ public final class Main {
      */
     private static int refused(RenderOptions render) {
         if (!render.json()) {
-            System.err.println(Messages.get("cli.warnings.refused",
-                    Messages.resolveLocale(render.lang)));
+            System.err.println(Messages.get("cli.warnings.refused", render.locale()));
         }
         return 1;
     }
@@ -645,7 +644,7 @@ public final class Main {
     /** Prints each diagnostic to stderr as the chosen renderer renders it, quoting the file it
      * belongs to. Errors and warnings take the same path; only where they come from differs. */
     private static void report(List<Located> located, List<Path> sources, RenderOptions render) {
-        Locale locale = Messages.resolveLocale(render.lang);
+        Locale locale = render.locale();
         DiagnosticRenderer renderer = render.json()
                 ? new JsonRenderer() : new HumanRenderer(render.useColor());
         for (String line : DiagnosticRenderer.renderAll(
@@ -675,6 +674,18 @@ public final class Main {
 
         boolean json() {
             return "json".equals(format);
+        }
+
+        /**
+         * The language this invocation answers in: the {@code --lang} value if one was written,
+         * then {@code SOUTHER_LANG}, then the default.
+         *
+         * <p>The CLI's policy, in the CLI, and asked here by everything that prints. A place that
+         * resolves for itself is a second answer that happens to agree, with nothing saying it has
+         * to.
+         */
+        Locale locale() {
+            return Messages.resolveLocale(lang);
         }
 
         boolean useColor() {

--- a/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
+++ b/souther-compiler/src/main/java/souther/compiler/apt/SoutherProcessor.java
@@ -131,9 +131,20 @@ public final class SoutherProcessor extends AbstractProcessor {
 
     /** The same rendering for a warning, which arrives already carrying the source it belongs to. */
     private List<String> render(List<Located> located, List<Source> sources) {
-        Locale locale = Messages.resolveLocale(processingEnv.getOptions().get("souther.lang"));
         return DiagnosticRenderer.renderAll(
-                located, sourcesOf(sources), new HumanRenderer(false), locale);
+                located, sourcesOf(sources), new HumanRenderer(false), locale());
+    }
+
+    /**
+     * The language this compile answers in: the {@code souther.lang} processor option if the build
+     * passes one, then {@code SOUTHER_LANG}, then the default.
+     *
+     * <p>The processor's policy, in the processor. javac tells a processor nothing about who reads
+     * its output, so the option is what there is to read; a build that passes none is answered like
+     * a CLI invocation that named none.
+     */
+    private Locale locale() {
+        return Messages.resolveLocale(processingEnv.getOptions().get("souther.lang"));
     }
 
     /** What to quote for each source a diagnostic points into, under names no two of these files

--- a/souther-compiler/src/main/java/souther/compiler/query/Report.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Report.java
@@ -7,7 +7,6 @@ import souther.compiler.diag.Severity;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
 
 /**
  * One thing a query found: the structured {@link Diagnostic} a renderer works from, and the
@@ -145,11 +144,11 @@ public record Report(Diagnostic diagnostic, String legacyMessage, Delivery deliv
     }
 
     /** This report as an error to throw. One built from a raised exception throws that exception's
-     * message again; one built any other way renders its own, in English, because that message has
-     * always been English and a test that reads it should not move with the reader's locale. */
+     * message again; one built any other way renders its own, which is the legacy body and so takes
+     * no language — see {@link DiagnosticRenderer#legacyBody}. */
     public CompileException asException() {
         return legacyMessage == null
-                ? CompileException.of(diagnostic, DiagnosticRenderer.body(diagnostic, Locale.ENGLISH))
+                ? CompileException.of(diagnostic, DiagnosticRenderer.legacyBody(diagnostic))
                 : new CompileException(diagnostic, legacyMessage);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest.java
@@ -1,0 +1,52 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.DiagnosticCode;
+import souther.compiler.diag.Messages;
+
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * The one-line text a failing example is thrown with is the English catalog text, and stays it.
+ *
+ * <p>That text is what {@code getMessage()} answers. No surface prints it — the exception carries a
+ * diagnostic per failing row, and the CLI, the annotation processor and the LSP all render those —
+ * so what reads it is a caller holding the exception: a test, or something embedding the compiler.
+ * Which is why it is not the reader's language: there is no reader here to have one.
+ *
+ * <p>It was the language Souther fell back to, which is a different thing that agreed with it. When
+ * that fallback was Japanese this text was Japanese, and it stopped being Japanese because the
+ * fallback was decided again — not because anything decided anything about failing examples.
+ */
+class TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest {
+
+    private static final String KEY = "check.example.unreachable";
+    private static final String REASON = "no branch states this";
+
+    @Test
+    void aFailingExampleSaysWhatTheEnglishCatalogSays() {
+        Diagnostic failure = Diagnostic.of(DiagnosticCode.E1911, KEY).args(REASON).build();
+
+        String said = ExampleVerifier.legacySummary(List.of(failure));
+
+        assertEquals(Messages.get(KEY, Locale.ENGLISH, REASON), said);
+    }
+
+    /**
+     * And the catalog answers this key in more than one language, so the assertion above is a claim
+     * about which one rather than a claim two languages would both satisfy.
+     */
+    @Test
+    void theCatalogWouldHaveSaidSomethingElseInJapanese() {
+        Diagnostic failure = Diagnostic.of(DiagnosticCode.E1911, KEY).args(REASON).build();
+
+        String said = ExampleVerifier.legacySummary(List.of(failure));
+
+        assertNotEquals(Messages.get(KEY, Locale.JAPANESE, REASON), said);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest.java
@@ -14,7 +14,8 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 /**
  * The one-line text a failing example is thrown with is the English catalog text, and stays it.
  *
- * <p>That text is what {@code getMessage()} answers. No surface prints it — the exception carries a
+ * <p>That text is the body {@code getMessage()} is built from, under the position and code it puts
+ * in front. No surface prints it — the exception carries a
  * diagnostic per failing row, and the CLI, the annotation processor and the LSP all render those —
  * so what reads it is a caller holding the exception: a test, or something embedding the compiler.
  * Which is why it is not the reader's language: there is no reader here to have one.

--- a/souther-compiler/src/test/java/souther/compiler/diag/AskingForAMessageWithoutALanguageIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AskingForAMessageWithoutALanguageIsRefusedTest.java
@@ -1,0 +1,39 @@
+package souther.compiler.diag;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Rendering a message takes a language, and "none" is not one of them.
+ *
+ * <p>No locale used to mean the default one, which put the default back within reach of every
+ * caller: a site with no reader to resolve for could pass nothing and be answered out of the
+ * language chosen for readers who named none — the same mistake {@code defaultLocale()} being
+ * public allowed, spelled differently and invisible to a scan for the ways a locale is picked.
+ *
+ * <p>So the two ways in refuse it. A caller either resolved a language for a reader or is building
+ * text that has no reader, and the second has {@link DiagnosticRenderer#legacyBody} to build it
+ * with. Neither is a caller with a language it did not decide.
+ */
+class AskingForAMessageWithoutALanguageIsRefusedTest {
+
+    private static final String KEY = "check.example.unreachable";
+
+    @Test
+    void aMessageLookupWithNoLanguageIsRefused() {
+        assertThrows(NullPointerException.class, () -> Messages.get(KEY, null, "why"));
+    }
+
+    @Test
+    void askingWhetherTheCatalogDefinesAKeyWithNoLanguageIsRefused() {
+        assertThrows(NullPointerException.class, () -> Messages.has(KEY, null));
+    }
+
+    @Test
+    void renderingABodyWithNoLanguageIsRefused() {
+        Diagnostic d = Diagnostic.of(DiagnosticCode.E1911, KEY).args("why").build();
+
+        assertThrows(NullPointerException.class, () -> DiagnosticRenderer.body(d, null));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
@@ -85,7 +85,7 @@ class EveryShippedMessageCatalogIsCompleteAndValidTest {
      *
      * <p>The base file carries no language in its name. To {@link ResourceBundle} it is the root
      * bundle, which is a fallback rather than a language; to Souther it is the English catalog,
-     * which is what {@link Messages#defaultLocale()} says and what makes "the same keys as the base"
+     * which is what Souther answers when nobody names a language and what makes "the same keys as the base"
      * a statement about a language rather than about a default.
      */
     private record Catalog(Path path, Locale locale) {
@@ -523,7 +523,7 @@ class EveryShippedMessageCatalogIsCompleteAndValidTest {
     /**
      * The language a catalog file's name says it is in. The base names none and is English.
      *
-     * <p>English as a fact about the file, not as {@link Messages#defaultLocale()}. The two agree
+     * <p>English as a fact about the file, not as the language Souther falls back to. The two agree
      * and are different things: one is the language the base catalog is written in, the other is
      * which language is chosen when nobody names one. Reading the second here would make the base's
      * text get checked against whatever the default becomes.

--- a/souther-compiler/src/test/java/souther/compiler/diag/EverySurfaceThatAnswersAReaderNamesItsLanguageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/EverySurfaceThatAnswersAReaderNamesItsLanguageTest.java
@@ -7,8 +7,13 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -30,21 +35,30 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * The layer offers the resolution; naming which surface uses it is the surface's own line. This test
  * is where they are enumerated, so a new one is a line here rather than a fact nobody wrote down.
  *
- * <p>A tripwire and not a proof, like the machine-locale test next door: it reads the sources, and a
- * helper in between defeats it. What it does hold is the reading that would have to be added first.
+ * <p>A tripwire and not a proof, like the machine-locale test next door. What it reads is the source
+ * text, so a locale arriving through a helper, a field of another class, or a method parameter is
+ * invisible to it — what it holds is the spelling that would have to be written first, at the file
+ * where it would be written. The rest is held by the shape of the API: a message lookup refuses a
+ * null locale, so there is no way to be answered in a language without naming one.
  */
 class EverySurfaceThatAnswersAReaderNamesItsLanguageTest {
 
-    /** The ways a source picks a language for a diagnostic. {@code Locale.ROOT} is not one of them:
-     *  it is case folding, which is about the bytes and not about a reader. */
-    private static final List<String> PICKING = List.of(
-            "Messages.resolveLocale(",
-            "Messages.defaultLocale()",
-            "Locale.ENGLISH",
-            "Locale.JAPANESE",
-            "Locale.JAPAN",
-            "Locale.forLanguageTag(",
-            "Locale.of(");
+    /**
+     * The ways a source picks a language for a diagnostic: the resolution, and every way a
+     * {@link Locale} is produced — any of the constants, either factory, and the constructors.
+     *
+     * <p>Named as a shape rather than as a list of the ones in use, because a list is only as
+     * complete as whoever wrote it: {@code Locale.US} is as direct a choice as {@code Locale.ENGLISH}
+     * and would have to be thought of to be listed.
+     *
+     * <p>{@code Locale.ROOT} is not one of them. It is case folding, which is about the bytes and
+     * not about a reader.
+     */
+    private static final Pattern PICKING = Pattern.compile(
+            "Messages\\.resolveLocale\\(|Messages\\.defaultLocale\\(\\)"
+                    + "|new Locale(?:\\.Builder)?\\b"
+                    + "|Locale\\.of\\(|Locale\\.forLanguageTag\\("
+                    + "|Locale\\.(?!ROOT\\b)[A-Z][A-Z_]+");
 
     /** The resolution itself lives here, so this file names languages as its subject matter. */
     private static final String RESOLVER = "souther/compiler/diag/Messages.java";
@@ -79,13 +93,13 @@ class EverySurfaceThatAnswersAReaderNamesItsLanguageTest {
                 continue;
             }
             String text = Files.readString(source, StandardCharsets.UTF_8);
-            for (String picking : PICKING) {
-                int count = occurrences(text, picking);
-                if (count > 0) {
-                    picks.add(path + " picks " + picking
-                            + (count == 1 ? "" : " (" + count + " times)"));
-                }
+            Map<String, Integer> counts = new TreeMap<>();
+            Matcher found = PICKING.matcher(text);
+            while (found.find()) {
+                counts.merge(found.group(), 1, Integer::sum);
             }
+            counts.forEach((spelling, count) -> picks.add(path + " picks " + spelling
+                    + (count == 1 ? "" : " (" + count + " times)")));
         }
 
         assertEquals(new TreeSet<>(NAMED), picks,
@@ -93,13 +107,5 @@ class EverySurfaceThatAnswersAReaderNamesItsLanguageTest {
                         + " that names one picks it more than once. A surface answers a reader and"
                         + " says which reader, in one place; everything else is handed the language"
                         + " rather than choosing it.");
-    }
-
-    private static int occurrences(String text, String needle) {
-        int count = 0;
-        for (int at = text.indexOf(needle); at >= 0; at = text.indexOf(needle, at + needle.length())) {
-            count++;
-        }
-        return count;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/diag/EverySurfaceThatAnswersAReaderNamesItsLanguageTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/EverySurfaceThatAnswersAReaderNamesItsLanguageTest.java
@@ -1,0 +1,105 @@
+package souther.compiler.diag;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A diagnostic is rendered in a language, and every place that picks one is listed here.
+ *
+ * <p>The list is short because most of the tree never picks: a renderer is handed the language and a
+ * pass reporting a problem does not know there is one. What picks is a surface that answers a
+ * reader — it has to say which reader — and the one operation whose text is not for a reader at all.
+ *
+ * <p>Each surface picks once. Picking twice is how a surface stops having a policy: the second site
+ * is written to match the first and then only one of them is revisited. The LSP had two, and the
+ * CLI had three of one resolution.
+ *
+ * <p>What is deliberately not here is a table in the diagnostics layer naming the surfaces. That
+ * would make the layer know every adapter, and an adapter's language comes from the adapter's own
+ * option — the CLI's flag, the processor's option, the editor telling a language server nothing.
+ * The layer offers the resolution; naming which surface uses it is the surface's own line. This test
+ * is where they are enumerated, so a new one is a line here rather than a fact nobody wrote down.
+ *
+ * <p>A tripwire and not a proof, like the machine-locale test next door: it reads the sources, and a
+ * helper in between defeats it. What it does hold is the reading that would have to be added first.
+ */
+class EverySurfaceThatAnswersAReaderNamesItsLanguageTest {
+
+    /** The ways a source picks a language for a diagnostic. {@code Locale.ROOT} is not one of them:
+     *  it is case folding, which is about the bytes and not about a reader. */
+    private static final List<String> PICKING = List.of(
+            "Messages.resolveLocale(",
+            "Messages.defaultLocale()",
+            "Locale.ENGLISH",
+            "Locale.JAPANESE",
+            "Locale.JAPAN",
+            "Locale.forLanguageTag(",
+            "Locale.of(");
+
+    /** The resolution itself lives here, so this file names languages as its subject matter. */
+    private static final String RESOLVER = "souther/compiler/diag/Messages.java";
+
+    /**
+     * Every pick in the tree.
+     *
+     * <p>Three surfaces answer a reader. The CLI and the annotation processor resolve, from the flag
+     * and from the processor option; a language server is not told the editor's UI locale, so there
+     * is nothing for it to resolve from and it names English outright.
+     *
+     * <p>The fourth is not a surface. It is the one-line text a {@code CompileException} carries for
+     * {@code getMessage()}, which no adapter prints while the exception carries a diagnostic — and
+     * the two sites that build it always supply one. It has no reader whose language could be
+     * asked, so the language is written where the text is made and no caller can pass one.
+     */
+    private static final Set<String> NAMED = Set.of(
+            "souther/compiler/Main.java picks Messages.resolveLocale(",
+            "souther/compiler/apt/SoutherProcessor.java picks Messages.resolveLocale(",
+            "souther/lsp/analysis/Analyzer.java picks Locale.ENGLISH",
+            "souther/compiler/diag/DiagnosticRenderer.java picks Locale.ENGLISH");
+
+    @Test
+    void everyPickOfADiagnosticLanguageIsOneOfTheNamedOnes() throws IOException {
+        List<Path> sources = EveryShippedMessageCatalogIsCompleteAndValidTest.mainSources();
+        assertFalse(sources.isEmpty(), "found no sources at all — the scan missed the tree");
+
+        Set<String> picks = new TreeSet<>();
+        for (Path source : sources) {
+            String path = source.toString().replace('\\', '/').replaceAll(".*/src/main/java/", "");
+            if (path.equals(RESOLVER)) {
+                continue;
+            }
+            String text = Files.readString(source, StandardCharsets.UTF_8);
+            for (String picking : PICKING) {
+                int count = occurrences(text, picking);
+                if (count > 0) {
+                    picks.add(path + " picks " + picking
+                            + (count == 1 ? "" : " (" + count + " times)"));
+                }
+            }
+        }
+
+        assertEquals(new TreeSet<>(NAMED), picks,
+                "a diagnostic's language is picked somewhere this test does not name, or a surface"
+                        + " that names one picks it more than once. A surface answers a reader and"
+                        + " says which reader, in one place; everything else is handed the language"
+                        + " rather than choosing it.");
+    }
+
+    private static int occurrences(String text, String needle) {
+        int count = 0;
+        for (int at = text.indexOf(needle); at >= 0; at = text.indexOf(needle, at + needle.length())) {
+            count++;
+        }
+        return count;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/diag/TheDiagnosticLanguageIsNeverDerivedFromTheMachineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/TheDiagnosticLanguageIsNeverDerivedFromTheMachineTest.java
@@ -30,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * never goes through.
  *
  * <p>This is a tripwire and not a proof. It reads the sources for the ways the machine's language
- * is asked for, and a static import or a helper in between defeats it. What makes the property
- * structurally true is one owner for the choice, which the adapters do not have yet — each decides
- * for itself which language it renders in, and that is tracked on its own. Until then, the reading
- * that would have to be added first is the one this fails on.
+ * is asked for, and a static import or a helper in between defeats it. The reading that would have
+ * to be added first is the one this fails on. Which surfaces pick a language at all, and where each
+ * of them writes its policy, is held next door by
+ * {@link EverySurfaceThatAnswersAReaderNamesItsLanguageTest}.
  */
 class TheDiagnosticLanguageIsNeverDerivedFromTheMachineTest {
 
@@ -67,6 +67,6 @@ class TheDiagnosticLanguageIsNeverDerivedFromTheMachineTest {
         assertEquals(Set.of(), reading,
                 "the machine's language is being read; a diagnostic is answered in a language that"
                         + " was named — through `--lang`, `SOUTHER_LANG` or an adapter's own"
-                        + " option — or in Messages.defaultLocale()");
+                        + " option — or in the language Souther defaults to");
     }
 }

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -61,6 +61,17 @@ import java.util.Set;
 public final class Analyzer {
 
     /**
+     * The language an editor's markers are written in.
+     *
+     * <p>The server's policy, in the server, and English rather than resolved. A language server is
+     * told which files the workspace holds and nothing about which language its user reads, so there
+     * is no answer here to resolve from; reaching for {@code SOUTHER_LANG} would let whichever shell
+     * happened to launch the editor decide what the editor shows. Named once, because a marker's
+     * text and a linked location's label are the same answer.
+     */
+    private static final Locale EDITOR_LANGUAGE = Locale.ENGLISH;
+
+    /**
      * The workspace's compile, kept between edits. An answer is recomputed only when something it
      * read has changed, so a keystroke costs what it reached rather than a whole workspace — and a
      * source that is edited back to what it said costs nothing at all.
@@ -1882,7 +1893,7 @@ public final class Analyzer {
     private LspDiagnostic project(Diagnostic d, String primarySourceId, String publishedUri,
                                   java.util.function.Function<String, LineIndex> linesOf,
                                   java.util.function.Function<String, String> uriOf) {
-        String message = DiagnosticRenderer.body(d, Locale.ENGLISH);
+        String message = DiagnosticRenderer.body(d, EDITOR_LANGUAGE);
         if (d.diff() != null) {
             message = message + " (expected " + d.diff().expectedType()
                     + ", but was " + d.diff().actualType() + ")";
@@ -1899,7 +1910,7 @@ public final class Analyzer {
             }
             related.add(new LspDiagnostic.Related(uri, rangeOfRegion(other.region()),
                     other.labelled()
-                            ? Messages.get(other.labelKey(), Locale.ENGLISH, other.labelArgs())
+                            ? Messages.get(other.labelKey(), EDITOR_LANGUAGE, other.labelArgs())
                             : message));
         }
         Range range = view.anchor().region() != null

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
@@ -40,6 +40,20 @@ public interface DiagnosticRenderer {
         return List.copyOf(rendered);
     }
 
+    /**
+     * The one-line text a {@code CompileException} carries for {@code getMessage()}.
+     *
+     * <p>There is no language to pass. An adapter prints that text only for an exception carrying no
+     * diagnostic, and the two sites that build this always supply one, so nothing rendering for a
+     * reader ever reads it; what reads it is {@code getMessage()} itself, in a test or an embedding
+     * caller. What it has to do is not change when the language a reader is answered in is decided
+     * again — a different requirement from being English, and the reason the caller does not get to
+     * choose one. English is what this text is.
+     */
+    static String legacyBody(Diagnostic d) {
+        return body(d, Locale.ENGLISH);
+    }
+
     /** The message body, from the catalog key or the compatibility literal. */
     static String body(Diagnostic d, Locale locale) {
         if (d.literalMessage() != null) {

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticRenderer.java
@@ -41,7 +41,8 @@ public interface DiagnosticRenderer {
     }
 
     /**
-     * The one-line text a {@code CompileException} carries for {@code getMessage()}.
+     * The body a {@code CompileException} builds its {@code getMessage()} from — that text with
+     * the position and the code put in front of it.
      *
      * <p>There is no language to pass. An adapter prints that text only for an exception carrying no
      * diagnostic, and the two sites that build this always supply one, so nothing rendering for a
@@ -56,6 +57,7 @@ public interface DiagnosticRenderer {
 
     /** The message body, from the catalog key or the compatibility literal. */
     static String body(Diagnostic d, Locale locale) {
+        java.util.Objects.requireNonNull(locale, Messages.NEEDS_A_LANGUAGE);
         if (d.literalMessage() != null) {
             return d.literalMessage();
         }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Messages.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Messages.java
@@ -2,6 +2,7 @@ package souther.compiler.diag;
 
 import java.text.MessageFormat;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
@@ -85,6 +86,7 @@ public final class Messages {
      * place to raise another one.
      */
     public static String get(String key, Locale locale, Object... args) {
+        Objects.requireNonNull(locale, NEEDS_A_LANGUAGE);
         String template = lookup(key, locale);
         if (template == null) {
             return key;
@@ -102,8 +104,23 @@ public final class Messages {
 
     /** Whether the catalog defines {@code key} for {@code locale} (or its English base). */
     public static boolean has(String key, Locale locale) {
+        Objects.requireNonNull(locale, NEEDS_A_LANGUAGE);
         return lookup(key, locale) != null;
     }
+
+    /**
+     * What a caller passing no locale is told.
+     *
+     * <p>No locale is not the default one. Reading it that way puts the default back within reach of
+     * every caller — a site with no reader to resolve for passes nothing and is answered out of the
+     * language chosen for readers who named none, which is the same mistake a public
+     * {@link #defaultLocale()} allowed, spelled so that nothing looking for a locale being picked
+     * would see it. A caller either resolved a language for a reader or is building text that has no
+     * reader, and the second has {@link DiagnosticRenderer#legacyBody}.
+     */
+    static final String NEEDS_A_LANGUAGE =
+            "a message is written in a language, and no language is not one of them:"
+                    + " resolve one for the reader, or take the body that has no reader";
 
     // No-fallback control so an explicit `--lang en` resolves to the English base rather than being
     // diverted to the JVM default locale's bundle (which ResourceBundle would otherwise insert into
@@ -114,8 +131,7 @@ public final class Messages {
 
     private static String lookup(String key, Locale locale) {
         try {
-            ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE,
-                    locale == null ? defaultLocale() : locale, CONTROL);
+            ResourceBundle bundle = ResourceBundle.getBundle(BUNDLE, locale, CONTROL);
             return bundle.getString(key);
         } catch (MissingResourceException _) {
             return null;

--- a/souther-syntax/src/main/java/souther/compiler/diag/Messages.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Messages.java
@@ -56,8 +56,16 @@ public final class Messages {
         return defaultLocale();
     }
 
-    /** The locale when none is chosen: English, the one the shipped documents are written in. */
-    public static Locale defaultLocale() {
+    /**
+     * The locale when none is chosen: English, the one the shipped documents are written in.
+     *
+     * <p>Not callable from outside. It is the tail of the resolution above and nothing else: it
+     * answers the reader who named no language. Offered as a way to get a locale it reads as one,
+     * and a caller that needs a value but has no reader to resolve for takes it — after which that
+     * caller's text changes language the next time the default is decided, which is a decision
+     * about readers who named nothing and not about that caller.
+     */
+    private static Locale defaultLocale() {
         return Locale.ENGLISH;
     }
 


### PR DESCRIPTION
Closes #420.

Five call sites picked a `Locale` for a diagnostic. They were not five instances of one policy.

Three answer a reader and have to say which reader. The other two build the one-line text a
`CompileException` carries for `getMessage()`, and have no reader at all: every adapter prints that
text only for an exception carrying no diagnostic, and both sites always supply one. What reads it
is a caller holding the exception.

## Each surface names the language it answers in

The CLI resolved `--lang` at three call sites and the language server wrote English at two, with
nothing saying the sites of one surface had to agree. Now each names its policy once, where the
surface is: `RenderOptions.locale()`, `SoutherProcessor.locale()`, and `Analyzer.EDITOR_LANGUAGE` —
English because an editor tells a server which files the workspace holds and nothing about which
language its user reads.

Not a table in the diagnostics layer. An adapter's language comes from the adapter's own option, and
a layer holding the list would have to know every adapter to answer a question each of them can
answer for itself.

## The legacy text stops picking one

`Report` wrote English outright, which cannot move. `ExampleVerifier` wrote
`Messages.defaultLocale()`, which is the tail of the reader-locale resolution and answers whatever
that resolution most recently settled on — so the text of a failing example was Japanese, which is
not something anyone decided about failing examples. Both spellings meant "do not change when the
reader's language is decided again", and only one of them says it.

`DiagnosticRenderer.legacyBody(Diagnostic)` now builds that text and takes no locale, so neither
site chooses.

## No locale stops meaning the default locale

Making `defaultLocale()` private is not enough on its own. The message lookup read a null locale as
the default, so `Messages.get(key, null, args)` reached it — the same mistake, spelled so that
nothing looking for a locale being chosen would see it, and `DiagnosticRenderer.body` is a static
method on an interface and so public too.

`Messages.get`, `Messages.has` and `DiagnosticRenderer.body` refuse a null locale, and the lookup's
fallback is gone. A caller has either resolved a language for a reader or is building a text that
has no reader, and there is a way to say each. `defaultLocale()`'s one caller is now the last step
of the resolution.

The javadoc on `ExampleVerifier.legacyOf` said the LSP surfaces that string. It does not —
`souther-lsp` never mentions `ExampleVerifier`, and the analyzer renders the diagnostics the
exception carries. Describing the text as something a reader sees is what made picking a reader's
locale for it look right, so the correction ships with the API change rather than after it.

## What holds it

`EverySurfaceThatAnswersAReaderNamesItsLanguageTest` scans every module's main sources for the ways
a language gets picked and requires the set to equal an enumeration, one entry per surface. Picking
twice fails it, and so does picking anywhere not named. The enumeration lives in the test rather
than in the diagnostics layer, so a new surface is a line there and the layer stays ignorant of the
adapters. What it matches is every way a `Locale` is produced other than `ROOT`, as a shape rather
than a list of the spellings in use — `Locale.US` is as direct a choice as `Locale.ENGLISH` and
would have to be thought of to be listed. It is a tripwire like the machine-locale test beside it,
and the two now point at each other.

`AskingForAMessageWithoutALanguageIsRefusedTest` holds the null path, which no source scan can see.

`TheOneLineTextOfAFailingExampleIsNotAddressedToAReaderTest` pins that text to the English catalog
and asserts the Japanese catalog answers the key differently, so the first assertion is a claim
about which language rather than one both would satisfy.

ADR-0044's *Revision* said the per-adapter policy was a separate problem; amended in place with what
this settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
