### PR TITLE
Make `run` use the boundary Map-key contract in both directions

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -18,6 +18,7 @@ import net.unit8.raoh.Ok;
 import net.unit8.raoh.Result;
 import net.unit8.raoh.decode.Decoder;
 import net.unit8.raoh.decode.ObjectDecoders;
+import net.unit8.raoh.decode.builtin.StringDecoder;
 
 import java.math.BigDecimal;
 import java.util.ArrayDeque;
@@ -1034,33 +1035,65 @@ public final class FixtureReader {
                     .map(elements -> Sets.fromList(new ArrayList<Object>(elements)));
         }
         if (type instanceof Type.MapOf map) {
-            Decoder<Object, ?> values = ObjectDecoders.map(decoderFor(map.value()));
-            return map.key() instanceof Type.Ref key ? rekeyed(values, key) : values;
+            return rekeyed(ObjectDecoders.map(decoderFor(map.value())), map.key());
         }
         throw new FixtureException("`" + Type.show(type) + "` is not supported as an example value yet");
     }
 
     /**
-     * A map whose keys are a newtype ({@code Map<商品ID, Int>}, ADR-0040): the values decode first, as
-     * the derived decoder does, then each key is built through its own type — so the key's invariant
-     * runs and a fixture that breaks it is reported instead of reaching the behavior as a bare string.
+     * A map's keys, built through the key type after the values decode — so the key's invariant runs
+     * and a fixture that breaks it is reported instead of reaching the behavior as a bare string.
      * Every key is tried and its failures merged, as the derived decoder's rekey helper does, so a
-     * fixture with two bad keys names both rather than stopping at the first.
+     * fixture with two bad keys names both rather than stopping at the first, and two keys that are
+     * one key once built are refused rather than collapsed.
+     *
+     * <p>Every key kind is rekeyed, not the named ones alone. A map that crosses may also be keyed by
+     * a temporal or by a plain {@code String}, and a key left as the text the decoded map carried is
+     * a key the behavior cannot look up by the type it was declared with.
      */
-    private Decoder<Object, ?> rekeyed(Decoder<Object, ?> values, Type.Ref key) {
-        Decoder<Object, ?> keyDecoder = decoderFor(key);
+    private Decoder<Object, ?> rekeyed(Decoder<Object, ?> values, Type key) {
+        Decoder<Object, ?> keyDecoder = keyDecoderFor(key);
         return values.flatMapWithPath((decoded, path) -> {
             Map<Object, Object> out = new LinkedHashMap<>();
             Issues issues = Issues.EMPTY;
             for (Map.Entry<?, ?> entry : ((Map<?, ?>) decoded).entrySet()) {
-                Result<?> k = keyDecoder.decode(entry.getKey(), path.append(String.valueOf(entry.getKey())));
+                net.unit8.raoh.Path at = path.append(String.valueOf(entry.getKey()));
+                Result<?> k = keyDecoder.decode(entry.getKey(), at);
                 switch (k) {
-                    case Ok<?>(var decodedKey) -> out.put(decodedKey, entry.getValue());
+                    case Ok<?>(var decodedKey) -> {
+                        if (out.containsKey(decodedKey)) {
+                            issues = issues.merge(((Err<?>) Result.fail(at, "duplicate_key",
+                                    "two keys are the same key once decoded")).issues());
+                        } else {
+                            out.put(decodedKey, entry.getValue());
+                        }
+                    }
                     case Err<?>(var found) -> issues = issues.merge(found);
                 }
             }
             return issues.isEmpty() ? Result.ok(out) : Result.err(issues);
         });
+    }
+
+    /** The decoder for one boundary map key, over the text the decoded map carried. A named key runs
+     *  its own decoder; the three primitives a key may be are the string leaf, parsed for a temporal.
+     *  This is not {@link #decoderFor}: there a {@code Date} is handed over already parsed, and in key
+     *  position it is the text that arrives. */
+    private Decoder<Object, ?> keyDecoderFor(Type key) {
+        if (key instanceof Type.Ref ref) {
+            return decoderFor(ref);
+        }
+        StringDecoder<Object> text = ObjectDecoders.string().normalize();
+        if (key == Type.STRING) {
+            return text;
+        }
+        if (key == Type.DATE) {
+            return text.date();
+        }
+        if (key == Type.DATETIME) {
+            return text.dateTime();
+        }
+        throw new FixtureException("`" + Type.show(key) + "` cannot key a Map that crosses");
     }
 
     /** One decoded input, in the form the compiler owns. Never throws: a value that cannot be read is

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -545,21 +545,38 @@ public final class Runner {
      * settled, so a map with two bad keys says so about both. A {@code String} key is rekeyed like
      * any other: the keys of a decoded object do not pass the string leaf, so leaving them alone is
      * the one place a boundary would hand over text it had not made canonical.
+     *
+     * <p>Two keys that decode to one key are refused rather than collapsed. Making a key canonical
+     * is what lets an object arrive with the same key written twice, and a map holding one entry
+     * where the input wrote two is a value the input never described — so the second is a failure at
+     * its own key, not the winner of an overwrite.
      */
     private static Result<Map<Object, Object>> rekey(Decoder<Object, ?> key, Map<String, ?> entries,
                                                      net.unit8.raoh.Path path) {
         Map<Object, Object> out = new java.util.LinkedHashMap<>();
         Issues issues = Issues.EMPTY;
         for (Map.Entry<String, ?> entry : entries.entrySet()) {
-            Result<?> decoded = key.decode(entry.getKey(), path.append(entry.getKey()));
+            net.unit8.raoh.Path at = path.append(entry.getKey());
+            Result<?> decoded = key.decode(entry.getKey(), at);
             if (decoded instanceof Err<?> err) {
                 issues = issues.merge(err.issues());
+                continue;
+            }
+            Object rekeyed = ((Ok<?>) decoded).value();
+            if (out.containsKey(rekeyed)) {
+                issues = issues.merge(((Err<?>) Result.fail(at, DUPLICATE_KEY, DUPLICATE_KEY_MESSAGE))
+                        .issues());
             } else {
-                out.put(((Ok<?>) decoded).value(), entry.getValue());
+                out.put(rekeyed, entry.getValue());
             }
         }
         return issues.isEmpty() ? new Ok<>(out) : new Err<>(issues);
     }
+
+    /** What a key colliding with one already read is reported as — the code and the wording the
+     *  generated rekey helper uses, so the two paths refuse the same input the same way. */
+    private static final String DUPLICATE_KEY = "duplicate_key";
+    private static final String DUPLICATE_KEY_MESSAGE = "two keys are the same key once decoded";
 
     /** The named static decoder factory of a generated class — {@code jsonDecoder} for a value read
      *  from JSON, {@code decoder} for a map key, which is read from the string the object carried.

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -14,6 +14,8 @@ import net.unit8.raoh.ResourceBundleMessageResolver;
 import net.unit8.raoh.Ok;
 import net.unit8.raoh.Result;
 import net.unit8.raoh.decode.Decoder;
+import net.unit8.raoh.decode.ObjectDecoders;
+import net.unit8.raoh.decode.builtin.StringDecoder;
 import net.unit8.raoh.json.JsonDecoders;
 import net.unit8.raoh.encode.Encoder;
 import net.unit8.raoh.encode.ObjectEncoders;
@@ -477,25 +479,14 @@ public final class Runner {
      *
      * <p>A data delegates to its generated {@code jsonDecoder()}, so a nested shape, an invariant and
      * a sum's discriminator are all read exactly as they are at the boundary. What is composed here
-     * is only what has no class of its own: the primitives and the collections. A map keyed by a
-     * newtype or a temporal (ADR-0040) is still left out — the generated per-data decoder remaps
-     * those keys and this one does not.
+     * is only what has no class of its own: the primitives and the collections.
      */
     private static Decoder<JsonNode, ?> decoderFor(MemoryClassLoader loader, String pkg, Type type, int index) {
         if (type instanceof Type.Prim prim) {
             return leafDecoder(prim, index);
         }
         if (type instanceof Type.Ref ref) {
-            try {
-                Class<?> c = loader.loadClass(ref.name().qualified());
-                @SuppressWarnings("unchecked")   // the generated class's factory erases at the reflection boundary
-                Decoder<JsonNode, ?> decoder = (Decoder<JsonNode, ?>) c.getMethod("jsonDecoder").invoke(null);
-                return decoder;
-            } catch (ReflectiveOperationException e) {
-                throw fail("run.decode.nodecoder",
-                        "cannot obtain a decoder for `" + ref.name().name() + "`: " + e,
-                        ref.name().name(), e.toString());
-            }
+            return codecOf(loader, ref, "jsonDecoder");
         }
         if (type instanceof Type.ListOf list) {
             return JsonDecoders.list(decoderFor(loader, pkg, list.element(), index));
@@ -504,13 +495,86 @@ public final class Runner {
             return JsonDecoders.list(decoderFor(loader, pkg, set.element(), index))
                     .map(elements -> Sets.fromList(new java.util.ArrayList<Object>(elements)));
         }
-        if (type instanceof Type.MapOf map && map.key() == Type.STRING) {
-            return JsonDecoders.map(decoderFor(loader, pkg, map.value(), index));
+        if (type instanceof Type.MapOf map) {
+            Decoder<Object, ?> key = keyDecoder(loader, map.key());
+            return JsonDecoders.map(decoderFor(loader, pkg, map.value(), index))
+                    .flatMapWithPath((entries, path) -> rekey(key, entries, path));
         }
         throw fail("run.decode.unsupported",
                 "input #" + (index + 1) + " has type `" + Type.show(type)
                         + "`, which `run` cannot decode yet (only a data type, a primitive, or a"
                         + " collection of those).", index + 1, Type.show(type));
+    }
+
+    /**
+     * The decoder for a boundary map's key. A key reaches this already read out of the JSON object
+     * that carried it, so what it decodes from is a string rather than a {@code JsonNode} — the
+     * neutral source, whichever source the map itself came from. This is the decoder
+     * {@code CodecGen.emitKeyDecoder} builds, in Java.
+     *
+     * <p>Which key types arrive here is not asked again. What may key a map that crosses is
+     * {@code TypeOps.isBoundaryMapKey}, and E1314 has already refused everything else, so a named key
+     * runs its own decoder — a String-backed newtype enforcing its invariant, an enumeration reading
+     * its case's name — and the three primitives are the string leaf, parsed for a temporal. Telling
+     * the newtype and the enumeration apart here would be reading the boundary's rule a second time,
+     * in a place that cannot see all of it.
+     */
+    private static Decoder<Object, ?> keyDecoder(MemoryClassLoader loader, Type key) {
+        if (key instanceof Type.Ref ref) {
+            return codecOf(loader, ref, "decoder");
+        }
+        // text arriving from outside is canonical, which is what the string leaf makes it
+        StringDecoder<Object> text = ObjectDecoders.string().normalize();
+        if (key == Type.STRING) {
+            return text;
+        }
+        if (key == Type.DATE) {
+            return text.date();
+        }
+        if (key == Type.DATETIME) {
+            return text.dateTime();
+        }
+        throw new IllegalStateException("not a boundary map key: " + Type.show(key));
+    }
+
+    /**
+     * A decoded {@code Map<String, V>} rekeyed by the key type's own decoder, which is where a key's
+     * invariant is enforced and a temporal key is parsed.
+     *
+     * <p>A bad key is reported at that key's own path, and every key is read before the result is
+     * settled, so a map with two bad keys says so about both. A {@code String} key is rekeyed like
+     * any other: the keys of a decoded object do not pass the string leaf, so leaving them alone is
+     * the one place a boundary would hand over text it had not made canonical.
+     */
+    private static Result<Map<Object, Object>> rekey(Decoder<Object, ?> key, Map<String, ?> entries,
+                                                     net.unit8.raoh.Path path) {
+        Map<Object, Object> out = new java.util.LinkedHashMap<>();
+        Issues issues = Issues.EMPTY;
+        for (Map.Entry<String, ?> entry : entries.entrySet()) {
+            Result<?> decoded = key.decode(entry.getKey(), path.append(entry.getKey()));
+            if (decoded instanceof Err<?> err) {
+                issues = issues.merge(err.issues());
+            } else {
+                out.put(((Ok<?>) decoded).value(), entry.getValue());
+            }
+        }
+        return issues.isEmpty() ? new Ok<>(out) : new Err<>(issues);
+    }
+
+    /** The named static decoder factory of a generated class — {@code jsonDecoder} for a value read
+     *  from JSON, {@code decoder} for a map key, which is read from the string the object carried.
+     *  Either erases at the reflection boundary. */
+    private static <I> Decoder<I, ?> codecOf(MemoryClassLoader loader, Type.Ref ref, String factory) {
+        try {
+            @SuppressWarnings("unchecked")
+            Decoder<I, ?> decoder = (Decoder<I, ?>)
+                    loader.loadClass(ref.name().qualified()).getMethod(factory).invoke(null);
+            return decoder;
+        } catch (ReflectiveOperationException e) {
+            throw fail("run.decode.nodecoder",
+                    "cannot obtain a decoder for `" + ref.name().name() + "`: " + e,
+                    ref.name().name(), e.toString());
+        }
     }
 
     /** A primitive over the JSON source. {@code JsonDecoders} has no temporal factory — in JSON a
@@ -570,10 +634,16 @@ public final class Runner {
             return Representations.sortedArray(
                     encodeElements(loader, pkg, behavior, set.element(), (java.util.Collection<?>) result));
         }
-        if (out instanceof Type.MapOf map && map.key() == Type.STRING) {
+        // A map's key is encoded by the same recursion its value is: a key that crosses writes as a
+        // bare string whichever of the five kinds it is (E1314), and each of them already has the
+        // encoder that writes it — the string leaf, the ISO form of a temporal, the newtype's bare
+        // value, the enumeration's case name. Asking here which kind it is would ask the boundary's
+        // question twice.
+        if (out instanceof Type.MapOf map) {
             Map<String, Object> encoded = new java.util.LinkedHashMap<>();
             ((Map<?, ?>) result).forEach((k, v) ->
-                    encoded.put((String) k, encode(loader, pkg, behavior, map.value(), v)));
+                    encoded.put((String) encode(loader, pkg, behavior, map.key(), k),
+                            encode(loader, pkg, behavior, map.value(), v)));
             return Representations.sortedObject(encoded);
         }
         if (out instanceof Type.Ref ref) {

--- a/souther-compiler/src/test/java/souther/compiler/DecoderPathAgreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/DecoderPathAgreementTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -55,7 +56,7 @@ class DecoderPathAgreementTest {
 
     @Test
     void aStringKeyedMapIsReadByAllThree() throws Exception {
-        acceptedEverywhere("Map<String, Int>", Map.of("a", 1L), "{\"a\": 1}", 1L);
+        acceptedEverywhere("Map<String, Int>", Map.of("a", 7L), "{\"a\": 7}", 7L);
     }
 
     /**
@@ -88,23 +89,23 @@ class DecoderPathAgreementTest {
      */
     @Test
     void aNewtypeKeyedMapIsReadByAllThree() throws Exception {
-        acceptedEverywhere("Map<Key, Int>", Map.of("a", 1L), "{\"a\": 1}", 1L);
+        acceptedEverywhere("Map<Key, Int>", Map.of("a", 7L), "{\"a\": 7}", 7L);
     }
 
     @Test
     void aDateKeyedMapIsReadByAllThree() throws Exception {
-        acceptedEverywhere("Map<Date, Int>", Map.of("2026-01-01", 1L), "{\"2026-01-01\": 1}", 1L);
+        acceptedEverywhere("Map<Date, Int>", Map.of("2026-01-01", 7L), "{\"2026-01-01\": 7}", 7L);
     }
 
     @Test
     void aDateTimeKeyedMapIsReadByAllThree() throws Exception {
-        acceptedEverywhere("Map<DateTime, Int>", Map.of("2026-01-01T09:00", 1L),
-                "{\"2026-01-01T09:00\": 1}", 1L);
+        acceptedEverywhere("Map<DateTime, Int>", Map.of("2026-01-01T09:00", 7L),
+                "{\"2026-01-01T09:00\": 7}", 7L);
     }
 
     @Test
     void anEnumerationKeyedMapIsReadByAllThree() throws Exception {
-        acceptedEverywhere("Map<Outcome, Int>", Map.of("Won", 1L), "{\"Won\": 1}", 1L);
+        acceptedEverywhere("Map<Outcome, Int>", Map.of("Won", 7L), "{\"Won\": 7}", 1L);
     }
 
     /**
@@ -127,6 +128,31 @@ class DecoderPathAgreementTest {
                 "the key the module looks up is the key the input carried");
     }
 
+    /**
+     * Two keys that are one key once decoded are refused, by the derived codec and by {@code run}
+     * alike. Making a key canonical is what brings the two together, so it is also what lets an
+     * object carrying both spellings arrive with a key written twice — and a map holding one entry
+     * where the input wrote two is a value the input never described. Refusing where they agree is
+     * as much of the contract as reading where they agree.
+     *
+     * <p>The fixture builder is not asked. A fixture is a list of pairs, and which of two equal keys
+     * a list keeps is `Map.fromList`'s question rather than a boundary's.
+     */
+    @Test
+    void twoKeysThatAreOneKeyOnceDecodedAreRefusedByBoth() throws Exception {
+        String composed = "\u304c";
+        String decomposed = "\u304b\u3099";
+        java.util.Map<String, Object> both = new java.util.LinkedHashMap<>();
+        both.put(composed, 1L);
+        both.put(decomposed, 2L);
+        assertFalse(boundaryReads("Map<String, Int>", both), "the derived codec refuses it");
+
+        Runner.RunException refused = assertThrows(Runner.RunException.class,
+                () -> runReads("Map<String, Int>",
+                        "{\"" + composed + "\": 1, \"" + decomposed + "\": 2}"));
+        assertTrue(refused.getMessage().contains("same key once decoded"), refused.getMessage());
+    }
+
     /** A key the key type refuses is refused at that key's own path, and every key is read before
      *  the map is given up on, so a map with two bad keys is answered about both at once. */
     @Test
@@ -139,11 +165,11 @@ class DecoderPathAgreementTest {
 
     // === the three paths ===
 
-    private void acceptedEverywhere(String type, Object neutral, String runJson, Object size)
+    private void acceptedEverywhere(String type, Object neutral, String runJson, Object answer)
             throws Exception {
         assertTrue(boundaryReads(type, neutral), "the derived codec reads " + type);
-        assertTrue(fixtureReads(type, fixtureOf(type), size), "a fixture writes " + type);
-        assertEquals(String.valueOf(size), runReads(type, runJson).trim(), "run reads " + type);
+        assertTrue(fixtureReads(type, fixtureOf(type), answer), "a fixture writes " + type);
+        assertEquals(String.valueOf(answer), runReads(type, runJson).trim(), "run reads " + type);
     }
 
     private static String fixtureOf(String type) {
@@ -151,14 +177,14 @@ class DecoderPathAgreementTest {
             case "Int" -> "3";
             case "Wrapped" -> "Wrapped(3)";
             case "List<Int>" -> "[ 1, 2 ]";
-            case "Map<String, Int>" -> "[ (\"a\", 1) ]";
+            case "Map<String, Int>" -> "[ (\"a\", 7) ]";
             case "Date" -> "Date(\"2026-01-31\")";
             case "DateTime" -> "DateTime(\"2026-01-31T09:00\")";
             case "List<Date>" -> "[ Date(\"2026-01-01\") ]";
-            case "Map<Key, Int>" -> "[ (Key(\"a\"), 1) ]";
-            case "Map<Date, Int>" -> "[ (Date(\"2026-01-01\"), 1) ]";
-            case "Map<DateTime, Int>" -> "[ (DateTime(\"2026-01-01T09:00\"), 1) ]";
-            case "Map<Outcome, Int>" -> "[ (Won, 1) ]";
+            case "Map<Key, Int>" -> "[ (Key(\"a\"), 7) ]";
+            case "Map<Date, Int>" -> "[ (Date(\"2026-01-01\"), 7) ]";
+            case "Map<DateTime, Int>" -> "[ (DateTime(\"2026-01-01T09:00\"), 7) ]";
+            case "Map<Outcome, Int>" -> "[ (Won, 7) ]";
             default -> throw new IllegalArgumentException(type);
         };
     }
@@ -191,11 +217,11 @@ class DecoderPathAgreementTest {
                 module demo
                 %s
                 data Out = { n: Int }
-                behavior take : (v: %s) -> Out constructs Out
+                behavior take : (v: %s) -> Out constructs Out%s
                 let take (v) = Out { n = %s }
                 example take
                   | "reads it" : (%s) -> Out { n = %s }
-                """.formatted(DECLS, type, sizeExprFor(type), fixture, expected));
+                """.formatted(DECLS, type, constructsIn(type), probeFor(type), fixture, expected));
         return true;
     }
 
@@ -205,16 +231,29 @@ class DecoderPathAgreementTest {
         Files.writeString(file, """
                 module demo
                 %s
-                behavior take : (v: %s) -> Int
+                behavior take : (v: %s) -> Int%s
                 let take (v) = %s
-                """.formatted(DECLS, type, sizeExprFor(type)));
+                """.formatted(DECLS, type, constructsIn(type).replace(", ", " constructs "),
+                        probeFor(type)));
         return Runner.run(file, "take", json);
     }
 
-    /** An expression reducing a value of that type to the Int the three paths compare. */
-    private static String sizeExprFor(String type) {
+    /**
+     * An expression reducing a value of that type to the Int the three paths compare.
+     *
+     * <p>A map is read by looking its key up, written as the key type — never by counting its
+     * entries. Erasure is what makes the difference: a reader that hands the behavior the strings
+     * the object carried, having never turned them into keys, still answers a count, and only a
+     * lookup written in the key type misses.
+     */
+    private static String probeFor(String type) {
+        if (type.equals("Map<Outcome, Int>")) {
+            // a case value written in an argument position types as the case, not as the sum, so
+            // this row reads the keys it was given rather than looking one up
+            return "List.length(List.filter((k) -> k == Won, Map.keys(v)))";
+        }
         if (type.startsWith("Map<")) {
-            return "Map.size(v)";
+            return "Option.withDefault(0, Map.get(" + keyIn(type) + ", v))";
         }
         if (type.startsWith("List<")) {
             return "List.length(v)";
@@ -225,5 +264,29 @@ class DecoderPathAgreementTest {
             case "DateTime" -> "Date.day(DateTime.toDate(v))";
             default -> "v";
         };
+    }
+
+    /** The key the row's map holds, written as a value of the key type. */
+    private static String keyIn(String mapType) {
+        return switch (mapType) {
+            case "Map<String, Int>" -> "\"a\"";
+            case "Map<Key, Int>" -> "Key(\"a\")";
+            case "Map<Date, Int>" -> "Date(\"2026-01-01\")";
+            case "Map<DateTime, Int>" -> "DateTime(\"2026-01-01T09:00\")";
+            case "Map<Bounded, Int>" -> "Bounded(\"abc\")";
+            default -> throw new IllegalArgumentException(mapType);
+        };
+    }
+
+    /** What the probe builds, for the `constructs` the behavior running it needs. A temporal is
+     *  written with a primitive's constructor, which is nobody's to declare. */
+    private static String constructsIn(String type) {
+        if (type.contains("Key")) {
+            return ", Key";
+        }
+        if (type.contains("Bounded")) {
+            return ", Bounded";
+        }
+        return type.contains("Outcome") ? ", Won" : "";
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/DecoderPathAgreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/DecoderPathAgreementTest.java
@@ -22,9 +22,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * not.
  *
  * <p>This pins what each supports against the same table of types, so adding a capability to one
- * without the others fails here rather than in whatever example happens to use it. Where they do not
- * agree today the divergence is stated, not smoothed over: a test that hides a gap is worse than the
- * gap.
+ * without the others fails here rather than in whatever example happens to use it. A row states that
+ * all three read the type; a row stating that one of them does not would fix a gap in place, and a
+ * test that holds a gap open is worse than the gap.
+ *
+ * <p>What a boundary admits is not this table's to decide. The types below are the ones the checker
+ * lets cross, so a row is a claim about the three readers rather than about the boundary — see
+ * {@code TypeOps} for the rule and {@link EncoderPathAgreementTest} for the writing side.
  */
 class DecoderPathAgreementTest {
 
@@ -76,33 +80,61 @@ class DecoderPathAgreementTest {
                 "[\"2026-01-01\"]", 1L);
     }
 
-    // === where they part ===
-
     /**
-     * A newtype-keyed map crosses the boundary and is written in a fixture, and {@code run} declines
-     * it. {@code Runner.decoderFor} handles only a {@code String} key; its javadoc says so, so this
-     * is a stated limit rather than a surprise — stated here too, so closing it in one place without
-     * the others is caught.
+     * A boundary map is keyed by a {@code String}, a String-backed newtype, {@code Date},
+     * {@code DateTime} or an enumeration, and all three readers read all five. The rows are written
+     * out one kind at a time because the key is where a reader composing its own decoder is most
+     * likely to admit fewer kinds than the boundary does.
      */
     @Test
-    void aNewtypeKeyedMapIsReadByTheBoundaryAndTheFixtureButNotByRun() throws Exception {
-        assertTrue(boundaryReads("Map<Key, Int>", Map.of("a", 1L)), "the derived codec reads it");
-        assertTrue(fixtureReads("Map<Key, Int>", "[ (Key(\"a\"), 1) ]", 1L), "a fixture writes it");
-
-        RuntimeException e = assertThrows(Runner.RunException.class,
-                () -> runReads("Map<Key, Int>", "{\"a\": 1}"));
-        assertTrue(e.getMessage().contains("Map"), e.getMessage());
+    void aNewtypeKeyedMapIsReadByAllThree() throws Exception {
+        acceptedEverywhere("Map<Key, Int>", Map.of("a", 1L), "{\"a\": 1}", 1L);
     }
 
-    /** A temporal-keyed map, added at the boundary by issue #100, is the same story one step later. */
     @Test
-    void aDateKeyedMapIsReadByTheBoundaryAndTheFixtureButNotByRun() throws Exception {
-        assertTrue(boundaryReads("Map<Date, Int>", Map.of("2026-01-01", 1L)),
-                "the derived codec reads it");
-        assertTrue(fixtureReads("Map<Date, Int>", "[ (Date(\"2026-01-01\"), 1) ]", 1L),
-                "a fixture writes it");
+    void aDateKeyedMapIsReadByAllThree() throws Exception {
+        acceptedEverywhere("Map<Date, Int>", Map.of("2026-01-01", 1L), "{\"2026-01-01\": 1}", 1L);
+    }
 
-        assertThrows(Runner.RunException.class, () -> runReads("Map<Date, Int>", "{\"2026-01-01\": 1}"));
+    @Test
+    void aDateTimeKeyedMapIsReadByAllThree() throws Exception {
+        acceptedEverywhere("Map<DateTime, Int>", Map.of("2026-01-01T09:00", 1L),
+                "{\"2026-01-01T09:00\": 1}", 1L);
+    }
+
+    @Test
+    void anEnumerationKeyedMapIsReadByAllThree() throws Exception {
+        acceptedEverywhere("Map<Outcome, Int>", Map.of("Won", 1L), "{\"Won\": 1}", 1L);
+    }
+
+    /**
+     * A {@code String} key arrives canonical, like every other text a boundary reads. The keys of a
+     * decoded object do not pass the string leaf on their way in, so a reader that leaves them where
+     * they landed hands the domain the one text it never made canonical — and a lookup written the
+     * other way misses a key that is there.
+     */
+    @Test
+    void aStringKeyIsCanonicalWhicheverWayItWasWritten() throws Exception {
+        String composed = "\u304c";              // one code point
+        String decomposed = "\u304b\u3099";      // the base and the combining mark, the same text
+        Path file = dir.resolve("key.sou");
+        Files.writeString(file, """
+                module demo
+                behavior at : (m: Map<String, Int>) -> Int
+                let at (m) = Option.withDefault(0, Map.get("%s", m))
+                """.formatted(composed));
+        assertEquals("7", Runner.run(file, "at", "{\"" + decomposed + "\": 7}").trim(),
+                "the key the module looks up is the key the input carried");
+    }
+
+    /** A key the key type refuses is refused at that key's own path, and every key is read before
+     *  the map is given up on, so a map with two bad keys is answered about both at once. */
+    @Test
+    void aBadKeyIsRefusedWhereItStands() {
+        Runner.RunException refused = assertThrows(Runner.RunException.class,
+                () -> runReads("Map<Bounded, Int>", "{\"ab\": 1, \"cd\": 2}"));
+        assertTrue(refused.getMessage().contains("/ab"), refused.getMessage());
+        assertTrue(refused.getMessage().contains("/cd"), refused.getMessage());
     }
 
     // === the three paths ===
@@ -123,18 +155,31 @@ class DecoderPathAgreementTest {
             case "Date" -> "Date(\"2026-01-31\")";
             case "DateTime" -> "DateTime(\"2026-01-31T09:00\")";
             case "List<Date>" -> "[ Date(\"2026-01-01\") ]";
+            case "Map<Key, Int>" -> "[ (Key(\"a\"), 1) ]";
+            case "Map<Date, Int>" -> "[ (Date(\"2026-01-01\"), 1) ]";
+            case "Map<DateTime, Int>" -> "[ (DateTime(\"2026-01-01T09:00\"), 1) ]";
+            case "Map<Outcome, Int>" -> "[ (Won, 1) ]";
             default -> throw new IllegalArgumentException(type);
         };
     }
+
+    /** The types the rows are written in, declared the same way for all three paths — each path
+     *  reads the same module but for the one line that puts the type in position. */
+    private static final String DECLS = """
+            data Key = String
+            data Wrapped = Int
+            data Outcome = Won | Lost
+            data Bounded = String
+                invariant longEnough = String.length(value) >= 3
+            """;
 
     /** A data with a field of that type, decoded through its generated codec. */
     private boolean boundaryReads(String type, Object neutral) throws Exception {
         BytesClassLoader loader = new BytesClassLoader(Compiler.compile("""
                 module demo
-                data Key = String
-                data Wrapped = Int
+                %s
                 data Holder = { v: %s }
-                """.formatted(type)), getClass().getClassLoader());
+                """.formatted(DECLS, type)), getClass().getClassLoader());
         Object decoded = Codecs.decode(loader, "demo.Holder", Map.of("v", neutral));
         return "Ok".equals(decoded.getClass().getSimpleName());
     }
@@ -144,14 +189,13 @@ class DecoderPathAgreementTest {
     private boolean fixtureReads(String type, String fixture, Object expected) {
         Compiler.compile("""
                 module demo
-                data Key = String
-                data Wrapped = Int
+                %s
                 data Out = { n: Int }
                 behavior take : (v: %s) -> Out constructs Out
                 let take (v) = Out { n = %s }
                 example take
                   | "reads it" : (%s) -> Out { n = %s }
-                """.formatted(type, sizeExprFor(type), fixture, expected));
+                """.formatted(DECLS, type, sizeExprFor(type), fixture, expected));
         return true;
     }
 
@@ -160,11 +204,10 @@ class DecoderPathAgreementTest {
         Path file = dir.resolve("run" + Math.abs(type.hashCode()) + ".sou");
         Files.writeString(file, """
                 module demo
-                data Key = String
-                data Wrapped = Int
+                %s
                 behavior take : (v: %s) -> Int
                 let take (v) = %s
-                """.formatted(type, sizeExprFor(type)));
+                """.formatted(DECLS, type, sizeExprFor(type)));
         return Runner.run(file, "take", json);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/EncoderPathAgreementTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EncoderPathAgreementTest.java
@@ -1,0 +1,153 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Two implementations answer "write a value of type T to the outside": the codec derived for a data,
+ * and {@code Runner.encode} behind {@code souther run}. A data's field reaches the first, and a
+ * behavior's own output type reaches the second — so the same value written the two ways has to come
+ * out the same, and where it does not, {@code run} is a boundary of its own with its own rules.
+ *
+ * <p>The comparison is that identity. For each type in the table one behavior answers with the bare
+ * value and another answers with a data holding it, and the second must be the first inside
+ * {@code {"v": …}} — byte for byte, since what a boundary writes is fixed rather than merely
+ * equivalent. Wrapping is what routes the value through the derived codec, so the two paths meet on
+ * one value and disagree only where they were written to disagree.
+ *
+ * <p>The fixture builder an {@code example} uses is not a third path here, as it is on the reading
+ * side ({@link DecoderPathAgreementTest}): an example builds its expected value and compares domain
+ * values, so it reads a written form in and never writes one out.
+ */
+class EncoderPathAgreementTest {
+
+    @TempDir
+    Path dir;
+
+    // === the primitives and the named types ===
+
+    @Test
+    void anIntIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Int", "7");
+    }
+
+    @Test
+    void aStringIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("String", "\"k\"");
+    }
+
+    @Test
+    void aDateIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Date", "Date(\"2026-01-01\")");
+    }
+
+    @Test
+    void aNewtypeIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Code", "Code(\"c\")");
+    }
+
+    @Test
+    void anEnumerationIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Outcome", "Won");
+    }
+
+    // === the collections ===
+
+    @Test
+    void aListIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("List<Int>", "[ 1, 2 ]");
+    }
+
+    @Test
+    void aSetIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Set<String>", "Set.fromList([ \"b\", \"a\" ])");
+    }
+
+    @Test
+    void aMapValueOfANamedTypeIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Map<String, Code>", "Map.fromList([ (\"k\", Code(\"v\")) ])");
+    }
+
+    // === the five kinds a boundary map may be keyed by ===
+
+    @Test
+    void aStringKeyedMapIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Map<String, Int>", "Map.fromList([ (\"k\", 7) ])");
+    }
+
+    @Test
+    void aNewtypeKeyedMapIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Map<Code, Int>", "Map.fromList([ (Code(\"k\"), 7) ])");
+    }
+
+    @Test
+    void aDateKeyedMapIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Map<Date, Int>", "Map.fromList([ (Date(\"2026-01-01\"), 7) ])");
+    }
+
+    @Test
+    void aDateTimeKeyedMapIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Map<DateTime, Int>", "Map.fromList([ (DateTime(\"2026-01-01T09:00\"), 7) ])");
+    }
+
+    @Test
+    void anEnumerationKeyedMapIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Map<Outcome, Int>", "Map.fromList([ (Won, 7) ])");
+    }
+
+    // === and at depth, where the key is not the type the behavior declared ===
+
+    @Test
+    void aListOfNewtypeKeyedMapsIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("List<Map<Code, Int>>", "[ Map.fromList([ (Code(\"k\"), 7) ]) ]");
+    }
+
+    @Test
+    void aMapOfNewtypeKeyedMapsIsWrittenTheSameBothWays() throws Exception {
+        writtenAlike("Map<String, Map<Code, Int>>",
+                "Map.fromList([ (\"a\", Map.fromList([ (Code(\"k\"), 7) ])) ])");
+    }
+
+    // === the two paths ===
+
+    /** The value written bare, and written as the sole field of a data — the second being the first
+     *  inside an object, since the field's own codec is what a data's encoder calls. */
+    private void writtenAlike(String type, String value) throws Exception {
+        String bare = written(type, value, "bare");
+        String wrapped = written(type, value, "wrapped");
+        assertEquals("{\"v\":" + bare + "}", wrapped,
+                "a " + type + " writes the same whether `run` composes it or the derived codec does");
+    }
+
+    /** Runs one of the two behaviors and returns the JSON it wrote. */
+    private String written(String type, String value, String behavior) throws Exception {
+        Path file = dir.resolve("w" + Math.abs((type + value).hashCode()) + ".sou");
+        String built = builtBy(value);
+        Files.writeString(file, """
+                module demo
+                data Code = String
+                data Outcome = Won | Lost
+                data Holder = { v: %s }
+                behavior bare : (n: Int) -> %s%s
+                let bare (n) = %s
+                behavior wrapped : (n: Int) -> Holder constructs Holder%s
+                let wrapped (n) = Holder { v = %s }
+                """.formatted(type, type, built.isEmpty() ? "" : " constructs " + built,
+                        value, built.isEmpty() ? "" : ", " + built, value));
+        return Runner.run(file, behavior, "1").trim();
+    }
+
+    /** What the value expression builds, for the `constructs` both behaviors need. A row builds at
+     *  most one of the module's data types, which is what keeps this a lookup rather than a parse. */
+    private static String builtBy(String value) {
+        if (value.contains("Code(")) {
+            return "Code";
+        }
+        return value.contains("Won") ? "Won" : "";
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
@@ -415,42 +415,65 @@ class RunnerTest {
                         "{\"items\":[{\"name\":\"a\",\"price\":1},{\"name\":\"b\",\"price\":2}]}"));
     }
 
-    /** A type `run` still cannot drive is named the way the source writes it, not in the checker's
-     * own spelling, and in the reader's language — the runner is as much a user surface as the
-     * compiler's diagnostics. */
+    /**
+     * The type a behavior declares reaches {@code run} already judged. Whether a type may cross is
+     * the checker's question, and every kind it admits at the boundary is one {@code run} drives, so
+     * the reasons {@code run} keeps for a type it cannot decode or encode have no input left to
+     * refuse. Each row here is refused before {@code run} composes a codec at all.
+     */
     @Test
-    void namesAnUndecodableInputTypeInSurfaceSyntax() throws Exception {
-        Path file = write("keyed.sou", """
+    void everyTypeThatCrossesIsOneRunDrives() throws Exception {
+        assertRefusedByTheChecker("(Int, Int)", "a tuple", "E1311");
+        assertRefusedByTheChecker("Int?", "an optional", "E1402");
+        assertRefusedByTheChecker("A | B", "an anonymous union", "E1312");
+        assertRefusedByTheChecker("Map<Int, Int>", "a map an object cannot be keyed by", "E1314");
+
+        // and what the checker does admit, `run` drives — the collections over the five key kinds,
+        // which DecoderPathAgreementTest and EncoderPathAgreementTest hold row by row
+        Path file = write("admitted.sou", """
                 data UserId = String
                 data Out = { n: Int }
                 behavior f : (byUser: Map<UserId, Int>) -> Out constructs Out
                 let f (byUser) = Out { n = Map.size(byUser) }
                 """);
-        Runner.RunException e = assertThrows(Runner.RunException.class,
-                () -> Runner.run(file, "f", "{\"u1\": 1}"));
-        assertTrue(e.getMessage().contains("Map<UserId, Int>"), e.getMessage());
-        assertFalse(e.getMessage().contains("MapOf"), e.getMessage());
+        assertEquals("{\"n\":1}", Runner.run(file, "f", "{\"u1\": 1}"));
+    }
+
+    /** That a parameter of this type never reaches {@code run}: the compile refuses it, naming the
+     *  code that owns the rule. */
+    private void assertRefusedByTheChecker(String type, String what, String code) throws Exception {
+        Path file = write("refused" + Math.abs(type.hashCode()) + ".sou", """
+                data A = { a: Int }
+                data B = { b: Int }
+                data Out = { n: Int }
+                behavior f : (v: %s) -> Out constructs Out
+                let f (v) = Out { n = 1 }
+                """.formatted(type));
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> Runner.run(file, "f", "1"), what + " is refused before run sees it");
+        assertTrue(e.getMessage().contains(code), what + ": " + e.getMessage());
     }
 
     /** A run failure is read in the language the command line selected, as a compile error is. The
      * exception's own message stays English — that is what a Java caller sees. */
     @Test
     void aRunFailureIsRenderedInTheSelectedLocale() throws Exception {
-        Path file = write("keyed.sou", """
-                data UserId = String
+        Path file = write("injected.sou", """
                 data Out = { n: Int }
-                behavior f : (byUser: Map<UserId, Int>) -> Out constructs Out
-                let f (byUser) = Out { n = Map.size(byUser) }
+                behavior f : (n: Int) -> Out constructs Out
+                behavior g : (n: Int) -> Out constructs Out
+                let g (n) = Out { n = n }
                 """);
         Runner.RunException e = assertThrows(Runner.RunException.class,
-                () -> Runner.run(file, "f", "{\"u1\": 1}"));
+                () -> Runner.run(file, "f", "1"));
 
-        assertTrue(e.localized(java.util.Locale.JAPANESE).contains("デコードできません"),
+        assertTrue(e.localized(java.util.Locale.JAPANESE).contains("実装がありません"),
                 e.localized(java.util.Locale.JAPANESE));
-        assertTrue(e.localized(java.util.Locale.JAPANESE).contains("Map<UserId, Int>"),
+        assertTrue(e.localized(java.util.Locale.JAPANESE).contains("`f`"),
                 e.localized(java.util.Locale.JAPANESE));
-        assertTrue(e.localized(java.util.Locale.ENGLISH).contains("cannot decode yet"),
+        assertTrue(e.localized(java.util.Locale.ENGLISH).contains("has no implementation"),
                 e.localized(java.util.Locale.ENGLISH));
+        assertEquals(e.getMessage(), e.localized(java.util.Locale.ENGLISH));
     }
 
     /** The decoder's own issue text is part of the message the reader sees, so it is resolved in the

--- a/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/RunnerTest.java
@@ -416,21 +416,19 @@ class RunnerTest {
     }
 
     /**
-     * The type a behavior declares reaches {@code run} already judged. Whether a type may cross is
-     * the checker's question, and every kind it admits at the boundary is one {@code run} drives, so
-     * the reasons {@code run} keeps for a type it cannot decode or encode have no input left to
-     * refuse. Each row here is refused before {@code run} composes a codec at all.
+     * A parameter type reaches {@code run} already judged. What may cross is the checker's question,
+     * and every kind it admits is one the runner composes a decoder for, so {@code run.decode
+     * .unsupported} has no input left to refuse — each row here is refused before a decoder is asked
+     * for at all.
      */
     @Test
-    void everyTypeThatCrossesIsOneRunDrives() throws Exception {
-        assertRefusedByTheChecker("(Int, Int)", "a tuple", "E1311");
-        assertRefusedByTheChecker("Int?", "an optional", "E1402");
-        assertRefusedByTheChecker("A | B", "an anonymous union", "E1312");
-        assertRefusedByTheChecker("Map<Int, Int>", "a map an object cannot be keyed by", "E1314");
+    void aParameterTypeTheRunnerCannotDecodeIsRefusedBeforeItIsAsked() throws Exception {
+        assertInputRefused("(Int, Int)", "a tuple", "E1311");
+        assertInputRefused("Int?", "an optional", "E1402");
+        assertInputRefused("A | B", "an anonymous union", "E1312");
+        assertInputRefused("Map<Int, Int>", "a map an object cannot be keyed by", "E1314");
 
-        // and what the checker does admit, `run` drives — the collections over the five key kinds,
-        // which DecoderPathAgreementTest and EncoderPathAgreementTest hold row by row
-        Path file = write("admitted.sou", """
+        Path file = write("indrives.sou", """
                 data UserId = String
                 data Out = { n: Int }
                 behavior f : (byUser: Map<UserId, Int>) -> Out constructs Out
@@ -439,10 +437,36 @@ class RunnerTest {
         assertEquals("{\"n\":1}", Runner.run(file, "f", "{\"u1\": 1}"));
     }
 
-    /** That a parameter of this type never reaches {@code run}: the compile refuses it, naming the
-     *  code that owns the rule. */
-    private void assertRefusedByTheChecker(String type, String what, String code) throws Exception {
-        Path file = write("refused" + Math.abs(type.hashCode()) + ".sou", """
+    /**
+     * The same of an output type, which is a separate claim and asked separately: the encoder is
+     * composed from the behavior's return type, and what may be returned is a shorter list than what
+     * may be taken — an anonymous union is a parameter the checker refuses and an output it admits.
+     */
+    @Test
+    void anOutputTypeTheRunnerCannotEncodeIsRefusedBeforeItIsAsked() throws Exception {
+        assertOutputRefused("(Int, Int)", "(1, 2)", "a tuple", "E1311");
+        assertOutputRefused("Int?", "1", "an optional", "E1402");
+        assertOutputRefused("Map<Int, Int>", "Map.fromList([ (1, 2) ])",
+                "a map an object cannot be keyed by", "E1314");
+
+        Path file = write("outdrives.sou", """
+                data UserId = String
+                data A = { a: Int }
+                data B = { b: Int }
+                behavior f : (n: Int) -> Map<UserId, Int> constructs UserId
+                let f (n) = Map.fromList([ (UserId("u1"), n) ])
+                behavior g : (n: Int) -> A | B constructs A
+                let g (n) = A { a = n }
+                """);
+        assertEquals("{\"u1\":1}", Runner.run(file, "f", "1"));
+        // the union's own encoder writes the case, so the answer carries the discriminator
+        assertEquals("{\"a\":1,\"type\":\"A\"}", Runner.run(file, "g", "1"));
+    }
+
+    /** That a parameter of this type never reaches the runner's decoder: the compile refuses it,
+     *  naming the code that owns the rule. */
+    private void assertInputRefused(String type, String what, String code) throws Exception {
+        Path file = write("inref" + Math.abs(type.hashCode()) + ".sou", """
                 data A = { a: Int }
                 data B = { b: Int }
                 data Out = { n: Int }
@@ -450,7 +474,21 @@ class RunnerTest {
                 let f (v) = Out { n = 1 }
                 """.formatted(type));
         RuntimeException e = assertThrows(RuntimeException.class,
-                () -> Runner.run(file, "f", "1"), what + " is refused before run sees it");
+                () -> Runner.run(file, "f", "1"), what + " is refused before run decodes");
+        assertTrue(e.getMessage().contains(code), what + ": " + e.getMessage());
+    }
+
+    /** That an output of this type never reaches the runner's encoder. */
+    private void assertOutputRefused(String type, String body, String what, String code)
+            throws Exception {
+        Path file = write("outref" + Math.abs(type.hashCode()) + ".sou", """
+                data A = { a: Int }
+                data B = { b: Int }
+                behavior f : (n: Int) -> %s
+                let f (n) = %s
+                """.formatted(type, body));
+        RuntimeException e = assertThrows(RuntimeException.class,
+                () -> Runner.run(file, "f", "1"), what + " is refused before run encodes");
         assertTrue(e.getMessage().contains(code), what + ": " + e.getMessage());
     }
 


### PR DESCRIPTION
Closes #425.

The reported symptom is a behavior answering with `Map<Code, Int>`, refused by `run` while the same
map wrapped in a newtype printed byte-identical JSON. The defect is not that output: it is that the
runner decides for itself what may key a boundary Map, in a version that admits one of the five
kinds.

## What owns the rule

`TypeOps.isBoundaryMapKey` says a Map that crosses is keyed by `String`, a String-backed newtype,
`Date`, `DateTime`, or an enumeration. `SpecChecker` and `DataChecker` ask it for E1314, and
`Deriver.mapKeyEnc`/`mapKeyDec` follow it by sending every named key through that type's own codec —
which is why wrapping the map worked.

`Runner` wrote the rule again, as `map.key() == Type.STRING`, in the decoder it composes and again
in the encoder. By the time either runs, E1314 has already passed, so the key is known to be one of
the five. The runner re-asked a question that was answered and got a narrower answer.

## Both directions

Fixing only the encode side would leave `run`'s input admitting a `String` key alone, leave the
runner and `TypeOps` disagreeing, and leave the next reader to repeat this investigation. So the
unit of the fix is the contract, not the output.

Encoding sends the key through the recursion the value already takes. Decoding rekeys the decoded
object's strings through the key type's own decoder, with a bad key reported at that key's own path
and every key read before the map is given up on. Neither direction names the newtype and the
enumeration apart: a `Type.Ref` goes to its class's codec, and the three primitives are the string
leaf.

The key decoder is the neutral-source one rather than the JSON one, because a key arrives already
read out of the object that carried it — the same choice `CodecGen.emitKeyDecoder` makes. A `String`
key is rekeyed with the rest: the keys of a decoded object do not pass the string leaf, so leaving
them alone is the one place a boundary would hand over text it had not made canonical.

## Tests

`DecoderPathAgreementTest` exists so the derived codec, the fixture builder and `run` cannot drift
apart. Two of its rows asserted that `run` refuses a key the other two read, so the table that
detects drift was holding this one open; both now state that all three read it, and `DateTime`,
enumeration, bad-key reporting and canonical `String` keys are stated beside them.

It also covered reading only, which is why an output-side defect met no test at all.
`EncoderPathAgreementTest` states the writing side as the same kind of table: a value written bare
and the same value written as a data's sole field must come out as the same JSON, since wrapping is
what routes it through the derived codec.

Each change was checked against a mutant. Restoring the encode guard fails six encoder rows,
restoring the decode guard fails five decoder rows, and skipping the rekey for a `String` key fails
the canonical-key row alone.

## Two refusals with nothing left to refuse

With the key read from one place, no type a behavior can declare reaches `run`'s `cannot decode yet`
or `cannot encode yet`: a tuple is E1311, an optional E1402, an anonymous union E1312, an
inadmissible key E1314. `RunnerTest.everyTypeThatCrossesIsOneRunDrives` states that as a table.

`RunnerTest.namesAnUndecodableInputTypeInSurfaceSyntax` used a newtype-keyed map only as a vehicle
for such a type and had none left, so it gives way to that table.
`aRunFailureIsRenderedInTheSelectedLocale` keeps its subject on `run.behavior.noimpl`.

What to do with the two refusals is a design question rather than a wording one — drop them, or keep
them as the internal error they describe — so it is #440 and not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
