### PR TITLE
A nested numeric newtype is a number to the analysis

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -371,7 +371,7 @@ public final class InvariantChecker {
             return true;
         }
         if (data.newtype()) {
-            if (!everyRuleBecameABound(data, symbols)) {
+            if (!everyRuleBecameABound(named, data, symbols)) {
                 return false;
             }
         } else {
@@ -398,16 +398,19 @@ public final class InvariantChecker {
      * one that gave none — {@code isOdd(value)} beside {@code value >= 0} — is a way the type refuses
      * a value that the bounds do not express.
      */
-    private static boolean everyRuleBecameABound(Ast.Data data, Symbols symbols) {
-        Type base = TypeOps.newtypeInner(new TypeName("", data.name()), symbols);
-        if (base == null) {
-            base = TypeOps.fieldTypes(data, symbols).get("value");
-        }
-        for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
-            for (Ast.Expr each
-                    : souther.compiler.codegen.InvariantConstraints.clauses(clause.expr())) {
-                if (souther.compiler.codegen.InvariantConstraints.of(each, base).isEmpty()) {
-                    return false;
+    private static boolean everyRuleBecameABound(TypeName named, Ast.Data data, Symbols symbols) {
+        Type carried = TypeOps.numericBase(Type.ref(named), symbols);
+        Type base = carried != null ? carried : TypeOps.fieldTypes(data, symbols).get("value");
+        // Every name the value wears, read against what it is carried as. Asking only the outermost
+        // one leaves a rule a layer down unaccounted for, and reading it against the type that layer
+        // declares rather than against the number underneath makes every such rule unreadable.
+        for (TypeOps.Layer layer : TypeOps.newtypeChain(Type.ref(named), symbols)) {
+            for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
+                for (Ast.Expr each
+                        : souther.compiler.codegen.InvariantConstraints.clauses(clause.expr())) {
+                    if (souther.compiler.codegen.InvariantConstraints.of(each, base).isEmpty()) {
+                        return false;
+                    }
                 }
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -1146,7 +1146,7 @@ public final class InvariantChecker {
         // assigns that name its own form, and an assignment drops what was known of what it assigns
         // to — the bound on it would be lost to the copy. A location is always this; a term is where
         // the form is that term's own atom.
-        if (what instanceof Denotes.Term term && terms.isNumeric(li.value().type())) {
+        if (what instanceof Denotes.Term term && terms.affineScalarBase(li.value().type()) != null) {
             LinearForm vf = terms.affineOf(li.value(), at, k);
             if (vf != null && !vf.equals(LinearForm.atom(term.key()))) {
                 out = out.assigning(term.key(), vf,

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -771,6 +771,12 @@ final class Terms {
      * numbers or dense ones would otherwise classify the type a second time, and two classifications
      * of one type are two chances to disagree.
      *
+     * <p>Every number the language calls one, today: the domain holds a scalar, and a value the
+     * language compares as a number is one it can hold. The two are answered by one call for that
+     * reason and not because they are one question — an equality reaches values no domain carries,
+     * and a type being comparable is no promise that an affine domain can hold it. Where those come
+     * apart this stops delegating; until then the delegation is what says why the answers agree.
+     *
      * <p>Remembered by the type it names — asked at every leaf of every affine walk, and answering it
      * walks the declaration's fields.
      */
@@ -779,10 +785,10 @@ final class Terms {
             return t;
         }
         if (!(t instanceof Type.Ref ref)) {
-            return TypeOps.directNumericNewtypeBase(t, symbols);
+            return TypeOps.numericBase(t, symbols);
         }
         return affineScalarBases.computeIfAbsent(ref.name(),
-                _ -> java.util.Optional.ofNullable(TypeOps.directNumericNewtypeBase(t, symbols)))
+                _ -> java.util.Optional.ofNullable(TypeOps.numericBase(t, symbols)))
                 .orElse(null);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -39,7 +39,7 @@ import java.util.Set;
 final class Terms {
 
     private final Symbols symbols;
-    private final Map<TypeName, Boolean> numericNewtypes = new HashMap<>();
+    private final Map<TypeName, java.util.Optional<Type>> affineScalarBases = new HashMap<>();
     /** How the values of each atom this has named are spaced. Kept here because this is where an
      * atom's name is made: the key and the kind of number behind it are decided in one step, and
      * anywhere else would be a second place that has to agree about which is which. */
@@ -138,7 +138,7 @@ final class Terms {
         return affine(e, n -> {
             if (n instanceof Core.NewData nd && nd.spreads().isEmpty() && nd.inits().size() == 1
                     && nd.inits().get(0).name().equals("value")
-                    && numericNewtype(Type.ref(nd.typeName()))) {
+                    && affineScalarBase(Type.ref(nd.typeName())) != null) {
                 return affineOf(nd.inits().get(0).value(), at, k);
             }
             Core written = writtenValue(n, at);
@@ -170,7 +170,7 @@ final class Terms {
      */
     private LinearForm givenForm(Core e, Denotations at, Known k) {
         if (!(e instanceof Core.Read r) || !(at.of(r.binding()) instanceof Denotes.Term)
-                || !isNumeric(e.type())) {
+                || affineScalarBase(e.type()) == null) {
             return null;
         }
         Core given = at.valueOf(r.binding());
@@ -225,7 +225,7 @@ final class Terms {
         if (size != null) {
             return size;
         }
-        if (!isNumeric(e.type())) {
+        if (affineScalarBase(e.type()) == null) {
             return null;
         }
         // A path rooted at a binding is the atom of what that binding denotes, and only where a clause
@@ -263,20 +263,14 @@ final class Terms {
 
     /** How the values of a numeric type are spaced. */
     Granularity granularityOf(Type t) {
-        if (t == Type.INT) {
+        Type carrier = affineScalarBase(t);
+        if (carrier == Type.INT) {
             return Granularity.DISCRETE;
         }
-        if (t == Type.DECIMAL) {
+        if (carrier == Type.DECIMAL) {
             return Granularity.DENSE;
         }
-        Type base = TypeOps.directNumericNewtypeBase(t, symbols);
-        if (base == Type.INT) {
-            return Granularity.DISCRETE;
-        }
-        if (base == Type.DECIMAL) {
-            return Granularity.DENSE;
-        }
-        throw new IllegalStateException("not a number: " + Type.show(t));
+        throw new IllegalStateException("not a number the domain carries: " + Type.show(t));
     }
 
     /** The spacing of every atom {@code f} is written over, for the domain to record. Every one of
@@ -761,18 +755,35 @@ final class Terms {
         return null;
     }
 
-    /** Whether {@code t} is a newtype over a number, remembered by the type it names. Asked at every
-     * leaf of every affine walk, and answering it walks the declaration's fields. */
-    boolean numericNewtype(Type t) {
-        if (!(t instanceof Type.Ref ref)) {
-            return TypeOps.directNumericNewtypeBase(t, symbols) != null;
+    /**
+     * The number the affine domain can carry a value of {@code t} as, or null where it can carry
+     * none.
+     *
+     * <p>This is the analyser's own capability and is named for the domain that has it. Two other
+     * questions read like it and are not it: whether arithmetic is closed over the type, which the
+     * language answers only for a newtype directly over a number ({@link
+     * TypeOps#directNumericNewtypeBase}, spec §newtype-arithmetic), and whether the type is an
+     * ordered number, which reaches the recursive base ({@link TypeOps#base}, ADR-0047). Answering
+     * this one with the first is how a comparison the language accepts stopped reaching the
+     * reasoning.
+     *
+     * <p>The carrier and not a yes: a caller that has to know whether it is stepping through whole
+     * numbers or dense ones would otherwise classify the type a second time, and two classifications
+     * of one type are two chances to disagree.
+     *
+     * <p>Remembered by the type it names — asked at every leaf of every affine walk, and answering it
+     * walks the declaration's fields.
+     */
+    Type affineScalarBase(Type t) {
+        if (t == Type.INT || t == Type.DECIMAL) {
+            return t;
         }
-        return numericNewtypes.computeIfAbsent(ref.name(),
-                _ -> TypeOps.directNumericNewtypeBase(t, symbols) != null);
-    }
-
-    boolean isNumeric(Type t) {
-        return t == Type.INT || t == Type.DECIMAL || numericNewtype(t);
+        if (!(t instanceof Type.Ref ref)) {
+            return TypeOps.directNumericNewtypeBase(t, symbols);
+        }
+        return affineScalarBases.computeIfAbsent(ref.name(),
+                _ -> java.util.Optional.ofNullable(TypeOps.directNumericNewtypeBase(t, symbols)))
+                .orElse(null);
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1302,6 +1302,19 @@ public final class TypeOps {
         return t;
     }
 
+    /**
+     * The {@code Int} or {@code Decimal} a value of {@code t} is carried as, reaching through as many
+     * newtypes as it is written with, or {@code null} where it is carried as neither.
+     *
+     * <p>The language's own reading: a comparison of two such values compares the numbers underneath
+     * however many names are wrapped round them (ADR-0047). Not what arithmetic asks — that is
+     * {@link #directNumericNewtypeBase} and stops at one layer, which the language means.
+     */
+    public static Type numericBase(Type t, Symbols symbols) {
+        Type carried = base(t, symbols);
+        return carried == Type.INT || carried == Type.DECIMAL ? carried : null;
+    }
+
     /** What a single-value newtype directly wraps (one level, so a newtype over a newtype answers
      * with that newtype), or {@code null} for anything that is not one. */
     static Type wrapped(Type t, Symbols symbols) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1289,18 +1289,45 @@ public final class TypeOps {
         return owners;
     }
 
-    /** The underlying base of a type: itself, or — for a single-value newtype ({@code data X = Y}) —
+    /**
+     * The underlying base of a type: itself, or — for a single-value newtype ({@code data X = Y}) —
      * the base of its {@code value} type, recursively (so {@code 管理職 = レベル = Int} bases to Int).
-     * A newtype's value is what its comparison and equality read. */
+     * A newtype's value is what its comparison and equality read.
+     */
     public static Type base(Type t, Symbols symbols) {
-        if (isSingleValueNewtype(t, symbols)) {
-            Type inner = fieldTypes((Ast.Data) symbols.get(((Type.Ref) t).name()), symbols).get("value");
-            if (inner != null) {
-                return base(inner, symbols);
-            }
-        }
-        return t;
+        return newtypeSpine(t, symbols).terminal();
     }
+
+    /**
+     * The names wrapped round a value and what is left when they are off.
+     *
+     * <p>The one walk. How far a newtype reaches is a fact about the declarations and not about who
+     * is asking, and two readers deciding it apart is what #461 was: a comparison reaching the base
+     * while the range beside it stopped at the first name. Everything that needs to know derives from
+     * here — what a value is carried as, which declarations' rules apply to it, whether it is a
+     * number at all.
+     *
+     * <p>Stops on a name already worn, so a declaration reachable from itself ends the walk rather
+     * than repeating it, and stops where a newtype's {@code value} is not declared.
+     */
+    public static NewtypeSpine newtypeSpine(Type t, Symbols symbols) {
+        List<Layer> layers = new ArrayList<>();
+        Set<TypeName> worn = new LinkedHashSet<>();
+        Type at = t;
+        while (isSingleValueNewtype(at, symbols) && worn.add(((Type.Ref) at).name())) {
+            Ast.Data data = (Ast.Data) symbols.get(((Type.Ref) at).name());
+            layers.add(new Layer(((Type.Ref) at).name(), data));
+            Type inner = fieldTypes(data, symbols).get("value");
+            if (inner == null) {
+                break;
+            }
+            at = inner;
+        }
+        return new NewtypeSpine(List.copyOf(layers), at);
+    }
+
+    /** The names a value wears, and the type underneath them. */
+    public record NewtypeSpine(List<Layer> layers, Type terminal) {}
 
     /**
      * One name a value wears, and the declaration it is written by.
@@ -1323,15 +1350,7 @@ public final class TypeOps {
      * than repeating it. A type that is not a newtype has one layer or none.
      */
     public static List<Layer> newtypeChain(Type t, Symbols symbols) {
-        List<Layer> layers = new ArrayList<>();
-        Set<TypeName> worn = new LinkedHashSet<>();
-        Type at = t;
-        while (at instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data
-                && data.newtype() && worn.add(ref.name())) {
-            layers.add(new Layer(ref.name(), data));
-            at = fieldTypes(data, symbols).get("value");
-        }
-        return List.copyOf(layers);
+        return newtypeSpine(t, symbols).layers();
     }
 
     /**
@@ -1343,7 +1362,7 @@ public final class TypeOps {
      * {@link #directNumericNewtypeBase} and stops at one layer, which the language means.
      */
     public static Type numericBase(Type t, Symbols symbols) {
-        Type carried = base(t, symbols);
+        Type carried = newtypeSpine(t, symbols).terminal();
         return carried == Type.INT || carried == Type.DECIMAL ? carried : null;
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1303,6 +1303,38 @@ public final class TypeOps {
     }
 
     /**
+     * One name a value wears, and the declaration it is written by.
+     *
+     * <p>Kept together because a rule is read at a layer and reported by the declaration that wrote
+     * it — a failure names a clause of a type, and dropping which type that was leaves a diagnostic
+     * with nothing to point at.
+     */
+    public record Layer(TypeName named, Ast.Data data) {}
+
+    /**
+     * The names wrapped round a value of {@code t}, outermost first.
+     *
+     * <p>One place says how far a newtype reaches, because more than one thing needs to know: what a
+     * construction has to satisfy, what a position's range is, what a comparison of two such values
+     * compares. Each working it out for itself is how they came to disagree about a value wearing two
+     * names — the projection reading through and the range reader stopping at the first.
+     *
+     * <p>Stops on a name already worn, so a declaration that wraps its own kind ends the walk rather
+     * than repeating it. A type that is not a newtype has one layer or none.
+     */
+    public static List<Layer> newtypeChain(Type t, Symbols symbols) {
+        List<Layer> layers = new ArrayList<>();
+        Set<TypeName> worn = new LinkedHashSet<>();
+        Type at = t;
+        while (at instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data
+                && data.newtype() && worn.add(ref.name())) {
+            layers.add(new Layer(ref.name(), data));
+            at = fieldTypes(data, symbols).get("value");
+        }
+        return List.copyOf(layers);
+    }
+
+    /**
      * The {@code Int} or {@code Decimal} a value of {@code t} is carried as, reaching through as many
      * newtypes as it is written with, or {@code null} where it is carried as neither.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -306,8 +306,9 @@ public final class Partitions {
             return own;
         }
         return new Bounds(own.min() == null ? null : highest(own.min(), projected.min()),
+                own.minFrom(),
                 own.max() == null ? null : lowest(own.max(), projected.max()),
-                own.decimal());
+                own.maxFrom(), own.decimal());
     }
 
     /** A record's fields, or nothing where the type is not one. A newtype is not taken apart: its
@@ -383,7 +384,15 @@ public final class Partitions {
     // --- reading an invariant's bounds -------------------------------------------------------------
 
     /** What a newtype's invariant says about the range of its value. */
-    private record Bounds(BigDecimal min, BigDecimal max, boolean decimal) {
+    /**
+     * What a newtype's rules leave the value between, and which of the names it wears said so.
+     *
+     * <p>The layer is kept because a boundary is reported by the rule that drew it, and a value
+     * wearing two names is bounded by rules written on either. Read off the outermost name, an edge
+     * that `Minute` drew would be reported as `StartMinute`'s.
+     */
+    private record Bounds(BigDecimal min, TypeName minFrom, BigDecimal max, TypeName maxFrom,
+                          boolean decimal) {
 
         boolean isEmpty() {
             return min == null && max == null;
@@ -392,39 +401,58 @@ public final class Partitions {
     }
 
     private static Bounds boundsOf(Type type, Symbols symbols) {
-        if (!(type instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)
-                || !data.newtype()) {
+        Type base = TypeOps.numericBase(type, symbols);
+        if (base == null) {
             return null;
         }
-        Type base = TypeOps.newtypeInner(ref.name(), symbols);
-        if (base != Type.INT && base != Type.DECIMAL) {
-            return null;
-        }
-        boolean decimal = base == Type.DECIMAL;
         BigDecimal min = null;
         BigDecimal max = null;
-        for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
-            for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
-                Optional<InvariantConstraints.Constraint> read =
-                        InvariantConstraints.of(each, base);
-                if (read.isEmpty()) {
-                    continue;
-                }
-                switch (read.get()) {
-                    case InvariantConstraints.Min m -> min = highest(min, BigDecimal.valueOf(m.n()));
-                    case InvariantConstraints.Max m -> max = lowest(max, BigDecimal.valueOf(m.n()));
-                    case InvariantConstraints.Positive _ -> min = highest(min, BigDecimal.ONE);
-                    case InvariantConstraints.NonNegative _ -> min = highest(min, BigDecimal.ZERO);
-                    case InvariantConstraints.DecimalMin m -> min = highest(min, m.n());
-                    case InvariantConstraints.DecimalMax m -> max = lowest(max, m.n());
-                    case InvariantConstraints.DecimalPositive _ -> min = highest(min, BigDecimal.ONE);
-                    case InvariantConstraints.DecimalNonNegative _ ->
-                            min = highest(min, BigDecimal.ZERO);
-                    default -> { }   // a rule this partition does not read: length, pattern, size
+        TypeName minFrom = null;
+        TypeName maxFrom = null;
+        // Every name the value wears, not the outermost one. A rule written on the type a newtype
+        // wraps bounds the value as much as one written on the newtype does, and the two intersect:
+        // `Inner: value >= 0` under `Outer: value <= 10` is a range of `[0, 10]`, and neither layer
+        // alone says so. How far that reaches is asked of `TypeOps` rather than walked again here,
+        // and which layer each end came from is kept, because that is the rule a report names.
+        for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
+            for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
+                for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
+                    BigDecimal low = lowerOf(InvariantConstraints.of(each, base).orElse(null));
+                    BigDecimal high = upperOf(InvariantConstraints.of(each, base).orElse(null));
+                    if (low != null && (min == null || low.compareTo(min) > 0)) {
+                        min = low;
+                        minFrom = layer.named();
+                    }
+                    if (high != null && (max == null || high.compareTo(max) < 0)) {
+                        max = high;
+                        maxFrom = layer.named();
+                    }
                 }
             }
         }
-        return new Bounds(min, max, decimal);
+        return new Bounds(min, minFrom, max, maxFrom, base == Type.DECIMAL);
+    }
+
+    /** The lower bound a constraint states, or null where it states none. */
+    private static BigDecimal lowerOf(InvariantConstraints.Constraint read) {
+        return switch (read) {
+            case InvariantConstraints.Min m -> BigDecimal.valueOf(m.n());
+            case InvariantConstraints.Positive _, InvariantConstraints.DecimalPositive _ ->
+                    BigDecimal.ONE;
+            case InvariantConstraints.NonNegative _, InvariantConstraints.DecimalNonNegative _ ->
+                    BigDecimal.ZERO;
+            case InvariantConstraints.DecimalMin m -> m.n();
+            case null, default -> null;   // length, pattern, size, or a rule this cannot read
+        };
+    }
+
+    /** The upper bound a constraint states, or null where it states none. */
+    private static BigDecimal upperOf(InvariantConstraints.Constraint read) {
+        return switch (read) {
+            case InvariantConstraints.Max m -> BigDecimal.valueOf(m.n());
+            case InvariantConstraints.DecimalMax m -> m.n();
+            case null, default -> null;
+        };
     }
 
     /** The cuts of a position, each carrying the rule that drew it. */
@@ -441,11 +469,11 @@ public final class Partitions {
         }
         Map<String, Cut> byValue = new LinkedHashMap<>();
         if (bounds.min != null) {
-            put(byValue, numeric(bounds.min, bounds.decimal), ref.name(), "min",
+            put(byValue, numeric(bounds.min, bounds.decimal), bounds.minFrom(), "min",
                     moved(own == null ? null : own.min(), bounds.min) ? within : null);
         }
         if (bounds.max != null) {
-            put(byValue, numeric(bounds.max, bounds.decimal), ref.name(), "max",
+            put(byValue, numeric(bounds.max, bounds.decimal), bounds.maxFrom(), "max",
                     moved(own == null ? null : own.max(), bounds.max) ? within : null);
         }
         return List.copyOf(byValue.values());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -247,7 +247,9 @@ public final class Partitions {
         boolean nothingExists = placed != null && placed.domains().infeasible();
         Bounds here = nothingExists ? null : narrowed(own, placed == null ? null : placed.at(path));
         if (here != null && !here.isEmpty()) {
-            domains.put(path.toString(), new NumericDomain.Bounds(here.min(), here.max()));
+            domains.put(path.toString(), new NumericDomain.Bounds(
+                    here.min() == null ? null : here.min().value(),
+                    here.max() == null ? null : here.max().value()));
         }
         List<Cut> cuts = nothingExists ? List.of()
                 : cutsOf(type, here, own, placed == null ? null : placed.value());
@@ -305,10 +307,14 @@ public final class Partitions {
         if (own == null || projected == null) {
             return own;
         }
-        return new Bounds(own.min() == null ? null : highest(own.min(), projected.min()),
-                own.minFrom(),
-                own.max() == null ? null : lowest(own.max(), projected.max()),
-                own.maxFrom(), own.decimal());
+        // The value moves and the names do not: a record narrowing an edge does not take it away
+        // from the rule that put one there, and which record did the narrowing is said beside it.
+        return new Bounds(
+                own.min() == null ? null
+                        : new End(highest(own.min().value(), projected.min()), own.min().from()),
+                own.max() == null ? null
+                        : new End(lowest(own.max().value(), projected.max()), own.max().from()),
+                own.decimal());
     }
 
     /** A record's fields, or nothing where the type is not one. A newtype is not taken apart: its
@@ -385,14 +391,40 @@ public final class Partitions {
 
     /** What a newtype's invariant says about the range of its value. */
     /**
+     * One end of a range, and every name that put it there.
+     *
+     * <p>Names, plural. Two layers can state the same bound — a wrapper repeating what it wraps — and
+     * they are two rules a row could be owed to, which is the accounting a cut already keeps. Holding
+     * one would drop an obligation rather than a line of text.
+     */
+    private record End(BigDecimal value, List<TypeName> from) {
+
+        /** This end, or {@code other} where it is the stronger, or both where they agree. */
+        static End tighter(End had, End one, boolean upper) {
+            if (one == null) {
+                return had;
+            }
+            if (had == null) {
+                return one;
+            }
+            int order = one.value().compareTo(had.value());
+            if (order == 0) {
+                List<TypeName> both = new ArrayList<>(had.from());
+                one.from().stream().filter(n -> !both.contains(n)).forEach(both::add);
+                return new End(had.value(), List.copyOf(both));
+            }
+            return (upper ? order < 0 : order > 0) ? one : had;
+        }
+    }
+
+    /**
      * What a newtype's rules leave the value between, and which of the names it wears said so.
      *
      * <p>The layer is kept because a boundary is reported by the rule that drew it, and a value
      * wearing two names is bounded by rules written on either. Read off the outermost name, an edge
      * that `Minute` drew would be reported as `StartMinute`'s.
      */
-    private record Bounds(BigDecimal min, TypeName minFrom, BigDecimal max, TypeName maxFrom,
-                          boolean decimal) {
+    private record Bounds(End min, End max, boolean decimal) {
 
         boolean isEmpty() {
             return min == null && max == null;
@@ -405,33 +437,31 @@ public final class Partitions {
         if (base == null) {
             return null;
         }
-        BigDecimal min = null;
-        BigDecimal max = null;
-        TypeName minFrom = null;
-        TypeName maxFrom = null;
+        End min = null;
+        End max = null;
         // Every name the value wears, not the outermost one. A rule written on the type a newtype
         // wraps bounds the value as much as one written on the newtype does, and the two intersect:
         // `Inner: value >= 0` under `Outer: value <= 10` is a range of `[0, 10]`, and neither layer
         // alone says so. How far that reaches is asked of `TypeOps` rather than walked again here,
-        // and which layer each end came from is kept, because that is the rule a report names.
+        // and every layer that put an end where it is is kept, because each is a rule a row is owed.
         for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
             for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
                 for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
-                    BigDecimal low = lowerOf(InvariantConstraints.of(each, base).orElse(null));
-                    BigDecimal high = upperOf(InvariantConstraints.of(each, base).orElse(null));
-                    if (low != null && (min == null || low.compareTo(min) > 0)) {
-                        min = low;
-                        minFrom = layer.named();
-                    }
-                    if (high != null && (max == null || high.compareTo(max) < 0)) {
-                        max = high;
-                        maxFrom = layer.named();
-                    }
+                    InvariantConstraints.Constraint read =
+                            InvariantConstraints.of(each, base).orElse(null);
+                    min = End.tighter(min, endOf(lowerOf(read), layer), false);
+                    max = End.tighter(max, endOf(upperOf(read), layer), true);
                 }
             }
         }
-        return new Bounds(min, minFrom, max, maxFrom, base == Type.DECIMAL);
+        return new Bounds(min, max, base == Type.DECIMAL);
     }
+
+    private static End endOf(BigDecimal value, TypeOps.Layer layer) {
+        return value == null ? null : new End(value, List.of(layer.named()));
+    }
+
+
 
     /** The lower bound a constraint states, or null where it states none. */
     private static BigDecimal lowerOf(InvariantConstraints.Constraint read) {
@@ -464,19 +494,25 @@ public final class Partitions {
      * @param within the record, or null at a position that is not a field of one
      */
     private static List<Cut> cutsOf(Type type, Bounds bounds, Bounds own, TypeName within) {
-        if (bounds == null || bounds.isEmpty() || !(type instanceof Type.Ref ref)) {
+        if (bounds == null || bounds.isEmpty() || !(type instanceof Type.Ref)) {
             return List.of();
         }
         Map<String, Cut> byValue = new LinkedHashMap<>();
-        if (bounds.min != null) {
-            put(byValue, numeric(bounds.min, bounds.decimal), bounds.minFrom(), "min",
-                    moved(own == null ? null : own.min(), bounds.min) ? within : null);
-        }
-        if (bounds.max != null) {
-            put(byValue, numeric(bounds.max, bounds.decimal), bounds.maxFrom(), "max",
-                    moved(own == null ? null : own.max(), bounds.max) ? within : null);
-        }
+        cut(byValue, bounds.min(), own == null ? null : own.min(), "min", bounds.decimal(), within);
+        cut(byValue, bounds.max(), own == null ? null : own.max(), "max", bounds.decimal(), within);
         return List.copyOf(byValue.values());
+    }
+
+    /** One end as a cut, owed once to each rule that put it there. */
+    private static void cut(Map<String, Cut> into, End end, End own, String clause, boolean decimal,
+                            TypeName within) {
+        if (end == null) {
+            return;
+        }
+        boolean moved = own != null && own.value().compareTo(end.value()) != 0;
+        for (TypeName from : end.from()) {
+            put(into, numeric(end.value(), decimal), from, clause, moved ? within : null);
+        }
     }
 
     /** Whether an end is somewhere other than where the type's own rule left it. */
@@ -611,8 +647,8 @@ public final class Partitions {
     /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge
      * there is, and it is the value a boundary wants written anyway. */
     private static BigDecimal inside(Bounds bounds) {
-        return bounds.min() != null ? bounds.min()
-                : bounds.max() != null ? bounds.max() : BigDecimal.ZERO;
+        return bounds.min() != null ? bounds.min().value()
+                : bounds.max() != null ? bounds.max().value() : BigDecimal.ZERO;
     }
 
     private static boolean isBool(ObservedValue v, boolean expected) {

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
@@ -230,18 +230,15 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
     }
 
     /**
-     * A newtype over a newtype is bounded by neither reading.
+     * A rule reaches through as many names as are wrapped round the number.
      *
-     * <p>The range a boundary is derived from and the range this projects are read by two different
-     * walks, and what matters is that they agree: a bound only one of them found would narrow one end
-     * of a position and leave the other where its type left it, which is not a range of anything.
-     * They agree here on nothing — `data StartMinute = Minute` carries no bound to either, and the
-     * position is reported as not derivable — so there is nothing to take in. That the inner rule is
-     * lost is older than this and is a limit of what a bound is read off, not of the projection.
-     * Reported separately; this holds the agreement, and will want the bounds once that is fixed.
+     * <p>`data StartMinute = Minute` is a number the language compares, so it is one the domain
+     * carries (#461). Both ends are minutes of a day and the rule between them is read at the atoms
+     * they are, so `from` stops where `to` can still be — a name wrapped round a number is not a
+     * place a rule stops.
      */
     @Test
-    void aNewtypeOverANewtypeIsBoundedByNeitherReading() {
+    void aRuleReachesThroughAsManyNamesAsAreWrappedRoundTheNumber() {
         FieldDomains domains = domainsIn("""
                 module example.nested
 
@@ -258,8 +255,8 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
                     invariant ordered = from.value < to.value
                 """, "Span");
 
-        assertNull(domains.at("from"));
-        assertNull(domains.at("to"));
+        assertBounds(domains.at("from"), 0, 1439);
+        assertBounds(domains.at("to"), 1, 1440);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
@@ -1,0 +1,95 @@
+package souther.compiler.check;
+
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a number is, asked three ways, of the same six types.
+ *
+ * <p>They read alike and they are not one question. Arithmetic is closed only over a newtype directly
+ * over a number, which the language states and means (spec §newtype-arithmetic). Being an ordered
+ * number reaches the recursive base, which is what a comparison reads (ADR-0047). Whether the affine
+ * domain can carry a value is the analyser's own capability, and answering it with the first is how a
+ * comparison the language accepts stopped reaching the reasoning (#461).
+ *
+ * <p>Held as a table because the three coincide on most types and part on exactly the ones that
+ * matter. A change to any of them shows here as a cell, and which cell says whether the language's
+ * capability moved or the analyser's did.
+ */
+class ThreeQuestionsAboutANumberAndThreeAnswersTest {
+
+    private static final String TYPES = """
+            module example.numbers
+
+            data Minute = Int
+            data StartMinute = Minute
+
+            data Ratio = Decimal
+            data Share = Ratio
+
+            data Label = String
+            data Tag = Label
+            """;
+
+    private record Answers(Type arithmetic, Type ordered, Type affine) {}
+
+    private static Answers of(String type) {
+        Compilation compilation = Compilation.ofSource(TYPES, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        assertNotNull(symbols, "the model did not compile");
+        Type t = switch (type) {
+            case "Int" -> Type.INT;
+            case "Decimal" -> Type.DECIMAL;
+            default -> Type.ref(new TypeName(module, type));
+        };
+        Type base = TypeOps.base(t, symbols);
+        return new Answers(
+                TypeOps.directNumericNewtypeBase(t, symbols),
+                base == Type.INT || base == Type.DECIMAL ? base : null,
+                new Terms(symbols).affineScalarBase(t));
+    }
+
+    /** A primitive is not a newtype, so arithmetic answers nothing about it as one; it is a number
+     * either way. */
+    @Test
+    void aPrimitiveIsANumberWithoutBeingANewtypeOverOne() {
+        assertEquals(new Answers(null, Type.INT, Type.INT), of("Int"));
+        assertEquals(new Answers(null, Type.DECIMAL, Type.DECIMAL), of("Decimal"));
+    }
+
+    /** One layer over a number: all three agree. */
+    @Test
+    void aNewtypeDirectlyOverANumberIsANumberEveryWay() {
+        assertEquals(new Answers(Type.INT, Type.INT, Type.INT), of("Minute"));
+        assertEquals(new Answers(Type.DECIMAL, Type.DECIMAL, Type.DECIMAL), of("Ratio"));
+    }
+
+    /**
+     * Two layers: arithmetic says no and means it, and the analyser says no by borrowing that answer.
+     *
+     * <p>The middle column is what the language does with such a value — `StartMinute < StartMinute`
+     * compares, because comparison reaches the base. The third is what the analyser can do with it,
+     * and today it is the first column's answer wearing the third column's name.
+     */
+    @Test
+    void aNewtypeOverANewtypeIsANumberTheAnalyserCannotCarry() {
+        assertEquals(new Answers(null, Type.INT, null), of("StartMinute"));
+        assertEquals(new Answers(null, Type.DECIMAL, null), of("Share"));
+    }
+
+    /** And a chain over something that is no number is no number by any of the three. */
+    @Test
+    void aChainOverSomethingElseIsNotANumberAtAll() {
+        assertEquals(new Answers(null, null, null), of("Label"));
+        assertEquals(new Answers(null, null, null), of("Tag"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
@@ -13,11 +13,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 /**
  * What a number is, asked three ways, of the same six types.
  *
- * <p>They read alike and they are not one question. Arithmetic is closed only over a newtype directly
- * over a number, which the language states and means (spec §newtype-arithmetic). Being an ordered
- * number reaches the recursive base, which is what a comparison reads (ADR-0047). Whether the affine
- * domain can carry a value is the analyser's own capability, and answering it with the first is how a
- * comparison the language accepts stopped reaching the reasoning (#461).
+ * <p>They read alike and they are not one question. The first is what gives a <em>newtype</em> closed
+ * arithmetic, which the language grants only for one directly over a number and means to (spec
+ * §newtype-arithmetic) — it is not "arithmetic works here", which is also true of a bare `Int`, and
+ * the column is named for what it measures so the table does not repeat the confusion it is about.
+ * Being an ordered number reaches the recursive base, which is what a comparison reads (ADR-0047).
+ * Whether the affine domain can carry a value is the analyser's own capability, and answering it with
+ * the first is how a comparison the language accepts stopped reaching the reasoning (#461).
  *
  * <p>Held as a table because the three coincide on most types and part on exactly the ones that
  * matter. A change to any of them shows here as a cell, and which cell says whether the language's
@@ -38,7 +40,7 @@ class ThreeQuestionsAboutANumberAndThreeAnswersTest {
             data Tag = Label
             """;
 
-    private record Answers(Type arithmetic, Type ordered, Type affine) {}
+    private record Answers(Type directNewtypeArithmetic, Type ordered, Type affine) {}
 
     private static Answers of(String type) {
         Compilation compilation = Compilation.ofSource(TYPES, "Main");
@@ -58,8 +60,8 @@ class ThreeQuestionsAboutANumberAndThreeAnswersTest {
                 new Terms(symbols).affineScalarBase(t));
     }
 
-    /** A primitive is not a newtype, so arithmetic answers nothing about it as one; it is a number
-     * either way. */
+    /** A primitive is no newtype, so the first column has nothing to say about it; it is a number to
+     * the other two. */
     @Test
     void aPrimitiveIsANumberWithoutBeingANewtypeOverOne() {
         assertEquals(new Answers(null, Type.INT, Type.INT), of("Int"));
@@ -74,11 +76,11 @@ class ThreeQuestionsAboutANumberAndThreeAnswersTest {
     }
 
     /**
-     * Two layers: arithmetic says no and means it, and the other two say yes.
+     * Two layers: no newtype arithmetic, and a number to the other two.
      *
      * <p>This is the row the three questions part on, and the row #461 was. The language compares
      * such a value because comparison reaches the base; the analyser carries it for the same reason,
-     * and used to refuse it by answering with the arithmetic column.
+     * and used to refuse it by answering with the first column.
      */
     @Test
     void aNewtypeOverANewtypeIsNoArithmeticAndStillANumber() {

--- a/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ThreeQuestionsAboutANumberAndThreeAnswersTest.java
@@ -74,16 +74,16 @@ class ThreeQuestionsAboutANumberAndThreeAnswersTest {
     }
 
     /**
-     * Two layers: arithmetic says no and means it, and the analyser says no by borrowing that answer.
+     * Two layers: arithmetic says no and means it, and the other two say yes.
      *
-     * <p>The middle column is what the language does with such a value — `StartMinute < StartMinute`
-     * compares, because comparison reaches the base. The third is what the analyser can do with it,
-     * and today it is the first column's answer wearing the third column's name.
+     * <p>This is the row the three questions part on, and the row #461 was. The language compares
+     * such a value because comparison reaches the base; the analyser carries it for the same reason,
+     * and used to refuse it by answering with the arithmetic column.
      */
     @Test
-    void aNewtypeOverANewtypeIsANumberTheAnalyserCannotCarry() {
-        assertEquals(new Answers(null, Type.INT, null), of("StartMinute"));
-        assertEquals(new Answers(null, Type.DECIMAL, null), of("Share"));
+    void aNewtypeOverANewtypeIsNoArithmeticAndStillANumber() {
+        assertEquals(new Answers(null, Type.INT, Type.INT), of("StartMinute"));
+        assertEquals(new Answers(null, Type.DECIMAL, Type.DECIMAL), of("Share"));
     }
 
     /** And a chain over something that is no number is no number by any of the three. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -105,6 +105,112 @@ class PartitionsTest {
                 cost.cuts().stream().map(Cut::value).toList());
     }
 
+    /**
+     * A rule reaches through as many names as are wrapped round the number.
+     *
+     * <p>`data StartMinute = Minute` is one the language compares and bounds, and was one the
+     * derivation read nothing off — the range reader stopped at the first name and the position came
+     * back as one the model draws no line through (#461). Both ends and the rule between them are
+     * read at the numbers underneath, so the cuts are the type's edges taken in by the record.
+     */
+    @Test
+    void aBoundReachesThroughEveryNameWrappedRoundTheNumber() {
+        Partitions.Partitioning span = partitioningOf("""
+                module example.nested
+
+                data Minute = Int
+                    invariant withinDay = value >= 0 && value <= 1440
+
+                data StartMinute = Minute
+                data EndMinute = Minute
+
+                data Span =
+                    { from: StartMinute
+                    , to: EndMinute
+                    }
+                    invariant ordered = from.value < to.value
+
+                data Ok = { at: String }
+
+                behavior classify : (span: Span) -> Ok
+                    constructs Ok
+
+                let classify (span) = Ok { at = "x" }
+                """, "classify");
+
+        assertEquals(List.of(new ObservedValue.Integer(0L), new ObservedValue.Integer(1439L)),
+                axis(span, "span.from").cuts().stream().map(Cut::value).toList());
+        assertEquals(List.of(new ObservedValue.Integer(1L), new ObservedValue.Integer(1440L)),
+                axis(span, "span.to").cuts().stream().map(Cut::value).toList());
+        assertEquals(List.of("invariant Minute (min)", "invariant Minute (max) within Span"),
+                axis(span, "span.from").cuts().stream()
+                        .map(c -> c.origins().get(0).describe()).toList(),
+                "the rule that drew each end is the one that wrote it, not the outermost name");
+    }
+
+    /**
+     * Bounds on two of the names a value wears intersect, and each end is owed to the rule that put
+     * it there.
+     *
+     * <p>Neither layer alone says the range is `[0, 10]`. A reader that took the outermost
+     * declaration's clauses would answer `[nothing, 10]`, and one that kept a single name per end
+     * would drop an obligation where two layers state the same bound.
+     */
+    @Test
+    void boundsOnTwoOfTheNamesIntersectAndBothAreOwed() {
+        Partitions.Partitioning wrapped = partitioningOf("""
+                module example.wrapped
+
+                data Inner = Int
+                    invariant innerMin = value >= 0
+
+                data Outer = Inner
+                    invariant outerMin = value >= 0
+                    invariant outerMax = value <= 10
+
+                data Ok = { at: String }
+
+                behavior classify : (o: Outer) -> Ok
+                    constructs Ok
+
+                let classify (o) = Ok { at = "x" }
+                """, "classify");
+        Axis o = axis(wrapped, "o");
+
+        assertEquals(List.of(new ObservedValue.Integer(0L), new ObservedValue.Integer(10L)),
+                o.cuts().stream().map(Cut::value).toList());
+        assertEquals(List.of("invariant Outer (min)", "invariant Inner (min)"),
+                o.cuts().get(0).origins().stream().map(OriginRef::describe).toList(),
+                "one value, two rules, and a row is owed to each");
+        assertEquals(List.of("invariant Outer (max)"),
+                o.cuts().get(1).origins().stream().map(OriginRef::describe).toList());
+    }
+
+    /** A `Decimal` under two names reads the same way. */
+    @Test
+    void theSameHoldsOverADecimalBase() {
+        Partitions.Partitioning share = partitioningOf("""
+                module example.share
+
+                data Ratio = Decimal
+                    invariant withinOne = value >= 0.0m && value <= 1.0m
+
+                data Share = Ratio
+
+                data Ok = { at: String }
+
+                behavior classify : (s: Share) -> Ok
+                    constructs Ok
+
+                let classify (s) = Ok { at = "x" }
+                """, "classify");
+
+        assertEquals(List.of(new ObservedValue.Decimal(java.math.BigDecimal.ZERO),
+                        new ObservedValue.Decimal(new java.math.BigDecimal("1.0"))),
+                axis(share, "s").cuts().stream().map(Cut::value).toList(),
+                "`>= 0.0m` is read as non-negative, which is the zero the reader already normalises to");
+    }
+
     @Test
     void aTypeTheModelDrawsNoLineThroughIsNotDerivable() {
         Axis note = axis(partitioningOf(KINDS, "submit"), "request.note");


### PR DESCRIPTION
Closes #461.

`data StartMinute = Minute` where `Minute = Int` is a number the language compares and bounds, and one
the analysis did not model as a number at all. No atom stood for it, so a `guard` over it entered no
reasoning; no bound was read off it, so the position was reported as one the model draws no line
through.

```
                  T = Minute                      T = StartMinute
boundary          0/4                             0/0
                  · s.a = 1439 (within Span)      · not derivable: s.a
                  · s.b = 1    (within Span)      · not derivable: s.b

guard a < b       discharges                      E2011
```

## The distinction that is real, and the one that was not

Arithmetic is closed only over a newtype directly over a number — "a newtype over another newtype does
not" (spec §newtype-arithmetic) — and that is the language's, deliberately. Comparison reaches the
recursive base: "(`Manager = Level = Int`) reaches its base" (ADR-0047).

`TypeOps` has both and the names are right, `directNumericNewtypeBase` down to the word *direct*. What
was wrong is that the analyser reused the arithmetic answer as its general notion of a number, so
atoms, bounds and guard reasoning inherited a cutoff meant for arithmetic. Making a newtype lookup
recursive would have repaired the symptom by deleting a distinction the language means.

## Three commits, in the order the causes come apart

**Name the question the analyser is actually asking.** `isNumeric` read like a fact about the type and
was a fact about arithmetic; it is gone, and the analyser's capability is named for the domain that
has it — `affineScalarBase` — and answers with the carrier rather than yes, so `granularityOf` stops
classifying the same type a second time. No answer changes. The three questions and the answer each
gives are written down as a table beside them.

**The domain carries every number the language calls one.** `affineScalarBase` delegates to
`TypeOps.numericBase`, the recursive base filtered to the two the domain holds. The delegation is
where the reason they agree is written: the domain holds a scalar, and a value the language compares
as a number is one it can hold. Not one question — an equality reaches values no domain carries — so
where they come apart the delegation stops. One cell of the table moves.

**How far a newtype reaches is written down once.** Finding the carrier and collecting the rules along
the way are two jobs and the second stopped at the outermost name for its own reason:
`Inner: value >= 0` under `Outer: value <= 10` is `[0, 10]` and only `Outer`'s half was read.
`TypeOps.newtypeChain` says how far a newtype reaches and the readers ask it rather than walking
again — `boundsOf` growing its own recursion would have made a second answer to a question the seeding
already answers its own way. Each end keeps the name that drew it, so a bound `Minute` wrote is not
reported as `StartMinute`'s. `everyRuleBecameABound` was a third reading of the same thing and is now
the same one.

## What is held to what

The capability table is the executable half of the diagnosis — six types against three questions — so
a change to any of them shows as a cell, and which cell says whether the language's capability moved
or the analyser's did. Above it: atom visibility, constraint visibility, guard discharge, boundary
derivation, and that `StartMinute + StartMinute` stays E1324, which is the spec and not a regression.

## What changed for a compiling program

Nothing on `souther-examples` — no model there wraps a number twice.

```
E2011  19 -> 19        E2010  0 -> 0
boundaries counted     138 -> 138      said and not counted  82 -> 82
adequacy verdicts      every module unchanged
```

Where a model does wrap a number twice, a guard over it now discharges what the same guard discharges
one layer down, and rules that were invisible become visible — the direction #466 moved things.

## Left in

`seedAt` still recurses through a newtype itself. It does more than walk — it substitutes what each
field is given, and it is depth limited — so folding it onto the chain is a change to a load-bearing
walk rather than a tidy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
