### PR TITLE
Define the boundary Map-key rule once, and carry its answer into the codec IR

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -1077,16 +1077,17 @@ public final class FixtureReader {
     }
 
     /** The decoder for one boundary map key, over the text the decoded map carried. Which key it is
-     *  was settled when the checker admitted it, so this reads that witness rather than asking the
-     *  type again. This is not {@link #decoderFor}: there a {@code Date} is handed over already
-     *  parsed, and in key position it is the text that arrives. */
+     *  is the checker's rule to say, asked here rather than written out again — a fixture is read
+     *  from a written expression, not from the codec IR the witness travels in. This is not
+     *  {@link #decoderFor}: there a {@code Date} is handed over already parsed, and in key position
+     *  it is the text that arrives. */
     private Decoder<Object, ?> keyDecoderFor(Type key) {
         BoundaryMapKey classified = TypeOps.classifyConcreteMapKey(key, symbols);
         if (classified == null) {
             throw new FixtureException("`" + Type.show(key) + "` cannot key a Map that crosses");
         }
         return switch (classified) {
-            case BoundaryMapKey.Newtype n -> decoderFor(Type.ref(n.name()));
+            case BoundaryMapKey.StringNewtype n -> decoderFor(Type.ref(n.name()));
             case BoundaryMapKey.UnitEnum e -> decoderFor(Type.ref(e.name()));
             case BoundaryMapKey.Text _ -> keyText();
             case BoundaryMapKey.Date _ -> keyText().date();

--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -7,6 +7,7 @@ import souther.compiler.check.TypeOps;
 import souther.compiler.observe.Limits;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.BindingId;
+import souther.compiler.types.BoundaryMapKey;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.types.ValueName;
@@ -1075,25 +1076,27 @@ public final class FixtureReader {
         });
     }
 
-    /** The decoder for one boundary map key, over the text the decoded map carried. A named key runs
-     *  its own decoder; the three primitives a key may be are the string leaf, parsed for a temporal.
-     *  This is not {@link #decoderFor}: there a {@code Date} is handed over already parsed, and in key
-     *  position it is the text that arrives. */
+    /** The decoder for one boundary map key, over the text the decoded map carried. Which key it is
+     *  was settled when the checker admitted it, so this reads that witness rather than asking the
+     *  type again. This is not {@link #decoderFor}: there a {@code Date} is handed over already
+     *  parsed, and in key position it is the text that arrives. */
     private Decoder<Object, ?> keyDecoderFor(Type key) {
-        if (key instanceof Type.Ref ref) {
-            return decoderFor(ref);
+        BoundaryMapKey classified = TypeOps.classifyConcreteMapKey(key, symbols);
+        if (classified == null) {
+            throw new FixtureException("`" + Type.show(key) + "` cannot key a Map that crosses");
         }
-        StringDecoder<Object> text = ObjectDecoders.string().normalize();
-        if (key == Type.STRING) {
-            return text;
-        }
-        if (key == Type.DATE) {
-            return text.date();
-        }
-        if (key == Type.DATETIME) {
-            return text.dateTime();
-        }
-        throw new FixtureException("`" + Type.show(key) + "` cannot key a Map that crosses");
+        return switch (classified) {
+            case BoundaryMapKey.Newtype n -> decoderFor(Type.ref(n.name()));
+            case BoundaryMapKey.UnitEnum e -> decoderFor(Type.ref(e.name()));
+            case BoundaryMapKey.Text _ -> keyText();
+            case BoundaryMapKey.Date _ -> keyText().date();
+            case BoundaryMapKey.DateTime _ -> keyText().dateTime();
+        };
+    }
+
+    /** The string leaf a key's text is read through, canonicalizing as every arriving text is. */
+    private static StringDecoder<Object> keyText() {
+        return ObjectDecoders.string().normalize();
     }
 
     /** One decoded input, in the form the compiler owns. Never throws: a value that cannot be read is

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -521,11 +521,12 @@ public final class Runner {
      * neutral source, whichever source the map itself came from. This is the decoder
      * {@code CodecGen.emitKeyDecoder} builds, in Java.
      *
-     * <p>Which key types arrive here is not worked out again. The checker classified the key when it
-     * admitted it, and this reads that witness: a named key runs its own decoder, and a
-     * representation is the string leaf, parsed for a temporal. A key that classifies as nothing
-     * never reached a codec, so it is reported as an input this cannot decode rather than asserted
-     * away.
+     * <p>Which key types arrive here is not decided again. The classification is asked for rather
+     * than carried — {@code run} holds a {@code Type} the compile handed back, not the codec IR the
+     * witness travels in — but it is the checker's rule that answers, so this reads the answer
+     * instead of writing the kinds out: a named key runs its own decoder, and a representation is
+     * the string leaf, parsed for a temporal. A key that classifies as nothing never reached a
+     * codec, so it is reported as an input this cannot decode rather than asserted away.
      */
     private static Decoder<Object, ?> keyDecoder(MemoryClassLoader loader, Symbols symbols, Type key,
                                                  Type map, int index) {
@@ -537,7 +538,7 @@ public final class Runner {
                             + " collection of those).", index + 1, Type.show(map));
         }
         return switch (classified) {
-            case BoundaryMapKey.Newtype n -> codecOf(loader, n.name(), "decoder");
+            case BoundaryMapKey.StringNewtype n -> codecOf(loader, n.name(), "decoder");
             case BoundaryMapKey.UnitEnum e -> codecOf(loader, e.name(), "decoder");
             case BoundaryMapKey.Text _ -> text();
             case BoundaryMapKey.Date _ -> text().date();

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -3,7 +3,11 @@ package souther.compiler;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.PipelineSigs;
 import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
+import souther.compiler.types.BoundaryMapKey;
 import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
 import souther.compiler.query.Compilation;
 import souther.compiler.codegen.Backend;
 import souther.compiler.diag.Located;
@@ -195,7 +199,8 @@ public final class Runner {
         List<Type> ins = sig.ins();
 
         MemoryClassLoader loader = new MemoryClassLoader(classes, Runner.class.getClassLoader());
-        Object[] args = decodeInputs(loader, module.name(), spec.name(), ins, inputJson);
+        Object[] args = decodeInputs(loader, compilation.symbols(module.name()), module.name(),
+                spec.name(), ins, inputJson);
 
         Object result = invoke(loader, module.name(), spec.name(), args);
         Object encoded = encodeOutput(loader, module.name(), spec.name(), sig.out(), result);
@@ -380,8 +385,8 @@ public final class Runner {
      * Arity cannot tell them apart; only decoding against the parameter type can. So the split and the
      * decode are one step, taken with the types in hand.
      */
-    private static Object[] decodeInputs(MemoryClassLoader loader, String pkg, String name,
-                                         List<Type> ins, String inputJson) {
+    private static Object[] decodeInputs(MemoryClassLoader loader, Symbols symbols, String pkg,
+                                         String name, List<Type> ins, String inputJson) {
         int arity = ins.size();
         if (arity == 0) {
             return new Object[0];
@@ -392,7 +397,7 @@ public final class Runner {
         }
         JsonNode tree = parseJson(inputJson);
         if (arity == 1) {
-            return new Object[] {decodeSoleInput(loader, pkg, ins.get(0), tree)};
+            return new Object[] {decodeSoleInput(loader, symbols, pkg, ins.get(0), tree)};
         }
         if (!tree.isArray()) {
             throw fail("run.input.notarray", "`" + name + "` takes " + arity
@@ -404,7 +409,7 @@ public final class Runner {
         }
         Object[] args = new Object[arity];
         for (int i = 0; i < arity; i++) {
-            args[i] = decode(loader, pkg, ins.get(i), tree.get(i), i);
+            args[i] = decode(loader, symbols, pkg, ins.get(i), tree.get(i), i);
         }
         return args;
     }
@@ -418,11 +423,12 @@ public final class Runner {
      * the value while succeeding as the array's sole element is. When the element fails too, the input
      * is wrong for some other reason and the decoder's own report is what says so.
      */
-    private static Object decodeSoleInput(MemoryClassLoader loader, String pkg, Type type, JsonNode tree) {
+    private static Object decodeSoleInput(MemoryClassLoader loader, Symbols symbols, String pkg,
+                                          Type type, JsonNode tree) {
         try {
-            return decode(loader, pkg, type, tree, 0);
+            return decode(loader, symbols, pkg, type, tree, 0);
         } catch (RunException asWritten) {
-            if (tree.isArray() && tree.size() == 1 && decodes(loader, pkg, type, tree.get(0))) {
+            if (tree.isArray() && tree.size() == 1 && decodes(loader, symbols, pkg, type, tree.get(0))) {
                 throw fail("run.input.wrapped", "This behavior has one parameter. Pass its value"
                         + " directly to --input; remove the outer array.");
             }
@@ -431,9 +437,10 @@ public final class Runner {
     }
 
     /** Whether {@code raw} decodes as {@code type}, asked without reporting anything. */
-    private static boolean decodes(MemoryClassLoader loader, String pkg, Type type, JsonNode raw) {
+    private static boolean decodes(MemoryClassLoader loader, Symbols symbols, String pkg, Type type,
+                                   JsonNode raw) {
         try {
-            decode(loader, pkg, type, raw, 0);
+            decode(loader, symbols, pkg, type, raw, 0);
             return true;
         } catch (RunException _) {
             return false;
@@ -442,8 +449,9 @@ public final class Runner {
 
     // --- decode / encode ----------------------------------------------------------------------
 
-    private static Object decode(MemoryClassLoader loader, String pkg, Type type, JsonNode raw, int index) {
-        Decoder<JsonNode, ?> decoder = decoderFor(loader, pkg, type, index);
+    private static Object decode(MemoryClassLoader loader, Symbols symbols, String pkg, Type type,
+                                 JsonNode raw, int index) {
+        Decoder<JsonNode, ?> decoder = decoderFor(loader, symbols, pkg, type, index);
         Result<?> result;
         try {
             result = decoder.decode(raw, net.unit8.raoh.Path.ROOT);
@@ -481,23 +489,24 @@ public final class Runner {
      * a sum's discriminator are all read exactly as they are at the boundary. What is composed here
      * is only what has no class of its own: the primitives and the collections.
      */
-    private static Decoder<JsonNode, ?> decoderFor(MemoryClassLoader loader, String pkg, Type type, int index) {
+    private static Decoder<JsonNode, ?> decoderFor(MemoryClassLoader loader, Symbols symbols,
+                                                   String pkg, Type type, int index) {
         if (type instanceof Type.Prim prim) {
             return leafDecoder(prim, index);
         }
         if (type instanceof Type.Ref ref) {
-            return codecOf(loader, ref, "jsonDecoder");
+            return codecOf(loader, ref.name(), "jsonDecoder");
         }
         if (type instanceof Type.ListOf list) {
-            return JsonDecoders.list(decoderFor(loader, pkg, list.element(), index));
+            return JsonDecoders.list(decoderFor(loader, symbols, pkg, list.element(), index));
         }
         if (type instanceof Type.SetOf set) {
-            return JsonDecoders.list(decoderFor(loader, pkg, set.element(), index))
+            return JsonDecoders.list(decoderFor(loader, symbols, pkg, set.element(), index))
                     .map(elements -> Sets.fromList(new java.util.ArrayList<Object>(elements)));
         }
         if (type instanceof Type.MapOf map) {
-            Decoder<Object, ?> key = keyDecoder(loader, map.key());
-            return JsonDecoders.map(decoderFor(loader, pkg, map.value(), index))
+            Decoder<Object, ?> key = keyDecoder(loader, symbols, map.key(), type, index);
+            return JsonDecoders.map(decoderFor(loader, symbols, pkg, map.value(), index))
                     .flatMapWithPath((entries, path) -> rekey(key, entries, path));
         }
         throw fail("run.decode.unsupported",
@@ -512,29 +521,34 @@ public final class Runner {
      * neutral source, whichever source the map itself came from. This is the decoder
      * {@code CodecGen.emitKeyDecoder} builds, in Java.
      *
-     * <p>Which key types arrive here is not asked again. What may key a map that crosses is
-     * {@code TypeOps.isBoundaryMapKey}, and E1314 has already refused everything else, so a named key
-     * runs its own decoder — a String-backed newtype enforcing its invariant, an enumeration reading
-     * its case's name — and the three primitives are the string leaf, parsed for a temporal. Telling
-     * the newtype and the enumeration apart here would be reading the boundary's rule a second time,
-     * in a place that cannot see all of it.
+     * <p>Which key types arrive here is not worked out again. The checker classified the key when it
+     * admitted it, and this reads that witness: a named key runs its own decoder, and a
+     * representation is the string leaf, parsed for a temporal. A key that classifies as nothing
+     * never reached a codec, so it is reported as an input this cannot decode rather than asserted
+     * away.
      */
-    private static Decoder<Object, ?> keyDecoder(MemoryClassLoader loader, Type key) {
-        if (key instanceof Type.Ref ref) {
-            return codecOf(loader, ref, "decoder");
+    private static Decoder<Object, ?> keyDecoder(MemoryClassLoader loader, Symbols symbols, Type key,
+                                                 Type map, int index) {
+        BoundaryMapKey classified = TypeOps.classifyConcreteMapKey(key, symbols);
+        if (classified == null) {
+            throw fail("run.decode.unsupported",
+                    "input #" + (index + 1) + " has type `" + Type.show(map)
+                            + "`, which `run` cannot decode yet (only a data type, a primitive, or a"
+                            + " collection of those).", index + 1, Type.show(map));
         }
-        // text arriving from outside is canonical, which is what the string leaf makes it
-        StringDecoder<Object> text = ObjectDecoders.string().normalize();
-        if (key == Type.STRING) {
-            return text;
-        }
-        if (key == Type.DATE) {
-            return text.date();
-        }
-        if (key == Type.DATETIME) {
-            return text.dateTime();
-        }
-        throw new IllegalStateException("not a boundary map key: " + Type.show(key));
+        return switch (classified) {
+            case BoundaryMapKey.Newtype n -> codecOf(loader, n.name(), "decoder");
+            case BoundaryMapKey.UnitEnum e -> codecOf(loader, e.name(), "decoder");
+            case BoundaryMapKey.Text _ -> text();
+            case BoundaryMapKey.Date _ -> text().date();
+            case BoundaryMapKey.DateTime _ -> text().dateTime();
+        };
+    }
+
+    /** The string leaf a key is read through. Text arriving from outside is canonical, which is what
+     *  the leaf makes it (ADR-0096). */
+    private static StringDecoder<Object> text() {
+        return ObjectDecoders.string().normalize();
     }
 
     /**
@@ -581,16 +595,16 @@ public final class Runner {
     /** The named static decoder factory of a generated class — {@code jsonDecoder} for a value read
      *  from JSON, {@code decoder} for a map key, which is read from the string the object carried.
      *  Either erases at the reflection boundary. */
-    private static <I> Decoder<I, ?> codecOf(MemoryClassLoader loader, Type.Ref ref, String factory) {
+    private static <I> Decoder<I, ?> codecOf(MemoryClassLoader loader, TypeName type, String factory) {
         try {
             @SuppressWarnings("unchecked")
             Decoder<I, ?> decoder = (Decoder<I, ?>)
-                    loader.loadClass(ref.name().qualified()).getMethod(factory).invoke(null);
+                    loader.loadClass(type.qualified()).getMethod(factory).invoke(null);
             return decoder;
         } catch (ReflectiveOperationException e) {
             throw fail("run.decode.nodecoder",
-                    "cannot obtain a decoder for `" + ref.name().name() + "`: " + e,
-                    ref.name().name(), e.toString());
+                    "cannot obtain a decoder for `" + type.name() + "`: " + e,
+                    type.name(), e.toString());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
+++ b/souther-compiler/src/main/java/souther/compiler/ast/Ast.java
@@ -3,6 +3,7 @@ package souther.compiler.ast;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
+import souther.compiler.types.BoundaryMapKey;
 import souther.compiler.types.ConstructionOrigin;
 import souther.compiler.types.ReachName;
 import souther.compiler.types.Type;
@@ -828,10 +829,13 @@ public interface Ast {
     record OptionDecRef(DecRef element, SourcePos pos) implements DecRef {}
 
     /** A {@code Map<K, T>} decoder: each object value is decoded with {@code value}, and each of the
-     * object's string keys with {@code key} — a {@code PrimDecRef} of {@code STRING} (the key passes
-     * through), of {@code DATE}/{@code DATETIME} (parsed from its ISO form), or a {@code DataDecRef}
-     * naming the String-backed newtype the keys are constructed into. */
-    record MapDecRef(DecRef value, DecRef key, SourcePos pos) implements DecRef {}
+     * object's string keys through {@code key}.
+     *
+     * <p>The key is a {@link BoundaryMapKey} rather than a {@code DecRef}: a key position holds one of
+     * the representations the boundary admits, and nothing else — not a list, not an option — so the
+     * type says as much and a reader that switches on it needs no arm for what cannot be there. It is
+     * also the classification the checker already made, carried here rather than worked out again. */
+    record MapDecRef(DecRef value, BoundaryMapKey key, SourcePos pos) implements DecRef {}
 
     /** A primitive field decoder kind. */
     enum PrimKind { STRING, INT, BOOL, DECIMAL, DATE, DATETIME }
@@ -889,10 +893,9 @@ public interface Ast {
                     SetEnc, OptionRaw, MapEnc {}
 
     /** Encodes a {@code Map<K, T>} to a {@code Raw.Object}, each value via {@code elem} and each key
-     * to its bare string via {@code key} — a {@code PrimEnc} of {@code STRING} (already a string),
-     * of {@code DATE}/{@code DATETIME} (its ISO form), or a {@code DataEnc} naming the String-backed
-     * newtype whose wrapped value is rendered. */
-    record MapEnc(Expr source, EncElem elem, EncElem key, SourcePos pos) implements RawExpr {}
+     * to its bare string through {@code key} — the representation the checker admitted it as, closed
+     * for the reason {@link MapDecRef}'s is. */
+    record MapEnc(Expr source, EncElem elem, BoundaryMapKey key, SourcePos pos) implements RawExpr {}
 
     /** Encodes an optional field: {@code None} becomes {@code Raw.Null}, {@code Some(v)} encodes
      * {@code v} via {@code inner}, which reads the unwrapped value bound to {@code elemVar}. */
@@ -944,7 +947,7 @@ public interface Ast {
 
     /** A {@code Map<K, V>} element, each value encoded by {@code value} and each key by {@code key},
      * as {@link MapEnc} does for a field. */
-    record MapElemEnc(EncElem value, EncElem key, SourcePos pos) implements EncElem {}
+    record MapElemEnc(EncElem value, BoundaryMapKey key, SourcePos pos) implements EncElem {}
 
     record RawEntry(String key, RawExpr value, SourcePos pos) implements Ast {}
 

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -536,11 +536,9 @@ public final class DataChecker {
                         Diagnostic.of(DiagnosticCode.E1314, "check.map.key.field")
                                 .at(fieldRegion(ctx.data(), e.getKey()))
                                 .args(ctx.data().name() + "." + e.getKey(), Type.show(badKey))
-                                .hint("check.map.key.field.hint").build(),
-                        "a Map crossing the boundary at `" + ctx.data().name() + "." + e.getKey()
-                                + "` must be keyed by String, a String-backed newtype (`data X ="
-                                + " String`), Date or DateTime, got " + Type.show(badKey)
-                                + " (ADR-0040)");
+                                .hint("check.map.key.hint").build(),
+                        "`" + ctx.data().name() + "." + e.getKey() + "` is keyed by "
+                                + Type.show(badKey) + ": " + TypeOps.MAP_KEY_RULE);
             }
         }
 
@@ -626,8 +624,7 @@ public final class DataChecker {
             }
             case Ast.ListDecRef l -> Type.list(decRefType(l.element(), symbols));
             case Ast.OptionDecRef o -> Type.option(decRefType(o.element(), symbols));
-            case Ast.MapDecRef mp -> Type.map(
-                    decRefType(mp.key(), symbols), decRefType(mp.value(), symbols));
+            case Ast.MapDecRef mp -> Type.map(mp.key().type(), decRefType(mp.value(), symbols));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -513,7 +513,8 @@ public final class Resolve {
             case Ast.ListDecRef l -> new Ast.ListDecRef(decRef(l.element()), l.pos());
             case Ast.SetDecRef s -> new Ast.SetDecRef(decRef(s.element()), s.pos());
             case Ast.OptionDecRef o -> new Ast.OptionDecRef(decRef(o.element()), o.pos());
-            case Ast.MapDecRef m -> new Ast.MapDecRef(decRef(m.value()), decRef(m.key()), m.pos());
+            // the key is already the classification the checker made, carrying a resolved name
+            case Ast.MapDecRef m -> new Ast.MapDecRef(decRef(m.value()), m.key(), m.pos());
         };
     }
 
@@ -545,7 +546,7 @@ public final class Resolve {
             case Ast.ListEnc l -> new Ast.ListEnc(expr(l.source(), bound), encElem(l.elem()), l.pos());
             case Ast.SetEnc s -> new Ast.SetEnc(expr(s.source(), bound), encElem(s.elem()), s.pos());
             case Ast.MapEnc m -> new Ast.MapEnc(expr(m.source(), bound), encElem(m.elem()),
-                    encElem(m.key()), m.pos());
+                    m.key(), m.pos());
             // the inner expression reads the element the option holds, under the name given here
             case Ast.OptionRaw o -> {
                 Answered elem = bind(bound, o.elem());
@@ -569,7 +570,7 @@ public final class Resolve {
             case Ast.DataEnc d -> new Ast.DataEnc(type(d.typeName()), d.pos());
             case Ast.ListElemEnc l -> new Ast.ListElemEnc(encElem(l.elem()), l.pos());
             case Ast.SetElemEnc s -> new Ast.SetElemEnc(encElem(s.elem()), s.pos());
-            case Ast.MapElemEnc m -> new Ast.MapElemEnc(encElem(m.value()), encElem(m.key()), m.pos());
+            case Ast.MapElemEnc m -> new Ast.MapElemEnc(encElem(m.value()), m.key(), m.pos());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -587,11 +587,9 @@ public final class SpecChecker {
                 throw CompileException.of(
                         Diagnostic.of(DiagnosticCode.E1314, "check.map.key.param")
                                 .at(p.written().region()).args(p.name(), Type.show(bad))
-                                .hint("check.map.key.param.hint").build(),
+                                .hint("check.map.key.hint").build(),
                         "parameter `" + p.name() + "` carries a Map keyed by " + Type.show(bad)
-                                + "; a Map crossing the boundary must be keyed by String, a"
-                                + " String-backed newtype (`data X = String`), Date or DateTime"
-                                + " (ADR-0040)");
+                                + "; " + TypeOps.MAP_KEY_RULE);
             }
         }
         Type bad = TypeOps.nonBoundaryMapKey(TypeOps.successType(spec.ret(), symbols), symbols);
@@ -599,10 +597,9 @@ public final class SpecChecker {
             throw CompileException.of(
                     Diagnostic.of(DiagnosticCode.E1314, "check.map.key.output")
                             .at(spec.pos()).args(spec.name(), Type.show(bad))
-                            .hint("check.map.key.output.hint").build(),
+                            .hint("check.map.key.hint").build(),
                     "behavior `" + spec.name() + "` outputs a Map keyed by " + Type.show(bad)
-                            + "; a Map crossing the boundary must be keyed by String, a String-backed"
-                            + " newtype (`data X = String`), Date or DateTime (ADR-0040)");
+                            + "; " + TypeOps.MAP_KEY_RULE);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -8,6 +8,7 @@ import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
+import souther.compiler.types.BoundaryMapKey;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
@@ -1012,27 +1013,71 @@ public final class TypeOps {
         return null;
     }
 
-    /** Whether {@code name} is a newtype over {@code String} ({@code data X = String}) — the only key
-     *  type a {@code Map} admits besides {@code String} itself (ADR-0040). */
-    static boolean isStringNewtype(TypeName name, Symbols symbols) {
-        return symbols.get(name) instanceof Ast.Data d && d.newtype()
+    /**
+     * The representation a newtype's own value crosses as in key position, or null when it has none.
+     * {@code data X = String} is the whole of it today: a key is a JSON object's key, so what a
+     * newtype wraps has to be text already. This is the one place that set is written, so admitting a
+     * second base is a change here and a case in {@link BoundaryMapKey}, not a line in every reader.
+     */
+    private static BoundaryMapKey newtypeKeyRepresentation(TypeName name, Symbols symbols) {
+        if (symbols.get(name) instanceof Ast.Data d && d.newtype()
                 && d.fields().size() == 1
-                && d.fields().get(0).type() instanceof Ast.TypeRef base && "String".equals(base.name());
+                && d.fields().get(0).type() instanceof Ast.TypeRef base && "String".equals(base.name())) {
+            return new BoundaryMapKey.Text();
+        }
+        return null;
+    }
+
+    /** How a refused {@code Map} key is described to a Java caller, in one place. Which types are
+     *  admitted is {@link #classifyConcreteMapKey}'s, and a message that listed them here would be a
+     *  second copy of that rule — which is what happened when the enumeration was admitted and three
+     *  of the four sentences went on naming four kinds. The kinds are named in the catalog's hint,
+     *  where a reader is told what to write instead. */
+    public static final String MAP_KEY_RULE =
+            "a Map crossing the boundary must be keyed by a type with a boundary text"
+                    + " representation (ADR-0040)";
+
+    /**
+     * Whether {@code key} may stand as a {@code Map} key in a signature. This is not the question the
+     * codecs ask: a type variable may be written — the {@code core}'s {@code Map<'k, 'a>} signatures
+     * are — and stands for a key rather than being one, so it is admissible and classifies as
+     * nothing. Everything else is admissible exactly when it classifies.
+     */
+    public static boolean isMapKeyAdmissibleInSignature(Type key, Symbols symbols) {
+        return key instanceof Type.Var || classifyConcreteMapKey(key, symbols) != null;
     }
 
     /**
-     * Whether {@code key} can key a {@code Map} that crosses the boundary. A map's external form is a
-     * JSON object, whose keys are strings, so the key type must render as and parse from a bare
-     * string: {@code String}, a String-backed newtype (ADR-0040), or a temporal — a {@code Date}
-     * field already travels as its ISO form, so an ISO key is the same representation in key
-     * position. A key type variable is admitted for the {@code core} signatures, which monomorphise
-     * to one of those.
+     * What a concrete {@code key} is converted through at the boundary, or null when it cannot cross.
+     * A map's external form is a JSON object, whose keys are strings, so an admitted key renders as
+     * and parses from a bare string: {@code String} itself, a String-backed newtype (ADR-0040), a
+     * temporal as the ISO form a {@code Date} field already travels as, or an enumeration as its
+     * case's name (issue #161).
+     *
+     * <p>The answer is the witness rather than a yes, and it is this function's alone. A reader that
+     * builds a decoder, renders an encoder's keys or lowers a key into the codec IR takes what it
+     * needs from the result; none of them asks the type again.
      */
-    public static boolean isBoundaryMapKey(Type key, Symbols symbols) {
-        return key == Type.STRING || key == Type.DATE || key == Type.DATETIME
-                || key instanceof Type.Var
-                || (key instanceof Type.Ref r
-                    && (isStringNewtype(r.name(), symbols) || isUnitOnlySum(key, symbols)));
+    public static BoundaryMapKey classifyConcreteMapKey(Type key, Symbols symbols) {
+        if (key == Type.STRING) {
+            return new BoundaryMapKey.Text();
+        }
+        if (key == Type.DATE) {
+            return new BoundaryMapKey.Date();
+        }
+        if (key == Type.DATETIME) {
+            return new BoundaryMapKey.DateTime();
+        }
+        if (key instanceof Type.Ref r) {
+            BoundaryMapKey wrapped = newtypeKeyRepresentation(r.name(), symbols);
+            if (wrapped != null) {
+                return new BoundaryMapKey.Newtype(r.name(), wrapped);
+            }
+            if (isUnitOnlySum(key, symbols)) {
+                return new BoundaryMapKey.UnitEnum(r.name());
+            }
+        }
+        return null;
     }
 
     /**
@@ -1071,7 +1116,7 @@ public final class TypeOps {
     /** The key of the first {@code Map} inside {@code t} that cannot cross the boundary, or null when
      * every one can — what a data field or a behavior's input/output is checked against. */
     public static Type nonBoundaryMapKey(Type t, Symbols symbols) {
-        if (t instanceof Type.MapOf m && !isBoundaryMapKey(m.key(), symbols)) {
+        if (t instanceof Type.MapOf m && !isMapKeyAdmissibleInSignature(m.key(), symbols)) {
             return m.key();
         }
         return switch (t) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1013,19 +1013,14 @@ public final class TypeOps {
         return null;
     }
 
-    /**
-     * The representation a newtype's own value crosses as in key position, or null when it has none.
-     * {@code data X = String} is the whole of it today: a key is a JSON object's key, so what a
-     * newtype wraps has to be text already. This is the one place that set is written, so admitting a
-     * second base is a change here and a case in {@link BoundaryMapKey}, not a line in every reader.
-     */
-    private static BoundaryMapKey newtypeKeyRepresentation(TypeName name, Symbols symbols) {
-        if (symbols.get(name) instanceof Ast.Data d && d.newtype()
+    /** Whether {@code name} is a newtype over {@code String} ({@code data X = String}). A key is a
+     *  JSON object's key, so what a newtype wraps has to be text already; a newtype over another
+     *  base would be converted and rendered differently, which is a case of its own in
+     *  {@link BoundaryMapKey} rather than a widening of this. */
+    private static boolean isStringNewtype(TypeName name, Symbols symbols) {
+        return symbols.get(name) instanceof Ast.Data d && d.newtype()
                 && d.fields().size() == 1
-                && d.fields().get(0).type() instanceof Ast.TypeRef base && "String".equals(base.name())) {
-            return new BoundaryMapKey.Text();
-        }
-        return null;
+                && d.fields().get(0).type() instanceof Ast.TypeRef base && "String".equals(base.name());
     }
 
     /** How a refused {@code Map} key is described to a Java caller, in one place. Which types are
@@ -1069,9 +1064,8 @@ public final class TypeOps {
             return new BoundaryMapKey.DateTime();
         }
         if (key instanceof Type.Ref r) {
-            BoundaryMapKey wrapped = newtypeKeyRepresentation(r.name(), symbols);
-            if (wrapped != null) {
-                return new BoundaryMapKey.Newtype(r.name(), wrapped);
+            if (isStringNewtype(r.name(), symbols)) {
+                return new BoundaryMapKey.StringNewtype(r.name());
             }
             if (isUnitOnlySum(key, symbols)) {
                 return new BoundaryMapKey.UnitEnum(r.name());

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -3,6 +3,7 @@ package souther.compiler.codegen;
 import souther.compiler.check.MatchElaborator;
 import souther.compiler.check.Symbols;
 import souther.compiler.ast.Ast;
+import souther.compiler.types.BoundaryMapKey;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeOps;
@@ -125,26 +126,23 @@ final class CodecGen {
     }
 
 
-    private void emitKeyDecoder(CodeBuilder code, Ast.DecRef key) {
+    private void emitKeyDecoder(CodeBuilder code, BoundaryMapKey key) {
         switch (key) {
-            case Ast.DataDecRef d -> invokeCodec(code, d.typeName(), "decoder", MTD_Rdecoder);
-            case Ast.PrimDecRef p -> {
-                // A String key is the string leaf itself, which canonicalizes and does nothing else.
-                // A temporal is that leaf parsed. No other primitive is a boundary key.
-                if (p.kind() == Ast.PrimKind.STRING) {
-                    emitStringLeaf(code, CD_ObjectDecoders);
-                    return;
-                }
-                String parse = switch (p.kind()) {
-                    case DATE -> "date";
-                    case DATETIME -> "dateTime";
-                    case STRING, INT, BOOL, DECIMAL ->
-                            throw new IllegalStateException("not a map key decoder: " + p.kind());
-                };
+            // a named key runs its own decoder: a newtype's applies its invariant, an enumeration's
+            // reads the case name
+            case BoundaryMapKey.Newtype n -> invokeCodec(code, n.name(), "decoder", MTD_Rdecoder);
+            case BoundaryMapKey.UnitEnum e -> invokeCodec(code, e.name(), "decoder", MTD_Rdecoder);
+            // text is the string leaf itself, which canonicalizes and does nothing else; a temporal
+            // is that leaf parsed
+            case BoundaryMapKey.Text _ -> emitStringLeaf(code, CD_ObjectDecoders);
+            case BoundaryMapKey.Date _ -> {
                 emitStringLeaf(code, CD_ObjectDecoders);
-                code.invokevirtual(CD_StringDecoder, parse, MTD_leafTemporal);
+                code.invokevirtual(CD_StringDecoder, "date", MTD_leafTemporal);
             }
-            default -> throw new IllegalStateException("not a map key decoder: " + key);
+            case BoundaryMapKey.DateTime _ -> {
+                emitStringLeaf(code, CD_ObjectDecoders);
+                code.invokevirtual(CD_StringDecoder, "dateTime", MTD_leafTemporal);
+            }
         }
     }
 
@@ -162,24 +160,26 @@ final class CodecGen {
      * canonicalization collision is caught, and that is a property of every key type, not of the
      * ones that need converting.
      */
-    private static boolean needsRekey(Ast.DecRef key) {
+    private static boolean needsRekey(BoundaryMapKey key) {
         return true;
     }
 
     /** The name of the generated per-$Dec helper that remaps a decoded {@code Map<String, V>}'s keys
      *  into the key type, invariant-checked. A temporal key is named with a second {@code $} so it
      *  cannot collide with a data whose name is {@code Date}. */
-    private static String rekeyMethod(Ast.DecRef key) {
+    private static String rekeyMethod(BoundaryMapKey key) {
         return switch (key) {
-            case Ast.DataDecRef d -> "__rekey$" + d.typeName().denotes().qualified().replace('.', '$');
-            case Ast.PrimDecRef p -> "__rekey$$" + p.kind();
-            default -> throw new IllegalStateException("not a map key decoder: " + key);
+            case BoundaryMapKey.Newtype n -> "__rekey$" + n.name().qualified().replace('.', '$');
+            case BoundaryMapKey.UnitEnum e -> "__rekey$" + e.name().qualified().replace('.', '$');
+            case BoundaryMapKey.Text _ -> "__rekey$$STRING";
+            case BoundaryMapKey.Date _ -> "__rekey$$DATE";
+            case BoundaryMapKey.DateTime _ -> "__rekey$$DATETIME";
         };
     }
 
     /** {@code invokedynamic} producing a {@code BiFunction<Map, Path, Result>} over the current $Dec
      *  class's {@code __rekey$<keyType>}, for {@code Decoder.flatMapWithPath} in a newtype-keyed map. */
-    private static DynamicCallSiteDesc rekeyCallSite(ClassDesc cdDec, Ast.DecRef key) {
+    private static DynamicCallSiteDesc rekeyCallSite(ClassDesc cdDec, BoundaryMapKey key) {
         DirectMethodHandleDesc impl = MethodHandleDesc.ofMethod(
                 DirectMethodHandleDesc.Kind.STATIC, cdDec, rekeyMethod(key), MTD_rekey);
         return DynamicCallSiteDesc.of(
@@ -192,51 +192,55 @@ final class CodecGen {
 
     /** {@code invokedynamic} producing a {@code Function<K, String>} over the key newtype's bare
      *  {@code value()} accessor, for {@code Maps.mapKeys} when encoding a newtype-keyed map. */
-    private DynamicCallSiteDesc keyValueCallSite(Ast.EncElem key) {
+    private DynamicCallSiteDesc keyValueCallSite(BoundaryMapKey key) {
         return switch (key) {
             // an enumeration key renders as its case's name, the same string its decoder reads
-            case Ast.DataEnc d when symbols.get(d.typeName().denotes()) instanceof Ast.SumData sum
-                    && TypeOps.isUnitOnlySum(sum, symbols) -> DynamicCallSiteDesc.of(
+            case BoundaryMapKey.UnitEnum e -> DynamicCallSiteDesc.of(
                     BSM_METAFACTORY, "apply",
                     MethodTypeDesc.of(CD_Function),
                     MethodTypeDesc.of(CD_Object, CD_Object),
                     MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC,
-                            cd(d.typeName().denotes()), TAG_METHOD, MTD_tag),
+                            cd(e.name()), TAG_METHOD, MTD_tag),
                     MTD_tag);
-            case Ast.DataEnc d -> {
+            case BoundaryMapKey.Newtype n -> {
                 DirectMethodHandleDesc impl = MethodHandleDesc.ofMethod(
-                        DirectMethodHandleDesc.Kind.VIRTUAL, cd(d.typeName().denotes()), "value", MTD_value);
+                        DirectMethodHandleDesc.Kind.VIRTUAL, cd(n.name()), "value", MTD_value);
                 yield DynamicCallSiteDesc.of(
                         BSM_METAFACTORY, "apply",
                         MethodTypeDesc.of(CD_Function),                  // no captures: () -> Function
                         MethodTypeDesc.of(CD_Object, CD_Object),         // samMethodType: (Object) -> Object
                         impl,                                            // implMethod: K.value() -> String
-                        MethodTypeDesc.of(CD_String, cd(d.typeName().denotes()))); // (K) -> String
+                        MethodTypeDesc.of(CD_String, cd(n.name())));     // (K) -> String
             }
             // a temporal renders as its ISO form, which is its `toString` — the same rendering an
             // IsoTextRaw field gets
-            case Ast.PrimEnc _ -> DynamicCallSiteDesc.of(
+            case BoundaryMapKey.Date _, BoundaryMapKey.DateTime _ -> DynamicCallSiteDesc.of(
                     BSM_METAFACTORY, "apply",
                     MethodTypeDesc.of(CD_Function),
                     MethodTypeDesc.of(CD_Object, CD_Object),
                     MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.STATIC, CD_String,
                             "valueOf", MethodTypeDesc.of(CD_String, CD_Object)),
                     MethodTypeDesc.of(CD_String, CD_Object));
-            default -> throw new IllegalStateException("not a map key encoder: " + key);
+            // text is already the string the map encoder wants; needsKeyRender keeps it from here
+            case BoundaryMapKey.Text _ ->
+                    throw new IllegalStateException("a text key is not rendered");
         };
     }
 
     /** Whether a map's keys are rendered before the String-keyed encoder sees them: a {@code String}
      *  key is already what it wants. */
-    private static boolean needsKeyRender(Ast.EncElem key) {
-        return !(key instanceof Ast.PrimEnc p && p.kind() == Ast.PrimKind.STRING);
+    private static boolean needsKeyRender(BoundaryMapKey key) {
+        return !(key instanceof BoundaryMapKey.Text);
     }
 
     /** Invokes a type's static {@code decoder()}/{@code encoder()} factory, as an interface
      * method reference when the type is a sum (its factory lives on a sealed interface). */
     private void invokeCodec(CodeBuilder code, Ast.Name typeName, String method, MethodTypeDesc mtd) {
-        code.invokestatic(cd(typeName.denotes()), method, mtd,
-                symbols.get(typeName.denotes()) instanceof Ast.SumData);
+        invokeCodec(code, typeName.denotes(), method, mtd);
+    }
+
+    private void invokeCodec(CodeBuilder code, TypeName type, String method, MethodTypeDesc mtd) {
+        code.invokestatic(cd(type), method, mtd, symbols.get(type) instanceof Ast.SumData);
     }
 
     byte[] generateSumEncoder(Ast.SumData sum, Ast.SumEncoder enc) {
@@ -609,9 +613,9 @@ final class CodecGen {
             });
             // One key-remap helper per key type used as a map key anywhere in this decoder; the
             // decode body's flatMapWithPath call sites reference them.
-            Map<String, Ast.DecRef> keyTypes = new LinkedHashMap<>();
+            Map<String, BoundaryMapKey> keyTypes = new LinkedHashMap<>();
             collectKeyedMapTypes(dec, keyTypes);
-            for (Ast.DecRef key : keyTypes.values()) {
+            for (BoundaryMapKey key : keyTypes.values()) {
                 emitRekeyHelper(cb, key);
             }
             emitSharedInstance(cb, cdDec, ClassFile.ACC_PUBLIC, emitPatternFields(cb, invariants));
@@ -716,7 +720,7 @@ final class CodecGen {
     }
 
     /** Collects the String-backed newtypes used as map keys anywhere in a derived decoder. */
-    private void collectKeyedMapTypes(Ast.DecoderDef dec, Map<String, Ast.DecRef> out) {
+    private void collectKeyedMapTypes(Ast.DecoderDef dec, Map<String, BoundaryMapKey> out) {
         switch (dec) {
             case Ast.ObjectDecoder obj -> {
                 for (Ast.Bind bind : obj.binds()) {
@@ -728,7 +732,7 @@ final class CodecGen {
         }
     }
 
-    private void collectKeyedMapTypes(Ast.DecRef ref, Map<String, Ast.DecRef> out) {
+    private void collectKeyedMapTypes(Ast.DecRef ref, Map<String, BoundaryMapKey> out) {
         switch (ref) {
             case Ast.MapDecRef mp -> {
                 if (needsRekey(mp.key())) {
@@ -751,7 +755,7 @@ final class CodecGen {
      * (spec 15) and a failure lands at the key's path; on success it returns a {@code Map<K, V>} in
      * iteration order. Materialised as a {@code BiFunction} for {@code Decoder.flatMapWithPath}.
      */
-    private void emitRekeyHelper(ClassBuilder cb, Ast.DecRef key) {
+    private void emitRekeyHelper(ClassBuilder cb, BoundaryMapKey key) {
         cb.withMethodBody(rekeyMethod(key), MTD_rekey, ClassFile.ACC_STATIC | ClassFile.ACC_SYNTHETIC,
                 code -> {
             // locals: src=0, path=1, keyDec=2, out=3, issues=4, it=5, entry=6, key=7, kr=8, decoded=9
@@ -1164,7 +1168,7 @@ final class CodecGen {
             case Ast.ListDecRef l -> Type.list(bindType(l.element()));
             case Ast.SetDecRef s -> Type.set(bindType(s.element()));
             case Ast.OptionDecRef o -> Type.option(bindType(o.element()));
-            case Ast.MapDecRef mp -> Type.map(bindType(mp.key()), bindType(mp.value()));
+            case Ast.MapDecRef mp -> Type.map(mp.key().type(), bindType(mp.value()));
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodecGen.java
@@ -130,7 +130,7 @@ final class CodecGen {
         switch (key) {
             // a named key runs its own decoder: a newtype's applies its invariant, an enumeration's
             // reads the case name
-            case BoundaryMapKey.Newtype n -> invokeCodec(code, n.name(), "decoder", MTD_Rdecoder);
+            case BoundaryMapKey.StringNewtype n -> invokeCodec(code, n.name(), "decoder", MTD_Rdecoder);
             case BoundaryMapKey.UnitEnum e -> invokeCodec(code, e.name(), "decoder", MTD_Rdecoder);
             // text is the string leaf itself, which canonicalizes and does nothing else; a temporal
             // is that leaf parsed
@@ -169,7 +169,7 @@ final class CodecGen {
      *  cannot collide with a data whose name is {@code Date}. */
     private static String rekeyMethod(BoundaryMapKey key) {
         return switch (key) {
-            case BoundaryMapKey.Newtype n -> "__rekey$" + n.name().qualified().replace('.', '$');
+            case BoundaryMapKey.StringNewtype n -> "__rekey$" + n.name().qualified().replace('.', '$');
             case BoundaryMapKey.UnitEnum e -> "__rekey$" + e.name().qualified().replace('.', '$');
             case BoundaryMapKey.Text _ -> "__rekey$$STRING";
             case BoundaryMapKey.Date _ -> "__rekey$$DATE";
@@ -191,7 +191,9 @@ final class CodecGen {
     }
 
     /** {@code invokedynamic} producing a {@code Function<K, String>} over the key newtype's bare
-     *  {@code value()} accessor, for {@code Maps.mapKeys} when encoding a newtype-keyed map. */
+     *  {@code value()} accessor, for {@code Maps.mapKeys} when encoding a newtype-keyed map. The
+     *  accessor is typed {@code () -> String} because the case is a String-backed newtype; a newtype
+     *  over another base would need a rendering step here, and is a case this does not have. */
     private DynamicCallSiteDesc keyValueCallSite(BoundaryMapKey key) {
         return switch (key) {
             // an enumeration key renders as its case's name, the same string its decoder reads
@@ -202,7 +204,7 @@ final class CodecGen {
                     MethodHandleDesc.ofMethod(DirectMethodHandleDesc.Kind.INTERFACE_STATIC,
                             cd(e.name()), TAG_METHOD, MTD_tag),
                     MTD_tag);
-            case BoundaryMapKey.Newtype n -> {
+            case BoundaryMapKey.StringNewtype n -> {
                 DirectMethodHandleDesc impl = MethodHandleDesc.ofMethod(
                         DirectMethodHandleDesc.Kind.VIRTUAL, cd(n.name()), "value", MTD_value);
                 yield DynamicCallSiteDesc.of(

--- a/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
+++ b/souther-compiler/src/main/java/souther/compiler/derive/Deriver.java
@@ -7,6 +7,7 @@ import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.ast.Ast;
 import souther.compiler.types.BindingOwner;
+import souther.compiler.types.BoundaryMapKey;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeChecker;
@@ -74,7 +75,7 @@ public final class Deriver {
                                 BindingOwner.Pass.DERIVER, 0))));
         Optional<Ast.EncoderDef> encoder = d.encoder().isPresent()
                 ? d.encoder()
-                : Optional.of(deriveEncoder(d, fields, isCase,
+                : Optional.of(deriveEncoder(d, fields, isCase, symbols,
                         new Ast.Binders(new BindingOwner.Synthesized(declared,
                                 BindingOwner.Pass.DERIVER, 1))));
         return new Ast.Data(d.written(), d.newtype(), d.includes(), d.fields(), d.invariants(),
@@ -104,7 +105,7 @@ public final class Deriver {
             Ast.Construct result = new Ast.Construct(self,
                     List.of(new Ast.FieldInit(only.getKey(), Ast.Var.local(input, pos), pos)), pos);
             return new Ast.NewtypeDecoder(
-                    decRef(only.getValue(), d, only.getKey(), fieldPos(d, only.getKey())),
+                    decRef(only.getValue(), d, only.getKey(), fieldPos(d, only.getKey()), symbols),
                     input, result, pos);
         }
         List<Ast.Bind> binds = new ArrayList<>();
@@ -112,7 +113,7 @@ public final class Deriver {
         for (Map.Entry<String, Type> f : fields.entrySet()) {
             Ast.Binder took = binders.binder(f.getKey(), pos);
             binds.add(new Ast.Bind(took, f.getKey(),
-                    decRef(f.getValue(), d, f.getKey(), fieldPos(d, f.getKey())), pos));
+                    decRef(f.getValue(), d, f.getKey(), fieldPos(d, f.getKey()), symbols), pos));
             inits.add(new Ast.FieldInit(f.getKey(), Ast.Var.local(took, pos), pos));
         }
         return new Ast.ObjectDecoder(binds, new Ast.Construct(self, inits, pos), pos);
@@ -156,7 +157,8 @@ public final class Deriver {
         return Ast.PrimKind.INT;
     }
 
-    private static Ast.DecRef decRef(Type t, Ast.Data d, String field, SourcePos pos) {
+    private static Ast.DecRef decRef(Type t, Ast.Data d, String field, SourcePos pos,
+                                     Symbols symbols) {
         if (t == Type.STRING || t == Type.INT || t == Type.BOOL
                 || t == Type.DECIMAL || t == Type.DATE || t == Type.DATETIME) {
             return new Ast.PrimDecRef(primKind(t), pos);
@@ -165,16 +167,17 @@ public final class Deriver {
             return new Ast.DataDecRef(Ast.Name.resolved(r.name(), pos), pos);
         }
         if (t instanceof Type.ListOf lo) {
-            return new Ast.ListDecRef(decRef(lo.element(), d, field, pos), pos);
+            return new Ast.ListDecRef(decRef(lo.element(), d, field, pos, symbols), pos);
         }
         if (t instanceof Type.SetOf so) {
-            return new Ast.SetDecRef(decRef(so.element(), d, field, pos), pos);
+            return new Ast.SetDecRef(decRef(so.element(), d, field, pos, symbols), pos);
         }
         if (t instanceof Type.OptionOf oo) {
-            return new Ast.OptionDecRef(decRef(oo.element(), d, field, pos), pos);
+            return new Ast.OptionDecRef(decRef(oo.element(), d, field, pos, symbols), pos);
         }
         if (t instanceof Type.MapOf mo) {
-            return new Ast.MapDecRef(decRef(mo.value(), d, field, pos), mapKeyDec(mo, d, field, pos), pos);
+            return new Ast.MapDecRef(decRef(mo.value(), d, field, pos, symbols),
+                    mapKey(mo, d, field, pos, symbols), pos);
         }
         throw noCodec(t, d, field, pos);
     }
@@ -182,7 +185,7 @@ public final class Deriver {
     // --- encoder derivation ---
 
     private static Ast.EncoderDef deriveEncoder(Ast.Data d, Map<String, Type> fields, boolean isCase,
-                                                Ast.Binders binders) {
+                                                Symbols symbols, Ast.Binders binders) {
         SourcePos pos = d.pos();
         Ast.Binder self = binders.binder("self", pos);
         Map.Entry<String, Type> single = bareField(d, fields, isCase);
@@ -197,12 +200,12 @@ public final class Deriver {
             Map.Entry<String, Type> only = fields.entrySet().iterator().next();
             Ast.Expr access = new Ast.FieldAccess(Ast.Var.local(self, pos), only.getKey(), pos);
             return new Ast.EncoderDef(self,
-                    rawForAccess(only.getValue(), access, d, only.getKey(), pos, binders), pos);
+                    rawForAccess(only.getValue(), access, d, only.getKey(), symbols, pos, binders), pos);
         }
         List<Ast.RawEntry> entries = new ArrayList<>();
         for (Map.Entry<String, Type> f : fields.entrySet()) {
             entries.add(new Ast.RawEntry(f.getKey(),
-                    rawFor(f.getValue(), f.getKey(), d, fieldPos(d, f.getKey()), self, binders), pos));
+                    rawFor(f.getValue(), f.getKey(), d, fieldPos(d, f.getKey()), symbols, self, binders), pos));
         }
         return new Ast.EncoderDef(self, new Ast.ObjectRaw(entries, pos), pos);
     }
@@ -228,13 +231,14 @@ public final class Deriver {
                 || t == Type.DECIMAL || t == Type.DATE || t == Type.DATETIME;
     }
 
-    private static Ast.RawExpr rawFor(Type t, String field, Ast.Data d, SourcePos pos,
+    private static Ast.RawExpr rawFor(Type t, String field, Ast.Data d, SourcePos pos, Symbols symbols,
                                       Ast.Binder self, Ast.Binders binders) {
         return rawForAccess(t, new Ast.FieldAccess(Ast.Var.local(self, pos), field, pos),
-                d, field, pos, binders);
+                d, field, symbols, pos, binders);
     }
 
     private static Ast.RawExpr rawForAccess(Type t, Ast.Expr access, Ast.Data d, String field,
+                                            Symbols symbols,
                                             SourcePos pos, Ast.Binders binders) {
         if (isPrim(t)) {
             return primRaw(t, access, pos);
@@ -243,48 +247,37 @@ public final class Deriver {
             return new Ast.EncodeRaw(Ast.Name.resolved(r.name(), pos), access, pos);
         }
         if (t instanceof Type.ListOf lo) {
-            return new Ast.ListEnc(access, encElem(lo.element(), d, field, pos), pos);
+            return new Ast.ListEnc(access, encElem(lo.element(), d, field, pos, symbols), pos);
         }
         if (t instanceof Type.SetOf so) {
-            return new Ast.SetEnc(access, encElem(so.element(), d, field, pos), pos);
+            return new Ast.SetEnc(access, encElem(so.element(), d, field, pos, symbols), pos);
         }
         if (t instanceof Type.OptionOf oo) {
             Ast.Binder elem = binders.binder("$opt", pos);
-            Ast.RawExpr inner = rawForAccess(oo.element(), Ast.Var.local(elem, pos), d, field, pos,
+            Ast.RawExpr inner = rawForAccess(oo.element(), Ast.Var.local(elem, pos), d, field, symbols, pos,
                     binders);
             return new Ast.OptionRaw(access, inner, elem, pos);
         }
         if (t instanceof Type.MapOf mo) {
-            return new Ast.MapEnc(access, encElem(mo.value(), d, field, pos), mapKeyEnc(mo, d, field, pos), pos);
+            return new Ast.MapEnc(access, encElem(mo.value(), d, field, pos, symbols),
+                    mapKey(mo, d, field, pos, symbols), pos);
         }
         throw noCodec(t, d, field, pos);
     }
 
     /**
      * How a map's keys cross the boundary. A JSON object's keys are strings, so a key is decoded from
-     * and encoded to a bare string: a {@code String} key passes through, a String-backed newtype
-     * ({@code Map<商品ID, V>}) is constructed on decode (its invariant enforced) and rendered bare on
-     * encode, and a temporal key is parsed from and written as its ISO form — the same representation
-     * a {@code Date} field already has. Any other key type is rejected before here (ADR-0040).
+     * and encoded to a bare string, and which string is the checker's answer rather than one worked
+     * out here: this asks for the classification and puts it in the codec IR, where the backend reads
+     * it. A key with no classification never had a boundary representation, and is refused (ADR-0040).
      */
-    private static Ast.DecRef mapKeyDec(Type.MapOf mo, Ast.Data d, String field, SourcePos pos) {
-        if (mo.key() instanceof Type.Ref r) {
-            return new Ast.DataDecRef(Ast.Name.resolved(r.name(), pos), pos);
+    private static BoundaryMapKey mapKey(Type.MapOf mo, Ast.Data d, String field, SourcePos pos,
+                                         Symbols symbols) {
+        BoundaryMapKey key = TypeOps.classifyConcreteMapKey(mo.key(), symbols);
+        if (key == null) {
+            throw badMapKey(mo.key(), d, field, pos);
         }
-        if (mo.key() == Type.STRING || mo.key() == Type.DATE || mo.key() == Type.DATETIME) {
-            return new Ast.PrimDecRef(primKind(mo.key()), pos);
-        }
-        throw badMapKey(mo.key(), d, field, pos);
-    }
-
-    private static Ast.EncElem mapKeyEnc(Type.MapOf mo, Ast.Data d, String field, SourcePos pos) {
-        if (mo.key() instanceof Type.Ref r) {
-            return new Ast.DataEnc(Ast.Name.resolved(r.name(), pos), pos);
-        }
-        if (mo.key() == Type.STRING || mo.key() == Type.DATE || mo.key() == Type.DATETIME) {
-            return new Ast.PrimEnc(primKind(mo.key()), pos);
-        }
-        throw badMapKey(mo.key(), d, field, pos);
+        return key;
     }
 
     /**
@@ -297,10 +290,9 @@ public final class Deriver {
         return CompileException.of(
                 Diagnostic.of(DiagnosticCode.E1314, "check.map.key.field")
                         .at(pos).args(where(d, field), Type.show(key))
-                        .hint("check.map.key.field.hint").build(),
-                "a Map crossing the boundary at `" + where(d, field) + "` must be keyed by String, a"
-                        + " String-backed newtype (`data X = String`), Date or DateTime, got "
-                        + Type.show(key));
+                        .hint("check.map.key.hint").build(),
+                "`" + where(d, field) + "` is keyed by " + Type.show(key) + ": "
+                        + TypeOps.MAP_KEY_RULE);
     }
 
     /** How to name the place a boundary complaint belongs to. A newtype's single field is implicit —
@@ -313,7 +305,8 @@ public final class Deriver {
     /** The encoder for one element of a collection. A collection may hold a collection
      * ({@code Map<String, List<商品ID>>}), so this recurses the same way {@link #decRef} does on the
      * decoding side — the two stay symmetric, and what decodes in encodes back out. */
-    private static Ast.EncElem encElem(Type t, Ast.Data d, String field, SourcePos pos) {
+    private static Ast.EncElem encElem(Type t, Ast.Data d, String field, SourcePos pos,
+                                       Symbols symbols) {
         if (isPrim(t)) {
             return new Ast.PrimEnc(primKind(t), pos);   // every primitive has a leaf encoder
         }
@@ -321,13 +314,14 @@ public final class Deriver {
             return new Ast.DataEnc(Ast.Name.resolved(r.name(), pos), pos);
         }
         if (t instanceof Type.ListOf lo) {
-            return new Ast.ListElemEnc(encElem(lo.element(), d, field, pos), pos);
+            return new Ast.ListElemEnc(encElem(lo.element(), d, field, pos, symbols), pos);
         }
         if (t instanceof Type.SetOf so) {
-            return new Ast.SetElemEnc(encElem(so.element(), d, field, pos), pos);
+            return new Ast.SetElemEnc(encElem(so.element(), d, field, pos, symbols), pos);
         }
         if (t instanceof Type.MapOf mo) {
-            return new Ast.MapElemEnc(encElem(mo.value(), d, field, pos), mapKeyEnc(mo, d, field, pos), pos);
+            return new Ast.MapElemEnc(encElem(mo.value(), d, field, pos, symbols),
+                    mapKey(mo, d, field, pos, symbols), pos);
         }
         throw noCodec(t, d, field, pos);
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -158,8 +158,9 @@ public final class Compilation {
         return db.ask(new Shapes.Prepared(name)).value();
     }
 
-    /** What the names in {@code module} denote — the table a question about a type is asked against,
-     *  for a reader outside the compile that holds a type and has to ask what it is. */
+    /** What the names in {@code module} denote — the table a question about a type is asked against.
+     *  {@code souther run} needs it because it is handed the behavior's types rather than the codec
+     *  IR: a classification it cannot be given, it has to ask the same rule for. */
     public Symbols symbols(String module) {
         return db.ask(new Shapes.Scope(module)).value();
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -2,6 +2,7 @@ package souther.compiler.query;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.LabeledRegion;
 import souther.compiler.diag.Located;
@@ -155,6 +156,12 @@ public final class Compilation {
      * recursive prelude helpers it reaches. */
     public Ast.Module module(String name) {
         return db.ask(new Shapes.Prepared(name)).value();
+    }
+
+    /** What the names in {@code module} denote — the table a question about a type is asked against,
+     *  for a reader outside the compile that holds a type and has to ask what it is. */
+    public Symbols symbols(String module) {
+        return db.ask(new Shapes.Scope(module)).value();
     }
 
     /** The signatures of the behaviors {@code module} declares. */

--- a/souther-compiler/src/main/java/souther/compiler/types/BoundaryMapKey.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BoundaryMapKey.java
@@ -10,11 +10,18 @@ package souther.compiler.types;
  * that fact; before this, each worked it out again from whatever representation it held, and the
  * checker's own rule was read a second time in the backend.
  *
- * <p>The set closed here is the representations a reader branches on, not the types a key may be
- * written as. Another {@code data CustomerId = String} is a {@link Newtype} over {@link Text} and
- * moves nothing. A representation that does not yet exist is a new case, and every reader that acts
- * on a representation stops compiling until it says what to do with it — while a reader that only
- * wraps and unwraps a named key is left alone, because that distinction is not the one that changed.
+ * <p>The cases are flat, and {@link StringNewtype} names the base it wraps rather than holding it.
+ * A nested case — a newtype carrying its representation inside it — would be a witness no reader
+ * reads: a named key is decoded by that type's own generated {@code decoder()}, which has the
+ * conversion and the invariant inside it, and encoded through a {@code value()} accessor typed
+ * {@code () -> String}. Both hold of a String-backed newtype and of nothing else, so the base
+ * belongs in the case's name, where admitting a newtype over another base is a new case and every
+ * reader is asked what to do with it. Nested, the same widening would leave the newtype arm
+ * untouched and compiling.
+ *
+ * <p>What the set closes over is that: the representations a reader branches on, not the types a key
+ * may be written as. Another {@code data CustomerId = String} is a {@link StringNewtype} and moves
+ * nothing.
  */
 public sealed interface BoundaryMapKey {
 
@@ -22,7 +29,7 @@ public sealed interface BoundaryMapKey {
      *  Answered per case rather than by switching, so a case added here cannot forget it. */
     Type type();
 
-    /** A bare string: {@code String} itself, and what a String-backed newtype is admitted through. */
+    /** A bare string, {@code String} itself. */
     record Text() implements BoundaryMapKey {
         @Override
         public Type type() {
@@ -46,12 +53,10 @@ public sealed interface BoundaryMapKey {
         }
     }
 
-    /**
-     * A newtype key: the type to construct and unwrap, and the representation the value inside it
-     * crosses as. The two are separate because different readers need different halves — the codec
-     * wraps and unwraps by name, and only the text conversion depends on {@code representation}.
-     */
-    record Newtype(TypeName name, BoundaryMapKey representation) implements BoundaryMapKey {
+    /** A newtype over {@code String} ({@code data X = String}): built by its own decoder, which
+     *  applies its invariant, and rendered by its {@code value()}, which is the bare string. Both
+     *  hold because the base is text, which is why the base is in the name. */
+    record StringNewtype(TypeName name) implements BoundaryMapKey {
         @Override
         public Type type() {
             return Type.ref(name);
@@ -59,8 +64,8 @@ public sealed interface BoundaryMapKey {
     }
 
     /** A sum every case of which is a unit data: it crosses as the case's name, a bare string
-     *  (issue #161). Not a {@link Newtype}: it is built from and rendered to that name rather than
-     *  wrapping a value, which is a difference the encoder's call site branches on. */
+     *  (issue #161). Not a {@link StringNewtype}: it is built from and rendered to that name rather
+     *  than wrapping a value, which is a difference the encoder's call site branches on. */
     record UnitEnum(TypeName name) implements BoundaryMapKey {
         @Override
         public Type type() {

--- a/souther-compiler/src/main/java/souther/compiler/types/BoundaryMapKey.java
+++ b/souther-compiler/src/main/java/souther/compiler/types/BoundaryMapKey.java
@@ -1,0 +1,70 @@
+package souther.compiler.types;
+
+/**
+ * What a {@code Map} key admitted at the boundary is converted through. A map's external form is a
+ * JSON object, whose keys are strings, so an admitted key both renders as and parses from a bare
+ * string — and which string is what this names (ADR-0040).
+ *
+ * <p>It is a witness rather than a yes. Admitting a key establishes a fact about it, and a reader
+ * that has to build a decoder, render an encoder's keys or lower the key into the codec IR needs
+ * that fact; before this, each worked it out again from whatever representation it held, and the
+ * checker's own rule was read a second time in the backend.
+ *
+ * <p>The set closed here is the representations a reader branches on, not the types a key may be
+ * written as. Another {@code data CustomerId = String} is a {@link Newtype} over {@link Text} and
+ * moves nothing. A representation that does not yet exist is a new case, and every reader that acts
+ * on a representation stops compiling until it says what to do with it — while a reader that only
+ * wraps and unwraps a named key is left alone, because that distinction is not the one that changed.
+ */
+public sealed interface BoundaryMapKey {
+
+    /** The type in the language a key of this representation has — what the map it keys is a map of.
+     *  Answered per case rather than by switching, so a case added here cannot forget it. */
+    Type type();
+
+    /** A bare string: {@code String} itself, and what a String-backed newtype is admitted through. */
+    record Text() implements BoundaryMapKey {
+        @Override
+        public Type type() {
+            return Type.STRING;
+        }
+    }
+
+    /** A {@code Date}, as the ISO form a date field already crosses with. */
+    record Date() implements BoundaryMapKey {
+        @Override
+        public Type type() {
+            return Type.DATE;
+        }
+    }
+
+    /** A {@code DateTime}, as its ISO form. */
+    record DateTime() implements BoundaryMapKey {
+        @Override
+        public Type type() {
+            return Type.DATETIME;
+        }
+    }
+
+    /**
+     * A newtype key: the type to construct and unwrap, and the representation the value inside it
+     * crosses as. The two are separate because different readers need different halves — the codec
+     * wraps and unwraps by name, and only the text conversion depends on {@code representation}.
+     */
+    record Newtype(TypeName name, BoundaryMapKey representation) implements BoundaryMapKey {
+        @Override
+        public Type type() {
+            return Type.ref(name);
+        }
+    }
+
+    /** A sum every case of which is a unit data: it crosses as the case's name, a bare string
+     *  (issue #161). Not a {@link Newtype}: it is built from and rendered to that name rather than
+     *  wrapping a value, which is a difference the encoder's call site branches on. */
+    record UnitEnum(TypeName name) implements BoundaryMapKey {
+        @Override
+        public Type type() {
+            return Type.ref(name);
+        }
+    }
+}

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -283,12 +283,10 @@ check.typearg.list=`List` needs a type argument, e.g. `List<Int>`.
 check.typearg.set=`Set` needs a type argument, e.g. `Set<String>`.
 check.typearg.option=`Option` needs a type argument.
 check.typearg.map=`Map` needs a value type, e.g. `Map<String, Int>`.
-check.map.key.field=`{0}` crosses the boundary, so the Map it holds must be keyed by String, a String-backed newtype (`data X = String`), Date, DateTime, or a sum all of whose cases are unit data, but is keyed by {1}.
-check.map.key.field.hint=A Map is a JSON object, whose keys are strings. Inside a behavior body a Map may be keyed by any value.
+check.map.key.field=`{0}` crosses the boundary, so the Map it holds cannot be keyed by {1}.
 check.map.key.param=Parameter `{0}` carries a Map keyed by {1}, which cannot cross the boundary.
-check.map.key.param.hint=A Map crossing the boundary must be keyed by String, a String-backed newtype (`data X = String`), Date, DateTime, or a sum all of whose cases are unit data.
 check.map.key.output=`{0}` outputs a Map keyed by {1}, which cannot cross the boundary.
-check.map.key.output.hint=A Map crossing the boundary must be keyed by String, a String-backed newtype (`data X = String`), Date, DateTime, or a sum all of whose cases are unit data.
+check.map.key.hint=A Map is a JSON object, whose keys are strings, so a key must render as and parse from a bare string: String, a String-backed newtype (`data X = String`), Date, DateTime, or a sum all of whose cases are unit data. Inside a behavior body a Map may be keyed by any value.
 
 # comparison / arithmetic operands
 check.compare.ordered=The two operands of a comparison must be ordered values of the same type (Int, String, Decimal, Date, DateTime, a newtype over one of these, or one enumeration — two cases order against each other only when one sum lists them both), but got {0} and {1}.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -286,7 +286,7 @@ check.typearg.map=`Map` needs a value type, e.g. `Map<String, Int>`.
 check.map.key.field=`{0}` crosses the boundary, so the Map it holds cannot be keyed by {1}.
 check.map.key.param=Parameter `{0}` carries a Map keyed by {1}, which cannot cross the boundary.
 check.map.key.output=`{0}` outputs a Map keyed by {1}, which cannot cross the boundary.
-check.map.key.hint=A Map is a JSON object, whose keys are strings, so a key must render as and parse from a bare string: String, a String-backed newtype (`data X = String`), Date, DateTime, or a sum all of whose cases are unit data. Inside a behavior body a Map may be keyed by any value.
+check.map.key.hint=A Map is a JSON object, whose keys are strings, so a Map that crosses needs a key that renders as and parses from a bare string. Inside a behavior body a Map may be keyed by any value.
 
 # comparison / arithmetic operands
 check.compare.ordered=The two operands of a comparison must be ordered values of the same type (Int, String, Decimal, Date, DateTime, a newtype over one of these, or one enumeration — two cases order against each other only when one sum lists them both), but got {0} and {1}.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -279,12 +279,10 @@ check.typearg.list=`List` には型引数が必要です（例: `List<Int>`）�
 check.typearg.set=`Set` には型引数が必要です（例: `Set<String>`）。
 check.typearg.option=`Option` には型引数が必要です。
 check.typearg.map=`Map` には値の型が必要です（例: `Map<String, Int>`）。
-check.map.key.field=`{0}` は境界を越えるので、持っている Map のキーは String・String ベースの newtype（`data X = String`）・Date・DateTime・全ケースが単位データの直和 のいずれかでなければなりませんが、{1} です。
-check.map.key.field.hint=Map の外部表現は JSON オブジェクトで、そのキーは文字列です。behavior の本体内であれば Map のキーは任意の値でかまいません。
+check.map.key.field=`{0}` は境界を越えるので、持っている Map のキーを {1} にはできません。
 check.map.key.param=引数 `{0}` が持つ Map のキーが {1} で、境界を越えられません。
-check.map.key.param.hint=境界を越える Map のキーは String・String ベースの newtype（`data X = String`）・Date・DateTime・全ケースが単位データの直和（ケース名として渡ります）のいずれかです。
 check.map.key.output=`{0}` が返す Map のキーが {1} で、境界を越えられません。
-check.map.key.output.hint=境界を越える Map のキーは String・String ベースの newtype（`data X = String`）・Date・DateTime・全ケースが単位データの直和（ケース名として渡ります）のいずれかです。
+check.map.key.hint=Map の外部表現は JSON オブジェクトで、そのキーは文字列です。キーは裸の文字列として書き出され読み取られる型に限られ、String・String ベースの newtype（`data X = String`）・Date・DateTime・全ケースが単位データの直和（ケース名として渡ります）のいずれかです。behavior の本体内であれば Map のキーは任意の値でかまいません。
 
 # 比較・算術のオペランド
 check.compare.ordered=比較の2つのオペランドは同じ順序型（Int, String, Decimal, Date, DateTime、それらの newtype、または1つの列挙）の値でなければなりません。ケース同士が比較できるのは、両方を挙げている直和が1つに定まるときだけです。ここでは {0} と {1} です。

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -282,7 +282,7 @@ check.typearg.map=`Map` には値の型が必要です（例: `Map<String, Int>`
 check.map.key.field=`{0}` は境界を越えるので、持っている Map のキーを {1} にはできません。
 check.map.key.param=引数 `{0}` が持つ Map のキーが {1} で、境界を越えられません。
 check.map.key.output=`{0}` が返す Map のキーが {1} で、境界を越えられません。
-check.map.key.hint=Map の外部表現は JSON オブジェクトで、そのキーは文字列です。キーは裸の文字列として書き出され読み取られる型に限られ、String・String ベースの newtype（`data X = String`）・Date・DateTime・全ケースが単位データの直和（ケース名として渡ります）のいずれかです。behavior の本体内であれば Map のキーは任意の値でかまいません。
+check.map.key.hint=Map の外部表現は JSON オブジェクトで、そのキーは文字列です。境界を越える Map のキーは、裸の文字列として書き出され読み取られる型でなければなりません。behavior の本体内であれば Map のキーは任意の値でかまいません。
 
 # 比較・算術のオペランド
 check.compare.ordered=比較の2つのオペランドは同じ順序型（Int, String, Decimal, Date, DateTime、それらの newtype、または1つの列挙）の値でなければなりません。ケース同士が比較できるのは、両方を挙げている直和が1つに定まるときだけです。ここでは {0} と {1} です。

--- a/souther-compiler/src/test/java/souther/compiler/ARefusedMapKeyStatesItsRuleOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ARefusedMapKeyStatesItsRuleOnceTest.java
@@ -1,0 +1,87 @@
+package souther.compiler;
+
+import souther.compiler.check.TypeOps;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Note;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A Map key is refused in three places — a data's field, a behavior's input, a behavior's output —
+ * and there is one rule behind all three. Each used to describe it in its own words, and the copies
+ * drifted: the enumeration became an admitted key (issue #161) and only the catalog was told, so
+ * three of the sentences went on listing four kinds.
+ *
+ * <p>So the rule is stated once and the sites point at it. What each site says of its own is where
+ * the key sits; what the rule is, is not theirs to word.
+ */
+class ARefusedMapKeyStatesItsRuleOnceTest {
+
+    private static final String FIELD = """
+            module demo
+
+            data EmployeeNo = Int
+            data Roster = { byNo: Map<EmployeeNo, String> }
+            data Out = { count: Int }
+
+            behavior count : (r: Roster) -> Out constructs Out
+
+            let count (r) = Out { count = 0 }
+            """;
+
+    private static final String PARAM = """
+            module demo
+
+            data EmployeeNo = Int
+            data Out = { count: Int }
+
+            behavior count : (byNo: Map<EmployeeNo, String>) -> Out constructs Out
+
+            let count (byNo) = Out { count = 0 }
+            """;
+
+    private static final String OUTPUT = """
+            module demo
+
+            data EmployeeNo = Int
+            data In = { n: Int }
+
+            behavior widen : (i: In) -> Map<EmployeeNo, String> constructs EmployeeNo
+
+            let widen (i) = Map.empty
+            """;
+
+    private static CompileException refusal(String source) {
+        return assertThrows(CompileException.class, () -> Compiler.compile(source));
+    }
+
+    private static String hintKey(CompileException e) {
+        List<Note> notes = e.diagnostic().notes();
+        assertEquals(1, notes.size(), e.getMessage());
+        return notes.get(0).messageKey();
+    }
+
+    /** One rule, one place it is written down. Three hint keys were three chances to say it
+     *  differently, and one of them was already saying something else. */
+    @Test
+    void theThreeSitesPointAtOneStatementOfTheRule() {
+        assertEquals(hintKey(refusal(FIELD)), hintKey(refusal(PARAM)));
+        assertEquals(hintKey(refusal(PARAM)), hintKey(refusal(OUTPUT)));
+    }
+
+    /** The sentence a Java caller reads is the same rule, taken from the one place it is written
+     *  rather than restated per site. A fourth site wording it itself fails here. */
+    @Test
+    void eachSiteCarriesTheRuleItWasGivenRatherThanItsOwn() {
+        for (String source : List.of(FIELD, PARAM, OUTPUT)) {
+            String message = refusal(source).getMessage();
+            assertTrue(message.contains(TypeOps.MAP_KEY_RULE), message);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ABoundaryMapKeyIsClassifiedByOneRuleTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ABoundaryMapKeyIsClassifiedByOneRuleTest.java
@@ -14,14 +14,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Admitting a boundary Map key establishes what its text representation is, and that is what the
- * checker hands on: a witness, not a yes. What a reader that has to build a codec needs is which
- * representation, and it must not have to work that out again from the type.
+ * checker answers with: a witness, not a yes. Every reader that has to build a codec asks this one
+ * rule which representation it has, rather than writing the kinds out again.
  *
  * <p>The two questions the one predicate used to answer are separate here. Whether a type may stand
  * as a key in a signature admits a type variable, which the core's generic signatures are written
  * with; whether a concrete key can be converted does not, because a variable is evidence of nothing.
  */
-class ABoundaryMapKeyIsClassifiedOnceTest {
+class ABoundaryMapKeyIsClassifiedByOneRuleTest {
 
     private static final String MODULE = """
             module demo
@@ -66,11 +66,13 @@ class ABoundaryMapKeyIsClassifiedOnceTest {
         assertEquals(new BoundaryMapKey.DateTime(), classify(Type.DATETIME));
     }
 
-    /** A newtype carries both what it is called and what it is admitted through, so a reader that
-     *  wraps a key and a reader that converts the text it wraps take different parts of one answer. */
+    /** The base a newtype wraps is in the case rather than beside it. Every reader of a named key
+     *  delegates to that type's own decoder and to a {@code value()} typed {@code () -> String},
+     *  which is true of a String-backed newtype and of nothing else — so a newtype over another base
+     *  is a case of its own, and reaches every reader as one. */
     @Test
-    void aNewtypeCarriesTheRepresentationItIsAdmittedThrough() {
-        assertEquals(new BoundaryMapKey.Newtype(symbols.own("ProductId"), new BoundaryMapKey.Text()),
+    void aStringBackedNewtypeIsItsOwnCase() {
+        assertEquals(new BoundaryMapKey.StringNewtype(symbols.own("ProductId")),
                 classify(named("ProductId")));
     }
 
@@ -79,9 +81,8 @@ class ABoundaryMapKeyIsClassifiedOnceTest {
         assertEquals(new BoundaryMapKey.UnitEnum(symbols.own("Outcome")), classify(named("Outcome")));
     }
 
-    /** The representations a newtype may be admitted through are the rule's, not the witness type's.
-     *  A newtype over a primitive with no key representation is refused, and the refusal is the
-     *  classifier's — nothing downstream repeats it. */
+    /** Which bases a newtype key may wrap is the rule's, and the refusal is the classifier's —
+     *  nothing downstream repeats it. */
     @Test
     void aNewtypeOverAPrimitiveWithNoKeyRepresentationIsNotClassified() {
         assertNull(classify(named("EmployeeNo")));

--- a/souther-compiler/src/test/java/souther/compiler/check/ABoundaryMapKeyIsClassifiedOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ABoundaryMapKeyIsClassifiedOnceTest.java
@@ -1,0 +1,127 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.BoundaryMapKey;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Admitting a boundary Map key establishes what its text representation is, and that is what the
+ * checker hands on: a witness, not a yes. What a reader that has to build a codec needs is which
+ * representation, and it must not have to work that out again from the type.
+ *
+ * <p>The two questions the one predicate used to answer are separate here. Whether a type may stand
+ * as a key in a signature admits a type variable, which the core's generic signatures are written
+ * with; whether a concrete key can be converted does not, because a variable is evidence of nothing.
+ */
+class ABoundaryMapKeyIsClassifiedOnceTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data ProductId = String
+            data EmployeeNo = Int
+            data Price = Decimal
+            data Nested = ProductId
+
+            data Won
+            data Lost
+            data Outcome = Won | Lost
+
+            data Slot = { hour: Int, room: String }
+            """;
+
+    private final Symbols symbols = Symbols.of(resolved());
+
+    /** A sum's cases are read by name, so the module has to be resolved before its enumerations can
+     *  be asked about. */
+    private static Ast.Module resolved() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    private BoundaryMapKey classify(Type key) {
+        return TypeOps.classifyConcreteMapKey(key, symbols);
+    }
+
+    private Type named(String name) {
+        return Type.ref(symbols.own(name));
+    }
+
+    @Test
+    void aStringKeyIsText() {
+        assertEquals(new BoundaryMapKey.Text(), classify(Type.STRING));
+    }
+
+    @Test
+    void aTemporalKeyIsItsOwnRepresentation() {
+        assertEquals(new BoundaryMapKey.Date(), classify(Type.DATE));
+        assertEquals(new BoundaryMapKey.DateTime(), classify(Type.DATETIME));
+    }
+
+    /** A newtype carries both what it is called and what it is admitted through, so a reader that
+     *  wraps a key and a reader that converts the text it wraps take different parts of one answer. */
+    @Test
+    void aNewtypeCarriesTheRepresentationItIsAdmittedThrough() {
+        assertEquals(new BoundaryMapKey.Newtype(symbols.own("ProductId"), new BoundaryMapKey.Text()),
+                classify(named("ProductId")));
+    }
+
+    @Test
+    void anEnumerationIsNamedApartFromANewtype() {
+        assertEquals(new BoundaryMapKey.UnitEnum(symbols.own("Outcome")), classify(named("Outcome")));
+    }
+
+    /** The representations a newtype may be admitted through are the rule's, not the witness type's.
+     *  A newtype over a primitive with no key representation is refused, and the refusal is the
+     *  classifier's — nothing downstream repeats it. */
+    @Test
+    void aNewtypeOverAPrimitiveWithNoKeyRepresentationIsNotClassified() {
+        assertNull(classify(named("EmployeeNo")));
+        assertNull(classify(named("Price")));
+    }
+
+    @Test
+    void aNewtypeOverANewtypeIsNotClassified() {
+        assertNull(classify(named("Nested")));
+    }
+
+    @Test
+    void aProductDataIsNotClassified() {
+        assertNull(classify(named("Slot")));
+    }
+
+    @Test
+    void aPrimitiveWithNoKeyRepresentationIsNotClassified() {
+        assertNull(classify(Type.INT));
+        assertNull(classify(Type.BOOL));
+        assertNull(classify(Type.DECIMAL));
+    }
+
+    /**
+     * A type variable stands for a key rather than being one. The core's {@code Map<'k, 'a>}
+     * signatures are written with it, so a signature admits it; it classifies as nothing, because
+     * there is no representation to name until it is monomorphised.
+     */
+    @Test
+    void aTypeVariableIsAdmissibleInASignatureAndClassifiesAsNothing() {
+        Type var = Type.var("'k");
+        assertTrue(TypeOps.isMapKeyAdmissibleInSignature(var, symbols));
+        assertNull(classify(var));
+    }
+
+    @Test
+    void aSignatureAdmitsExactlyWhatClassifiesPlusTheVariable() {
+        assertTrue(TypeOps.isMapKeyAdmissibleInSignature(Type.STRING, symbols));
+        assertTrue(TypeOps.isMapKeyAdmissibleInSignature(named("Outcome"), symbols));
+        assertFalse(TypeOps.isMapKeyAdmissibleInSignature(Type.INT, symbols));
+        assertFalse(TypeOps.isMapKeyAdmissibleInSignature(named("EmployeeNo"), symbols));
+    }
+}


### PR DESCRIPTION
Closes #442.

## What changed

`TypeOps.classifyConcreteMapKey` answers with a `BoundaryMapKey` witness — `Text`, `Date`, `DateTime`, `StringNewtype(name)`, `UnitEnum(name)` — in place of the old boolean. Whether a key may stand in a signature is a separate predicate, because a type variable is admissible there and is evidence of nothing.

The witness reaches the backend rather than being worked out again:

- `MapDecRef`, `MapEnc` and `MapElemEnc` hold a `BoundaryMapKey` in place of a `DecRef`/`EncElem`, so a key position cannot hold a list or an option. The three key switches in `CodecGen` lose their `default -> throw`.
- `CodecGen.keyValueCallSite` no longer calls `TypeOps.isUnitOnlySum` back out of the backend to learn what kind of named key it has.
- `Resolve` no longer rebuilds the key; `DataChecker` and `bindType` read `key.type()`.
- `Runner.keyDecoder` and `FixtureReader.keyDecoderFor` read the classification instead of writing the kinds out.

The rule is stated once: one hint key (`check.map.key.hint`) and one Java sentence (`TypeOps.MAP_KEY_RULE`) in place of three hints and four hand-written enumerations, and neither lists the admitted kinds. Those four Java bodies had already drifted — the enumeration was admitted in #161 and only the catalog was updated, so all four went on naming four kinds.

## Why the newtype case names its base

`StringNewtype(name)` rather than `Newtype(name, representation)`. A named key is decoded by that type's own generated `decoder()`, which has the conversion and the invariant inside it, and encoded through a `value()` accessor typed `() -> String`. Neither reads a representation, so a nested witness would be one nobody consumes: admitting `data Price = Decimal` would add a representation case, stop the readers once, and leave the newtype arm compiling on a `() -> String` that had just become false. With the base in the case, that widening is a case of its own.

## What the closed type guarantees

Admitting `data X = Decimal` as a key — a new case plus the classifier line — stops exactly five sites:

- `FixtureReader.keyDecoderFor`
- `Runner.keyDecoder`
- `CodecGen.emitKeyDecoder`, `rekeyMethod`, `keyValueCallSite`

and leaves `Deriver`, `Resolve`, `DataChecker`, `needsKeyRender` and `Runner.encode` alone — they carry the witness, read `key.type()`, or recurse through the ordinary encoder, and none of that changed. What the set closes over is the representations a reader branches on, not the types a key may be written as: another `data CustomerId = String` is a `StringNewtype` and moves nothing.

Before this change the same widening compiled, derived a codec, generated its classes and passed every map-key test, failing only at decode time with `Err`.

## What it does not do

The rule is defined once; the witness is not transported everywhere. `souther run` and the fixture reader hold a `Type` the compile handed back rather than the codec IR the witness travels in, so each asks `classifyConcreteMapKey` again. That is why `Compilation.symbols(String)` is added — the one new public API. Carrying a classified type tree out to those two readers is a larger change and is not attempted here.

## Tests

- `ABoundaryMapKeyIsClassifiedByOneRuleTest` — the five representations, what classifies as nothing, and the split between signature admission and concrete classification.
- `ARefusedMapKeyStatesItsRuleOnceTest` — the field, parameter and output refusals point at one statement of the rule and carry it rather than their own.

Both were written failing first. The IR change and the consumer moves preserve behaviour; their guarantee is the exhaustiveness above, and the regression net is the existing suite.

`mvn clean test` passes across all modules (3767 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
