### PR TITLE
Formatter comment handling is lossless and provenance-preserving

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
@@ -81,6 +81,106 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 """, below);
     }
 
+    /** A sum's cases are identifiers rather than nodes, so a case cannot be named the way a field
+     * can. The comment is held against where the identifier is instead. The last case is the
+     * exception: the declaration ends where it does, and what ends on a line is what the line was
+     * about. */
+    @Test
+    void onTheSumCaseItWasWrittenAfter() {
+        String formatted = Formatter.format("""
+                module m
+                data A
+                data B
+                data C
+                data S = A   // about A
+                    | B
+                    | C
+                """);
+
+        assertEquals("""
+                module m
+
+                data A
+
+                data B
+
+                data C
+
+                data S = A // about A
+                    | B
+                    | C
+                """, formatted);
+    }
+
+    /** A comment above an attempt's departure, and above a pipeline's stage. Both are written one to
+     * a line, and neither was asked for its comments. */
+    @Test
+    void aboveADepartureAndAboveAStage() {
+        String departures = Formatter.format("""
+                module m
+                data Amount = Int
+                    invariant value > 0
+                data O = { n: Int }
+                behavior f : (n: Int) -> O | Amount constructs O, Amount
+                let f (n) = {
+                    guard Amount(n) as a else
+                        // why this arm
+                        | value -> Amount(1)
+                    O { n = a.value }
+                }
+                """);
+        String stages = Formatter.format("""
+                module m exposing ( p )
+                data A = { n: Int }
+                data B = { n: Int }
+                behavior one : (a: A) -> B constructs B
+                behavior p =
+                    one
+                    // why this stage
+                    >-> one
+                """);
+
+        assertEquals("""
+                module m
+
+                data Amount = Int
+                    invariant value > 0
+
+                data O =
+                    { n: Int
+                    }
+
+                behavior f : (n: Int) -> O | Amount
+                    constructs O, Amount
+
+                let f (n) = {
+                    guard Amount(n) as a else
+                        // why this arm
+                        | value -> Amount(1)
+                    O { n = a.value }
+                }
+                """, departures);
+        assertEquals("""
+                module m exposing ( p )
+
+                data A =
+                    { n: Int
+                    }
+
+                data B =
+                    { n: Int
+                    }
+
+                behavior one : (a: A) -> B
+                    constructs B
+
+                behavior p =
+                    one
+                    // why this stage
+                    >-> one
+                """, stages);
+    }
+
     @Test
     void onTheFieldItWasWrittenAfter() {
         String formatted = Formatter.format("""

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
@@ -38,6 +38,49 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 """, formatted);
     }
 
+    /**
+     * The same words in the same place in the child list, told apart by the whitespace in front of
+     * them: the one below carries the newline that ended the line above it and the one beside does
+     * not. Written as a pair because either half alone is satisfied by a formatter that treats every
+     * comment the same way.
+     */
+    @Test
+    void whichOfTheTwoItIsComesFromTheWhitespaceBeforeIt() {
+        String beside = Formatter.format("""
+                module m
+                data D =
+                    { a: Int   // the comment
+                    , b: Int
+                    }
+                """);
+        String below = Formatter.format("""
+                module m
+                data D =
+                    { a: Int
+                    // the comment
+                    , b: Int
+                    }
+                """);
+
+        assertEquals("""
+                module m
+
+                data D =
+                    { a: Int // the comment
+                    , b: Int
+                    }
+                """, beside);
+        assertEquals("""
+                module m
+
+                data D =
+                    { a: Int
+                    // the comment
+                    , b: Int
+                    }
+                """, below);
+    }
+
     @Test
     void onTheFieldItWasWrittenAfter() {
         String formatted = Formatter.format("""

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
@@ -38,6 +38,109 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 """, formatted);
     }
 
+    @Test
+    void onTheFieldItWasWrittenAfter() {
+        String formatted = Formatter.format("""
+                module m
+                data AccountId = String
+                data DomainName = String
+                data Industry
+                data Account =
+                    { id: AccountId
+                    , domain: DomainName?         // an honest optional
+                    , industry: Industry
+                    }
+                """);
+
+        assertEquals("""
+                module m
+
+                data AccountId = String
+
+                data DomainName = String
+
+                data Industry
+
+                data Account =
+                    { id: AccountId
+                    , domain: DomainName? // an honest optional
+                    , industry: Industry
+                    }
+                """, formatted);
+    }
+
+    /** In a list whose members are separated rather than opened, the comment goes after the comma:
+     * the comma is on that line too, and one written after the comment would be inside it. */
+    @Test
+    void afterTheCommaWhenTheMemberIsFollowedByOne() {
+        String formatted = Formatter.format("""
+                module m
+                data O = { a: Int, b: Int }
+                behavior f : (n: Int) -> O constructs O
+                let f (n) = O {
+                  a = n,   // the first
+                  b = n
+                }
+                """);
+
+        assertEquals("""
+                module m
+
+                data O =
+                    { a: Int
+                    , b: Int
+                    }
+
+                behavior f : (n: Int) -> O
+                    constructs O
+
+                let f (n) =
+                    O {
+                        a = n, // the first
+                        b = n
+                    }
+                """, formatted);
+    }
+
+    @Test
+    void onTheMatchArmItWasWrittenAfter() {
+        String formatted = Formatter.format("""
+                module m
+                data A
+                data B
+                data S = A | B
+                data O = { n: Int }
+                behavior f : (s: S) -> O constructs O
+                let f (s) = O { n = match s with
+                  | A -> 1   // the first
+                  | B -> 2 }
+                """);
+
+        assertEquals("""
+                module m
+
+                data A
+
+                data B
+
+                data S = A | B
+
+                data O =
+                    { n: Int
+                    }
+
+                behavior f : (s: S) -> O
+                    constructs O
+
+                let f (s) =
+                    O {
+                        n = match s with
+                            | A -> 1 // the first
+                            | B -> 2
+                    }
+                """, formatted);
+    }
+
     /** A trailing comment is not content the width has to make room for. It sits past the end of the
      * line whatever its length, so measuring the line against it would break a construct that fits. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
@@ -1,0 +1,96 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A comment written after code on the same line was written about that code, and it comes back on
+ * that code's line. It used to be handed to whatever was declared next, which is a different claim
+ * about the same words and one a reader has no way to see was ever made.
+ *
+ * <p>The line it comes back on is the line the code ends on after formatting, which is not
+ * necessarily the line it ended on before: the layout is re-derived, so where a construct ends is a
+ * derived value and only which construct the comment is about is preserved.
+ */
+class ACommentAtTheEndOfALineStaysOnItTest {
+
+    @Test
+    void onTheDeclarationItWasWrittenAfter() {
+        String formatted = Formatter.format("""
+                module m
+                data WebForm
+                data PhoneInquiry
+                data Inbound = WebForm | PhoneInquiry      // three units; nothing to attribute
+                data LeadSource = Inbound
+                """);
+
+        assertEquals("""
+                module m
+
+                data WebForm
+
+                data PhoneInquiry
+
+                data Inbound = WebForm | PhoneInquiry // three units; nothing to attribute
+
+                data LeadSource = Inbound
+                """, formatted);
+    }
+
+    /** A trailing comment is not content the width has to make room for. It sits past the end of the
+     * line whatever its length, so measuring the line against it would break a construct that fits. */
+    @Test
+    void andDoesNotCountTowardsTheWidth() {
+        String formatted = Formatter.format("""
+                module m
+                data WebForm
+                data PhoneInquiry
+                data Inbound = WebForm | PhoneInquiry   // a comment long enough that the line it is written on runs well past the hundred columns the canonical form is measured against
+                """);
+
+        assertEquals("""
+                module m
+
+                data WebForm
+
+                data PhoneInquiry
+
+                data Inbound = WebForm | PhoneInquiry // a comment long enough that the line it is written on runs well past the hundred columns the canonical form is measured against
+                """, formatted);
+    }
+
+    /** The declaration's own layout still comes from its own width. */
+    @Test
+    void whileTheDeclarationItselfStillBreaksOnIts() {
+        String formatted = Formatter.format("""
+                module m
+                data AlphaMeasurement
+                data BetaMeasurement
+                data GammaMeasurement
+                data DeltaMeasurement
+                data EpsilonMeasurement
+                data Measurement = AlphaMeasurement | BetaMeasurement | GammaMeasurement | DeltaMeasurement | EpsilonMeasurement   // five of them
+                """);
+
+        assertEquals("""
+                module m
+
+                data AlphaMeasurement
+
+                data BetaMeasurement
+
+                data GammaMeasurement
+
+                data DeltaMeasurement
+
+                data EpsilonMeasurement
+
+                data Measurement = AlphaMeasurement
+                    | BetaMeasurement
+                    | GammaMeasurement
+                    | DeltaMeasurement
+                    | EpsilonMeasurement // five of them
+                """, formatted);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -232,6 +232,77 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 """));
     }
 
+    /**
+     * Written as part of a run the layout flattens. The parser reads {@code 1 |> b |> c} as nesting
+     * and the layout writes it as one run of segments, so what the comment is about — the inner
+     * {@code 1 |> b} — is not a construct the output has a line for. Its segment is.
+     */
+    @Test
+    void aMemberWrittenAsPartOfAFlattenedRun() {
+        assertEquals("""
+                module m
+
+                let b (x: Int) = x
+
+                let c (x: Int) = x
+
+                let value =
+                    1
+                        |> b // about the b stage
+                        |> c
+                """, Formatter.format("""
+                module m
+                let b (x: Int) = x
+                let c (x: Int) = x
+                let value = 1
+                    |> b   // about the b stage
+                    |> c
+                """));
+    }
+
+    /** An operator run is the same shape, and was the same defect: the segments are what the layout
+     * writes, and only the pipeline had been asked. */
+    @Test
+    void andAnOperatorRunIsTheSameShape() {
+        assertEquals("""
+                module m
+
+                let value =
+                    1
+                        + 2 // about the second term
+                        + 3
+                """, Formatter.format("""
+                module m
+                let value = 1
+                    + 2   // about the second term
+                    + 3
+                """));
+    }
+
+    /** Written as a member of a nested bracketed construct: a type argument. It is a node, like a
+     * field, and unlike a field it was not being read as a member. */
+    @Test
+    void aMemberWrittenInsideNestedBrackets() {
+        assertEquals("""
+                module m
+
+                data D =
+                    { xs: List<
+                        // element type
+                        Int
+                    >
+                    }
+                """, Formatter.format("""
+                module m
+                data D =
+                    { xs: List<
+                        // element type
+                        Int
+                      >
+                    }
+                """));
+    }
+
     /** No member to be about: the comment was written above the construct, and stays above it rather
      * than moving inside where the construct's own end comments go. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -373,6 +373,50 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 """));
     }
 
+    /**
+     * Written about one part of a row, which the layout writes as a chain of segments the way it
+     * writes a pipeline. A row's input and its expected value are segments, and so is a match arm's
+     * body; none of the three was asked what was written about it, so all three answered with the
+     * row or the arm.
+     */
+    @Test
+    void aPartOfARowWrittenAsAChain() {
+        assertEquals("""
+                module m
+
+                let helper (n: Int) = n
+
+                example helper
+                    | (2)
+                        // expected result
+                        -> 2
+                """, Formatter.format("""
+                module m
+                let helper (n: Int) = n
+
+                example helper
+                    | (2) ->
+                        // expected result
+                        2
+                """));
+        assertEquals("""
+                module m
+
+                let helper (n: Int) = n
+
+                example helper
+                    | (2) // input
+                        -> 2
+                """, Formatter.format("""
+                module m
+                let helper (n: Int) = n
+
+                example helper
+                    | (2)   // input
+                        -> 2
+                """));
+    }
+
     /** No member to be about: the comment was written above the construct, and stays above it rather
      * than moving inside where the construct's own end comments go. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -303,6 +303,52 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 """));
     }
 
+    /** The other side of an operator run: what is written above a segment rather than at the end of
+     * one. The two are separate paths and only the first had been asked for. */
+    @Test
+    void andAboveASegmentOfAnOperatorRun() {
+        assertEquals("""
+                module m
+
+                let value =
+                    1
+                        // about the second term
+                        + 2
+                        + 3
+                """, Formatter.format("""
+                module m
+                let value = 1
+                    // about the second term
+                    + 2
+                    + 3
+                """));
+    }
+
+    /** Under the last member of a nested bracketed construct. What closes a type's arguments is the
+     * same angle bracket the grammar compares with, so it had to be read as the closer it is here
+     * before it was read as the operator it is elsewhere. */
+    @Test
+    void underTheLastMemberOfNestedBrackets() {
+        assertEquals("""
+                module m
+
+                data D =
+                    { xs: List<
+                        Int
+                        // why Int is allowed
+                    >
+                    }
+                """, Formatter.format("""
+                module m
+                data D =
+                    { xs: List<
+                        Int
+                        // why Int is allowed
+                      >
+                    }
+                """));
+    }
+
     /** No member to be about: the comment was written above the construct, and stays above it rather
      * than moving inside where the construct's own end comments go. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -1,0 +1,188 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A comment stays on the member it was written about, whichever way the grammar writes that member.
+ *
+ * <p>The cases here are the ways a member can be written rather than the constructs that have
+ * members: a member is a node, or a bare identifier the enclosing construct holds directly, or a
+ * segment of a chain, or absent because the construct is empty, or a part of an expression with no
+ * line of its own. A sum's cases needed their own answer because they are identifiers, and the
+ * answer was written for sums alone — which left an import's names and a {@code constructs} clause's
+ * names, the same way of writing a member under a different construct, still losing theirs.
+ *
+ * <p>The survival sweep cannot ask this. A comment moved from one member to the next is one comment
+ * in and one comment out, and the code around it is unchanged; what changed is the only thing a
+ * comment is for.
+ */
+class ACommentKeepsItsMemberHoweverItIsWrittenTest {
+
+    /** Written as a node: a field of a product block. */
+    @Test
+    void aMemberWrittenAsANode() {
+        assertEquals("""
+                module m
+
+                data D =
+                    { a: Int
+                    // about b
+                    , b: Int
+                    }
+                """, Formatter.format("""
+                module m
+                data D =
+                    { a: Int
+                    // about b
+                    , b: Int
+                    }
+                """));
+    }
+
+    /** Written as an identifier the construct holds directly: the names an import lists. */
+    @Test
+    void aMemberWrittenAsAnIdentifier() {
+        assertEquals("""
+                module m
+                import other.mod (
+                    A,
+                    // about B
+                    B
+                )
+
+                data O =
+                    { n: Int
+                    }
+                """, Formatter.format("""
+                module m
+                import other.mod (
+                    A,
+                    // about B
+                    B
+                )
+                data O = { n: Int }
+                """));
+    }
+
+    /** The same way of writing a member, under a construct that is not a list of names. */
+    @Test
+    void aMemberWrittenAsAnIdentifierOfAClause() {
+        assertEquals("""
+                module m
+
+                data A =
+                    { n: Int
+                    }
+
+                data B =
+                    { n: Int
+                    }
+
+                behavior f : (n: Int) -> A | B
+                    constructs A,
+                        // about B
+                        B
+
+                let f (n) = A { n = n }
+                """, Formatter.format("""
+                module m
+                data A = { n: Int }
+                data B = { n: Int }
+                behavior f : (n: Int) -> A | B
+                    constructs A,
+                    // about B
+                    B
+                let f (n) = A { n = n }
+                """));
+    }
+
+    /** Written as a segment of a chain: a stage of a pipeline. */
+    @Test
+    void aMemberWrittenAsASegmentOfAChain() {
+        assertEquals("""
+                module m
+
+                data O =
+                    { n: Int
+                    }
+
+                let g (x: Int) = x
+
+                let h (x: Int) = x
+
+                behavior f : (n: Int) -> O
+                    constructs O
+
+                let f (n) =
+                    O {
+                        n = n
+                            |> g
+                            // about h
+                            |> h
+                    }
+                """, Formatter.format("""
+                module m
+                data O = { n: Int }
+                let g (x: Int) = x
+                let h (x: Int) = x
+                behavior f : (n: Int) -> O constructs O
+                let f (n) = O { n = n
+                    |> g
+                    // about h
+                    |> h }
+                """));
+    }
+
+    /** No member to be about: the comment was written above the construct, and stays above it rather
+     * than moving inside where the construct's own end comments go. */
+    @Test
+    void aConstructWithNoMemberToBeAbout() {
+        assertEquals("""
+                module m
+
+                data O =
+                    { xs: List<Int>
+                    }
+
+                behavior f : () -> O
+                    constructs O
+
+                let f =
+                    O {
+                        // empty for now
+                        xs = []
+                    }
+                """, Formatter.format("""
+                module m
+                data O = { xs: List<Int> }
+                behavior f : () -> O constructs O
+                let f = O { xs =
+                    // empty for now
+                    [] }
+                """));
+    }
+
+    /** Written as part of an expression, which has no line of its own. The comment goes to the end
+     * of the line the construct holding it ends, which is further than it was written and is what
+     * keeps it out of the middle of a line. */
+    @Test
+    void aPartOfAnExpressionWithNoLineOfItsOwn() {
+        assertEquals("""
+                module m
+
+                data One
+
+                data Two
+
+                let value (n: Int) = if n > 0 then One else Two // about the test
+                """, Formatter.format("""
+                module m
+                data One
+                data Two
+                let value (n: Int) = if n > 0   // about the test
+                    then One else Two
+                """));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -349,6 +349,30 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 """));
     }
 
+    /**
+     * Written at the end of a line a construct opens with rather than the line it ends on. A
+     * construct written over several lines has more lines than its last, and `data D =`,
+     * `match x with` and the `{` of a block each end one of them. The whole construct's line was the
+     * only one anything could be attached to, so a comment there came back after its last line.
+     */
+    @Test
+    void aLineAConstructOpensWith() {
+        assertEquals("""
+                module m
+
+                data D = // about the block
+                    { a: Int
+                    , b: Int
+                    }
+                """, Formatter.format("""
+                module m
+                data D =   // about the block
+                    { a: Int
+                    , b: Int
+                    }
+                """));
+    }
+
     /** No member to be about: the comment was written above the construct, and stays above it rather
      * than moving inside where the construct's own end comments go. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -98,7 +98,75 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 """));
     }
 
-    /** Written as a segment of a chain: a stage of a pipeline. */
+    /** One member written as several identifiers. A comment anywhere in the name is about the
+     * whole name, so the two ends of the run have to agree on which member they are — reading each
+     * identifier as a member of its own left the comment owned by something nobody asked for. */
+    @Test
+    void aMemberWrittenAsSeveralIdentifiers() {
+        assertEquals("""
+                module m
+
+                data A =
+                    { n: Int
+                    }
+
+                behavior f : (n: Int) -> A
+                    // why this one
+                    constructs other.A
+
+                let f (n) = A { n = n }
+                """, Formatter.format("""
+                module m
+                data A = { n: Int }
+                behavior f : (n: Int) -> A
+                    constructs other.
+                        // why this one
+                        A
+                let f (n) = A { n = n }
+                """));
+    }
+
+    /** Written as the tail of a header line: a behavior's return type, with clauses under it. The
+     * clauses are the construct's next lines, so a comment ending the header's line is not a comment
+     * about them. */
+    @Test
+    void aMemberWrittenAsTheTailOfAHeader() {
+        assertEquals("""
+                module m
+
+                data A =
+                    { n: Int
+                    }
+
+                behavior f : (n: Int) -> A // result
+                    constructs A
+
+                let f (n) = A { n = n }
+                """, Formatter.format("""
+                module m
+                data A = { n: Int }
+                behavior f : (n: Int) -> A   // result
+                    constructs A
+                let f (n) = A { n = n }
+                """));
+    }
+
+    /** The same shape one construct down: what a newtype wraps, with an invariant under it. */
+    @Test
+    void andTheSameTailOnADataHeader() {
+        assertEquals("""
+                module m
+
+                data Positive = Int // representation
+                    invariant value > 0
+                """, Formatter.format("""
+                module m
+                data Positive = Int   // representation
+                    invariant value > 0
+                """));
+    }
+
+    /** Written as a segment of a chain: a stage of a pipeline, and a member of a written union. */
     @Test
     void aMemberWrittenAsASegmentOfAChain() {
         assertEquals("""
@@ -132,6 +200,35 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                     |> g
                     // about h
                     |> h }
+                """));
+    }
+
+    @Test
+    void aMemberWrittenAsASegmentOfAWrittenUnion() {
+        assertEquals("""
+                module m
+
+                data A =
+                    { n: Int
+                    }
+
+                data B =
+                    { n: Int
+                    }
+
+                behavior f : (n: Int) -> A
+                    // exceptional result
+                    | B
+
+                let f (n) = A { n = n }
+                """, Formatter.format("""
+                module m
+                data A = { n: Int }
+                data B = { n: Int }
+                behavior f : (n: Int) -> A
+                    // exceptional result
+                    | B
+                let f (n) = A { n = n }
                 """));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -460,6 +460,30 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 """));
     }
 
+    /** The head of a chain is the part written before the first connector, and it stands for
+     * something written as much as the parts after it do — a match arm's pattern, an example row's
+     * description. This is the other side of the arm and the row from the two above. */
+    @Test
+    void theHeadOfAChain() {
+        assertEquals("""
+                module m
+
+                let helper (n: Int) = n
+
+                example helper
+                    | "doubles" // scenario description
+                        : (2)
+                        -> 2
+                """, Formatter.format("""
+                module m
+                let helper (n: Int) = n
+
+                example helper
+                    | "doubles"   // scenario description
+                        : (2) -> 2
+                """));
+    }
+
     /** No member to be about: the comment was written above the construct, and stays above it rather
      * than moving inside where the construct's own end comments go. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -417,6 +417,49 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 """));
     }
 
+    /** A match arm's body is a segment of the same shape, and was the third instance of the same
+     * miss. */
+    @Test
+    void andAMatchArmsBody() {
+        assertEquals("""
+                module m
+
+                data A
+
+                data B
+
+                data S = A | B
+
+                data O =
+                    { n: Int
+                    }
+
+                behavior f : (s: S) -> O
+                    constructs O
+
+                let f (s) =
+                    O {
+                        n = match s with
+                            | A
+                                // result for A
+                                -> 1
+                            | B -> 2
+                    }
+                """, Formatter.format("""
+                module m
+                data A
+                data B
+                data S = A | B
+                data O = { n: Int }
+                behavior f : (s: S) -> O constructs O
+                let f (s) = O { n = match s with
+                    | A ->
+                        // result for A
+                        1
+                    | B -> 2 }
+                """));
+    }
+
     /** No member to be about: the comment was written above the construct, and stays above it rather
      * than moving inside where the construct's own end comments go. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentSitsAboveTheWholeMemberLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentSitsAboveTheWholeMemberLineTest.java
@@ -1,0 +1,110 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A member whose line is opened by something the enclosing block writes — a leading comma, a union's
+ * {@code |}, the brace of a product body — is one line, and a comment written above it belongs above
+ * that whole line. Decorating the member alone left the comment after the opener and dropped the
+ * member itself to the nesting indent, so the block stopped being written in the form the rest of it
+ * is written in.
+ */
+class ACommentSitsAboveTheWholeMemberLineTest {
+
+    @Test
+    void aboveAFieldThatOpensWithAComma() {
+        String formatted = Formatter.format("""
+                module m
+                data D =
+                    { a: Int
+                    // the comment
+                    , b: Int
+                    }
+                """);
+
+        assertEquals("""
+                module m
+
+                data D =
+                    { a: Int
+                    // the comment
+                    , b: Int
+                    }
+                """, formatted);
+    }
+
+    @Test
+    void aboveTheFieldThatOpensWithTheBrace() {
+        String formatted = Formatter.format("""
+                module m
+                data D =
+                    {
+                    // the comment
+                      a: Int
+                    , b: Int
+                    }
+                """);
+
+        assertEquals("""
+                module m
+
+                data D =
+                    // the comment
+                    { a: Int
+                    , b: Int
+                    }
+                """, formatted);
+    }
+
+    @Test
+    void aboveACaseThatOpensWithABar() {
+        String formatted = Formatter.format("""
+                module m
+                data A
+                data B
+                data S = A
+                    // the comment
+                    | B
+                """);
+
+        assertEquals("""
+                module m
+
+                data A
+
+                data B
+
+                data S = A
+                    // the comment
+                    | B
+                """, formatted);
+    }
+
+    /** The comment is what breaks the union here: {@code data S = A | B} fits the canonical width,
+     * and a {@code //} on a line the group had collapsed would swallow the case after it. */
+    @Test
+    void aCommentedUnionCannotBeWrittenFlat() {
+        String formatted = Formatter.format("""
+                module m
+                data A
+                data B
+                data S =
+                    // the comment
+                    A | B
+                """);
+
+        assertEquals("""
+                module m
+
+                data A
+
+                data B
+
+                data S =
+                    // the comment
+                    A | B
+                """, formatted);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentUnderTheLastMemberStaysInsideTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentUnderTheLastMemberStaysInsideTest.java
@@ -1,0 +1,98 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A comment written under a construct's last member was written inside that construct, and comes
+ * back inside it. It is above no member, so a walk that hands a run of comments to the next member
+ * it meets never hands this one to anybody; and a construct with no members at all has nothing to
+ * hand it to and still has somewhere to put it, which is between its brackets.
+ *
+ * <p>Two comments on consecutive lines stay two comments. Writing the one that ends a member's line
+ * after the one written under it puts the second inside the first, which reads back as one comment
+ * and is a comment lost — through a check that counts what was consumed rather than what was
+ * written.
+ */
+class ACommentUnderTheLastMemberStaysInsideTest {
+
+    @Test
+    void underTheLastMemberOfAnEmptyList() {
+        String formatted = Formatter.format("""
+                module m exposing (
+                    // keep me
+                )
+                data O = { n: Int }
+                """);
+
+        assertEquals("""
+                module m exposing (
+                    // keep me
+                )
+
+                data O =
+                    { n: Int
+                    }
+                """, formatted);
+    }
+
+    @Test
+    void underTheLastMemberOfAnEmptyRecordLiteral() {
+        String formatted = Formatter.format("""
+                module m
+                data O
+                behavior f : () -> O constructs O
+                let f = O {
+                    // keep me
+                }
+                """);
+
+        assertEquals("""
+                module m
+
+                data O
+
+                behavior f : () -> O
+                    constructs O
+
+                let f =
+                    O {
+                        // keep me
+                    }
+                """, formatted);
+    }
+
+    @Test
+    void besideTheLastMemberAndUnderItAtOnce() {
+        String formatted = Formatter.format("""
+                module m
+                data O = { a: Int, b: Int }
+                behavior f : (n: Int) -> O constructs O
+                let f (n) = O {
+                    a = n,
+                    b = n   // about b
+                    // before close
+                }
+                """);
+
+        assertEquals("""
+                module m
+
+                data O =
+                    { a: Int
+                    , b: Int
+                    }
+
+                behavior f : (n: Int) -> O
+                    constructs O
+
+                let f (n) =
+                    O {
+                        a = n,
+                        b = n // about b
+                        // before close
+                    }
+                """, formatted);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
@@ -14,7 +14,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * A comment survives formatting wherever the grammar admits one.
+ * A comment survives formatting at every boundary between two of a fixture's tokens.
+ *
+ * <p>Not at every position the grammar admits one, which is what this used to claim: what is
+ * quantified over is the boundaries of the fixtures below, and a form no fixture is written in is a
+ * form nothing here asks about. A qualified name in a {@code constructs} clause was such a form, and
+ * the formatter refused it.
  *
  * <p>The places are found rather than listed. {@link CommentSurvivalTest} lists them, and a list is
  * the formatter's own idea of where a comment goes written down a second time: the places it omits
@@ -33,7 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * path through the formatter than its occupied one — an {@code exposing} clause with no entries has
  * no member to hang a comment on and is exactly where one went missing.
  */
-class EveryCommentTheGrammarAdmitsSurvivesTest {
+class AProbeSurvivesAtEveryTokenBoundaryTest {
 
     private static final String PROBE = "// probe";
 
@@ -63,7 +68,7 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
             data S = One | Two
 
             behavior run : (a: A, n: Int) -> B | Small
-                constructs B
+                constructs B, other.mod.Thing
                 depends on helper
 
             let helper (n: Int) = n
@@ -169,6 +174,11 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
                     formatted = Formatter.format(variant);
                 } catch (RuntimeException e) {
                     refused.add(context(variant) + "  " + e.getMessage());
+                    continue;
+                }
+                if (!CstParser.parse(formatted).errors().isEmpty()) {
+                    rewritten.add(context(variant) + "  did not parse: "
+                            + CstParser.parse(formatted).errors());
                     continue;
                 }
                 List<String> got = commentsOf(formatted);

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
@@ -27,6 +27,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * the end of a member list went unnoticed. So a probe comment is written into every boundary between
  * two of a fixture's tokens, and required back from every variant that still parses.
  *
+ * <p>And required to be a fixed point. A comment can be put somewhere the next formatting reads
+ * differently, and then it settles somewhere else again; the first output is already wrong and
+ * nothing that looks at one formatting can see it. The corpus has been checked for this all along
+ * and said nothing, because the corpus does not write a comment at every boundary.
+ *
  * <p>Required back as a comment, not as text. Counting {@code // probe} in the output says it
  * survived when it was written into another comment's line, where it is no longer a comment and a
  * reader has lost it. So the output is parsed and its {@code LINE_COMMENT} tokens compared against
@@ -178,6 +183,7 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
     private static void sweep(boolean onItsOwnLine) {
         List<String> lost = new ArrayList<>();
         List<String> moved = new ArrayList<>();
+        List<String> unstable = new ArrayList<>();
         List<String> rewritten = new ArrayList<>();
         List<String> refused = new ArrayList<>();
         int checked = 0;
@@ -206,6 +212,10 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
                             + CstParser.parse(formatted).errors());
                     continue;
                 }
+                if (!formatted.equals(Formatter.format(formatted))) {
+                    unstable.add(context(variant));
+                    continue;
+                }
                 int was = neighbour(variant, onItsOwnLine);
                 int now = neighbour(formatted, onItsOwnLine);
                 if (was != now && was >= 0 && was < mustStay.size() && mustStay.get(was)) {
@@ -232,6 +242,10 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
                 moved.size() + " of " + checked + " probes left code that ends or begins a line of"
                         + " the canonical form, which is code a comment can stay beside:\n"
                         + String.join("\n", moved));
+        assertTrue(unstable.isEmpty(),
+                unstable.size() + " of " + checked + " came back as something the next formatting"
+                        + " writes differently, so the first placement was already wrong:\n"
+                        + String.join("\n", unstable));
         assertTrue(lost.isEmpty() && rewritten.isEmpty() && refused.isEmpty(),
                 "of " + checked + " swept, " + lost.size() + " came back with the comments changed,"
                         + " " + rewritten.size() + " with the code changed and " + refused.size()

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
@@ -155,28 +155,27 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
 
     @Test
     void aProbeOnALineOfItsOwnComesBackExactlyOnce() {
-        sweep(true, 245);
+        sweep(true);
     }
 
     @Test
     void aProbeAtTheEndOfALineComesBackExactlyOnce() {
-        sweep(false, 293);
+        sweep(false);
     }
 
     /**
-     * {@code travelled} is how many of the boundaries are inside a construct the layout gives no
-     * line of its own. A comment written there cannot stay: the rest of that line would be written
-     * inside it, so it goes to the nearest construct that has a line. Which construct that is, is
-     * measured rather than listed — the probe's neighbour is an index into the code tokens, and
-     * those are required to come back unchanged, so an index that moved says the comment left the
-     * code it was written next to.
+     * Which boundaries have to keep their comment is read from the canonical form rather than from
+     * the formatter: a comment at the end of a line has to come back at the end of that line, and
+     * one on a line of its own has to come back above the same line. So a token that already ends a
+     * line of the fixture is a place a comment must stay, and one in the middle of a line is a place
+     * it cannot — the rest of that line would be written inside it, and it goes to the nearest
+     * construct the layout gives a line to.
      *
-     * <p>The number goes down as constructs are given lines of their own, and each time it does, a
-     * comment that used to travel now stays. It going up is a comment that stopped staying, which
-     * nothing else here would report: the comment is still there and the code around it is
-     * unchanged, and only what it is next to has changed.
+     * <p>The probe's neighbour is an index into the code tokens, and those are required to come back
+     * unchanged, so the index names the same token before and after. That makes this an answer to
+     * what the comment is next to that needs neither an oracle nor the classifier under test.
      */
-    private static void sweep(boolean onItsOwnLine, int travelled) {
+    private static void sweep(boolean onItsOwnLine) {
         List<String> lost = new ArrayList<>();
         List<String> moved = new ArrayList<>();
         List<String> rewritten = new ArrayList<>();
@@ -185,6 +184,7 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
         java.util.Map<Integer, Integer> contributed = new java.util.LinkedHashMap<>();
         for (String fixture : List.of(WHOLE_MODULE, THE_OTHER_FORMS)) {
             List<String> expected = commentsOf(fixture);
+            List<Boolean> mustStay = mustStay(fixture, onItsOwnLine);
             int before = checked;
             for (String variant : variants(fixture, onItsOwnLine)) {
                 if (!CstParser.parse(variant).errors().isEmpty()) {
@@ -208,8 +208,8 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
                 }
                 int was = neighbour(variant, onItsOwnLine);
                 int now = neighbour(formatted, onItsOwnLine);
-                if (was != now) {
-                    moved.add(context(variant) + "  from " + was + " to " + now);
+                if (was != now && was >= 0 && was < mustStay.size() && mustStay.get(was)) {
+                    moved.add(context(variant) + "  left token " + was + " for " + now);
                 }
                 List<String> got = commentsOf(formatted);
                 got.sort(null);
@@ -228,9 +228,9 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
                     "a fixture contributed only " + e.getValue() + " variants; it is not being swept");
         }
         assertTrue(checked > 150, "only " + checked + " variants parsed; the sweep found nothing");
-        assertTrue(moved.size() <= travelled,
-                moved.size() + " of " + checked + " probes left the code they were written next to,"
-                        + " where " + travelled + " have no line to stay on:\n"
+        assertTrue(moved.isEmpty(),
+                moved.size() + " of " + checked + " probes left code that ends or begins a line of"
+                        + " the canonical form, which is code a comment can stay beside:\n"
                         + String.join("\n", moved));
         assertTrue(lost.isEmpty() && rewritten.isEmpty() && refused.isEmpty(),
                 "of " + checked + " swept, " + lost.size() + " came back with the comments changed,"
@@ -261,6 +261,38 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
             if (!t.isTrivia() && t.kind() != SyntaxKind.EOF && !out.contains(t.end())) {
                 out.add(t.end());
             }
+        }
+        return out;
+    }
+
+    /**
+     * For each code token of {@code source}, whether a comment written beside it has a line to stay
+     * on: the token ends a line, for a comment written at the end of one, or begins a line, for a
+     * comment written above one.
+     */
+    private static List<Boolean> mustStay(String source, boolean onItsOwnLine) {
+        List<Boolean> out = new ArrayList<>();
+        List<SyntaxToken> all = tokens(CstParser.parse(source).root());
+        List<Integer> code = new ArrayList<>();
+        for (int i = 0; i < all.size(); i++) {
+            if (!all.get(i).isTrivia() && all.get(i).kind() != SyntaxKind.EOF) {
+                code.add(i);
+            }
+        }
+        for (int c = 0; c < code.size(); c++) {
+            int step = onItsOwnLine ? -1 : 1;
+            boolean ends = true;
+            for (int i = code.get(c) + step; i >= 0 && i < all.size(); i += step) {
+                SyntaxToken t = all.get(i);
+                if (!t.isTrivia()) {
+                    ends = t.kind() == SyntaxKind.EOF;
+                    break;
+                }
+                if (t.text().indexOf('\n') >= 0) {
+                    break;                            // a line break before the next code: it ends
+                }
+            }
+            out.add(ends);
         }
         return out;
     }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
@@ -155,16 +155,30 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
 
     @Test
     void aProbeOnALineOfItsOwnComesBackExactlyOnce() {
-        sweep(true);
+        sweep(true, 245);
     }
 
     @Test
     void aProbeAtTheEndOfALineComesBackExactlyOnce() {
-        sweep(false);
+        sweep(false, 293);
     }
 
-    private static void sweep(boolean onItsOwnLine) {
+    /**
+     * {@code travelled} is how many of the boundaries are inside a construct the layout gives no
+     * line of its own. A comment written there cannot stay: the rest of that line would be written
+     * inside it, so it goes to the nearest construct that has a line. Which construct that is, is
+     * measured rather than listed — the probe's neighbour is an index into the code tokens, and
+     * those are required to come back unchanged, so an index that moved says the comment left the
+     * code it was written next to.
+     *
+     * <p>The number goes down as constructs are given lines of their own, and each time it does, a
+     * comment that used to travel now stays. It going up is a comment that stopped staying, which
+     * nothing else here would report: the comment is still there and the code around it is
+     * unchanged, and only what it is next to has changed.
+     */
+    private static void sweep(boolean onItsOwnLine, int travelled) {
         List<String> lost = new ArrayList<>();
+        List<String> moved = new ArrayList<>();
         List<String> rewritten = new ArrayList<>();
         List<String> refused = new ArrayList<>();
         int checked = 0;
@@ -192,6 +206,11 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
                             + CstParser.parse(formatted).errors());
                     continue;
                 }
+                int was = neighbour(variant, onItsOwnLine);
+                int now = neighbour(formatted, onItsOwnLine);
+                if (was != now) {
+                    moved.add(context(variant) + "  from " + was + " to " + now);
+                }
                 List<String> got = commentsOf(formatted);
                 got.sort(null);
                 if (!want.equals(got)) {
@@ -209,6 +228,10 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
                     "a fixture contributed only " + e.getValue() + " variants; it is not being swept");
         }
         assertTrue(checked > 150, "only " + checked + " variants parsed; the sweep found nothing");
+        assertTrue(moved.size() <= travelled,
+                moved.size() + " of " + checked + " probes left the code they were written next to,"
+                        + " where " + travelled + " have no line to stay on:\n"
+                        + String.join("\n", moved));
         assertTrue(lost.isEmpty() && rewritten.isEmpty() && refused.isEmpty(),
                 "of " + checked + " swept, " + lost.size() + " came back with the comments changed,"
                         + " " + rewritten.size() + " with the code changed and " + refused.size()
@@ -240,6 +263,34 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
             }
         }
         return out;
+    }
+
+    /**
+     * Where the probe sits in {@code source}, as an index into the code tokens: the one before it
+     * for a comment that ends a line, the one after it for a comment on a line of its own. The code
+     * tokens themselves are required to come back unchanged, so the index names the same token
+     * before and after — which makes it an answer to what the comment is next to that needs no
+     * oracle and no classifier.
+     */
+    private static int neighbour(String source, boolean onItsOwnLine) {
+        int code = 0;
+        int before = -1;
+        boolean seen = false;
+        for (SyntaxToken t : tokens(CstParser.parse(source).root())) {
+            if (t.kind() == SyntaxKind.LINE_COMMENT && t.text().stripTrailing().equals(PROBE)) {
+                if (!onItsOwnLine) {
+                    return before;
+                }
+                seen = true;
+            } else if (!t.isTrivia()) {
+                if (seen) {
+                    return code;
+                }
+                before = code;
+                code++;
+            }
+        }
+        return -1;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
@@ -118,6 +118,17 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
 
             let empty = Out {}
 
+            let counted = 1 + 2 + 3
+
+            let piped = 1 |> plus |> plus
+
+            let plus (x: Int) = x + 1
+
+            data Held =
+                { xs: List<Int>
+                , pair: (Int, Int)
+                }
+
             let make (n) = {
                 guard Amount(n) as a else
                     | value -> Amount(1)

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryCommentTheGrammarAdmitsSurvivesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryCommentTheGrammarAdmitsSurvivesTest.java
@@ -10,6 +10,7 @@ import souther.compiler.cst.SyntaxToken;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -108,11 +109,9 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
             behavior through : (i: In) -> Out
                 constructs Out
 
-            behavior piped = through >-> through
+            behavior piped = through >-> through -> Out
 
             let empty = Out {}
-
-            let none () = 1
 
             let make (n) = {
                 guard Amount(n) as a else
@@ -127,11 +126,14 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
                 | "it makes" : (2) with n = 2 -> Out { n = 2 }
             """;
 
+    /** A fixture that does not parse contributes nothing: every variant of it is skipped, and the
+     * sweep reports a clean run over the ones that are left. So the fixtures are checked, and so is
+     * how many variants each of them actually contributed. */
     @Test
-    void theFixturesAreInCanonicalForm() {
+    void theFixturesParseAndAreInCanonicalForm() {
         for (String fixture : List.of(WHOLE_MODULE, THE_OTHER_FORMS)) {
-            org.junit.jupiter.api.Assertions.assertEquals(fixture, Formatter.format(fixture),
-                    "a fixture is not in canonical form");
+            assertEquals(List.of(), CstParser.parse(fixture).errors(), "a fixture does not parse");
+            assertEquals(fixture, Formatter.format(fixture), "a fixture is not in canonical form");
         }
     }
 
@@ -147,10 +149,13 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
 
     private static void sweep(boolean onItsOwnLine) {
         List<String> lost = new ArrayList<>();
+        List<String> rewritten = new ArrayList<>();
         List<String> refused = new ArrayList<>();
         int checked = 0;
+        java.util.Map<Integer, Integer> contributed = new java.util.LinkedHashMap<>();
         for (String fixture : List.of(WHOLE_MODULE, THE_OTHER_FORMS)) {
             List<String> expected = commentsOf(fixture);
+            int before = checked;
             for (String variant : variants(fixture, onItsOwnLine)) {
                 if (!CstParser.parse(variant).errors().isEmpty()) {
                     continue;   // the probe made this one unparseable; nothing to ask of it
@@ -171,15 +176,24 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
                 if (!want.equals(got)) {
                     lost.add(context(variant) + "  gave " + got);
                 }
+                if (!code(variant).equals(code(formatted))) {
+                    rewritten.add(context(variant) + "  gave " + code(formatted));
+                }
             }
+            contributed.put(contributed.size(), checked - before);
         }
 
+        for (var e : contributed.entrySet()) {
+            assertTrue(e.getValue() > 50,
+                    "a fixture contributed only " + e.getValue() + " variants; it is not being swept");
+        }
         assertTrue(checked > 150, "only " + checked + " variants parsed; the sweep found nothing");
-        assertTrue(lost.isEmpty() && refused.isEmpty(),
-                "of " + checked + " swept, " + lost.size() + " came back with the comments changed"
-                        + " and " + refused.size() + " were refused.\nchanged after:\n"
-                        + String.join("\n", lost) + "\nrefused after:\n"
-                        + String.join("\n", refused));
+        assertTrue(lost.isEmpty() && rewritten.isEmpty() && refused.isEmpty(),
+                "of " + checked + " swept, " + lost.size() + " came back with the comments changed,"
+                        + " " + rewritten.size() + " with the code changed and " + refused.size()
+                        + " were refused.\ncomments changed after:\n" + String.join("\n", lost)
+                        + "\ncode changed after:\n" + String.join("\n", rewritten)
+                        + "\nrefused after:\n" + String.join("\n", refused));
     }
 
     /** {@code source} with a probe comment written into one boundary between two of its tokens, one
@@ -202,6 +216,21 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
         for (SyntaxToken t : tokens(CstParser.parse(source).root())) {
             if (!t.isTrivia() && t.kind() != SyntaxKind.EOF && !out.contains(t.end())) {
                 out.add(t.end());
+            }
+        }
+        return out;
+    }
+
+    /**
+     * What {@code source} says, with the trivia dropped. Formatting rewrites the layout and nothing
+     * else, so this is the same before and after — and a comment that swallowed the code after it
+     * shows up here rather than in the comments, which come back one for one either way.
+     */
+    private static List<String> code(String source) {
+        List<String> out = new ArrayList<>();
+        for (SyntaxToken t : tokens(CstParser.parse(source).root())) {
+            if (!t.isTrivia()) {
+                out.add(t.kind() + " " + t.text());
             }
         }
         return out;

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryCommentTheGrammarAdmitsSurvivesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryCommentTheGrammarAdmitsSurvivesTest.java
@@ -10,7 +10,6 @@ import souther.compiler.cst.SyntaxToken;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -19,25 +18,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>The places are found rather than listed. {@link CommentSurvivalTest} lists them, and a list is
  * the formatter's own idea of where a comment goes written down a second time: the places it omits
  * are exactly the places the formatter drops a comment, which is how an {@code invariant} clause and
- * the end of a member list went unnoticed. So this walks a fixture's whitespace, writes a probe
- * comment into each gap between two tokens, and requires the probe back — once — from every variant
- * that still parses.
+ * the end of a member list went unnoticed. So a probe comment is written into every boundary between
+ * two of a fixture's tokens, and required back from every variant that still parses.
  *
- * <p>Only comments written on a line of their own are swept. One written at the end of a line of
- * code is a second question — which construct it belongs to, and where that construct's line ends
- * once the layout has been re-derived — and it is asked where that is decided.
+ * <p>Required back as a comment, not as text. Counting {@code // probe} in the output says it
+ * survived when it was written into another comment's line, where it is no longer a comment and a
+ * reader has lost it. So the output is parsed and its {@code LINE_COMMENT} tokens compared against
+ * the input's.
  *
- * <p>What the probe is attached to is not asserted here either. That needs an expected owner, and
- * deriving one from the insertion point would be the classifier under test written twice; it is
- * asked of hand-written cases instead.
+ * <p>Boundaries, not existing whitespace: a comment goes between two tokens whether or not anything
+ * was written between them already, so {@code f(a)} admits one after its {@code (} as much as
+ * between two statements. And several fixtures, because a construct's empty form takes a different
+ * path through the formatter than its occupied one — an {@code exposing} clause with no entries has
+ * no member to hang a comment on and is exactly where one went missing.
  */
 class EveryCommentTheGrammarAdmitsSurvivesTest {
 
     private static final String PROBE = "// probe";
 
-    /** One of everything a module can be written with, since a gap only exists where the fixture put
-     * two tokens. Kept in canonical form, so a variant differs from it only by the probe. */
-    private static final String FIXTURE = """
+    /** One of everything a module can be written with. Kept in canonical form, so a variant differs
+     * from it only by the probe. */
+    private static final String WHOLE_MODULE = """
             module m exposing ( A, B, S, run, value )
             import other.mod ( Thing )
 
@@ -82,122 +83,157 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
 
             fake helper
                 | (2) -> 4
+            """;
 
-            data Wide =
-                { alphaMeasurement: Int
-                , betaMeasurement: Int
-                , gammaMeasurement: Int
-                , deltaMeasurement: Int
+    /** The forms the whole module has no room for: an attempt's departures, a pipeline's stages, an
+     * example's bindings, a comprehension, and the empty forms of the bracketed constructs. */
+    private static final String THE_OTHER_FORMS = """
+            module m exposing (  )
+            import other.mod
+
+            data Amount = Int
+                invariant value > 0
+
+            data In =
+                { n: Int
                 }
 
-            behavior widen : (
-                alphaMeasurement: Int,
-                betaMeasurement: Int,
-                gammaMeasurement: Int,
-                deltaMeasurement: Int
-            ) -> Wide
-                constructs Wide
-
-            let widen (alphaMeasurement, betaMeasurement, gammaMeasurement, deltaMeasurement) =
-                Wide {
-                    alphaMeasurement = alphaMeasurement,
-                    betaMeasurement = betaMeasurement,
-                    gammaMeasurement = gammaMeasurement,
-                    deltaMeasurement = deltaMeasurement
+            data Out =
+                { n: Int
                 }
 
-            let manyNumbers =
-                [1000000000, 2000000000, 3000000000, 4000000000, 5000000000, 6000000000, 7000000000]
+            behavior make : (n: Int) -> Out | Amount
+                constructs Out, Amount
+
+            behavior through : (i: In) -> Out
+                constructs Out
+
+            behavior piped = through >-> through
+
+            let empty = Out {}
+
+            let none () = 1
+
+            let make (n) = {
+                guard Amount(n) as a else
+                    | value -> Amount(1)
+                let evens = [x | x > 0]
+                Out { n = a.value }
+            }
+
+            let through (i) = if i.n > 0 then Out { n = 1 } else Out { n = 0 }
+
+            example make
+                | "it makes" : (2) with n = 2 -> Out { n = 2 }
             """;
 
     @Test
-    void theFixtureIsInCanonicalFormAndHasGaps() {
-        assertEquals(FIXTURE, Formatter.format(FIXTURE), "the fixture is not in canonical form");
-        assertTrue(gaps(FIXTURE, true).size() + gaps(FIXTURE, false).size() > 100,
-                "too few gaps to be a useful sweep");
+    void theFixturesAreInCanonicalForm() {
+        for (String fixture : List.of(WHOLE_MODULE, THE_OTHER_FORMS)) {
+            org.junit.jupiter.api.Assertions.assertEquals(fixture, Formatter.format(fixture),
+                    "a fixture is not in canonical form");
+        }
     }
 
     @Test
     void aProbeOnALineOfItsOwnComesBackExactlyOnce() {
-        sweep(gaps(FIXTURE, true));
+        sweep(true);
     }
 
     @Test
     void aProbeAtTheEndOfALineComesBackExactlyOnce() {
-        sweep(gaps(FIXTURE, false));
+        sweep(false);
     }
 
-    private static void sweep(List<String> variants) {
+    private static void sweep(boolean onItsOwnLine) {
         List<String> lost = new ArrayList<>();
-        List<String> duplicated = new ArrayList<>();
+        List<String> refused = new ArrayList<>();
         int checked = 0;
-        for (String variant : variants) {
-            if (!CstParser.parse(variant).errors().isEmpty()) {
-                continue;   // the probe made this one unparseable; nothing to ask of it
-            }
-            checked++;
-            int n = occurrences(Formatter.format(variant), PROBE);
-            if (n == 0) {
-                lost.add(context(variant));
-            } else if (n > 1) {
-                duplicated.add(context(variant));
+        for (String fixture : List.of(WHOLE_MODULE, THE_OTHER_FORMS)) {
+            List<String> expected = commentsOf(fixture);
+            for (String variant : variants(fixture, onItsOwnLine)) {
+                if (!CstParser.parse(variant).errors().isEmpty()) {
+                    continue;   // the probe made this one unparseable; nothing to ask of it
+                }
+                checked++;
+                List<String> want = new ArrayList<>(expected);
+                want.add(PROBE);
+                want.sort(null);
+                String formatted;
+                try {
+                    formatted = Formatter.format(variant);
+                } catch (RuntimeException e) {
+                    refused.add(context(variant) + "  " + e.getMessage());
+                    continue;
+                }
+                List<String> got = commentsOf(formatted);
+                got.sort(null);
+                if (!want.equals(got)) {
+                    lost.add(context(variant) + "  gave " + got);
+                }
             }
         }
 
-        assertTrue(checked > 20, "only " + checked + " variants parsed; the sweep found nothing");
-        assertTrue(lost.isEmpty() && duplicated.isEmpty(),
-                "the probe was dropped in " + lost.size() + " gaps and written twice in "
-                        + duplicated.size() + ", of " + checked + " swept.\ndropped after:\n"
-                        + String.join("\n", lost) + "\nduplicated after:\n"
-                        + String.join("\n", duplicated));
+        assertTrue(checked > 150, "only " + checked + " variants parsed; the sweep found nothing");
+        assertTrue(lost.isEmpty() && refused.isEmpty(),
+                "of " + checked + " swept, " + lost.size() + " came back with the comments changed"
+                        + " and " + refused.size() + " were refused.\nchanged after:\n"
+                        + String.join("\n", lost) + "\nrefused after:\n"
+                        + String.join("\n", refused));
     }
 
-    /**
-     * {@code source} with a probe comment written into one gap between two tokens, one variant per
-     * gap. The two ways a comment is written are swept separately, because they are separate
-     * questions: {@code onItsOwnLine} takes the gaps that already span a line and writes the probe
-     * as a line between them, and the rest take it at the end of the line they are inside.
-     */
-    private static List<String> gaps(String source, boolean onItsOwnLine) {
+    /** {@code source} with a probe comment written into one boundary between two of its tokens, one
+     * variant per boundary. A comment is written either on a line of its own or at the end of the
+     * line it is inside, and the two are separate questions, so a sweep asks one of them. */
+    private static List<String> variants(String source, boolean onItsOwnLine) {
         List<String> out = new ArrayList<>();
-        for (SyntaxToken w : whitespace(CstParser.parse(source).root())) {
-            String text = w.text();
-            int nl = text.indexOf('\n');
-            if ((nl >= 0) != onItsOwnLine) {
-                continue;
-            }
-            String replacement = nl < 0
-                    ? " " + PROBE + "\n" + text
-                    : text.substring(0, nl + 1) + PROBE + text.substring(nl);
-            out.add(source.substring(0, w.start()) + replacement + source.substring(w.end()));
+        for (int at : boundaries(source)) {
+            String written = onItsOwnLine ? "\n" + PROBE + "\n" : " " + PROBE + "\n";
+            out.add(source.substring(0, at) + written + source.substring(at));
         }
         return out;
     }
 
-    private static List<SyntaxToken> whitespace(SyntaxNode n) {
+    /** Where a comment can go: after each token that is not trivia. Trivia is skipped when the
+     * parser looks for its next token, so a boundary exists whether or not anything was written at
+     * it. */
+    private static List<Integer> boundaries(String source) {
+        List<Integer> out = new ArrayList<>();
+        for (SyntaxToken t : tokens(CstParser.parse(source).root())) {
+            if (!t.isTrivia() && t.kind() != SyntaxKind.EOF && !out.contains(t.end())) {
+                out.add(t.end());
+            }
+        }
+        return out;
+    }
+
+    /** The comments {@code source} holds, read back as comments rather than as text. */
+    private static List<String> commentsOf(String source) {
+        List<String> out = new ArrayList<>();
+        for (SyntaxToken t : tokens(CstParser.parse(source).root())) {
+            if (t.kind() == SyntaxKind.LINE_COMMENT) {
+                out.add(t.text().stripTrailing());
+            }
+        }
+        return out;
+    }
+
+    private static List<SyntaxToken> tokens(SyntaxNode n) {
         List<SyntaxToken> out = new ArrayList<>();
         for (SyntaxElement e : n.children()) {
             if (e instanceof SyntaxNode c) {
-                out.addAll(whitespace(c));
-            } else if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.WHITESPACE) {
+                out.addAll(tokens(c));
+            } else if (e instanceof SyntaxToken t) {
                 out.add(t);
             }
         }
         return out;
     }
 
-    /** The words the probe was written after, so a failure names the gap rather than an offset. */
+    /** The words the probe was written after, so a failure names the boundary rather than an offset. */
     private static String context(String variant) {
         int at = variant.indexOf(PROBE);
         int from = Math.max(0, at - 40);
         return "    ..." + variant.substring(from, at).replace("\n", "\\n") + "[probe]";
-    }
-
-    private static int occurrences(String haystack, String needle) {
-        int n = 0;
-        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
-            n++;
-        }
-        return n;
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryCommentTheGrammarAdmitsSurvivesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryCommentTheGrammarAdmitsSurvivesTest.java
@@ -122,6 +122,11 @@ class EveryCommentTheGrammarAdmitsSurvivesTest {
         sweep(gaps(FIXTURE, true));
     }
 
+    @Test
+    void aProbeAtTheEndOfALineComesBackExactlyOnce() {
+        sweep(gaps(FIXTURE, false));
+    }
+
     private static void sweep(List<String> variants) {
         List<String> lost = new ArrayList<>();
         List<String> duplicated = new ArrayList<>();

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryCommentTheGrammarAdmitsSurvivesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryCommentTheGrammarAdmitsSurvivesTest.java
@@ -1,0 +1,198 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.cst.CstParser;
+import souther.compiler.cst.SyntaxElement;
+import souther.compiler.cst.SyntaxKind;
+import souther.compiler.cst.SyntaxNode;
+import souther.compiler.cst.SyntaxToken;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A comment survives formatting wherever the grammar admits one.
+ *
+ * <p>The places are found rather than listed. {@link CommentSurvivalTest} lists them, and a list is
+ * the formatter's own idea of where a comment goes written down a second time: the places it omits
+ * are exactly the places the formatter drops a comment, which is how an {@code invariant} clause and
+ * the end of a member list went unnoticed. So this walks a fixture's whitespace, writes a probe
+ * comment into each gap between two tokens, and requires the probe back — once — from every variant
+ * that still parses.
+ *
+ * <p>Only comments written on a line of their own are swept. One written at the end of a line of
+ * code is a second question — which construct it belongs to, and where that construct's line ends
+ * once the layout has been re-derived — and it is asked where that is decided.
+ *
+ * <p>What the probe is attached to is not asserted here either. That needs an expected owner, and
+ * deriving one from the insertion point would be the classifier under test written twice; it is
+ * asked of hand-written cases instead.
+ */
+class EveryCommentTheGrammarAdmitsSurvivesTest {
+
+    private static final String PROBE = "// probe";
+
+    /** One of everything a module can be written with, since a gap only exists where the fixture put
+     * two tokens. Kept in canonical form, so a variant differs from it only by the probe. */
+    private static final String FIXTURE = """
+            module m exposing ( A, B, S, run, value )
+            import other.mod ( Thing )
+
+            data A =
+                { id: Int
+                , name: String
+                }
+
+            data B =
+                { ...A
+                , extra: Int
+                }
+
+            data Small = Int
+                invariant value > 0
+
+            data One
+
+            data Two
+
+            data S = One | Two
+
+            behavior run : (a: A, n: Int) -> B | Small
+                constructs B
+                depends on helper
+
+            let helper (n: Int) = n
+
+            let run (a, n, helper) = {
+                let doubled = helper(n)
+                let list = [1, 2, doubled]
+                guard doubled > 0 else Small(1)
+                match value(a) with
+                    | One -> B { ...a, extra = doubled }
+                    | Two -> B { ...a, extra = 0 }
+            }
+
+            let value (a: A) = if a.id > 0 then One else Two
+
+            example helper
+                | "it doubles" : (2) -> 2
+
+            fake helper
+                | (2) -> 4
+
+            data Wide =
+                { alphaMeasurement: Int
+                , betaMeasurement: Int
+                , gammaMeasurement: Int
+                , deltaMeasurement: Int
+                }
+
+            behavior widen : (
+                alphaMeasurement: Int,
+                betaMeasurement: Int,
+                gammaMeasurement: Int,
+                deltaMeasurement: Int
+            ) -> Wide
+                constructs Wide
+
+            let widen (alphaMeasurement, betaMeasurement, gammaMeasurement, deltaMeasurement) =
+                Wide {
+                    alphaMeasurement = alphaMeasurement,
+                    betaMeasurement = betaMeasurement,
+                    gammaMeasurement = gammaMeasurement,
+                    deltaMeasurement = deltaMeasurement
+                }
+
+            let manyNumbers =
+                [1000000000, 2000000000, 3000000000, 4000000000, 5000000000, 6000000000, 7000000000]
+            """;
+
+    @Test
+    void theFixtureIsInCanonicalFormAndHasGaps() {
+        assertEquals(FIXTURE, Formatter.format(FIXTURE), "the fixture is not in canonical form");
+        assertTrue(gaps(FIXTURE, true).size() + gaps(FIXTURE, false).size() > 100,
+                "too few gaps to be a useful sweep");
+    }
+
+    @Test
+    void aProbeOnALineOfItsOwnComesBackExactlyOnce() {
+        sweep(gaps(FIXTURE, true));
+    }
+
+    private static void sweep(List<String> variants) {
+        List<String> lost = new ArrayList<>();
+        List<String> duplicated = new ArrayList<>();
+        int checked = 0;
+        for (String variant : variants) {
+            if (!CstParser.parse(variant).errors().isEmpty()) {
+                continue;   // the probe made this one unparseable; nothing to ask of it
+            }
+            checked++;
+            int n = occurrences(Formatter.format(variant), PROBE);
+            if (n == 0) {
+                lost.add(context(variant));
+            } else if (n > 1) {
+                duplicated.add(context(variant));
+            }
+        }
+
+        assertTrue(checked > 20, "only " + checked + " variants parsed; the sweep found nothing");
+        assertTrue(lost.isEmpty() && duplicated.isEmpty(),
+                "the probe was dropped in " + lost.size() + " gaps and written twice in "
+                        + duplicated.size() + ", of " + checked + " swept.\ndropped after:\n"
+                        + String.join("\n", lost) + "\nduplicated after:\n"
+                        + String.join("\n", duplicated));
+    }
+
+    /**
+     * {@code source} with a probe comment written into one gap between two tokens, one variant per
+     * gap. The two ways a comment is written are swept separately, because they are separate
+     * questions: {@code onItsOwnLine} takes the gaps that already span a line and writes the probe
+     * as a line between them, and the rest take it at the end of the line they are inside.
+     */
+    private static List<String> gaps(String source, boolean onItsOwnLine) {
+        List<String> out = new ArrayList<>();
+        for (SyntaxToken w : whitespace(CstParser.parse(source).root())) {
+            String text = w.text();
+            int nl = text.indexOf('\n');
+            if ((nl >= 0) != onItsOwnLine) {
+                continue;
+            }
+            String replacement = nl < 0
+                    ? " " + PROBE + "\n" + text
+                    : text.substring(0, nl + 1) + PROBE + text.substring(nl);
+            out.add(source.substring(0, w.start()) + replacement + source.substring(w.end()));
+        }
+        return out;
+    }
+
+    private static List<SyntaxToken> whitespace(SyntaxNode n) {
+        List<SyntaxToken> out = new ArrayList<>();
+        for (SyntaxElement e : n.children()) {
+            if (e instanceof SyntaxNode c) {
+                out.addAll(whitespace(c));
+            } else if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.WHITESPACE) {
+                out.add(t);
+            }
+        }
+        return out;
+    }
+
+    /** The words the probe was written after, so a failure names the gap rather than an offset. */
+    private static String context(String variant) {
+        int at = variant.indexOf(PROBE);
+        int from = Math.max(0, at - 40);
+        return "    ..." + variant.substring(from, at).replace("\n", "\\n") + "[probe]";
+    }
+
+    private static int occurrences(String haystack, String needle) {
+        int n = 0;
+        for (int i = haystack.indexOf(needle); i >= 0; i = haystack.indexOf(needle, i + needle.length())) {
+            n++;
+        }
+        return n;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheFormatterAccountsForEveryCommentTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheFormatterAccountsForEveryCommentTest.java
@@ -1,0 +1,72 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.cst.CstParser;
+import souther.compiler.cst.SyntaxNode;
+import souther.compiler.cst.SyntaxToken;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The formatter counts the comments it took against the comments the tree holds, and a construct
+ * that takes none of its own is a failure rather than a file that quietly comes back shorter.
+ *
+ * <p>Structure is what makes the count small enough to be worth taking: comments are found in one
+ * pass and consumed in one place. It is not what makes it right. A construct added later that never
+ * asks for its comments loses them exactly as an {@code invariant} clause did, and no arrangement of
+ * the code prevents that — only the count does.
+ */
+class TheFormatterAccountsForEveryCommentTest {
+
+    private static final String SOURCE = """
+            module m
+            // above the data
+            data D =
+                { a: Int   // after the field
+                , b: Int
+                }
+            """;
+
+    @Test
+    void everyCommentInTheTreeIsAccountedFor() {
+        SyntaxNode file = CstParser.parse(SOURCE).root();
+
+        assertEquals(List.of(), Formatter.unconsumed(file, offsetsOfEveryComment(file)));
+    }
+
+    @Test
+    void andOneLeftOutIsReported() {
+        SyntaxNode file = CstParser.parse(SOURCE).root();
+        Set<Integer> allButOne = new HashSet<>(offsetsOfEveryComment(file));
+        int dropped = allButOne.stream().min(Integer::compare).orElseThrow();
+        allButOne.remove(dropped);
+
+        List<SyntaxToken> missing = Formatter.unconsumed(file, allButOne);
+
+        assertEquals(1, missing.size(), "one comment was left out and one should be reported");
+        assertEquals(dropped, missing.get(0).start());
+    }
+
+    /** And the check is wired in: a real format of the same source raises nothing. */
+    @Test
+    void formattingThisSourceAccountsForAllOfThem() {
+        String formatted = Formatter.format(SOURCE);
+
+        assertTrue(formatted.contains("// above the data"), formatted);
+        assertTrue(formatted.contains("// after the field"), formatted);
+    }
+
+    private static Set<Integer> offsetsOfEveryComment(SyntaxNode file) {
+        Set<Integer> out = new HashSet<>();
+        for (SyntaxToken t : Formatter.unconsumed(file, Set.of())) {
+            out.add(t.start());
+        }
+        assertEquals(2, out.size(), "the source is written with two comments");
+        return out;
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -27,6 +27,13 @@ public sealed interface Doc {
     record Nest(int indent, Doc doc) implements Doc {}
     record Group(Doc doc) implements Doc {}
 
+    /**
+     * A comment written at the end of a line of code. It is not content the width has to make room
+     * for — it sits past the end of the line whatever its length — but nothing else can share the
+     * line after it, so a group holding one cannot be laid out flat.
+     */
+    record Trailing(String s) implements Doc {}
+
     static Doc text(String s) {
         return new Text(s);
     }
@@ -37,6 +44,11 @@ public sealed interface Doc {
 
     static Doc concat(List<Doc> parts) {
         return new Concat(List.copyOf(parts));
+    }
+
+    /** A comment at the end of the line the preceding document ends on. */
+    static Doc trailing(String s) {
+        return new Trailing(s);
     }
 
     static Doc nest(int indent, Doc doc) {
@@ -99,6 +111,10 @@ public sealed interface Doc {
                     sb.append('\n').append(" ".repeat(it.indent));
                     col = it.indent;
                 }
+                case Trailing t -> {
+                    sb.append(' ').append(t.s());
+                    col += t.s().length() + 1;
+                }
             }
         }
         return sb.toString();
@@ -151,6 +167,12 @@ public sealed interface Doc {
                 case Hard _ -> {
                     // a hardline cannot be laid out flat: inside the group under test (FLAT) it forces
                     // a break; in an already-broken outer context it just ends the measured line.
+                    return it.mode != Mode.FLAT;
+                }
+                case Trailing _ -> {
+                    // the same, and for the same reason: whatever follows starts a new line, so it
+                    // is measured against that line rather than this one, and the comment's own
+                    // width is measured against nothing.
                     return it.mode != Mode.FLAT;
                 }
             }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -19,6 +19,12 @@ public sealed interface Doc {
     Doc SOFTLINE = new Line("");     // nothing when flat, a newline when broken
     Doc HARDLINE = new Hard();       // always a newline; forces the enclosing group to break
 
+    /** Writes nothing, and the group holding it is never laid out flat. A comment cannot share the
+     * line after it, so a construct holding one breaks even where its own content would have fitted
+     * — and where the break itself is the enclosing construct's to write, as the brackets of a list
+     * whose only content is a comment. */
+    Doc MUST_BREAK = new MustBreak();
+
     record Nil() implements Doc {}
     record Text(String s) implements Doc {}
     record Line(String flat) implements Doc {}
@@ -33,6 +39,8 @@ public sealed interface Doc {
      * line after it, so a group holding one cannot be laid out flat.
      */
     record Trailing(String s) implements Doc {}
+
+    record MustBreak() implements Doc {}
 
     static Doc text(String s) {
         return new Text(s);
@@ -115,6 +123,7 @@ public sealed interface Doc {
                     sb.append(' ').append(t.s());
                     col += t.s().length() + 1;
                 }
+                case MustBreak _ -> { }
             }
         }
         return sb.toString();
@@ -173,6 +182,9 @@ public sealed interface Doc {
                     // the same, and for the same reason: whatever follows starts a new line, so it
                     // is measured against that line rather than this one, and the comment's own
                     // width is measured against nothing.
+                    return it.mode != Mode.FLAT;
+                }
+                case MustBreak _ -> {
                     return it.mode != Mode.FLAT;
                 }
             }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -49,16 +49,9 @@ public final class Formatter {
      * formats one file, so this lives as long as that. */
     private final java.util.Set<Integer> consumedComments = new java.util.HashSet<>();
 
-    /** {@link #commentsBefore} per parent, computed once. It is asked for every member of a parent,
-     * and answering means walking that parent's children, so without this a construct with n members
-     * walks them n times. One instance formats one file, so the cache lives exactly as long as the
-     * tree it describes. */
-    private final Map<SyntaxNode, ParentComments> commentsByParent = new IdentityHashMap<>();
-
-    /** The comments written at the end of a line of code, by the construct that line belongs to.
-     * Computed once for the file: which of the two a comment is depends on the whitespace before it,
-     * which is a fact about the token stream rather than about any one parent. */
-    private Map<SyntaxNode, List<SyntaxToken>> trailing = new IdentityHashMap<>();
+    /** Where each of the file's comments goes, decided once before any of it is written. One
+     * instance formats one file, so this lives exactly as long as the tree it describes. */
+    private Attachments comments = Attachments.empty();
 
     private Formatter() {
     }
@@ -217,7 +210,7 @@ public final class Formatter {
     // --- top level ---
 
     private Doc file(SyntaxNode file) {
-        trailing = scanTrailing(file);
+        comments = attach(file);
         List<Doc> parts = new ArrayList<>();
         SyntaxKind prev = null;
         for (SyntaxNode item : file.childNodes()) {
@@ -227,29 +220,19 @@ public final class Formatter {
             // A top-level item's comments are read the same way a member's are, and marked written
             // the same way: an `example`'s comment is the item's leading trivia here and the first
             // row's from inside, and it belongs to whichever asks first.
-            List<SyntaxToken> lead = new ArrayList<>(
-                    commentsBefore(file).getOrDefault(item, List.of()));
-            lead.addAll(leadingDeep(item));
+            Doc lead = aboveOf(item);
             if (prev != null) {
                 parts.add(HARDLINE);
                 if (blankBetween(prev, item.kind())) {
                     parts.add(HARDLINE);
                 }
             }
-            for (Doc c : unwritten(lead)) {
-                parts.add(c);
-                parts.add(HARDLINE);
-            }
+            parts.add(lead);
             parts.add(item(item));
-            for (Doc c : trailingOf(item)) {
-                parts.add(c);
-            }
+            parts.add(afterOf(item));
             prev = item.kind();
         }
-        for (Doc c : unwritten(trailingComments(file))) {
-            parts.add(HARDLINE);
-            parts.add(c);
-        }
+        parts.add(endOf(file));
         parts.add(HARDLINE);   // files end with a single newline
         return concat(parts);
     }
@@ -294,10 +277,10 @@ public final class Formatter {
         String target = ids.size() >= 2 ? ids.get(1).text() : "";
         List<Doc> rows = new ArrayList<>();
         for (SyntaxNode row : childNodes(n, SyntaxKind.EXAMPLE_ROW)) {
-            rows.add(concat(HARDLINE, withComments(n, row, exampleRow(row)),
-                    concat(trailingOf(row))));
+            rows.add(concat(HARDLINE, concat(aboveOf(row), exampleRow(row)),
+                    afterOf(row)));
         }
-        rows.add(endComments(n));
+        rows.add(endOf(n));
         return concat(text("example "), text(target), nest(INDENT, concat(rows)));
     }
 
@@ -308,18 +291,18 @@ public final class Formatter {
      * which part was which.
      */
     private Doc exampleRow(SyntaxNode n) {
-        List<Doc> args = new ArrayList<>();
-        for (SyntaxNode a : n.child(SyntaxKind.ARG_LIST).map(this::exprChildren).orElse(List.of())) {
-            args.add(expr(a));
-        }
-        Doc input = delimited("(", SOFTLINE, plain(args), ")");
+        Doc input = n.child(SyntaxKind.ARG_LIST)
+                .map(a -> delimited("(", SOFTLINE, exprDocs(a), ")"))
+                .orElse(text("()"));
         var with = n.child(SyntaxKind.WITH_CLAUSE);
         if (with.isPresent()) {
-            List<Doc> binds = new ArrayList<>();
+            List<Member> binds = new ArrayList<>();
             for (SyntaxNode b : childNodes(with.get(), SyntaxKind.WITH_BINDING)) {
-                binds.add(concat(text(firstIdent(b)), text(" = "), expr(firstExprChildOpt(b).orElseThrow())));
+                binds.add(member(b, concat(text(firstIdent(b)), text(" = "),
+                        expr(firstExprChildOpt(b).orElseThrow()))));
             }
-            input = concat(input, text(" with "), group(nest(INDENT, separated(plain(binds)))));
+            input = concat(input, text(" with "),
+                    group(nest(INDENT, separated(withEndComments(with.get(), binds)))));
         }
 
         List<Segment> segs = new ArrayList<>();
@@ -341,9 +324,9 @@ public final class Formatter {
         String target = ids.size() >= 2 ? ids.get(1).text() : "";
         List<Doc> rows = new ArrayList<>();
         for (SyntaxNode row : childNodes(n, SyntaxKind.FAKE_ROW)) {
-            rows.add(concat(HARDLINE, withComments(n, row, fakeRow(row)), concat(trailingOf(row))));
+            rows.add(concat(HARDLINE, concat(aboveOf(row), fakeRow(row)), afterOf(row)));
         }
-        rows.add(endComments(n));
+        rows.add(endOf(n));
         return concat(text("fake "), text(target), nest(INDENT, concat(rows)));
     }
 
@@ -351,11 +334,7 @@ public final class Formatter {
         var args = n.child(SyntaxKind.ARG_LIST);
         Doc input;
         if (args.isPresent()) {
-            List<Doc> as = new ArrayList<>();
-            for (SyntaxNode a : exprChildren(args.get())) {
-                as.add(expr(a));
-            }
-            input = delimited("(", SOFTLINE, plain(as), ")");
+            input = delimited("(", SOFTLINE, exprDocs(args.get()), ")");
         } else {
             input = text("_");   // the default row
         }
@@ -375,7 +354,7 @@ public final class Formatter {
         List<Member> entries = new ArrayList<>();
         for (SyntaxNode e : childNodes(clause, SyntaxKind.EXPOSED_ENTRY)) {
             Doc name = qualifiedName(e.child(SyntaxKind.QUALIFIED_NAME).orElseThrow());
-            entries.add(member(clause, e, e.child(SyntaxKind.RET_TYPE)
+            entries.add(member(e, e.child(SyntaxKind.RET_TYPE)
                     .map(rt -> concat(name, text(" : "), retType(rt)))
                     .orElse(name)));
         }
@@ -409,8 +388,8 @@ public final class Formatter {
             String label = inv.token(SyntaxKind.ASSIGN).isPresent()
                     ? firstIdent(inv) + " = " : "";
             invariants.add(concat(HARDLINE,
-                    withComments(n, inv, concat(text("invariant " + label), expr(onlyExpr(inv)))),
-                    concat(trailingOf(inv))));
+                    concat(aboveOf(inv), text("invariant " + label), expr(onlyExpr(inv))),
+                    afterOf(inv)));
         }
 
         var product = n.child(SyntaxKind.PRODUCT_BODY);
@@ -420,28 +399,28 @@ public final class Formatter {
         }
         var sum = n.child(SyntaxKind.SUM_BODY);
         if (sum.isPresent()) {
-            // A sum's cases are bare idents, not nodes, so the comments between them are picked up
-            // from the token stream rather than from a member node.
-            List<Doc> pending = new ArrayList<>();
+            // A sum's cases are bare idents, not nodes, so a case's comments are held against where
+            // its identifier is rather than against a member node.
             Doc head = null;
-            List<Doc> headComments = List.of();
+            List<Doc> headComments = new ArrayList<>();
             List<Segment> cases = new ArrayList<>();
             for (SyntaxElement e : sum.get().children()) {
-                if (!(e instanceof SyntaxToken t)) {
+                if (!(e instanceof SyntaxToken t) || t.kind() != SyntaxKind.IDENT) {
                     continue;
                 }
-                if (t.kind() == SyntaxKind.LINE_COMMENT) {
-                    for (Doc c : unwritten(List.of(t))) {
-                        pending.add(concat(c, HARDLINE));
+                Doc body = concat(text(t.text()), afterCase(t));
+                if (head == null) {
+                    head = body;
+                    headComments = new ArrayList<>();
+                    for (Doc c : aboveCase(t)) {
+                        headComments.add(concat(c, HARDLINE));
                     }
-                } else if (t.kind() == SyntaxKind.IDENT) {
-                    if (head == null) {
-                        head = text(t.text());
-                        headComments = List.copyOf(pending);
-                    } else {
-                        cases.add(new Segment("| ", text(t.text()), concat(pending)));
+                } else {
+                    List<Doc> lead = new ArrayList<>();
+                    for (Doc c : aboveCase(t)) {
+                        lead.add(concat(c, HARDLINE));
                     }
-                    pending.clear();
+                    cases.add(new Segment("| ", body, concat(lead)));
                 }
             }
             Doc chain = chained(head, cases);
@@ -477,11 +456,11 @@ public final class Formatter {
             // a comment written after it would leave the member starting a line of its own, at the
             // block's indent rather than after the comma the rest of the block is written with.
             boolean first = lines.isEmpty();
-            Doc line = concat(withComments(body, m, concat(text(first ? "{ " : ", "), member)),
-                    concat(trailingOf(m)));
+            Doc line = concat(concat(aboveOf(m), text(first ? "{ " : ", "), member),
+                    afterOf(m));
             lines.add(first ? line : concat(HARDLINE, line));
         }
-        lines.add(endComments(body));
+        lines.add(endOf(body));
         lines.add(concat(HARDLINE, text("}")));
         return concat(lines);
     }
@@ -504,12 +483,12 @@ public final class Formatter {
             for (SyntaxNode c : s.childNodes()) {
                 if (c.kind() == SyntaxKind.CONSTRUCTS_CLAUSE) {
                     clauses.add(concat(HARDLINE,
-                            withComments(s, c, concat(text("constructs "), nameList(c, 0))),
-                            concat(trailingOf(c))));
+                            concat(aboveOf(c), text("constructs "), nameList(c, 0)),
+                            afterOf(c)));
                 } else if (c.kind() == SyntaxKind.DEPENDS_CLAUSE) {
                     clauses.add(concat(HARDLINE,
-                            withComments(s, c, concat(text("depends on "), nameList(c, 1))),
-                            concat(trailingOf(c))));
+                            concat(aboveOf(c), text("depends on "), nameList(c, 1)),
+                            afterOf(c)));
                 }
             }
             return concat(text("behavior "), text(name), text(" : "), params, text(" -> "), ret,
@@ -519,9 +498,11 @@ public final class Formatter {
         List<SyntaxNode> stages = childNodes(pipe, SyntaxKind.STAGE);
         List<Doc> tail = new ArrayList<>();
         for (int i = 1; i < stages.size(); i++) {
-            tail.add(concat(LINE, text(">-> "), stage(stages.get(i))));
+            SyntaxNode st = stages.get(i);
+            tail.add(concat(LINE, aboveOf(st), text(">-> "), stage(st), afterOf(st)));
         }
-        Doc body = group(nest(INDENT, concat(LINE, stage(stages.get(0)), concat(tail))));
+        Doc body = group(nest(INDENT, concat(LINE, aboveOf(stages.get(0)),
+                stage(stages.get(0)), afterOf(stages.get(0)), concat(tail))));
         Doc declaredOut = pipe.child(SyntaxKind.RET_TYPE)
                 .map(rt -> concat(text(" -> "), retType(rt))).orElse(Doc.NIL);
         return concat(text("behavior "), text(name), text(" ="), body, declaredOut);
@@ -530,7 +511,7 @@ public final class Formatter {
     private Doc paramList(SyntaxNode n) {
         List<Member> params = new ArrayList<>();
         for (SyntaxNode p : childNodes(n, SyntaxKind.PARAM)) {
-            params.add(member(n, p, concat(text(firstIdent(p)), text(": "),
+            params.add(member(p, concat(text(firstIdent(p)), text(": "),
                     retType(p.child(SyntaxKind.RET_TYPE).orElseThrow()))));
         }
         return delimited("(", SOFTLINE, withEndComments(n, params), ")");
@@ -639,7 +620,7 @@ public final class Formatter {
     }
 
     private Doc fnParamList(SyntaxNode n) {
-        List<Doc> params = new ArrayList<>();
+        List<Member> params = new ArrayList<>();
         for (SyntaxNode p : childNodes(n, SyntaxKind.FN_PARAM)) {
             SyntaxNode pat = optionalPatternChild(p);
             Doc d = pat == null ? text(firstIdent(p)) : pattern(pat);
@@ -647,9 +628,9 @@ public final class Formatter {
             if (rt.isPresent()) {
                 d = concat(d, text(": "), retType(rt.get()));
             }
-            params.add(d);
+            params.add(member(p, d));
         }
-        return delimited("(", SOFTLINE, plain(params), ")");
+        return delimited("(", SOFTLINE, withEndComments(n, params), ")");
     }
 
     // --- types ---
@@ -763,13 +744,14 @@ public final class Formatter {
     /** The bracketed argument list of a call or an application. */
     private Doc arguments(SyntaxNode n) {
         List<SyntaxNode> args = n.child(SyntaxKind.ARG_LIST).map(this::exprChildren).orElse(List.of());
+        SyntaxNode argList = n.child(SyntaxKind.ARG_LIST).orElse(null);
         if (args.isEmpty()) {
-            return text("()");
+            List<Member> only = argList == null ? List.of() : withEndComments(argList, List.of());
+            return only.isEmpty() ? text("()") : delimited("(", SOFTLINE, only, ")");
         }
-        SyntaxNode argList = n.child(SyntaxKind.ARG_LIST).orElseThrow();
         List<Member> argDocs = new ArrayList<>();
         for (SyntaxNode a : args) {
-            argDocs.add(member(argList, a, expr(a)));
+            argDocs.add(member(a, expr(a)));
         }
         return delimited("(", SOFTLINE, withEndComments(argList, argDocs), ")");
     }
@@ -848,7 +830,7 @@ public final class Formatter {
     private Doc list(SyntaxNode n) {
         List<Member> elems = exprDocs(n);
         if (elems.isEmpty()) {
-            return text("[]");
+            return text("[]");   // exprDocs has already asked for what was written inside
         }
         return delimited("[", SOFTLINE, elems, "]");
     }
@@ -880,8 +862,10 @@ public final class Formatter {
         }
         List<Doc> lines = new ArrayList<>();
         for (SyntaxNode arm : childNodes(arms.get(), SyntaxKind.ELSE_ARM)) {
-            lines.add(concat(HARDLINE, text("| " + firstIdent(arm) + " -> "), expr(onlyExpr(arm))));
+            lines.add(concat(HARDLINE, aboveOf(arm), text("| " + firstIdent(arm) + " -> "),
+                    expr(onlyExpr(arm)), afterOf(arm)));
         }
+        lines.add(endOf(arms.get()));
         return nest(INDENT, concat(lines));
     }
 
@@ -904,9 +888,9 @@ public final class Formatter {
         SyntaxNode scrutinee = exprChildren(n).get(0);
         List<Doc> cases = new ArrayList<>();
         for (SyntaxNode c : childNodes(n, SyntaxKind.MATCH_CASE)) {
-            cases.add(concat(HARDLINE, withComments(n, c, matchCase(c)), concat(trailingOf(c))));
+            cases.add(concat(HARDLINE, concat(aboveOf(c), matchCase(c)), afterOf(c)));
         }
-        cases.add(endComments(n));
+        cases.add(endOf(n));
         return concat(text("match "), expr(scrutinee), text(" with"), nest(INDENT, concat(cases)));
     }
 
@@ -968,10 +952,12 @@ public final class Formatter {
             // A member's leading comments come before it, each on its own line. The HARDLINE forces
             // the enclosing group to break, which is what a literal with a comment in it wants
             // anyway: a `//` on a line the group had collapsed would swallow the rest of it.
-            members.add(member(n, c, member));
+            members.add(member(c, member));
         }
         if (members.isEmpty()) {
-            return concat(text(typeName), text(" {}"));
+            List<Member> only = withEndComments(n, List.of());
+            return only.isEmpty() ? concat(text(typeName), text(" {}"))
+                    : concat(text(typeName), text(" "), delimited("{", LINE, only, "}"));
         }
         return concat(text(typeName), text(" "),
                 delimited("{", LINE, withEndComments(n, members), "}"));
@@ -983,12 +969,7 @@ public final class Formatter {
             // A statement inside a block carries its leading comments the same way a top-level item
             // does. Walking only the child nodes dropped them, so a comment explaining a step was
             // lost on the first format.
-            for (Doc comment : unwritten(commentsBefore(n).getOrDefault(c, List.of()))) {
-                lines.add(concat(HARDLINE, comment));
-            }
-            for (Doc comment : unwritten(leadingDeep(c))) {
-                lines.add(concat(HARDLINE, comment));
-            }
+            Doc lead = aboveOf(c);
             Doc d = switch (c.kind()) {
                 case LET_STMT -> concat(text("let "), text(firstIdent(c)), writtenType(c),
                         text(" = "), expr(onlyExpr(c)));
@@ -997,9 +978,9 @@ public final class Formatter {
                 case GUARD_STMT -> guardStmt(c);
                 default -> expr(c);   // the result expression
             };
-            lines.add(concat(HARDLINE, d, concat(trailingOf(c))));
+            lines.add(concat(HARDLINE, lead, d, afterOf(c)));
         }
-        lines.add(endComments(n));
+        lines.add(endOf(n));
         return concat(text("{"), nest(INDENT, concat(lines)), HARDLINE, text("}"));
     }
 
@@ -1074,176 +1055,61 @@ public final class Formatter {
                 text(" else "), expr(exprs.get(1)));
     }
 
-    // --- comments / blank lines ---
+    // --- comments ---
+    //
+    // Where a comment goes is decided once, for the file, and in two steps. What it was written
+    // about is read off the token stream: a comment with a newline between it and the code before it
+    // was written above the line that follows, and one without was written at the end of the line
+    // before. That is a fact about the source and it is in the tree, since whitespace is kept.
+    //
+    // Where it is written back is a second question, and the answer is not always the construct it
+    // was written about. Only a construct the layout gives a line of its own can carry a comment: put
+    // anywhere else, the rest of that line would be written inside it, which changes what the code
+    // says rather than how it reads. So the anchor moves up to the nearest construct that has a
+    // line, and a comment written after the condition of an `if` is written at the end of the
+    // declaration that holds it. It travels further than it was written; the alternative is dropping
+    // it.
 
-    /**
-     * A member with the comments written above it in front of it, each on its own line.
-     *
-     * <p>Where a comment lands in the tree is the parser's business and it is not uniform: a comment
-     * above a record-literal field becomes that field's own leading trivia, while one above a match
-     * arm becomes a child of the enclosing {@code MATCH_EXPR}, sitting between the scrutinee and the
-     * first arm. Asking each member for its leading trivia therefore finds some comments and not
-     * others — which is why a comment survived in three constructs and disappeared in eight.
-     *
-     * <p>So the question is asked of the parent instead: walk its children in document order and the
-     * comments fall between the members they were written above, wherever the parser attached them.
-     * A member's own leading trivia is added to that, since the two are disjoint — a token belongs to
-     * one node.
-     *
-     * <p>The {@link Doc#HARDLINE} after each comment forces the enclosing group to break. That is not
-     * a preference: a {@code //} on a line the group had collapsed would swallow everything after it.
-     */
-    private Doc withComments(SyntaxNode parent, SyntaxNode member, Doc d) {
-        List<SyntaxToken> comments = new ArrayList<>(commentsBefore(parent).getOrDefault(member, List.of()));
-        comments.addAll(leadingDeep(member));
-        List<Doc> parts = new ArrayList<>();
-        for (Doc comment : unwritten(comments)) {
-            parts.add(concat(comment, HARDLINE));
-        }
-        if (parts.isEmpty()) {
-            return d;
-        }
-        parts.add(d);
-        return concat(parts);
-    }
+    /** Where the comments of a file go, decided before any of it is written. */
+    private record Attachments(
+            /** Above the line the node opens. */
+            Map<SyntaxNode, List<SyntaxToken>> above,
+            /** At the end of the line the node ends. */
+            Map<SyntaxNode, List<SyntaxToken>> after,
+            /** Inside the node, under its last member and before it closes. */
+            Map<SyntaxNode, List<SyntaxToken>> atEnd,
+            /** Against a bare token rather than a node — a sum's cases, which are identifiers.
+             * Keyed by where the identifier starts, since a token has no identity of its own. */
+            Map<Integer, List<SyntaxToken>> aboveCase,
+            Map<Integer, List<SyntaxToken>> afterCase) {
 
-    /**
-     * The comments at the front of a member's own text. {@link #leading} reads only the node's direct
-     * children and stops at its first child node, but a parser may put the member's first token a
-     * level or two down — an {@code exposing} entry's name is a {@code QUALIFIED_NAME}, and the
-     * comment above the entry becomes *that* node's leading trivia. What is written above a member is
-     * at the front of its text however deep the front is, so the walk follows the leftmost spine.
-     */
-    private List<SyntaxToken> leadingDeep(SyntaxNode member) {
-        List<SyntaxToken> comments = new ArrayList<>();
-        for (SyntaxElement e : member.children()) {
-            if (e instanceof SyntaxToken t) {
-                if (t.kind() == SyntaxKind.WHITESPACE) {
-                    continue;
-                }
-                if (t.kind() == SyntaxKind.LINE_COMMENT) {
-                    comments.add(t);
-                    continue;
-                }
-                break;                      // a real token: the front of the text is here
-            }
-            if (e instanceof SyntaxNode first) {
-                comments.addAll(leadingDeep(first));
-                break;                      // only the leftmost child is the front
-            }
+        static Attachments empty() {
+            return new Attachments(new IdentityHashMap<>(), new IdentityHashMap<>(),
+                    new IdentityHashMap<>(), new java.util.HashMap<>(), new java.util.HashMap<>());
         }
-        return comments;
     }
 
     /**
-     * A parent's comments, by the member each run was written above. {@link #atEnd} is the run after
-     * the last member: it was written above nothing, and a walk that only hands a run to the next
-     * member it meets never hands that one to anybody. Dropping it is how a comment written at the
-     * end of a list disappeared, so it is kept apart rather than left in the walk's state.
+     * Every comment of {@code file}, against where it will be written. One pass over the tokens: a
+     * comment is read as written above the code that follows it or at the end of the code before it,
+     * and then given to whichever construct has the line that code is on.
      */
-    private record ParentComments(Map<SyntaxNode, List<SyntaxToken>> above, List<SyntaxToken> atEnd) {}
-
-    /** Each of {@code parent}'s child nodes against the comment lines written above it — the comments
-     * that sit in the parent's own child list rather than on the member. */
-    private Map<SyntaxNode, List<SyntaxToken>> commentsBefore(SyntaxNode parent) {
-        return comments(parent).above();
-    }
-
-    private ParentComments comments(SyntaxNode parent) {
-        return commentsByParent.computeIfAbsent(parent, Formatter::scanComments);
-    }
-
-    private static ParentComments scanComments(SyntaxNode parent) {
-        Map<SyntaxNode, List<SyntaxToken>> above = new IdentityHashMap<>();
-        List<SyntaxToken> pending = new ArrayList<>();
-        for (SyntaxElement e : parent.children()) {
-            if (e instanceof SyntaxToken t) {
-                if (t.kind() == SyntaxKind.LINE_COMMENT) {
-                    pending.add(t);
-                }
-            } else if (e instanceof SyntaxNode n && !pending.isEmpty()) {
-                above.put(n, List.copyOf(pending));
-                pending.clear();
-            }
-        }
-        return new ParentComments(above, List.copyOf(pending));
-    }
-
-    /** The comments of {@code run} that have not been written yet, one document each. A comment is
-     * reachable from a parent's child list and from the front of a member's own subtree, so which
-     * ones are already written is remembered rather than derived. */
-    private List<Doc> unwritten(List<SyntaxToken> run) {
-        List<Doc> out = new ArrayList<>();
-        for (SyntaxToken c : run) {
-            if (consumedComments.add(c.start())) {
-                out.add(text(c.text().stripTrailing()));
-            }
-        }
-        return out;
-    }
-
-    /** The comments written after {@code parent}'s last member, each opening a line of its own. They
-     * stay inside the construct, under the member they were written under. */
-    private Doc endComments(SyntaxNode parent) {
-        List<Doc> parts = new ArrayList<>();
-        for (Doc c : unwritten(comments(parent).atEnd())) {
-            parts.add(concat(HARDLINE, c));
-        }
-        return concat(parts);
-    }
-
-    /** {@code members} with {@code parent}'s end comments under the last of them — for a construct
-     * whose members are joined rather than written a line at a time, where there is no line to add
-     * one to except the last member's own document. */
-    private List<Member> withEndComments(SyntaxNode parent, List<Member> members) {
-        List<Doc> lines = unwritten(comments(parent).atEnd());
-        if (lines.isEmpty() || members.isEmpty()) {
-            return members;
-        }
-        List<Member> out = new ArrayList<>(members);
-        Member last = out.get(out.size() - 1);
-        Doc doc = last.doc();
-        for (Doc c : lines) {
-            doc = concat(doc, HARDLINE, c);
-        }
-        out.set(out.size() - 1, new Member(doc, last.trailing()));
-        return out;
-    }
-
-    /** A member with the comments written above its line in front of it, and the one written at the
-     * end of that line kept apart, since what the enclosing construct writes between this member and
-     * the next goes between them. */
-    private Member member(SyntaxNode parent, SyntaxNode node, Doc d) {
-        return new Member(withComments(parent, node, d), concat(trailingOf(node)));
-    }
-
-    /**
-     * Every comment written after code on the same line, by the construct that code ends. Whether a
-     * comment was written above a line or at the end of one is in the tree — the whitespace before a
-     * comment on its own line carries the newline that ended the line before it, and the whitespace
-     * before a trailing comment does not — so this reads it rather than guessing from position.
-     */
-    private static Map<SyntaxNode, List<SyntaxToken>> scanTrailing(SyntaxNode file) {
-        Map<SyntaxNode, List<SyntaxToken>> out = new IdentityHashMap<>();
+    private static Attachments attach(SyntaxNode file) {
+        Attachments out = Attachments.empty();
+        List<SyntaxToken> all = tokens(file);
         List<SyntaxToken> code = new ArrayList<>();   // the tokens that were not trivia
-        boolean lineEnded = true;            // nothing precedes the first token on its line
-        for (SyntaxToken t : tokens(file)) {
+        boolean lineEnded = true;                     // nothing precedes the first token of a file
+        for (int i = 0; i < all.size(); i++) {
+            SyntaxToken t = all.get(i);
             if (t.kind() == SyntaxKind.WHITESPACE) {
                 lineEnded |= t.text().indexOf('\n') >= 0;
             } else if (t.kind() == SyntaxKind.LINE_COMMENT) {
-                // a comma is the enclosing construct's, so a comment after one was written about
-                // the member the comma closed rather than about the comma
-                int i = code.size() - 1;
-                while (i >= 0 && code.get(i).kind() == SyntaxKind.COMMA) {
-                    i--;
+                if (lineEnded) {
+                    above(out, nextCode(all, i), t, file);
+                } else {
+                    after(out, lastCode(code), t);
                 }
-                if (!lineEnded && i >= 0) {
-                    SyntaxNode o = onItsOwnLine(owner(code.get(i)));
-                    if (o != null) {
-                        out.computeIfAbsent(o, _ -> new ArrayList<>()).add(t);
-                    }
-                }
-                lineEnded = true;            // a line comment runs to the end of its line
+                lineEnded = true;                     // a line comment runs to the end of its line
             } else {
                 code.add(t);
                 lineEnded = false;
@@ -1253,29 +1119,103 @@ public final class Formatter {
     }
 
     /**
-     * The construct a comment written after {@code code} was written about: the outermost one that
-     * ends where {@code code} does. {@code data D = A | B   // c} is about the declaration and not
-     * about {@code B}, and {@code , f: T   // c} is about the field and not about the block, and the
-     * two are the same rule — what ends on that line is what the line was about.
+     * What separates one member of a construct from the next. It belongs to the construct rather
+     * than to either member, so it is not what a comment was written about in either direction: a
+     * comment before a {@code |} was written about the case after it, and one after a {@code ,} about
+     * the member the comma closed.
      */
-    private static SyntaxNode owner(SyntaxToken code) {
-        SyntaxNode node = code.parent();
-        while (node.parent() != null && node.parent().parent() != null
-                && node.parent().end() == code.end()) {
-            node = node.parent();
+    private static boolean separates(SyntaxToken t) {
+        return switch (t.kind()) {
+            case COMMA, PIPE, PIPEFWD, VPIPE -> true;
+            default -> false;
+        };
+    }
+
+    /** What opens a construct. It is the construct's too, so a comment written above it was written
+     * above the first member rather than above the bracket — which is also what keeps the answer
+     * the same on a second formatting, when the bracket has moved onto the member's line. */
+    private static boolean opens(SyntaxToken t) {
+        return switch (t.kind()) {
+            case LBRACE, LPAREN, LBRACKET -> true;
+            default -> false;
+        };
+    }
+
+    /** The code the comment at {@code i} was written above, or null where the file ends first. */
+    private static SyntaxToken nextCode(List<SyntaxToken> all, int i) {
+        for (int j = i + 1; j < all.size(); j++) {
+            SyntaxToken t = all.get(j);
+            if (t.isTrivia() || separates(t) || opens(t)) {
+                continue;
+            }
+            return t.kind() == SyntaxKind.EOF ? null : t;
         }
-        return node;
+        return null;
+    }
+
+    /** The code a comment was written after. */
+    private static SyntaxToken lastCode(List<SyntaxToken> code) {
+        for (int i = code.size() - 1; i >= 0; i--) {
+            if (!separates(code.get(i))) {
+                return code.get(i);
+            }
+        }
+        return null;
+    }
+
+    private static void above(Attachments out, SyntaxToken next, SyntaxToken comment, SyntaxNode file) {
+        if (next == null) {
+            add(out.atEnd(), file, comment);          // nothing follows: it closes the file
+        } else if (isCase(next)) {
+            out.aboveCase().computeIfAbsent(next.start(), _ -> new ArrayList<>()).add(comment);
+        } else if (closes(next)) {
+            add(out.atEnd(), next.parent(), comment);
+        } else {
+            SyntaxNode owner = hasALine(next);
+            add(owner == null ? out.atEnd() : out.above(), owner == null ? file : owner, comment);
+        }
+    }
+
+    private static void after(Attachments out, SyntaxToken code, SyntaxToken comment) {
+        if (code == null) {
+            return;                                   // a comment with no code before it is above
+        }
+        // A case is only its own line's owner while something follows it. The last case of a sum
+        // ends where the declaration does, and what ends on that line is the declaration.
+        if (isCase(code) && code.end() != code.parent().end()) {
+            out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
+            return;
+        }
+        SyntaxNode owner = hasALine(code);
+        if (owner != null) {
+            add(out.after(), owner, comment);
+        }
+    }
+
+    private static void add(Map<SyntaxNode, List<SyntaxToken>> to, SyntaxNode key, SyntaxToken c) {
+        to.computeIfAbsent(key, _ -> new ArrayList<>()).add(c);
+    }
+
+    /** A case of a sum, which the grammar writes as a bare identifier rather than as a node. */
+    private static boolean isCase(SyntaxToken t) {
+        return t.kind() == SyntaxKind.IDENT && t.parent().kind() == SyntaxKind.SUM_BODY;
+    }
+
+    /** Whether {@code t} is what closes a construct whose members take a line each — the place a
+     * comment written under the last member goes. */
+    private static boolean closes(SyntaxToken t) {
+        return switch (t.kind()) {
+            case RBRACE, RPAREN, RBRACKET -> holdsLines(t.parent().kind());
+            default -> false;
+        };
     }
 
     /**
-     * The construct whose line a comment can be written at the end of, at or above {@code n}. Only a
-     * construct the layout gives a line of its own can carry one: a comment put after part of a line
-     * would have the rest of that line written inside it, which is a change to what the code says
-     * rather than to how it reads. So the owner moves up until it reaches one, and a comment written
-     * after the condition of an {@code if} is written at the end of the declaration that holds it.
+     * The construct whose line {@code t} is on: the nearest one at or above it that the layout gives
+     * a line of its own.
      */
-    private static SyntaxNode onItsOwnLine(SyntaxNode n) {
-        for (SyntaxNode c = n; c != null && c.parent() != null; c = c.parent()) {
+    private static SyntaxNode hasALine(SyntaxToken t) {
+        for (SyntaxNode c = t.parent(); c != null && c.parent() != null; c = c.parent()) {
             if (takesALineOf(c.parent().kind(), c.kind())) {
                 return c;
             }
@@ -1284,9 +1224,8 @@ public final class Formatter {
     }
 
     /** Whether a {@code child} of {@code parent} is written on a line of its own. These are the
-     * places a member's comments are asked for; a construct added to one of these lists without
-     * being asked is what the count of comments consumed against the comments the tree holds is
-     * there to catch. */
+     * places a construct is asked for its comments; one added to a list here without being asked is
+     * what counting the comments consumed against the comments the tree holds is there to catch. */
     private static boolean takesALineOf(SyntaxKind parent, SyntaxKind child) {
         return switch (parent) {
             case SOURCE_FILE -> isTopLevel(child);
@@ -1298,24 +1237,123 @@ public final class Formatter {
             case FAKE_DEF -> child == SyntaxKind.FAKE_ROW;
             case EXPOSING_CLAUSE -> child == SyntaxKind.EXPOSED_ENTRY;
             case PARAM_LIST -> child == SyntaxKind.PARAM;
+            case FN_PARAM_LIST -> child == SyntaxKind.FN_PARAM;
+            case WITH_CLAUSE -> child == SyntaxKind.WITH_BINDING;
+            case ELSE_ARMS -> child == SyntaxKind.ELSE_ARM;
+            case PIPE_BEHAVIOR -> child == SyntaxKind.STAGE;
             case DATA_DEF -> child == SyntaxKind.INVARIANT_CLAUSE;
             case BEHAVIOR_SIG -> child == SyntaxKind.CONSTRUCTS_CLAUSE
                     || child == SyntaxKind.DEPENDS_CLAUSE;
             case BLOCK_EXPR -> true;
-            case ARG_LIST, LIST_EXPR, TUPLE_EXPR -> isExprKind(child);
+            case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> isExprKind(child);
             default -> false;
         };
     }
 
-    /** {@code n}'s trailing comments, marked consumed. Empty where it has none, or where they have
-     * been written already. */
-    private List<Doc> trailingOf(SyntaxNode n) {
+    /** Whether a construct writes its members one to a line, so that its closer opens a line a
+     * comment can be written on. */
+    private static boolean holdsLines(SyntaxKind k) {
+        return switch (k) {
+            case PRODUCT_BODY, NEW_DATA_EXPR, EXPOSING_CLAUSE, PARAM_LIST, FN_PARAM_LIST, ARG_LIST,
+                 LIST_EXPR, TUPLE_EXPR, LIST_COMP, BLOCK_EXPR -> true;
+            default -> false;
+        };
+    }
+
+    // --- writing them back ---
+
+    /** {@code run} as documents, each marked consumed as it is taken. A comment is taken once. */
+    private List<Doc> unwritten(List<SyntaxToken> run) {
         List<Doc> out = new ArrayList<>();
-        for (SyntaxToken c : trailing.getOrDefault(n, List.of())) {
+        for (SyntaxToken c : run) {
             if (consumedComments.add(c.start())) {
-                out.add(Doc.trailing(c.text().stripTrailing()));
+                out.add(text(c.text().stripTrailing()));
             }
         }
+        return out;
+    }
+
+    /** The comments written above {@code n}, each on its own line in front of it. The
+     * {@link Doc#HARDLINE} after each forces the enclosing group to break: a {@code //} on a line the
+     * group had collapsed would swallow everything after it. */
+    private Doc aboveOf(SyntaxNode n) {
+        List<Doc> parts = new ArrayList<>();
+        for (Doc c : unwritten(comments.above().getOrDefault(n, List.of()))) {
+            parts.add(concat(c, HARDLINE));
+        }
+        return concat(parts);
+    }
+
+    /** The comment written at the end of {@code n}'s line. */
+    private Doc afterOf(SyntaxNode n) {
+        List<Doc> parts = new ArrayList<>();
+        for (SyntaxToken c : comments.after().getOrDefault(n, List.of())) {
+            if (consumedComments.add(c.start())) {
+                parts.add(Doc.trailing(c.text().stripTrailing()));
+            }
+        }
+        return concat(parts);
+    }
+
+    /** The comments written inside {@code n} under its last member, each opening a line. */
+    private Doc endOf(SyntaxNode n) {
+        List<Doc> parts = new ArrayList<>();
+        for (Doc c : endLines(n)) {
+            parts.add(concat(HARDLINE, c));
+        }
+        return concat(parts);
+    }
+
+    private List<Doc> endLines(SyntaxNode n) {
+        return unwritten(comments.atEnd().getOrDefault(n, List.of()));
+    }
+
+    /** The comments written above a sum's case, which is an identifier and not a node. */
+    private List<Doc> aboveCase(SyntaxToken ident) {
+        return unwritten(comments.aboveCase().getOrDefault(ident.start(), List.of()));
+    }
+
+    /** The comment written at the end of a sum case's line. */
+    private Doc afterCase(SyntaxToken ident) {
+        List<Doc> parts = new ArrayList<>();
+        for (SyntaxToken c : comments.afterCase().getOrDefault(ident.end(), List.of())) {
+            if (consumedComments.add(c.start())) {
+                parts.add(Doc.trailing(c.text().stripTrailing()));
+            }
+        }
+        return concat(parts);
+    }
+
+    /** A member: what is written above its line, the member, and what ends that line — the last kept
+     * apart because whatever the enclosing construct writes between this member and the next belongs
+     * on this line, before the comment. */
+    private Member member(SyntaxNode node, Doc d) {
+        return new Member(concat(aboveOf(node), d), afterOf(node));
+    }
+
+    /** {@code members} of {@code parent} with the comments written under the last of them. A
+     * construct with no members at all still has somewhere to put them: between its brackets, which
+     * is where they were written. */
+    private List<Member> withEndComments(SyntaxNode parent, List<Member> members) {
+        List<Doc> end = endLines(parent);
+        if (end.isEmpty()) {
+            return members;
+        }
+        List<Doc> lines = new ArrayList<>();
+        for (Doc c : end) {
+            lines.add(concat(HARDLINE, c));
+        }
+        List<Member> out = new ArrayList<>(members);
+        if (out.isEmpty()) {
+            // a construct with no members still has between its brackets, which is where they were
+            // written; the comments stand where a member would have, so they bring no line of their
+            // own — the brackets already open and close one
+            out.add(new Member(concat(Doc.MUST_BREAK, Doc.join(HARDLINE, end)), Doc.NIL));
+            return out;
+        }
+        Member last = out.get(out.size() - 1);
+        out.set(out.size() - 1,
+                new Member(concat(last.doc(), last.trailing(), concat(lines)), Doc.NIL));
         return out;
     }
 
@@ -1332,22 +1370,6 @@ public final class Formatter {
         return out;
     }
 
-    private List<SyntaxToken> trailingComments(SyntaxNode file) {
-        List<SyntaxToken> out = new ArrayList<>();
-        int lastNode = -1;
-        List<SyntaxElement> es = file.children();
-        for (int i = 0; i < es.size(); i++) {
-            if (es.get(i) instanceof SyntaxNode) {
-                lastNode = i;
-            }
-        }
-        for (int i = lastNode + 1; i < es.size(); i++) {
-            if (es.get(i) instanceof SyntaxToken t && t.kind() == SyntaxKind.LINE_COMMENT) {
-                out.add(t);
-            }
-        }
-        return out;
-    }
 
     // --- CST navigation ---
 
@@ -1365,7 +1387,7 @@ public final class Formatter {
     private List<Member> exprDocs(SyntaxNode n) {
         List<Member> out = new ArrayList<>();
         for (SyntaxNode c : exprChildren(n)) {
-            out.add(member(n, c, expr(c)));
+            out.add(member(c, expr(c)));
         }
         return withEndComments(n, out);
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -55,6 +55,11 @@ public final class Formatter {
      * tree it describes. */
     private final Map<SyntaxNode, ParentComments> commentsByParent = new IdentityHashMap<>();
 
+    /** The comments written at the end of a line of code, by the construct that line belongs to.
+     * Computed once for the file: which of the two a comment is depends on the whitespace before it,
+     * which is a fact about the token stream rather than about any one parent. */
+    private Map<SyntaxNode, List<SyntaxToken>> trailing = new IdentityHashMap<>();
+
     private Formatter() {
     }
 
@@ -160,6 +165,7 @@ public final class Formatter {
     // --- top level ---
 
     private Doc file(SyntaxNode file) {
+        trailing = scanTrailing(file);
         List<Doc> parts = new ArrayList<>();
         SyntaxKind prev = null;
         for (SyntaxNode item : file.childNodes()) {
@@ -183,6 +189,9 @@ public final class Formatter {
                 parts.add(HARDLINE);
             }
             parts.add(item(item));
+            for (Doc c : trailingOf(item)) {
+                parts.add(c);
+            }
             prev = item.kind();
         }
         for (Doc c : unwritten(trailingComments(file))) {
@@ -1140,6 +1149,72 @@ public final class Formatter {
             last = concat(last, HARDLINE, c);
         }
         out.set(out.size() - 1, last);
+        return out;
+    }
+
+    /**
+     * Every comment written after code on the same line, by the construct that code ends. Whether a
+     * comment was written above a line or at the end of one is in the tree — the whitespace before a
+     * comment on its own line carries the newline that ended the line before it, and the whitespace
+     * before a trailing comment does not — so this reads it rather than guessing from position.
+     */
+    private static Map<SyntaxNode, List<SyntaxToken>> scanTrailing(SyntaxNode file) {
+        Map<SyntaxNode, List<SyntaxToken>> out = new IdentityHashMap<>();
+        SyntaxToken code = null;             // the last token that was not trivia
+        boolean lineEnded = true;            // nothing precedes the first token on its line
+        for (SyntaxToken t : tokens(file)) {
+            if (t.kind() == SyntaxKind.WHITESPACE) {
+                lineEnded |= t.text().indexOf('\n') >= 0;
+            } else if (t.kind() == SyntaxKind.LINE_COMMENT) {
+                if (!lineEnded && code != null) {
+                    out.computeIfAbsent(owner(code), _ -> new ArrayList<>()).add(t);
+                }
+                lineEnded = true;            // a line comment runs to the end of its line
+            } else {
+                code = t;
+                lineEnded = false;
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The construct a comment written after {@code code} was written about: the outermost one that
+     * ends where {@code code} does. {@code data D = A | B   // c} is about the declaration and not
+     * about {@code B}, and {@code , f: T   // c} is about the field and not about the block, and the
+     * two are the same rule — what ends on that line is what the line was about.
+     */
+    private static SyntaxNode owner(SyntaxToken code) {
+        SyntaxNode node = code.parent();
+        while (node.parent() != null && node.parent().parent() != null
+                && node.parent().end() == code.end()) {
+            node = node.parent();
+        }
+        return node;
+    }
+
+    /** {@code n}'s trailing comments, marked consumed. Empty where it has none, or where they have
+     * been written already. */
+    private List<Doc> trailingOf(SyntaxNode n) {
+        List<Doc> out = new ArrayList<>();
+        for (SyntaxToken c : trailing.getOrDefault(n, List.of())) {
+            if (consumedComments.add(c.start())) {
+                out.add(Doc.trailing(c.text().stripTrailing()));
+            }
+        }
+        return out;
+    }
+
+    /** Every token of {@code n}'s subtree, in document order. */
+    private static List<SyntaxToken> tokens(SyntaxNode n) {
+        List<SyntaxToken> out = new ArrayList<>();
+        for (SyntaxElement e : n.children()) {
+            if (e instanceof SyntaxNode c) {
+                out.addAll(tokens(c));
+            } else if (e instanceof SyntaxToken t) {
+                out.add(t);
+            }
+        }
         return out;
     }
 

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -1267,8 +1267,6 @@ public final class Formatter {
         }
         if (next == null) {
             add(out.atEnd(), file, comment);          // nothing follows: it closes the file
-        } else if (isChainHead(next)) {
-            out.aboveCase().computeIfAbsent(next.start(), _ -> new ArrayList<>()).add(comment);
         } else if (isBareMember(next)) {
             // A clause keyword opens the line its first name is on, the way a bracket does, so a
             // comment above that name is above the clause rather than between the two.
@@ -1324,6 +1322,18 @@ public final class Formatter {
         boolean moreOfTheLineFollows = slot.parent() != null
                 && slot.parent().kind() == SyntaxKind.PIPE_BEHAVIOR
                 && slot.end() != slot.parent().end();
+        // The construct the slot ends together with may itself sit in the middle of a line — a
+        // `with` clause ends where its last binding does and the row goes on to its expected value.
+        SyntaxToken slotEnd = lastCodeTokenOf(slot);
+        SyntaxNode ends = slotEnd == null ? slot : endingAt(slotEnd);
+        if (ends.parent() != null && ends.parent().parent() != null
+                && ends.end() != ends.parent().end()
+                && !takesALineOf(ends.parent().kind(), ends.kind())
+                && !isSpine(ends.parent())   // a run's parts are its lines, not the run's
+                && slotOf(ends.parent()) != null) {
+            add(out.after(), slotOf(ends.parent()), comment);
+            return;
+        }
         if ((slot.end() != code.end() || moreOfTheLineFollows) && !endsAWrittenLine(code)) {
             SyntaxToken last = lastCodeTokenOf(moreOfTheLineFollows ? slot.parent() : slot);
             if (last != null && last.end() != code.end()) {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -73,12 +73,37 @@ public final class Formatter {
         }
     }
 
+    /**
+     * The comments {@code file} holds that {@code consumed} does not — the ones the formatter found
+     * and did not write. {@link SyntaxKind#LINE_COMMENT} is the only kind of comment the grammar
+     * has, so this is all of them.
+     */
+    static List<SyntaxToken> unconsumed(SyntaxNode file, java.util.Set<Integer> consumed) {
+        List<SyntaxToken> out = new ArrayList<>();
+        for (SyntaxToken t : tokens(file)) {
+            if (t.kind() == SyntaxKind.LINE_COMMENT && !consumed.contains(t.start())) {
+                out.add(t);
+            }
+        }
+        return out;
+    }
+
     /** Formats an already-parsed file into its canonical form — for a caller that has parsed the
      * source (e.g. to check for syntax errors) and need not parse it again. Assumes {@code file}
      * came from a clean parse. */
     public static String format(SyntaxNode file) {
         try {
-            return new Formatter().file(file).render(WIDTH);
+            Formatter formatter = new Formatter();
+            Doc doc = formatter.file(file);
+            List<SyntaxToken> missing = unconsumed(file, formatter.consumedComments);
+            if (!missing.isEmpty()) {
+                throw new IllegalStateException(
+                        missing.size() + " comment(s) in this source reached no construct and would"
+                                + " have been dropped; the first is at offset "
+                                + missing.get(0).start() + ": "
+                                + missing.get(0).text().stripTrailing());
+            }
+            return doc.render(WIDTH);
         } catch (StackOverflowError _) {
             throw tooDeep();
         }
@@ -1213,7 +1238,10 @@ public final class Formatter {
                     i--;
                 }
                 if (!lineEnded && i >= 0) {
-                    out.computeIfAbsent(owner(code.get(i)), _ -> new ArrayList<>()).add(t);
+                    SyntaxNode o = onItsOwnLine(owner(code.get(i)));
+                    if (o != null) {
+                        out.computeIfAbsent(o, _ -> new ArrayList<>()).add(t);
+                    }
                 }
                 lineEnded = true;            // a line comment runs to the end of its line
             } else {
@@ -1237,6 +1265,46 @@ public final class Formatter {
             node = node.parent();
         }
         return node;
+    }
+
+    /**
+     * The construct whose line a comment can be written at the end of, at or above {@code n}. Only a
+     * construct the layout gives a line of its own can carry one: a comment put after part of a line
+     * would have the rest of that line written inside it, which is a change to what the code says
+     * rather than to how it reads. So the owner moves up until it reaches one, and a comment written
+     * after the condition of an {@code if} is written at the end of the declaration that holds it.
+     */
+    private static SyntaxNode onItsOwnLine(SyntaxNode n) {
+        for (SyntaxNode c = n; c != null && c.parent() != null; c = c.parent()) {
+            if (takesALineOf(c.parent().kind(), c.kind())) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    /** Whether a {@code child} of {@code parent} is written on a line of its own. These are the
+     * places a member's comments are asked for; a construct added to one of these lists without
+     * being asked is what the count of comments consumed against the comments the tree holds is
+     * there to catch. */
+    private static boolean takesALineOf(SyntaxKind parent, SyntaxKind child) {
+        return switch (parent) {
+            case SOURCE_FILE -> isTopLevel(child);
+            case PRODUCT_BODY, NEW_DATA_EXPR ->
+                    child == SyntaxKind.FIELD || child == SyntaxKind.FIELD_INIT
+                            || child == SyntaxKind.SPREAD_MEMBER;
+            case MATCH_EXPR -> child == SyntaxKind.MATCH_CASE;
+            case EXAMPLE_DEF -> child == SyntaxKind.EXAMPLE_ROW;
+            case FAKE_DEF -> child == SyntaxKind.FAKE_ROW;
+            case EXPOSING_CLAUSE -> child == SyntaxKind.EXPOSED_ENTRY;
+            case PARAM_LIST -> child == SyntaxKind.PARAM;
+            case DATA_DEF -> child == SyntaxKind.INVARIANT_CLAUSE;
+            case BEHAVIOR_SIG -> child == SyntaxKind.CONSTRUCTS_CLAUSE
+                    || child == SyntaxKind.DEPENDS_CLAUSE;
+            case BLOCK_EXPR -> true;
+            case ARG_LIST, LIST_EXPR, TUPLE_EXPR -> isExprKind(child);
+            default -> false;
+        };
     }
 
     /** {@code n}'s trailing comments, marked consumed. Empty where it has none, or where they have

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -371,11 +371,12 @@ public final class Formatter {
         if (list.isEmpty()) {
             return d;   // an import that only renames the module, or only names the dependency
         }
-        List<Doc> names = new ArrayList<>();
+        List<Member> names = new ArrayList<>();
         for (SyntaxToken t : idents(list.get())) {
-            names.add(text(t.text()));
+            names.add(tokenMember(t, t, text(t.text())));
         }
-        return concat(d, text(" "), delimited("(", LINE, plain(names), ")"));
+        return concat(d, text(" "),
+                delimited("(", LINE, withEndComments(list.get(), names), ")"));
     }
 
     // --- data ---
@@ -496,16 +497,18 @@ public final class Formatter {
         }
         SyntaxNode pipe = n.child(SyntaxKind.PIPE_BEHAVIOR).orElseThrow();
         List<SyntaxNode> stages = childNodes(pipe, SyntaxKind.STAGE);
-        List<Doc> tail = new ArrayList<>();
-        for (int i = 1; i < stages.size(); i++) {
-            SyntaxNode st = stages.get(i);
-            tail.add(concat(LINE, aboveOf(st), text(">-> "), stage(st), afterOf(st)));
-        }
-        Doc body = group(nest(INDENT, concat(LINE, aboveOf(stages.get(0)),
-                stage(stages.get(0)), afterOf(stages.get(0)), concat(tail))));
         Doc declaredOut = pipe.child(SyntaxKind.RET_TYPE)
                 .map(rt -> concat(text(" -> "), retType(rt))).orElse(Doc.NIL);
-        return concat(text("behavior "), text(name), text(" ="), body, declaredOut);
+        List<Doc> parts = new ArrayList<>();
+        for (int i = 0; i < stages.size(); i++) {
+            SyntaxNode st = stages.get(i);
+            // What the declaration writes after the last stage is on that stage's line, so it comes
+            // before the comment that ends the line rather than after it.
+            parts.add(concat(LINE, aboveOf(st), text(i == 0 ? "" : ">-> "), stage(st),
+                    i == stages.size() - 1 ? declaredOut : Doc.NIL, afterOf(st)));
+        }
+        return concat(text("behavior "), text(name), text(" ="),
+                group(nest(INDENT, concat(parts))));
     }
 
     private Doc paramList(SyntaxNode n) {
@@ -534,8 +537,10 @@ public final class Formatter {
     private Doc nameList(SyntaxNode clause, int skipIdents) {
         // an entry may name through a module, so the dots of one name are kept and only a comma
         // starts the next
-        List<Doc> names = new ArrayList<>();
+        List<Member> names = new ArrayList<>();
         StringBuilder current = new StringBuilder();
+        SyntaxToken opened = null;
+        SyntaxToken ended = null;
         int skipped = 0;
         for (SyntaxElement e : meaningful(clause)) {
             if (!(e instanceof SyntaxToken t)) {
@@ -546,19 +551,27 @@ public final class Formatter {
                 continue;
             }
             switch (t.kind()) {
-                case IDENT -> current.append(t.text());
+                case IDENT -> {
+                    if (opened == null) {
+                        opened = t;
+                    }
+                    ended = t;
+                    current.append(t.text());
+                }
                 case DOT -> current.append('.');
                 case COMMA -> {
-                    names.add(text(current.toString()));
+                    names.add(tokenMember(opened, ended, text(current.toString())));
                     current.setLength(0);
+                    opened = null;
+                    ended = null;
                 }
                 default -> { }   // the `constructs` / `depends` keyword
             }
         }
         if (current.length() > 0) {
-            names.add(text(current.toString()));
+            names.add(tokenMember(opened, ended, text(current.toString())));
         }
-        return group(nest(INDENT, separated(plain(names))));
+        return group(nest(INDENT, separated(withEndComments(clause, names))));
     }
 
     /** The {@code : T} a node wrote, or nothing — a helper's return type, a local binding's annotation. */
@@ -806,14 +819,14 @@ public final class Formatter {
     }
 
     private Doc pipe(SyntaxNode n) {
-        List<Doc> stages = new ArrayList<>();
+        List<Segment> stages = new ArrayList<>();
         Doc head = collectPipe(n, stages);
-        return chained(head, segments("|> ", stages));
+        return chained(head, stages);
     }
 
     /** Flattens a left-nested {@code |>} chain: returns the head doc and fills {@code stages} with each
      * right-hand stage in source order. */
-    private Doc collectPipe(SyntaxNode n, List<Doc> stages) {
+    private Doc collectPipe(SyntaxNode n, List<Segment> stages) {
         List<SyntaxNode> ops = exprChildren(n);
         SyntaxNode left = ops.get(0);
         SyntaxNode right = ops.get(1);
@@ -821,9 +834,9 @@ public final class Formatter {
         if (left.kind() == SyntaxKind.PIPE_EXPR) {
             head = collectPipe(left, stages);
         } else {
-            head = expr(left);
+            head = concat(aboveOf(left), expr(left), afterOf(left));
         }
-        stages.add(expr(right));
+        stages.add(new Segment("|> ", concat(expr(right), afterOf(right)), aboveOf(right)));
         return head;
     }
 
@@ -837,9 +850,12 @@ public final class Formatter {
 
     private Doc listComp(SyntaxNode n) {
         List<Member> exprs = exprDocs(n);
+        Member element = exprs.get(0);
         List<Member> guards = exprs.subList(1, exprs.size());
-        return concat(text("["), exprs.get(0).doc(), text(" | "),
-                group(nest(INDENT, separated(guards))), text("]"));
+        // The `|` is the comprehension's and it is on the element's line, so it goes before the
+        // comment that ends that line — as a comma does for a member of a list.
+        return group(concat(text("["), element.doc(), text(" |"), element.trailing(),
+                nest(INDENT, concat(LINE, separated(guards))), SOFTLINE, text("]")));
     }
 
     private Doc ifExpr(SyntaxNode n) {
@@ -1145,7 +1161,7 @@ public final class Formatter {
     private static SyntaxToken nextCode(List<SyntaxToken> all, int i) {
         for (int j = i + 1; j < all.size(); j++) {
             SyntaxToken t = all.get(j);
-            if (t.isTrivia() || separates(t) || opens(t)) {
+            if (t.isTrivia() || separates(t)) {
                 continue;
             }
             return t.kind() == SyntaxKind.EOF ? null : t;
@@ -1164,9 +1180,21 @@ public final class Formatter {
     }
 
     private static void above(Attachments out, SyntaxToken next, SyntaxToken comment, SyntaxNode file) {
+        if (next != null && opens(next)) {
+            // what opens a construct is the construct's, and it shares a line with the first member
+            SyntaxElement first = firstMemberOf(next.parent());
+            if (first instanceof SyntaxNode node) {
+                add(out.above(), node, comment);
+                return;
+            }
+            if (first instanceof SyntaxToken token) {
+                out.aboveCase().computeIfAbsent(token.start(), _ -> new ArrayList<>()).add(comment);
+                return;
+            }
+        }
         if (next == null) {
             add(out.atEnd(), file, comment);          // nothing follows: it closes the file
-        } else if (isCase(next)) {
+        } else if (isBareMember(next)) {
             out.aboveCase().computeIfAbsent(next.start(), _ -> new ArrayList<>()).add(comment);
         } else if (closes(next)) {
             add(out.atEnd(), next.parent(), comment);
@@ -1180,9 +1208,9 @@ public final class Formatter {
         if (code == null) {
             return;                                   // a comment with no code before it is above
         }
-        // A case is only its own line's owner while something follows it. The last case of a sum
-        // ends where the declaration does, and what ends on that line is the declaration.
-        if (isCase(code) && code.end() != code.parent().end()) {
+        // A bare member is only its own line's owner while something follows it. The last case of a
+        // sum ends where the declaration does, and what ends on that line is the declaration.
+        if (isBareMember(code) && code.end() != code.parent().end()) {
             out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
             return;
         }
@@ -1196,9 +1224,47 @@ public final class Formatter {
         to.computeIfAbsent(key, _ -> new ArrayList<>()).add(c);
     }
 
-    /** A case of a sum, which the grammar writes as a bare identifier rather than as a node. */
-    private static boolean isCase(SyntaxToken t) {
-        return t.kind() == SyntaxKind.IDENT && t.parent().kind() == SyntaxKind.SUM_BODY;
+    /** The first of {@code container}'s members, which is what shares the line its opener starts.
+     * Nothing where it has no members: an empty construct's brackets open and close one line. */
+    private static SyntaxElement firstMemberOf(SyntaxNode container) {
+        for (SyntaxElement e : container.children()) {
+            if (e instanceof SyntaxNode c && takesALineOf(container.kind(), c.kind())) {
+                return c;
+            }
+            if (e instanceof SyntaxToken t && isBareMember(t)) {
+                return t;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * A member the grammar writes as a bare identifier rather than as a node — a sum's cases, the
+     * names an import or a {@code constructs} clause lists. It has no node to be named by, so it is
+     * named by where its identifier is.
+     *
+     * <p>The identifier a {@code depends on} clause opens with is the {@code on}, which is the
+     * keyword and not a name.
+     */
+    private static boolean isBareMember(SyntaxToken t) {
+        if (t.kind() != SyntaxKind.IDENT) {
+            return false;
+        }
+        SyntaxNode parent = t.parent();
+        return switch (parent.kind()) {
+            case SUM_BODY, NAME_LIST, CONSTRUCTS_CLAUSE -> true;
+            case DEPENDS_CLAUSE -> !t.equals(firstIdentToken(parent));
+            default -> false;
+        };
+    }
+
+    private static SyntaxToken firstIdentToken(SyntaxNode n) {
+        for (SyntaxElement e : n.children()) {
+            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
+                return t;
+            }
+        }
+        return null;
     }
 
     /** Whether {@code t} is what closes a construct whose members take a line each — the place a
@@ -1246,6 +1312,7 @@ public final class Formatter {
                     || child == SyntaxKind.DEPENDS_CLAUSE;
             case BLOCK_EXPR -> true;
             case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> isExprKind(child);
+            case PIPE_EXPR -> isExprKind(child) && child != SyntaxKind.PIPE_EXPR;
             default -> false;
         };
     }
@@ -1322,6 +1389,16 @@ public final class Formatter {
             }
         }
         return concat(parts);
+    }
+
+    /** A member the grammar wrote as an identifier: the same shape as one written as a node, held
+     * against where the identifier is. */
+    private Member tokenMember(SyntaxToken above, SyntaxToken end, Doc d) {
+        List<Doc> lead = new ArrayList<>();
+        for (Doc c : aboveCase(above)) {
+            lead.add(concat(c, HARDLINE));
+        }
+        return new Member(concat(concat(lead), d), afterCase(end));
     }
 
     /** A member: what is written above its line, the member, and what ends that line — the last kept

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -1194,7 +1194,15 @@ public final class Formatter {
      */
     private static boolean separates(SyntaxToken t) {
         return switch (t.kind()) {
-            case COMMA, PIPE, PIPEFWD, VPIPE, ARROW, COLON -> true;
+            case COMMA, PIPE, PIPEFWD, VPIPE -> true;
+            // An arrow joins two parts of a chain only where a chain is what the layout writes. A
+            // function type and a lambda are written as one line with an arrow in it, and a comment
+            // before that arrow has no part after it to be about — reading it as a connector there
+            // moved the comment on the first formatting and moved it again on the second.
+            case ARROW, COLON -> switch (t.parent().kind()) {
+                case EXAMPLE_ROW, FAKE_ROW, MATCH_CASE -> true;
+                default -> false;
+            };
             default -> isBinaryOperator(t.kind());
         };
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -120,8 +120,18 @@ public final class Formatter {
                 boundary, text(close)));
     }
 
-    /** One part of a chain, written after the connector that joins it to what came before. */
-    private record Segment(String connector, Doc doc) {}
+    /**
+     * One part of a chain, written after the connector that joins it to what came before.
+     * {@code leading} is what goes above the line the part opens — its comments. The connector is
+     * part of that line, so the two are written in this order and not the other: a comment placed
+     * after the connector leaves the part itself starting a line the connector never opened.
+     */
+    private record Segment(String connector, Doc doc, Doc leading) {
+
+        Segment(String connector, Doc doc) {
+            this(connector, doc, Doc.NIL);
+        }
+    }
 
     /**
      * A head and the parts written after it, each opening with its connector — a union's {@code |},
@@ -132,7 +142,7 @@ public final class Formatter {
     private static Doc chained(Doc head, List<Segment> segments) {
         List<Doc> parts = new ArrayList<>();
         for (Segment s : segments) {
-            parts.add(concat(LINE, text(s.connector()), s.doc()));
+            parts.add(concat(LINE, s.leading(), text(s.connector()), s.doc()));
         }
         return group(concat(head, nest(INDENT, concat(parts))));
     }
@@ -347,25 +357,34 @@ public final class Formatter {
         if (sum.isPresent()) {
             // A sum's cases are bare idents, not nodes, so the comments between them are picked up
             // from the token stream rather than from a member node.
-            List<Doc> cases = new ArrayList<>();
-            List<String> pending = new ArrayList<>();
+            List<Doc> pending = new ArrayList<>();
+            Doc head = null;
+            List<Doc> headComments = List.of();
+            List<Segment> cases = new ArrayList<>();
             for (SyntaxElement e : sum.get().children()) {
                 if (!(e instanceof SyntaxToken t)) {
                     continue;
                 }
                 if (t.kind() == SyntaxKind.LINE_COMMENT) {
-                    pending.add(t.text().stripTrailing());
+                    pending.add(concat(text(t.text().stripTrailing()), HARDLINE));
                 } else if (t.kind() == SyntaxKind.IDENT) {
-                    Doc c = text(t.text());
-                    for (int i = pending.size() - 1; i >= 0; i--) {
-                        c = concat(text(pending.get(i)), HARDLINE, c);
+                    if (head == null) {
+                        head = text(t.text());
+                        headComments = List.copyOf(pending);
+                    } else {
+                        cases.add(new Segment("| ", text(t.text()), concat(pending)));
                     }
                     pending.clear();
-                    cases.add(c);
                 }
             }
-            return concat(text("data "), text(name), text(" = "),
-                    chained(cases.get(0), segments("| ", cases.subList(1, cases.size()))));
+            Doc chain = chained(head, cases);
+            if (headComments.isEmpty()) {
+                return concat(text("data "), text(name), text(" = "), chain);
+            }
+            // The first case shares its line with `data S =`, so its comments cannot go above that
+            // line without describing the declaration instead. The union moves down a line instead.
+            return concat(text("data "), text(name), text(" ="),
+                    nest(INDENT, concat(HARDLINE, concat(headComments), chain)));
         }
         var newtype = n.child(SyntaxKind.NEWTYPE_BODY);
         if (newtype.isPresent()) {
@@ -377,17 +396,22 @@ public final class Formatter {
 
     /** The leading-comma product block: {@code { f1: T1\n, f2: T2\n}}. Always multi-line. */
     private Doc productBody(SyntaxNode body) {
-        List<Doc> members = new ArrayList<>();
-        for (SyntaxNode m : body.childNodes()) {
-            if (m.kind() == SyntaxKind.FIELD) {
-                members.add(withComments(body, m, field(m)));
-            } else if (m.kind() == SyntaxKind.SPREAD_MEMBER) {
-                members.add(withComments(body, m, concat(text("..."), text(firstIdent(m)))));
-            }
-        }
         List<Doc> lines = new ArrayList<>();
-        for (int i = 0; i < members.size(); i++) {
-            lines.add(concat(i == 0 ? text("{ ") : concat(HARDLINE, text(", ")), members.get(i)));
+        for (SyntaxNode m : body.childNodes()) {
+            Doc member;
+            if (m.kind() == SyntaxKind.FIELD) {
+                member = field(m);
+            } else if (m.kind() == SyntaxKind.SPREAD_MEMBER) {
+                member = concat(text("..."), text(firstIdent(m)));
+            } else {
+                continue;
+            }
+            // The opener is part of the member's line, so it is inside what the comments decorate:
+            // a comment written after it would leave the member starting a line of its own, at the
+            // block's indent rather than after the comma the rest of the block is written with.
+            boolean first = lines.isEmpty();
+            Doc line = withComments(body, m, concat(text(first ? "{ " : ", "), member));
+            lines.add(first ? line : concat(HARDLINE, line));
         }
         lines.add(concat(HARDLINE, text("}")));
         return concat(lines);

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -1305,35 +1305,26 @@ public final class Formatter {
             out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
             return;
         }
-        // A construct written over several lines has more lines than its last: `data D =` and
-        // `match x with` and the `{` of a block each end one. A comment there ends that line, not
-        // the construct, so it is held against the token rather than against the node.
-        SyntaxNode slot = slotOf(endingAt(code));
+        // Of the constructs ending where the comment is, the outermost one the layout gives a line
+        // to. Outermost because `data D = A | B // c` is about the declaration and not about `B`;
+        // only among those that have a line, because a `with` binding has one even though the row
+        // it is in goes on to its expected value — the comment is itself what ends that line.
+        SyntaxNode slot = slotEndingAt(code);
+        if (slot == null) {
+            // Nothing ends here, so the comment was written in the middle of a construct: it ends
+            // the line that construct is on, which is where the same comment written after that
+            // construct's last token would go. Reading the two the same way is what makes the
+            // answer survive a second formatting.
+            slot = slotOf(endingAt(code));
+        }
         if (slot == null) {
             return;
         }
-        // A comment after a token in the middle of a construct ends no construct's line. It ends
-        // the line that construct is on, and what ends that line is whatever ends where the
-        // construct does — which is where the same comment would go if it had been written after
-        // the construct's last token instead. Reading the two the same way is what makes the answer
-        // survive a second formatting.
         // A pipeline's declared output is written after its last stage and on that stage's line, so
         // the stage is not what ends the line: what ends it is the declaration.
         boolean moreOfTheLineFollows = slot.parent() != null
                 && slot.parent().kind() == SyntaxKind.PIPE_BEHAVIOR
                 && slot.end() != slot.parent().end();
-        // The construct the slot ends together with may itself sit in the middle of a line — a
-        // `with` clause ends where its last binding does and the row goes on to its expected value.
-        SyntaxToken slotEnd = lastCodeTokenOf(slot);
-        SyntaxNode ends = slotEnd == null ? slot : endingAt(slotEnd);
-        if (ends.parent() != null && ends.parent().parent() != null
-                && ends.end() != ends.parent().end()
-                && !takesALineOf(ends.parent().kind(), ends.kind())
-                && !isSpine(ends.parent())   // a run's parts are its lines, not the run's
-                && slotOf(ends.parent()) != null) {
-            add(out.after(), slotOf(ends.parent()), comment);
-            return;
-        }
         if ((slot.end() != code.end() || moreOfTheLineFollows) && !endsAWrittenLine(code)) {
             SyntaxToken last = lastCodeTokenOf(moreOfTheLineFollows ? slot.parent() : slot);
             if (last != null && last.end() != code.end()) {
@@ -1414,6 +1405,25 @@ public final class Formatter {
             }
         }
         return last;
+    }
+
+    /** The outermost construct ending at {@code code} that the layout gives a line of its own, or
+     * nothing where none of them has one. */
+    private static SyntaxNode slotEndingAt(SyntaxToken code) {
+        SyntaxNode best = null;
+        for (SyntaxNode c = code.parent();
+                c != null && c.parent() != null && c.end() == code.end();
+                c = c.parent()) {
+            // The last part of a run has a line only while the run is inside another one. The last
+            // part of the outermost run ends where the run does, and what the run is inside goes on
+            // writing that line — a condition's `then`, a call's `)`.
+            boolean endsTheOutermostRun = isSpine(c.parent()) && c.end() == c.parent().end()
+                    && !isSpine(c.parent().parent());
+            if (takesALineOf(c.parent().kind(), c.kind()) && !endsTheOutermostRun) {
+                best = c;
+            }
+        }
+        return best;
     }
 
     /** The construct that owns the line {@code owner} is written on. */

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -281,7 +281,8 @@ public final class Formatter {
                     afterOf(row)));
         }
         rows.add(endOf(n));
-        return concat(text("example "), text(target), nest(INDENT, concat(rows)));
+        return concat(text("example "), text(target),
+                afterToken(ids.get(ids.size() - 1), ids.size() >= 2), nest(INDENT, concat(rows)));
     }
 
     /**
@@ -327,7 +328,8 @@ public final class Formatter {
             rows.add(concat(HARDLINE, concat(aboveOf(row), fakeRow(row)), afterOf(row)));
         }
         rows.add(endOf(n));
-        return concat(text("fake "), text(target), nest(INDENT, concat(rows)));
+        return concat(text("fake "), text(target),
+                afterToken(ids.get(ids.size() - 1), ids.size() >= 2), nest(INDENT, concat(rows)));
     }
 
     private Doc fakeRow(SyntaxNode n) {
@@ -396,6 +398,7 @@ public final class Formatter {
         var product = n.child(SyntaxKind.PRODUCT_BODY);
         if (product.isPresent()) {
             return concat(text("data "), text(name), text(" ="),
+                    afterToken(n.token(SyntaxKind.ASSIGN)),
                     nest(INDENT, concat(concat(HARDLINE, productBody(product.get())), concat(invariants))));
         }
         var sum = n.child(SyntaxKind.SUM_BODY);
@@ -625,13 +628,13 @@ public final class Formatter {
     /** A lambda's parameters as a definition's parameter list — always parenthesised, which is the
      * only shape a definition writes. */
     private Doc lambdaParams(SyntaxNode lambda) {
-        List<Doc> params = new ArrayList<>();
+        List<Member> params = new ArrayList<>();
         for (SyntaxNode c : lambda.childNodes()) {
             if (isPatternNode(c.kind())) {
-                params.add(pattern(c));
+                params.add(member(c, pattern(c)));
             }
         }
-        return delimited("(", SOFTLINE, plain(params), ")");
+        return delimited("(", SOFTLINE, withEndComments(lambda, params), ")");
     }
 
     private Doc fnParamList(SyntaxNode n) {
@@ -665,7 +668,8 @@ public final class Formatter {
                 }
             }
         }
-        return concat(delimited("(", SOFTLINE, params, ")"), text(" -> "), result);
+        return concat(delimited("(", SOFTLINE, withEndComments(n, params), ")"),
+                text(" -> "), result);
     }
 
     private Doc retType(SyntaxNode n) {
@@ -887,6 +891,7 @@ public final class Formatter {
             return Doc.NIL;
         }
         List<Doc> lines = new ArrayList<>();
+        lines.add(afterToken(n.token(SyntaxKind.ELSE_KW)));
         for (SyntaxNode arm : childNodes(arms.get(), SyntaxKind.ELSE_ARM)) {
             lines.add(concat(HARDLINE, aboveOf(arm), text("| " + firstIdent(arm) + " -> "),
                     expr(onlyExpr(arm)), afterOf(arm)));
@@ -917,7 +922,8 @@ public final class Formatter {
             cases.add(concat(HARDLINE, concat(aboveOf(c), matchCase(c)), afterOf(c)));
         }
         cases.add(endOf(n));
-        return concat(text("match "), expr(scrutinee), text(" with"), nest(INDENT, concat(cases)));
+        return concat(text("match "), expr(scrutinee), text(" with"),
+                afterToken(n.token(SyntaxKind.WITH_KW)), nest(INDENT, concat(cases)));
     }
 
     private Doc matchCase(SyntaxNode n) {
@@ -948,16 +954,16 @@ public final class Formatter {
     }
 
     private Doc lambda(SyntaxNode n) {
-        List<Doc> params = new ArrayList<>();
+        List<Member> params = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             if (isPatternNode(c.kind())) {
-                params.add(pattern(c));
+                params.add(member(c, pattern(c)));
             }
         }
         // `x -> e` keeps its bare parameter; anything parenthesised was written that way
         Doc paramsDoc = n.token(SyntaxKind.LPAREN).isPresent()
-                ? delimited("(", SOFTLINE, plain(params), ")")
-                : params.get(0);
+                ? delimited("(", SOFTLINE, withEndComments(n, params), ")")
+                : concat(params.get(0).doc(), params.get(0).trailing());
         return concat(paramsDoc, text(" -> "), expr(lastExprChild(n)));
     }
 
@@ -1007,7 +1013,8 @@ public final class Formatter {
             lines.add(concat(HARDLINE, lead, d, afterOf(c)));
         }
         lines.add(endOf(n));
-        return concat(text("{"), nest(INDENT, concat(lines)), HARDLINE, text("}"));
+        return concat(text("{"), afterToken(n.token(SyntaxKind.LBRACE)),
+                nest(INDENT, concat(lines)), HARDLINE, text("}"));
     }
 
     /** A binding pattern, written back as it was: a name, a tuple, a newtype opened by its
@@ -1018,29 +1025,29 @@ public final class Formatter {
                 return text(firstIdent(n));
             }
             case PATTERN_TUPLE -> {
-                List<Doc> elems = new ArrayList<>();
+                List<Member> elems = new ArrayList<>();
                 for (SyntaxNode c : n.childNodes()) {
                     if (isPatternNode(c.kind())) {
-                        elems.add(pattern(c));
+                        elems.add(member(c, pattern(c)));
                     }
                 }
-                return delimited("(", SOFTLINE, plain(elems), ")");
+                return delimited("(", SOFTLINE, withEndComments(n, elems), ")");
             }
             case PATTERN_CTOR -> {
                 return concat(qualifiedName(n), text("("), pattern(patternChild(n)), text(")"));
             }
             case PATTERN_RECORD -> {
-                List<Doc> fields = new ArrayList<>();
+                List<Member> fields = new ArrayList<>();
                 for (SyntaxNode f : n.childNodes()) {
                     if (f.kind() != SyntaxKind.PATTERN_FIELD) {
                         continue;
                     }
                     List<SyntaxToken> names = idents(f);
-                    fields.add(names.size() > 1
+                    fields.add(member(f, names.size() > 1
                             ? concat(text(names.get(0).text()), text(" = "), text(names.get(1).text()))
-                            : text(names.get(0).text()));
+                            : text(names.get(0).text())));
                 }
-                return delimited("{", LINE, plain(fields), "}");
+                return delimited("{", LINE, withEndComments(n, fields), "}");
             }
             default -> {
                 return text(firstIdent(n));
@@ -1198,8 +1205,13 @@ public final class Formatter {
      * together is what turned a comment about a case into a comment about the declaration.
      */
     private static void above(Attachments out, SyntaxToken next, SyntaxToken comment, SyntaxNode file) {
-        if (next != null && opens(next)) {
-            // what opens a construct is the construct's, and it shares a line with the first member
+        SyntaxNode begins = next == null ? null : beginningAt(next);
+        // What opens a construct is the construct's, and it shares a line with the first member —
+        // unless a member begins at that bracket itself, as a `fake` row does at its `(`, in which
+        // case the comment is above the member and not above what the member opens with.
+        boolean opensSomethingElse = begins != null && begins.parent() != null
+                && !takesALineOf(begins.parent().kind(), begins.kind());
+        if (next != null && opens(next) && opensSomethingElse) {
             SyntaxElement first = firstMemberOf(next.parent());
             if (first instanceof SyntaxNode node) {
                 place(out, node, comment, true);
@@ -1227,7 +1239,7 @@ public final class Formatter {
         } else if (closes(next)) {
             add(out.atEnd(), next.parent(), comment);
         } else {
-            place(out, beginningAt(next), comment, true);
+            place(out, begins, comment, true);
         }
     }
 
@@ -1243,7 +1255,18 @@ public final class Formatter {
             out.afterCase().computeIfAbsent(nameEnd(code), _ -> new ArrayList<>()).add(comment);
             return;
         }
-        place(out, endingAt(code), comment, false);
+        // A construct written over several lines has more lines than its last: `data D =` and
+        // `match x with` and the `{` of a block each end one. A comment there ends that line, not
+        // the construct, so it is held against the token rather than against the node.
+        SyntaxNode slot = slotOf(endingAt(code));
+        if (slot == null) {
+            return;
+        }
+        if (slot.end() != code.end() && endsAWrittenLine(code)) {
+            out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
+        } else {
+            add(out.after(), slot, comment);
+        }
     }
 
     /**
@@ -1255,6 +1278,47 @@ public final class Formatter {
      * rather than about what the comment was written about.
      */
     private static void place(Attachments out, SyntaxNode owner, SyntaxToken comment, boolean above) {
+        SyntaxNode slot = slotOf(owner);
+        if (slot != null) {
+            add(above ? out.above() : out.after(), slot, comment);
+        }
+    }
+
+    /**
+     * Whether the layout always ends a line at {@code t}. These are the tokens a construct written
+     * over several lines opens with — the {@code =} of a product block, the {@code with} of a match,
+     * the {@code {} of a block — where the line a comment ends is the construct's first and not its
+     * last. Whether a bracketed construct breaks depends on its width, so its brackets are not here:
+     * a comment there goes to the line the whole construct ends.
+     */
+    private static boolean endsAWrittenLine(SyntaxToken t) {
+        SyntaxNode parent = t.parent();
+        return switch (t.kind()) {
+            case ASSIGN -> parent.kind() == SyntaxKind.DATA_DEF
+                    && parent.child(SyntaxKind.PRODUCT_BODY).isPresent();
+            case WITH_KW -> parent.kind() == SyntaxKind.MATCH_EXPR;
+            case LBRACE -> parent.kind() == SyntaxKind.BLOCK_EXPR;
+            case ELSE_KW -> parent.child(SyntaxKind.ELSE_ARMS).isPresent();
+            case IDENT -> (parent.kind() == SyntaxKind.EXAMPLE_DEF
+                        || parent.kind() == SyntaxKind.FAKE_DEF)
+                    // the target, not the `example` that opens the line with it
+                    && lastIdentOf(parent) != null && lastIdentOf(parent).end() == t.end();
+            default -> false;
+        };
+    }
+
+    private static SyntaxToken lastIdentOf(SyntaxNode n) {
+        SyntaxToken last = null;
+        for (SyntaxElement e : n.children()) {
+            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
+                last = t;
+            }
+        }
+        return last;
+    }
+
+    /** The construct that owns the line {@code owner} is written on. */
+    private static SyntaxNode slotOf(SyntaxNode owner) {
         SyntaxNode from = owner;
         // A run the layout flattens is written as segments, and a part of the spine ends where its
         // own segment does rather than where the whole run does. Only inside the run, though: the
@@ -1265,10 +1329,10 @@ public final class Formatter {
         }
         for (SyntaxNode c = from; c != null && c.parent() != null; c = c.parent()) {
             if (takesALineOf(c.parent().kind(), c.kind())) {
-                add(above ? out.above() : out.after(), c, comment);
-                return;
+                return c;
             }
         }
+        return null;
     }
 
     /** Whether {@code n} is a run the layout writes as one chain of segments rather than as the
@@ -1421,10 +1485,18 @@ public final class Formatter {
     /** Whether {@code t} is what closes a construct whose members take a line each — the place a
      * comment written under the last member goes. */
     private static boolean closes(SyntaxToken t) {
-        if (t.end() != t.parent().end() || !holdsLines(t.parent().kind())) {
-            return false;   // a bracket in the middle of a construct closes nothing
+        if (!holdsLines(t.parent().kind())) {
+            return false;
         }
-        return switch (t.kind()) {
+        // Usually a construct's members run to its own end. A function type and a parenthesised
+        // lambda are written as one node whose members stop at a bracket in the middle of it —
+        // `(Int, String) -> Bool` — and the layout writes that bracketed run as a construct of its
+        // own, so what closes the run closes something even though it closes no node.
+        boolean ends = t.end() == t.parent().end()
+                || ((t.parent().kind() == SyntaxKind.FN_TYPE
+                        || t.parent().kind() == SyntaxKind.LAMBDA_EXPR)
+                    && t.kind() == SyntaxKind.RPAREN);
+        return ends && switch (t.kind()) {
             case RBRACE, RPAREN, RBRACKET, GT -> true;
             default -> false;
         };
@@ -1484,6 +1556,8 @@ public final class Formatter {
                     || k == SyntaxKind.DEPENDS_CLAUSE || k == SyntaxKind.RET_TYPE;
             case RET_TYPE, TYPE_ARGS, TUPLE_TYPE -> Formatter::isTypeNode;
             case FN_TYPE -> k -> k == SyntaxKind.RET_TYPE;
+            case LAMBDA_EXPR, PATTERN_TUPLE -> Formatter::isPatternNode;
+            case PATTERN_RECORD -> k -> k == SyntaxKind.PATTERN_FIELD;
             case BINARY_EXPR -> k -> isExprKind(k) && k != SyntaxKind.BINARY_EXPR;
             case BLOCK_EXPR -> _ -> true;
             case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> Formatter::isExprKind;
@@ -1549,6 +1623,26 @@ public final class Formatter {
     private Doc afterCase(SyntaxToken ident) {
         List<Doc> parts = new ArrayList<>();
         for (SyntaxToken c : comments.afterCase().getOrDefault(ident.end(), List.of())) {
+            if (consumedComments.add(c.start())) {
+                parts.add(Doc.trailing(c.text().stripTrailing()));
+            }
+        }
+        return concat(parts);
+    }
+
+    /** The comment written at the end of the line {@code t} ends, where that is a line inside a
+     * construct rather than the construct's own last line. */
+    private Doc afterToken(java.util.Optional<SyntaxToken> t) {
+        return t.map(this::afterToken).orElse(Doc.NIL);
+    }
+
+    private Doc afterToken(SyntaxToken t, boolean present) {
+        return present ? afterToken(t) : Doc.NIL;
+    }
+
+    private Doc afterToken(SyntaxToken t) {
+        List<Doc> parts = new ArrayList<>();
+        for (SyntaxToken c : comments.afterCase().getOrDefault(t.end(), List.of())) {
             if (consumedComments.add(c.start())) {
                 parts.add(Doc.trailing(c.text().stripTrailing()));
             }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -1296,7 +1296,10 @@ public final class Formatter {
         }
         // A bare member is only its own line's owner while something follows it. The last case of a
         // sum ends where the declaration does, and what ends on that line is the declaration.
-        if (isBareMember(code) && code.end() != code.parent().end()) {
+        // Measured from the end of the whole name, not from the identifier the comment happens to
+        // follow: a comment inside `other.mod.Thing` and one after it are about the same member, and
+        // the last member of a run ends where the run does, which is the run's line and not its own.
+        if (isBareMember(code) && nameEnd(code) != code.parent().end()) {
             out.afterCase().computeIfAbsent(nameEnd(code), _ -> new ArrayList<>()).add(comment);
             return;
         }
@@ -1310,6 +1313,25 @@ public final class Formatter {
         SyntaxNode slot = slotOf(endingAt(code));
         if (slot == null) {
             return;
+        }
+        // A comment after a token in the middle of a construct ends no construct's line. It ends
+        // the line that construct is on, and what ends that line is whatever ends where the
+        // construct does — which is where the same comment would go if it had been written after
+        // the construct's last token instead. Reading the two the same way is what makes the answer
+        // survive a second formatting.
+        // A pipeline's declared output is written after its last stage and on that stage's line, so
+        // the stage is not what ends the line: what ends it is the declaration.
+        boolean moreOfTheLineFollows = slot.parent() != null
+                && slot.parent().kind() == SyntaxKind.PIPE_BEHAVIOR
+                && slot.end() != slot.parent().end();
+        if ((slot.end() != code.end() || moreOfTheLineFollows) && !endsAWrittenLine(code)) {
+            SyntaxToken last = lastCodeTokenOf(moreOfTheLineFollows ? slot.parent() : slot);
+            if (last != null && last.end() != code.end()) {
+                SyntaxNode wider = slotOf(endingAt(last));
+                if (wider != null) {
+                    slot = wider;
+                }
+            }
         }
         if (slot.end() != code.end() && endsAWrittenLine(code)) {
             out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
@@ -1327,7 +1349,7 @@ public final class Formatter {
      * rather than about what the comment was written about.
      */
     private static void place(Attachments out, SyntaxNode owner, SyntaxToken comment, boolean above) {
-        SyntaxNode slot = slotOf(owner);
+        SyntaxNode slot = slotOf(owner, above);
         if (slot != null) {
             add(above ? out.above() : out.after(), slot, comment);
         }
@@ -1356,6 +1378,24 @@ public final class Formatter {
         };
     }
 
+    /** {@code n}'s first child node, whether or not the layout gives it a line. */
+    private static SyntaxNode firstChildOf(SyntaxNode n) {
+        for (SyntaxNode c : n.childNodes()) {
+            return c;
+        }
+        return null;
+    }
+
+    private static SyntaxToken lastCodeTokenOf(SyntaxNode n) {
+        SyntaxToken last = null;
+        for (SyntaxToken t : tokens(n)) {
+            if (!t.isTrivia()) {
+                last = t;
+            }
+        }
+        return last;
+    }
+
     private static SyntaxToken lastIdentOf(SyntaxNode n) {
         SyntaxToken last = null;
         for (SyntaxElement e : n.children()) {
@@ -1367,7 +1407,51 @@ public final class Formatter {
     }
 
     /** The construct that owns the line {@code owner} is written on. */
+    /**
+     * Whether {@code child} opens a line of {@code parent} as well as ending one. A construct the
+     * parent writes a prefix in front of — a newtype's body after the {@code =}, a signature's
+     * return type after the {@code ->} — ends the line it is on and does not begin it, since the
+     * prefix is already there. A comment above it goes above the line the prefix opens, which
+     * belongs to whatever wrote the prefix.
+     */
+    private static boolean opensALine(SyntaxNode c) {
+        if (!takesALineOf(c.parent().kind(), c.kind())) {
+            return false;
+        }
+        SyntaxKind parent = c.parent().kind();
+        if (parent == SyntaxKind.DATA_DEF && c.kind() == SyntaxKind.NEWTYPE_BODY) {
+            return false;
+        }
+        if (parent == SyntaxKind.BEHAVIOR_SIG && c.kind() == SyntaxKind.RET_TYPE) {
+            return false;
+        }
+        // The first of a run is written after whatever opens it and the rest after a break, so only
+        // the rest have a line of their own to be written above. The head of a chain is the first of
+        // its run, and so is the first binding of a `with`.
+        return !isFirstOfItsRun(c);
+    }
+
+    /** Whether {@code c} is the first member of a run the layout opens with text of its own rather
+     * than with a break — the left of a chain, an example row's input where no description precedes
+     * it, the first binding after a {@code with}. */
+    private static boolean isFirstOfItsRun(SyntaxNode c) {
+        SyntaxNode parent = c.parent();
+        return switch (parent.kind()) {
+            // the left of a run, which is the run's own left where the run nests: `a |> b |> c` is
+            // read as `(a |> b) |> c`, and the part that opens the line is `a`
+            case BINARY_EXPR, PIPE_EXPR, RET_TYPE, WITH_CLAUSE, LIST_COMP -> firstChildOf(parent) == c;
+            case EXAMPLE_ROW -> c.kind() == SyntaxKind.ARG_LIST
+                    && parent.token(SyntaxKind.STRING_LIT).isEmpty();
+            case FAKE_ROW -> c.kind() == SyntaxKind.ARG_LIST;
+            default -> false;
+        };
+    }
+
     private static SyntaxNode slotOf(SyntaxNode owner) {
+        return slotOf(owner, false);
+    }
+
+    private static SyntaxNode slotOf(SyntaxNode owner, boolean above) {
         SyntaxNode from = owner;
         // A run the layout flattens is written as segments, and a part of the spine ends where its
         // own segment does rather than where the whole run does. Only inside the run, though: the
@@ -1377,7 +1461,7 @@ public final class Formatter {
             from = lastSegmentOf(from);
         }
         for (SyntaxNode c = from; c != null && c.parent() != null; c = c.parent()) {
-            if (takesALineOf(c.parent().kind(), c.kind())) {
+            if (above ? opensALine(c) : takesALineOf(c.parent().kind(), c.kind())) {
                 return c;
             }
         }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -191,6 +191,17 @@ public final class Formatter {
                 : new Segment(connector, concat(doc, afterOf(owner)), aboveOf(owner));
     }
 
+    /** The same for a part the grammar writes as a bare identifier rather than as a node — a sum's
+     * cases. It is the only other way a chain's part can stand for something written, so between the
+     * two of them nothing else builds a {@link Segment}. */
+    private Segment segment(String connector, SyntaxToken owner, Doc doc) {
+        List<Doc> lead = new ArrayList<>();
+        for (Doc c : aboveCase(owner)) {
+            lead.add(concat(c, HARDLINE));
+        }
+        return new Segment(connector, concat(doc, afterCase(owner)), concat(lead));
+    }
+
     /**
      * A head and the parts written after it, each opening with its connector — a union's {@code |},
      * an operator chain's operator, a pipeline's {@code |>}, an example row's {@code :} and
@@ -418,19 +429,14 @@ public final class Formatter {
                 if (!(e instanceof SyntaxToken t) || t.kind() != SyntaxKind.IDENT) {
                     continue;
                 }
-                Doc body = concat(text(t.text()), afterCase(t));
                 if (head == null) {
-                    head = body;
+                    head = concat(text(t.text()), afterCase(t));
                     headComments = new ArrayList<>();
                     for (Doc c : aboveCase(t)) {
                         headComments.add(concat(c, HARDLINE));
                     }
                 } else {
-                    List<Doc> lead = new ArrayList<>();
-                    for (Doc c : aboveCase(t)) {
-                        lead.add(concat(c, HARDLINE));
-                    }
-                    cases.add(new Segment("| ", body, concat(lead)));   // a case is a token
+                    cases.add(segment("| ", t, text(t.text())));
                 }
             }
             Doc chain = chained(head, cases);

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -41,18 +41,19 @@ public final class Formatter {
      * takes the width. */
     private static final int WIDTH = 100;
 
-    /** The comments already written, keyed by where they are in the source. A comment is reachable
+    /** The comments taken by some construct, by where they are in the source. A comment is reachable
      * two ways once members nest — from the parent's child list and from the front of the member's
      * own subtree — and it must be written once. The offset identifies a comment without depending on
-     * how the tree hands nodes back. One instance formats one file, so this lives as long as that. */
-    private final java.util.Set<Integer> written = new java.util.HashSet<>();
+     * how the tree hands nodes back. It records what was consumed rather than what reached the
+     * output, which is what makes it comparable against the comments the tree holds. One instance
+     * formats one file, so this lives as long as that. */
+    private final java.util.Set<Integer> consumedComments = new java.util.HashSet<>();
 
     /** {@link #commentsBefore} per parent, computed once. It is asked for every member of a parent,
      * and answering means walking that parent's children, so without this a construct with n members
      * walks them n times. One instance formats one file, so the cache lives exactly as long as the
      * tree it describes. */
-    private final Map<SyntaxNode, Map<SyntaxNode, List<SyntaxToken>>> commentsByParent =
-            new IdentityHashMap<>();
+    private final Map<SyntaxNode, ParentComments> commentsByParent = new IdentityHashMap<>();
 
     private Formatter() {
     }
@@ -177,18 +178,16 @@ public final class Formatter {
                     parts.add(HARDLINE);
                 }
             }
-            for (SyntaxToken c : lead) {
-                if (written.add(c.start())) {
-                    parts.add(text(c.text().stripTrailing()));
-                    parts.add(HARDLINE);
-                }
+            for (Doc c : unwritten(lead)) {
+                parts.add(c);
+                parts.add(HARDLINE);
             }
             parts.add(item(item));
             prev = item.kind();
         }
-        for (String c : trailingComments(file)) {
+        for (Doc c : unwritten(trailingComments(file))) {
             parts.add(HARDLINE);
-            parts.add(text(c));
+            parts.add(c);
         }
         parts.add(HARDLINE);   // files end with a single newline
         return concat(parts);
@@ -236,6 +235,7 @@ public final class Formatter {
         for (SyntaxNode row : childNodes(n, SyntaxKind.EXAMPLE_ROW)) {
             rows.add(concat(HARDLINE, withComments(n, row, exampleRow(row))));
         }
+        rows.add(endComments(n));
         return concat(text("example "), text(target), nest(INDENT, concat(rows)));
     }
 
@@ -279,8 +279,9 @@ public final class Formatter {
         String target = ids.size() >= 2 ? ids.get(1).text() : "";
         List<Doc> rows = new ArrayList<>();
         for (SyntaxNode row : childNodes(n, SyntaxKind.FAKE_ROW)) {
-            rows.add(concat(HARDLINE, fakeRow(row)));
+            rows.add(concat(HARDLINE, withComments(n, row, fakeRow(row))));
         }
+        rows.add(endComments(n));
         return concat(text("fake "), text(target), nest(INDENT, concat(rows)));
     }
 
@@ -316,7 +317,7 @@ public final class Formatter {
                     .map(rt -> concat(name, text(" : "), retType(rt)))
                     .orElse(name)));
         }
-        return delimited("exposing (", LINE, entries, ")");
+        return delimited("exposing (", LINE, withEndComments(clause, entries), ")");
     }
 
     private Doc importDecl(SyntaxNode n) {
@@ -345,7 +346,8 @@ public final class Formatter {
             // A named clause keeps its name: it is what an attempt's arm and a boundary issue call it.
             String label = inv.token(SyntaxKind.ASSIGN).isPresent()
                     ? firstIdent(inv) + " = " : "";
-            invariants.add(concat(HARDLINE, text("invariant " + label), expr(onlyExpr(inv))));
+            invariants.add(concat(HARDLINE,
+                    withComments(n, inv, concat(text("invariant " + label), expr(onlyExpr(inv))))));
         }
 
         var product = n.child(SyntaxKind.PRODUCT_BODY);
@@ -366,7 +368,9 @@ public final class Formatter {
                     continue;
                 }
                 if (t.kind() == SyntaxKind.LINE_COMMENT) {
-                    pending.add(concat(text(t.text().stripTrailing()), HARDLINE));
+                    for (Doc c : unwritten(List.of(t))) {
+                        pending.add(concat(c, HARDLINE));
+                    }
                 } else if (t.kind() == SyntaxKind.IDENT) {
                     if (head == null) {
                         head = text(t.text());
@@ -413,6 +417,7 @@ public final class Formatter {
             Doc line = withComments(body, m, concat(text(first ? "{ " : ", "), member));
             lines.add(first ? line : concat(HARDLINE, line));
         }
+        lines.add(endComments(body));
         lines.add(concat(HARDLINE, text("}")));
         return concat(lines);
     }
@@ -434,9 +439,11 @@ public final class Formatter {
             List<Doc> clauses = new ArrayList<>();
             for (SyntaxNode c : s.childNodes()) {
                 if (c.kind() == SyntaxKind.CONSTRUCTS_CLAUSE) {
-                    clauses.add(concat(HARDLINE, text("constructs "), nameList(c, 0)));
+                    clauses.add(concat(HARDLINE,
+                            withComments(s, c, concat(text("constructs "), nameList(c, 0)))));
                 } else if (c.kind() == SyntaxKind.DEPENDS_CLAUSE) {
-                    clauses.add(concat(HARDLINE, text("depends on "), nameList(c, 1)));
+                    clauses.add(concat(HARDLINE,
+                            withComments(s, c, concat(text("depends on "), nameList(c, 1)))));
                 }
             }
             return concat(text("behavior "), text(name), text(" : "), params, text(" -> "), ret,
@@ -460,7 +467,7 @@ public final class Formatter {
             params.add(withComments(n, p, concat(text(firstIdent(p)), text(": "),
                     retType(p.child(SyntaxKind.RET_TYPE).orElseThrow()))));
         }
-        return delimited("(", SOFTLINE, params, ")");
+        return delimited("(", SOFTLINE, withEndComments(n, params), ")");
     }
 
     private Doc stage(SyntaxNode n) {
@@ -698,7 +705,7 @@ public final class Formatter {
         for (SyntaxNode a : args) {
             argDocs.add(withComments(argList, a, expr(a)));
         }
-        return delimited("(", SOFTLINE, argDocs, ")");
+        return delimited("(", SOFTLINE, withEndComments(argList, argDocs), ")");
     }
 
     private Doc binary(SyntaxNode n) {
@@ -833,6 +840,7 @@ public final class Formatter {
         for (SyntaxNode c : childNodes(n, SyntaxKind.MATCH_CASE)) {
             cases.add(concat(HARDLINE, withComments(n, c, matchCase(c))));
         }
+        cases.add(endComments(n));
         return concat(text("match "), expr(scrutinee), text(" with"), nest(INDENT, concat(cases)));
     }
 
@@ -899,7 +907,8 @@ public final class Formatter {
         if (members.isEmpty()) {
             return concat(text(typeName), text(" {}"));
         }
-        return concat(text(typeName), text(" "), delimited("{", LINE, members, "}"));
+        return concat(text(typeName), text(" "),
+                delimited("{", LINE, withEndComments(n, members), "}"));
     }
 
     private Doc block(SyntaxNode n) {
@@ -908,15 +917,11 @@ public final class Formatter {
             // A statement inside a block carries its leading comments the same way a top-level item
             // does. Walking only the child nodes dropped them, so a comment explaining a step was
             // lost on the first format.
-            for (SyntaxToken comment : commentsBefore(n).getOrDefault(c, List.of())) {
-                if (written.add(comment.start())) {
-                    lines.add(concat(HARDLINE, text(comment.text().stripTrailing())));
-                }
+            for (Doc comment : unwritten(commentsBefore(n).getOrDefault(c, List.of()))) {
+                lines.add(concat(HARDLINE, comment));
             }
-            for (SyntaxToken comment : leadingDeep(c)) {
-                if (written.add(comment.start())) {
-                    lines.add(concat(HARDLINE, text(comment.text().stripTrailing())));
-                }
+            for (Doc comment : unwritten(leadingDeep(c))) {
+                lines.add(concat(HARDLINE, comment));
             }
             Doc d = switch (c.kind()) {
                 case LET_STMT -> concat(text("let "), text(firstIdent(c)), writtenType(c),
@@ -928,6 +933,7 @@ public final class Formatter {
             };
             lines.add(concat(HARDLINE, d));
         }
+        lines.add(endComments(n));
         return concat(text("{"), nest(INDENT, concat(lines)), HARDLINE, text("}"));
     }
 
@@ -1025,10 +1031,8 @@ public final class Formatter {
         List<SyntaxToken> comments = new ArrayList<>(commentsBefore(parent).getOrDefault(member, List.of()));
         comments.addAll(leadingDeep(member));
         List<Doc> parts = new ArrayList<>();
-        for (SyntaxToken comment : comments) {
-            if (written.add(comment.start())) {
-                parts.add(concat(text(comment.text().stripTrailing()), HARDLINE));
-            }
+        for (Doc comment : unwritten(comments)) {
+            parts.add(concat(comment, HARDLINE));
         }
         if (parts.isEmpty()) {
             return d;
@@ -1065,14 +1069,26 @@ public final class Formatter {
         return comments;
     }
 
+    /**
+     * A parent's comments, by the member each run was written above. {@link #atEnd} is the run after
+     * the last member: it was written above nothing, and a walk that only hands a run to the next
+     * member it meets never hands that one to anybody. Dropping it is how a comment written at the
+     * end of a list disappeared, so it is kept apart rather than left in the walk's state.
+     */
+    private record ParentComments(Map<SyntaxNode, List<SyntaxToken>> above, List<SyntaxToken> atEnd) {}
+
     /** Each of {@code parent}'s child nodes against the comment lines written above it — the comments
      * that sit in the parent's own child list rather than on the member. */
     private Map<SyntaxNode, List<SyntaxToken>> commentsBefore(SyntaxNode parent) {
-        return commentsByParent.computeIfAbsent(parent, Formatter::scanCommentsBefore);
+        return comments(parent).above();
     }
 
-    private static Map<SyntaxNode, List<SyntaxToken>> scanCommentsBefore(SyntaxNode parent) {
-        Map<SyntaxNode, List<SyntaxToken>> out = new IdentityHashMap<>();
+    private ParentComments comments(SyntaxNode parent) {
+        return commentsByParent.computeIfAbsent(parent, Formatter::scanComments);
+    }
+
+    private static ParentComments scanComments(SyntaxNode parent) {
+        Map<SyntaxNode, List<SyntaxToken>> above = new IdentityHashMap<>();
         List<SyntaxToken> pending = new ArrayList<>();
         for (SyntaxElement e : parent.children()) {
             if (e instanceof SyntaxToken t) {
@@ -1080,15 +1096,55 @@ public final class Formatter {
                     pending.add(t);
                 }
             } else if (e instanceof SyntaxNode n && !pending.isEmpty()) {
-                out.put(n, List.copyOf(pending));
+                above.put(n, List.copyOf(pending));
                 pending.clear();
+            }
+        }
+        return new ParentComments(above, List.copyOf(pending));
+    }
+
+    /** The comments of {@code run} that have not been written yet, one document each. A comment is
+     * reachable from a parent's child list and from the front of a member's own subtree, so which
+     * ones are already written is remembered rather than derived. */
+    private List<Doc> unwritten(List<SyntaxToken> run) {
+        List<Doc> out = new ArrayList<>();
+        for (SyntaxToken c : run) {
+            if (consumedComments.add(c.start())) {
+                out.add(text(c.text().stripTrailing()));
             }
         }
         return out;
     }
 
-    private List<String> trailingComments(SyntaxNode file) {
-        List<String> out = new ArrayList<>();
+    /** The comments written after {@code parent}'s last member, each opening a line of its own. They
+     * stay inside the construct, under the member they were written under. */
+    private Doc endComments(SyntaxNode parent) {
+        List<Doc> parts = new ArrayList<>();
+        for (Doc c : unwritten(comments(parent).atEnd())) {
+            parts.add(concat(HARDLINE, c));
+        }
+        return concat(parts);
+    }
+
+    /** {@code members} with {@code parent}'s end comments under the last of them — for a construct
+     * whose members are joined rather than written a line at a time, where there is no line to add
+     * one to except the last member's own document. */
+    private List<Doc> withEndComments(SyntaxNode parent, List<Doc> members) {
+        List<Doc> lines = unwritten(comments(parent).atEnd());
+        if (lines.isEmpty() || members.isEmpty()) {
+            return members;
+        }
+        List<Doc> out = new ArrayList<>(members);
+        Doc last = out.get(out.size() - 1);
+        for (Doc c : lines) {
+            last = concat(last, HARDLINE, c);
+        }
+        out.set(out.size() - 1, last);
+        return out;
+    }
+
+    private List<SyntaxToken> trailingComments(SyntaxNode file) {
+        List<SyntaxToken> out = new ArrayList<>();
         int lastNode = -1;
         List<SyntaxElement> es = file.children();
         for (int i = 0; i < es.size(); i++) {
@@ -1098,7 +1154,7 @@ public final class Formatter {
         }
         for (int i = lastNode + 1; i < es.size(); i++) {
             if (es.get(i) instanceof SyntaxToken t && t.kind() == SyntaxKind.LINE_COMMENT) {
-                out.add(t.text().stripTrailing());
+                out.add(t);
             }
         }
         return out;
@@ -1122,7 +1178,7 @@ public final class Formatter {
         for (SyntaxNode c : exprChildren(n)) {
             out.add(withComments(n, c, expr(c)));
         }
-        return out;
+        return withEndComments(n, out);
     }
 
     private List<SyntaxNode> exprChildren(SyntaxNode n) {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -109,10 +109,37 @@ public final class Formatter {
     // in the document before the renderer can choose it, and the renderer breaks the outermost group
     // that does not fit, so a member is split only when the structure around it had nothing to give.
 
+    /**
+     * A member and the comment written at the end of the line it takes. The comment goes after
+     * whatever the enclosing construct writes between this member and the next, because that
+     * punctuation is on this line too — a comma written after the comment would be inside it.
+     */
+    private record Member(Doc doc, Doc trailing) {}
+
+    /** Members that carry no comment of their own. */
+    private static List<Member> plain(List<Doc> docs) {
+        List<Member> out = new ArrayList<>();
+        for (Doc d : docs) {
+            out.add(new Member(d, Doc.NIL));
+        }
+        return out;
+    }
+
     /** Members with a comma between them, one to a line where they do not fit. The comma stays on
-     * the line its member ends. */
-    private static Doc separated(List<Doc> members) {
-        return Doc.join(concat(text(","), LINE), members);
+     * the line its member ends, and a comment written at the end of that line follows the comma. */
+    private static Doc separated(List<Member> members) {
+        List<Doc> parts = new ArrayList<>();
+        for (int i = 0; i < members.size(); i++) {
+            if (i > 0) {
+                parts.add(LINE);
+            }
+            parts.add(members.get(i).doc());
+            if (i < members.size() - 1) {
+                parts.add(text(","));
+            }
+            parts.add(members.get(i).trailing());
+        }
+        return concat(parts);
     }
 
     /**
@@ -120,7 +147,7 @@ public final class Formatter {
      * where the flat form has a space there ({@code exposing ( a, b )}, {@code T { a, b }}),
      * {@link Doc#SOFTLINE} where it does not ({@code f(a, b)}, {@code [a, b]}).
      */
-    private static Doc delimited(String open, Doc boundary, List<Doc> members, String close) {
+    private static Doc delimited(String open, Doc boundary, List<Member> members, String close) {
         return group(concat(text(open),
                 nest(INDENT, concat(boundary, separated(members))),
                 boundary, text(close)));
@@ -242,7 +269,8 @@ public final class Formatter {
         String target = ids.size() >= 2 ? ids.get(1).text() : "";
         List<Doc> rows = new ArrayList<>();
         for (SyntaxNode row : childNodes(n, SyntaxKind.EXAMPLE_ROW)) {
-            rows.add(concat(HARDLINE, withComments(n, row, exampleRow(row))));
+            rows.add(concat(HARDLINE, withComments(n, row, exampleRow(row)),
+                    concat(trailingOf(row))));
         }
         rows.add(endComments(n));
         return concat(text("example "), text(target), nest(INDENT, concat(rows)));
@@ -259,14 +287,14 @@ public final class Formatter {
         for (SyntaxNode a : n.child(SyntaxKind.ARG_LIST).map(this::exprChildren).orElse(List.of())) {
             args.add(expr(a));
         }
-        Doc input = delimited("(", SOFTLINE, args, ")");
+        Doc input = delimited("(", SOFTLINE, plain(args), ")");
         var with = n.child(SyntaxKind.WITH_CLAUSE);
         if (with.isPresent()) {
             List<Doc> binds = new ArrayList<>();
             for (SyntaxNode b : childNodes(with.get(), SyntaxKind.WITH_BINDING)) {
                 binds.add(concat(text(firstIdent(b)), text(" = "), expr(firstExprChildOpt(b).orElseThrow())));
             }
-            input = concat(input, text(" with "), group(nest(INDENT, separated(binds))));
+            input = concat(input, text(" with "), group(nest(INDENT, separated(plain(binds)))));
         }
 
         List<Segment> segs = new ArrayList<>();
@@ -288,7 +316,7 @@ public final class Formatter {
         String target = ids.size() >= 2 ? ids.get(1).text() : "";
         List<Doc> rows = new ArrayList<>();
         for (SyntaxNode row : childNodes(n, SyntaxKind.FAKE_ROW)) {
-            rows.add(concat(HARDLINE, withComments(n, row, fakeRow(row))));
+            rows.add(concat(HARDLINE, withComments(n, row, fakeRow(row)), concat(trailingOf(row))));
         }
         rows.add(endComments(n));
         return concat(text("fake "), text(target), nest(INDENT, concat(rows)));
@@ -302,7 +330,7 @@ public final class Formatter {
             for (SyntaxNode a : exprChildren(args.get())) {
                 as.add(expr(a));
             }
-            input = delimited("(", SOFTLINE, as, ")");
+            input = delimited("(", SOFTLINE, plain(as), ")");
         } else {
             input = text("_");   // the default row
         }
@@ -319,10 +347,10 @@ public final class Formatter {
     }
 
     private Doc exposing(SyntaxNode clause) {
-        List<Doc> entries = new ArrayList<>();
+        List<Member> entries = new ArrayList<>();
         for (SyntaxNode e : childNodes(clause, SyntaxKind.EXPOSED_ENTRY)) {
             Doc name = qualifiedName(e.child(SyntaxKind.QUALIFIED_NAME).orElseThrow());
-            entries.add(withComments(clause, e, e.child(SyntaxKind.RET_TYPE)
+            entries.add(member(clause, e, e.child(SyntaxKind.RET_TYPE)
                     .map(rt -> concat(name, text(" : "), retType(rt)))
                     .orElse(name)));
         }
@@ -343,7 +371,7 @@ public final class Formatter {
         for (SyntaxToken t : idents(list.get())) {
             names.add(text(t.text()));
         }
-        return concat(d, text(" "), delimited("(", LINE, names, ")"));
+        return concat(d, text(" "), delimited("(", LINE, plain(names), ")"));
     }
 
     // --- data ---
@@ -356,7 +384,8 @@ public final class Formatter {
             String label = inv.token(SyntaxKind.ASSIGN).isPresent()
                     ? firstIdent(inv) + " = " : "";
             invariants.add(concat(HARDLINE,
-                    withComments(n, inv, concat(text("invariant " + label), expr(onlyExpr(inv))))));
+                    withComments(n, inv, concat(text("invariant " + label), expr(onlyExpr(inv)))),
+                    concat(trailingOf(inv))));
         }
 
         var product = n.child(SyntaxKind.PRODUCT_BODY);
@@ -423,7 +452,8 @@ public final class Formatter {
             // a comment written after it would leave the member starting a line of its own, at the
             // block's indent rather than after the comma the rest of the block is written with.
             boolean first = lines.isEmpty();
-            Doc line = withComments(body, m, concat(text(first ? "{ " : ", "), member));
+            Doc line = concat(withComments(body, m, concat(text(first ? "{ " : ", "), member)),
+                    concat(trailingOf(m)));
             lines.add(first ? line : concat(HARDLINE, line));
         }
         lines.add(endComments(body));
@@ -449,10 +479,12 @@ public final class Formatter {
             for (SyntaxNode c : s.childNodes()) {
                 if (c.kind() == SyntaxKind.CONSTRUCTS_CLAUSE) {
                     clauses.add(concat(HARDLINE,
-                            withComments(s, c, concat(text("constructs "), nameList(c, 0)))));
+                            withComments(s, c, concat(text("constructs "), nameList(c, 0))),
+                            concat(trailingOf(c))));
                 } else if (c.kind() == SyntaxKind.DEPENDS_CLAUSE) {
                     clauses.add(concat(HARDLINE,
-                            withComments(s, c, concat(text("depends on "), nameList(c, 1)))));
+                            withComments(s, c, concat(text("depends on "), nameList(c, 1))),
+                            concat(trailingOf(c))));
                 }
             }
             return concat(text("behavior "), text(name), text(" : "), params, text(" -> "), ret,
@@ -471,9 +503,9 @@ public final class Formatter {
     }
 
     private Doc paramList(SyntaxNode n) {
-        List<Doc> params = new ArrayList<>();
+        List<Member> params = new ArrayList<>();
         for (SyntaxNode p : childNodes(n, SyntaxKind.PARAM)) {
-            params.add(withComments(n, p, concat(text(firstIdent(p)), text(": "),
+            params.add(member(n, p, concat(text(firstIdent(p)), text(": "),
                     retType(p.child(SyntaxKind.RET_TYPE).orElseThrow()))));
         }
         return delimited("(", SOFTLINE, withEndComments(n, params), ")");
@@ -520,7 +552,7 @@ public final class Formatter {
         if (current.length() > 0) {
             names.add(text(current.toString()));
         }
-        return group(nest(INDENT, separated(names)));
+        return group(nest(INDENT, separated(plain(names))));
     }
 
     /** The {@code : T} a node wrote, or nothing — a helper's return type, a local binding's annotation. */
@@ -578,7 +610,7 @@ public final class Formatter {
                 params.add(pattern(c));
             }
         }
-        return delimited("(", SOFTLINE, params, ")");
+        return delimited("(", SOFTLINE, plain(params), ")");
     }
 
     private Doc fnParamList(SyntaxNode n) {
@@ -592,7 +624,7 @@ public final class Formatter {
             }
             params.add(d);
         }
-        return delimited("(", SOFTLINE, params, ")");
+        return delimited("(", SOFTLINE, plain(params), ")");
     }
 
     // --- types ---
@@ -612,7 +644,7 @@ public final class Formatter {
                 }
             }
         }
-        return concat(delimited("(", SOFTLINE, params, ")"), text(" -> "), result);
+        return concat(delimited("(", SOFTLINE, plain(params), ")"), text(" -> "), result);
     }
 
     private Doc retType(SyntaxNode n) {
@@ -636,7 +668,7 @@ public final class Formatter {
                     elems.add(typeTerm(c));
                 }
             }
-            return delimited("(", SOFTLINE, elems, ")");
+            return delimited("(", SOFTLINE, plain(elems), ")");
         }
         var typevar = n.token(SyntaxKind.TYPEVAR);
         if (typevar.isPresent()) {
@@ -653,7 +685,7 @@ public final class Formatter {
                 typeArgs.add(typeTerm(c));
             }
         }
-        return concat(name, delimited("<", SOFTLINE, typeArgs, ">"));
+        return concat(name, delimited("<", SOFTLINE, plain(typeArgs), ">"));
     }
 
     private static boolean isTypeNode(SyntaxKind k) {
@@ -710,9 +742,9 @@ public final class Formatter {
             return text("()");
         }
         SyntaxNode argList = n.child(SyntaxKind.ARG_LIST).orElseThrow();
-        List<Doc> argDocs = new ArrayList<>();
+        List<Member> argDocs = new ArrayList<>();
         for (SyntaxNode a : args) {
-            argDocs.add(withComments(argList, a, expr(a)));
+            argDocs.add(member(argList, a, expr(a)));
         }
         return delimited("(", SOFTLINE, withEndComments(argList, argDocs), ")");
     }
@@ -789,7 +821,7 @@ public final class Formatter {
     }
 
     private Doc list(SyntaxNode n) {
-        List<Doc> elems = exprDocs(n);
+        List<Member> elems = exprDocs(n);
         if (elems.isEmpty()) {
             return text("[]");
         }
@@ -797,9 +829,9 @@ public final class Formatter {
     }
 
     private Doc listComp(SyntaxNode n) {
-        List<Doc> exprs = exprDocs(n);
-        List<Doc> guards = exprs.subList(1, exprs.size());
-        return concat(text("["), exprs.get(0), text(" | "),
+        List<Member> exprs = exprDocs(n);
+        List<Member> guards = exprs.subList(1, exprs.size());
+        return concat(text("["), exprs.get(0).doc(), text(" | "),
                 group(nest(INDENT, separated(guards))), text("]"));
     }
 
@@ -847,7 +879,7 @@ public final class Formatter {
         SyntaxNode scrutinee = exprChildren(n).get(0);
         List<Doc> cases = new ArrayList<>();
         for (SyntaxNode c : childNodes(n, SyntaxKind.MATCH_CASE)) {
-            cases.add(concat(HARDLINE, withComments(n, c, matchCase(c))));
+            cases.add(concat(HARDLINE, withComments(n, c, matchCase(c)), concat(trailingOf(c))));
         }
         cases.add(endComments(n));
         return concat(text("match "), expr(scrutinee), text(" with"), nest(INDENT, concat(cases)));
@@ -889,14 +921,14 @@ public final class Formatter {
         }
         // `x -> e` keeps its bare parameter; anything parenthesised was written that way
         Doc paramsDoc = n.token(SyntaxKind.LPAREN).isPresent()
-                ? delimited("(", SOFTLINE, params, ")")
+                ? delimited("(", SOFTLINE, plain(params), ")")
                 : params.get(0);
         return concat(paramsDoc, text(" -> "), expr(lastExprChild(n)));
     }
 
     private Doc newData(SyntaxNode n) {
         String typeName = firstIdent(n);
-        List<Doc> members = new ArrayList<>();
+        List<Member> members = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             Doc member;
             if (c.kind() == SyntaxKind.SPREAD_MEMBER) {
@@ -911,7 +943,7 @@ public final class Formatter {
             // A member's leading comments come before it, each on its own line. The HARDLINE forces
             // the enclosing group to break, which is what a literal with a comment in it wants
             // anyway: a `//` on a line the group had collapsed would swallow the rest of it.
-            members.add(withComments(n, c, member));
+            members.add(member(n, c, member));
         }
         if (members.isEmpty()) {
             return concat(text(typeName), text(" {}"));
@@ -940,7 +972,7 @@ public final class Formatter {
                 case GUARD_STMT -> guardStmt(c);
                 default -> expr(c);   // the result expression
             };
-            lines.add(concat(HARDLINE, d));
+            lines.add(concat(HARDLINE, d, concat(trailingOf(c))));
         }
         lines.add(endComments(n));
         return concat(text("{"), nest(INDENT, concat(lines)), HARDLINE, text("}"));
@@ -960,7 +992,7 @@ public final class Formatter {
                         elems.add(pattern(c));
                     }
                 }
-                return delimited("(", SOFTLINE, elems, ")");
+                return delimited("(", SOFTLINE, plain(elems), ")");
             }
             case PATTERN_CTOR -> {
                 return concat(qualifiedName(n), text("("), pattern(patternChild(n)), text(")"));
@@ -976,7 +1008,7 @@ public final class Formatter {
                             ? concat(text(names.get(0).text()), text(" = "), text(names.get(1).text()))
                             : text(names.get(0).text()));
                 }
-                return delimited("{", LINE, fields, "}");
+                return delimited("{", LINE, plain(fields), "}");
             }
             default -> {
                 return text(firstIdent(n));
@@ -1138,18 +1170,26 @@ public final class Formatter {
     /** {@code members} with {@code parent}'s end comments under the last of them — for a construct
      * whose members are joined rather than written a line at a time, where there is no line to add
      * one to except the last member's own document. */
-    private List<Doc> withEndComments(SyntaxNode parent, List<Doc> members) {
+    private List<Member> withEndComments(SyntaxNode parent, List<Member> members) {
         List<Doc> lines = unwritten(comments(parent).atEnd());
         if (lines.isEmpty() || members.isEmpty()) {
             return members;
         }
-        List<Doc> out = new ArrayList<>(members);
-        Doc last = out.get(out.size() - 1);
+        List<Member> out = new ArrayList<>(members);
+        Member last = out.get(out.size() - 1);
+        Doc doc = last.doc();
         for (Doc c : lines) {
-            last = concat(last, HARDLINE, c);
+            doc = concat(doc, HARDLINE, c);
         }
-        out.set(out.size() - 1, last);
+        out.set(out.size() - 1, new Member(doc, last.trailing()));
         return out;
+    }
+
+    /** A member with the comments written above its line in front of it, and the one written at the
+     * end of that line kept apart, since what the enclosing construct writes between this member and
+     * the next goes between them. */
+    private Member member(SyntaxNode parent, SyntaxNode node, Doc d) {
+        return new Member(withComments(parent, node, d), concat(trailingOf(node)));
     }
 
     /**
@@ -1160,18 +1200,24 @@ public final class Formatter {
      */
     private static Map<SyntaxNode, List<SyntaxToken>> scanTrailing(SyntaxNode file) {
         Map<SyntaxNode, List<SyntaxToken>> out = new IdentityHashMap<>();
-        SyntaxToken code = null;             // the last token that was not trivia
+        List<SyntaxToken> code = new ArrayList<>();   // the tokens that were not trivia
         boolean lineEnded = true;            // nothing precedes the first token on its line
         for (SyntaxToken t : tokens(file)) {
             if (t.kind() == SyntaxKind.WHITESPACE) {
                 lineEnded |= t.text().indexOf('\n') >= 0;
             } else if (t.kind() == SyntaxKind.LINE_COMMENT) {
-                if (!lineEnded && code != null) {
-                    out.computeIfAbsent(owner(code), _ -> new ArrayList<>()).add(t);
+                // a comma is the enclosing construct's, so a comment after one was written about
+                // the member the comma closed rather than about the comma
+                int i = code.size() - 1;
+                while (i >= 0 && code.get(i).kind() == SyntaxKind.COMMA) {
+                    i--;
+                }
+                if (!lineEnded && i >= 0) {
+                    out.computeIfAbsent(owner(code.get(i)), _ -> new ArrayList<>()).add(t);
                 }
                 lineEnded = true;            // a line comment runs to the end of its line
             } else {
-                code = t;
+                code.add(t);
                 lineEnded = false;
             }
         }
@@ -1248,10 +1294,10 @@ public final class Formatter {
         return text(sb.toString());
     }
 
-    private List<Doc> exprDocs(SyntaxNode n) {
-        List<Doc> out = new ArrayList<>();
+    private List<Member> exprDocs(SyntaxNode n) {
+        List<Member> out = new ArrayList<>();
         for (SyntaxNode c : exprChildren(n)) {
-            out.add(withComments(n, c, expr(c)));
+            out.add(member(n, c, expr(c)));
         }
         return withEndComments(n, out);
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -208,12 +208,32 @@ public final class Formatter {
      * {@code ->}. Broken, each part starts a line one indent in and the connector leads it, so what
      * joins two parts is visible at the front of the second.
      */
-    private static Doc chained(Doc head, List<Segment> segments) {
+    private static Doc chained(Member head, List<Segment> segments) {
         List<Doc> parts = new ArrayList<>();
         for (Segment s : segments) {
             parts.add(concat(LINE, s.leading(), text(s.connector()), s.doc()));
         }
-        return group(concat(head, nest(INDENT, concat(parts))));
+        return group(concat(head.doc(), head.trailing(), nest(INDENT, concat(parts))));
+    }
+
+    /** The part of a chain written before the first connector, from the construct it stands for. A
+     * head is a member like a segment is, and the same three things it can stand for: a node, an
+     * identifier, or nothing the source wrote. */
+    private Member head(SyntaxNode owner, Doc doc) {
+        return new Member(concat(aboveOf(owner), doc), afterOf(owner));
+    }
+
+    private Member head(SyntaxToken owner, Doc doc) {
+        List<Doc> lead = new ArrayList<>();
+        for (Doc c : aboveCase(owner)) {
+            lead.add(concat(c, HARDLINE));
+        }
+        return new Member(concat(concat(lead), doc), afterCase(owner));
+    }
+
+    /** A head the source has nothing at — a `fake` row's default `_`. */
+    private static Member synthetic(Doc doc) {
+        return new Member(doc, Doc.NIL);
     }
 
     // --- top level ---
@@ -317,15 +337,15 @@ public final class Formatter {
 
         List<Segment> segs = new ArrayList<>();
         var desc = n.token(SyntaxKind.STRING_LIT);
-        Doc head;
+        Member head;
         if (desc.isPresent()) {
-            head = concat(text("| "), text(desc.get().text()));
+            head = head(desc.get(), concat(text("| "), text(desc.get().text())));
             segs.add(segment(": ", n.child(SyntaxKind.ARG_LIST).orElse(null), input));
         } else {
             // with no description the input opens the row, so the row's head carries its comments
             SyntaxNode args = n.child(SyntaxKind.ARG_LIST).orElse(null);
-            head = args == null ? concat(text("| "), input)
-                    : concat(aboveOf(args), text("| "), input, afterOf(args));
+            head = args == null ? synthetic(concat(text("| "), input))
+                    : head(args, concat(text("| "), input));
         }
         List<SyntaxNode> expected = exprChildren(n);   // the row's expr child that is not the ARG_LIST
         segs.add(segment("-> ", expected.isEmpty() ? null : expected.get(0),
@@ -355,8 +375,8 @@ public final class Formatter {
         }
         List<SyntaxNode> outs = exprChildren(n);
         // the input opens the row, so the head carries what was written above and beside it
-        Doc head = args.map(a -> concat(aboveOf(a), text("| "), input, afterOf(a)))
-                .orElse(concat(text("| "), input));
+        Member head = args.map(a -> head(a, concat(text("| "), input)))
+                .orElse(synthetic(concat(text("| "), input)));
         return chained(head,
                 List.of(segment("-> ", outs.isEmpty() ? null : outs.get(0),
                         outs.isEmpty() ? Doc.NIL : expr(outs.get(0)))));
@@ -439,7 +459,7 @@ public final class Formatter {
                     cases.add(segment("| ", t, text(t.text())));
                 }
             }
-            Doc chain = chained(head, cases);
+            Doc chain = chained(synthetic(head), cases);
             if (headComments.isEmpty()) {
                 return concat(text("data "), text(name), text(" = "), chain);
             }
@@ -698,7 +718,7 @@ public final class Formatter {
                 rest.add(segment("| ", c, typeTerm(c)));
             }
         }
-        Doc d = cases.isEmpty() ? Doc.NIL : chained(cases.get(0), rest);
+        Doc d = cases.isEmpty() ? Doc.NIL : chained(synthetic(cases.get(0)), rest);
         // `T?` in a core signature, the same mark a field carries
         return n.token(SyntaxKind.QUESTION).isPresent() ? concat(d, text("?")) : d;
     }
@@ -796,7 +816,7 @@ public final class Formatter {
     private Doc binary(SyntaxNode n) {
         List<Segment> segs = new ArrayList<>();
         Doc head = collectChain(n, ladderLevel(operatorKind(n)), segs);
-        return chained(head, segs);
+        return chained(synthetic(head), segs);
     }
 
     /**
@@ -846,7 +866,7 @@ public final class Formatter {
     private Doc pipe(SyntaxNode n) {
         List<Segment> stages = new ArrayList<>();
         Doc head = collectPipe(n, stages);
-        return chained(head, stages);
+        return chained(synthetic(head), stages);
     }
 
     /** Flattens a left-nested {@code |>} chain: returns the head doc and fills {@code stages} with each
@@ -940,6 +960,7 @@ public final class Formatter {
     private Doc matchCase(SyntaxNode n) {
         StringBuilder pattern = new StringBuilder();
         SyntaxNode body = null;
+        SyntaxToken patternEnd = null;
         boolean afterArrow = false;
         for (SyntaxElement e : meaningful(n)) {
             if (afterArrow) {
@@ -958,9 +979,12 @@ public final class Formatter {
                     pattern.append(' ');
                 }
                 pattern.append(t.text());
+                patternEnd = t;
             }
         }
-        return chained(concat(text("| "), text(pattern.toString())),
+        return chained(patternEnd == null
+                        ? synthetic(concat(text("| "), text(pattern.toString())))
+                        : head(patternEnd, concat(text("| "), text(pattern.toString()))),
                 List.of(segment("-> ", body, expr(body))));
     }
 
@@ -1235,6 +1259,8 @@ public final class Formatter {
         }
         if (next == null) {
             add(out.atEnd(), file, comment);          // nothing follows: it closes the file
+        } else if (isChainHead(next)) {
+            out.aboveCase().computeIfAbsent(next.start(), _ -> new ArrayList<>()).add(comment);
         } else if (isBareMember(next)) {
             // A clause keyword opens the line its first name is on, the way a bracket does, so a
             // comment above that name is above the clause rather than between the two.
@@ -1264,6 +1290,10 @@ public final class Formatter {
         // sum ends where the declaration does, and what ends on that line is the declaration.
         if (isBareMember(code) && code.end() != code.parent().end()) {
             out.afterCase().computeIfAbsent(nameEnd(code), _ -> new ArrayList<>()).add(comment);
+            return;
+        }
+        if (isChainHead(code)) {
+            out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
             return;
         }
         // A construct written over several lines has more lines than its last: `data D =` and
@@ -1482,6 +1512,31 @@ public final class Formatter {
             case DEPENDS_CLAUSE -> !t.equals(firstIdentToken(parent));
             default -> false;
         };
+    }
+
+    /** A token the head of a chain is written from — a match arm's pattern, an example row's
+     * description. Like a sum's cases these are tokens rather than nodes, so they are named by where
+     * they are; unlike them they open a chain rather than being one of its parts. */
+    private static boolean isChainHead(SyntaxToken t) {
+        return switch (t.parent().kind()) {
+            case EXAMPLE_ROW -> t.kind() == SyntaxKind.STRING_LIT;
+            case MATCH_CASE -> t.kind() != SyntaxKind.ARROW && followedByArrow(t);
+            default -> false;
+        };
+    }
+
+    private static boolean followedByArrow(SyntaxToken t) {
+        boolean after = false;
+        for (SyntaxElement e : t.parent().children()) {
+            if (!(e instanceof SyntaxToken s) || s.isTrivia()) {
+                continue;
+            }
+            if (after) {
+                return s.kind() == SyntaxKind.ARROW;
+            }
+            after = s.start() == t.start();
+        }
+        return false;
     }
 
     private static SyntaxToken firstIdentToken(SyntaxNode n) {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -177,11 +177,18 @@ public final class Formatter {
      * part of that line, so the two are written in this order and not the other: a comment placed
      * after the connector leaves the part itself starting a line the connector never opened.
      */
-    private record Segment(String connector, Doc doc, Doc leading) {
+    private record Segment(String connector, Doc doc, Doc leading) {}
 
-        Segment(String connector, Doc doc) {
-            this(connector, doc, Doc.NIL);
-        }
+    /**
+     * A part of a chain that something in the source stands for. Every segment of every chain is
+     * built here: a chain is written from what the source holds, and one built without asking what
+     * was written above and beside it is one whose comments have nowhere to go. {@code owner} is
+     * null only where the source has nothing there — an example row with no expected value.
+     */
+    private Segment segment(String connector, SyntaxNode owner, Doc doc) {
+        return owner == null
+                ? new Segment(connector, doc, Doc.NIL)
+                : new Segment(connector, concat(doc, afterOf(owner)), aboveOf(owner));
     }
 
     /**
@@ -196,15 +203,6 @@ public final class Formatter {
             parts.add(concat(LINE, s.leading(), text(s.connector()), s.doc()));
         }
         return group(concat(head, nest(INDENT, concat(parts))));
-    }
-
-    /** {@code docs} as segments sharing one connector — a run of the same operator. */
-    private static List<Segment> segments(String connector, List<Doc> docs) {
-        List<Segment> out = new ArrayList<>();
-        for (Doc d : docs) {
-            out.add(new Segment(connector, d));
-        }
-        return out;
     }
 
     // --- top level ---
@@ -311,12 +309,16 @@ public final class Formatter {
         Doc head;
         if (desc.isPresent()) {
             head = concat(text("| "), text(desc.get().text()));
-            segs.add(new Segment(": ", input));
+            segs.add(segment(": ", n.child(SyntaxKind.ARG_LIST).orElse(null), input));
         } else {
-            head = concat(text("| "), input);
+            // with no description the input opens the row, so the row's head carries its comments
+            SyntaxNode args = n.child(SyntaxKind.ARG_LIST).orElse(null);
+            head = args == null ? concat(text("| "), input)
+                    : concat(aboveOf(args), text("| "), input, afterOf(args));
         }
         List<SyntaxNode> expected = exprChildren(n);   // the row's expr child that is not the ARG_LIST
-        segs.add(new Segment("-> ", expected.isEmpty() ? Doc.NIL : expr(expected.get(0))));
+        segs.add(segment("-> ", expected.isEmpty() ? null : expected.get(0),
+                expected.isEmpty() ? Doc.NIL : expr(expected.get(0))));
         return chained(head, segs);
     }
 
@@ -341,8 +343,12 @@ public final class Formatter {
             input = text("_");   // the default row
         }
         List<SyntaxNode> outs = exprChildren(n);
-        return chained(concat(text("| "), input),
-                List.of(new Segment("-> ", outs.isEmpty() ? Doc.NIL : expr(outs.get(0)))));
+        // the input opens the row, so the head carries what was written above and beside it
+        Doc head = args.map(a -> concat(aboveOf(a), text("| "), input, afterOf(a)))
+                .orElse(concat(text("| "), input));
+        return chained(head,
+                List.of(segment("-> ", outs.isEmpty() ? null : outs.get(0),
+                        outs.isEmpty() ? Doc.NIL : expr(outs.get(0)))));
     }
 
     private Doc moduleHeader(SyntaxNode n) {
@@ -424,7 +430,7 @@ public final class Formatter {
                     for (Doc c : aboveCase(t)) {
                         lead.add(concat(c, HARDLINE));
                     }
-                    cases.add(new Segment("| ", body, concat(lead)));
+                    cases.add(new Segment("| ", body, concat(lead)));   // a case is a token
                 }
             }
             Doc chain = chained(head, cases);
@@ -683,7 +689,7 @@ public final class Formatter {
             if (cases.isEmpty()) {
                 cases.add(concat(aboveOf(c), body));
             } else {
-                rest.add(new Segment("| ", body, aboveOf(c)));
+                rest.add(segment("| ", c, typeTerm(c)));
             }
         }
         Doc d = cases.isEmpty() ? Doc.NIL : chained(cases.get(0), rest);
@@ -807,8 +813,7 @@ public final class Formatter {
             head = concat(aboveOf(left), expr(left), afterOf(left));
         }
         SyntaxNode right = ops.get(1);
-        segs.add(new Segment(operatorText(n) + " ", concat(expr(right), afterOf(right)),
-                aboveOf(right)));
+        segs.add(segment(operatorText(n) + " ", right, expr(right)));
         return head;
     }
 
@@ -850,7 +855,7 @@ public final class Formatter {
         } else {
             head = concat(aboveOf(left), expr(left), afterOf(left));
         }
-        stages.add(new Segment("|> ", concat(expr(right), afterOf(right)), aboveOf(right)));
+        stages.add(segment("|> ", right, expr(right)));
         return head;
     }
 
@@ -950,7 +955,7 @@ public final class Formatter {
             }
         }
         return chained(concat(text("| "), text(pattern.toString())),
-                List.of(new Segment("-> ", expr(body))));
+                List.of(segment("-> ", body, expr(body))));
     }
 
     private Doc lambda(SyntaxNode n) {
@@ -1159,7 +1164,7 @@ public final class Formatter {
      */
     private static boolean separates(SyntaxToken t) {
         return switch (t.kind()) {
-            case COMMA, PIPE, PIPEFWD, VPIPE -> true;
+            case COMMA, PIPE, PIPEFWD, VPIPE, ARROW, COLON -> true;
             default -> isBinaryOperator(t.kind());
         };
     }
@@ -1542,6 +1547,8 @@ public final class Formatter {
                     k -> k == SyntaxKind.FIELD || k == SyntaxKind.FIELD_INIT
                             || k == SyntaxKind.SPREAD_MEMBER;
             case MATCH_EXPR -> k -> k == SyntaxKind.MATCH_CASE;
+            case MATCH_CASE -> Formatter::isExprKind;
+            case EXAMPLE_ROW, FAKE_ROW -> k -> k == SyntaxKind.ARG_LIST || isExprKind(k);
             case EXAMPLE_DEF -> k -> k == SyntaxKind.EXAMPLE_ROW;
             case FAKE_DEF -> k -> k == SyntaxKind.FAKE_ROW;
             case EXPOSING_CLAUSE -> k -> k == SyntaxKind.EXPOSED_ENTRY;

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -435,7 +435,8 @@ public final class Formatter {
         }
         var newtype = n.child(SyntaxKind.NEWTYPE_BODY);
         if (newtype.isPresent()) {
-            Doc inner = typeRef(typeChild(newtype.get()));
+            Doc inner = concat(aboveOf(newtype.get()), typeRef(typeChild(newtype.get())),
+                    afterOf(newtype.get()));
             return concat(text("data "), text(name), text(" = "), inner, nest(INDENT, concat(invariants)));
         }
         return concat(text("data "), text(name));   // unit
@@ -479,7 +480,8 @@ public final class Formatter {
         if (sig.isPresent()) {
             SyntaxNode s = sig.get();
             Doc params = paramList(s.child(SyntaxKind.PARAM_LIST).orElseThrow());
-            Doc ret = retType(s.child(SyntaxKind.RET_TYPE).orElseThrow());
+            SyntaxNode retNode = s.child(SyntaxKind.RET_TYPE).orElseThrow();
+            Doc ret = concat(aboveOf(retNode), retType(retNode), afterOf(retNode));
             List<Doc> clauses = new ArrayList<>();
             for (SyntaxNode c : s.childNodes()) {
                 if (c.kind() == SyntaxKind.CONSTRUCTS_CLAUSE) {
@@ -668,13 +670,19 @@ public final class Formatter {
 
     private Doc retType(SyntaxNode n) {
         List<Doc> cases = new ArrayList<>();
+        List<Segment> rest = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
-            if (isTypeNode(c.kind())) {
-                cases.add(typeTerm(c));
+            if (!isTypeNode(c.kind())) {
+                continue;
+            }
+            Doc body = concat(typeTerm(c), afterOf(c));
+            if (cases.isEmpty()) {
+                cases.add(concat(aboveOf(c), body));
+            } else {
+                rest.add(new Segment("| ", body, aboveOf(c)));
             }
         }
-        Doc d = cases.isEmpty() ? Doc.NIL
-                : chained(cases.get(0), segments("| ", cases.subList(1, cases.size())));
+        Doc d = cases.isEmpty() ? Doc.NIL : chained(cases.get(0), rest);
         // `T?` in a core signature, the same mark a field carries
         return n.token(SyntaxKind.QUESTION).isPresent() ? concat(d, text("?")) : d;
     }
@@ -1179,31 +1187,48 @@ public final class Formatter {
         return null;
     }
 
+    /**
+     * What a comment written above {@code next} was written about: the outermost construct that
+     * begins there. This is what the comment describes, and it is decided without asking whether
+     * that construct has anywhere to put it — that is the next question, and answering the two
+     * together is what turned a comment about a case into a comment about the declaration.
+     */
     private static void above(Attachments out, SyntaxToken next, SyntaxToken comment, SyntaxNode file) {
         if (next != null && opens(next)) {
             // what opens a construct is the construct's, and it shares a line with the first member
             SyntaxElement first = firstMemberOf(next.parent());
             if (first instanceof SyntaxNode node) {
-                add(out.above(), node, comment);
+                place(out, node, comment, true);
                 return;
             }
             if (first instanceof SyntaxToken token) {
-                out.aboveCase().computeIfAbsent(token.start(), _ -> new ArrayList<>()).add(comment);
+                out.aboveCase().computeIfAbsent(nameStart(token), _ -> new ArrayList<>()).add(comment);
                 return;
             }
         }
         if (next == null) {
             add(out.atEnd(), file, comment);          // nothing follows: it closes the file
         } else if (isBareMember(next)) {
-            out.aboveCase().computeIfAbsent(next.start(), _ -> new ArrayList<>()).add(comment);
+            // A clause keyword opens the line its first name is on, the way a bracket does, so a
+            // comment above that name is above the clause rather than between the two.
+            SyntaxElement first = firstMemberOf(next.parent());
+            boolean opensTheClause = first instanceof SyntaxToken t && t.start() == nameStart(next)
+                    && (next.parent().kind() == SyntaxKind.CONSTRUCTS_CLAUSE
+                            || next.parent().kind() == SyntaxKind.DEPENDS_CLAUSE);
+            if (opensTheClause) {
+                place(out, next.parent(), comment, true);
+            } else {
+                out.aboveCase().computeIfAbsent(nameStart(next), _ -> new ArrayList<>()).add(comment);
+            }
         } else if (closes(next)) {
             add(out.atEnd(), next.parent(), comment);
         } else {
-            SyntaxNode owner = hasALine(next);
-            add(owner == null ? out.atEnd() : out.above(), owner == null ? file : owner, comment);
+            place(out, beginningAt(next), comment, true);
         }
     }
 
+    /** What a comment written after {@code code} was written about: the outermost construct that
+     * ends there. */
     private static void after(Attachments out, SyntaxToken code, SyntaxToken comment) {
         if (code == null) {
             return;                                   // a comment with no code before it is above
@@ -1211,13 +1236,110 @@ public final class Formatter {
         // A bare member is only its own line's owner while something follows it. The last case of a
         // sum ends where the declaration does, and what ends on that line is the declaration.
         if (isBareMember(code) && code.end() != code.parent().end()) {
-            out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
+            out.afterCase().computeIfAbsent(nameEnd(code), _ -> new ArrayList<>()).add(comment);
             return;
         }
-        SyntaxNode owner = hasALine(code);
-        if (owner != null) {
-            add(out.after(), owner, comment);
+        place(out, endingAt(code), comment, false);
+    }
+
+    /**
+     * Files {@code comment} against {@code owner}, or against the nearest construct above it that
+     * the layout gives a line of its own. A construct with no line of its own has nowhere to put a
+     * comment: written there, the rest of that line would be written inside it. So the comment
+     * travels — a comment after the condition of an {@code if} is written at the end of the
+     * declaration that holds the {@code if} — and how far it travels is a fact about the layout
+     * rather than about what the comment was written about.
+     */
+    private static void place(Attachments out, SyntaxNode owner, SyntaxToken comment, boolean above) {
+        for (SyntaxNode c = owner; c != null && c.parent() != null; c = c.parent()) {
+            if (takesALineOf(c.parent().kind(), c.kind())) {
+                add(above ? out.above() : out.after(), c, comment);
+                return;
+            }
         }
+    }
+
+    /** The outermost construct beginning at {@code t}. */
+    private static SyntaxNode beginningAt(SyntaxToken t) {
+        SyntaxNode node = t.parent();
+        while (node.parent() != null && node.parent().parent() != null
+                && firstCodeOffset(node.parent()) == t.start()) {
+            node = node.parent();
+        }
+        return node;
+    }
+
+    /** The outermost construct ending at {@code t}. */
+    private static SyntaxNode endingAt(SyntaxToken t) {
+        SyntaxNode node = t.parent();
+        while (node.parent() != null && node.parent().parent() != null
+                && node.parent().end() == t.end()) {
+            node = node.parent();
+        }
+        return node;
+    }
+
+    /** Where {@code n}'s own text begins, past whatever trivia the parser put in front of it. */
+    private static int firstCodeOffset(SyntaxNode n) {
+        for (SyntaxToken t : tokens(n)) {
+            if (!t.isTrivia()) {
+                return t.start();
+            }
+        }
+        return n.start();
+    }
+
+    /**
+     * A qualified name is one member written as several identifiers, so a comment anywhere in it is
+     * about the whole name. These answer where that name begins and ends, so the two ends of the
+     * run agree on which member they are, however deep into it the comment was written.
+     */
+    private static int nameStart(SyntaxToken ident) {
+        SyntaxToken at = ident;
+        for (SyntaxToken before = previousOfName(at); before != null; before = previousOfName(at)) {
+            at = before;
+        }
+        return at.start();
+    }
+
+    private static int nameEnd(SyntaxToken ident) {
+        SyntaxToken at = ident;
+        for (SyntaxToken after = nextOfName(at); after != null; after = nextOfName(at)) {
+            at = after;
+        }
+        return at.end();
+    }
+
+    private static SyntaxToken previousOfName(SyntaxToken ident) {
+        List<SyntaxToken> siblings = codeTokensOf(ident.parent());
+        int i = indexOf(siblings, ident);
+        return i >= 2 && siblings.get(i - 1).kind() == SyntaxKind.DOT ? siblings.get(i - 2) : null;
+    }
+
+    private static SyntaxToken nextOfName(SyntaxToken ident) {
+        List<SyntaxToken> siblings = codeTokensOf(ident.parent());
+        int i = indexOf(siblings, ident);
+        return i >= 0 && i + 2 < siblings.size() && siblings.get(i + 1).kind() == SyntaxKind.DOT
+                ? siblings.get(i + 2) : null;
+    }
+
+    private static List<SyntaxToken> codeTokensOf(SyntaxNode n) {
+        List<SyntaxToken> out = new ArrayList<>();
+        for (SyntaxElement e : n.children()) {
+            if (e instanceof SyntaxToken t && !t.isTrivia()) {
+                out.add(t);
+            }
+        }
+        return out;
+    }
+
+    private static int indexOf(List<SyntaxToken> tokens, SyntaxToken t) {
+        for (int i = 0; i < tokens.size(); i++) {
+            if (tokens.get(i).start() == t.start()) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private static void add(Map<SyntaxNode, List<SyntaxToken>> to, SyntaxNode key, SyntaxToken c) {
@@ -1307,9 +1429,11 @@ public final class Formatter {
             case WITH_CLAUSE -> child == SyntaxKind.WITH_BINDING;
             case ELSE_ARMS -> child == SyntaxKind.ELSE_ARM;
             case PIPE_BEHAVIOR -> child == SyntaxKind.STAGE;
-            case DATA_DEF -> child == SyntaxKind.INVARIANT_CLAUSE;
+            case DATA_DEF -> child == SyntaxKind.INVARIANT_CLAUSE
+                    || child == SyntaxKind.NEWTYPE_BODY;
             case BEHAVIOR_SIG -> child == SyntaxKind.CONSTRUCTS_CLAUSE
-                    || child == SyntaxKind.DEPENDS_CLAUSE;
+                    || child == SyntaxKind.DEPENDS_CLAUSE || child == SyntaxKind.RET_TYPE;
+            case RET_TYPE -> isTypeNode(child);
             case BLOCK_EXPR -> true;
             case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> isExprKind(child);
             case PIPE_EXPR -> isExprKind(child) && child != SyntaxKind.PIPE_EXPR;
@@ -1395,10 +1519,16 @@ public final class Formatter {
      * against where the identifier is. */
     private Member tokenMember(SyntaxToken above, SyntaxToken end, Doc d) {
         List<Doc> lead = new ArrayList<>();
-        for (Doc c : aboveCase(above)) {
+        for (Doc c : unwritten(comments.aboveCase().getOrDefault(nameStart(above), List.of()))) {
             lead.add(concat(c, HARDLINE));
         }
-        return new Member(concat(concat(lead), d), afterCase(end));
+        List<Doc> parts = new ArrayList<>();
+        for (SyntaxToken c : comments.afterCase().getOrDefault(nameEnd(end), List.of())) {
+            if (consumedComments.add(c.start())) {
+                parts.add(Doc.trailing(c.text().stripTrailing()));
+            }
+        }
+        return new Member(concat(concat(lead), d), concat(parts));
     }
 
     /** A member: what is written above its line, the member, and what ends that line — the last kept

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -1153,7 +1153,7 @@ public final class Formatter {
     private static boolean separates(SyntaxToken t) {
         return switch (t.kind()) {
             case COMMA, PIPE, PIPEFWD, VPIPE -> true;
-            default -> false;
+            default -> isBinaryOperator(t.kind());
         };
     }
 
@@ -1171,7 +1171,9 @@ public final class Formatter {
     private static SyntaxToken nextCode(List<SyntaxToken> all, int i) {
         for (int j = i + 1; j < all.size(); j++) {
             SyntaxToken t = all.get(j);
-            if (t.isTrivia() || separates(t)) {
+            // what closes a construct is asked about before what separates its members, because a
+            // type's `>` is both: it is the angle bracket here and the comparison everywhere else
+            if (t.isTrivia() || (separates(t) && !closes(t))) {
                 continue;
             }
             return t.kind() == SyntaxKind.EOF ? null : t;
@@ -1182,7 +1184,7 @@ public final class Formatter {
     /** The code a comment was written after. */
     private static SyntaxToken lastCode(List<SyntaxToken> code) {
         for (int i = code.size() - 1; i >= 0; i--) {
-            if (!separates(code.get(i))) {
+            if (!separates(code.get(i)) || closes(code.get(i))) {
                 return code.get(i);
             }
         }
@@ -1419,8 +1421,11 @@ public final class Formatter {
     /** Whether {@code t} is what closes a construct whose members take a line each — the place a
      * comment written under the last member goes. */
     private static boolean closes(SyntaxToken t) {
+        if (t.end() != t.parent().end() || !holdsLines(t.parent().kind())) {
+            return false;   // a bracket in the middle of a construct closes nothing
+        }
         return switch (t.kind()) {
-            case RBRACE, RPAREN, RBRACKET -> holdsLines(t.parent().kind());
+            case RBRACE, RPAREN, RBRACKET, GT -> true;
             default -> false;
         };
     }
@@ -1438,45 +1443,52 @@ public final class Formatter {
         return null;
     }
 
-    /** Whether a {@code child} of {@code parent} is written on a line of its own. These are the
-     * places a construct is asked for its comments; one added to a list here without being asked is
-     * what counting the comments consumed against the comments the tree holds is there to catch. */
+    /** Whether a {@code child} of {@code parent} is written on a line of its own. */
     private static boolean takesALineOf(SyntaxKind parent, SyntaxKind child) {
-        return switch (parent) {
-            case SOURCE_FILE -> isTopLevel(child);
-            case PRODUCT_BODY, NEW_DATA_EXPR ->
-                    child == SyntaxKind.FIELD || child == SyntaxKind.FIELD_INIT
-                            || child == SyntaxKind.SPREAD_MEMBER;
-            case MATCH_EXPR -> child == SyntaxKind.MATCH_CASE;
-            case EXAMPLE_DEF -> child == SyntaxKind.EXAMPLE_ROW;
-            case FAKE_DEF -> child == SyntaxKind.FAKE_ROW;
-            case EXPOSING_CLAUSE -> child == SyntaxKind.EXPOSED_ENTRY;
-            case PARAM_LIST -> child == SyntaxKind.PARAM;
-            case FN_PARAM_LIST -> child == SyntaxKind.FN_PARAM;
-            case WITH_CLAUSE -> child == SyntaxKind.WITH_BINDING;
-            case ELSE_ARMS -> child == SyntaxKind.ELSE_ARM;
-            case PIPE_BEHAVIOR -> child == SyntaxKind.STAGE;
-            case DATA_DEF -> child == SyntaxKind.INVARIANT_CLAUSE
-                    || child == SyntaxKind.NEWTYPE_BODY;
-            case BEHAVIOR_SIG -> child == SyntaxKind.CONSTRUCTS_CLAUSE
-                    || child == SyntaxKind.DEPENDS_CLAUSE || child == SyntaxKind.RET_TYPE;
-            case RET_TYPE, TYPE_ARGS, TUPLE_TYPE -> isTypeNode(child);
-            case FN_TYPE -> child == SyntaxKind.RET_TYPE;
-            case BINARY_EXPR -> isExprKind(child) && child != SyntaxKind.BINARY_EXPR;
-            case BLOCK_EXPR -> true;
-            case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> isExprKind(child);
-            case PIPE_EXPR -> isExprKind(child) && child != SyntaxKind.PIPE_EXPR;
-            default -> false;
-        };
+        java.util.function.Predicate<SyntaxKind> children = linesOf(parent);
+        return children != null && children.test(child);
     }
 
-    /** Whether a construct writes its members one to a line, so that its closer opens a line a
-     * comment can be written on. */
-    private static boolean holdsLines(SyntaxKind k) {
-        return switch (k) {
-            case PRODUCT_BODY, NEW_DATA_EXPR, EXPOSING_CLAUSE, PARAM_LIST, FN_PARAM_LIST, ARG_LIST,
-                 LIST_EXPR, TUPLE_EXPR, LIST_COMP, BLOCK_EXPR -> true;
-            default -> false;
+    /** Whether {@code parent} writes any of its children on lines of their own, so that what closes
+     * it opens a line too. Read from the same table as {@link #takesALineOf}: a construct that holds
+     * lines and a construct whose members can be written above are the same construct, and keeping
+     * two lists of them is how a type argument came to have somewhere to put the comment under it
+     * while nothing put one there. */
+    private static boolean holdsLines(SyntaxKind parent) {
+        return linesOf(parent) != null;
+    }
+
+    /**
+     * Which children of {@code parent} are written on lines of their own, or null where none are.
+     * These are the places a construct is asked for its comments; one added here without being asked
+     * is what counting the comments consumed against the comments the tree holds is there to catch.
+     */
+    private static java.util.function.Predicate<SyntaxKind> linesOf(SyntaxKind parent) {
+        return switch (parent) {
+            case SOURCE_FILE -> Formatter::isTopLevel;
+            case PRODUCT_BODY, NEW_DATA_EXPR ->
+                    k -> k == SyntaxKind.FIELD || k == SyntaxKind.FIELD_INIT
+                            || k == SyntaxKind.SPREAD_MEMBER;
+            case MATCH_EXPR -> k -> k == SyntaxKind.MATCH_CASE;
+            case EXAMPLE_DEF -> k -> k == SyntaxKind.EXAMPLE_ROW;
+            case FAKE_DEF -> k -> k == SyntaxKind.FAKE_ROW;
+            case EXPOSING_CLAUSE -> k -> k == SyntaxKind.EXPOSED_ENTRY;
+            case PARAM_LIST -> k -> k == SyntaxKind.PARAM;
+            case FN_PARAM_LIST -> k -> k == SyntaxKind.FN_PARAM;
+            case WITH_CLAUSE -> k -> k == SyntaxKind.WITH_BINDING;
+            case ELSE_ARMS -> k -> k == SyntaxKind.ELSE_ARM;
+            case PIPE_BEHAVIOR -> k -> k == SyntaxKind.STAGE;
+            case DATA_DEF -> k -> k == SyntaxKind.INVARIANT_CLAUSE
+                    || k == SyntaxKind.NEWTYPE_BODY;
+            case BEHAVIOR_SIG -> k -> k == SyntaxKind.CONSTRUCTS_CLAUSE
+                    || k == SyntaxKind.DEPENDS_CLAUSE || k == SyntaxKind.RET_TYPE;
+            case RET_TYPE, TYPE_ARGS, TUPLE_TYPE -> Formatter::isTypeNode;
+            case FN_TYPE -> k -> k == SyntaxKind.RET_TYPE;
+            case BINARY_EXPR -> k -> isExprKind(k) && k != SyntaxKind.BINARY_EXPR;
+            case BLOCK_EXPR -> _ -> true;
+            case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> Formatter::isExprKind;
+            case PIPE_EXPR -> k -> isExprKind(k) && k != SyntaxKind.PIPE_EXPR;
+            default -> null;
         };
     }
 

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -651,7 +651,7 @@ public final class Formatter {
     // --- types ---
 
     private Doc fnType(SyntaxNode n) {
-        List<Doc> params = new ArrayList<>();
+        List<Member> params = new ArrayList<>();
         Doc result = Doc.NIL;
         boolean afterArrow = false;
         for (SyntaxElement e : meaningful(n)) {
@@ -659,13 +659,13 @@ public final class Formatter {
                 afterArrow = true;
             } else if (e instanceof SyntaxNode c && c.kind() == SyntaxKind.RET_TYPE) {
                 if (afterArrow) {
-                    result = retType(c);
+                    result = concat(aboveOf(c), retType(c), afterOf(c));
                 } else {
-                    params.add(retType(c));
+                    params.add(member(c, retType(c)));
                 }
             }
         }
-        return concat(delimited("(", SOFTLINE, plain(params), ")"), text(" -> "), result);
+        return concat(delimited("(", SOFTLINE, params, ")"), text(" -> "), result);
     }
 
     private Doc retType(SyntaxNode n) {
@@ -689,13 +689,13 @@ public final class Formatter {
 
     private Doc typeRef(SyntaxNode n) {
         if (n.kind() == SyntaxKind.TUPLE_TYPE) {
-            List<Doc> elems = new ArrayList<>();
+            List<Member> elems = new ArrayList<>();
             for (SyntaxNode c : n.childNodes()) {
                 if (isTypeNode(c.kind())) {
-                    elems.add(typeTerm(c));
+                    elems.add(member(c, typeTerm(c)));
                 }
             }
-            return delimited("(", SOFTLINE, plain(elems), ")");
+            return delimited("(", SOFTLINE, withEndComments(n, elems), ")");
         }
         var typevar = n.token(SyntaxKind.TYPEVAR);
         if (typevar.isPresent()) {
@@ -706,13 +706,13 @@ public final class Formatter {
         if (args.isEmpty()) {
             return name;
         }
-        List<Doc> typeArgs = new ArrayList<>();
+        List<Member> typeArgs = new ArrayList<>();
         for (SyntaxNode c : args.get().childNodes()) {
             if (isTypeNode(c.kind())) {
-                typeArgs.add(typeTerm(c));
+                typeArgs.add(member(c, typeTerm(c)));
             }
         }
-        return concat(name, delimited("<", SOFTLINE, plain(typeArgs), ">"));
+        return concat(name, delimited("<", SOFTLINE, withEndComments(args.get(), typeArgs), ">"));
     }
 
     private static boolean isTypeNode(SyntaxKind k) {
@@ -800,9 +800,11 @@ public final class Formatter {
         if (left.kind() == SyntaxKind.BINARY_EXPR && ladderLevel(operatorKind(left)) == level) {
             head = collectChain(left, level, segs);
         } else {
-            head = expr(left);
+            head = concat(aboveOf(left), expr(left), afterOf(left));
         }
-        segs.add(new Segment(operatorText(n) + " ", expr(ops.get(1))));
+        SyntaxNode right = ops.get(1);
+        segs.add(new Segment(operatorText(n) + " ", concat(expr(right), afterOf(right)),
+                aboveOf(right)));
         return head;
     }
 
@@ -1251,12 +1253,37 @@ public final class Formatter {
      * rather than about what the comment was written about.
      */
     private static void place(Attachments out, SyntaxNode owner, SyntaxToken comment, boolean above) {
-        for (SyntaxNode c = owner; c != null && c.parent() != null; c = c.parent()) {
+        SyntaxNode from = owner;
+        // A run the layout flattens is written as segments, and a part of the spine ends where its
+        // own segment does rather than where the whole run does. Only inside the run, though: the
+        // last segment of the outermost run is followed by whatever the construct holding it writes
+        // — a `then`, a closing bracket — and a comment there would have that written inside it.
+        while (isSpine(from) && from.parent() != null && from.parent().kind() == from.kind()) {
+            from = lastSegmentOf(from);
+        }
+        for (SyntaxNode c = from; c != null && c.parent() != null; c = c.parent()) {
             if (takesALineOf(c.parent().kind(), c.kind())) {
                 add(above ? out.above() : out.after(), c, comment);
                 return;
             }
         }
+    }
+
+    /** Whether {@code n} is a run the layout writes as one chain of segments rather than as the
+     * nesting the parser read. */
+    private static boolean isSpine(SyntaxNode n) {
+        return n.kind() == SyntaxKind.PIPE_EXPR || n.kind() == SyntaxKind.BINARY_EXPR;
+    }
+
+    /** The part of a flattened run that is written last — the segment whose line the run ends on. */
+    private static SyntaxNode lastSegmentOf(SyntaxNode n) {
+        List<SyntaxNode> parts = new ArrayList<>();
+        for (SyntaxNode c : n.childNodes()) {
+            if (isExprKind(c.kind())) {
+                parts.add(c);
+            }
+        }
+        return parts.get(parts.size() - 1);
     }
 
     /** The outermost construct beginning at {@code t}. */
@@ -1433,7 +1460,9 @@ public final class Formatter {
                     || child == SyntaxKind.NEWTYPE_BODY;
             case BEHAVIOR_SIG -> child == SyntaxKind.CONSTRUCTS_CLAUSE
                     || child == SyntaxKind.DEPENDS_CLAUSE || child == SyntaxKind.RET_TYPE;
-            case RET_TYPE -> isTypeNode(child);
+            case RET_TYPE, TYPE_ARGS, TUPLE_TYPE -> isTypeNode(child);
+            case FN_TYPE -> child == SyntaxKind.RET_TYPE;
+            case BINARY_EXPR -> isExprKind(child) && child != SyntaxKind.BINARY_EXPR;
             case BLOCK_EXPR -> true;
             case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> isExprKind(child);
             case PIPE_EXPR -> isExprKind(child) && child != SyntaxKind.PIPE_EXPR;


### PR DESCRIPTION
Closes #453, #454, #455, and with them #451.

A comment is trivia to the language and not to a pretty-printer, which owes it three things: it has to survive the transformation, it has to keep the construct it was written about, and it constrains the layout the printer is otherwise free to choose. #451 was filed as a defect in the second. Reproducing it found the formatter had no model for any of the three.

## What was wrong

Formatting `souther-bench`'s corpus dropped comments — `crm.sou` one, `quoting.sou` nine, `pipeline.sou` two — and nothing reported it. That was two separate holes: a run of comments after a parent's last member was handed to nobody, and an `invariant` clause, a `constructs` / `depends on` clause and a `fake` row never asked for comments at all.

A comment written at the end of a line came back describing whatever was declared next. Three collectors turned every position into "the leading comments of the next node", and the one the issue named turned out to handle the record-field example but not the headline one.

A comment above a member of a leading-comma block came back below the comma, with the member itself at the nesting indent. That one had nothing to do with trailing comments: an ordinary full-line comment above a field did it too.

Every symptom was a fixed point. Formatting the output reproduced it, so `fmt -w` wrote the wrong form and `fmt --check` demanded it, and the idempotence the formatter is tested for held throughout.

## What it does now

**A comment decorates a whole line, opener included** (#453). A member of a leading-comma block or a union is written on a line the block opens for it, so the opener is part of what the comments decorate. `separated` is the only place that has to know which side the punctuation goes on.

**Discovery is exhaustive, and counted** (#454). Comments are found in one pass and consumed in one place. The run after a parent's last member is kept apart from the runs a member is under, and the clauses that never asked now ask.

**A comment keeps which construct it is about** (#455). Whether a comment was written above a line or at the end of one is already in the tree — the whitespace before a full-line comment carries the newline that ended the line above it, and the whitespace before a trailing one does not. The parser was not losing the provenance; comment interpretation was discarding it. Nothing in the grammar or the parser changed.

What is preserved is `(owner, relation)` and not line and column. Where a trailing comment goes is derived: it is written at the end of the line its construct ends on *after* formatting, which is not the line it ended on before. Its width is measured against nothing, since nothing can share the line after it — which is also why a group holding one is never laid out flat. `Doc.Trailing` carries both facts.

The owner is the outermost construct ending where the code before the comment ends: `data D = A | B // c` is about the declaration and `, f: T // c` about the field, which is one rule. A comma is nobody's, so a comment after one is put against the member the comma closed. Where the owner has no line of its own — a comment after the condition of an `if` — it moves up to the nearest construct that does, and is written at the end of that line. It travels further than it was written. Writing it where it was written would put the rest of that line inside it.

## Measurements

A probe comment is written into every boundary between two of a fixture's tokens — not only where whitespace already was — and required back from every variant that still parses. Not every position the grammar admits one: what is quantified over is the boundaries of the fixtures, and a form no fixture is written in is a form nothing here asks about. A qualified name in a `constructs` clause was such a form, and the formatter refused it, so it is a fixture now.

Four things are required of each variant, and each was added because something got past the ones before it.

- the comments come back, as comments and not as text: one written into another one's line is still in the output and is no longer a comment
- the tokens that are not trivia come back unchanged: a comment that swallowed the code after it looked like a comment that survived, and that is how a pipeline's declared output was being deleted
- the output parses
- what each comment is next to, as an index into those tokens, is either unchanged or one of the boundaries that has no line to stay on

Of 404 boundaries, none loses a comment, changes the code or fails to parse, and none of the comments that had a line to stay on left it.

Which of them had one is read from the canonical form rather than from the formatter: a token that already ends a line is a place a comment can stay, and one in the middle of a line is a place it cannot, since the rest of that line would be written inside it. A comment written there goes to the nearest construct the layout gives a line to — further than it was written, and the alternative is writing code into a comment. That check replaced a count of how many travelled, which said nothing about which: a comment that started staying and one that stopped cancel out. It found thirteen reassignments the count had been hiding, all of them the same thing — a construct written over several lines has more lines than its last, and only the last was a line anything could be attached to.

Against `develop` the corpus loses twelve comment lines and now loses none: `crm.sou` 232 in and 232 out, `quoting.sou` 114, `pipeline.sou` 238. That number is the small one — the corpus writes trailing comments only where a construct already fits on one line.

`format` also compares the comments the tree holds against the ones some construct consumed, and refuses rather than returning a file that came back shorter. That is the inner half and the sweep is the outer: a construct can take a comment and write nothing, which is how an empty `exposing` clause lost one with the count green.

Five rounds of review found defects, and each round is as much a change to the sweep as to the formatter. What survival cannot ask is which member a comment is about — moved from one member to the next it is one comment in and one out with the code unchanged — which is why that question is now counted rather than enumerated, and why the cases written out by hand are written by how a member is rendered rather than by which construct holds it.

## Relation to #444

The canonical form changed, so #444 can be written from this output rather than from the previous one. Two of its rules did not exist before in any form: a trailing comment goes at the end of its owner's last content line, and a construct holding one is never laid out flat.
