### PR TITLE
A behavior's boundary carries the types a model declared

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -595,6 +595,47 @@ public final class SpecChecker {
                     + " a data, or name it as a case of a sum, which where the whole output is the"
                     + " optional is written directly as `-> A | Missing`";
 
+    /**
+     * A behavior's boundary carries types a model declared. The language declares vocabulary of its
+     * own — what a division by zero answers with, what a rounding takes, the reserved {@code Raw} —
+     * and each of those says what one of the language's operations can answer or take. A behavior with
+     * the same thing to report declares the case itself, so that what it publishes stays its own when
+     * the language's account of itself changes.
+     *
+     * <p>Asked of the boundary's shape, so a collection carrying such a name is subject to it and a
+     * member of an output union is too. A data a model declared crosses as itself whatever it holds
+     * inside, which is where the walk stops.
+     */
+    static void rejectForeignBoundaryName(Ast.SpecBehavior spec, Symbols symbols) {
+        for (Ast.Param p : spec.params()) {
+            TypeName foreign =
+                    TypeOps.foreignNameInBoundaryShape(TypeOps.successType(p.type(), symbols), symbols);
+            if (foreign != null) {
+                throw CompileException.of(
+                        Diagnostic.of(DiagnosticCode.E1325, "check.param.foreignname")
+                                .at(p.written().region()).args(p.name(), foreign.name())
+                                .hint("check.foreignname.hint").build(),
+                        "parameter `" + p.name() + "` takes `" + foreign.name() + "`, which the"
+                                + " language declares rather than this model; " + FOREIGN_NAME_ADVICE);
+            }
+        }
+        TypeName foreign =
+                TypeOps.foreignNameInBoundaryShape(TypeOps.successType(spec.ret(), symbols), symbols);
+        if (foreign != null) {
+            throw CompileException.of(
+                    Diagnostic.of(DiagnosticCode.E1325, "check.output.foreignname")
+                            .at(spec.pos()).args(spec.name(), foreign.name())
+                            .hint("check.foreignname.hint").build(),
+                    "`" + spec.name() + "` answers `" + foreign.name() + "`, which the language"
+                            + " declares rather than this model; " + FOREIGN_NAME_ADVICE);
+        }
+    }
+
+    /** What to write instead. Said as declaring the case rather than as supplying a codec: the name is
+     *  refused for whose vocabulary it is, and a codec for it would not change that. */
+    private static final String FOREIGN_NAME_ADVICE =
+            "declare the case this model has to report and answer that";
+
     /** A behavior's input and output cross a decoder/encoder, so a map they carry is a JSON object
      * and its keys are strings (ADR-0040). A map that stays inside the body is unrestricted — the
      * same rule, read where it applies. */

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -631,10 +631,11 @@ public final class SpecChecker {
         }
     }
 
-    /** What to write instead. Said as declaring the case rather than as supplying a codec: the name is
-     *  refused for whose vocabulary it is, and a codec for it would not change that. */
+    /** What to write instead. Said as declaring a type rather than as supplying a codec: the name is
+     *  refused for whose vocabulary it is, and a codec for it would not change that. Said of a type
+     *  rather than of a case, because a parameter is refused for the same reason and takes one. */
     private static final String FOREIGN_NAME_ADVICE =
-            "declare the case this model has to report and answer that";
+            "declare this as a type of the model and write that at the boundary";
 
     /** A behavior's input and output cross a decoder/encoder, so a map they carry is a JSON object
      * and its keys are strings (ADR-0040). A map that stays inside the body is unrestricted — the

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -266,6 +266,7 @@ public final class TypeChecker {
                 SpecChecker.rejectFunctionIO(spec, symbols);
                 SpecChecker.rejectOptionalIO(spec, symbols);
                 SpecChecker.rejectNonBoundaryMapKeyIO(spec, symbols);
+                SpecChecker.rejectForeignBoundaryName(spec, symbols);
                 List<String> outputCases = new ArrayList<>();
                 for (Ast.TypeTerm t : spec.ret().cases()) {
                     // a function output is refused as unrepresentable; it names no output case

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1153,6 +1153,52 @@ public final class TypeOps {
         };
     }
 
+    /**
+     * The first named type in {@code t}'s boundary shape that a model did not declare, or null when
+     * every one of them did — what a behavior's parameter and its output are checked against.
+     *
+     * <p>The walk is the one {@link #optionalInBoundaryShape} takes, with an output union's members
+     * asked as well: a member is a name in what crosses, and the encoder writes it like any other.
+     *
+     * <p>A primitive names a scalar the boundary already writes and is nothing to a model to declare.
+     * {@code Raw} is written like one and is not one — it is reserved, no stage produces it — so it is
+     * asked for a declaration and has none.
+     */
+    public static TypeName foreignNameInBoundaryShape(Type t, Symbols symbols) {
+        return switch (t) {
+            case Type.Ref r -> declaredByAModel(r.name(), symbols) ? null : r.name();
+            case Type.Union u -> u.members().stream()
+                    .filter(m -> !declaredByAModel(m, symbols)).findFirst().orElse(null);
+            case Type.ListOf l -> foreignNameInBoundaryShape(l.element(), symbols);
+            case Type.SetOf s -> foreignNameInBoundaryShape(s.element(), symbols);
+            case Type.OptionOf o -> foreignNameInBoundaryShape(o.element(), symbols);
+            case Type.MapOf m -> {
+                TypeName inKey = foreignNameInBoundaryShape(m.key(), symbols);
+                yield inKey != null ? inKey : foreignNameInBoundaryShape(m.value(), symbols);
+            }
+            case Type.TupleOf tu -> tu.elements().stream()
+                    .map(e -> foreignNameInBoundaryShape(e, symbols))
+                    .filter(n -> n != null).findFirst().orElse(null);
+            default -> null;
+        };
+    }
+
+    /**
+     * Whether {@code name} is a type a model declares, as against one the language declares of its own
+     * operations. The two are already told apart where construction is governed — what a compilation
+     * declares answers to {@code constructs} and the language's vocabulary does not — and the same
+     * line decides what a boundary may carry.
+     *
+     * <p>A primitive is neither: it is a scalar the boundary writes, with no declaration anywhere.
+     * {@code Raw} is spelled as one and answers no, having no declaration to be found.
+     */
+    private static boolean declaredByAModel(TypeName name, Symbols symbols) {
+        if (name.isPrimitive()) {
+            return !"Raw".equals(name.name());
+        }
+        return symbols.declaredByCompilation(name);
+    }
+
     public static boolean isSingleValueNewtype(Type t, Symbols symbols) {
         return t instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data d && d.newtype();

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1166,6 +1166,10 @@ public final class TypeOps {
      */
     public static TypeName foreignNameInBoundaryShape(Type t, Symbols symbols) {
         return switch (t) {
+            // Asked of the type, not of the name a source spelling resolved to. `Raw` is the
+            // language's own — an encoder's output at a railway's edge, which no stage produces — and
+            // it answers the same whether it arrives as the primitive or as a name that denotes it.
+            case Type.Prim p -> p == Type.Prim.RAW ? TypeName.primitive("Raw") : null;
             case Type.Ref r -> declaredByAModel(r.name(), symbols) ? null : r.name();
             case Type.Union u -> u.members().stream()
                     .filter(m -> !declaredByAModel(m, symbols)).findFirst().orElse(null);
@@ -1179,7 +1183,13 @@ public final class TypeOps {
             case Type.TupleOf tu -> tu.elements().stream()
                     .map(e -> foreignNameInBoundaryShape(e, symbols))
                     .filter(n -> n != null).findFirst().orElse(null);
-            default -> null;
+            // Each of these is refused before this is asked, by the obligation that owns it: a
+            // function has no external form, and an open type, a bottom or an error type is not
+            // something a signature can be written with. Answering null for them is a decision about
+            // each, written here rather than left to a default arm that would also answer for a
+            // constructor added later.
+            case Type.FnOf _, Type.Var _, Type.MetaVar _,
+                 Type.Nothing _, Type.Never _, Type.Erroneous _ -> null;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -1045,8 +1045,15 @@ public final class Backend {
      * imported declaration as one the writer was held to, so a jar built when a parameter could be
      * written {@code Option<Int>} carries a signature this compiler would refuse, and calling it would
      * put the runtime's {@code Option} across a boundary that no longer admits one.
+     *
+     * <p>Version 8 narrows it again: a named type standing in a behavior's boundary is one a model
+     * declares, so the vocabulary the language keeps for its own operations — what a division by zero
+     * answers with, what a rounding takes, the reserved {@code Raw} — is not carried across one. A
+     * module written without an {@code exposing} line publishes every behavior it declares, so a jar
+     * built before this carries a public {@code Behavior<souther.runtime.DivisionByZero, …>} that this
+     * compiler refuses to write.
      */
-    public static final int BOUNDARY_VERSION = 7;
+    public static final int BOUNDARY_VERSION = 8;
 
     /** The class a module's own declarations are published on. It carries nothing but them. */
     public static String moduleClassName(String moduleName) {

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -276,6 +276,9 @@ check.output.function=`{0}` outputs a function ({1}); a function has no external
 check.output.optional=The output of `{0}` carries an optional ({1}).
 check.param.optional=Parameter `{0}` carries an optional ({1}).
 check.optional.hint=A model type has to own the absence where the optional stands: put it on a `?` field of a data, or name it as a case of a sum. Where the whole output is the optional, that sum is written directly — `-> A | Missing`.
+check.param.foreignname=Parameter `{0}` takes `{1}`, which the language declares rather than this model.
+check.output.foreignname=`{0}` answers `{1}`, which the language declares rather than this model.
+check.foreignname.hint=Declare the case this model has to report and answer that, so what the behavior publishes stays its own.
 check.param.tuple=parameter `{0}` is a tuple; a tuple has no external representation and cannot cross the boundary, so a behavior''s input must be a named data.
 check.output.tuple=behavior `{0}` outputs a tuple; a tuple cannot cross the boundary, so a behavior''s output must be a named data or a sum of them.
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -278,7 +278,7 @@ check.param.optional=Parameter `{0}` carries an optional ({1}).
 check.optional.hint=A model type has to own the absence where the optional stands: put it on a `?` field of a data, or name it as a case of a sum. Where the whole output is the optional, that sum is written directly — `-> A | Missing`.
 check.param.foreignname=Parameter `{0}` takes `{1}`, which the language declares rather than this model.
 check.output.foreignname=`{0}` answers `{1}`, which the language declares rather than this model.
-check.foreignname.hint=Declare the case this model has to report and answer that, so what the behavior publishes stays its own.
+check.foreignname.hint=Declare this as a type of the model and write that at the boundary — a case the behavior answers, or a data it takes — so what the behavior publishes stays its own.
 check.param.tuple=parameter `{0}` is a tuple; a tuple has no external representation and cannot cross the boundary, so a behavior''s input must be a named data.
 check.output.tuple=behavior `{0}` outputs a tuple; a tuple cannot cross the boundary, so a behavior''s output must be a named data or a sum of them.
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -274,7 +274,7 @@ check.param.optional=引数 `{0}` は optional ({1}) を含みます。
 check.optional.hint=その optional がある位置で、不在をモデルの型に持たせてください。data の `?` フィールドに置くか、和型のケースとして名付けます。出力そのものが optional なら、その和型は `-> A | 不在のケース` と直接書けます。
 check.param.foreignname=引数 `{0}` は `{1}` を取ります。これはこのモデルではなく言語が宣言している型です。
 check.output.foreignname=`{0}` は `{1}` を答えます。これはこのモデルではなく言語が宣言している型です。
-check.foreignname.hint=このモデルが報告したいケースを自分で宣言し、それを答えてください。behavior が公開するものがモデル自身のものになります。
+check.foreignname.hint=これをモデルの型として宣言し、境界にはそちらを書いてください。behavior が答えるケースにも、受け取る data にもできます。
 check.param.tuple=引数 `{0}` はタプルです。タプルは外部表現を持たず境界を越えられないため、behavior の入力は名前付き data でなければなりません。
 check.output.tuple=behavior `{0}` はタプルを出力します。タプルは境界を越えられないため、behavior の出力は名前付き data かその直和でなければなりません。
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -272,6 +272,9 @@ check.output.function=`{0}` は関数を出力します（{1}）。関数は外�
 check.output.optional=`{0}` の出力は optional ({1}) を含みます。
 check.param.optional=引数 `{0}` は optional ({1}) を含みます。
 check.optional.hint=その optional がある位置で、不在をモデルの型に持たせてください。data の `?` フィールドに置くか、和型のケースとして名付けます。出力そのものが optional なら、その和型は `-> A | 不在のケース` と直接書けます。
+check.param.foreignname=引数 `{0}` は `{1}` を取ります。これはこのモデルではなく言語が宣言している型です。
+check.output.foreignname=`{0}` は `{1}` を答えます。これはこのモデルではなく言語が宣言している型です。
+check.foreignname.hint=このモデルが報告したいケースを自分で宣言し、それを答えてください。behavior が公開するものがモデル自身のものになります。
 check.param.tuple=引数 `{0}` はタプルです。タプルは外部表現を持たず境界を越えられないため、behavior の入力は名前付き data でなければなりません。
 check.output.tuple=behavior `{0}` はタプルを出力します。タプルは境界を越えられないため、behavior の出力は名前付き data かその直和でなければなりません。
 

--- a/souther-compiler/src/test/java/souther/compiler/ABoundaryCarriesTheModelsOwnVocabularyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABoundaryCarriesTheModelsOwnVocabularyTest.java
@@ -1,0 +1,118 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The language declares vocabulary of its own — what a division by zero answers with, what a rounding
+ * takes, the reserved `Raw` — and each says what one of its operations can answer or take. A behavior
+ * publishes what a model declared, so none of those may stand in its boundary. Before this they were
+ * written freely: a parameter compiled and failed at run with a reflection exception, and an output
+ * union raised inside codegen.
+ */
+class ABoundaryCarriesTheModelsOwnVocabularyTest {
+
+    private static CompileException err(String model) {
+        return assertThrows(CompileException.class, () -> Compiler.compile(model));
+    }
+
+    private static void refuses(String signature, String body, String named) {
+        CompileException e = err("module demo\n\n" + signature + "\n" + body + "\n");
+        assertTrue(e.getMessage().contains("E1325"), e.getMessage());
+        assertTrue(e.getMessage().contains("`" + named + "`"), "names the type: " + e.getMessage());
+        assertTrue(e.getMessage().contains("declare the case"), "says what to write: " + e.getMessage());
+    }
+
+    @Test
+    void aParameterMayNotTakeATypeTheLanguageDeclares() {
+        refuses("behavior f : (x: DivisionByZero) -> Int", "let f (x) = 1", "DivisionByZero");
+    }
+
+    @Test
+    void anOutputUnionMemberIsAskedToo() {
+        // Before, this reached `CodecGen.flatMember`, which had no arm for a name no module declares
+        // and raised `IllegalStateException: not a union member`.
+        refuses("behavior f : (n: Int) -> Int | DivisionByZero", "let f (n) = Int.divide(10, n)",
+                "DivisionByZero");
+    }
+
+    @Test
+    void theReservedTypeIsAskedLikeAnyOtherName() {
+        // `Raw` is spelled like a primitive and is not one: no stage produces it, and the module that
+        // compiled published `Behavior<souther.Raw, Long>` for a class that does not exist.
+        refuses("behavior f : (x: Raw) -> Int", "let f (x) = 1", "Raw");
+    }
+
+    @Test
+    void aParseFailureCaseIsAskedToo() {
+        refuses("behavior f : (x: NotANumber) -> Int", "let f (x) = 1", "NotANumber");
+    }
+
+    @Test
+    void aTypeTheLanguageDeclaresForItsOwnOperationIsAskedToo() {
+        // `RoundingMode` is declared, and by the language: it says what `Decimal.round` takes.
+        refuses("behavior f : (m: RoundingMode) -> Int", "let f (m) = 1", "RoundingMode");
+    }
+
+    @Test
+    void aCollectionCarryingOneIsAskedAtItsDepth() {
+        refuses("behavior f : (xs: List<DivisionByZero>) -> Int", "let f (xs) = List.length(xs)",
+                "DivisionByZero");
+    }
+
+    @Test
+    void aMapCarryingOneUnderItsValueIsAskedToo() {
+        refuses("behavior f : (m: Map<String, NotANumber>) -> Int", "let f (m) = Map.size(m)",
+                "NotANumber");
+    }
+
+    @Test
+    void aModelsOwnCaseIsWhatTheBehaviorAnswers() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Undivided
+
+                behavior divide : (a: Int, b: Int) -> Int | Undivided
+                    constructs Undivided
+                let divide (a, b) = {
+                    guard b /= 0 else Undivided
+                    a
+                }
+                """));
+    }
+
+    @Test
+    void aModelMayStillReadTheLanguagesCaseInsideItsBody() {
+        // The rule is about what crosses. Inside a body the language's own case is what `Int.divide`
+        // answers, and a `match` arm names it as it always has.
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Undivided
+
+                behavior divide : (a: Int, b: Int) -> Int | Undivided
+                    constructs Undivided
+                let divide (a, b) = match Int.divide(a, b) with
+                    | Int as n -> n
+                    | DivisionByZero -> Undivided
+                """));
+    }
+
+    @Test
+    void aDataAModelDeclaredCrossesWhateverItHoldsInside() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data Note = { text: String }
+
+                behavior write : (n: Note) -> Note
+                let write (n) = n
+                """));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ABoundaryCarriesTheModelsOwnVocabularyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABoundaryCarriesTheModelsOwnVocabularyTest.java
@@ -25,7 +25,18 @@ class ABoundaryCarriesTheModelsOwnVocabularyTest {
         CompileException e = err("module demo\n\n" + signature + "\n" + body + "\n");
         assertTrue(e.getMessage().contains("E1325"), e.getMessage());
         assertTrue(e.getMessage().contains("`" + named + "`"), "names the type: " + e.getMessage());
-        assertTrue(e.getMessage().contains("declare the case"), "says what to write: " + e.getMessage());
+        assertTrue(e.getMessage().contains("declare this as a type of the model"),
+                "says what to write: " + e.getMessage());
+    }
+
+    @Test
+    void anOutputThatIsOneOnItsOwnIsAskedToo() {
+        refuses("behavior f : (n: Int) -> DivisionByZero", "", "DivisionByZero");
+    }
+
+    @Test
+    void anOutputCarryingOneInACollectionIsAskedToo() {
+        refuses("behavior f : (n: Int) -> List<DivisionByZero>", "let f (n) = []", "DivisionByZero");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileRoundingModeBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileRoundingModeBoundaryTest.java
@@ -11,7 +11,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code RoundingMode} is ordinary data for typing, evaluation, composition and ordering, but it
  * provides no codec, so it cannot appear where a codec is required. The absence is intentional: a
  * rounding policy is a computation's input, not a value that crosses a serialization boundary, and
- * these tests pin the refusal so the type never quietly gains an external representation.
+ * these tests pin the refusal so the type never quietly gains an external representation. It is also
+ * the language's own vocabulary — it says what {@code Decimal.round} takes — which is what a
+ * behavior's boundary is refused for, and that refusal comes first.
  */
 class CompileRoundingModeBoundaryTest {
 
@@ -27,9 +29,13 @@ class CompileRoundingModeBoundaryTest {
         assertTrue(e.getMessage().contains("RoundingMode"), e.getMessage());
     }
 
-    /** An example fixture would have to decode the mode, and there is no decoder to call. */
+    /**
+     * A behavior taking the mode is refused where it is declared, not later. It used to compile and
+     * fail only where something asked for the decoder — an example fixture, or `souther run` reaching
+     * for it by reflection — so what a reader was shown depended on what they happened to write next.
+     */
     @Test
-    void anExampleOverARoundingModeParameterIsRefused() {
+    void aBehaviorTakingARoundingModeIsRefusedAtItsSignature() {
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
                 module demo
 
@@ -42,7 +48,7 @@ class CompileRoundingModeBoundaryTest {
                     | "rounds up at the half" :
                         (HALF_UP, 2.5m) -> Out { n = 3 }
                 """));
-        assertTrue(e.getMessage().contains("E1903"), e.getMessage());
-        assertTrue(e.getMessage().contains("no decoder for `RoundingMode`"), e.getMessage());
+        assertTrue(e.getMessage().contains("E1325"), e.getMessage());
+        assertTrue(e.getMessage().contains("RoundingMode"), e.getMessage());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/TheBoundaryVocabularyRuleReadsTheTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheBoundaryVocabularyRuleReadsTheTypeTest.java
@@ -1,0 +1,43 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The rule is asked of the type, not of the name a source spelling happened to resolve to. Written
+ * `Raw` currently denotes a reference rather than the primitive, and asking the reference is what
+ * refuses it in a compiled module — but the primitive is the same type, so correcting that
+ * representation must not be what decides whether the boundary admits it.
+ *
+ * <p>A primitive is classified without asking the model anything, which is why these pass no symbols:
+ * needing them would mean the answer could depend on what a module declared, and it cannot.
+ */
+class TheBoundaryVocabularyRuleReadsTheTypeTest {
+
+    @Test
+    void theReservedPrimitiveIsRefusedAsItself() {
+        assertEquals("Raw", TypeOps.foreignNameInBoundaryShape(Type.RAW, null).name());
+    }
+
+    @Test
+    void theReservedPrimitiveIsRefusedAtDepth() {
+        assertEquals("Raw",
+                TypeOps.foreignNameInBoundaryShape(Type.list(Type.RAW), null).name());
+        assertEquals("Raw",
+                TypeOps.foreignNameInBoundaryShape(Type.map(Type.STRING, Type.RAW), null).name());
+    }
+
+    @Test
+    void theScalarsTheBoundaryWritesAreNotRefused() {
+        for (Type.Prim prim : Type.Prim.values()) {
+            if (prim == Type.Prim.RAW) {
+                continue;
+            }
+            assertNull(TypeOps.foreignNameInBoundaryShape(prim, null), prim.toString());
+        }
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticCode.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticCode.java
@@ -86,6 +86,7 @@ public enum DiagnosticCode {
     E1322("a-temporal-value-is-written-as-a-literal", "check.type.mismatch.title"),
     E1323("a-matches-pattern-is-a-literal-regular-expression", "check.type.mismatch.title"),
     E1324("newtype-arithmetic-follows-the-units", "check.type.mismatch.title"),
+    E1325("a-boundary-carries-the-models-own-vocabulary", "check.boundary.title"),
     E1401("no-arbitrary-jvm-calls", "e1401.title"),
     E1402("core-privileges-stay-in-the-core", "parse.title"),
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -482,6 +482,7 @@ What crosses a decoder/encoder boundary is decided by representation, and five o
 * [[a-parameter-names-one-type]]a parameter MUST name a single type. An anonymous union is the shape of one behavior's answer and nobody names it (<<union-member>>), so it is written on an output and not taken as an input;
 * [[an-optional-does-not-stand-in-a-boundary]]an optional MUST NOT stand anywhere in a behavior's boundary shape — neither as a parameter nor as the output, and at any depth inside a collection either. A boundary carries the model's own vocabulary, and absence there is owned by the data that holds it, on a `+?+` field, or by a sum the model names (<<optional>>). The shape is read down to a named type and no further: a data carrying a `+?+` field crosses as that data;
 * [[a-map-that-crosses-is-keyed-by-a-text-key]]a `+Map+` that crosses MUST be keyed by something a key can be written as — `+String+`, a `+String+`-backed newtype, `+Date+`, `+DateTime+`, or an enumeration, a sum every one of whose cases is a unit data (<<collections>>). The boundary writes a key as text, and a key with no text is a key nothing can address;
+* [[a-boundary-carries-the-models-own-vocabulary]]a named type that crosses MUST be one a model declares. The language declares vocabulary of its own — the case a division by zero answers with, the rounding mode a `+Decimal+` operation takes, the reserved `+Raw+` — and those name what an operation can answer or take, not what a behavior publishes. A model that has such a case to report declares its own and names it (`+-> Int | Undivided+`), which is what keeps the behavior's protocol independent of how the language accounts for itself;
 * [[a-collection-member-supports-equality]]a `+Set+`'s element and a `+Map+`'s key MUST support equality. Both ask whether two of them are the same, and a function has no value to compare (<<equality>>).
 
 The external representation handled by Decoders and Encoders is not Souther's own types but the neutral value model of the boundary library Raoh (a tree of scalar / List / Map). Souther owns the domain's types, invariants, and behaviors; the external representation and its parsing and generation are delegated to the peripheral library Raoh (<<separate-representation>>, <<decoder>>).
@@ -4296,6 +4297,16 @@ Reported at the pattern (<<a-matches-pattern-is-a-literal-regular-expression>>).
 ----
 
 Reported at the operator (<<newtype-arithmetic-follows-the-units>>). Which rule was broken — same-newtype addition, a product's units, a quotient's, a scalar, a reciprocal — is what an author needs and is not readable from the operand types, so the refusal names its own rule rather than reporting a type mismatch.
+
+[#e1325]
+=== A type the language declares stands in a behavior's boundary
+
+[,text]
+----
+`divide` answers `DivisionByZero`, which the language declares rather than this model.
+----
+
+Reported at the parameter, or at the behavior for its output (<<a-boundary-carries-the-models-own-vocabulary>>). `+DivisionByZero+` and `+NotANumber+` say what `+Int.divide+` and `+String.toInt+` can answer, `+RoundingMode+` says what `+Decimal.round+` takes, and `+Raw+` is reserved; each is the language's account of one of its own operations. A behavior that has the same thing to report declares the case — `+data Undivided+`, answered as `+-> Int | Undivided+` — so that what the behavior publishes stays its own even when the language's account of itself changes. Reported wherever the name stands in what crosses, at any depth and as a member of an output union.
 
 [#e1401]
 === Arbitrary Java calls


### PR DESCRIPTION
Closes #456. Needs closing by hand after merge (the default branch is `main`).

## What was reachable

Four names the language declares of its own operations could stand in a behavior's boundary, and no
two positions failed alike:

| written | before | now |
|---|---|---|
| `(x: DivisionByZero)` | compiles; `run` reports `NoSuchMethodException: …DivisionByZero.jsonDecoder()` | E1325 |
| `(x: NotANumber)` | the same | E1325 |
| `(m: RoundingMode)` | compiles; refused only where something asked for the decoder | E1325 |
| `(x: Raw)` | compiles; publishes `Behavior<souther.Raw, Long>` for a class that does not exist | E1325 |
| `(xs: List<DivisionByZero>)` | the same as its element | E1325 |
| `-> Int \| DivisionByZero` | **internal compiler error** — `IllegalStateException: not a union member` | E1325 |
| `-> Int \| NoAnswer`, `NoAnswer` declared | works | works |

The last row is the shape the others were mistaken for. None of this was introduced by #440.

They reach a type position through the fallback that lets `Int | DivisionByZero` be *declared* rather
than only met: a name no module declares is asked of `Symbols.resolveCase`, which admits these three
beside the primitives, and `TypeOps.denoted` cannot see which position it is resolving for.

## The rule

> A named type standing in a behavior's boundary MUST be one a model declares.

Asked at any depth, and of an output union's members, and stopping at a named type — a data crosses
as itself whatever it holds inside.

The refusal is deliberately not "no codec exists for this". `DivisionByZero` fails that test today,
which makes it a tempting way to write the rule, and it would hold only until someone gave the
runtime cases a codec for a reason of their own. What is wrong with `-> Int | DivisionByZero` is
whose vocabulary the name is: it says what `Int.divide` can answer, and a behavior publishes what its
model declares. So the reader is told to declare a type of the model and write that, not to supply a
codec:

```
data Undivided
behavior divide : (a: Int, b: Int) -> Int | Undivided
```

That keeps the behavior's protocol independent of how the language accounts for its own operations —
the sentence #440 settled on, applied to a different type.

The axis is the semantic category of a named type, not where its class lives. The compiler already
tells the two apart where construction is governed — `Symbols.declaredByCompilation`, whose comment
says what a compilation declares answers to `constructs` and the language's vocabulary does not — and
the same line decides what a boundary may carry. A primitive is neither: it is a scalar the boundary
writes, with no declaration anywhere. `Raw` is spelled like one and answers no, having no declaration
to be found.

## Boundary version

`Backend.BOUNDARY_VERSION` moves 7 → 8.

Where a module writes an `exposing` line, a jar could not carry one of these already: an exposed
signature names only exposed types (E1611), and the language's own name cannot be added to `exposing`
(E1609), which closes the way out. Measured for a parameter, for a direct output, and for
`List<DivisionByZero>`.

A module written without an `exposing` line is the case that matters. It publishes every behavior it
declares, and the compiler before this one wrote

```
public interface shared.err2.Pick
        extends souther.runtime.Behavior<souther.runtime.DivisionByZero, java.lang.Long>
```

for one. That is a published boundary this compiler refuses to write, which is what the number
records, so a jar carrying it is refused rather than read — E1505, measured against a jar built by
the earlier compiler.

## Verification

`mvn clean test` green — compiler 3564, syntax 184, runtime 109, cli 1.

`ABoundaryCarriesTheModelsOwnVocabularyTest` kills each arm on its own: the three reserved case names,
`RoundingMode`, a collection element, a `Map` value, an output that is one on its own, an output
carrying one in a `List`, and the output union member that used to raise. The positions are not
collapsed, because what this fixes is the same name failing differently in each of them.

`TheBoundaryVocabularyRuleReadsTheTypeTest` asks the rule of `Type.Prim.RAW` itself. Written `Raw`
denotes a reference today, and asking the reference is what refuses it in a compiled module — but the
primitive is the same type, so correcting that representation later must not decide whether the
boundary admits it. The walk carries no `default` arm either: every constructor says why it answers
what it answers, so one added later stops the build instead of being admitted in silence.

Kept as evidence the rule does not overreach: a model's own case in an output union compiles, a
`match` arm still names the language's case inside a body, and a data a model declared crosses
whatever it holds.

`CompileRoundingModeBoundaryTest` moves with the rule. It pinned the parameter being refused only
once an example forced a decoder — so what a reader saw depended on what they wrote next — and now
pins the refusal at the declaration. Its field case, which is the codec question rather than this
one, is unchanged. E1903 keeps its coverage in a dozen other tests.

## What this does not do

`CodecGen.flatMember`'s `default -> throw` is now unreachable, and so are the runner's two
`unsupported` branches for these names. Whether such an arm is dropped or kept as a stated
impossibility is #446's subject, and this is the regression that had to close before the boundary
witness it proposes could be built — a witness whose construction requires this invariant is what
would make all three consumers' assumptions true by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
