### PR TITLE
A caller listing is the whole set, whatever that caller can invoke

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/doc/Caller.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/Caller.java
@@ -14,6 +14,12 @@ package souther.compiler.doc;
  * <p>These are the offers a command composes. A document that sends its reader somewhere writes
  * the same kind of offer in its own text, as an {@link Affordance}, and this is what picks its
  * spelling too.
+ *
+ * <p>How to ask for something is the whole of what varies here. Which documents there are, and
+ * which names a listing gives, are the same over every wire: a caller with no way to invoke a
+ * command still gets the manual for it, with whatever that manual sends its reader to spelled as a
+ * call that caller can make. Holding a topic back from one listing would answer a reader who has no
+ * other map with a smaller world rather than with a spelling of its own.
  */
 enum Caller {
 

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -44,13 +44,8 @@ public final class DocCommand {
                 out.println(s.anchor() + "\t" + "  ".repeat(s.level() - 2) + s.title());
             }
             for (LibraryDocs.Topic topic : shipped.topics()) {
-                // The listing is the map a caller navigates by, so it names what this one can use.
-                // A topic left out of it is still read by name, which is how a reader who is asking
-                // about the toolchain rather than about their next step still arrives at it.
-                if (topic.listedFor(caller)) {
-                    out.println(topic.name() + "\t"
-                            + "  ".repeat(Math.max(0, topic.depth() - 1)) + topic.title());
-                }
+                out.println(topic.name() + "\t"
+                        + "  ".repeat(Math.max(0, topic.depth() - 1)) + topic.title());
             }
             return 0;
         }

--- a/souther-compiler/src/main/java/souther/compiler/doc/LibraryDocs.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/LibraryDocs.java
@@ -63,21 +63,10 @@ public final class LibraryDocs {
      * finding it once and finding it at all the same guarantee.
      *
      * <p>{@code depth} is 0 for a document and the heading's level for a part of one, which is what
-     * a listing indents by. {@code listedFor} is null for a topic every caller is shown, which is
-     * nearly all of them. A topic that documents an interface only one caller has is named in that
-     * caller's listing alone: the listing is where a client with no other map of what is here
-     * decides what to read, and a manual for a wire this one is not on is not an answer it can use.
-     * It stays readable by name, because what the toolchain is remains worth knowing to a reader
-     * who asks.
+     * a listing indents by.
      */
     public record Topic(String name, String title, int depth, String resource, int from, int to,
-            List<Slice> own, Caller listedFor) {
-
-        /** Whether {@code caller}'s listing names this topic. */
-        boolean listedFor(Caller caller) {
-            return listedFor == null || listedFor == caller;
-        }
-    }
+            List<Slice> own) {}
 
     /** A run of a file, from one position up to another. */
     public record Slice(int from, int to) {}
@@ -124,28 +113,22 @@ public final class LibraryDocs {
                         continue;
                     }
                     for (String entry : lines(indexUrl)) {
-                        // A file, and after a tab the caller whose listing names it. An index that
-                        // writes only the file names every caller's listing, which is what a doc
-                        // set that has never had to think about wires writes.
-                        String[] written = entry.split("\t", 2);
-                        String file = written[0].strip();
+                        String file = entry.strip();
                         String topic = set + "/" + file.replaceFirst("\\.md$", "");
                         String resource = ROOT + set + "/" + file;
-                        Caller listedFor = written.length < 2
-                                ? null : listedFor(written[1].strip(), topic);
                         String text = Affordance.materialize(text(loader, resource), caller);
                         List<Named> parts = named(topic, text);
                         // The file, and then each part it names. What is searched of each is its
                         // extent with the parts named inside it taken out, so the file and its parts
                         // divide it between them: nothing is counted twice and nothing is left out.
                         Topic whole = new Topic(topic, titleOf(text, file), 0, resource, 0,
-                                text.length(), without(0, text.length(), parts), listedFor);
+                                text.length(), without(0, text.length(), parts));
                         register(byName, whole);
                         ranked.add(whole);
                         for (Named part : parts) {
                             Topic held = new Topic(part.name(), part.title(), part.level(), resource,
                                     part.from(), part.to(),
-                                    without(part.from(), part.to(), inside(part, parts)), listedFor);
+                                    without(part.from(), part.to(), inside(part, parts)));
                             register(byName, held);
                             ranked.add(held);
                         }
@@ -267,17 +250,6 @@ public final class LibraryDocs {
             left.add(new Slice(at, to));
         }
         return List.copyOf(left);
-    }
-
-    /** The caller an index names beside a topic, refusing one no caller answers to. */
-    private static Caller listedFor(String written, String topic) {
-        for (Caller caller : Caller.values()) {
-            if (caller.name().equalsIgnoreCase(written)) {
-                return caller;
-            }
-        }
-        throw new IllegalStateException("`" + topic + "` is listed for `" + written
-                + "`, which is nobody this answers");
     }
 
     /** Every shipped topic, in registry order. */

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/index
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/index
@@ -1,3 +1,3 @@
 start-here.md
 commands.md
-run.md	CLI
+run.md

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
@@ -9,6 +9,11 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -22,34 +27,63 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <p>These tests ask for each answer the way a client would have to, over the protocol, and hold
  * it against what the same command prints at a prompt.
+ *
+ * <p>The two differ in how an operation is asked for and in nothing else. Which documents there
+ * are, and which names a listing gives, are the same over both wires: a caller that cannot invoke
+ * a command still gets the manual for it, with whatever that manual sends the reader to spelled as
+ * a call this caller can make. A name held back from one listing would be a hole in the only map a
+ * client has, and a name it cannot see is content that does not exist for it.
  */
 class EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
+    /** A document sending a client to one name: {@code `doc_read {name: "sum-discrimination"}`}. */
+    private static final Pattern SENT_TO = Pattern.compile("`doc_read \\{name: \"([^\"]+)\"}`");
+
     @Test
-    void aClientThatKnowsNoNameIsGivenEveryNameItCanUse() {
+    void aClientThatKnowsNoNameIsGivenEveryNameThereIs() {
         String listing = text(call("doc_read", "{}"));
 
+        assertEquals(printed(new String[]{}), listing,
+                "the listing a reader gets for no argument is the listing a client gets for no name");
         assertTrue(listing.lines().count() > 300, "every section and every shipped topic, not a page of them");
         assertTrue(listing.contains("cli/start-here"),
                 "including the topic written for a reader who has never written Souther");
-
-        List<String> onlyAtAPrompt = printed(new String[]{}).lines()
-                .filter(line -> !listing.contains(line)).toList();
-        assertEquals(List.of("cli/run\tRunning a behavior: `souther run`"), onlyAtAPrompt,
-                "the listing is this caller's map, and what it leaves out is a manual for a"
-                        + " command this caller has no way to invoke");
     }
 
+    /**
+     * A client that starts at the listing and follows what it reads has to stay inside the set the
+     * listing named. A document pointing out of it is an answer reachable only by a reader who was
+     * already holding the document that points there, which is not the reader this listing is for.
+     */
     @Test
-    void aTopicTheListingLeavesOutIsStillReadByName() {
-        JsonNode answer = call("doc_read", "{\"name\":\"cli/run\"}");
+    void everyNameADocumentSendsThisClientToIsOnTheListingItStartedFrom() {
+        Set<String> listed = new TreeSet<>();
+        text(call("doc_read", "{}")).lines()
+                .forEach(line -> listed.add(DocName.canonical(line.substring(0, line.indexOf('\t')))));
 
-        assertFalse(answer.get("isError").asBoolean(),
-                "not being on the map is not being unreachable — what the toolchain is stays"
-                        + " worth knowing to a client that asks about it");
-        assertTrue(text(answer).contains("--behavior"), text(answer));
+        Set<String> sentTo = new TreeSet<>();
+        LibraryDocs docs = LibraryDocs.on(getClass().getClassLoader(), Caller.MCP);
+        docs.topics().forEach(topic -> namesIn(docs.read(topic.name()), sentTo));
+        SpecDocument.bundled(Caller.MCP).sections()
+                .forEach(section -> namesIn(section.body(), sentTo));
+
+        assertFalse(sentTo.isEmpty(), "there are names to follow, so this is not passing on silence");
+        assertEquals(Set.of(),
+                sentTo.stream().filter(name -> !listed.contains(DocName.canonical(name)))
+                        .collect(Collectors.toCollection(TreeSet::new)),
+                "a document sends this client to these and the listing it starts from does not name them");
+    }
+
+    /** The names {@code text} sends a client to, leaving out one standing in for a name it supplies. */
+    private void namesIn(String text, Set<String> found) {
+        Matcher sent = SENT_TO.matcher(text);
+        while (sent.find()) {
+            if (!sent.group(1).contains("<")) {
+                found.add(sent.group(1));
+            }
+        }
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
@@ -41,15 +41,45 @@ class EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest {
     /** A document sending a client to one name: {@code `doc_read {name: "sum-discrimination"}`}. */
     private static final Pattern SENT_TO = Pattern.compile("`doc_read \\{name: \"([^\"]+)\"}`");
 
+    /** An argument standing for one the reader supplies, which is not a name to look for. */
+    private static final Pattern STANDS_IN = Pattern.compile("<[^>]+>");
+
+    /**
+     * The listing is every section of the specification and every topic the shipped sets carry,
+     * which is what a client is told it is. Held against those rather than against the other
+     * caller's listing: two listings agreeing is not either of them being whole, and a name this
+     * one holds and does not print is a name only a reader who already knew it can ask for.
+     *
+     * <p>That the sets themselves hold what their indexes promise is a separate guarantee, kept
+     * where a doc set's own contract is.
+     */
     @Test
     void aClientThatKnowsNoNameIsGivenEveryNameThereIs() {
-        String listing = text(call("doc_read", "{}"));
+        Set<String> listed = names(text(call("doc_read", "{}")));
 
-        assertEquals(printed(new String[]{}), listing,
-                "the listing a reader gets for no argument is the listing a client gets for no name");
-        assertTrue(listing.lines().count() > 300, "every section and every shipped topic, not a page of them");
-        assertTrue(listing.contains("cli/start-here"),
+        Set<String> thereIs = new TreeSet<>();
+        SpecDocument.bundled(Caller.MCP).sections()
+                .forEach(section -> thereIs.add(DocName.canonical(section.anchor())));
+        LibraryDocs.on(getClass().getClassLoader(), Caller.MCP).topics()
+                .forEach(topic -> thereIs.add(DocName.canonical(topic.name())));
+
+        assertTrue(thereIs.size() > 300, "every section and every shipped topic, not a page of them");
+        assertEquals(Set.of(), missing(thereIs, listed),
+                "these are answered by name and the listing that names what there is does not give them");
+        assertEquals(Set.of(), missing(listed, thereIs),
+                "and the listing gives these, which nothing here is");
+        assertTrue(listed.contains("cli/start-here"),
                 "including the topic written for a reader who has never written Souther");
+    }
+
+    /**
+     * A caller is answered in its own spelling, and a document's title is spelled as its text is,
+     * so what the two listings have to agree on is which names they give rather than how each line
+     * reads. Which documents there are is not something a wire decides.
+     */
+    @Test
+    void aClientAndAReaderAtAPromptAreGivenTheSameNames() {
+        assertEquals(names(printed(new String[]{})), names(text(call("doc_read", "{}"))));
     }
 
     /**
@@ -59,9 +89,7 @@ class EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest {
      */
     @Test
     void everyNameADocumentSendsThisClientToIsOnTheListingItStartedFrom() {
-        Set<String> listed = new TreeSet<>();
-        text(call("doc_read", "{}")).lines()
-                .forEach(line -> listed.add(DocName.canonical(line.substring(0, line.indexOf('\t')))));
+        Set<String> listed = names(text(call("doc_read", "{}")));
 
         Set<String> sentTo = new TreeSet<>();
         LibraryDocs docs = LibraryDocs.on(getClass().getClassLoader(), Caller.MCP);
@@ -76,14 +104,27 @@ class EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest {
                 "a document sends this client to these and the listing it starts from does not name them");
     }
 
+    /** What {@code asked} holds and {@code given} does not, which is what a failure has to say. */
+    private Set<String> missing(Set<String> asked, Set<String> given) {
+        return asked.stream().filter(name -> !given.contains(name))
+                .collect(Collectors.toCollection(TreeSet::new));
+    }
+
     /** The names {@code text} sends a client to, leaving out one standing in for a name it supplies. */
     private void namesIn(String text, Set<String> found) {
         Matcher sent = SENT_TO.matcher(text);
         while (sent.find()) {
-            if (!sent.group(1).contains("<")) {
+            if (!STANDS_IN.matcher(sent.group(1)).find()) {
                 found.add(sent.group(1));
             }
         }
+    }
+
+    /** The names a listing gives, each as the lookup itself reads it. */
+    private Set<String> names(String listing) {
+        return listing.lines()
+                .map(line -> DocName.canonical(line.substring(0, line.indexOf('\t'))))
+                .collect(Collectors.toCollection(TreeSet::new));
     }
 
     @Test


### PR DESCRIPTION
Closes #424.

`cli/run` was in the listing at a prompt and not in the one an MCP client gets — 316 names against
315. Its entry in `cli/index` named `CLI` as the caller whose listing carries it.

## Why the mark does not hold

**Its reason had already been taken away.** The commit that added the mark also turned the two
places `cli/run` sends its reader into affordances, spelled per caller. What is left in the topic is
descriptive shell text — the same kind `cli/commands` keeps and every caller is shown. The mark took
a reachable answer off one map rather than rewriting an instruction one caller cannot follow.

**It was the only topic marked.** `cli/commands` documents eight commands a client cannot invoke and
is listed for everyone. `cli/commands/run` is among them: a section about the same command, whose
body past the usage line is a pointer into the topic the listing had just left out.

**It reached one route of three.** `doc_search` ranked `cli/run` for a client and `doc_read`
answered it by name. Only the listing — the one `doc_read`'s description calls the place to start —
held it back.

## What changed

`Topic.listedFor` and the caller column in an index are gone, and `DocCommand`'s listing prints
every topic. `caller` still reaches `LibraryDocs` and `SpecDocument`, where it decides how an
affordance is spelled. `Caller`'s javadoc now says where that boundary is: how to ask for something
varies by caller, which documents there are and which names a listing gives do not.

## Tests

- `aClientThatKnowsNoNameIsGivenEveryNameThereIs` is back to the two listings being one set.
- `everyNameADocumentSendsThisClientToIsOnTheListingItStartedFrom` is new: every ``doc_read {name: "X"}``
  a document offers a client names something the listing gave. Placeholders standing in for a name
  the reader supplies are left out; names are compared the way `doc_read` resolves them, so
  `{{doc:E2011}}` matches the `e2011` the listing prints.

Two mutants fail them apart: the mark restored fails only the closure test, and dropping `cli/run`
from both listings passes the set-equality test and fails the closure test.

`mvn clean verify` passes. On the shipped jar, `souther doc` and `doc_read {}` both answer 316
names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)