### PR TITLE
A measure with no number says why, and nothing downstream works it out

### DIFF
--- a/docs/adr/0089-adequacy-evidence-accumulates-and-the-measures-do-not-switch.md
+++ b/docs/adr/0089-adequacy-evidence-accumulates-and-the-measures-do-not-switch.md
@@ -50,6 +50,14 @@ replaces *observed*, because applying a behavior to a value claims nothing about
 A measure that could not be made says so, as a third value beside met and unmet. A row whose value
 could not be read leaves that position undecided, not uncovered.
 
+An unavailable measurement must expose why no value exists. The reason is stored when it would
+otherwise be lost, and derived when it is already encoded by the evidence — what the contract
+requires is the meaning, not a field. Consumers may interpret evidence but must not reconstruct
+measurement meaning from declarations or unrelated report state. Structural non-applicability is
+currently represented as `UNAVAILABLE` with a reason of `NO_BODY`, to keep `MeasurementStatus`
+stable; that encoding must remain encapsulated by the evidence model, and callers ask
+`applicable()` rather than reading the constant.
+
 Nothing is reduced to a single score, at any level.
 
 ## Consequences
@@ -69,6 +77,14 @@ nothing confirms it; the model gives it.
 
 Undecided as a third value means every consumer handles three states. A report that collapsed it into
 unmet would send authors after rows they may already have written.
+
+The reason costs a field on most measures and a check wherever one is built. It is paid because
+without it the layer that has to choose a sentence works the reason out from whatever else is to
+hand — the row count, whether the behavior is injected, whether the declaration has a body. Each of
+those correlates with the reason and is not it, so each such rule is right about the cases it was
+written against and wrong about one nobody had in mind: a `>->` composition is implemented, carries
+rows, and has no arms all the same. Keeping the reason where the measurement is made is also what
+lets `NOT_APPLICABLE` be added to `MeasurementStatus` later without touching a consumer.
 
 Comparing two runs is left out. Quantifying "how much did implementing this behavior reveal?" needs
 the two reports matched arm by arm, and an arm has no identity that survives an edit

--- a/souther-compiler/src/main/java/souther/compiler/observe/InputCaseEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/InputCaseEvidence.java
@@ -58,4 +58,16 @@ public record InputCaseEvidence(Set<TypeName> declared, Set<TypeName> specified,
     public MeasurementStatus status() {
         return Evidence.status(declared, unclassifiedRows);
     }
+
+    /** Why there are no numbers, where there are none. Derived rather than held, for the reason
+     * {@link OutputCaseEvidence#reason()} gives. */
+    public Reason reason() {
+        return declared.isEmpty() ? Reason.NOT_A_SUM : null;
+    }
+
+    /** Why one input's cases have no numbers. */
+    public enum Reason {
+        /** The position is one data rather than a sum, so there is no case to cover. */
+        NOT_A_SUM
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/observe/MeasurementStatus.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/MeasurementStatus.java
@@ -11,6 +11,12 @@ package souther.compiler.observe;
  * <p>The three are read the same way everywhere. Only {@link #COMPLETE} may raise a missing-coverage
  * diagnostic; {@link #PARTIAL} reports what it saw and says it could not decide; {@link #UNAVAILABLE}
  * has no number to show at all.
+ *
+ * <p>Why there is no number is not one of these. Nothing to measure, nobody asking, and a run that
+ * could not read what it needed all arrive as {@link #UNAVAILABLE}, and they ask opposite things of
+ * whoever reads it, so each measure carries its own reason beside this. Which reasons a measure can
+ * have is that measure's own business; that it has one wherever this is {@link #UNAVAILABLE}, and
+ * none wherever it is not, is the same everywhere.
  */
 public enum MeasurementStatus {
 
@@ -20,7 +26,7 @@ public enum MeasurementStatus {
     /** Something this measure reads was unreadable, so a gap may not be one. */
     PARTIAL,
 
-    /** The measure could not run here at all — an injected behavior has no branches to cover. */
+    /** No number, for a reason the measure gives. */
     UNAVAILABLE;
 
     /** The weaker of two statuses, for a measure assembled from several sources. */

--- a/souther-compiler/src/main/java/souther/compiler/observe/OutputCaseEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/OutputCaseEvidence.java
@@ -52,4 +52,18 @@ public record OutputCaseEvidence(Set<TypeName> declared, Set<TypeName> specified
     public MeasurementStatus status() {
         return Evidence.status(declared, unclassifiedRows);
     }
+
+    /** Why there are no numbers, where there are none. Derived rather than held: what makes this
+     * measure unavailable is that {@link #declared} is empty, so a field beside it would be a second
+     * copy of a fact this record already carries and a second thing to keep true. */
+    public Reason reason() {
+        return declared.isEmpty() ? Reason.NOT_A_SUM : null;
+    }
+
+    /** Why a behavior's output cases have no numbers. */
+    public enum Reason {
+        /** The output is one data rather than a sum, so there is no case to cover and no row can
+         *  fail to cover it. */
+        NOT_A_SUM
+    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -125,9 +125,22 @@ public final class Adequacy {
 
     /** What the rows say about one behavior's signature. */
     public record SignatureEvidence(OutputCaseEvidence output, List<InputCaseEvidence> inputs,
-                                    MeasurementStatus status) {
+                                    MeasurementStatus status, Reason reason) {
+
+        /** Why the signature has no numbers. */
+        public enum Reason {
+            /** No row names this behavior, so nothing was established about it either way. */
+            NO_ROWS
+        }
+
+        public static SignatureEvidence unavailable(OutputCaseEvidence output,
+                                                    List<InputCaseEvidence> inputs, Reason reason) {
+            return new SignatureEvidence(output, inputs, MeasurementStatus.UNAVAILABLE, reason);
+        }
+
         public SignatureEvidence {
             inputs = List.copyOf(inputs);
+            Unavailable.check(status, reason);
         }
     }
 
@@ -256,8 +269,11 @@ public final class Adequacy {
                     continue;
                 }
                 Observed seen = byTarget.getOrDefault(spec.name(), Observed.NONE);
+                // Asked and readable are handed over apart. A line nobody asked about and one whose
+                // instrumentation was lost are both unmeasured, and only the second is a run that
+                // failed at it; one boolean for the pair leaves the measure unable to say which.
                 out.put(spec.name(), Coverages.of(spec, sig, scope.value(), bodies.get(spec.name()),
-                        plan, seen, armsMeasured && !seen.armsUnseen(),
+                        plan, seen, armsMeasured,
                         excluded == null ? Exclusions.NONE
                                 : excluded.getOrDefault(spec.name(), Exclusions.NONE)));
             }
@@ -283,14 +299,55 @@ public final class Adequacy {
      * @param covered the ones a row went through
      */
     public record BranchEvidence(List<souther.compiler.coverage.CoverageSites.Site> all,
-                                 Set<Integer> covered, MeasurementStatus status) {
+                                 Set<Integer> covered, MeasurementStatus status, Reason reason) {
 
-        public static final BranchEvidence UNAVAILABLE =
-                new BranchEvidence(List.of(), Set.of(), MeasurementStatus.UNAVAILABLE);
+        /**
+         * Why a behavior's arms have no number, in the order the measurement asks.
+         *
+         * <p>The first gate that did not open is the answer. They are asked in that order because that
+         * is the order the work happens in: a body has to exist before anything can be asked about it,
+         * the build has to ask before the classes are generated, the classes have to survive before a
+         * row can carry what it went through, and a row has to name the behavior before any of it is
+         * about this one.
+         */
+        public enum Reason {
+            /** A {@code >->} composition or a behavior with no {@code let}. It has no arms of its own,
+             *  so the measure does not apply rather than failing. */
+            NO_BODY,
+            /** The build did not ask for the arms, which cost a second run of every row. */
+            NOT_ASKED,
+            /** The rows ran without instrumentation, so what they went through went with it. */
+            UNREADABLE,
+            /** No row names this behavior. The measurement is opted into by writing one, and reaching
+             *  the behavior through somebody else's row is not opting in. */
+            NO_ROWS
+        }
+
+        public static BranchEvidence unavailable(Reason reason) {
+            return new BranchEvidence(List.of(), Set.of(), MeasurementStatus.UNAVAILABLE, reason);
+        }
+
+        public static BranchEvidence measured(List<souther.compiler.coverage.CoverageSites.Site> all,
+                                              Set<Integer> covered, MeasurementStatus status) {
+            return new BranchEvidence(all, covered, status, null);
+        }
 
         public BranchEvidence {
             all = List.copyOf(all);
             covered = Set.copyOf(covered);
+            Unavailable.check(status, reason);
+        }
+
+        /**
+         * Whether this behavior has arms for the measure to be about.
+         *
+         * <p>Asked instead of reading {@link Reason#NO_BODY} at each caller. Having nothing to measure
+         * is not the same as failing to measure, and {@link MeasurementStatus} has no word for the
+         * first; {@code NO_BODY} is where that distinction is kept until it does. A caller that read
+         * the constant would be holding the encoding rather than the question.
+         */
+        public boolean applicable() {
+            return reason != Reason.NO_BODY;
         }
 
         public List<souther.compiler.coverage.CoverageSites.Site> unreached() {
@@ -345,12 +402,10 @@ public final class Adequacy {
                 List<souther.compiler.coverage.CoverageSites.Site> arms = plan.sites().stream()
                         .filter(site -> site.behavior().equals(behavior.name())).toList();
                 Observed observed = byTarget.getOrDefault(behavior.name(), Observed.NONE);
-                if (!measured || observed.armsUnseen() || !withBodies.contains(behavior.name())
-                        || observed.rows().isEmpty()) {
-                    // Nothing to measure, or nothing asking. A behavior with no body has no arms; one
-                    // no row names has not been opted into the measurement, and reaching it through
-                    // somebody else's row is not opting in.
-                    out.put(behavior.name(), BranchEvidence.UNAVAILABLE);
+                BranchEvidence.Reason absent =
+                        whyNoArms(behavior.name(), withBodies, measured, observed);
+                if (absent != null) {
+                    out.put(behavior.name(), BranchEvidence.unavailable(absent));
                     continue;
                 }
                 Set<Integer> covered = new LinkedHashSet<>(lit);
@@ -361,10 +416,40 @@ public final class Adequacy {
                 // unreached, and the whole measure says so — the arms that were lit are still lit.
                 boolean partial = !observed.complete() || observed.rows().stream()
                         .anyMatch(row -> row.disposition() == Disposition.INCOMPLETE);
-                out.put(behavior.name(), new BranchEvidence(arms, covered,
+                out.put(behavior.name(), BranchEvidence.measured(arms, covered,
                         partial ? MeasurementStatus.PARTIAL : MeasurementStatus.COMPLETE));
             }
             return Answer.of(Ordered.map(out));
+        }
+
+        /**
+         * The first gate the arm measurement did not get through, or null where it got through them
+         * all.
+         *
+         * <p>One gate per condition, in the order the work happens in, so that what a caller reads back
+         * is the thing that stopped it rather than whichever condition an expression happened to test
+         * first. The bodies say which behaviors have arms; the arm count cannot, since a body with no
+         * fork in it also has none.
+         */
+        private static BranchEvidence.Reason whyNoArms(String behavior, Set<String> withBodies,
+                                                       boolean measured, Observed observed) {
+            if (!withBodies.contains(behavior)) {
+                return BranchEvidence.Reason.NO_BODY;
+            }
+            if (!measured) {
+                return BranchEvidence.Reason.NOT_ASKED;
+            }
+            if (observed.armsUnseen()) {
+                return BranchEvidence.Reason.UNREADABLE;
+            }
+            // Nothing read is not the same as nothing written. Where a source could not be evaluated
+            // at all, the rows this behavior is waiting on may be sitting in it, and answering
+            // `NO_ROWS` would tell an author to write what is already there. The measure goes ahead
+            // on what was seen and comes back undecided, which is what it is.
+            if (observed.rows().isEmpty() && !observed.someRowsUnseen()) {
+                return BranchEvidence.Reason.NO_ROWS;
+            }
+            return null;
         }
     }
 
@@ -812,6 +897,12 @@ public final class Adequacy {
                 return;
             }
             for (PartitionEvidence.AxisCoverage axis : partition.axes()) {
+                // A class nothing sits in, where nothing was measured, is not a class no row is in.
+                // Stopped here rather than where the line is printed: a finding is something a measure
+                // established, and one from a measure that was never made is not established at all.
+                if (axis.status() == MeasurementStatus.UNAVAILABLE) {
+                    continue;
+                }
                 for (String missing : axis.uncovered()) {
                     out.add(new Finding(Kind.AXIS_CLASS_UNCOVERED, behavior.name(), axis.status(),
                             behavior.pos(), List.of(missing)));
@@ -1035,10 +1126,11 @@ public final class Adequacy {
         // counted, above: its state is dropped rather than read, so it has no arm and no input case
         // and shows up as one nothing could classify.
         partial |= seen.someRowsUnseen();
-        MeasurementStatus status = rows.isEmpty() && seen.complete()
-                ? MeasurementStatus.UNAVAILABLE
-                : partial ? MeasurementStatus.PARTIAL : MeasurementStatus.COMPLETE;
-        return new SignatureEvidence(output, inputs, status);
+        if (rows.isEmpty() && seen.complete()) {
+            return SignatureEvidence.unavailable(output, inputs, SignatureEvidence.Reason.NO_ROWS);
+        }
+        return new SignatureEvidence(output, inputs,
+                partial ? MeasurementStatus.PARTIAL : MeasurementStatus.COMPLETE, null);
     }
 
     private Adequacy() {}

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -53,13 +53,15 @@ final class Coverages {
     }
 
     /**
-     * @param armsMeasured whether the rows were run against classes that record which arms they went
-     *                     through. A boundary a {@code guard} drew is not decided without that: the
-     *                     value being written is not the same as the comparison having been evaluated.
+     * @param armsAsked whether the build asked for the arms at all. A boundary a {@code guard} drew is
+     *                  not decided without them: the value being written is not the same as the
+     *                  comparison having been evaluated. Whether the run then managed to read them is
+     *                  a second question, and {@code observed} answers it — the two fail differently
+     *                  and a measure that took one boolean for both could not say which had happened.
      */
     static PartitionEvidence of(Ast.SpecBehavior behavior, Sig sig, Symbols symbols, Core body,
                                 CoverageSites.Plan plan, souther.compiler.query.Adequacy.Observed observed,
-                                boolean armsMeasured, Exclusions excluded) {
+                                boolean armsAsked, Exclusions excluded) {
         List<RowOutcome> rows = observed.rows();
         List<String> parameters = behavior.params().stream().map(Ast.Param::name).toList();
         Partitions.Partitioning partitioning =
@@ -85,7 +87,7 @@ final class Coverages {
             // *missing* hit undecidable and takes nothing away from one that was found: a row that
             // wrote the value and went through the comparison did so whatever else stopped.
             boundaries.addAll(boundariesOf(axis, parameters, rows, symbols,
-                    armsMeasured, observed.someRowsUnseen()));
+                    armsAsked, observed.armsUnseen(), observed.someRowsUnseen()));
         }
         return new PartitionEvidence(axes, boundaries, pairsOf(divided, readings),
                 notDerivable, partitioning.omitted());
@@ -177,9 +179,16 @@ final class Coverages {
         if (total == 0) {
             return PartitionEvidence.PairSpace.NONE;
         }
+        // Before the size of the space is worth mentioning. A combination nothing tried to sit in is
+        // not a combination left untried by anybody, and how many of them there are says nothing
+        // about a behavior no row names.
+        if (readings.noRows() && !readings.someRowsUnseen()) {
+            return PartitionEvidence.PairSpace.unavailable((int) Math.min(total, Integer.MAX_VALUE),
+                    PartitionEvidence.PairSpace.Reason.NO_ROWS);
+        }
         if (total > PAIR_LIMIT) {
             return new PartitionEvidence.PairSpace((int) Math.min(total, Integer.MAX_VALUE), 0, 0, 0,
-                    (int) Math.min(total, Integer.MAX_VALUE), true, MeasurementStatus.PARTIAL);
+                    (int) Math.min(total, Integer.MAX_VALUE), true, MeasurementStatus.PARTIAL, null);
         }
         Set<String> covered = new LinkedHashSet<>();
         for (Map<AxisId, Classification> where : readings.byRow()) {
@@ -198,11 +207,25 @@ final class Coverages {
         }
         int reached = covered.size();
         return new PartitionEvidence.PairSpace((int) total, reached, reached, 0,
-                (int) total - reached, false, readings.status(axes));
+                (int) total - reached, false, readings.status(axes), null);
     }
 
     private static PartitionEvidence.AxisCoverage coverageOf(Axis axis, Readings readings,
                                                              Exclusions excluded) {
+        List<String> classes = axis.eligible().stream().map(PartitionClass::id).toList();
+        // The model's own words for why, carried through so a report can say what it took out of the
+        // denominator rather than showing a position with fewer classes than its type has. Said
+        // whether or not a row was written: what the body rules out is a fact about the body.
+        List<PartitionEvidence.ExcludedClass> ruled = excluded.at(axis.path()).stream()
+                .filter(each -> axis.excluded().contains(each.name()))
+                .map(each -> new PartitionEvidence.ExcludedClass(each.name(),
+                        excluded.reasonsFor(axis.path(), each)))
+                .toList();
+        if (readings.noRows() && !readings.someRowsUnseen()) {
+            return PartitionEvidence.AxisCoverage.unavailable(axis.id().toString(),
+                    axis.path().toString(), classes, ruled,
+                    PartitionEvidence.AxisCoverage.Reason.NO_ROWS);
+        }
         Set<String> covered = new LinkedHashSet<>();
         for (Map<AxisId, Classification> where : readings.byRow()) {
             String in = Readings.classIn(where, axis);
@@ -210,18 +233,9 @@ final class Coverages {
                 covered.add(in);
             }
         }
-        MeasurementStatus status = readings.noRows() && !readings.someRowsUnseen()
-                ? MeasurementStatus.UNAVAILABLE : readings.status(List.of(axis));
-        // The model's own words for why, carried through so a report can say what it took out of the
-        // denominator rather than showing a position with fewer classes than its type has.
-        List<PartitionEvidence.ExcludedClass> ruled = excluded.at(axis.path()).stream()
-                .filter(each -> axis.excluded().contains(each.name()))
-                .map(each -> new PartitionEvidence.ExcludedClass(each.name(),
-                        excluded.reasonsFor(axis.path(), each)))
-                .toList();
         return new PartitionEvidence.AxisCoverage(axis.id().toString(), axis.path().toString(),
-                axis.eligible().stream().map(PartitionClass::id).toList(), covered,
-                ruled, readings.couldNotSay(axis), status);
+                classes, covered, ruled, readings.couldNotSay(axis),
+                readings.status(List.of(axis)), null);
     }
 
     /**
@@ -235,12 +249,13 @@ final class Coverages {
      */
     private static List<PartitionEvidence.BoundaryCoverage> boundariesOf(
             Axis axis, List<String> parameters, List<RowOutcome> rows, Symbols symbols,
-            boolean armsMeasured, boolean someRowsUnseen) {
+            boolean armsAsked, boolean armsUnseen, boolean someRowsUnseen) {
         List<PartitionEvidence.BoundaryCoverage> out = new ArrayList<>();
         for (BoundaryObligation each : Partitions.obligationsOf(axis, symbols)) {
-            boolean available = !rows.isEmpty()
-                    && (!(each.origin() instanceof OriginRef.GuardOrigin) || armsMeasured);
-            Met met = !available ? Met.UNDECIDED : switch (each.origin()) {
+            PartitionEvidence.BoundaryCoverage.Reason absent = each.origin() instanceof OriginRef.GuardOrigin
+                    ? whyNoGuardLine(rows, armsAsked, armsUnseen, someRowsUnseen)
+                    : whyNoInvariantLine(rows, someRowsUnseen);
+            Met met = absent != null ? Met.UNDECIDED : switch (each.origin()) {
                 case OriginRef.GuardOrigin g -> evaluatedAt(axis, parameters, rows, each.value(), g);
                 default -> writtenAt(axis, parameters, rows, each.value());
             };
@@ -261,9 +276,46 @@ final class Coverages {
                     met == Met.YES,
                     met == Met.UNDECIDED ? MeasurementStatus.UNAVAILABLE
                             : met == Met.UNREADABLE ? MeasurementStatus.PARTIAL
-                                    : MeasurementStatus.COMPLETE));
+                                    : MeasurementStatus.COMPLETE,
+                    met == Met.UNDECIDED ? absent : null));
         }
         return out;
+    }
+
+    /**
+     * The first gate a {@code guard}'s line did not get through.
+     *
+     * <p>Its own path, because a guard's line and an invariant's are not measured the same way and so
+     * cannot fail to be measured for the same reasons. Meeting this one takes the comparison having
+     * run, which puts the arms in front of the rows: nothing a row carries decides it until the
+     * classes that record where the row went exist and survived.
+     */
+    private static PartitionEvidence.BoundaryCoverage.Reason whyNoGuardLine(
+            List<RowOutcome> rows, boolean armsAsked, boolean armsUnseen, boolean someRowsUnseen) {
+        if (!armsAsked) {
+            return PartitionEvidence.BoundaryCoverage.Reason.ARMS_NOT_ASKED;
+        }
+        if (armsUnseen) {
+            return PartitionEvidence.BoundaryCoverage.Reason.ARMS_UNREADABLE;
+        }
+        return whyNoInvariantLine(rows, someRowsUnseen);
+    }
+
+    /**
+     * The first gate an invariant's line did not get through.
+     *
+     * <p>Only the one: nothing outside the bound can be constructed, so writing the value is the whole
+     * of what there is to reach and no instrumentation is owed. This is why the two origins are asked
+     * separately — an invariant's line can never be waiting on the arms, and a measure that could say
+     * so would be able to say something that is not true of it.
+     */
+    private static PartitionEvidence.BoundaryCoverage.Reason whyNoInvariantLine(
+            List<RowOutcome> rows, boolean someRowsUnseen) {
+        // Nothing read is not the same as nothing written. A source that could not be evaluated may
+        // hold the row that is at this line, so the question is undecided rather than unasked, and
+        // the reading below settles it that way.
+        return rows.isEmpty() && !someRowsUnseen
+                ? PartitionEvidence.BoundaryCoverage.Reason.NO_ROWS : null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -58,10 +58,24 @@ public record PartitionEvidence(List<AxisCoverage> axes, List<BoundaryCoverage> 
      *                  is not reached is then undecided rather than untried
      */
     public record PairSpace(int total, int covered, int witnessedFeasible, int provenInfeasible,
-                            int unknown, boolean truncated, MeasurementStatus status) {
+                            int unknown, boolean truncated, MeasurementStatus status, Reason reason) {
+
+        /** Why the combinations have no numbers. */
+        public enum Reason {
+            /** No row names this behavior, so nothing sits anywhere. */
+            NO_ROWS
+        }
 
         public static final PairSpace NONE =
-                new PairSpace(0, 0, 0, 0, 0, false, MeasurementStatus.COMPLETE);
+                new PairSpace(0, 0, 0, 0, 0, false, MeasurementStatus.COMPLETE, null);
+
+        public static PairSpace unavailable(int total, Reason reason) {
+            return new PairSpace(total, 0, 0, 0, total, false, MeasurementStatus.UNAVAILABLE, reason);
+        }
+
+        public PairSpace {
+            Unavailable.check(status, reason);
+        }
 
         /** Whether a single ratio would say anything. With unknowns in the denominator it would not. */
         public boolean decided() {
@@ -95,12 +109,28 @@ public record PartitionEvidence(List<AxisCoverage> axes, List<BoundaryCoverage> 
      */
     public record AxisCoverage(String axis, String path, List<String> classes, Set<String> covered,
                                List<ExcludedClass> excluded, int unclassifiedRows,
-                               MeasurementStatus status) {
+                               MeasurementStatus status, Reason reason) {
+
+        /** Why a position has no coverage numbers. */
+        public enum Reason {
+            /** No row names this behavior. An absence of evidence is not a set of gaps, so the classes
+             *  nothing sits in are not classes nothing reaches. */
+            NO_ROWS
+        }
+
+        /** What the body rules out is still said. Which classes there are and which the body answers
+         * for are facts about the model, and no row has to exist for either. */
+        public static AxisCoverage unavailable(String axis, String path, List<String> classes,
+                                               List<ExcludedClass> excluded, Reason reason) {
+            return new AxisCoverage(axis, path, classes, Set.of(), excluded, 0,
+                    MeasurementStatus.UNAVAILABLE, reason);
+        }
 
         public AxisCoverage {
             classes = List.copyOf(classes);
             covered = Set.copyOf(covered);
             excluded = List.copyOf(excluded);
+            Unavailable.check(status, reason);
         }
 
         public List<String> uncovered() {
@@ -111,10 +141,30 @@ public record PartitionEvidence(List<AxisCoverage> axes, List<BoundaryCoverage> 
     /**
      * One value a row has to be written at, and whether one was.
      *
-     * @param status {@code UNAVAILABLE} where the rule is a guard: meeting it takes more than writing
-     *               the value — the comparison has to have been evaluated — and nothing measures that
-     *               until the branches are instrumented.
+     * @param reason why it could not be told, where it could not. A guard's line and an invariant's
+     *               are not measured the same way and do not fail to be measured for the same
+     *               reasons, which is why the two are built along separate paths
      */
     public record BoundaryCoverage(String axis, String origin, BoundaryObligation.BoundarySide side,
-                                   String value, boolean hit, MeasurementStatus status) {}
+                                   String value, boolean hit, MeasurementStatus status,
+                                   Reason reason) {
+
+        /** Why a line has no answer. */
+        public enum Reason {
+            /** The build did not ask for the arms, and a guard's line is met by reaching the
+             *  comparison rather than by writing the value. Never a reason for an invariant's line,
+             *  which needs no arms. */
+            ARMS_NOT_ASKED,
+            /** The rows ran without instrumentation, so no row can be shown to have reached the
+             *  comparison. Never a reason for an invariant's line. */
+            ARMS_UNREADABLE,
+            /** No row names this behavior. */
+            NO_ROWS
+        }
+
+        public BoundaryCoverage {
+            Unavailable.check(status, reason);
+        }
+    }
+
 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Unavailable.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Unavailable.java
@@ -1,0 +1,23 @@
+package souther.compiler.query;
+
+import souther.compiler.observe.MeasurementStatus;
+
+/**
+ * The one thing every measure keeps: a measure with no number says why, and a measure with a number
+ * has nothing to say.
+ *
+ * <p>Checked where the value is built rather than where it is read. A measure whose reason went
+ * missing was read back from whatever else was to hand — the row count, the kind of behavior, the
+ * declaration — and every one of those is a different question that happens to correlate. What each
+ * reason can be is the measure's own business, so this holds the shape and not the words.
+ */
+final class Unavailable {
+
+    static void check(MeasurementStatus status, Object reason) {
+        if ((status == MeasurementStatus.UNAVAILABLE) != (reason != null)) {
+            throw new IllegalArgumentException(status + " with " + reason);
+        }
+    }
+
+    private Unavailable() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -77,18 +77,13 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
 
     /**
      * @param injected  whether the behavior still has no {@code let} to run
-     * @param hasBody   whether there is a body with arms in it. A {@code >->} composition is
-     *                  implemented and is not one: its stages have arms and it has none of its own, so
-     *                  a branch measure does not apply to it rather than failing on it. Read from the
-     *                  declaration, because the evidence for "not measured" and for "nothing to
-     *                  measure" is the same {@code UNAVAILABLE}
      * @param rows      how many {@code example} rows name it, across every source that writes one
      * @param pending   how many of those are recorded rather than evaluated
      * @param signature what those rows establish about the cases of its inputs and its output
      * @param findings  what the measures found and nothing filled, which is what the lines under this
      *                  behavior print and what a build is warned about — one list, read three ways
      */
-    public record BehaviorReport(String name, boolean injected, boolean hasBody, int rows, int pending,
+    public record BehaviorReport(String name, boolean injected, int rows, int pending,
                                  MeasurementStatus status,
                                  Adequacy.SignatureEvidence signature,
                                  PartitionEvidence partition,
@@ -202,11 +197,12 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                     signatures == null ? null : signatures.get(behavior.name());
             PartitionEvidence partition = partitions == null ? null
                     : partitions.getOrDefault(behavior.name(), PartitionEvidence.NONE);
-            Adequacy.BranchEvidence branch = branches == null ? Adequacy.BranchEvidence.UNAVAILABLE
-                    : branches.getOrDefault(behavior.name(), Adequacy.BranchEvidence.UNAVAILABLE);
-            boolean injected = ExampleVerifier.isPending(module, behavior.name());
-            behaviors.add(new BehaviorReport(behavior.name(), injected,
-                    behavior instanceof Ast.SpecBehavior && !injected, rows.size(), pending,
+            // Null where the compile did not get far enough to be asked, which is not a measure that
+            // came back with nothing. Every measure that did run says why it has no number.
+            Adequacy.BranchEvidence branch =
+                    branches == null ? null : branches.get(behavior.name());
+            behaviors.add(new BehaviorReport(behavior.name(),
+                    ExampleVerifier.isPending(module, behavior.name()), rows.size(), pending,
                     unreadable ? MeasurementStatus.PARTIAL : statusOf(signature, partition, branch),
                     signature, partition, branch,
                     findings == null ? List.of()
@@ -307,11 +303,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * like: a behavior whose arms were never asked about and one whose arms could not be measured both
      * carry an {@code UNAVAILABLE} branch, and only the first of them leaves the rows adequate.
      *
-     * <p>Whether a measure applies at all is read from the declaration and never from the shape of
-     * what came back. A behavior with no body has no arms, and a position dropped for being past the
-     * axis limit left no boundary behind — in both cases the evidence looks exactly like a measure
-     * that was made and found nothing, so a report reading it back would call the first adequate and
-     * the second covered.
+     * <p>Whether a measure applies at all is the measure's own answer, and never the shape of what
+     * came back. A behavior with no body has no arms, and a position dropped for being past the axis
+     * limit left no boundary behind — in both cases the numbers look exactly like a measure that was
+     * made and found nothing, so a report reading them back would call the first adequate and the
+     * second covered.
      */
     private List<MeasurementStatus> requiredMeasures() {
         List<MeasurementStatus> measures = new ArrayList<>();
@@ -323,7 +319,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 if (!askedLevel.measuresArms()) {
                     continue;
                 }
-                if (behavior.branch() != null && behavior.hasBody()) {
+                if (behavior.branch() != null && behavior.branch().applicable()) {
                     measures.add(behavior.branch().status());
                 }
                 if (behavior.partition() == null) {
@@ -469,12 +465,21 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 && partition.notDerivable().isEmpty())) {
             return;
         }
-        int classes = partition.axes().stream().mapToInt(a -> a.classes().size()).sum();
-        int covered = partition.axes().stream().mapToInt(a -> a.covered().size()).sum();
+        // Counted over the positions that were measured. A position nothing was measured at
+        // contributes no classes to the denominator: nought out of two reads as two gaps, and a
+        // measure that was never made found none. What the body ruled out is counted over all of
+        // them — that is what the model says, and no row has to exist for it to be so.
+        List<PartitionEvidence.AxisCoverage> measuredAxes = partition.axes().stream()
+                .filter(a -> a.status() != MeasurementStatus.UNAVAILABLE).toList();
+        int classes = measuredAxes.stream().mapToInt(a -> a.classes().size()).sum();
+        int covered = measuredAxes.stream().mapToInt(a -> a.covered().size()).sum();
         int excluded = partition.axes().stream().mapToInt(a -> a.excluded().size()).sum();
-        out.append(String.format("    partition   axes %d   single-axis %d/%d%s%s%n",
+        out.append(String.format("    partition   axes %d   single-axis %d/%d%s%s%s%n",
                 partition.axes().size(), covered, classes,
-                excluded == 0 ? "" : "   excluded " + excluded, pairs(partition.pairs())));
+                excluded == 0 ? "" : "   excluded " + excluded,
+                notes(partition.axes(), a -> a.status() == MeasurementStatus.UNAVAILABLE,
+                        a -> whyNoAxis(a.reason())),
+                pairs(partition.pairs())));
         for (Adequacy.Finding f : behavior.of(Adequacy.Kind.AXIS_CLASS_UNCOVERED)) {
             out.append(String.format("      · %s `%s`%n",
                     f.status() == MeasurementStatus.PARTIAL
@@ -491,11 +496,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         List<PartitionEvidence.BoundaryCoverage> measured = partition.boundaries().stream()
                 .filter(b -> b.status() != MeasurementStatus.UNAVAILABLE).toList();
         long met = measured.stream().filter(PartitionEvidence.BoundaryCoverage::hit).count();
-        long deferred = partition.boundaries().size() - measured.size();
         long undecided = measured.stream()
                 .filter(b -> b.status() == MeasurementStatus.PARTIAL).filter(b -> !b.hit()).count();
         out.append(String.format("    boundary    %d/%d%s%s%n", met, measured.size(),
-                deferred == 0 ? "" : "   (" + deferred + " not measured until branches are)",
+                notes(partition.boundaries(), b -> b.status() == MeasurementStatus.UNAVAILABLE,
+                        b -> whyNoBoundary(b.reason())),
                 undecided == 0 ? "" : "   (" + undecided + " undecided: a value was not read)"));
         for (Adequacy.Finding f : behavior.of(Adequacy.Kind.BOUNDARY_UNMET)) {
             out.append(String.format("      · no row is at %s = %s (%s)%n",
@@ -518,13 +523,23 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      */
     private static void branch(StringBuilder out, BehaviorReport behavior) {
         Adequacy.BranchEvidence branch = behavior.branch();
-        if (branch == null || branch.status() == MeasurementStatus.UNAVAILABLE) {
-            // Said only where there were arms to measure. A `>->` composition has none of its own, and
-            // telling its author the arms were not measured sends them after a measurement that was
-            // never owed.
-            if (branch != null && behavior.hasBody() && behavior.rows() > 0) {
-                out.append("    branch      unavailable (the arms were not measured)%n"
-                        .formatted());
+        if (branch == null) {
+            return;
+        }
+        if (branch.status() == MeasurementStatus.UNAVAILABLE) {
+            // The measure's own answer, translated. Nothing here works out why from the row count or
+            // the kind of behavior: those correlate with the reason and are not it, and the line an
+            // author reads is the one place that difference shows.
+            String said = switch (branch.reason()) {
+                case NO_BODY -> "not applicable (this behavior has no body)";
+                case UNREADABLE -> "unavailable (the arms could not be measured)";
+                // A build that did not ask, and a behavior nobody wrote a row for, are both quiet.
+                // The first is one fact about the run and saying it against every behavior repeats it;
+                // the second is what writing a row turns on, and an absence of evidence is not a gap.
+                case NOT_ASKED, NO_ROWS -> null;
+            };
+            if (said != null) {
+                out.append(String.format("    branch      %s%n", said));
             }
             return;
         }
@@ -552,7 +567,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * be five impossibilities.
      */
     private static String pairs(PartitionEvidence.PairSpace pairs) {
-        if (pairs == null || pairs.total() == 0) {
+        if (pairs == null || pairs.total() == 0
+                || pairs.status() == MeasurementStatus.UNAVAILABLE) {
             return "";
         }
         if (pairs.truncated()) {
@@ -566,6 +582,41 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         return String.format("   pairs %d reached / %d known reachable, %d %s",
                 pairs.covered(), pairs.witnessedFeasible(), pairs.unknown(),
                 pairs.status() == MeasurementStatus.COMPLETE ? "untried" : "undecided");
+    }
+
+    /**
+     * How many of a measure's parts have no number, and why, one note per distinct reason.
+     *
+     * <p>Grouped rather than summed. Two lines left unmeasured for two different reasons are two
+     * facts, and one count over both would be a number whose sentence is true of only some of what it
+     * counts — which is the shape of the thing this report stopped doing.
+     */
+    private static <T> String notes(List<T> all, java.util.function.Predicate<T> unmeasured,
+                                    java.util.function.Function<T, String> why) {
+        Map<String, Long> counted = new LinkedHashMap<>();
+        for (T each : all) {
+            if (unmeasured.test(each)) {
+                counted.merge(why.apply(each), 1L, Long::sum);
+            }
+        }
+        StringBuilder out = new StringBuilder();
+        counted.forEach((said, count) ->
+                out.append("   (").append(count).append(" not measured: ").append(said).append(')'));
+        return out.toString();
+    }
+
+    private static String whyNoAxis(PartitionEvidence.AxisCoverage.Reason reason) {
+        return switch (reason) {
+            case NO_ROWS -> "no row names this behavior";
+        };
+    }
+
+    private static String whyNoBoundary(PartitionEvidence.BoundaryCoverage.Reason reason) {
+        return switch (reason) {
+            case ARMS_NOT_ASKED -> "the arms were not asked for";
+            case ARMS_UNREADABLE -> "the arms could not be measured";
+            case NO_ROWS -> "no row names this behavior";
+        };
     }
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
@@ -615,7 +666,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             return;
         }
         ObjectNode out = behavior.putObject("signature");
-        out.put("status", signature.status().name().toLowerCase(java.util.Locale.ROOT));
+        measured(out, signature.status(), signature.reason());
         ObjectNode output = out.putObject("output");
         names(output.putArray("declared"), signature.output().declared());
         names(output.putArray("specified"), signature.output().specified());
@@ -653,7 +704,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                 ruled.reasons().forEach(e.putArray("reasons")::add);
             }
             a.put("unclassifiedRows", axis.unclassifiedRows());
-            a.put("status", axis.status().name().toLowerCase(java.util.Locale.ROOT));
+            measured(a, axis.status(), axis.reason());
         }
         ArrayNode boundaries = out.putArray("boundaries");
         for (PartitionEvidence.BoundaryCoverage boundary : partition.boundaries()) {
@@ -663,7 +714,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             b.put("side", boundary.side().name().toLowerCase(java.util.Locale.ROOT));
             b.put("value", boundary.value());
             b.put("hit", boundary.hit());
-            b.put("status", boundary.status().name().toLowerCase(java.util.Locale.ROOT));
+            measured(b, boundary.status(), boundary.reason());
         }
         ObjectNode pairs = out.putObject("pairs");
         pairs.put("total", partition.pairs().total());
@@ -672,7 +723,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         pairs.put("provenInfeasible", partition.pairs().provenInfeasible());
         pairs.put("unknown", partition.pairs().unknown());
         pairs.put("truncated", partition.pairs().truncated());
-        pairs.put("status", partition.pairs().status().name().toLowerCase(java.util.Locale.ROOT));
+        measured(pairs, partition.pairs().status(), partition.pairs().reason());
         partition.notDerivable().forEach(out.putArray("notDerivable")::add);
         ArrayNode omitted = out.putArray("omitted");
         partition.omitted().forEach(o -> omitted.add(o.reason().subject()));
@@ -683,7 +734,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             return;
         }
         ObjectNode out = behavior.putObject("branch");
-        out.put("status", branch.status().name().toLowerCase(java.util.Locale.ROOT));
+        measured(out, branch.status(), branch.reason());
         out.put("arms", branch.all().size());
         out.put("covered", branch.covered().size());
         // Only where every row was read. An arm a row that never finished might have gone through is
@@ -700,6 +751,21 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             at.put("sourceId", arm.at().sourceId());
             at.put("line", arm.at().pos().line());
             at.put("column", arm.at().pos().column());
+        }
+    }
+
+    /**
+     * What a measure managed, and where it managed nothing, why.
+     *
+     * <p>Two fields and not one. {@code status} says whether there is a number; {@code reason} says
+     * why there is not, and is absent where there is. A reader that only knows {@code status} reads
+     * exactly what it read before, and one that wants to tell a measure nobody asked for from a
+     * measure that failed no longer has to work it out from the numbers beside it.
+     */
+    private static void measured(ObjectNode of, MeasurementStatus status, Enum<?> reason) {
+        of.put("status", status.name().toLowerCase(java.util.Locale.ROOT));
+        if (reason != null) {
+            of.put("reason", reason.name().toLowerCase(java.util.Locale.ROOT));
         }
     }
 

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
@@ -30,6 +30,7 @@
   },
   "$defs": {
     "status": {
+      "description": "Whether a measure has a number. `unavailable` says only that it has none; the `reason` beside it says why, and the two are not read off one another.",
       "enum": ["complete", "partial", "unavailable"]
     },
     "module": {
@@ -81,9 +82,10 @@
       "required": ["status", "arms", "covered", "unreached"],
       "additionalProperties": false,
       "properties": {
-        "status": {
-          "$ref": "#/$defs/status",
-          "description": "`unavailable` where nothing measured the arms: a behavior with no `let`, one no row names, or a run whose instrumentation could not be tied back to the body."
+        "status": { "$ref": "#/$defs/status" },
+        "reason": {
+          "description": "Why there is no number, present exactly where `status` is `unavailable`. `no_body` is a behavior that has no arms to measure at all — a `>->` composition or one with no `let` — rather than arms nothing measured; `not_asked` is a build that did not ask for them; `unreadable` is a run whose instrumentation could not be tied back to the body; `no_rows` is a behavior no row names.",
+          "enum": ["no_body", "not_asked", "unreadable", "no_rows"]
         },
         "arms": { "type": "integer", "minimum": 0 },
         "covered": { "type": "integer", "minimum": 0 },
@@ -138,7 +140,11 @@
                 }
               },
               "unclassifiedRows": { "type": "integer", "minimum": 0 },
-              "status": { "$ref": "#/$defs/status" }
+              "status": { "$ref": "#/$defs/status" },
+              "reason": {
+                "description": "Why there is no number, present exactly where `status` is `unavailable`. A behavior no row names was not measured here, so the classes nothing sits in are not classes nothing reaches.",
+                "enum": ["no_rows"]
+              }
             }
           }
         },
@@ -154,9 +160,10 @@
               "side": { "enum": ["below", "at", "above"] },
               "value": { "type": "string" },
               "hit": { "type": "boolean" },
-              "status": {
-                "$ref": "#/$defs/status",
-                "description": "`unavailable` for a guard's boundary: meeting it takes the comparison having run, which nothing measures until the arms are instrumented."
+              "status": { "$ref": "#/$defs/status" },
+              "reason": {
+                "description": "Why there is no answer, present exactly where `status` is `unavailable`. `arms_not_asked` and `arms_unreadable` belong to a guard's line only, which is met by reaching the comparison rather than by writing the value; an invariant's line is met by writing it and is never waiting on the arms.",
+                "enum": ["arms_not_asked", "arms_unreadable", "no_rows"]
               }
             }
           }
@@ -184,6 +191,10 @@
             "$ref": "#/$defs/status",
             "description": "`partial` where some rows were not read at all: a combination none of the rows seen reaches has not been left untried by anybody."
           },
+          "reason": {
+            "description": "Why there are no numbers, present exactly where `status` is `unavailable`. How large the space is says nothing about a behavior no row names.",
+            "enum": ["no_rows"]
+          },
           "truncated": { "type": "boolean" }
           }
         },
@@ -206,6 +217,10 @@
       "additionalProperties": false,
       "properties": {
         "status": { "$ref": "#/$defs/status" },
+        "reason": {
+          "description": "Why there is no number, present exactly where `status` is `unavailable`.",
+          "enum": ["no_rows"]
+        },
         "output": {
           "type": "object",
           "required": ["declared", "specified", "observed", "verified", "unclassifiedRows"],

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -1,0 +1,418 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.MeasurementStatus;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.report.AdequacyReport;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Why a measure has no number, kept by the measure and not worked out again downstream.
+ *
+ * <p>Every one of these has the same shape underneath. A measure came back with nothing, the reason
+ * was not carried with it, and whatever read it next rebuilt the reason out of what else was to
+ * hand — the row count, whether the behavior was injected, whether the declaration had a body. Those
+ * correlate with the reason and are not it, so each rebuild was right about the cases it was written
+ * against and wrong about one nobody had in mind.
+ */
+class AMeasureWithNoNumberSaysWhyTest {
+
+    /**
+     * One model holding each way a measure can come back empty.
+     *
+     * <p>Together in one module on purpose: what the report says about any one of these is only
+     * right if it is still right beside the others, and the run that measures them is the same run.
+     */
+    private static final String MODEL = """
+            module example.repro
+
+            data Wrap = { v: String }
+            data Mid = { v: String }
+            data Out = { v: String }
+
+            behavior widen : (w: Wrap) -> Mid constructs Mid
+            let widen (w) = Mid { v = w.v }
+            behavior narrow : (m: Mid) -> Out constructs Out
+            let narrow (m) = Out { v = m.v }
+
+            behavior both = widen >-> narrow
+
+            example both
+                | (Wrap { v = "x" }) -> Out { v = "x" }
+
+            data Amount = Int
+                invariant value >= 0 && value <= 1000
+
+            data Req = { cost: Amount }
+            data Res = { n: Int }
+
+            behavior baseRate : (r: Req) -> Res
+                constructs Res
+
+            behavior rated : (r: Req) -> Res
+                constructs Res
+            let rated (r) = Res { n = r.cost.value }
+
+            data Yes
+            data No
+            data Flag = Yes | No
+            data Ask = { flag: Flag }
+
+            behavior classify : (q: Ask) -> Res
+                constructs Res
+            let classify (q) = Res { n = 1 }
+
+            example classify
+                | (Ask { flag = Yes }) -> Res { n = 1 }
+
+            data Pair = { left: Flag, right: Flag }
+
+            behavior sift : (p: Pair) -> Res
+                constructs Res
+            let sift (p) = Res { n = 0 }
+            """;
+
+    private static Compilation compiled() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static String human() {
+        return AdequacyReport.of(compiled()).human();
+    }
+
+    /**
+     * The whole report, fixed.
+     *
+     * <p>Fixed whole rather than line by line. Every wrong line this issue was about could have been
+     * removed by printing less, and a test that only forbids the wrong sentences passes on a report
+     * that says nothing at all. What each behavior is told about it is here to be read.
+     */
+    @Test
+    void theReportSaysWhatEachMeasureManagedAndWhyWhereItManagedNothing() {
+        assertEquals("""
+                example.repro                                            measurement: complete
+                  widen                    implemented   rows 0    pending 0
+                    partition   axes 0   single-axis 0/0
+                    boundary    0/0
+                      · not derivable: w.v
+                  narrow                   implemented   rows 0    pending 0
+                    partition   axes 0   single-axis 0/0
+                    boundary    0/0
+                      · not derivable: m.v
+                  both                     implemented   rows 1    pending 0
+                    branch      not applicable (this behavior has no body)
+                  baseRate                 injected      rows 0    pending 0
+                    partition   axes 0   single-axis 0/0
+                    boundary    0/0   (2 not measured: no row names this behavior)
+                    branch      not applicable (this behavior has no body)
+                  rated                    implemented   rows 0    pending 0
+                    partition   axes 0   single-axis 0/0
+                    boundary    0/0   (2 not measured: no row names this behavior)
+                  classify                 implemented   rows 1    pending 0
+                    partition   axes 1   single-axis 1/2
+                      · no row is in `No`
+                    boundary    0/0
+                    branch      0/0
+                  sift                     implemented   rows 0    pending 0
+                    partition   axes 2   single-axis 0/0   (2 not measured: no row names this behavior)
+                    boundary    0/0
+
+                7 behaviors: 6 implemented, 1 injected; 0 rows waiting for a `let`.
+                adequacy: undetermined
+                """, human());
+    }
+
+    /** What the report may not say, checked over the whole of it: a line removed from one behavior
+     * and left on another is the defect, not the fix. */
+    @Test
+    void nothingSaysAMeasurementIsStillComing() {
+        String human = human();
+        assertFalse(human.contains("until branches are"), human);
+        assertFalse(human.contains("were not measured"), human);
+    }
+
+    /**
+     * A behavior no row names has no gaps to be told about.
+     *
+     * <p>An absence of evidence is not a set of gaps, and naming the classes nothing sits in sends an
+     * author after rows on the strength of a measurement nobody made. Asked of {@code sift}, which
+     * has positions the model divides and no row at any of them — a behavior with no positions at all
+     * would pass this whatever the code did.
+     */
+    @Test
+    void aBehaviorNoRowNamesIsNotToldWhichClassesItMisses() {
+        PartitionEvidence partition = partitions().get("sift");
+        assertEquals(2, partition.axes().size(), "the model divides two positions here");
+        for (PartitionEvidence.AxisCoverage axis : partition.axes()) {
+            assertEquals(2, axis.classes().size(), axis.path());
+            assertEquals(PartitionEvidence.AxisCoverage.Reason.NO_ROWS, axis.reason(), axis.path());
+        }
+        assertEquals(List.of(), findings("sift", Adequacy.Kind.AXIS_CLASS_UNCOVERED),
+                "nothing was established, so nothing was found");
+
+        String sift = behaviorBlock(human(), "sift");
+        assertFalse(sift.contains("no row is in"), sift);
+        String classify = behaviorBlock(human(), "classify");
+        assertTrue(classify.contains("no row is in `No`"),
+                "the same line is still said where a row was written: " + classify);
+    }
+
+    /** How large the space of combinations is says nothing about a behavior no row names, so the
+     * numbers are not shown and the reason is. */
+    @Test
+    void thePairsOfABehaviorNoRowNamesAreNotCountedEither() {
+        PartitionEvidence.PairSpace pairs = partitions().get("sift").pairs();
+        assertEquals(4, pairs.total(), "two positions of two classes each");
+        assertEquals(MeasurementStatus.UNAVAILABLE, pairs.status());
+        assertEquals(PartitionEvidence.PairSpace.Reason.NO_ROWS, pairs.reason());
+        assertFalse(behaviorBlock(human(), "sift").contains("pairs"),
+                "untried is what nobody tried, and nobody was asked");
+    }
+
+    /** A composition has no arms of its own. Its stages have them, and it is not asked. */
+    @Test
+    void aCompositionSaysItsArmsDoNotApply() {
+        Adequacy.BranchEvidence branch = branches().get("both");
+        assertEquals(MeasurementStatus.UNAVAILABLE, branch.status());
+        assertEquals(Adequacy.BranchEvidence.Reason.NO_BODY, branch.reason());
+        assertFalse(branch.applicable(), "nothing here is owed a branch measure");
+    }
+
+    /** An injected behavior has none either, and it is the body and not the `let` that decides:
+     * the composition above is implemented and has no body all the same. */
+    @Test
+    void anInjectedBehaviorSaysTheSame() {
+        Adequacy.BranchEvidence branch = branches().get("baseRate");
+        assertEquals(Adequacy.BranchEvidence.Reason.NO_BODY, branch.reason());
+    }
+
+    /** A body with arms, that no row names, is a measure that was not made rather than one that does
+     * not apply. The verdict reads these apart. */
+    @Test
+    void aBodyNoRowNamesIsUnmeasuredAndNotInapplicable() {
+        Adequacy.BranchEvidence branch = branches().get("rated");
+        assertEquals(Adequacy.BranchEvidence.Reason.NO_ROWS, branch.reason());
+        assertTrue(branch.applicable(), "there are arms here; nothing asked about them");
+    }
+
+    /** A line an invariant drew is met by writing the value, so it is never waiting on the arms.
+     * The two origins are measured along separate paths for exactly this reason. */
+    @Test
+    void anInvariantsLineIsNeverWaitingOnTheArms() {
+        List<PartitionEvidence.BoundaryCoverage> lines = partitions().get("rated").boundaries();
+        assertFalse(lines.isEmpty(), "the invariant draws two");
+        for (PartitionEvidence.BoundaryCoverage line : lines) {
+            assertEquals(PartitionEvidence.BoundaryCoverage.Reason.NO_ROWS, line.reason(),
+                    line.origin() + " at " + line.value());
+        }
+    }
+
+    /**
+     * A source that could not be evaluated, holding the only rows one behavior has.
+     *
+     * <p>The attached file redeclares a name the module already declares, so it does not evaluate.
+     * `take` keeps the row written beside it; `elsewhere` has every row it owns in there, and what
+     * comes back for it is an empty list of rows and a reason saying the list is not the model's.
+     */
+    private static final List<String> UNSEEN = List.of("""
+            module example.unseen
+
+            data Amount = Int
+                invariant value >= 0 && value <= 1000
+
+            data Yes
+            data No
+            data Flag = Yes | No
+
+            data Draft = { cost: Amount, flag: Flag }
+            data Ok = { n: Int }
+
+            let shared = Draft { cost = Amount(7), flag = Yes }
+
+            behavior take : (request: Draft) -> Ok
+                constructs Ok
+            let take (request) = Ok { n = request.cost.value }
+
+            behavior elsewhere : (request: Draft) -> Ok
+                constructs Ok
+            let elsewhere (request) = {
+                guard request.cost.value <= 100 else Ok { n = 0 }
+                Ok { n = request.cost.value }
+            }
+
+            example take
+                | (Draft { cost = Amount(7), flag = Yes }) -> Ok { n = 7 }
+            """, """
+            examples for example.unseen
+
+            let shared = Draft { cost = Amount(0), flag = No }
+
+            example elsewhere
+                | (Draft { cost = Amount(0), flag = No }) -> Ok { n = 0 }
+            """);
+
+    private static Compilation unseen() {
+        Compilation compilation = Compilation.ofSources(UNSEEN,
+                souther.compiler.meta.ModulePath.EMPTY);
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    /**
+     * No rows to read and no rows are two different things.
+     *
+     * <p>A behavior nobody wrote a row for is not being asked. A behavior whose rows are in a source
+     * that would not evaluate is being asked and cannot be answered, and the rows it is waiting on may
+     * already be written. Calling the second `no_rows` tells an author to write what is sitting in the
+     * file the run could not read — which is the mistake this whole change is about, made once more
+     * about a different pair of correlated states.
+     */
+    @Test
+    void rowsNothingCouldReadAreNotRowsThatWereNeverWritten() {
+        Compilation compilation = unseen();
+        AdequacyReport.BehaviorReport reported = AdequacyReport.of(compilation)
+                .modules().get(0).behaviors().stream()
+                .filter(b -> b.name().equals("elsewhere")).findFirst().orElseThrow();
+        assertEquals(0, reported.rows(), "nothing was read");
+        assertTrue(AdequacyReport.of(compilation).modules().get(0).incompleteness().stream()
+                        .anyMatch(gap -> gap.code() == Incompleteness.Code.RUNTIME_ABSENT),
+                "and there may well have been something to read");
+
+        Adequacy.BranchEvidence branch = compilation.db()
+                .ask(new Adequacy.BranchCoverage("example.unseen")).value().get("elsewhere");
+        assertNotEquals(Adequacy.BranchEvidence.Reason.NO_ROWS, branch.reason(),
+                "the rows this is waiting on may be the ones that went unread");
+        assertEquals(MeasurementStatus.PARTIAL, branch.status(),
+                "there are arms, and which of them were reached is undecided");
+
+        PartitionEvidence partition = compilation.db()
+                .ask(new Adequacy.Coverage("example.unseen")).value().get("elsewhere");
+        assertFalse(partition.boundaries().isEmpty(), "the invariant and the guard draw lines");
+        for (PartitionEvidence.BoundaryCoverage line : partition.boundaries()) {
+            assertNotEquals(PartitionEvidence.BoundaryCoverage.Reason.NO_ROWS, line.reason(),
+                    line.origin() + " at " + line.value());
+            assertEquals(MeasurementStatus.PARTIAL, line.status(),
+                    line.origin() + " at " + line.value());
+        }
+    }
+
+    /** The behavior beside it, whose own row was read, still answers from what was read. */
+    @Test
+    void aBehaviorWhoseRowsWereReadIsUnaffectedByTheSourceThatWasNot() {
+        Adequacy.BranchEvidence branch = unseen().db()
+                .ask(new Adequacy.BranchCoverage("example.unseen")).value().get("take");
+        assertNull(branch.reason(), "this one was measured");
+    }
+
+    /**
+     * The contract, both ways, over every measure the model produced.
+     *
+     * <p>Both ways because one way alone lets the opposite mistake in. Without the first a measure
+     * can go back to coming home empty and silent; without the second a measure can carry a reason
+     * beside a number, which says a value is missing and gives it in the same breath.
+     */
+    @Test
+    void aMeasureWithNoNumberSaysWhyAndOneWithANumberDoesNot() {
+        List<Object[]> measures = new ArrayList<>();
+        for (Map.Entry<String, Adequacy.BranchEvidence> each : branches().entrySet()) {
+            measures.add(new Object[] {"branch " + each.getKey(),
+                    each.getValue().status(), each.getValue().reason()});
+        }
+        for (Map.Entry<String, Adequacy.SignatureEvidence> each : signatures().entrySet()) {
+            measures.add(new Object[] {"signature " + each.getKey(),
+                    each.getValue().status(), each.getValue().reason()});
+            measures.add(new Object[] {"out " + each.getKey(),
+                    each.getValue().output().status(), each.getValue().output().reason()});
+            each.getValue().inputs().forEach(in -> measures.add(
+                    new Object[] {"in " + each.getKey(), in.status(), in.reason()}));
+        }
+        for (Map.Entry<String, PartitionEvidence> each : partitions().entrySet()) {
+            PartitionEvidence partition = each.getValue();
+            measures.add(new Object[] {"pairs " + each.getKey(),
+                    partition.pairs().status(), partition.pairs().reason()});
+            partition.axes().forEach(a -> measures.add(
+                    new Object[] {"axis " + each.getKey(), a.status(), a.reason()}));
+            partition.boundaries().forEach(b -> measures.add(
+                    new Object[] {"boundary " + each.getKey(), b.status(), b.reason()}));
+        }
+        assertTrue(measures.size() > 20, "the model produces every kind: " + measures.size());
+        for (Object[] measure : measures) {
+            if (measure[1] == MeasurementStatus.UNAVAILABLE) {
+                assertNotNull(measure[2], measure[0] + " has no number and does not say why");
+            } else {
+                assertNull(measure[2], measure[0] + " has a number and says why it has none");
+            }
+        }
+    }
+
+    /** Held where the value is built, so that no measure can be assembled without it. */
+    @Test
+    void aMeasureCannotBeBuiltWithoutKeepingThatContract() {
+        assertThrows(IllegalArgumentException.class, () -> new Adequacy.BranchEvidence(
+                List.of(), java.util.Set.of(), MeasurementStatus.UNAVAILABLE, null));
+        assertThrows(IllegalArgumentException.class, () -> new Adequacy.BranchEvidence(
+                List.of(), java.util.Set.of(), MeasurementStatus.COMPLETE,
+                Adequacy.BranchEvidence.Reason.NO_BODY));
+        assertThrows(IllegalArgumentException.class, () -> new PartitionEvidence.AxisCoverage(
+                "a", "a", List.of(), java.util.Set.of(), List.of(), 0,
+                MeasurementStatus.UNAVAILABLE, null));
+    }
+
+    private static String behaviorBlock(String human, String behavior) {
+        List<String> kept = new ArrayList<>();
+        boolean inside = false;
+        for (String line : human.lines().toList()) {
+            if (line.startsWith("  ") && !line.startsWith("    ") && !line.startsWith("      ")) {
+                inside = line.trim().startsWith(behavior + " ");
+            }
+            if (inside) {
+                kept.add(line);
+            }
+        }
+        assertFalse(kept.isEmpty(), behavior + " is in the report");
+        return String.join("\n", kept);
+    }
+
+    private static Map<String, Adequacy.BranchEvidence> branches() {
+        Compilation compilation = compiled();
+        return compilation.db()
+                .ask(new Adequacy.BranchCoverage(compilation.modules().get(0))).value();
+    }
+
+    private static Map<String, PartitionEvidence> partitions() {
+        Compilation compilation = compiled();
+        return compilation.db().ask(new Adequacy.Coverage(compilation.modules().get(0))).value();
+    }
+
+    private static List<Adequacy.Finding> findings(String behavior, Adequacy.Kind kind) {
+        Compilation compilation = compiled();
+        Map<String, List<Adequacy.Finding>> all = compilation.db()
+                .ask(new Adequacy.Findings(compilation.modules().get(0))).value();
+        return all.getOrDefault(behavior, List.of()).stream()
+                .filter(f -> f.kind() == kind).toList();
+    }
+
+    private static Map<String, Adequacy.SignatureEvidence> signatures() {
+        Compilation compilation = compiled();
+        return compilation.db().ask(new Adequacy.Witnesses(compilation.modules().get(0))).value();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/MainExamplesSubcommandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/MainExamplesSubcommandTest.java
@@ -195,6 +195,53 @@ class MainExamplesSubcommandTest {
         JsonNode behaviorDef = schema.get("$defs").get("behavior");
         agrees(module.get("behaviors").get(0), behaviorDef.get("properties"),
                 behaviorDef.get("required"));
+
+        // Down to where the measures are. What each of them says about itself is the part that has
+        // grown, and a check that stopped at the behavior would not have seen any of it arrive.
+        for (JsonNode behavior : module.get("behaviors")) {
+            for (String measure : List.of("signature", "partition", "branch")) {
+                if (behavior.has(measure)) {
+                    JsonNode def = schema.get("$defs").get(measure);
+                    agrees(behavior.get(measure), def.get("properties"), def.get("required"));
+                }
+            }
+            if (!behavior.has("partition")) {
+                continue;
+            }
+            JsonNode partitionDef = schema.get("$defs").get("partition").get("properties");
+            JsonNode partition = behavior.get("partition");
+            for (String each : List.of("axes", "boundaries")) {
+                JsonNode itemDef = partitionDef.get(each).get("items");
+                for (JsonNode item : partition.get(each)) {
+                    agrees(item, itemDef.get("properties"), itemDef.get("required"));
+                }
+            }
+            JsonNode pairsDef = partitionDef.get("pairs");
+            agrees(partition.get("pairs"), pairsDef.get("properties"), pairsDef.get("required"));
+        }
+    }
+
+    /**
+     * A measure with no number says why, in the emitted document and not only in the evidence.
+     *
+     * <p>Both directions. A reader told the arms are unavailable and left to work out whether that is
+     * a behavior with none or a run that failed is the reader this field exists for, and a reason
+     * printed beside a number would say a value is missing and give it in the same breath.
+     */
+    @Test
+    void everyUnavailableMeasureInTheJsonSaysWhy() throws Exception {
+        JsonNode root = JSON.readTree(run("--format", "json"));
+        int seen = 0;
+        for (JsonNode node : root.findParents("status")) {
+            if (!node.has("reason") && !"unavailable".equals(node.get("status").asString())) {
+                continue;
+            }
+            seen++;
+            assertEquals("unavailable", node.get("status").asString(),
+                    "a reason is given beside a number: " + node);
+            assertTrue(node.has("reason"), "no number and no reason: " + node);
+        }
+        assertTrue(seen > 0, "the model under test has a measure with no number: " + root);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
@@ -228,7 +228,7 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
     void anAxisDroppedPastTheLimitHoldsTheVerdictOpenOnlyWhereItCarriedAnObligation() {
         PartitionEvidence.BoundaryCoverage met = new PartitionEvidence.BoundaryCoverage(
                 "weigh/w.a", "guard", BoundaryObligation.BoundarySide.AT, "100", true,
-                MeasurementStatus.COMPLETE);
+                MeasurementStatus.COMPLETE, null);
 
         assertEquals(AdequacyReport.AdequacyStatus.SATISFIED, verdictOf(partition(met)),
                 "nothing dropped");
@@ -254,7 +254,7 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
     /** What one behavior's partition makes of the whole report, with nothing else asked about. */
     private static AdequacyReport.AdequacyStatus verdictOf(PartitionEvidence partition) {
         AdequacyReport.BehaviorReport behavior = new AdequacyReport.BehaviorReport(
-                "weigh", false, true, 1, 0, MeasurementStatus.COMPLETE, null, partition,
+                "weigh", false, 1, 0, MeasurementStatus.COMPLETE, null, partition,
                 null, List.of());
         return new AdequacyReport(AdequacyReport.SCHEMA_VERSION, "test", Adequacy.Level.ALL,
                 MeasurementStatus.COMPLETE,

--- a/specification.adoc
+++ b/specification.adoc
@@ -2676,6 +2676,29 @@ A function written where a call takes one is made there and run elsewhere. Evalu
 
 *A boundary a guard drew is met by reaching the comparison, not by writing the value.* A threshold read off a `+guard+` is a boundary to reach (<<example-adequacy>>), and a row can carry exactly that value and never get to the guard because an earlier branch went the other way. Such a boundary counts as met only where a row both wrote the value and went through one of the two arms of the `+if+` whose condition compares it. A boundary an invariant drew is met by writing the value: nothing outside the bound can be constructed, so the edge is the whole of what there is to reach.
 
+[#example-report-vocabulary]
+=== The words the report uses
+
+`+souther examples+` writes its own words, and a reader who wants to know what one of them means has nowhere to look it up unless it is written down. A diagnostic carries a code and a code names a rule; a line of this report carries neither, so its vocabulary is fixed here.
+
+*What the rows establish about a case.* `+specified+` — a row expects this case; `+observed+` — the behavior was seen to answer with it; `+verified+` — a row expected it and the behavior produced it. An input position carries `+executed+` where an output carries `+observed+` (<<example-adequacy>>).
+
+*What the rows reach of the model's own distinctions.* `+partition axes+` is how many positions the model divides at all; `+single-axis+` is how many of those positions' classes some row is in; `+pairs+` counts combinations across two positions, as counts rather than a ratio (<<example-partition>>). `+boundary+` is the lines some rule drew that a row is at. `+not derivable+` is a position the model draws no line through, which is a fact about the model and not a gap in the rows.
+
+*Whether a measure has a number.* Three states, and the report's own word for each. `+complete+` — the measure was made and everything it reads was readable, so a gap is a gap. `+partial+` — it was made and something it reads was not, so it shows what it saw and what it could not decide; a line under a partial measure reads `+undecided+`, which is that measure's account of one thing rather than a state of its own. `+unavailable+` — there is no number.
+
+*Why a measure has none.* `+unavailable+` alone does not say, and the two states it covers ask opposite things of a reader:
+
+* [[a-measure-says-why-it-has-no-number]]a measure that has no number MUST say why, and one that has a number MUST NOT.
+
+`+not applicable+` — there is nothing here for the measure to be about, and no row could change that: a `+>->+` composition and a behavior with no `+let+` have no arms, and a position that is not a sum has no cases to cover. `+not measured+` — it could have been made and was not, and which of the reasons is given: no row names this behavior, the build did not ask for the arms, or the run's instrumentation could not be tied back to the body.
+
+That difference is the one worth reading. `+not applicable+` asks nothing of an author. `+not measured+` says what to do: write a row, ask for the arms, or find out why the run could not read them. Rows that nothing could read are neither — a source that would not evaluate may hold the row being asked for, so what it was carrying is undecided rather than absent.
+
+*A measure's reason is the measure's own.* It is not worked out from the numbers beside it, from how many rows a behavior has, or from whether the behavior is injected. Those correlate with the reason and are not it.
+
+*The JSON form carries the same two.* Every measure emits `+status+`, and emits `+reason+` exactly where `+status+` is `+unavailable+`. `+schemaVersion+` is raised when a field is removed or renamed, and not when one is added: a document written before a field existed is still a document of this version. That holds one way only. Every object in the schema is closed, so an older copy of it refuses a document carrying a field added since; a reader that has to accept newer documents wants the newer schema rather than a higher number.
+
 [#control-flow]
 == Control structures
 


### PR DESCRIPTION
Two lines of the `examples` report named a measure that would never be taken, in wording that read as a measurement that failed. Both came from one thing: `MeasurementStatus.UNAVAILABLE` said a measure had no value and never said why.

## What was happening

The layer that has to choose a sentence rebuilt the reason from whatever else was to hand — the row count, whether the behavior was injected, whether the declaration had a body. Each correlates with the reason and is not it, so each rule was right about the cases it was written against and wrong about one nobody had in mind.

| measure | reasons collapsed into one value | what the report inferred instead | result |
|---|---|---|---|
| branch | no body / not asked / unreadable / no rows | `hasBody && rows > 0` | a `>->` composition told the arms were not measured |
| boundary | no rows / a guard's line waiting on the arms | every unavailable line | a behavior no row names told its lines wait on branches |
| axis | no rows | `UNAVAILABLE` treated as `COMPLETE` | classes named as missed on a measurement nobody made |

The third contradicted `[#example-adequacy]` outright: an absence of evidence is not a set of gaps. Three more measures — pairs, signature, and the case evidence — had the same gap and no symptom yet.

## What this does

Every measure carries why it has no value. The reason is stored where it would otherwise be lost and derived where the evidence already encodes it: `NOT_A_SUM` is `declared.isEmpty()`, so a field beside it would be a second copy of a fact the record holds. What the contract requires is the meaning, not the field. `Unavailable.check` holds both directions where the value is built — a measure cannot be assembled without a reason, or with one beside a number.

Each measurement resolves its reason as a sequence of gates and answers with the first that did not open, so a reader gets what stopped it rather than whichever condition an expression tested first. A guard's line and an invariant's resolve along separate paths: meeting a guard's takes the comparison having run, an invariant's is met by writing the value, and `ARMS_NOT_ASKED` can no longer appear on a line that needs no arms.

Structural non-applicability stays encoded as `UNAVAILABLE` with `NO_BODY` rather than widening `MeasurementStatus`, and `applicable()` encapsulates that. Callers ask the question instead of reading the constant, so adding `NOT_APPLICABLE` later touches no consumer.

`BehaviorReport.hasBody` is gone. #428 added it to recover from the declaration what the evidence had dropped, and its second reader was the adequacy verdict — what `--strict` exits on — so this was not only about wording. That the field can be deleted is the check that the provenance is back where it belongs.

A class of an axis nothing measured no longer becomes a finding at all. A finding is something a measure established, and one from a measure that was never made is not. It happened to carry no exit code; that was luck, not design.

## Before and after

```
  underwrite               implemented   rows 0    pending 0
-   branch      unavailable (the arms were not measured)
+   branch      not applicable (this behavior has no body)
  baseRate                 injected      rows 0    pending 0
-   boundary    0/0   (2 not measured until branches are)
+   boundary    0/0   (2 not measured: no row names this behavior)
```

## JSON

`reason` is emitted beside `status` wherever a measure has no value. `schemaVersion` stays 1: the shipped schema says a removal or a rename raises it, and this adds. The schema's own descriptions of `unavailable` had the same conflation written into them and now say what each reason is. The schema-agreement test reached only the top, module and behavior levels, so none of the measures were covered; it now descends to them.

## Docs

`[#example-report-vocabulary]` gives the report's words an anchor. A diagnostic carries a code and a code names a rule; a line of this report carried neither, so `specified` / `observed` / `verified`, `partition axes`, `not derivable`, `not applicable` and `not measured` could not be looked up. ADR-0089 is revised in place rather than joined by a new one — this states a consequence of the evidence model it already establishes.

## Checks

`mvn clean install` across every module: 3776 tests, no failures. Nine new tests fix the whole report as a snapshot, forbid the old sentences over the whole of the output, hold the contract both ways across every measure the model produces, and check that a measure cannot be built breaking it. Verified through the CLI on a model shaped like the one in the issue.

## Compatibility

The shipped schema already states the policy and states it one way: an added field does not raise the version, so a document written before it existed is still a document of this version, and every object is closed, so an older copy of the schema refuses a document carrying a field added since. `[#example-report-vocabulary]` says the same, rather than the stronger and untrue "a reader ignores what it does not know" — no wording here can make a strict decoder that already shipped accept a key it was never told about.

## Review

Four things came back and all four are in.

Rows nothing could read were being called rows that were never written. Where a source will not evaluate, `Observed` comes back with an empty list and a reason saying the list is not the model's, and both `whyNoArms` and the boundary path answered `NO_ROWS` on the empty list alone — telling an author to write a row that may be sitting in the file the run could not read. That is this issue's own mistake made once more about a different pair of correlated states, so it is a blocker, not a polish item. Both now let the measure go ahead on what was seen and come back `PARTIAL`; axis, pairs and signature already did.

The axis regression was not covered. Every zero-row behavior in the fixture had no divided position, so the assertion that none of them is told which classes it misses passed on an empty set, and no behavior had two axes and no rows, so `PairSpace.NO_ROWS` was never produced. `sift` is there now — two positions, two classes each, no row — and the axis reason, the absent finding and the pair space are all held.

`MeasurementStatus.UNAVAILABLE` still carried the old definition in its javadoc, naming one of the four reasons as if it were the meaning. The glossary listed four states while the vocabulary on screen has `partial`, which is not a state without a number. Both say what is actually there.

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)
