### PR TITLE
A construct that does not fit breaks at its own separator

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheCanonicalFormBreaksAtTheEnclosingStructureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheCanonicalFormBreaksAtTheEnclosingStructureTest.java
@@ -1,0 +1,393 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The canonical width applies to every breakable construct, declarations included, and a construct
+ * that does not fit breaks at its own separator rather than inside one of its members.
+ *
+ * <p>Each row of {@link #shapes} is one repeated or joined construct, written long enough not to
+ * fit, against the multi-line form it is required to take. A construct with no row here is a
+ * construct whose canonical form nothing pins.
+ */
+class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
+
+    private static final int WIDTH = 100;
+
+    record Shape(String name, String source, String expected) {
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static Stream<Shape> shapes() {
+        return Stream.of(
+                new Shape("exposing",
+                        """
+                        module fmtprobe exposing ( AlphaType, BetaType, GammaType, DeltaType, EpsilonType, ZetaType, EtaType )
+                        """,
+                        """
+                        module fmtprobe exposing (
+                            AlphaType,
+                            BetaType,
+                            GammaType,
+                            DeltaType,
+                            EpsilonType,
+                            ZetaType,
+                            EtaType
+                        )
+                        """),
+
+                new Shape("import name list",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        import some.other.place ( alphaName, betaName, gammaName, deltaName, epsilonName, zetaName, etaName, thetaName )
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+                        import some.other.place (
+                            alphaName,
+                            betaName,
+                            gammaName,
+                            deltaName,
+                            epsilonName,
+                            zetaName,
+                            etaName,
+                            thetaName
+                        )
+                        """),
+
+                new Shape("behavior parameter list",
+                        """
+                        module fmtprobe exposing ( settle )
+
+                        behavior settleTheOutstandingBalance : (accountIdentifier: AccountId, requestedAmount: Amount, effectiveDate: Date) -> Receipt
+                        """,
+                        """
+                        module fmtprobe exposing ( settle )
+
+                        behavior settleTheOutstandingBalance : (
+                            accountIdentifier: AccountId,
+                            requestedAmount: Amount,
+                            effectiveDate: Date
+                        ) -> Receipt
+                        """),
+
+                new Shape("definition parameter list",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let settleTheOutstandingBalance (accountIdentifier: AccountId, requestedAmount: Amount, effectiveDate: Date): Receipt = accountIdentifier
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let settleTheOutstandingBalance (
+                            accountIdentifier: AccountId,
+                            requestedAmount: Amount,
+                            effectiveDate: Date
+                        ): Receipt = accountIdentifier
+                        """),
+
+                new Shape("return type union",
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        behavior judge : (code: Code) -> AcceptedOutcome | RefusedOutcome | DeferredOutcome | EscalatedOutcome
+                        """,
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        behavior judge : (code: Code) -> AcceptedOutcome
+                            | RefusedOutcome
+                            | DeferredOutcome
+                            | EscalatedOutcome
+                        """),
+
+                new Shape("sum cases",
+                        """
+                        module fmtprobe exposing ( Verdict )
+
+                        data Verdict = AcceptedOutright | RefusedOutright | DeferredForReview | EscalatedToManager | WithdrawnByCustomer
+                        """,
+                        """
+                        module fmtprobe exposing ( Verdict )
+
+                        data Verdict = AcceptedOutright
+                            | RefusedOutright
+                            | DeferredForReview
+                            | EscalatedToManager
+                            | WithdrawnByCustomer
+                        """),
+
+                new Shape("constructs clause",
+                        """
+                        module fmtprobe exposing ( b )
+
+                        behavior b : (a: A) -> R
+                            constructs FirstConstructed, SecondConstructed, ThirdConstructed, FourthConstructed, FifthConstructed, SixthConstructed
+                        """,
+                        """
+                        module fmtprobe exposing ( b )
+
+                        behavior b : (a: A) -> R
+                            constructs FirstConstructed,
+                                SecondConstructed,
+                                ThirdConstructed,
+                                FourthConstructed,
+                                FifthConstructed,
+                                SixthConstructed
+                        """),
+
+                new Shape("tuple expression",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = (aLongEnoughName, anotherLongEnoughName, yetAnotherLongName, andTheVeryLastOne, andOneFinalName, andReallyTheLast)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int =
+                            (
+                                aLongEnoughName,
+                                anotherLongEnoughName,
+                                yetAnotherLongName,
+                                andTheVeryLastOne,
+                                andOneFinalName,
+                                andReallyTheLast
+                            )
+                        """),
+
+                new Shape("operator chain",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let lateNightMinutes (s: Int, e: Int): Int = overlapLength(s, e, 0, lateNightMorningEnd) + overlapLength(s, e, lateNightEveningStart, minutesInADay)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let lateNightMinutes (s: Int, e: Int): Int =
+                            overlapLength(s, e, 0, lateNightMorningEnd)
+                                + overlapLength(s, e, lateNightEveningStart, minutesInADay)
+                        """),
+
+                new Shape("example row",
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        example judge
+                            | "an amount that sits exactly on the line is accepted rather than refused" : (Code("c-1"), Amount(100)) -> Accepted
+                        """,
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        example judge
+                            | "an amount that sits exactly on the line is accepted rather than refused"
+                                : (Code("c-1"), Amount(100))
+                                -> Accepted
+                        """),
+
+                new Shape("match case",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = match a with | Zero -> aVeryLongFunctionName(withSomeArgument, andAnotherOne, andYetAnotherOne, andFinalOne)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int =
+                            match a with
+                                | Zero
+                                    -> aVeryLongFunctionName(withSomeArgument, andAnotherOne, andYetAnotherOne, andFinalOne)
+                        """),
+
+                new Shape("intrinsic body",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let truncatingRemainder (dividend: Int, divisor: Int): Int | DivisionByZero = intrinsic "int.truncatingRemainder"
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let truncatingRemainder (dividend: Int, divisor: Int): Int | DivisionByZero =
+                            intrinsic "int.truncatingRemainder"
+                        """),
+
+                new Shape("call arguments",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = aFunctionWithAName(aLongEnoughName, anotherLongEnoughName, yetAnotherLongName, andTheVeryLastOne)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int =
+                            aFunctionWithAName(
+                                aLongEnoughName,
+                                anotherLongEnoughName,
+                                yetAnotherLongName,
+                                andTheVeryLastOne
+                            )
+                        """),
+
+                new Shape("record literal",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = Receipt { firstField = aLongEnoughName, secondField = anotherLongEnoughName, thirdField = yetAnotherName }
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int =
+                            Receipt {
+                                firstField = aLongEnoughName,
+                                secondField = anotherLongEnoughName,
+                                thirdField = yetAnotherName
+                            }
+                        """),
+
+                new Shape("list literal",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = [aLongEnoughName, anotherLongEnoughName, yetAnotherLongName, andTheVeryLastOne, andOneFinalName, andReallyTheLast]
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int =
+                            [
+                                aLongEnoughName,
+                                anotherLongEnoughName,
+                                yetAnotherLongName,
+                                andTheVeryLastOne,
+                                andOneFinalName,
+                                andReallyTheLast
+                            ]
+                        """));
+    }
+
+    /** Each source is written on one line, and that line has to be over the width — a fixture that
+     * fits proves nothing about breaking, and would pass whatever the formatter did. */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shapes")
+    void theFixtureDoesNotFitOnOneLine(Shape shape) {
+        int longest = 0;
+        for (String line : shape.source().split("\n", -1)) {
+            longest = Math.max(longest, line.length());
+        }
+        assertTrue(longest > WIDTH, shape.name() + " fits in " + longest + " columns");
+    }
+
+    /** The canonical multi-line form of each construct. */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shapes")
+    void canonicalMultilineShape(Shape shape) {
+        assertEquals(shape.expected(), Formatter.format(shape.source()));
+    }
+
+    /** Every construct here has a break that resolves the overflow, so no line is left over the
+     * width. This is not a general property of the formatter — a long pattern, an indivisible token
+     * and a deep enough indent all leave a line over — it is a property of these fixtures, and it is
+     * the one an unbreakable declaration fails. */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shapes")
+    void everyLineFitsTheWidth(Shape shape) {
+        for (String line : Formatter.format(shape.source()).split("\n", -1)) {
+            assertTrue(line.length() <= WIDTH,
+                    "line of " + line.length() + " columns: " + line);
+        }
+    }
+
+    /** Formatting the canonical form gives it back. */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shapes")
+    void theCanonicalFormIsAFixedPoint(Shape shape) {
+        assertEquals(shape.expected(), Formatter.format(shape.expected()));
+    }
+
+    /** A source written flat and a source already broken reach the same canonical form, so the
+     * layout carries no meaning the tree does not have. */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("shapes")
+    void aFlatSourceAndABrokenSourceAgree(Shape shape) {
+        assertEquals(Formatter.format(shape.source()), Formatter.format(shape.expected()));
+    }
+
+    record Nesting(String name, String source, List<String> membersThatStayOnOneLine) {
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+
+    static Stream<Nesting> nestings() {
+        return Stream.of(
+                new Nesting("a call inside a call",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = outerFunction(innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc))
+                        """,
+                        List.of("innerFunction(aaa, bbb, ccc),", "innerFunction(aaa, bbb, ccc)")),
+
+                new Nesting("a call inside a tuple",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = (innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc))
+                        """,
+                        List.of("innerFunction(aaa, bbb, ccc),", "innerFunction(aaa, bbb, ccc)")),
+
+                new Nesting("a call inside an operator chain",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = innerFunction(aaa, bbb, ccc) + innerFunction(aaa, bbb, ccc) + innerFunction(aaa, bbb, ccc) + innerFunction(aaa, bbb, ccc)
+                        """,
+                        List.of("innerFunction(aaa, bbb, ccc)", "+ innerFunction(aaa, bbb, ccc)")),
+
+                new Nesting("a call inside an example row",
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        example judge
+                            | "an amount that sits exactly on the line is accepted rather than refused" : (Code("c-1"), Amount(100)) -> Accepted
+                        """,
+                        List.of(": (Code(\"c-1\"), Amount(100))")));
+    }
+
+    /**
+     * The regression #431 leaves behind: a member that fits on a line of its own is written on one,
+     * because the structure enclosing it took the break. The formatter used to descend past the
+     * enclosing structure — which had no break to take — and split the first call that crossed the
+     * width, so a row's three parts stopped being visible and calls written to look alike stopped
+     * looking alike.
+     */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("nestings")
+    void aMemberIsNotSplitWhenTheStructureAroundItCanBreak(Nesting nesting) {
+        List<String> lines = List.of(Formatter.format(nesting.source()).split("\n", -1));
+        for (String member : nesting.membersThatStayOnOneLine()) {
+            assertTrue(lines.stream().anyMatch(l -> l.strip().equals(member)),
+                    "no line holds `" + member + "` on its own; got:\n"
+                            + String.join("\n", lines));
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheCanonicalFormBreaksAtTheEnclosingStructureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheCanonicalFormBreaksAtTheEnclosingStructureTest.java
@@ -1,10 +1,11 @@
 package souther.compiler.fmt;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -22,7 +23,14 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
 
     private static final int WIDTH = 100;
 
-    record Shape(String name, String source, String expected) {
+    /**
+     * @param source the construct on one line, over the width
+     * @param brokenSource the same construct broken somewhere the canonical form does not break — a
+     *     legal layout that is not this one, so that reaching {@code expected} from it says the
+     *     layout carried no meaning rather than repeating that {@code expected} is a fixed point
+     * @param expected the canonical form
+     */
+    record Shape(String name, String source, String brokenSource, String expected) {
         @Override
         public String toString() {
             return name;
@@ -34,6 +42,11 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                 new Shape("exposing",
                         """
                         module fmtprobe exposing ( AlphaType, BetaType, GammaType, DeltaType, EpsilonType, ZetaType, EtaType )
+                        """,
+                        """
+                        module fmtprobe exposing (
+                            AlphaType, BetaType, GammaType,
+                            DeltaType, EpsilonType, ZetaType, EtaType )
                         """,
                         """
                         module fmtprobe exposing (
@@ -52,6 +65,12 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         module fmtprobe exposing ( f )
 
                         import some.other.place ( alphaName, betaName, gammaName, deltaName, epsilonName, zetaName, etaName, thetaName )
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+                        import some.other.place ( alphaName, betaName,
+                            gammaName, deltaName, epsilonName,
+                            zetaName, etaName, thetaName )
                         """,
                         """
                         module fmtprobe exposing ( f )
@@ -76,6 +95,12 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         """
                         module fmtprobe exposing ( settle )
 
+                        behavior settleTheOutstandingBalance : (accountIdentifier: AccountId,
+                            requestedAmount: Amount, effectiveDate: Date) -> Receipt
+                        """,
+                        """
+                        module fmtprobe exposing ( settle )
+
                         behavior settleTheOutstandingBalance : (
                             accountIdentifier: AccountId,
                             requestedAmount: Amount,
@@ -88,6 +113,12 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         module fmtprobe exposing ( f )
 
                         let settleTheOutstandingBalance (accountIdentifier: AccountId, requestedAmount: Amount, effectiveDate: Date): Receipt = accountIdentifier
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let settleTheOutstandingBalance (accountIdentifier: AccountId, requestedAmount: Amount,
+                            effectiveDate: Date): Receipt = accountIdentifier
                         """,
                         """
                         module fmtprobe exposing ( f )
@@ -108,6 +139,12 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         """
                         module fmtprobe exposing ( judge )
 
+                        behavior judge : (code: Code) -> AcceptedOutcome | RefusedOutcome |
+                            DeferredOutcome | EscalatedOutcome
+                        """,
+                        """
+                        module fmtprobe exposing ( judge )
+
                         behavior judge : (code: Code) -> AcceptedOutcome
                             | RefusedOutcome
                             | DeferredOutcome
@@ -119,6 +156,13 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         module fmtprobe exposing ( Verdict )
 
                         data Verdict = AcceptedOutright | RefusedOutright | DeferredForReview | EscalatedToManager | WithdrawnByCustomer
+                        """,
+                        """
+                        module fmtprobe exposing ( Verdict )
+
+                        data Verdict = AcceptedOutright | RefusedOutright |
+                            DeferredForReview | EscalatedToManager |
+                            WithdrawnByCustomer
                         """,
                         """
                         module fmtprobe exposing ( Verdict )
@@ -141,6 +185,14 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         module fmtprobe exposing ( b )
 
                         behavior b : (a: A) -> R
+                            constructs FirstConstructed, SecondConstructed,
+                                ThirdConstructed, FourthConstructed,
+                                FifthConstructed, SixthConstructed
+                        """,
+                        """
+                        module fmtprobe exposing ( b )
+
+                        behavior b : (a: A) -> R
                             constructs FirstConstructed,
                                 SecondConstructed,
                                 ThirdConstructed,
@@ -154,6 +206,13 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         module fmtprobe exposing ( f )
 
                         let f (a: Int): Int = (aLongEnoughName, anotherLongEnoughName, yetAnotherLongName, andTheVeryLastOne, andOneFinalName, andReallyTheLast)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = (aLongEnoughName,
+                            anotherLongEnoughName, yetAnotherLongName, andTheVeryLastOne,
+                            andOneFinalName, andReallyTheLast)
                         """,
                         """
                         module fmtprobe exposing ( f )
@@ -178,6 +237,12 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         """
                         module fmtprobe exposing ( f )
 
+                        let lateNightMinutes (s: Int, e: Int): Int = overlapLength(s, e, 0, lateNightMorningEnd) +
+                            overlapLength(s, e, lateNightEveningStart, minutesInADay)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
                         let lateNightMinutes (s: Int, e: Int): Int =
                             overlapLength(s, e, 0, lateNightMorningEnd)
                                 + overlapLength(s, e, lateNightEveningStart, minutesInADay)
@@ -189,6 +254,15 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
 
                         example judge
                             | "an amount that sits exactly on the line is accepted rather than refused" : (Code("c-1"), Amount(100)) -> Accepted
+                        """,
+                        // what the formatter used to write, which is where #431 started
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        example judge
+                            | "an amount that sits exactly on the line is accepted rather than refused" : (Code(
+                                "c-1"
+                            ), Amount(100)) -> Accepted
                         """,
                         """
                         module fmtprobe exposing ( judge )
@@ -208,10 +282,42 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         """
                         module fmtprobe exposing ( f )
 
+                        let f (a: Int): Int = match a with
+                            | Zero -> aVeryLongFunctionName(withSomeArgument,
+                                andAnotherOne, andYetAnotherOne, andFinalOne)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
                         let f (a: Int): Int =
                             match a with
                                 | Zero
                                     -> aVeryLongFunctionName(withSomeArgument, andAnotherOne, andYetAnotherOne, andFinalOne)
+                        """),
+
+                new Shape("lambda in an expression",
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (xs: Int): Int = consume((firstVeryLongParameter, secondVeryLongParameter, thirdVeryLongParameter) -> firstVeryLongParameter)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (xs: Int): Int = consume((firstVeryLongParameter,
+                            secondVeryLongParameter, thirdVeryLongParameter) -> firstVeryLongParameter)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (xs: Int): Int =
+                            consume(
+                                (
+                                    firstVeryLongParameter,
+                                    secondVeryLongParameter,
+                                    thirdVeryLongParameter
+                                ) -> firstVeryLongParameter
+                            )
                         """),
 
                 new Shape("intrinsic body",
@@ -219,6 +325,12 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         module fmtprobe exposing ( f )
 
                         let truncatingRemainder (dividend: Int, divisor: Int): Int | DivisionByZero = intrinsic "int.truncatingRemainder"
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let truncatingRemainder (dividend: Int,
+                            divisor: Int): Int | DivisionByZero = intrinsic "int.truncatingRemainder"
                         """,
                         """
                         module fmtprobe exposing ( f )
@@ -232,6 +344,12 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         module fmtprobe exposing ( f )
 
                         let f (a: Int): Int = aFunctionWithAName(aLongEnoughName, anotherLongEnoughName, yetAnotherLongName, andTheVeryLastOne)
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = aFunctionWithAName(aLongEnoughName, anotherLongEnoughName,
+                            yetAnotherLongName, andTheVeryLastOne)
                         """,
                         """
                         module fmtprobe exposing ( f )
@@ -254,6 +372,12 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         """
                         module fmtprobe exposing ( f )
 
+                        let f (a: Int): Int = Receipt { firstField = aLongEnoughName,
+                            secondField = anotherLongEnoughName, thirdField = yetAnotherName }
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
                         let f (a: Int): Int =
                             Receipt {
                                 firstField = aLongEnoughName,
@@ -267,6 +391,13 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         module fmtprobe exposing ( f )
 
                         let f (a: Int): Int = [aLongEnoughName, anotherLongEnoughName, yetAnotherLongName, andTheVeryLastOne, andOneFinalName, andReallyTheLast]
+                        """,
+                        """
+                        module fmtprobe exposing ( f )
+
+                        let f (a: Int): Int = [aLongEnoughName, anotherLongEnoughName,
+                            yetAnotherLongName, andTheVeryLastOne,
+                            andOneFinalName, andReallyTheLast]
                         """,
                         """
                         module fmtprobe exposing ( f )
@@ -322,19 +453,33 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
         assertEquals(shape.expected(), Formatter.format(shape.expected()));
     }
 
-    /** A source written flat and a source already broken reach the same canonical form, so the
-     * layout carries no meaning the tree does not have. */
+    /** A source broken somewhere else legal reaches the same canonical form, so where the author put
+     * the newlines carried nothing the tree does not have. The broken form is not the canonical one,
+     * or this would only be asking again whether the canonical form is a fixed point. */
     @ParameterizedTest(name = "{0}")
     @MethodSource("shapes")
-    void aFlatSourceAndABrokenSourceAgree(Shape shape) {
-        assertEquals(Formatter.format(shape.source()), Formatter.format(shape.expected()));
+    void aDifferentLegalLayoutReachesTheSameCanonicalForm(Shape shape) {
+        assertTrue(!shape.brokenSource().equals(shape.expected()),
+                shape.name() + ": the broken source is the canonical form, so this asks nothing");
+        assertEquals(shape.expected(), Formatter.format(shape.brokenSource()));
     }
 
-    record Nesting(String name, String source, List<String> membersThatStayOnOneLine) {
+    /**
+     * @param membersOnTheirOwnLine each member against how many lines have to hold exactly it —
+     *     a count, because one member left intact says nothing about the others
+     */
+    record Nesting(String name, String source, Map<String, Integer> membersOnTheirOwnLine) {
         @Override
         public String toString() {
             return name;
         }
+    }
+
+    private static Map<String, Integer> members(String a, int na, String b, int nb) {
+        Map<String, Integer> out = new LinkedHashMap<>();
+        out.put(a, na);
+        out.put(b, nb);
+        return out;
     }
 
     static Stream<Nesting> nestings() {
@@ -345,7 +490,8 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
 
                         let f (a: Int): Int = outerFunction(innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc))
                         """,
-                        List.of("innerFunction(aaa, bbb, ccc),", "innerFunction(aaa, bbb, ccc)")),
+                        members("innerFunction(aaa, bbb, ccc),", 2,
+                                "innerFunction(aaa, bbb, ccc)", 1)),
 
                 new Nesting("a call inside a tuple",
                         """
@@ -353,7 +499,8 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
 
                         let f (a: Int): Int = (innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc), innerFunction(aaa, bbb, ccc))
                         """,
-                        List.of("innerFunction(aaa, bbb, ccc),", "innerFunction(aaa, bbb, ccc)")),
+                        members("innerFunction(aaa, bbb, ccc),", 3,
+                                "innerFunction(aaa, bbb, ccc)", 1)),
 
                 new Nesting("a call inside an operator chain",
                         """
@@ -361,7 +508,8 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
 
                         let f (a: Int): Int = innerFunction(aaa, bbb, ccc) + innerFunction(aaa, bbb, ccc) + innerFunction(aaa, bbb, ccc) + innerFunction(aaa, bbb, ccc)
                         """,
-                        List.of("innerFunction(aaa, bbb, ccc)", "+ innerFunction(aaa, bbb, ccc)")),
+                        members("innerFunction(aaa, bbb, ccc)", 1,
+                                "+ innerFunction(aaa, bbb, ccc)", 3)),
 
                 new Nesting("a call inside an example row",
                         """
@@ -370,24 +518,27 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         example judge
                             | "an amount that sits exactly on the line is accepted rather than refused" : (Code("c-1"), Amount(100)) -> Accepted
                         """,
-                        List.of(": (Code(\"c-1\"), Amount(100))")));
+                        members(": (Code(\"c-1\"), Amount(100))", 1,
+                                "-> Accepted", 1)));
     }
 
     /**
-     * The regression #431 leaves behind: a member that fits on a line of its own is written on one,
-     * because the structure enclosing it took the break. The formatter used to descend past the
-     * enclosing structure — which had no break to take — and split the first call that crossed the
+     * The regression #431 leaves behind: every member that fits on a line of its own is written on
+     * one, because the structure enclosing it took the break. The formatter used to descend past the
+     * enclosing structure — which had no break to take — and split the first member that crossed the
      * width, so a row's three parts stopped being visible and calls written to look alike stopped
-     * looking alike.
+     * looking alike. Counted rather than found, since splitting one of three members leaves the
+     * other two to be found.
      */
     @ParameterizedTest(name = "{0}")
     @MethodSource("nestings")
-    void aMemberIsNotSplitWhenTheStructureAroundItCanBreak(Nesting nesting) {
-        List<String> lines = List.of(Formatter.format(nesting.source()).split("\n", -1));
-        for (String member : nesting.membersThatStayOnOneLine()) {
-            assertTrue(lines.stream().anyMatch(l -> l.strip().equals(member)),
-                    "no line holds `" + member + "` on its own; got:\n"
-                            + String.join("\n", lines));
+    void everyMemberStaysWholeWhenTheStructureAroundItCanBreak(Nesting nesting) {
+        String formatted = Formatter.format(nesting.source());
+        List<String> lines = List.of(formatted.split("\n", -1));
+        for (Map.Entry<String, Integer> member : nesting.membersOnTheirOwnLine().entrySet()) {
+            long held = lines.stream().filter(l -> l.strip().equals(member.getKey())).count();
+            assertEquals(member.getValue().longValue(), held,
+                    "lines holding `" + member.getKey() + "` and nothing else, in:\n" + formatted);
         }
     }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -33,6 +33,12 @@ import static souther.compiler.fmt.Doc.text;
 public final class Formatter {
 
     private static final int INDENT = 4;
+
+    /** The canonical width. It applies to every breakable construct, a declaration's as much as an
+     * expression's: a module header that lists more names than fit breaks the same way a call with
+     * more arguments than fit does. A line wider than this is one whose content has no separator to
+     * break at — a long pattern, a single long token, or a nesting deep enough that the indent alone
+     * takes the width. */
     private static final int WIDTH = 100;
 
     /** The comments already written, keyed by where they are in the source. A comment is reachable
@@ -87,6 +93,58 @@ public final class Formatter {
                 Diagnostic.of(DiagnosticCode.E2104, "parse.toodeep").build(),
                 "this source nests too deeply to format;"
                         + " break the nesting into named parts to flatten it");
+    }
+
+    // --- layout ---
+    //
+    // Every repeated or joined construct is written through one of these two, so the separator of a
+    // construct is a place the layout may break rather than a literal the construct spelled itself.
+    // A construct that spells its own separators is one the width cannot reach: the break has to
+    // exist in the document before the renderer can choose it, and the renderer breaks the outermost
+    // group that does not fit, so a member is split only when the structure around it had nothing to
+    // give.
+
+    /** Members with a comma between them, one to a line where they do not fit. The comma stays on
+     * the line its member ends. */
+    private static Doc separated(List<Doc> members) {
+        return Doc.join(concat(text(","), LINE), members);
+    }
+
+    /**
+     * Members between brackets. {@code boundary} is what sits just inside them — {@link Doc#LINE}
+     * where the flat form has a space there ({@code exposing ( a, b )}, {@code T { a, b }}),
+     * {@link Doc#SOFTLINE} where it does not ({@code f(a, b)}, {@code [a, b]}).
+     */
+    private static Doc delimited(String open, Doc boundary, List<Doc> members, String close) {
+        return group(concat(text(open),
+                nest(INDENT, concat(boundary, separated(members))),
+                boundary, text(close)));
+    }
+
+    /** One part of a chain, written after the connector that joins it to what came before. */
+    private record Segment(String connector, Doc doc) {}
+
+    /**
+     * A head and the parts written after it, each opening with its connector — a union's {@code |},
+     * an operator chain's operator, a pipeline's {@code |>}, an example row's {@code :} and
+     * {@code ->}. Broken, each part starts a line one indent in and the connector leads it, so what
+     * joins two parts is visible at the front of the second.
+     */
+    private static Doc chained(Doc head, List<Segment> segments) {
+        List<Doc> parts = new ArrayList<>();
+        for (Segment s : segments) {
+            parts.add(concat(LINE, text(s.connector()), s.doc()));
+        }
+        return group(concat(head, nest(INDENT, concat(parts))));
+    }
+
+    /** {@code docs} as segments sharing one connector — a run of the same operator. */
+    private static List<Segment> segments(String connector, List<Doc> docs) {
+        List<Segment> out = new ArrayList<>();
+        for (Doc d : docs) {
+            out.add(new Segment(connector, d));
+        }
+        return out;
     }
 
     // --- top level ---
@@ -172,31 +230,39 @@ public final class Formatter {
         return concat(text("example "), text(target), nest(INDENT, concat(rows)));
     }
 
+    /**
+     * A row of an example: its description, its input and what it is expected to give. The three are
+     * the row's own parts, so the row is what breaks when it does not fit — a row that broke inside
+     * its input instead left {@code ), Amount(100)) -> Accepted} opening a line, and stopped showing
+     * which part was which.
+     */
     private Doc exampleRow(SyntaxNode n) {
-        List<Doc> parts = new ArrayList<>();
-        parts.add(text("| "));
-        n.token(SyntaxKind.STRING_LIT).ifPresent(desc -> {
-            parts.add(text(desc.text()));
-            parts.add(text(" : "));
-        });
         List<Doc> args = new ArrayList<>();
         for (SyntaxNode a : n.child(SyntaxKind.ARG_LIST).map(this::exprChildren).orElse(List.of())) {
             args.add(expr(a));
         }
-        parts.add(concat(text("("), Doc.join(text(", "), args), text(")")));
-        n.child(SyntaxKind.WITH_CLAUSE).ifPresent(clause -> {
+        Doc input = delimited("(", SOFTLINE, args, ")");
+        var with = n.child(SyntaxKind.WITH_CLAUSE);
+        if (with.isPresent()) {
             List<Doc> binds = new ArrayList<>();
-            for (SyntaxNode b : childNodes(clause, SyntaxKind.WITH_BINDING)) {
+            for (SyntaxNode b : childNodes(with.get(), SyntaxKind.WITH_BINDING)) {
                 binds.add(concat(text(firstIdent(b)), text(" = "), expr(firstExprChildOpt(b).orElseThrow())));
             }
-            parts.add(concat(text(" with "), Doc.join(text(", "), binds)));
-        });
-        parts.add(text(" -> "));
-        List<SyntaxNode> expected = exprChildren(n);   // the row's expr child that is not the ARG_LIST
-        if (!expected.isEmpty()) {
-            parts.add(expr(expected.get(0)));
+            input = concat(input, text(" with "), group(nest(INDENT, separated(binds))));
         }
-        return concat(parts);
+
+        List<Segment> segs = new ArrayList<>();
+        var desc = n.token(SyntaxKind.STRING_LIT);
+        Doc head;
+        if (desc.isPresent()) {
+            head = concat(text("| "), text(desc.get().text()));
+            segs.add(new Segment(": ", input));
+        } else {
+            head = concat(text("| "), input);
+        }
+        List<SyntaxNode> expected = exprChildren(n);   // the row's expr child that is not the ARG_LIST
+        segs.add(new Segment("-> ", expected.isEmpty() ? Doc.NIL : expr(expected.get(0))));
+        return chained(head, segs);
     }
 
     private Doc fakeDef(SyntaxNode n) {
@@ -210,24 +276,20 @@ public final class Formatter {
     }
 
     private Doc fakeRow(SyntaxNode n) {
-        List<Doc> parts = new ArrayList<>();
-        parts.add(text("| "));
         var args = n.child(SyntaxKind.ARG_LIST);
+        Doc input;
         if (args.isPresent()) {
             List<Doc> as = new ArrayList<>();
             for (SyntaxNode a : exprChildren(args.get())) {
                 as.add(expr(a));
             }
-            parts.add(concat(text("("), Doc.join(text(", "), as), text(")")));
+            input = delimited("(", SOFTLINE, as, ")");
         } else {
-            parts.add(text("_"));   // the default row
+            input = text("_");   // the default row
         }
-        parts.add(text(" -> "));
         List<SyntaxNode> outs = exprChildren(n);
-        if (!outs.isEmpty()) {
-            parts.add(expr(outs.get(0)));
-        }
-        return concat(parts);
+        return chained(concat(text("| "), input),
+                List.of(new Segment("-> ", outs.isEmpty() ? Doc.NIL : expr(outs.get(0)))));
     }
 
     private Doc moduleHeader(SyntaxNode n) {
@@ -245,7 +307,7 @@ public final class Formatter {
                     .map(rt -> concat(name, text(" : "), retType(rt)))
                     .orElse(name)));
         }
-        return concat(text("exposing ( "), Doc.join(text(", "), entries), text(" )"));
+        return delimited("exposing (", LINE, entries, ")");
     }
 
     private Doc importDecl(SyntaxNode n) {
@@ -262,7 +324,7 @@ public final class Formatter {
         for (SyntaxToken t : idents(list.get())) {
             names.add(text(t.text()));
         }
-        return concat(d, text(" ( "), Doc.join(text(", "), names), text(" )"));
+        return concat(d, text(" "), delimited("(", LINE, names, ")"));
     }
 
     // --- data ---
@@ -303,7 +365,8 @@ public final class Formatter {
                     cases.add(c);
                 }
             }
-            return concat(text("data "), text(name), text(" = "), Doc.join(text(" | "), cases));
+            return concat(text("data "), text(name), text(" = "),
+                    chained(cases.get(0), segments("| ", cases.subList(1, cases.size()))));
         }
         var newtype = n.child(SyntaxKind.NEWTYPE_BODY);
         if (newtype.isPresent()) {
@@ -374,7 +437,7 @@ public final class Formatter {
             params.add(withComments(n, p, concat(text(firstIdent(p)), text(": "),
                     retType(p.child(SyntaxKind.RET_TYPE).orElseThrow()))));
         }
-        return concat(text("("), Doc.join(text(", "), params), text(")"));
+        return delimited("(", SOFTLINE, params, ")");
     }
 
     private Doc stage(SyntaxNode n) {
@@ -418,7 +481,7 @@ public final class Formatter {
         if (current.length() > 0) {
             names.add(text(current.toString()));
         }
-        return Doc.join(text(", "), names);
+        return group(nest(INDENT, separated(names)));
     }
 
     /** The {@code : T} a node wrote, or nothing — a helper's return type, a local binding's annotation. */
@@ -446,7 +509,8 @@ public final class Formatter {
         var intrinsic = n.child(SyntaxKind.INTRINSIC_BODY);
         if (intrinsic.isPresent()) {
             String raw = intrinsic.get().token(SyntaxKind.STRING_LIT).orElseThrow().text();
-            return concat(head, text(" = intrinsic "), text(raw));
+            return concat(head, text(" ="),
+                    group(nest(INDENT, concat(LINE, text("intrinsic "), text(raw)))));
         }
         var block = n.child(SyntaxKind.BLOCK_EXPR);
         if (block.isPresent()) {
@@ -475,7 +539,7 @@ public final class Formatter {
                 params.add(pattern(c));
             }
         }
-        return concat(text("("), Doc.join(text(", "), params), text(")"));
+        return delimited("(", SOFTLINE, params, ")");
     }
 
     private Doc fnParamList(SyntaxNode n) {
@@ -489,7 +553,7 @@ public final class Formatter {
             }
             params.add(d);
         }
-        return concat(text("("), Doc.join(text(", "), params), text(")"));
+        return delimited("(", SOFTLINE, params, ")");
     }
 
     // --- types ---
@@ -509,7 +573,7 @@ public final class Formatter {
                 }
             }
         }
-        return concat(text("("), Doc.join(text(", "), params), text(") -> "), result);
+        return concat(delimited("(", SOFTLINE, params, ")"), text(" -> "), result);
     }
 
     private Doc retType(SyntaxNode n) {
@@ -519,7 +583,8 @@ public final class Formatter {
                 cases.add(typeTerm(c));
             }
         }
-        Doc d = Doc.join(text(" | "), cases);
+        Doc d = cases.isEmpty() ? Doc.NIL
+                : chained(cases.get(0), segments("| ", cases.subList(1, cases.size())));
         // `T?` in a core signature, the same mark a field carries
         return n.token(SyntaxKind.QUESTION).isPresent() ? concat(d, text("?")) : d;
     }
@@ -532,7 +597,7 @@ public final class Formatter {
                     elems.add(typeTerm(c));
                 }
             }
-            return concat(text("("), Doc.join(text(", "), elems), text(")"));
+            return delimited("(", SOFTLINE, elems, ")");
         }
         var typevar = n.token(SyntaxKind.TYPEVAR);
         if (typevar.isPresent()) {
@@ -549,7 +614,7 @@ public final class Formatter {
                 typeArgs.add(typeTerm(c));
             }
         }
-        return concat(name, text("<"), Doc.join(text(", "), typeArgs), text(">"));
+        return concat(name, delimited("<", SOFTLINE, typeArgs, ">"));
     }
 
     private static boolean isTypeNode(SyntaxKind k) {
@@ -574,7 +639,7 @@ public final class Formatter {
             case UNARY_EXPR -> concat(text("-"), expr(onlyExpr(n)));
             case PIPE_EXPR -> pipe(n);
             case PAREN_EXPR -> concat(text("("), expr(onlyExpr(n)), text(")"));
-            case TUPLE_EXPR -> concat(text("("), Doc.join(text(", "), exprDocs(n)), text(")"));
+            case TUPLE_EXPR -> delimited("(", SOFTLINE, exprDocs(n), ")");
             case LIST_EXPR -> list(n);
             case LIST_COMP -> listComp(n);
             case IF_EXPR -> ifExpr(n);
@@ -610,25 +675,58 @@ public final class Formatter {
         for (SyntaxNode a : args) {
             argDocs.add(withComments(argList, a, expr(a)));
         }
-        return group(concat(text("("),
-                nest(INDENT, concat(SOFTLINE, Doc.join(concat(text(","), LINE), argDocs))),
-                SOFTLINE, text(")")));
+        return delimited("(", SOFTLINE, argDocs, ")");
     }
 
     private Doc binary(SyntaxNode n) {
+        List<Segment> segs = new ArrayList<>();
+        Doc head = collectChain(n, ladderLevel(operatorKind(n)), segs);
+        return chained(head, segs);
+    }
+
+    /**
+     * Flattens a run of operators the parser reads at one level of its precedence ladder, so that
+     * what the source wrote as one run is laid out as one run: {@code a + b * c + d} breaks into
+     * {@code a}, {@code + b * c} and {@code + d}, the three parts the {@code +} level has.
+     *
+     * <p>Only the left spine, and only within the level. The right operand of a left-associative
+     * level is never that level's own operator unless the source parenthesised it, and a
+     * parenthesised operand is a structure its author wrote — descending into either would show a
+     * run the tree does not have.
+     */
+    private Doc collectChain(SyntaxNode n, int level, List<Segment> segs) {
         List<SyntaxNode> ops = exprChildren(n);
-        String op = operatorText(n);
-        return concat(expr(ops.get(0)), text(" " + op + " "), expr(ops.get(1)));
+        SyntaxNode left = ops.get(0);
+        Doc head;
+        if (left.kind() == SyntaxKind.BINARY_EXPR && ladderLevel(operatorKind(left)) == level) {
+            head = collectChain(left, level, segs);
+        } else {
+            head = expr(left);
+        }
+        segs.add(new Segment(operatorText(n) + " ", expr(ops.get(1))));
+        return head;
+    }
+
+    /**
+     * Which rung of {@link CstParser}'s precedence ladder an operator is read on. Operators on one
+     * rung are read by one loop and chain; the comparisons are read by a single test and never
+     * chain, so their runs are one operator long and flattening them is a no-op.
+     */
+    private static int ladderLevel(SyntaxKind k) {
+        return switch (k) {
+            case OR -> 1;
+            case AND -> 2;
+            case EQ, NE, LT, LE, GT, GE -> 3;
+            case PLUS, MINUS, PLUSPLUS -> 4;
+            case STAR, SLASH -> 5;
+            default -> 0;
+        };
     }
 
     private Doc pipe(SyntaxNode n) {
         List<Doc> stages = new ArrayList<>();
         Doc head = collectPipe(n, stages);
-        List<Doc> tail = new ArrayList<>();
-        for (Doc s : stages) {
-            tail.add(concat(LINE, text("|> "), s));
-        }
-        return group(concat(head, nest(INDENT, concat(tail))));
+        return chained(head, segments("|> ", stages));
     }
 
     /** Flattens a left-nested {@code |>} chain: returns the head doc and fills {@code stages} with each
@@ -652,15 +750,14 @@ public final class Formatter {
         if (elems.isEmpty()) {
             return text("[]");
         }
-        return group(concat(text("["),
-                nest(INDENT, concat(SOFTLINE, Doc.join(concat(text(","), LINE), elems))),
-                SOFTLINE, text("]")));
+        return delimited("[", SOFTLINE, elems, "]");
     }
 
     private Doc listComp(SyntaxNode n) {
         List<Doc> exprs = exprDocs(n);
         List<Doc> guards = exprs.subList(1, exprs.size());
-        return concat(text("["), exprs.get(0), text(" | "), Doc.join(text(", "), guards), text("]"));
+        return concat(text("["), exprs.get(0), text(" | "),
+                group(nest(INDENT, separated(guards))), text("]"));
     }
 
     private Doc ifExpr(SyntaxNode n) {
@@ -735,7 +832,8 @@ public final class Formatter {
                 pattern.append(t.text());
             }
         }
-        return concat(text("| "), text(pattern.toString()), text(" -> "), expr(body));
+        return chained(concat(text("| "), text(pattern.toString())),
+                List.of(new Segment("-> ", expr(body))));
     }
 
     private Doc lambda(SyntaxNode n) {
@@ -774,9 +872,7 @@ public final class Formatter {
         if (members.isEmpty()) {
             return concat(text(typeName), text(" {}"));
         }
-        return concat(text(typeName), group(concat(text(" {"),
-                nest(INDENT, concat(LINE, Doc.join(concat(text(","), LINE), members))),
-                LINE, text("}"))));
+        return concat(text(typeName), text(" "), delimited("{", LINE, members, "}"));
     }
 
     private Doc block(SyntaxNode n) {
@@ -822,7 +918,7 @@ public final class Formatter {
                         elems.add(pattern(c));
                     }
                 }
-                return concat(text("("), Doc.join(text(", "), elems), text(")"));
+                return delimited("(", SOFTLINE, elems, ")");
             }
             case PATTERN_CTOR -> {
                 return concat(qualifiedName(n), text("("), pattern(patternChild(n)), text(")"));
@@ -838,7 +934,7 @@ public final class Formatter {
                             ? concat(text(names.get(0).text()), text(" = "), text(names.get(1).text()))
                             : text(names.get(0).text()));
                 }
-                return concat(text("{ "), Doc.join(text(", "), fields), text(" }"));
+                return delimited("{", LINE, fields, "}");
             }
             default -> {
                 return text(firstIdent(n));
@@ -1094,9 +1190,17 @@ public final class Formatter {
     }
 
     private String operatorText(SyntaxNode n) {
+        return operatorToken(n).text();
+    }
+
+    private SyntaxKind operatorKind(SyntaxNode n) {
+        return operatorToken(n).kind();
+    }
+
+    private SyntaxToken operatorToken(SyntaxNode n) {
         for (SyntaxElement e : n.children()) {
             if (e instanceof SyntaxToken t && !t.isTrivia() && isBinaryOperator(t.kind())) {
-                return t.text();
+                return t;
             }
         }
         throw new IllegalStateException("no operator in " + n.kind());

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -97,12 +97,11 @@ public final class Formatter {
 
     // --- layout ---
     //
-    // Every repeated or joined construct is written through one of these two, so the separator of a
-    // construct is a place the layout may break rather than a literal the construct spelled itself.
-    // A construct that spells its own separators is one the width cannot reach: the break has to
-    // exist in the document before the renderer can choose it, and the renderer breaks the outermost
-    // group that does not fit, so a member is split only when the structure around it had nothing to
-    // give.
+    // Every repeated or joined construct is written through these, so the separator of a construct
+    // is a place the layout may break rather than a literal the construct spelled itself. A
+    // construct that spells its own separators is one the width cannot reach: the break has to exist
+    // in the document before the renderer can choose it, and the renderer breaks the outermost group
+    // that does not fit, so a member is split only when the structure around it had nothing to give.
 
     /** Members with a comma between them, one to a line where they do not fit. The comma stays on
      * the line its member ends. */
@@ -711,6 +710,10 @@ public final class Formatter {
      * Which rung of {@link CstParser}'s precedence ladder an operator is read on. Operators on one
      * rung are read by one loop and chain; the comparisons are read by a single test and never
      * chain, so their runs are one operator long and flattening them is a no-op.
+     *
+     * <p>An operator missing from here is refused rather than given a rung of its own: sharing one
+     * would lay out a run the parser does not read as a run, which is the reading a reader takes
+     * from the layout and cannot check.
      */
     private static int ladderLevel(SyntaxKind k) {
         return switch (k) {
@@ -719,7 +722,7 @@ public final class Formatter {
             case EQ, NE, LT, LE, GT, GE -> 3;
             case PLUS, MINUS, PLUSPLUS -> 4;
             case STAR, SLASH -> 5;
-            default -> 0;
+            default -> throw new IllegalStateException("no precedence rung for " + k);
         };
     }
 
@@ -845,7 +848,7 @@ public final class Formatter {
         }
         // `x -> e` keeps its bare parameter; anything parenthesised was written that way
         Doc paramsDoc = n.token(SyntaxKind.LPAREN).isPresent()
-                ? concat(text("("), Doc.join(text(", "), params), text(")"))
+                ? delimited("(", SOFTLINE, params, ")")
                 : params.get(0);
         return concat(paramsDoc, text(" -> "), expr(lastExprChild(n)));
     }


### PR DESCRIPTION
Closes #431.

## What was wrong

`Doc` breaks at a `Line` inside a `Group`. The formatter wrote one in six places — a call's arguments, a list, a record literal, an `if`, a pipeline, and a definition's body — and joined everything else with `text(", ")`, which the width cannot reach. The two symptoms #431 reports are that absence seen at two altitudes: a module header at 132 columns is left alone because nothing in it can break, and an example row breaks inside `Code("c-1")` because the renderer, finding no break at the row, descends to the first group on the line that crosses the width.

The report says the formatter picks the innermost call. It picks the first group whose flat rendering crosses the width — in a tuple of four calls it was the third, the first two having fit. The renderer was choosing correctly from what it was given.

## What changed

Every repeated or joined construct goes through one of two helpers, so a separator is a place the layout may break rather than a literal each method spelled for itself.

- `delimited(open, boundary, members, close)` — `boundary` is what sits just inside the brackets, `LINE` where the flat form has a space (`exposing ( a, b )`, `T { a, b }`) and `SOFTLINE` where it does not (`f(a, b)`, `[a, b]`).
- `chained(head, segments)` — each part written after the connector that joins it, the connector leading the line it starts: a union's `|`, a pipeline's `|>`, an operator, an example row's `:` and `->`.

The width applies to declarations as much as to expressions. That a declaration was never broken was not a decision — no ADR or spec section records one — it was the absence of one.

An operator run is flattened by the rung of the parser's precedence ladder it is read on, and only along the left spine. The rungs are the loops in `CstParser`: `||`, `&&`, `+ - ++` and `* /` each chain, while the comparisons are read by a single test and cannot — `a < b < c` is a parse error. Flattening across rungs would show a run the tree does not have.

An intrinsic body had no break either, which sent the break into the return type and left `| DivisionByZero = intrinsic "int.truncatingRemainder"` reading as an arm of the union. It takes the same break an ordinary body does.

No `fill`: groups stay all-or-nothing, so a sequence that does not fit goes one member to a line. That is the form the specification already writes `exposing` in.

## Before and after

```
| "an amount that sits exactly on the line is accepted rather than refused" : (Code(
    "c-1"
), Amount(100)) -> Accepted
```

```
| "an amount that sits exactly on the line is accepted rather than refused"
    : (Code("c-1"), Amount(100))
    -> Accepted
```

```
overlapLength(s, e, 0, lateNightMorningEnd) + overlapLength(
    s,
    e,
    lateNightEveningStart,
    minutesInADay
)
```

```
overlapLength(s, e, 0, lateNightMorningEnd)
    + overlapLength(s, e, lateNightEveningStart, minutesInADay)
```

## Tests

`TheCanonicalFormBreaksAtTheEnclosingStructureTest` pins one construct to a row, so a construct arriving without one is a construct nothing pins. Each source is written long enough not to fit, and that premise is itself asserted — seven fixtures fitted until it was.

Four assertions run over the table separately, so a failure says which broke: the multi-line shape, the width, the fixed point, and that a flat source and an already-broken source reach the same canonical form. A fifth holds what this change leaves behind — a member that fits on a line of its own is written on one, because the structure enclosing it took the break.

`everyLineFitsTheWidth` is a property of these fixtures, not of the formatter. A long match pattern, a single long token and a deep enough indent each still leave a line over, and this change does not claim otherwise.

3721 tests pass.

## Not in this PR

The `.sou` corpus is not reformatted. Fifteen of its sixteen files were already not in canonical form before this change — `list.sou` moves 178 lines under the old formatter and none under the new one — so `fmt --check` fails on them today, and running the formatter over them here would bury the change. Worth its own issue.

Also left alone: a `fill` combinator, writing a match pattern as a `Doc` rather than one `Text`, the shape a broken call takes, and overflow from indent depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
