### PR TITLE
A declaration is reached by the name it resolved to

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -35,7 +35,9 @@ final class Clauses {
     private final Map<TypeName, List<Ast.InvariantClause>> inTheAnalysisRepresentation;
     private final Map<Ast.Data, Map<String, Type>> fields = new HashMap<>();
     private final Map<TypeName, Map<String, BindingId>> bindings = new HashMap<>();
-    private final Map<Ast.Expr, Optional<Core>> typed = new IdentityHashMap<>();
+    /** Remembered per declaration, not per clause: a clause an include brings in is one expression
+     * reached under two names, and what it types to is read against the fields of the one asking. */
+    private final Map<TypeName, Map<Ast.Expr, Optional<Core>>> typed = new HashMap<>();
     private final Map<TypeName, List<Ast.InvariantClause>> effective = new HashMap<>();
     /** Which of a declaration's own fields each typed clause reads — what a construction has to have
      * filled for the clause to be read at all. */
@@ -88,16 +90,17 @@ final class Clauses {
      * declaration an author wrote wrongly.
      */
     Core typed(Ast.Expr clause, TypeName named, Ast.Data data) {
-        return typed.computeIfAbsent(clause, written -> {
-            try {
-                return Optional.ofNullable(Elaborator.elaborate(written,
-                        DataChecker.fieldScope(named, data, symbols),
-                        CheckContext.of(symbols).forData(data).forDischarge(),
-                        Type.BOOL));
-            } catch (RuntimeException _) {
-                return Optional.empty();
-            }
-        }).orElse(null);
+        return typed.computeIfAbsent(named, _ -> new IdentityHashMap<>())
+                .computeIfAbsent(clause, written -> {
+                    try {
+                        return Optional.ofNullable(Elaborator.elaborate(written,
+                                DataChecker.fieldScope(named, data, symbols),
+                                CheckContext.of(symbols).forData(data).forDischarge(),
+                                Type.BOOL));
+                    } catch (RuntimeException _) {
+                        return Optional.empty();
+                    }
+                }).orElse(null);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -34,7 +34,7 @@ final class Clauses {
     private final Symbols symbols;
     private final Map<TypeName, List<Ast.InvariantClause>> inTheAnalysisRepresentation;
     private final Map<Ast.Data, Map<String, Type>> fields = new HashMap<>();
-    private final Map<Ast.Data, Map<String, BindingId>> bindings = new HashMap<>();
+    private final Map<TypeName, Map<String, BindingId>> bindings = new HashMap<>();
     private final Map<Ast.Expr, Optional<Core>> typed = new IdentityHashMap<>();
     private final Map<TypeName, List<Ast.InvariantClause>> effective = new HashMap<>();
     /** Which of a declaration's own fields each typed clause reads — what a construction has to have
@@ -66,14 +66,20 @@ final class Clauses {
         return fields.computeIfAbsent(data, d -> TypeOps.fieldTypes(d, symbols));
     }
 
-    /** Which binding each of {@code data}'s fields is — what a clause reads, and what a construction
-     * fills. */
-    Map<String, BindingId> bindingsOf(Ast.Data data) {
-        return bindings.computeIfAbsent(data, d -> TypeOps.fieldBindings(d, symbols));
+    /**
+     * Which binding each of {@code named}'s fields is — what a clause reads, and what a construction
+     * fills.
+     *
+     * <p>Keyed by the name and not by the declaration, because that is what the binding is a function
+     * of: two modules may declare one spelling, and a reader with both in sight would otherwise have
+     * them answer alike.
+     */
+    Map<String, BindingId> bindingsOf(TypeName named, Ast.Data data) {
+        return bindings.computeIfAbsent(named, name -> TypeOps.fieldBindings(name, data, symbols));
     }
 
     /**
-     * {@code clause} as the checker types it: over the declaration's own fields, each a binding, in
+     * {@code clause} as the checker types it: over {@code named}'s own fields, each a binding, in
      * the representation this check reads. Asked once per clause, because typing one walks it.
      *
      * <p>Null where the clause is not one this compiler could type there. That is the same answer as
@@ -81,11 +87,11 @@ final class Clauses {
      * an answer rather than a failure because a declaration this check cannot read is not a
      * declaration an author wrote wrongly.
      */
-    Core typed(Ast.Expr clause, Ast.Data data) {
+    Core typed(Ast.Expr clause, TypeName named, Ast.Data data) {
         return typed.computeIfAbsent(clause, written -> {
             try {
                 return Optional.ofNullable(Elaborator.elaborate(written,
-                        DataChecker.fieldScope(data, symbols),
+                        DataChecker.fieldScope(named, data, symbols),
                         CheckContext.of(symbols).forData(data).forDischarge(),
                         Type.BOOL));
             } catch (RuntimeException _) {
@@ -102,13 +108,13 @@ final class Clauses {
      * that is not there, and the clause is left to the run-time check rather than read against
      * nothing.
      */
-    Core statedAt(Ast.Expr clause, Ast.Data data, Map<BindingId, Core> given) {
-        Core stated = typed(clause, data);
+    Core statedAt(Ast.Expr clause, TypeName named, Ast.Data data, Map<BindingId, Core> given) {
+        Core stated = typed(clause, named, data);
         if (stated == null) {
             return null;
         }
-        return given.keySet().containsAll(fieldsRead(stated, data)) ? substituted(stated, given)
-                : null;
+        return given.keySet().containsAll(fieldsRead(stated, named, data))
+                ? substituted(stated, given) : null;
     }
 
     /**
@@ -122,7 +128,7 @@ final class Clauses {
     List<Core> statedAt(TypeName named, Ast.Data data, Map<BindingId, Core> given) {
         List<Core> stated = new ArrayList<>();
         for (Ast.InvariantClause inv : of(named, data)) {
-            Core one = statedAt(inv.expr(), data, given);
+            Core one = statedAt(inv.expr(), named, data, given);
             if (one != null) {
                 stated.add(one);
             }
@@ -132,9 +138,9 @@ final class Clauses {
 
     /** Which of {@code data}'s own fields {@code clause} reads, remembered: a clause is read at every
      * construction of its type, and what it reads does not change between them. */
-    private Set<BindingId> fieldsRead(Core clause, Ast.Data data) {
+    private Set<BindingId> fieldsRead(Core clause, TypeName named, Ast.Data data) {
         return readsFields.computeIfAbsent(clause, read -> {
-            Set<BindingId> declared = new HashSet<>(bindingsOf(data).values());
+            Set<BindingId> declared = new HashSet<>(bindingsOf(named, data).values());
             Set<BindingId> found = new HashSet<>();
             readsOf(read, binding -> {
                 if (declared.contains(binding)) {

--- a/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DataChecker.java
@@ -566,14 +566,21 @@ public final class DataChecker {
     }
 
     private static Scope fieldScope(CheckContext ctx) {
-        return fieldScope(ctx.data(), ctx.symbols());
+        return fieldScope(ctx.symbols().own(ctx.data().name()), ctx.data(), ctx.symbols());
     }
 
-    /** The bindings a declaration's own invariant reads: its fields, each as the binding it is. */
-    static Scope fieldScope(Ast.Data data, Symbols symbols) {
+    /**
+     * The bindings a declaration's own invariant reads: its fields, each as the binding it is.
+     *
+     * <p>{@code declared} is which declaration these fields belong to, which is not always the module
+     * asking — the discharge check reads the clauses of types other modules declared. A field is
+     * bound where it was written, so that is what the scope offers, and the clause carried in with the
+     * declaration finds the very bindings it names.
+     */
+    static Scope fieldScope(TypeName declared, Ast.Data data, Symbols symbols) {
         Map<String, Type> types = TypeOps.fieldTypes(data, symbols);
         Map<BindingId, Scope.Binding> bindings = new LinkedHashMap<>();
-        TypeOps.fieldBindings(data, symbols).forEach((name, binding) ->
+        TypeOps.fieldBindings(declared, data, symbols).forEach((name, binding) ->
                 bindings.put(binding, new Scope.Binding(name, types.get(name))));
         return Scope.of(bindings);
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -124,16 +124,17 @@ public final class InvariantChecker {
      * where the clause is written, which is the pre-expansion position; {@code clause} is that clause
      * in the representation the check reads.
      */
-    public static ClauseDischarge capabilityOf(Ast.Expr clause, SourcePos at, Ast.Data data,
-                                               Symbols symbols) {
+    public static ClauseDischarge capabilityOf(Ast.Expr clause, SourcePos at, TypeName named,
+                                               Ast.Data data, Symbols symbols) {
         InvariantChecker c = new InvariantChecker(symbols, Map.of());
         // Read over the declaration's own fields, each standing for itself: a construction hands one
         // value per field, so a clause naming a field names something wherever it is built. These
         // stand for a value rather than holding one, so they are entered as locations and nothing is
         // seeded of them — what a clause owes is the question, and answering it here would be
         // assuming it.
-        Core stated = c.clauses.typed(clause, data);
-        Denotations fields = Denotations.none().locations(c.clauses.bindingsOf(data).values());
+        Core stated = c.clauses.typed(clause, named, data);
+        Denotations fields = Denotations.none()
+                .locations(c.clauses.bindingsOf(named, data).values());
         Predicates.Owed owed;
         try {
             owed = stated == null ? Predicates.Owed.UNREADABLE
@@ -370,7 +371,7 @@ public final class InvariantChecker {
         if (Terms.asOperator(e) instanceof Core.Binary bin && Terms.isArith(bin.op())
                 && bin.type() instanceof Type.Ref r
                 && symbols.get(r.name()) instanceof Ast.Data type && type.newtype()) {
-            BindingId value = clauses.bindingsOf(type).get("value");
+            BindingId value = clauses.bindingsOf(r.name(), type).get("value");
             if (value != null && terms.affineOf(bin, at, k) != null) {
                 report(bin, type, bin.pos(), attempted,
                         verdictOf(r.name(), type, Map.of(value, bin), k, at, true));
@@ -384,7 +385,7 @@ public final class InvariantChecker {
      * value and not a choice of two.
      */
     private Verdict verdictOf(Core.NewData nd, Ast.Data type, Known k, Denotations at) {
-        Map<String, BindingId> fields = clauses.bindingsOf(type);
+        Map<String, BindingId> fields = clauses.bindingsOf(nd.typeName(), type);
         Map<BindingId, Core> given = new HashMap<>();
         for (Core.FieldInit fi : nd.inits()) {
             BindingId field = fields.get(fi.name());
@@ -958,7 +959,7 @@ public final class InvariantChecker {
             return k;
         }
         Map<String, Type> fields = clauses.fieldsOf(data);
-        Map<String, BindingId> bindings = clauses.bindingsOf(data);
+        Map<String, BindingId> bindings = clauses.bindingsOf(ref.name(), data);
         Map<BindingId, Core> given = new HashMap<>();
         fields.forEach((name, type) -> {
             BindingId field = bindings.get(name);

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -430,7 +430,7 @@ public final class Resolve {
      * declaring declaration's, so this is where an editor is answered from either way.
      */
     private void declareFields(Ast.Data d) {
-        Map<String, BindingId> bindings = TypeOps.fieldBindings(d, symbols);
+        Map<String, BindingId> bindings = TypeOps.fieldBindings(symbols.own(d.name()), d, symbols);
         for (Ast.Field field : d.fields()) {
             BindingId binding = bindings.get(field.name());
             if (binding != null) {
@@ -443,7 +443,8 @@ public final class Resolve {
         Bindings bound = Bindings.NONE;
         // which binding each field is is answered in one place, so the pass that emits this
         // invariant reaches the same ones without working them out again
-        for (Map.Entry<String, BindingId> f : TypeOps.fieldBindings(d, symbols).entrySet()) {
+        for (Map.Entry<String, BindingId> f
+                : TypeOps.fieldBindings(symbols.own(d.name()), d, symbols).entrySet()) {
             bound = bound.and(f.getKey(), new ValueName.Local(f.getKey(), f.getValue()));
         }
         return bound;

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -795,10 +795,19 @@ public final class TypeOps {
      * <p>What is fixed is the numbering: a field is numbered among the fields of the declaration
      * that declares it, in the order that declaration writes them. An include brings a field in
      * without renumbering it, so the two passes agree however either of them reaches it.
+     *
+     * <p>{@code declared} is which declaration this is, and is asked of the caller because
+     * {@code data} cannot say: a declaration carries the name it was written under and not the module
+     * that wrote it. Worked out here from that name it would be worked out against whoever is
+     * reading, and a reader of another module's declaration would bind its fields under its own name
+     * — a different binding for the same field, and the clauses carried in with the declaration
+     * resolve against nothing. A caller reading its own declaration passes {@link Symbols#own}; a
+     * caller reading one it reached passes the name it reached it by.
      */
-    public static Map<String, BindingId> fieldBindings(Ast.Data data, Symbols symbols) {
+    public static Map<String, BindingId> fieldBindings(TypeName declared, Ast.Data data,
+                                                       Symbols symbols) {
         Map<String, BindingId> bindings = new LinkedHashMap<>();
-        walkFields(data, symbols.own(data.name()), symbols, new LinkedHashSet<>(), bindings);
+        walkFields(data, declared, symbols, new LinkedHashSet<>(), bindings);
         return bindings;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/ValueClassGen.java
@@ -162,7 +162,8 @@ final class ValueClassGen {
                 ClassFile.ACC_STATIC | ClassFile.ACC_PUBLIC, code -> {
                     BodyGen gen = new BodyGen(ctx, code, data, cdName, 0);
                     int slot = 0;
-                    Map<String, BindingId> bound = TypeOps.fieldBindings(data, symbols);
+                    Map<String, BindingId> bound =
+                            TypeOps.fieldBindings(symbols.own(data.name()), data, symbols);
                     for (Map.Entry<String, Type> f : fields.entrySet()) {
                         gen.bind(bound.get(f.getKey()), f.getKey(), slot, f.getValue());
                         slot += width(f.getValue());
@@ -657,7 +658,8 @@ final class ValueClassGen {
                     mb.withCode(code -> {
                         BodyGen gen = new BodyGen(ctx, code, data, cdName, 0);
                         int slot = 0;
-                        Map<String, BindingId> bound = TypeOps.fieldBindings(data, symbols);
+                        Map<String, BindingId> bound =
+                                TypeOps.fieldBindings(symbols.own(data.name()), data, symbols);
                         for (Map.Entry<String, Type> f : fields.entrySet()) {
                             gen.bind(bound.get(f.getKey()), f.getKey(), slot, f.getValue());
                             slot += width(f.getValue());

--- a/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Shapes.java
@@ -334,18 +334,19 @@ public final class Shapes {
                     HelperInliner inliner = HelperInliner.forHelpers(name,
                             HelperInliner.helpersOf(declaring), published, InliningPolicy.DISCHARGE);
                     List<ClauseDischarge> clauses = new ArrayList<>();
+                    TypeName named = new TypeName(name, data.name());
                     // A declared clause is one rule to depart by and may still be several conjuncts to
                     // discharge, so `a && b` under one name is classified twice under that name: what
                     // discharges each half is what an author needs, and the name is what a caller reads.
                     for (Ast.InvariantClause declared : data.invariants()) {
                         for (Ast.Expr written : HelperInvariants.conjunctsOf(declared.expr())) {
                             clauses.add(InvariantChecker.capabilityOf(
-                                    inliner.inline(written, new BindingOwner.OfData(
-                                            new TypeName(name, data.name()))),
-                                    leftmost(written), data, scope.value()).named(declared.name()));
+                                    inliner.inline(written, new BindingOwner.OfData(named)),
+                                    leftmost(written), named, data, scope.value())
+                                    .named(declared.name()));
                         }
                     }
-                    out.put(new TypeName(name, data.name()), List.copyOf(clauses));
+                    out.put(named, List.copyOf(clauses));
                 }
                 return Answer.of(Map.copyOf(out));
             } catch (CompileException e) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
@@ -12,7 +12,6 @@ import souther.compiler.query.Compilation;
 import souther.compiler.query.Names;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.BindingOwner;
-import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
 import java.util.Collections;
@@ -91,8 +90,9 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
         return (Ast.Data) def;
     }
 
-    private static Symbols readerScope(Compilation c) {
-        return c.db().ask(new Names.NameScope("demo")).value();
+    /** The clauses as the module named {@code reading} reads them. */
+    private static Clauses readBy(Compilation c, String reading) {
+        return new Clauses(c.db().ask(new Names.NameScope(reading)).value(), Map.of());
     }
 
     /**
@@ -107,7 +107,7 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
             Compilation c = compiled(reached);
 
             assertEquals(Map.of("lo", new BindingId(declaring, 0), "hi", new BindingId(declaring, 1)),
-                    TypeOps.fieldBindings(range(c), readerScope(c)),
+                    readBy(c, "demo").bindingsOf(RANGE, range(c)),
                     "reached " + reached + ": a field is bound by the declaration that wrote it");
         }
     }
@@ -125,18 +125,13 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
         for (Reached reached : Reached.values()) {
             Compilation c = compiled(reached);
             Ast.Data range = range(c);
+            Ast.Expr clause = range.invariants().get(0).expr();
 
-            Core athome = clause(range, c.db().ask(new Names.NameScope("up")).value());
+            Core athome = readBy(c, "up").typed(clause, RANGE, range);
             assertNotNull(athome, "the declaring module reads its own rule");
-            assertEquals(athome, clause(range, readerScope(c)),
+            assertEquals(athome, readBy(c, "demo").typed(clause, RANGE, range),
                     "reached " + reached + ": one rule, read the same either side of the boundary");
         }
-    }
-
-    private static Core clause(Ast.Data data, Symbols symbols) {
-        return Elaborator.elaborate(data.invariants().get(0).expr(),
-                DataChecker.fieldScope(data, symbols),
-                CheckContext.of(symbols).forData(data).forDischarge(), Type.BOOL);
     }
 
     /**
@@ -179,13 +174,13 @@ class AFieldIsBoundByTheDeclarationThatWroteItTest {
     @Test
     void aReadersOwnDeclarationDoesNotShareABindingWithAnImportedNamesake() {
         Compilation c = compiled(Reached.BESIDE_THE_READERS_OWN);
-        Symbols scope = readerScope(c);
+        Clauses read = readBy(c, "demo");
 
         TypeName ours = new TypeName("demo", "Range");
         Ast.Data mine = (Ast.Data) c.db().ask(new Names.ResolvedDeclaration(ours)).value();
 
-        assertTrue(Collections.disjoint(TypeOps.fieldBindings(range(c), scope).values(),
-                        TypeOps.fieldBindings(mine, scope).values()),
+        assertTrue(Collections.disjoint(read.bindingsOf(RANGE, range(c)).values(),
+                        read.bindingsOf(ours, mine).values()),
                 "two declarations of `Range` bind two sets of fields");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldIsBoundByTheDeclarationThatWroteItTest.java
@@ -1,0 +1,196 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Compiler;
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Severity;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Names;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A declaration's fields are bound where the declaration is written, and every reader gets those
+ * bindings.
+ *
+ * <p>A clause reads its declaration's fields as the bindings they are, and it is resolved once, by
+ * the module that wrote it. A reader that computes those bindings under its own module name gets a
+ * different binding for the same field, so the clause it was carried in with resolves against
+ * nothing — and {@code Clauses.typed} answers null, which every caller reads as a rule the language
+ * cannot express rather than one that was looked up in the wrong place.
+ *
+ * <p>Held over each way a reader can reach a declaration another module wrote. They break together
+ * today and need not stay that way: how a name arrives is the import representation's business, and
+ * a binding is not a function of it.
+ *
+ * <p>Held at three depths, because one alone would pass while the defect stood. The identity is
+ * where it goes wrong; the elaboration is what stops working; the diagnostic is what an author sees.
+ */
+class AFieldIsBoundByTheDeclarationThatWroteItTest {
+
+    private static final TypeName RANGE = new TypeName("up", "Range");
+
+    private static final String DECLARING = """
+            module up exposing ( Range )
+            data Range = { lo: Int, hi: Int }
+                invariant ordered = lo <= hi
+            """;
+
+    /** What the reader writes to reach {@code up.Range}, and what it calls it once it has. */
+    private enum Reached {
+        BY_NAME("import up ( Range )", "Range"),
+        QUALIFIED("", "up.Range"),
+        THROUGH_AN_ALIAS("import up as u", "u.Range"),
+        BESIDE_THE_READERS_OWN("data Range = { lo: Int, hi: Int }", "up.Range");
+
+        private final String preamble;
+        private final String written;
+
+        Reached(String preamble, String written) {
+            this.preamble = preamble;
+            this.written = written;
+        }
+
+        /** A reader whose own obligation is discharged only by what {@code up.Range} states. */
+        String reader() {
+            return "module demo\n" + preamble + """
+
+                    data Gap = Int
+                        invariant value >= 0
+
+                    behavior measure : (r: %s) -> Gap constructs Gap
+                    let measure (r) = Gap(r.hi - r.lo)
+                    """.formatted(written);
+        }
+    }
+
+    private static Compilation compiled(Reached reached) {
+        Compilation c = Compilation.ofSources(List.of(DECLARING, reached.reader()),
+                ModulePath.EMPTY);
+        c.answerEverything();
+        return c;
+    }
+
+    private static Ast.Data range(Compilation c) {
+        Ast.Def def = c.db().ask(new Names.ResolvedDeclaration(RANGE)).value();
+        assertNotNull(def, "the model under test compiles");
+        return (Ast.Data) def;
+    }
+
+    private static Symbols readerScope(Compilation c) {
+        return c.db().ask(new Names.NameScope("demo")).value();
+    }
+
+    /**
+     * The identity, where it is decided. A field of {@code up.Range} is {@code up.Range}'s field
+     * however it was reached, and the reader's own module name never stands in for the declaring one.
+     */
+    @Test
+    void aReaderBindsAnImportedDeclarationsFieldsWhereTheyWereWritten() {
+        BindingOwner declaring = new BindingOwner.OfFields(RANGE);
+
+        for (Reached reached : Reached.values()) {
+            Compilation c = compiled(reached);
+
+            assertEquals(Map.of("lo", new BindingId(declaring, 0), "hi", new BindingId(declaring, 1)),
+                    TypeOps.fieldBindings(range(c), readerScope(c)),
+                    "reached " + reached + ": a field is bound by the declaration that wrote it");
+        }
+    }
+
+    /**
+     * What stops working when it goes wrong: the clause no longer resolves, and E1023 says the field
+     * is unknown though the scope has it under another identity.
+     *
+     * <p>Asserted as the same {@code Core} the declaring module reads, not merely as something: a
+     * clause that typed to a different term would be a second reading of one rule. Asserted non-null
+     * beside it, because two readings that both answer nothing are also equal.
+     */
+    @Test
+    void anImportedClauseIsTypedAsItIsWhereItIsDeclared() {
+        for (Reached reached : Reached.values()) {
+            Compilation c = compiled(reached);
+            Ast.Data range = range(c);
+
+            Core athome = clause(range, c.db().ask(new Names.NameScope("up")).value());
+            assertNotNull(athome, "the declaring module reads its own rule");
+            assertEquals(athome, clause(range, readerScope(c)),
+                    "reached " + reached + ": one rule, read the same either side of the boundary");
+        }
+    }
+
+    private static Core clause(Ast.Data data, Symbols symbols) {
+        return Elaborator.elaborate(data.invariants().get(0).expr(),
+                DataChecker.fieldScope(data, symbols),
+                CheckContext.of(symbols).forData(data).forDischarge(), Type.BOOL);
+    }
+
+    /**
+     * What an author sees. The obligation is the reader's own ({@code Gap.value >= 0}) and what
+     * discharges it is the imported declaration's ({@code lo <= hi}), so the two do not go missing
+     * together — which is how this stayed invisible: a check that loses both reports nothing either
+     * way.
+     */
+    @Test
+    void anImportedRuleDischargesWhatItWouldDischargeAtHome() {
+        for (Reached reached : Reached.values()) {
+            assertEquals(List.of(), warnings(Compiler.compileModulesWithWarnings(
+                            List.of(DECLARING, reached.reader()))),
+                    "reached " + reached + ": `lo <= hi` discharges `hi - lo >= 0`");
+        }
+    }
+
+    /** The same model in one module, which is what the four above are held against. */
+    @Test
+    void theSameModelInOneModuleDischargesToo() {
+        assertEquals(List.of(), warnings(Compiler.compileModulesWithWarnings(List.of("""
+                module demo
+                data Range = { lo: Int, hi: Int }
+                    invariant ordered = lo <= hi
+
+                data Gap = Int
+                    invariant value >= 0
+
+                behavior measure : (r: Range) -> Gap constructs Gap
+                let measure (r) = Gap(r.hi - r.lo)
+                """))));
+    }
+
+    /**
+     * Two declarations of one spelling are two declarations. A reader that writes its own
+     * {@code Range} and reaches {@code up.Range} beside it must not have them share a binding: a
+     * field standing for two values is a clause read against the wrong one, which is worse than a
+     * clause not read at all.
+     */
+    @Test
+    void aReadersOwnDeclarationDoesNotShareABindingWithAnImportedNamesake() {
+        Compilation c = compiled(Reached.BESIDE_THE_READERS_OWN);
+        Symbols scope = readerScope(c);
+
+        TypeName ours = new TypeName("demo", "Range");
+        Ast.Data mine = (Ast.Data) c.db().ask(new Names.ResolvedDeclaration(ours)).value();
+
+        assertTrue(Collections.disjoint(TypeOps.fieldBindings(range(c), scope).values(),
+                        TypeOps.fieldBindings(mine, scope).values()),
+                "two declarations of `Range` bind two sets of fields");
+    }
+
+    private static List<String> warnings(Compiler.Compiled c) {
+        return c.warnings().stream().filter(d -> d.severity() == Severity.WARNING)
+                .map(Diagnostic::code).sorted().toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest.java
@@ -119,7 +119,7 @@ class EveryClauseADeclarationPassesTypesInTheDischargeRepresentationTest {
                 }
                 TypeName named = new TypeName(module, data.name());
                 for (Ast.InvariantClause clause : clauses.of(named, data)) {
-                    assertNotNull(clauses.typed(clause.expr(), data),
+                    assertNotNull(clauses.typed(clause.expr(), named, data),
                             "`" + data.name() + "` declares a clause this check could not type:\n"
                                     + source);
                     read++;


### PR DESCRIPTION
A newtype's invariant could not be read again once its declaration had crossed a module boundary (#464). The clause was there and the decoder ran it; what failed was re-elaborating it in a module that imports the type, and so everything that reads an invariant by elaborating it got nothing.

## The rule

Do not go back to a spelling once you hold what it resolved to.

`TypeOps.fieldBindings` named the declaration it was binding the fields of `symbols.own(data.name())` — this module's own name, whichever module actually wrote the declaration. An `Ast.Data` carries the name it was declared under and not the module that declared it, so a reader bound an imported declaration's fields under its own name, and the clauses carried in with that declaration — resolved once, by the module that wrote them — resolved against nothing:

```
E1023: unknown identifier `value`
  | fieldTypes=[value] | fieldBindings=[value] | newtype=true
```

`Clauses.typed` then answered null, which every caller reads as *a clause outside the fragment* — the answer for a rule the language cannot express, given to one that was looked up in the wrong place.

The callers already hold what the name resolved to: `nd.typeName()`, `r.name()`, `ref.name()`, and the name `Shapes` keys its answer by. Each was being thrown away in favour of a bare string the reader then answered for itself. So the resolved name is passed through instead — `fieldBindings`, `fieldScope`, `Clauses.bindingsOf`, `Clauses.typed`, `Clauses.statedAt`, `capabilityOf`.

No entry is left that takes the spelling. `Resolve` and `ValueClassGen` only ever see this module's own declarations and write `symbols.own` at the call, where it is a fact about the caller rather than an assumption inside a shared function.

## Four ways to reach a declaration, not one

A reader reaches another module's declaration by a bare import, by qualification, through an alias, or beside a local declaration of the same spelling. All four bound the fields wrongly, and any repair that answers from a bare name fixes at most the first. The last one is the argument: two declarations of one spelling would share a binding, and a field standing for two values is a clause read against the wrong one — worse than a clause not read at all.

They fail together today and need not stay that way. How a name arrives is the import representation's business; a binding is not a function of it, so each is held separately.

## What it was costing

The obligation and what discharges it were both being lost, which is why nothing showed: a check that loses both reports nothing either way. Held here on a model where only one side crosses the boundary — the obligation is the reader's own `Gap.value >= 0`, and `lo <= hi` on the imported `Range` is what discharges it.

| | before | after |
|---|---|---|
| same module | no warning | no warning |
| imported, four ways | E2011 | no warning |

On souther-examples the discharge check now has six more constructions it is asked to prove and cannot — `forecasting.sou:233,321,375,492`, `payroll.sou:195`, `socialinsurance.sou:461`. Warnings on code that compiles today, each a construction of an imported type that may abort at run time and had nothing said about it.

```
E2011  13 -> 19
E1922  34 -> 34
no diagnostic disappeared, BUILD SUCCESS
```

## Commits

1. The regression tests, four of five failing — binding identity, elaboration, and the discharge verdict, each over all four ways of reaching the declaration, plus two namesakes not sharing a binding.
2. The resolved name passed through.
3. `Clauses.typed` keyed by the declaration it was read against as well as by the clause, so the memo holds every input the answer depends on. Nothing observable changes; it is the same rule as the change before it.

Closes #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
