### PR TITLE
A value is listed the way it is written, without an argument list

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
@@ -80,7 +80,8 @@ public final class ApiCommand {
         return 0;
     }
 
-    /** One callable name's parameters, as written, and the type its call answers with. */
+    /** One published name's parameters, as written, and the type it answers with. A name declaring
+     *  none is a value rather than a function of no arguments. */
     record Signature(List<String> paramNames, List<Type> paramTypes, Type result) {}
 
     private static void listPublished(PrintStream out, String prefix) {
@@ -92,12 +93,12 @@ public final class ApiCommand {
     }
 
     /**
-     * Every name a call may be written with, in module order.
+     * Every name a program may write, in module order.
      *
-     * <p>This is the callable surface, not the declared one: a name written as sugar over a private
-     * helper — {@code List.fold}, which the checker rewrites to {@code List.foldFrom(…, 0)} — is
-     * what the specification tells a reader to call, so it is listed under its own name and with
-     * only the arguments its caller writes. Leaving it out would have this command contradict the
+     * <p>This is the surface a reader writes, not the declared one: a name written as sugar over a
+     * private helper — {@code List.fold}, which the checker rewrites to {@code List.foldFrom(…, 0)}
+     * — is what the specification tells a reader to call, so it is listed under its own name and
+     * with only the arguments its caller writes. Leaving it out would have this command contradict the
      * specification about what exists.
      *
      * <p>Which names those are and what order they come in are both {@link Prelude#published()}'s
@@ -136,16 +137,26 @@ public final class ApiCommand {
         return new Signature(names, kept, entry.signature().result());
     }
 
+    /**
+     * One name as its caller writes it. A parameter list is written where the declaration declares
+     * one; a declaration with none is a value, which is named where the value it stands for would go
+     * and refused where it is applied (E1803). No parameters is that case and only that case: the
+     * parameter list is what tells a function from a value, and an empty {@code ()} is refused
+     * rather than being a second spelling of either.
+     */
     private static String line(String qualifiedName, Signature signature) {
-        StringBuilder sb = new StringBuilder(qualifiedName).append("(");
-        for (int i = 0; i < signature.paramNames().size(); i++) {
-            if (i > 0) {
-                sb.append(", ");
+        StringBuilder sb = new StringBuilder(qualifiedName);
+        if (!signature.paramNames().isEmpty()) {
+            sb.append("(");
+            for (int i = 0; i < signature.paramNames().size(); i++) {
+                if (i > 0) {
+                    sb.append(", ");
+                }
+                sb.append(signature.paramNames().get(i)).append(": ")
+                        .append(Type.show(signature.paramTypes().get(i)));
             }
-            sb.append(signature.paramNames().get(i)).append(": ")
-                    .append(Type.show(signature.paramTypes().get(i)));
+            sb.append(")");
         }
-        sb.append(")");
         if (signature.result() != null) {
             sb.append(" : ").append(Type.show(signature.result()));
         }

--- a/souther-compiler/src/test/java/souther/compiler/doc/AListedValueIsWrittenWithoutAnArgumentListTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/AListedValueIsWrittenWithoutAnArgumentListTest.java
@@ -1,0 +1,99 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The listing writes each name the way its caller writes it. A {@code let} with a parameter list is
+ * a function and is called with one; a {@code let} without is a value, and applying one is refused
+ * ({@code <<fn-declaration>>}, E1803). A value written in the listing with an argument list teaches
+ * the single form the checker rejects, and the listing is where the documentation sends a reader to
+ * find out how a name is called.
+ *
+ * <p>Which of the two a name is comes from the surface the listing is built from, not from a list of
+ * names kept here: a parameter list is empty when the declaration had none, and the language admits
+ * no second reading of that — an empty {@code ()} is refused. So a value the library publishes later
+ * is held to this without the check being told about it.
+ */
+class AListedValueIsWrittenWithoutAnArgumentListTest {
+
+    private static String listing() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int code = ApiCommand.run(new String[]{},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+        assertEquals(0, code, err.toString(StandardCharsets.UTF_8));
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    /** What a line writes before the type it answers with: the name, and the argument list where one
+     *  is written. The type is left out, since a parameter's own type has parentheses of its own. */
+    private static String calledAs(String line) {
+        int type = line.indexOf(" : ");
+        return type < 0 ? line : line.substring(0, type);
+    }
+
+    @Test
+    void anArgumentListIsWrittenExactlyWhereTheDeclarationDeclaresOne() {
+        Map<String, ApiCommand.Signature> surface = ApiCommand.surface();
+        List<String> values = new ArrayList<>();
+        List<String> functions = new ArrayList<>();
+
+        for (String line : listing().lines().toList()) {
+            String called = calledAs(line);
+            int open = called.indexOf('(');
+            String name = open < 0 ? called : called.substring(0, open);
+            ApiCommand.Signature signature = surface.get(name);
+            assertNotNull(signature, "the listing writes a name the surface does not publish: " + line);
+            if (signature.paramNames().isEmpty()) {
+                values.add(name);
+                assertEquals(name, called,
+                        "`" + name + "` declares no parameter list, so it is a value and applying it"
+                                + " is refused — the listing must not write it as a call: " + line);
+            } else {
+                functions.add(name);
+                assertTrue(open >= 0,
+                        "`" + name + "` declares parameters, so a caller writes an argument list: " + line);
+            }
+        }
+
+        assertFalse(values.isEmpty(), "no value was checked at all — the scan settles nothing");
+        assertFalse(functions.isEmpty(), "no function was checked at all — the scan settles nothing");
+    }
+
+    @Test
+    void theEmptyCollectionsAreListedTheWayTheSpecificationSaysTheyAreWritten() {
+        List<String> lines = listing().lines().toList();
+
+        assertTrue(lines.contains("Map.empty : Map<'k, 'a>"), listing());
+        assertTrue(lines.contains("Set.empty : Set<'a>"), listing());
+        assertTrue(lines.stream().noneMatch(l -> l.contains("empty()")),
+                "`Map.empty()` is the spelling the specification says is never written:\n" + listing());
+    }
+
+    /** Every form of the answer is the same rendering, so a reader asking for one name is told what
+     *  the whole listing tells. */
+    @Test
+    void aNameLookedUpOnItsOwnIsWrittenTheSameWay() {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int code = ApiCommand.run(new String[]{"Map.empty"},
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+
+        assertEquals(0, code, err.toString(StandardCharsets.UTF_8));
+        assertEquals("Map.empty : Map<'k, 'a>", out.toString(StandardCharsets.UTF_8).strip());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheApiCommandAnswersTheStdlibSurfaceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheApiCommandAnswersTheStdlibSurfaceTest.java
@@ -20,6 +20,16 @@ class TheApiCommandAnswersTheStdlibSurfaceTest {
 
     private record Answer(int code, String out, String err) {}
 
+    /** The name a listed line stands for. The type it answers with comes after {@code " : "}, and an
+     *  argument list before that is written only where the name declares parameters — a value is
+     *  written with none, so a name is not what stands before a {@code (} the line may not have. */
+    private static String nameIn(String line) {
+        int type = line.indexOf(" : ");
+        String called = type < 0 ? line : line.substring(0, type);
+        int open = called.indexOf('(');
+        return open < 0 ? called : called.substring(0, open);
+    }
+
     private Answer run(String... args) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
@@ -45,7 +55,7 @@ class TheApiCommandAnswersTheStdlibSurfaceTest {
 
         assertEquals(0, answer.code());
         List<String> listed = answer.out().lines()
-                .map(line -> line.substring(0, line.indexOf('(')))
+                .map(TheApiCommandAnswersTheStdlibSurfaceTest::nameIn)
                 .toList();
 
         assertEquals(List.copyOf(Prelude.published()), listed,


### PR DESCRIPTION
Closes #432.

`souther api` built every line as a call, so the two standard-library values were printed as `Map.empty()` and `Set.empty()` — the spelling `[#stdlib-map]` and `[#stdlib-set]` say is never written, and the one E1803 refuses. The MCP `stdlib_api` tools route through the same command, so they answered the same text.

## What was wrong

`ApiCommand.line()` appended `(`, the parameters, and `)` unconditionally. The distinction was never lost on the way there: `surface()` carries the declaration's parameter list, and for `let empty : Map<'k, 'a> = intrinsic "map.empty"` that list is empty. `[#fn-declaration]` makes an empty parameter list the value form and refuses an empty `()`, so no parameters is that case and only that case. The renderer just never asked.

## The fix

An argument list is written where the declaration declares one. The rule is the general one about the surface, not knowledge about `Map` and `Set`: nothing added here names either module, and `Prelude.isEmptyCollectionValue` is not consulted, since a check written against it would rest on the accident that today's only values are the empty collections.

```
$ souther api
Map.empty : Map<'k, 'a>
Set.empty : Set<'a>
```

## Tests

`AListedValueIsWrittenWithoutAnArgumentListTest` walks the whole listing against the surface it is built from and asserts `params.isEmpty()` holds exactly where no argument list is written, so a value published later is covered without the check being told about it. It fails when no value or no function was seen at all, so it cannot pass by scanning nothing. The two lines are also asserted exactly, and the single-name lookup is asserted to render the same way.

`TheApiCommandAnswersTheStdlibSurfaceTest` took a name to be what stands before the first `(`, which assumed every line has one. It reads the name off the type separator instead — the assumption, not just the case that broke it, is what is removed.

The issue body has been corrected: the refusal is E1803 (`what-is-applied-is-a-function`), not E1804.

`mvn clean test` is green across every module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)