### PR TITLE
A gate does not withhold the difference it decided on

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The compiler suite and every example pass under the flag (`mvn test -DargLine="-
 
 The VS Code extension lives in [souther-lang/souther-vscode](https://github.com/souther-lang/souther-vscode) and is published to the Visual Studio Marketplace and Open VSX. It bundles the language server and fetches a Java 25 runtime by itself when the machine does not already have one, so installing it and opening a `.sou` file is enough. It gives diagnostics, the document outline, hover, go-to-definition, find-references, rename, completion, quick-fix code actions, formatting, and semantic tokens.
 
-The server is `souther-lsp`, a self-contained jar that speaks LSP over stdio, attached to every release here. Other editors can launch it with `java -jar souther-lsp.jar`. Formatting is also on the command line: `souther fmt <file.sou>` prints the canonical form, `-w` rewrites in place, and `--check` exits non-zero when a file is not formatted.
+The server is `souther-lsp`, a self-contained jar that speaks LSP over stdio, attached to every release here. Other editors can launch it with `java -jar souther-lsp.jar`. Formatting is also on the command line: `souther fmt <file.sou>` prints the canonical form, `-w` rewrites in place, and `--check` exits non-zero when a file is not formatted, printing each such file as a unified diff against its canonical form.
 
 ## Documentation on the command line
 

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -21,6 +21,7 @@ import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.report.AdequacyReport;
 import souther.compiler.report.GeneratedRows;
+import souther.compiler.report.UnifiedDiff;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -429,8 +430,15 @@ public final class Main {
     /**
      * {@code souther fmt <file.sou>... [-w] [--check]}: rewrites each file into its canonical form
      * (see {@link Formatter}). With no flag the formatted source is printed to stdout; {@code -w}
-     * writes it back in place; {@code --check} writes nothing and exits 1 if any file is not already
-     * formatted, listing those files. A file with a syntax error is reported and left untouched.
+     * writes it back in place; {@code --check} writes no file and exits 1 if any file is not already
+     * formatted, printing each one's difference from its canonical form. A file with a syntax error
+     * is reported and left untouched.
+     *
+     * <p>The difference is printed as the file is judged rather than gathered for the end. The
+     * canonical form is what the verdict is taken against, so a gate that answered with the file's
+     * name alone had computed the whole of what the reader needed and dropped it — leaving them to
+     * write the file over with {@code -w} against a copy, or run the formatter again into a scratch
+     * file, to be told what the gate already knew.
      */
     private static int fmtSubcommand(String[] args) {
         boolean write = false;
@@ -462,7 +470,7 @@ public final class Main {
             System.err.println("formatting multiple files needs `-w` (write in place) or `--check`");
             return 2;
         }
-        List<Path> unformatted = new ArrayList<>();
+        boolean unformatted = false;
         boolean failed = false;
         for (Path file : files) {
             String source;
@@ -498,7 +506,11 @@ public final class Main {
             }
             if (check) {
                 if (!formatted.equals(source)) {
-                    unformatted.add(file);
+                    unformatted = true;
+                    // Here, where both texts are still in hand. Nothing is kept for the end: what the
+                    // run has to remember about a file it has judged is that one of them differed.
+                    System.out.print(UnifiedDiff.of(file.toString(), file + " (formatted)",
+                            source, formatted));
                 }
             } else if (write) {
                 if (!formatted.equals(source)) {
@@ -513,12 +525,7 @@ public final class Main {
                 System.out.print(formatted);
             }
         }
-        if (check) {
-            for (Path f : unformatted) {
-                System.out.println(f);
-            }
-        }
-        return failed || (check && !unformatted.isEmpty()) ? 1 : 0;
+        return failed || unformatted ? 1 : 0;
     }
 
     /** {@code souther run <file.sou> [--behavior <name>] [--input <json>]}: compiles the file in

--- a/souther-compiler/src/main/java/souther/compiler/report/UnifiedDiff.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/UnifiedDiff.java
@@ -1,0 +1,212 @@
+package souther.compiler.report;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Two texts and where they differ, in unified-diff form.
+ *
+ * <p>It reads the two texts and nothing else. What produced either of them, and which rule of
+ * whatever produced them accounts for a line, is not a question this can answer and not one it is
+ * asked: a caller that holds two texts holds the whole of what is rendered here.
+ */
+public final class UnifiedDiff {
+
+    /** Unchanged lines kept on each side of a change, as {@code diff -u} keeps them. */
+    private static final int CONTEXT = 3;
+
+    /**
+     * The largest table {@link #script} will build, in cells of one {@code int} — about sixteen
+     * megabytes.
+     *
+     * <p>Which lines two texts share is answered by filling a table the size of one length times the
+     * other, so a pair of texts large enough is a pair answered by exhausting the heap. Past this
+     * size the differing part is shown whole: still the difference, and still one hunk of a unified
+     * diff, but without saying which lines inside it the two had in common.
+     */
+    private static final long MAX_CELLS = 4_000_000L;
+
+    private UnifiedDiff() {
+    }
+
+    /** One line of a text, and whether the text terminated it. Only the last line of a text can be
+     * unterminated, and a text and the same text without its final newline are two texts: compared
+     * as plain strings their lines are the same list, which leaves a difference with nothing to
+     * show for it. */
+    private record Line(String text, boolean terminated) {
+    }
+
+    private record Op(char kind, Line line) {
+    }
+
+    /**
+     * The difference between {@code from} and {@code to}, or the empty string when they are the same
+     * text. The labels name the two sides in the header and are written as given.
+     */
+    public static String of(String fromLabel, String toLabel, String from, String to) {
+        if (from.equals(to)) {
+            return "";
+        }
+        List<Line> a = lines(from);
+        List<Line> b = lines(to);
+        List<Op> ops = compare(a, b);
+        StringBuilder out = new StringBuilder();
+        out.append("--- ").append(fromLabel).append('\n');
+        out.append("+++ ").append(toLabel).append('\n');
+        render(ops, out);
+        return out.toString();
+    }
+
+    private static List<Line> lines(String text) {
+        List<Line> lines = new ArrayList<>();
+        int start = 0;
+        while (start < text.length()) {
+            int end = text.indexOf('\n', start);
+            if (end < 0) {
+                lines.add(new Line(text.substring(start), false));
+                return lines;
+            }
+            lines.add(new Line(text.substring(start, end), true));
+            start = end + 1;
+        }
+        return lines;
+    }
+
+    /**
+     * The whole edit script, with the lines the two texts already agree on at either end kept as
+     * they are.
+     *
+     * <p>Only what is left between them is searched for common lines, which is what keeps the cost
+     * of a file that is canonical everywhere but one place the cost of that one place. It is also
+     * what {@link #MAX_CELLS} is measured against: a file past the bound overall but agreeing on all
+     * but a few lines is the ordinary case, and it is not the case the bound is there for.
+     */
+    private static List<Op> compare(List<Line> a, List<Line> b) {
+        int prefix = 0;
+        while (prefix < a.size() && prefix < b.size() && a.get(prefix).equals(b.get(prefix))) {
+            prefix++;
+        }
+        int suffix = 0;
+        while (suffix < a.size() - prefix && suffix < b.size() - prefix
+                && a.get(a.size() - 1 - suffix).equals(b.get(b.size() - 1 - suffix))) {
+            suffix++;
+        }
+        List<Line> midA = a.subList(prefix, a.size() - suffix);
+        List<Line> midB = b.subList(prefix, b.size() - suffix);
+        List<Op> ops = new ArrayList<>();
+        for (int k = 0; k < prefix; k++) {
+            ops.add(new Op(' ', a.get(k)));
+        }
+        ops.addAll((long) midA.size() * midB.size() > MAX_CELLS
+                ? whole(midA, midB)
+                : script(midA, midB));
+        for (int k = a.size() - suffix; k < a.size(); k++) {
+            ops.add(new Op(' ', a.get(k)));
+        }
+        return ops;
+    }
+
+    /** Both texts in full, one replacing the other — the answer when finding what they share costs
+     * more than {@link #MAX_CELLS}. */
+    private static List<Op> whole(List<Line> a, List<Line> b) {
+        List<Op> ops = new ArrayList<>();
+        for (Line line : a) {
+            ops.add(new Op('-', line));
+        }
+        for (Line line : b) {
+            ops.add(new Op('+', line));
+        }
+        return ops;
+    }
+
+    private static List<Op> script(List<Line> a, List<Line> b) {
+        int n = a.size();
+        int m = b.size();
+        int[][] common = new int[n + 1][m + 1];
+        for (int i = n - 1; i >= 0; i--) {
+            for (int j = m - 1; j >= 0; j--) {
+                common[i][j] = a.get(i).equals(b.get(j))
+                        ? common[i + 1][j + 1] + 1
+                        : Math.max(common[i + 1][j], common[i][j + 1]);
+            }
+        }
+        List<Op> ops = new ArrayList<>();
+        int i = 0;
+        int j = 0;
+        while (i < n && j < m) {
+            if (a.get(i).equals(b.get(j))) {
+                ops.add(new Op(' ', a.get(i)));
+                i++;
+                j++;
+            } else if (common[i + 1][j] >= common[i][j + 1]) {
+                ops.add(new Op('-', a.get(i)));
+                i++;
+            } else {
+                ops.add(new Op('+', b.get(j)));
+                j++;
+            }
+        }
+        while (i < n) {
+            ops.add(new Op('-', a.get(i++)));
+        }
+        while (j < m) {
+            ops.add(new Op('+', b.get(j++)));
+        }
+        return ops;
+    }
+
+    /** The changed lines with their context, one hunk per run of them. */
+    private static void render(List<Op> ops, StringBuilder out) {
+        int[] fromAt = new int[ops.size() + 1];
+        int[] toAt = new int[ops.size() + 1];
+        for (int k = 0; k < ops.size(); k++) {
+            char kind = ops.get(k).kind();
+            fromAt[k + 1] = fromAt[k] + (kind == '+' ? 0 : 1);
+            toAt[k + 1] = toAt[k] + (kind == '-' ? 0 : 1);
+        }
+        int k = 0;
+        while (k < ops.size()) {
+            if (ops.get(k).kind() == ' ') {
+                k++;
+                continue;
+            }
+            int start = Math.max(0, k - CONTEXT);
+            int last = k;
+            // Runs closer than twice the context share one hunk: written apart they would repeat the
+            // lines between them, once as the first hunk's trailing context and once as the second's
+            // leading context.
+            for (int scan = k; scan < ops.size(); scan++) {
+                if (ops.get(scan).kind() != ' ') {
+                    last = scan;
+                } else if (scan - last > CONTEXT * 2) {
+                    break;
+                }
+            }
+            int end = Math.min(ops.size(), last + CONTEXT + 1);
+            hunk(ops, start, end, fromAt, toAt, out);
+            k = end;
+        }
+    }
+
+    private static void hunk(List<Op> ops, int start, int end, int[] fromAt, int[] toAt,
+            StringBuilder out) {
+        int fromCount = fromAt[end] - fromAt[start];
+        int toCount = toAt[end] - toAt[start];
+        out.append("@@ -").append(at(fromAt[start], fromCount)).append(',').append(fromCount)
+                .append(" +").append(at(toAt[start], toCount)).append(',').append(toCount)
+                .append(" @@\n");
+        for (int k = start; k < end; k++) {
+            Op op = ops.get(k);
+            out.append(op.kind()).append(op.line().text()).append('\n');
+            if (!op.line().terminated()) {
+                out.append("\\ No newline at end of file\n");
+            }
+        }
+    }
+
+    /** Where a hunk starts on one side: the first line it covers, or the line it follows when it
+     * covers none of that side at all. */
+    private static int at(int before, int count) {
+        return count == 0 ? before : before + 1;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/report/UnifiedDiff.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/UnifiedDiff.java
@@ -16,13 +16,18 @@ public final class UnifiedDiff {
     private static final int CONTEXT = 3;
 
     /**
-     * The largest table {@link #script} will build, in cells of one {@code int} — about sixteen
-     * megabytes.
+     * The largest table {@link #script} will build, in cells of one {@code int} — sixteen megabytes,
+     * and all of what the comparison allocates.
      *
-     * <p>Which lines two texts share is answered by filling a table the size of one length times the
-     * other, so a pair of texts large enough is a pair answered by exhausting the heap. Past this
-     * size the differing part is shown whole: still the difference, and still one hunk of a unified
-     * diff, but without saying which lines inside it the two had in common.
+     * <p>Which lines two texts share is answered by filling a table with a row per line of one and a
+     * column per line of the other, so a pair of texts large enough is a pair answered by exhausting
+     * the heap. Past this size the differing part is shown whole: still the difference, and still one
+     * hunk of a unified diff, but without saying which lines inside it the two had in common.
+     *
+     * <p>The count is of the whole table and not of the two lengths multiplied. A pair long on one
+     * side and a line or two on the other multiplies out to nothing while its table still has a row
+     * for every line of the long side, so measured that way the bound would let through the shape it
+     * exists to stop.
      */
     private static final long MAX_CELLS = 4_000_000L;
 
@@ -97,7 +102,7 @@ public final class UnifiedDiff {
         for (int k = 0; k < prefix; k++) {
             ops.add(new Op(' ', a.get(k)));
         }
-        ops.addAll((long) midA.size() * midB.size() > MAX_CELLS
+        ops.addAll(cells(midA.size(), midB.size()) > MAX_CELLS
                 ? whole(midA, midB)
                 : script(midA, midB));
         for (int k = a.size() - suffix; k < a.size(); k++) {
@@ -119,15 +124,25 @@ public final class UnifiedDiff {
         return ops;
     }
 
+    /** Cells in the table {@link #script} fills for two texts of these lengths — one row and one
+     * column more than they have lines, since the last of each is the empty tail past their end. */
+    private static long cells(int n, int m) {
+        return (long) (n + 1) * (m + 1);
+    }
+
     private static List<Op> script(List<Line> a, List<Line> b) {
         int n = a.size();
         int m = b.size();
-        int[][] common = new int[n + 1][m + 1];
+        // One array rather than one per row: a row is an object of its own, so a table of a million
+        // rows costs a million headers and a million references on top of the cells, and a bound
+        // that counted only the cells would not be a bound on what a lopsided pair allocates.
+        int stride = m + 1;
+        int[] common = new int[Math.toIntExact(cells(n, m))];
         for (int i = n - 1; i >= 0; i--) {
             for (int j = m - 1; j >= 0; j--) {
-                common[i][j] = a.get(i).equals(b.get(j))
-                        ? common[i + 1][j + 1] + 1
-                        : Math.max(common[i + 1][j], common[i][j + 1]);
+                common[i * stride + j] = a.get(i).equals(b.get(j))
+                        ? common[(i + 1) * stride + j + 1] + 1
+                        : Math.max(common[(i + 1) * stride + j], common[i * stride + j + 1]);
             }
         }
         List<Op> ops = new ArrayList<>();
@@ -138,7 +153,7 @@ public final class UnifiedDiff {
                 ops.add(new Op(' ', a.get(i)));
                 i++;
                 j++;
-            } else if (common[i + 1][j] >= common[i][j + 1]) {
+            } else if (common[(i + 1) * stride + j] >= common[i * stride + j + 1]) {
                 ops.add(new Op('-', a.get(i)));
                 i++;
             } else {

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -37,6 +37,11 @@ souther fmt <file.sou>... [-w] [--check]
 Prints the canonical form to stdout, rewrites in place with `-w`, or exits non-zero on a file that
 is not formatted with `--check`.
 
+`--check` prints each file it rejects as a unified diff against that file's canonical form. The
+canonical form is what the verdict is taken against, so a failing build says what differs rather
+than only which file did, and nothing has to be formatted a second time locally to read it. A file
+already in canonical form is not mentioned.
+
 <!-- souther-section: examples -->
 ## examples
 

--- a/souther-compiler/src/test/java/souther/compiler/AFormatCheckShowsTheDifferenceItDecidedOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AFormatCheckShowsTheDifferenceItDecidedOnTest.java
@@ -1,0 +1,101 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import souther.compiler.report.UnifiedDiff;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A gate that judged a file by computing its canonical form says what it compared.
+ *
+ * <p>The verdict alone was a file name and an exit code, which left the reader to obtain the other
+ * text themselves — by writing the file over with {@code -w} and diffing it against a copy, or by
+ * running the formatter a second time into a scratch file. Both texts are in hand at the moment the
+ * verdict is taken, so the difference goes out then, and the canonical form is never carried past
+ * the file it was computed for.
+ */
+class AFormatCheckShowsTheDifferenceItDecidedOnTest {
+
+    @TempDir
+    Path dir;
+
+    private record Said(int code, String err, String out) {}
+
+    private Said run(String... args) {
+        PrintStream originalErr = System.err;
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            int code = Main.dispatch(args);
+            return new Said(code, err.toString(StandardCharsets.UTF_8),
+                    out.toString(StandardCharsets.UTF_8));
+        } finally {
+            System.setErr(originalErr);
+            System.setOut(originalOut);
+        }
+    }
+
+    private Path source(String name, String text) throws Exception {
+        Path file = dir.resolve(name);
+        Files.writeString(file, text);
+        return file;
+    }
+
+    private static final String UNFORMATTED = "module billing\n\ndata Note = {   body: String }\n";
+
+    /** What the gate shows is the canonical form it judged against, and not another reading of the
+     * file: the same text {@code fmt} prints when asked for it. */
+    @Test
+    void aFileThatIsNotFormattedIsAnsweredWithTheDifferenceItDecidedOn() throws Exception {
+        Path file = source("m.sou", UNFORMATTED);
+        String canonical = run("fmt", file.toString()).out();
+        assertNotEquals(UNFORMATTED, canonical);
+
+        Said said = run("fmt", file.toString(), "--check");
+
+        assertEquals(1, said.code());
+        assertEquals(UnifiedDiff.of(file.toString(), file + " (formatted)", UNFORMATTED, canonical),
+                said.out());
+        assertTrue(said.out().contains("@@"), said.out());
+    }
+
+    /** The name the verdict used to be is in the header the difference already carries. Said twice,
+     * a reader scanning a CI log counts a file that differs as two. */
+    @Test
+    void theNameIsNotSaidApartFromTheDifferenceItHeads() throws Exception {
+        Path file = source("m.sou", UNFORMATTED);
+
+        Said said = run("fmt", file.toString(), "--check");
+
+        assertEquals("--- " + file, said.out().lines().findFirst().orElseThrow());
+        assertEquals(0, said.out().lines().filter(line -> line.equals(file.toString())).count(),
+                said.out());
+    }
+
+    /** A file that differs does not end the run: a reader who fixes only what the first line named
+     * comes back for the next one on the next build. */
+    @Test
+    void everyFileThatDiffersIsShownAndNotOnlyTheFirst() throws Exception {
+        Path first = source("first.sou", UNFORMATTED);
+        Path second = source("second.sou", UNFORMATTED);
+
+        Said said = run("fmt", first.toString(), second.toString(), "--check");
+
+        assertEquals(1, said.code());
+        assertTrue(said.out().contains("--- " + first), said.out());
+        assertTrue(said.out().contains("--- " + second), said.out());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/report/UnifiedDiffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/UnifiedDiffTest.java
@@ -97,12 +97,57 @@ class UnifiedDiffTest {
     }
 
     /**
+     * The bound counts the table that would be filled, which has a row and a column more than the
+     * texts have lines. Measured as the product of the two lengths instead, a pair sits under the
+     * bound while the table for it is over.
+     */
+    @Test
+    void theBoundCountsTheTableAndNotTheLines() {
+        StringBuilder from = new StringBuilder();
+        StringBuilder to = new StringBuilder();
+        for (int line = 0; line < 2000; line++) {
+            from.append("line ").append(line).append('\n');
+            // Both ends differ, so nothing is taken off before the bound is measured.
+            to.append(line % 2 == 1 && line != 1999 ? "line " + line : "changed " + line)
+                    .append('\n');
+        }
+
+        String diff = UnifiedDiff.of("m.sou", "m.sou (formatted)", from.toString(), to.toString());
+
+        assertEquals(List.of("@@ -1,2000 +1,2000 @@"),
+                diff.lines().filter(line -> line.startsWith("@@")).toList());
+        assertEquals(List.of(), diff.lines().filter(line -> line.startsWith(" ")).toList());
+    }
+
+    /**
+     * A pair one line wide on one side reaches the bound too. The lengths multiplied out say such a
+     * pair is small, while the table it needs has a row per line of the long side.
+     */
+    @Test
+    void aPairLongOnOneSideOnlyReachesTheBoundAsWell() {
+        StringBuilder from = new StringBuilder();
+        StringBuilder to = new StringBuilder();
+        for (int line = 0; line < 250_000; line++) {
+            from.append("line ").append(line).append('\n');
+        }
+        for (int line = 0; line < 15; line++) {
+            to.append(line % 2 == 0 ? "changed " + line : "line " + (line * 1000)).append('\n');
+        }
+
+        String diff = UnifiedDiff.of("m.sou", "m.sou (formatted)", from.toString(), to.toString());
+
+        assertEquals(List.of("@@ -1,250000 +1,15 @@"),
+                diff.lines().filter(line -> line.startsWith("@@")).toList());
+        assertEquals(List.of(), diff.lines().filter(line -> line.startsWith(" ")).toList());
+    }
+
+    /**
      * The size that decides is the size of what differs, not the size of the file. A file far past
      * the bound that is already canonical everywhere but one line is the ordinary case — a file kept
      * formatted, edited in one place — and it is shown one line at a time like any other.
      */
     @Test
-    void alargeFileThatDiffersInOnePlaceIsShownAtThatPlace() {
+    void aLargeFileThatDiffersInOnePlaceIsShownAtThatPlace() {
         StringBuilder from = new StringBuilder();
         StringBuilder to = new StringBuilder();
         for (int line = 0; line < 5000; line++) {

--- a/souther-compiler/src/test/java/souther/compiler/report/UnifiedDiffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/UnifiedDiffTest.java
@@ -1,0 +1,129 @@
+package souther.compiler.report;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The evidence a gate shows for the two texts it compared. It reads only the two texts and the
+ * labels they are shown under; nothing about how either was produced reaches here.
+ */
+class UnifiedDiffTest {
+
+    @Test
+    void aChangedLineIsShownAgainstItsContext() {
+        String from = "a\nb\nc\n";
+        String to = "a\nB\nc\n";
+
+        String diff = UnifiedDiff.of("m.sou", "m.sou (formatted)", from, to);
+
+        assertEquals("""
+                --- m.sou
+                +++ m.sou (formatted)
+                @@ -1,3 +1,3 @@
+                 a
+                -b
+                +B
+                 c
+                """, diff);
+    }
+
+    @Test
+    void twoTextsThatAreTheSameHaveNothingToShow() {
+        assertEquals("", UnifiedDiff.of("m.sou", "m.sou (formatted)", "a\nb\n", "a\nb\n"));
+    }
+
+    /**
+     * Changes further apart than twice the context are separate hunks. Written as one they would
+     * carry every line between them, which for a file formatted in two places is the whole file.
+     */
+    @Test
+    void changesTooFarApartToShareContextAreSeparateHunks() {
+        StringBuilder from = new StringBuilder();
+        StringBuilder to = new StringBuilder();
+        for (int line = 1; line <= 20; line++) {
+            from.append(line).append('\n');
+            to.append(line == 2 ? "B" : line == 18 ? "R" : String.valueOf(line)).append('\n');
+        }
+
+        String diff = UnifiedDiff.of("m.sou", "m.sou (formatted)", from.toString(), to.toString());
+
+        assertEquals(List.of("@@ -1,5 +1,5 @@", "@@ -15,6 +15,6 @@"),
+                diff.lines().filter(line -> line.startsWith("@@")).toList());
+    }
+
+    /**
+     * A text and the same text without its final newline are two texts, and a check that calls them
+     * different has to be able to show it. Compared as plain lines they are the same list, so the
+     * evidence for a verdict of "not formatted" would have been an empty diff.
+     */
+    @Test
+    void aMissingFinalNewlineIsShownAsADifference() {
+        String diff = UnifiedDiff.of("m.sou", "m.sou (formatted)", "a\nb", "a\nb\n");
+
+        assertEquals("""
+                --- m.sou
+                +++ m.sou (formatted)
+                @@ -1,2 +1,2 @@
+                 a
+                -b
+                \\ No newline at end of file
+                +b
+                """, diff);
+    }
+
+    /**
+     * Finding which lines two texts share costs the product of their lengths, so a pair large enough
+     * is a pair this would answer by exhausting the heap. Past that size it stops looking and shows
+     * the two texts whole — still the difference, and still one hunk of a unified diff, just not one
+     * that says which lines within it survived.
+     */
+    @Test
+    void aPairTooLargeToCompareLineByLineIsShownWhole() {
+        StringBuilder from = new StringBuilder();
+        StringBuilder to = new StringBuilder();
+        for (int line = 0; line <= 2100; line++) {
+            from.append("line ").append(line).append('\n');
+            to.append(line % 2 == 0 ? "changed " + line : "line " + line).append('\n');
+        }
+
+        String diff = UnifiedDiff.of("m.sou", "m.sou (formatted)", from.toString(), to.toString());
+
+        assertEquals(List.of("@@ -1,2101 +1,2101 @@"),
+                diff.lines().filter(line -> line.startsWith("@@")).toList());
+        assertEquals(List.of(), diff.lines().filter(line -> line.startsWith(" ")).toList());
+    }
+
+    /**
+     * The size that decides is the size of what differs, not the size of the file. A file far past
+     * the bound that is already canonical everywhere but one line is the ordinary case — a file kept
+     * formatted, edited in one place — and it is shown one line at a time like any other.
+     */
+    @Test
+    void alargeFileThatDiffersInOnePlaceIsShownAtThatPlace() {
+        StringBuilder from = new StringBuilder();
+        StringBuilder to = new StringBuilder();
+        for (int line = 0; line < 5000; line++) {
+            from.append("line ").append(line).append('\n');
+            to.append(line == 2500 ? "changed" : "line " + line).append('\n');
+        }
+
+        String diff = UnifiedDiff.of("m.sou", "m.sou (formatted)", from.toString(), to.toString());
+
+        assertEquals("""
+                --- m.sou
+                +++ m.sou (formatted)
+                @@ -2498,7 +2498,7 @@
+                 line 2497
+                 line 2498
+                 line 2499
+                -line 2500
+                +changed
+                 line 2501
+                 line 2502
+                 line 2503
+                """, diff);
+    }
+}


### PR DESCRIPTION
Closes #430.

`fmt --check` computed each file's canonical form to reach its verdict and printed the file's name. The comparison held both texts; the accumulator held a `List<Path>`, so the canonical form ended at the bottom of the loop. The reader was left to obtain it again — writing the file over with `-w` against a copy, or formatting a second time into a scratch file — to learn what the gate already knew.

## What changed

The list is a `boolean` and the difference goes out where the verdict is taken, while both texts are still in hand. Nothing is carried to the end, so what the run remembers about the files it has judged stays one bit rather than growing with their total size. This is the order `examples --strict` already takes: report, then gate.

```
fmt --check
    formatted == source → nothing, exit 0
    formatted != source → the unified diff, on to the next file, exit 1 at the end
```

`--check` shows it rather than a `--diff` opting into it. The cost this reports is the round trip from a failed build to a local run, and a flag the reader has to know about beforehand is a round trip for anyone who did not.

The name the verdict used to be is the header the difference carries, so it is not also said on a line of its own.

## The renderer

`souther.compiler.report.UnifiedDiff` reads two labels and two texts. It does not see the `Doc` the formatter built or the tree under it, so what it can say is which lines differ and where — not which formatting rule accounts for them. That question has no answer recorded anywhere in the formatter, and is filed separately as #444.

Two things it does that a line-by-line comparison would not:

- Lines carry whether the text terminated them. A file differing from its canonical form only by a missing final newline is the same list of lines compared as strings, which would have answered a verdict of "not formatted" with an empty diff.
- Common lines at either end come off before the comparison, which keeps a file that is canonical everywhere but one place the cost of that one place. Past four million cells the rest is shown whole rather than searched for common lines: that search fills a table with a row per line of one side and a column per line of the other, so a large pair that differs throughout — every line of a CRLF file, for one — is otherwise a pair answered by exhausting the heap. The table is one flat array and the bound counts the whole of it, so it is a bound on what the comparison allocates and not only on the lines multiplied, which for a pair long on one side and a line or two on the other is not the same number.

## Out of scope

Rule identity (#444) and a machine-readable form for `fmt` are both left alone. `--format` is not an option `fmt` takes, and while the formatter records no rule for a decision, a structured verdict would carry the same content as the text one.

## Verification

`mvn clean test` green across all modules. Each test here was watched to fail first; the no-final-newline case failed by printing two header lines and no hunk, which is this issue's own shape in miniature — a verdict of "differs" with nothing to show for it.

The CLI tests assert that `--check`'s output equals the diff between the file and what `fmt` prints for it, so the evidence is pinned to the canonical form the verdict was taken against rather than to a separate reading of the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

