### PR TITLE
A boundary is settled by evidence, and one place gathers it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -241,15 +241,18 @@ public final class Generator {
     /**
      * What building a row at one boundary came to: the row, or why there is none.
      *
-     * <p>Exactly one of the two. A caller measuring the boundary reads whether a row was built, which
-     * is a value that went through the decoder and so a witness that the edge can be written; a caller
-     * offering work to a person reads the row itself. The attempt is made once and both read it.
+     * <p>One or the other, and the type says so. A caller measuring the boundary reads whether a row
+     * was built, which is a value that went through the decoder and so a witness that the edge can be
+     * written; a caller offering work to a person reads the row itself. The attempt is made once and
+     * both read it.
      */
-    public record BoundaryAttempt(GeneratedRow row, UnresolvedCombination unresolved) {
+    public sealed interface BoundaryAttempt {
 
-        public boolean built() {
-            return row != null;
-        }
+        /** A value with the edge in it, built and accepted. */
+        record Built(GeneratedRow row) implements BoundaryAttempt {}
+
+        /** No row came of it, and why. Never a statement that none exists. */
+        record Unresolved(UnresolvedCombination why) implements BoundaryAttempt {}
     }
 
     /**
@@ -267,13 +270,13 @@ public final class Generator {
         Axis axis = subject.axes().stream().filter(a -> a.id().equals(obligation.axis())).findFirst()
                 .orElse(null);
         if (axis == null) {
-            return new BoundaryAttempt(null, new UnresolvedCombination(List.of(),
+            return new BoundaryAttempt.Unresolved(new UnresolvedCombination(List.of(),
                     UnresolvedCombination.Reason.NO_REPRESENTATIVE));
         }
         String label = axis.path() + " = " + written(obligation.value());
         FixtureTemplate at = valueOf(obligation.value(), axis.type(), subject.symbols());
         if (at == null) {
-            return new BoundaryAttempt(null, new UnresolvedCombination(List.of(label),
+            return new BoundaryAttempt.Unresolved(new UnresolvedCombination(List.of(label),
                     UnresolvedCombination.Reason.NO_REPRESENTATIVE));
         }
         List<FixtureTemplate> inputs = new ArrayList<>();
@@ -290,12 +293,12 @@ public final class Generator {
                             ? Map.of(axis.path().toString(), List.of(at)) : Map.of();
             Outcome tried = valueAt(subject, p, here, settled, check);
             if (tried.value() == null) {
-                return new BoundaryAttempt(null,
+                return new BoundaryAttempt.Unresolved(
                         new UnresolvedCombination(List.of(label), tried.reason(), tried.detail()));
             }
             inputs.add(tried.value());
         }
-        return new BoundaryAttempt(new GeneratedRow(List.of(label), inputs), null);
+        return new BoundaryAttempt.Built(new GeneratedRow(List.of(label), inputs));
     }
 
     // --- the pair space -------------------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -239,55 +239,63 @@ public final class Generator {
     }
 
     /**
-     * Rows at the boundaries nothing has been written at.
+     * What building a row at one boundary came to: the row, or why there is none.
+     *
+     * <p>Exactly one of the two. A caller measuring the boundary reads whether a row was built, which
+     * is a value that went through the decoder and so a witness that the edge can be written; a caller
+     * offering work to a person reads the row itself. The attempt is made once and both read it.
+     */
+    public record BoundaryAttempt(GeneratedRow row, UnresolvedCombination unresolved) {
+
+        public boolean built() {
+            return row != null;
+        }
+    }
+
+    /**
+     * A row at one boundary, built through the module's own decoders.
      *
      * <p>One row per boundary rather than one row covering several, because a row is a question put to
      * a person and a row sitting on three edges at once is three answers they have to separate.
+     *
+     * <p>Nothing here decides that a boundary cannot be written at. A refusal is a refusal of the
+     * candidates that were tried, and another value of the same edge may build; what comes back says
+     * which of the two happened and leaves the reading to the caller.
      */
-    public static GenerationResult forBoundaries(Subject subject, List<BoundaryObligation> unmet,
-                                                 CandidateCheck check) {
-        List<GeneratedRow> rows = new ArrayList<>();
-        List<UnresolvedCombination> unresolved = new ArrayList<>();
-        for (BoundaryObligation each : unmet) {
-            Axis axis = subject.axes().stream().filter(a -> a.id().equals(each.axis())).findFirst()
-                    .orElse(null);
-            if (axis == null) {
-                continue;
-            }
-            String label = axis.path() + " = " + written(each.value());
-            FixtureTemplate at = valueOf(each.value(), axis.type(), subject.symbols());
-            if (at == null) {
-                unresolved.add(new UnresolvedCombination(List.of(label),
-                        UnresolvedCombination.Reason.NO_REPRESENTATIVE));
-                continue;
-            }
-            List<FixtureTemplate> inputs = new ArrayList<>();
-            UnresolvedCombination left = null;
-            // What the rest of the row has to sit beside. A field of a record is not chosen from its
-            // own type once another field of that record is fixed: the rule relating them says what
-            // is left, and taking the bottom of the type's range instead is how a boundary that can
-            // be written came back as one every value tried was refused at.
-            BigDecimal settledAt = numberOf(each.value());
-            Map<String, BigDecimal> settled = settledAt == null ? Map.of()
-                    : Map.of(axis.path().toString(), settledAt);
-            for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
-                Map<String, List<FixtureTemplate>> here =
-                        TermPath.of(subject.parameters().get(p)).head().equals(axis.path().head())
-                                ? Map.of(axis.path().toString(), List.of(at)) : Map.of();
-                Outcome tried = valueAt(subject, p, here, settled, check);
-                if (tried.value() == null) {
-                    left = new UnresolvedCombination(List.of(label), tried.reason(), tried.detail());
-                    break;
-                }
-                inputs.add(tried.value());
-            }
-            if (left != null) {
-                unresolved.add(left);
-                continue;
-            }
-            rows.add(new GeneratedRow(List.of(label), inputs));
+    public static BoundaryAttempt probe(Subject subject, BoundaryObligation obligation,
+                                        CandidateCheck check) {
+        Axis axis = subject.axes().stream().filter(a -> a.id().equals(obligation.axis())).findFirst()
+                .orElse(null);
+        if (axis == null) {
+            return new BoundaryAttempt(null, new UnresolvedCombination(List.of(),
+                    UnresolvedCombination.Reason.NO_REPRESENTATIVE));
         }
-        return new GenerationResult(rows, unresolved, List.of());
+        String label = axis.path() + " = " + written(obligation.value());
+        FixtureTemplate at = valueOf(obligation.value(), axis.type(), subject.symbols());
+        if (at == null) {
+            return new BoundaryAttempt(null, new UnresolvedCombination(List.of(label),
+                    UnresolvedCombination.Reason.NO_REPRESENTATIVE));
+        }
+        List<FixtureTemplate> inputs = new ArrayList<>();
+        // What the rest of the row has to sit beside. A field of a record is not chosen from its
+        // own type once another field of that record is fixed: the rule relating them says what
+        // is left, and taking the bottom of the type's range instead is how a boundary that can
+        // be written came back as one every value tried was refused at.
+        BigDecimal settledAt = numberOf(obligation.value());
+        Map<String, BigDecimal> settled = settledAt == null ? Map.of()
+                : Map.of(axis.path().toString(), settledAt);
+        for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
+            Map<String, List<FixtureTemplate>> here =
+                    TermPath.of(subject.parameters().get(p)).head().equals(axis.path().head())
+                            ? Map.of(axis.path().toString(), List.of(at)) : Map.of();
+            Outcome tried = valueAt(subject, p, here, settled, check);
+            if (tried.value() == null) {
+                return new BoundaryAttempt(null,
+                        new UnresolvedCombination(List.of(label), tried.reason(), tried.detail()));
+            }
+            inputs.add(tried.value());
+        }
+        return new BoundaryAttempt(new GeneratedRow(List.of(label), inputs), null);
     }
 
     // --- the pair space -------------------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -815,10 +815,13 @@ public final class Adequacy {
             for (BoundaryAssessment each : boundaries) {
                 switch (each.attempt()) {
                     case BoundaryAssessment.Attempt.Built built -> rows.add(built.row());
-                    case BoundaryAssessment.Attempt.Refused why -> unresolved.add(why.why());
-                    // Nothing was tried. Only one of the reasons is news: the decoders could not be
-                    // reached, so this block is short of rows it would otherwise have offered. The
-                    // others are boundaries nobody is owed a row at, and saying so would be noise.
+                    case BoundaryAssessment.Attempt.Unresolved why -> unresolved.add(why.why());
+                    // Nothing was tried. Two of the reasons are news — the decoders could not be
+                    // reached, so this block is short of rows it would otherwise have offered — and
+                    // the other two are boundaries nobody is owed a row at, where saying so would be
+                    // noise. The two that are said arrive under one code, which is as fine a
+                    // distinction as the report has: a module that failed to generate and a runtime
+                    // that is not on the classpath are different, and nothing downstream can say so.
                     case BoundaryAssessment.Attempt.NotAttempted absent -> {
                         if (absent.reason() == BoundaryAssessment.Attempt.Reason.RUNTIME_ABSENT
                                 || absent.reason()

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -716,9 +716,10 @@ public final class Adequacy {
     /**
      * Rows that would fill what every behavior of one module has not covered.
      *
-     * <p>Its own key rather than part of the coverage, because it costs what the coverage does not: it
-     * builds values through the derived decoders to find out which of them a model admits. A report
-     * nobody asked to generate rows for should not pay for that.
+     * <p>Its own key rather than part of the coverage, because filling the combinations searches the
+     * pair space, which nobody who only wanted a report should pay for. The rows at the edges are not
+     * that: {@link Boundaries} builds one value per line to find out whether a line can be written at,
+     * and the row that comes of it is read from there rather than searched for again.
      *
      * <p>The two kinds of row stay apart in the answer. Filling a combination and writing a row at an
      * edge are different requests, asked with different flags, and a caller that merged them could not
@@ -774,7 +775,7 @@ public final class Adequacy {
                 if (sig == null) {
                     continue;
                 }
-                Generator.GenerationResult atEdges = offered(
+                Generator.GenerationResult atEdges = offered(spec.name(),
                         boundaries == null ? List.of()
                                 : boundaries.getOrDefault(spec.name(), List.of()));
                 try {
@@ -798,53 +799,37 @@ public final class Adequacy {
         }
 
         /**
-         * The rows at the edges, read off what the boundary assessment already built.
+         * The rows at the edges, read off what the boundary assessment already tried.
          *
-         * <p>Nothing is built here. A value at an edge was constructed to find out whether one could
-         * be, and the row that came of it is the row an author is offered — the same attempt read for
-         * a second purpose rather than made a second time. Which is what keeps the report and this
-         * block from naming different sets of boundaries.
+         * <p>Nothing is built here, and nothing is worked out from the verdict either. The attempt
+         * says what happened; this prints it. Reading it back off {@link BoundaryAssessment#writability()}
+         * would lose the case that matters most to an author — an edge the projection proves is
+         * writable and the search could not produce a row for — which came out as a verdict of
+         * "provable" with nothing said about the row that never appeared.
          */
-        private static Generator.GenerationResult offered(List<BoundaryAssessment> boundaries) {
+        private static Generator.GenerationResult offered(String behavior,
+                                                          List<BoundaryAssessment> boundaries) {
             List<Generator.GeneratedRow> rows = new ArrayList<>();
             List<Generator.UnresolvedCombination> unresolved = new ArrayList<>();
+            List<Incompleteness> stopped = new ArrayList<>();
             for (BoundaryAssessment each : boundaries) {
-                switch (each.writability()) {
-                    case BoundaryAssessment.Writability.WitnessedByConstruction built ->
-                            rows.add(built.row());
-                    case BoundaryAssessment.Writability.Unknown why -> {
-                        Generator.UnresolvedCombination.Reason said = unresolvedFor(why.reason());
-                        if (said != null) {
-                            unresolved.add(new Generator.UnresolvedCombination(
-                                    List.of(each.label()), said, why.detail()));
+                switch (each.attempt()) {
+                    case BoundaryAssessment.Attempt.Built built -> rows.add(built.row());
+                    case BoundaryAssessment.Attempt.Refused why -> unresolved.add(why.why());
+                    // Nothing was tried. Only one of the reasons is news: the decoders could not be
+                    // reached, so this block is short of rows it would otherwise have offered. The
+                    // others are boundaries nobody is owed a row at, and saying so would be noise.
+                    case BoundaryAssessment.Attempt.NotAttempted absent -> {
+                        if (absent.reason() == BoundaryAssessment.Attempt.Reason.RUNTIME_ABSENT
+                                || absent.reason()
+                                        == BoundaryAssessment.Attempt.Reason.NO_CLASSES) {
+                            stopped.add(Incompleteness.of(Incompleteness.Code.RUNTIME_ABSENT,
+                                    Incompleteness.Scope.BEHAVIOR, behavior));
                         }
                     }
-                    // A row is already at it, or the model proves one can be written and the attempt
-                    // that would have offered it was not needed. Neither is a piece of work to hand
-                    // over: the first is done, and the second is a boundary nothing missed.
-                    default -> { }
                 }
             }
-            return new Generator.GenerationResult(rows, unresolved, List.of());
-        }
-
-        /**
-         * Why no row was built, in the words the block prints — or nothing, where the block has
-         * nothing to say.
-         *
-         * <p>An attempt that was never made is the second. Every reason here describes what happened
-         * to a candidate, and a line saying "no value can be written there" about a boundary nothing
-         * was tried at would be a claim about the model made out of a missing classpath. What stopped
-         * the whole behavior is already said, once, where it stopped.
-         */
-        private static Generator.UnresolvedCombination.Reason unresolvedFor(
-                BoundaryAssessment.Writability.Unknown.Reason reason) {
-            return switch (reason) {
-                case REFUSED -> Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED;
-                case SEARCH_LIMIT -> Generator.UnresolvedCombination.Reason.SEARCH_LIMIT;
-                case NO_REPRESENTATIVE -> Generator.UnresolvedCombination.Reason.NO_REPRESENTATIVE;
-                case NOT_ATTEMPTED -> null;
-            };
+            return new Generator.GenerationResult(rows, unresolved, distinct(stopped));
         }
 
         private static Generator.GenerationResult pairsFor(

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -20,7 +20,6 @@ import souther.compiler.observe.RowOutcome;
 import souther.compiler.observe.Stage;
 import souther.compiler.partition.Axis;
 import souther.compiler.partition.AxisId;
-import souther.compiler.partition.BoundaryObligation;
 import souther.compiler.partition.Exclusions;
 import souther.compiler.partition.Generator;
 import souther.compiler.partition.RowClasses;
@@ -254,10 +253,9 @@ public final class Adequacy {
                     souther.compiler.coverage.CoverageSites.of(sourceIdOf(db, name), bodies);
             Map<String, Observed> byTarget = rowsOf(db, name);
             Map<String, Exclusions> excluded = db.ask(new Excluded(name)).value();
-            // Whether a guard's boundary can be decided at all: meeting it takes the comparison having
-            // been evaluated, which only the instrumented classes say. Read off the rows rather than
-            // off what was asked for — asking is not evidence that it happened.
-            boolean armsMeasured = levelOf(db).measuresArms();
+            // What every line this module's rules drew came to, asked once and read here. Measuring a
+            // line takes building values, which is not this measure's work and not work to do twice.
+            Map<String, List<BoundaryAssessment>> boundaries = db.ask(new Boundaries(name)).value();
 
             Map<String, PartitionEvidence> out = new LinkedHashMap<>();
             for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
@@ -269,11 +267,10 @@ public final class Adequacy {
                     continue;
                 }
                 Observed seen = byTarget.getOrDefault(spec.name(), Observed.NONE);
-                // Asked and readable are handed over apart. A line nobody asked about and one whose
-                // instrumentation was lost are both unmeasured, and only the second is a run that
-                // failed at it; one boolean for the pair leaves the measure unable to say which.
                 out.put(spec.name(), Coverages.of(spec, sig, scope.value(), bodies.get(spec.name()),
-                        plan, seen, armsMeasured,
+                        plan, seen,
+                        boundaries == null ? List.of()
+                                : boundaries.getOrDefault(spec.name(), List.of()),
                         excluded == null ? Exclusions.NONE
                                 : excluded.getOrDefault(spec.name(), Exclusions.NONE)));
             }
@@ -285,6 +282,119 @@ public final class Adequacy {
             return layout == null ? module : layout.idOfModule().getOrDefault(module, module);
         }
 
+    }
+
+    /**
+     * What is known about every line each behavior's rules drew.
+     *
+     * <p>The one authority on a boundary. Whether a row sits at it and whether a row could sit at it
+     * were established in two places under two sets of rules — the report read one, the generator read
+     * the other — and the two disagreed about the same line: a boundary the report declined to name
+     * because a row had gone unread was one the generator handed to an author anyway, and a boundary
+     * the projection could not promise was one the generator had already built a value for and thrown
+     * the answer away.
+     *
+     * <p>Its own key rather than part of the coverage, because it costs what a coverage count does not:
+     * it puts values through this module's own decoders. Not behind the flag that prints rows, though.
+     * Whether a value can be built is evidence, and whether an author is handed the row that proves it
+     * is a separate request — the first decides what the report may count, so tying it to the second
+     * would make one measure's number depend on another flag.
+     */
+    public record Boundaries(String name) implements Key<Map<String, List<BoundaryAssessment>>> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, List<BoundaryAssessment>>> compute(Db db) {
+            Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
+            if (!prepared.present() || !scope.present() || !sigs.present()) {
+                return Answer.absent();
+            }
+            souther.compiler.check.TypeChecker.Checked checked =
+                    db.ask(new Bodies.Checked(name)).value();
+            Map<String, souther.compiler.core.Core> bodies =
+                    checked == null ? Map.of() : checked.behaviorBodies();
+            souther.compiler.coverage.CoverageSites.Plan plan =
+                    souther.compiler.coverage.CoverageSites.of(
+                            Coverage.sourceIdOf(db, name), bodies);
+            Map<String, Observed> byTarget = rowsOf(db, name);
+            Map<String, Exclusions> excluded = db.ask(new Excluded(name)).value();
+            Symbols symbols = scope.value();
+            // Whether a guard's boundary can be decided at all: meeting it takes the comparison having
+            // been evaluated, which only the instrumented classes say.
+            boolean armsAsked = levelOf(db).measuresArms();
+            FixtureReader.Construction building = constructing(db, name, prepared.value(), symbols);
+
+            Map<String, List<BoundaryAssessment>> out = new LinkedHashMap<>();
+            for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
+                if (!(behavior instanceof Ast.SpecBehavior spec)) {
+                    continue;   // a composition's inputs are its first stage's, measured there
+                }
+                Sig sig = sigs.value().get(spec.name());
+                if (sig == null) {
+                    continue;
+                }
+                out.put(spec.name(), assess(spec, sig, symbols, bodies.get(spec.name()), plan,
+                        byTarget.getOrDefault(spec.name(), Observed.NONE), armsAsked, building,
+                        excluded == null ? Exclusions.NONE
+                                : excluded.getOrDefault(spec.name(), Exclusions.NONE)));
+            }
+            return Answer.of(Ordered.map(out));
+        }
+
+        /** Every line of one behavior, with what the rows and the decoder say about each. */
+        private static List<BoundaryAssessment> assess(
+                Ast.SpecBehavior spec, Sig sig, Symbols symbols, souther.compiler.core.Core body,
+                souther.compiler.coverage.CoverageSites.Plan plan, Observed observed,
+                boolean armsAsked, FixtureReader.Construction building, Exclusions excluded) {
+            List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
+            souther.compiler.partition.Partitions.Partitioning partitioning =
+                    Coverages.partitioningOf(spec, sig, symbols, body, plan, excluded);
+            Coverages.Probe probe = probing(partitioning, sig, symbols, parameters, building);
+            List<BoundaryAssessment> out = new ArrayList<>();
+            for (Axis axis : partitioning.axes()) {
+                if (!axis.measurable()) {
+                    continue;
+                }
+                out.addAll(Coverages.assess(axis, parameters, observed, symbols, armsAsked,
+                        partitioning.edgeIsKnownWritable(axis.path().toString()), probe));
+            }
+            return List.copyOf(out);
+        }
+
+        /**
+         * A way to try to build a row at a boundary, or nothing where there is nothing to try against.
+         *
+         * <p>Nothing rather than a check that refuses nothing. A row built without the decoder is a row
+         * nobody has put through anything, and counting one as a witness would turn "the classes are
+         * missing" into "the edge can be written".
+         */
+        private static Coverages.Probe probing(
+                souther.compiler.partition.Partitions.Partitioning partitioning, Sig sig,
+                Symbols symbols, List<String> parameters, FixtureReader.Construction building) {
+            if (building == null) {
+                return null;
+            }
+            Generator.Subject subject = new Generator.Subject(parameters, sig.inputTypes(),
+                    partitioning.axes(), symbols);
+            Generator.CandidateCheck check =
+                    (at, candidate) -> building.refuse(sig.ins().get(at), candidate.value());
+            return obligation -> {
+                try {
+                    return Generator.probe(subject, obligation, check);
+                } catch (LinkageError _) {
+                    // The runtime is not on this host's classpath, so nothing can be built to find out
+                    // what a model admits. Nothing was tried, which is not the same as everything
+                    // tried being refused, and neither of them says the edge cannot be written.
+                    return null;
+                }
+            };
+        }
     }
 
 
@@ -651,9 +761,11 @@ public final class Adequacy {
             Map<String, Exclusions> excluded = db.ask(new Excluded(name)).value();
             Symbols symbols = scope.value();
 
+            Map<String, List<BoundaryAssessment>> boundaries =
+                    db.ask(new Boundaries(name)).value();
+
             Map<String, Filling> out = new LinkedHashMap<>();
-            FixtureReader.Construction building =
-                    constructing(db, name, prepared.value(), symbols, sigs.value());
+            FixtureReader.Construction building = constructing(db, name, prepared.value(), symbols);
             for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
                 if (!(behavior instanceof Ast.SpecBehavior spec)) {
                     continue;
@@ -662,14 +774,16 @@ public final class Adequacy {
                 if (sig == null) {
                     continue;
                 }
+                Generator.GenerationResult atEdges = offered(
+                        boundaries == null ? List.of()
+                                : boundaries.getOrDefault(spec.name(), List.of()));
                 try {
-                    out.put(spec.name(), rowsFor(spec, sig, symbols, bodies.get(spec.name()), plan,
+                    out.put(spec.name(), new Filling(pairsFor(spec, sig, symbols,
+                            bodies.get(spec.name()), plan,
                             byTarget.getOrDefault(spec.name(), Observed.NONE), building,
-                            levelOf(db).measuresArms()
-                                    && !byTarget.getOrDefault(spec.name(), Observed.NONE)
-                                            .armsUnseen(),
                             excluded == null ? Exclusions.NONE
-                                    : excluded.getOrDefault(spec.name(), Exclusions.NONE)));
+                                    : excluded.getOrDefault(spec.name(), Exclusions.NONE)),
+                            atEdges));
                 } catch (LinkageError _) {
                     // The runtime is not on this host's classpath, so nothing can be built to find out
                     // what a model admits. Saying so is not the same as saying the combinations are
@@ -683,34 +797,66 @@ public final class Adequacy {
             return Answer.of(Ordered.map(out));
         }
 
-        /** A way to build values against this module's own classes, or nothing where there are none to
-         * build against. */
-        private static FixtureReader.Construction constructing(
-                Db db, String module, Ast.Module written, Symbols symbols, Map<String, Sig> sigs) {
-            Map<String, byte[]> classes = db.ask(new Output.Linked(module)).value();
-            Map<String, List<BehaviorRequirement>> requirements =
-                    db.ask(new Bodies.Requirements(module)).value();
-            if (classes == null || requirements == null) {
-                return null;
+        /**
+         * The rows at the edges, read off what the boundary assessment already built.
+         *
+         * <p>Nothing is built here. A value at an edge was constructed to find out whether one could
+         * be, and the row that came of it is the row an author is offered — the same attempt read for
+         * a second purpose rather than made a second time. Which is what keeps the report and this
+         * block from naming different sets of boundaries.
+         */
+        private static Generator.GenerationResult offered(List<BoundaryAssessment> boundaries) {
+            List<Generator.GeneratedRow> rows = new ArrayList<>();
+            List<Generator.UnresolvedCombination> unresolved = new ArrayList<>();
+            for (BoundaryAssessment each : boundaries) {
+                switch (each.writability()) {
+                    case BoundaryAssessment.Writability.WitnessedByConstruction built ->
+                            rows.add(built.row());
+                    case BoundaryAssessment.Writability.Unknown why -> {
+                        Generator.UnresolvedCombination.Reason said = unresolvedFor(why.reason());
+                        if (said != null) {
+                            unresolved.add(new Generator.UnresolvedCombination(
+                                    List.of(each.label()), said, why.detail()));
+                        }
+                    }
+                    // A row is already at it, or the model proves one can be written and the attempt
+                    // that would have offered it was not needed. Neither is a piece of work to hand
+                    // over: the first is done, and the second is a boundary nothing missed.
+                    default -> { }
+                }
             }
-            Map<String, Ast.FnDef> values = db.ask(new Bodies.ModuleDefinitions(module)).value();
-            // `requirements` is asked above as a readiness condition, not as an input: whether a
-            // value builds at this module's boundary is the decoder's answer, and nothing here runs.
-            return FixtureReader.constructing(written, symbols, classes,
-                    Output.loader(db, Map.of()), values == null ? Map.of() : values);
+            return new Generator.GenerationResult(rows, unresolved, List.of());
         }
 
-        private static Filling rowsFor(
+        /**
+         * Why no row was built, in the words the block prints — or nothing, where the block has
+         * nothing to say.
+         *
+         * <p>An attempt that was never made is the second. Every reason here describes what happened
+         * to a candidate, and a line saying "no value can be written there" about a boundary nothing
+         * was tried at would be a claim about the model made out of a missing classpath. What stopped
+         * the whole behavior is already said, once, where it stopped.
+         */
+        private static Generator.UnresolvedCombination.Reason unresolvedFor(
+                BoundaryAssessment.Writability.Unknown.Reason reason) {
+            return switch (reason) {
+                case REFUSED -> Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED;
+                case SEARCH_LIMIT -> Generator.UnresolvedCombination.Reason.SEARCH_LIMIT;
+                case NO_REPRESENTATIVE -> Generator.UnresolvedCombination.Reason.NO_REPRESENTATIVE;
+                case NOT_ATTEMPTED -> null;
+            };
+        }
+
+        private static Generator.GenerationResult pairsFor(
                 Ast.SpecBehavior spec, Sig sig, Symbols symbols, souther.compiler.core.Core body,
                 souther.compiler.coverage.CoverageSites.Plan plan, Observed observed,
-                FixtureReader.Construction building, boolean armsMeasured, Exclusions excluded) {
+                FixtureReader.Construction building, Exclusions excluded) {
             if (observed.someRowsUnseen()) {
                 // Rows exist that nothing read. What they cover is unknown, so what is left uncovered
                 // is unknown too — and a generated row is a specific piece of work handed to a person,
                 // which may already be sitting in the file that could not be evaluated.
-                Generator.GenerationResult stopped = new Generator.GenerationResult(List.of(),
-                        List.of(), observed.incompleteness());
-                return new Filling(stopped, stopped);
+                return new Generator.GenerationResult(List.of(), List.of(),
+                        observed.incompleteness());
             }
             List<RowOutcome> rows = observed.rows();
             List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
@@ -723,14 +869,34 @@ public final class Adequacy {
 
             List<Map<AxisId, Classification>> existing = rows.stream()
                     .map(row -> RowClasses.of(row, parameters, partitioning.axes())).toList();
-            Generator.GenerationResult pairs = Generator.fill(subject, existing, check);
-
-            List<BoundaryObligation> unmet = new ArrayList<>();
-            for (Axis axis : partitioning.axes()) {
-                unmet.addAll(Coverages.unmet(axis, parameters, rows, symbols, armsMeasured));
-            }
-            return new Filling(pairs, Generator.forBoundaries(subject, unmet, check));
+            return Generator.fill(subject, existing, check);
         }
+    }
+
+    /**
+     * A way to build values against this module's own classes, or nothing where there are none to
+     * build against.
+     *
+     * <p>The classes an evaluation runs against, not a second generation of them. Whether a value
+     * builds is the decoder's answer and the counting an evaluation carries does not change it —
+     * nothing here runs a row, so no budget is installed and the counted entry points count against
+     * nothing. Asking for the uncounted classes instead would generate every one of them again to get
+     * the same answers.
+     */
+    static FixtureReader.Construction constructing(Db db, String module, Ast.Module written,
+                                                   Symbols symbols) {
+        Map<String, byte[]> classes =
+                db.ask(new Output.EvaluationLinked(module, coverageAsked(db))).value();
+        Map<String, List<BehaviorRequirement>> requirements =
+                db.ask(new Bodies.Requirements(module)).value();
+        if (classes == null || requirements == null) {
+            return null;
+        }
+        Map<String, Ast.FnDef> values = db.ask(new Bodies.ModuleDefinitions(module)).value();
+        // `requirements` is asked above as a readiness condition, not as an input: whether a
+        // value builds at this module's boundary is the decoder's answer, and nothing here runs.
+        return FixtureReader.constructing(written, symbols, classes,
+                Output.evaluationLoader(db), values == null ? Map.of() : values);
     }
 
     /**
@@ -908,14 +1074,14 @@ public final class Adequacy {
                             behavior.pos(), List.of(missing)));
                 }
             }
-            for (PartitionEvidence.BoundaryCoverage boundary : partition.boundaries()) {
-                // A boundary nothing promises is writable is not a gap. Every rule reaching the
-                // value it sits in was not read, so this edge is where the reading stopped rather
-                // than where the model does, and a row at it may be one nobody can write.
-                if (boundary.status() == MeasurementStatus.COMPLETE && !boundary.hit()
-                        && boundary.knownWritable()) {
-                    out.add(new Finding(Kind.BOUNDARY_UNMET, behavior.name(), boundary.status(),
-                            behavior.pos(),
+            for (BoundaryAssessment boundary : partition.boundaries()) {
+                // Both halves, asked of the two answers the assessment keeps apart. A line no row was
+                // measured against is not a gap, and neither is one nothing has shown a row can be
+                // written at — that edge is where the reading stopped rather than where the model
+                // does, and a row at it may be one nobody can write.
+                if (boundary.isUnmetGap()) {
+                    out.add(new Finding(Kind.BOUNDARY_UNMET, behavior.name(),
+                            MeasurementStatus.COMPLETE, behavior.pos(),
                             List.of(boundary.axis(), boundary.value(), boundary.origin())));
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryAssessment.java
@@ -8,15 +8,18 @@ import souther.compiler.partition.Generator;
 import java.math.BigDecimal;
 
 /**
- * Everything known about one boundary a rule drew: whether a row sits at it, and whether a row can be
- * written there at all.
+ * Everything known about one boundary a rule drew.
  *
- * <p>Two answers rather than one word. They are established by different means and fail to be
- * established for different reasons: a row at the value is read off what this compilation ran, and
- * whether such a row can exist is settled by putting a value through the decoder. Writing the pair out
- * as a single state means writing the product of the two by hand, and the product has combinations
- * nothing rules out — a value nothing has been written at that something has built, and a value a row
- * sits on whose position nothing could promise.
+ * <p>Three answers rather than one state, because they are about three things and are established by
+ * three different means. What the rows showed is read off what this compilation ran. What is proven
+ * about a value existing there comes from the rules, or from a value that went through the decoder.
+ * What the search did is what the search did — and it is kept even where it changed neither of the
+ * others, because an edge the rules already prove is still one a search can fail to produce a row
+ * for, and the person who wanted that row is owed the reason.
+ *
+ * <p>Writing them as a single word means writing the product of three by hand, and the product has
+ * combinations nothing rules out: a value nothing has been written at that something built, a value a
+ * row sits on whose position nothing could promise, a value the rules prove and no search reached.
  *
  * <p>One of these per obligation, made in one place. What a report prints, what a build is warned
  * about and what the generator offers are three readings of this and not three measurements.
@@ -114,9 +117,16 @@ public record BoundaryAssessment(BoundaryObligation obligation, Coverage coverag
         /** A value with the edge in it, built and accepted by the module's own decoders. */
         record Built(Generator.GeneratedRow row) implements Attempt {}
 
-        /** Candidates were built and none survived, or none could be chosen. What the search met,
-         * in its own words, so that what is printed about it says what happened. */
-        record Refused(Generator.UnresolvedCombination why) implements Attempt {}
+        /**
+         * The search ran and no row came of it.
+         *
+         * <p>Named for what happened and not for one of the ways it happens. Every candidate being
+         * refused is one of them; a position with no value to write at all, and a search that stopped
+         * before it got here, are the others, and only the first is the decoder saying anything. A
+         * name that said "refused" would invite a reader to take the other two for a decision the
+         * decoder made — which is the mistake this type exists to prevent, one size down.
+         */
+        record Unresolved(Generator.UnresolvedCombination why) implements Attempt {}
 
         /** Nothing was tried, and why not. Separate from a refusal because they license different
          * sentences: one is a fact about values, the other is a fact about this run. */

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryAssessment.java
@@ -1,0 +1,193 @@
+package souther.compiler.query;
+
+import souther.compiler.observe.MeasurementStatus;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.partition.BoundaryObligation;
+import souther.compiler.partition.Generator;
+
+import java.math.BigDecimal;
+
+/**
+ * Everything known about one boundary a rule drew: whether a row sits at it, and whether a row can be
+ * written there at all.
+ *
+ * <p>Two answers rather than one word. They are established by different means and fail to be
+ * established for different reasons: a row at the value is read off what this compilation ran, and
+ * whether such a row can exist is settled by putting a value through the decoder. Writing the pair out
+ * as a single state means writing the product of the two by hand, and the product has combinations
+ * nothing rules out — a value nothing has been written at that something has built, and a value a row
+ * sits on whose position nothing could promise.
+ *
+ * <p>One of these per obligation, made in one place. What a report prints, what a build is warned
+ * about and what the generator offers are three readings of this and not three measurements.
+ */
+public record BoundaryAssessment(BoundaryObligation obligation, Coverage coverage,
+                                 Writability writability) {
+
+    /**
+     * Whether a row sits at the value, and whether that could be told.
+     *
+     * <p>An obligation from an invariant is met by a row whose value is the boundary. One from a guard
+     * is not: the comparison has to have been evaluated as well, because a value can reach the input of
+     * a behavior without reaching the guard that cares about it.
+     */
+    public sealed interface Coverage {
+
+        /** A row is at the value, and — for a guard's line — went through the comparison. Found is
+         * found: a row at the boundary settles this whatever else went unread. */
+        record Hit() implements Coverage {}
+
+        /** Every row that bears on this position was read, and none is at the value. */
+        record Missed() implements Coverage {}
+
+        /** Some row's value here could not be read, or some row was never seen. What is not found is
+         * then undecided rather than absent. */
+        record Undecided() implements Coverage {}
+
+        /** The question was not put. */
+        record NotMeasured(Reason reason) implements Coverage {}
+
+        /** Why a line has no answer. */
+        enum Reason {
+            /** The build did not ask for the arms, and a guard's line is met by reaching the
+             *  comparison rather than by writing the value. Never a reason for an invariant's line,
+             *  which needs no arms. */
+            ARMS_NOT_ASKED,
+            /** The rows ran without instrumentation, so no row can be shown to have reached the
+             *  comparison. Never a reason for an invariant's line. */
+            ARMS_UNREADABLE,
+            /** No row names this behavior. */
+            NO_ROWS
+        }
+
+        default boolean hit() {
+            return this instanceof Hit;
+        }
+    }
+
+    /**
+     * Whether a row can be written at the value, and what says so.
+     *
+     * <p>Three ways to know and one way not to. A refusal is not among the ways to know: the decoder
+     * refusing every candidate that was tried says nothing about the candidates that were not, so a
+     * boundary whose values were all refused stays unknown rather than becoming impossible. Nothing
+     * here can say a boundary is unwritable, and that is the point of the type.
+     */
+    public sealed interface Writability {
+
+        /** Every rule reaching the value this position sits in was read, and the edge is inside what
+         * they leave. Nothing had to be built to know it. */
+        record ProvenByProjection() implements Writability {}
+
+        /** A row already sits at the value, which is a value that went through the decoder. The
+         * strongest of these and the only one that costs nothing to find. */
+        record WitnessedByRow() implements Writability {}
+
+        /** A value with this edge in it was built through the module's own decoder. The row is kept
+         * because it is also the row an author is offered — one attempt, two readers. */
+        record WitnessedByConstruction(Generator.GeneratedRow row) implements Writability {}
+
+        /** Nothing has shown a row can be written here. Not a claim that none can. */
+        record Unknown(Reason reason, String detail) implements Writability {
+
+            public static Unknown of(Reason reason) {
+                return new Unknown(reason, null);
+            }
+
+            /** Why nothing was shown, which decides what an author can do about it. */
+            public enum Reason {
+                /** Candidates were built and the decoder refused every one of them. Another value of
+                 *  the same edge may well build. */
+                REFUSED,
+                /** No value at all can be written at some position of the row. */
+                NO_REPRESENTATIVE,
+                /** The search stopped before reaching it. */
+                SEARCH_LIMIT,
+                /** Nothing was built against: the module's classes or the runtime were not there. */
+                NOT_ATTEMPTED
+            }
+        }
+
+        /** Whether a row is known to be writable here. False leaves it open, never closed. */
+        default boolean known() {
+            return !(this instanceof Unknown);
+        }
+    }
+
+    /**
+     * How far the coverage half got, as the one word every measure is totalled under.
+     *
+     * <p>Derived rather than stored. A report adding up what it could and could not measure asks this
+     * of each measure in turn, and a copy of the answer kept beside the answer is a second thing to
+     * keep in step.
+     */
+    public MeasurementStatus status() {
+        return switch (coverage) {
+            case Coverage.NotMeasured _ -> MeasurementStatus.UNAVAILABLE;
+            case Coverage.Undecided _ -> MeasurementStatus.PARTIAL;
+            case Coverage.Hit _, Coverage.Missed _ -> MeasurementStatus.COMPLETE;
+        };
+    }
+
+    /**
+     * Why the coverage half has no answer, or null where it has one.
+     *
+     * <p>Beside {@link #status()} and derived like it. Every measure that comes back without a number
+     * is asked why, in the same words, and a line that could say {@code UNAVAILABLE} without saying
+     * what stopped it would be the one measure a reader has to guess about.
+     */
+    public Coverage.Reason reason() {
+        return coverage instanceof Coverage.NotMeasured absent ? absent.reason() : null;
+    }
+
+    /** The position this is on, as a report names it. */
+    public String axis() {
+        return obligation.axis().toString();
+    }
+
+    /** The rule that drew the line. */
+    public String origin() {
+        return obligation.origin().describe();
+    }
+
+    public BoundaryObligation.BoundarySide side() {
+        return obligation.side();
+    }
+
+    /** How a row at this boundary describes itself: where the edge is, and what value it takes. The
+     * generator writes these same words on the row it offers, so a row and a note about the boundary
+     * it stands for name it the same way. */
+    public String label() {
+        return obligation.axis().path() + " = " + value();
+    }
+
+    /** The value as an author would write it, not as a record prints itself. */
+    public String value() {
+        BigDecimal number = numberOf(obligation.value());
+        return number == null ? String.valueOf(obligation.value())
+                : number.stripTrailingZeros().toPlainString();
+    }
+
+    /**
+     * Whether this is a row an author is owed: the value was measured and missed, and something has
+     * shown a row can be written there.
+     *
+     * <p>The two halves are asked of the two answers rather than of one flattened state. A missed
+     * boundary nothing promises is writable is not a gap — the edge is where the reading stopped
+     * rather than where the model does — and a boundary nobody measured is not one either.
+     */
+    public boolean isUnmetGap() {
+        return coverage instanceof Coverage.Missed && writability.known();
+    }
+
+    /** A newtype and the number it wraps are the same value here, which is how a row writes it and how
+     * the boundary was read. */
+    private static BigDecimal numberOf(ObservedValue value) {
+        return switch (value) {
+            case ObservedValue.Integer i -> BigDecimal.valueOf(i.value());
+            case ObservedValue.Decimal d -> d.value();
+            case ObservedValue.Constructed c when c.field("value") != null -> numberOf(c.field("value"));
+            case null, default -> null;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryAssessment.java
@@ -22,7 +22,7 @@ import java.math.BigDecimal;
  * about and what the generator offers are three readings of this and not three measurements.
  */
 public record BoundaryAssessment(BoundaryObligation obligation, Coverage coverage,
-                                 Writability writability) {
+                                 Writability writability, Attempt attempt) {
 
     /**
      * Whether a row sits at the value, and whether that could be told.
@@ -83,34 +83,54 @@ public record BoundaryAssessment(BoundaryObligation obligation, Coverage coverag
          * strongest of these and the only one that costs nothing to find. */
         record WitnessedByRow() implements Writability {}
 
-        /** A value with this edge in it was built through the module's own decoder. The row is kept
-         * because it is also the row an author is offered — one attempt, two readers. */
-        record WitnessedByConstruction(Generator.GeneratedRow row) implements Writability {}
+        /** A value with this edge in it was built through the module's own decoder. What was built is
+         * in {@link BoundaryAssessment#attempt()} and not here: this says which evidence settled the
+         * question, and the evidence itself has one home. */
+        record WitnessedByConstruction() implements Writability {}
 
-        /** Nothing has shown a row can be written here. Not a claim that none can. */
-        record Unknown(Reason reason, String detail) implements Writability {
-
-            public static Unknown of(Reason reason) {
-                return new Unknown(reason, null);
-            }
-
-            /** Why nothing was shown, which decides what an author can do about it. */
-            public enum Reason {
-                /** Candidates were built and the decoder refused every one of them. Another value of
-                 *  the same edge may well build. */
-                REFUSED,
-                /** No value at all can be written at some position of the row. */
-                NO_REPRESENTATIVE,
-                /** The search stopped before reaching it. */
-                SEARCH_LIMIT,
-                /** Nothing was built against: the module's classes or the runtime were not there. */
-                NOT_ATTEMPTED
-            }
-        }
+        /** Nothing has shown a row can be written here. Not a claim that none can, and it carries no
+         * reason of its own — what was tried and what came of it is the attempt's to say. */
+        record Unknown() implements Writability {}
 
         /** Whether a row is known to be writable here. False leaves it open, never closed. */
         default boolean known() {
             return !(this instanceof Unknown);
+        }
+    }
+
+    /**
+     * What was built at this boundary, and what came of it.
+     *
+     * <p>Its own answer and not a shade of {@link Writability}. An edge the projection already proved
+     * is one a search can still fail to reach — the two are about different things, and a reader that
+     * recovered the attempt from the verdict would find nothing to say about a row it could not
+     * produce at an edge it knows exists. The report reads the verdict; {@code --generate} reads this.
+     *
+     * <p>Made once. The row a person is offered and the value that witnessed the edge are the same
+     * value, built one time and read twice.
+     */
+    public sealed interface Attempt {
+
+        /** A value with the edge in it, built and accepted by the module's own decoders. */
+        record Built(Generator.GeneratedRow row) implements Attempt {}
+
+        /** Candidates were built and none survived, or none could be chosen. What the search met,
+         * in its own words, so that what is printed about it says what happened. */
+        record Refused(Generator.UnresolvedCombination why) implements Attempt {}
+
+        /** Nothing was tried, and why not. Separate from a refusal because they license different
+         * sentences: one is a fact about values, the other is a fact about this run. */
+        record NotAttempted(Reason reason) implements Attempt {}
+
+        enum Reason {
+            /** A row already sits at the value. There is nothing to find out and nothing to offer. */
+            A_ROW_IS_ALREADY_THERE,
+            /** The line was not measured against the rows, so no row here is owed to anybody yet. */
+            NOT_MEASURED,
+            /** The module's classes were not there to build against. */
+            NO_CLASSES,
+            /** The runtime is not on this host's classpath, so the decoders could not be reached. */
+            RUNTIME_ABSENT
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -53,22 +53,21 @@ final class Coverages {
     }
 
     /**
-     * @param armsAsked whether the build asked for the arms at all. A boundary a {@code guard} drew is
-     *                  not decided without them: the value being written is not the same as the
-     *                  comparison having been evaluated. Whether the run then managed to read them is
-     *                  a second question, and {@code observed} answers it — the two fail differently
-     *                  and a measure that took one boolean for both could not say which had happened.
+     * @param boundaries what was established about every line this behavior's rules drew, made once
+     *                   by {@link souther.compiler.query.Adequacy.Boundaries} and read here. Measuring
+     *                   a line takes putting a value through the module's decoders, which is not
+     *                   something a coverage count can do on its own and not something that should
+     *                   happen twice.
      */
     static PartitionEvidence of(Ast.SpecBehavior behavior, Sig sig, Symbols symbols, Core body,
                                 CoverageSites.Plan plan, souther.compiler.query.Adequacy.Observed observed,
-                                boolean armsAsked, Exclusions excluded) {
+                                List<BoundaryAssessment> boundaries, Exclusions excluded) {
         List<RowOutcome> rows = observed.rows();
         List<String> parameters = behavior.params().stream().map(Ast.Param::name).toList();
         Partitions.Partitioning partitioning =
                 partitioningOf(behavior, sig, symbols, body, plan, excluded);
 
         List<PartitionEvidence.AxisCoverage> axes = new ArrayList<>();
-        List<PartitionEvidence.BoundaryCoverage> boundaries = new ArrayList<>();
         List<String> notDerivable = new ArrayList<>();
 
         List<Axis> divided = new ArrayList<>();
@@ -83,12 +82,6 @@ final class Coverages {
                 axes.add(coverageOf(axis, readings, excluded));
                 divided.add(axis);
             }
-            // Whether the arms were measured, and nothing else. A row that did not finish makes a
-            // *missing* hit undecidable and takes nothing away from one that was found: a row that
-            // wrote the value and went through the comparison did so whatever else stopped.
-            boundaries.addAll(boundariesOf(axis, parameters, rows, symbols,
-                    armsAsked, observed.armsUnseen(), observed.someRowsUnseen(),
-                    partitioning.edgeIsKnownWritable(axis.path().toString())));
         }
         return new PartitionEvidence(axes, boundaries, pairsOf(divided, readings),
                 notDerivable, partitioning.omitted());
@@ -240,51 +233,156 @@ final class Coverages {
     }
 
     /**
-     * Whether a row was written at each boundary.
+     * A way to find out whether a value can be built at a boundary, or nothing where there is nothing
+     * to build against.
+     *
+     * <p>The decoder a row's own fixture goes through, reached through the generator. It is the only
+     * thing in the compiler that can answer the question — an invariant relating two fields refuses a
+     * pair each field would have accepted alone — and it answers it one way: what it builds is a
+     * witness, and what it refuses is a refusal of the candidates it tried.
+     */
+    @FunctionalInterface
+    interface Probe {
+
+        /** What building a row at this boundary came to, or null where the attempt could not be made
+         * at all — which leaves the edge unknown rather than refused. */
+        souther.compiler.partition.Generator.BoundaryAttempt attempt(BoundaryObligation obligation);
+    }
+
+    /**
+     * Everything known about each line one position's rules drew.
+     *
+     * <p>The one place either question about a boundary is answered. Whether a row sits at it is read
+     * off this compilation's rows; whether a row could sit at it is settled by the projection where
+     * that read every rule, and by building a value where it did not. Both used to be worked out twice
+     * — once for the report and once for the rows the generator offers — under rules that did not
+     * quite agree, so a line the report called undecided was one the generator handed to an author
+     * anyway.
      *
      * <p>An invariant's bound is met by writing the value: outside it nothing can be constructed, so
      * the value is the whole of what there is to reach. A guard's is not — the comparison has to have
      * been evaluated, and a row can carry the exact value and never reach the guard that cares about
      * it because an earlier branch went the other way. Nothing measures that until the arms are
-     * instrumented, so a guard's boundary reports as unavailable rather than as met or missed.
+     * instrumented, so a guard's boundary is unmeasured rather than met or missed.
+     *
+     * @param armsAsked whether the build asked for the arms at all. Whether the run then managed to
+     *                  read them is a second question, and {@code observed} answers it — the two fail
+     *                  differently and a measure that took one boolean for both could not say which
+     *                  had happened.
+     * @param probe     null where the module's classes or the runtime are not there to build against
      */
-    private static List<PartitionEvidence.BoundaryCoverage> boundariesOf(
-            Axis axis, List<String> parameters, List<RowOutcome> rows, Symbols symbols,
-            boolean armsAsked, boolean armsUnseen, boolean someRowsUnseen,
-            boolean knownWritable) {
-        List<PartitionEvidence.BoundaryCoverage> out = new ArrayList<>();
+    static List<BoundaryAssessment> assess(
+            Axis axis, List<String> parameters, souther.compiler.query.Adequacy.Observed observed,
+            Symbols symbols, boolean armsAsked, boolean knownWritable, Probe probe) {
+        List<RowOutcome> rows = observed.rows();
+        List<BoundaryAssessment> out = new ArrayList<>();
         for (BoundaryObligation each : Partitions.obligationsOf(axis, symbols)) {
-            PartitionEvidence.BoundaryCoverage.Reason absent = each.origin() instanceof OriginRef.GuardOrigin
-                    ? whyNoGuardLine(rows, armsAsked, armsUnseen, someRowsUnseen)
-                    : whyNoInvariantLine(rows, someRowsUnseen);
-            Met met = absent != null ? Met.UNDECIDED : switch (each.origin()) {
-                case OriginRef.GuardOrigin g -> evaluatedAt(axis, parameters, rows, each.value(), g);
-                default -> writtenAt(axis, parameters, rows, each.value());
-            };
-            // A row nothing read may be the row that is at this value. Found is still found — one row
-            // at the boundary settles it whatever else went unread — but not-found is not settled.
-            if (met == Met.NO && someRowsUnseen) {
-                met = Met.UNREADABLE;
-            }
-            // Nor is a hit that could not be looked for: a row that never finished left no hits, and
-            // a guard's line is met by going through the comparison.
-            if (met == Met.NO && each.origin() instanceof OriginRef.GuardOrigin
-                    && rows.stream().anyMatch(
-                            row -> row.disposition() == souther.compiler.observe.Disposition.INCOMPLETE)) {
-                met = Met.UNREADABLE;
-            }
-            out.add(new PartitionEvidence.BoundaryCoverage(idOf(each.axis()),
-                    each.origin().describe(), each.side(), plain(each.value()),
-                    met == Met.YES,
-                    met == Met.UNDECIDED ? MeasurementStatus.UNAVAILABLE
-                            : met == Met.UNREADABLE ? MeasurementStatus.PARTIAL
-                                    : MeasurementStatus.COMPLETE,
-                    // A row at the value is a value that went through the decoder, which is the
-                    // whole of what writable means. Where there is one, what the projection could
-                    // not promise has been settled by something better than a promise.
-                    met == Met.UNDECIDED ? absent : null, knownWritable || met == Met.YES));
+            BoundaryAssessment.Coverage coverage =
+                    coverageOf(each, axis, parameters, observed, armsAsked);
+            out.add(new BoundaryAssessment(each, coverage,
+                    writabilityOf(each, coverage, knownWritable, probe)));
         }
         return out;
+    }
+
+    /** Whether a row sits at one boundary, and whether that could be told. */
+    private static BoundaryAssessment.Coverage coverageOf(
+            BoundaryObligation obligation, Axis axis, List<String> parameters,
+            souther.compiler.query.Adequacy.Observed observed, boolean armsAsked) {
+        List<RowOutcome> rows = observed.rows();
+        boolean guard = obligation.origin() instanceof OriginRef.GuardOrigin;
+        BoundaryAssessment.Coverage.Reason absent = guard
+                ? whyNoGuardLine(rows, armsAsked, observed.armsUnseen(), observed.someRowsUnseen())
+                : whyNoInvariantLine(rows, observed.someRowsUnseen());
+        if (absent != null) {
+            return new BoundaryAssessment.Coverage.NotMeasured(absent);
+        }
+        Met met = guard
+                ? evaluatedAt(axis, parameters, rows, obligation.value(),
+                        (OriginRef.GuardOrigin) obligation.origin())
+                : writtenAt(axis, parameters, rows, obligation.value());
+        if (met == Met.YES) {
+            return new BoundaryAssessment.Coverage.Hit();
+        }
+        if (met == Met.UNREADABLE) {
+            return new BoundaryAssessment.Coverage.Undecided();
+        }
+        // A row nothing read may be the row that is at this value. Found is still found — one row at
+        // the boundary settles it whatever else went unread — but not-found is not settled.
+        if (observed.someRowsUnseen()) {
+            return new BoundaryAssessment.Coverage.Undecided();
+        }
+        // Nor is a hit that could not be looked for: a row that never finished left no hits, and a
+        // guard's line is met by going through the comparison.
+        if (guard && rows.stream().anyMatch(
+                row -> row.disposition() == souther.compiler.observe.Disposition.INCOMPLETE)) {
+            return new BoundaryAssessment.Coverage.Undecided();
+        }
+        return new BoundaryAssessment.Coverage.Missed();
+    }
+
+    /**
+     * What says a row can be written at one boundary.
+     *
+     * <p>The strongest evidence already in hand first. A row at the value went through the decoder,
+     * which is the whole of what writable means, and costs nothing to read. Otherwise a value is built:
+     * that is the same attempt the generator offers an author, made once here and read by both. The
+     * projection stands behind the attempt rather than in front of it — where it read every rule it
+     * proves the edge inhabited whatever the decoder made of the particular candidates tried, which is
+     * what keeps a refusal from turning into a claim of impossibility.
+     *
+     * <p>Nothing is built where nothing is owed: a boundary a row already sits at needs no candidate,
+     * and one whose measurement never happened is not a piece of work to hand to anybody.
+     */
+    private static BoundaryAssessment.Writability writabilityOf(
+            BoundaryObligation obligation, BoundaryAssessment.Coverage coverage,
+            boolean knownWritable, Probe probe) {
+        if (coverage instanceof BoundaryAssessment.Coverage.Hit) {
+            return new BoundaryAssessment.Writability.WitnessedByRow();
+        }
+        if (!worthBuilding(coverage) || probe == null) {
+            return knownWritable ? new BoundaryAssessment.Writability.ProvenByProjection()
+                    : BoundaryAssessment.Writability.Unknown.of(
+                            BoundaryAssessment.Writability.Unknown.Reason.NOT_ATTEMPTED);
+        }
+        souther.compiler.partition.Generator.BoundaryAttempt attempt = probe.attempt(obligation);
+        if (attempt == null) {
+            return knownWritable ? new BoundaryAssessment.Writability.ProvenByProjection()
+                    : BoundaryAssessment.Writability.Unknown.of(
+                            BoundaryAssessment.Writability.Unknown.Reason.NOT_ATTEMPTED);
+        }
+        if (attempt.built()) {
+            return new BoundaryAssessment.Writability.WitnessedByConstruction(attempt.row());
+        }
+        // Every candidate refused. Which does not make the edge unwritable — another value of it may
+        // build — so a projection that read every rule still proves what the attempt could not find.
+        return knownWritable ? new BoundaryAssessment.Writability.ProvenByProjection()
+                : new BoundaryAssessment.Writability.Unknown(
+                        reasonOf(attempt.unresolved().reason()), attempt.unresolved().detail());
+    }
+
+    /**
+     * Whether a candidate is worth building for this boundary.
+     *
+     * <p>A line nothing measured is not a line an author is behind on. Where the arms were not asked
+     * for, a guard's line has no answer at all, and where a row went unread the row that is at this
+     * value may be one of the rows nothing saw — building a candidate for either hands somebody a
+     * specific piece of work that may already be done.
+     */
+    private static boolean worthBuilding(BoundaryAssessment.Coverage coverage) {
+        return coverage instanceof BoundaryAssessment.Coverage.Missed
+                || (coverage instanceof BoundaryAssessment.Coverage.NotMeasured absent
+                        && absent.reason() == BoundaryAssessment.Coverage.Reason.NO_ROWS);
+    }
+
+    private static BoundaryAssessment.Writability.Unknown.Reason reasonOf(
+            souther.compiler.partition.Generator.UnresolvedCombination.Reason reason) {
+        return switch (reason) {
+            case NO_REPRESENTATIVE ->
+                    BoundaryAssessment.Writability.Unknown.Reason.NO_REPRESENTATIVE;
+            case ALL_CANDIDATES_REJECTED -> BoundaryAssessment.Writability.Unknown.Reason.REFUSED;
+            case SEARCH_LIMIT -> BoundaryAssessment.Writability.Unknown.Reason.SEARCH_LIMIT;
+        };
     }
 
     /**
@@ -295,13 +393,13 @@ final class Coverages {
      * run, which puts the arms in front of the rows: nothing a row carries decides it until the
      * classes that record where the row went exist and survived.
      */
-    private static PartitionEvidence.BoundaryCoverage.Reason whyNoGuardLine(
+    private static BoundaryAssessment.Coverage.Reason whyNoGuardLine(
             List<RowOutcome> rows, boolean armsAsked, boolean armsUnseen, boolean someRowsUnseen) {
         if (!armsAsked) {
-            return PartitionEvidence.BoundaryCoverage.Reason.ARMS_NOT_ASKED;
+            return BoundaryAssessment.Coverage.Reason.ARMS_NOT_ASKED;
         }
         if (armsUnseen) {
-            return PartitionEvidence.BoundaryCoverage.Reason.ARMS_UNREADABLE;
+            return BoundaryAssessment.Coverage.Reason.ARMS_UNREADABLE;
         }
         return whyNoInvariantLine(rows, someRowsUnseen);
     }
@@ -314,13 +412,13 @@ final class Coverages {
      * separately — an invariant's line can never be waiting on the arms, and a measure that could say
      * so would be able to say something that is not true of it.
      */
-    private static PartitionEvidence.BoundaryCoverage.Reason whyNoInvariantLine(
+    private static BoundaryAssessment.Coverage.Reason whyNoInvariantLine(
             List<RowOutcome> rows, boolean someRowsUnseen) {
         // Nothing read is not the same as nothing written. A source that could not be evaluated may
         // hold the row that is at this line, so the question is undecided rather than unasked, and
         // the reading below settles it that way.
         return rows.isEmpty() && !someRowsUnseen
-                ? PartitionEvidence.BoundaryCoverage.Reason.NO_ROWS : null;
+                ? BoundaryAssessment.Coverage.Reason.NO_ROWS : null;
     }
 
     /**
@@ -358,36 +456,6 @@ final class Coverages {
             }
         }
         return unreadable ? Met.UNREADABLE : Met.NO;
-    }
-
-    /**
-     * The boundaries a row could have been written at and demonstrably none was.
-     *
-     * <p>Includes a line a {@code guard} drew, where the arms were measured. Writing the row and
-     * meeting the line are different questions and the second needs the arms — but the row to write is
-     * the same row either way, and a line the report names as unmet that the generator will not offer
-     * is the one place an author is told about a gap and left to fill it by hand.
-     *
-     * <p>Left out where the arms were not measured, and where some row wrote the position unreadably:
-     * a row generated for either may be a row that is already there.
-     */
-    static List<BoundaryObligation> unmet(Axis axis, List<String> parameters, List<RowOutcome> rows,
-                                          Symbols symbols, boolean armsMeasured) {
-        List<BoundaryObligation> out = new ArrayList<>();
-        for (BoundaryObligation each : Partitions.obligationsOf(axis, symbols)) {
-            boolean guard = each.origin() instanceof OriginRef.GuardOrigin;
-            if (guard && !armsMeasured) {
-                continue;
-            }
-            Met met = guard
-                    ? evaluatedAt(axis, parameters, rows, each.value(),
-                            (OriginRef.GuardOrigin) each.origin())
-                    : writtenAt(axis, parameters, rows, each.value());
-            if (met == Met.NO) {
-                out.add(each);
-            }
-        }
-        return out;
     }
 
     private static Met writtenAt(Axis axis, List<String> parameters, List<RowOutcome> rows,
@@ -433,16 +501,6 @@ final class Coverages {
             case ObservedValue.Constructed c when c.field("value") != null -> numberOf(c.field("value"));
             case null, default -> null;
         };
-    }
-
-    private static String idOf(AxisId axis) {
-        return axis.toString();
-    }
-
-    /** A boundary as the author would write it, not as a record prints itself. */
-    private static String plain(ObservedValue value) {
-        java.math.BigDecimal number = numberOf(value);
-        return number == null ? String.valueOf(value) : number.stripTrailingZeros().toPlainString();
     }
 
     private Coverages() {}

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -317,7 +317,7 @@ final class Coverages {
             case souther.compiler.partition.Generator.BoundaryAttempt.Built built ->
                     new BoundaryAssessment.Attempt.Built(built.row());
             case souther.compiler.partition.Generator.BoundaryAttempt.Unresolved left ->
-                    new BoundaryAssessment.Attempt.Refused(left.why());
+                    new BoundaryAssessment.Attempt.Unresolved(left.why());
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -279,10 +279,46 @@ final class Coverages {
         for (BoundaryObligation each : Partitions.obligationsOf(axis, symbols)) {
             BoundaryAssessment.Coverage coverage =
                     coverageOf(each, axis, parameters, observed, armsAsked);
+            BoundaryAssessment.Attempt attempt = attemptAt(each, coverage, probe);
             out.add(new BoundaryAssessment(each, coverage,
-                    writabilityOf(each, coverage, knownWritable, probe)));
+                    writabilityOf(coverage, knownWritable, attempt), attempt));
         }
         return out;
+    }
+
+    /**
+     * What building a row at this boundary came to, where one was worth building.
+     *
+     * <p>Nothing is built where nothing is owed: a boundary a row already sits at needs no candidate,
+     * and one whose measurement never happened is not a piece of work to hand to anybody. Where a
+     * candidate was worth building and there was nothing to build against, that is said as well —
+     * it is a fact about the run, and reading it as a fact about the value is how "the classpath is
+     * short of a jar" would become "this edge may not be writable".
+     */
+    private static BoundaryAssessment.Attempt attemptAt(BoundaryObligation obligation,
+                                                        BoundaryAssessment.Coverage coverage,
+                                                        Probe probe) {
+        if (coverage instanceof BoundaryAssessment.Coverage.Hit) {
+            return new BoundaryAssessment.Attempt.NotAttempted(
+                    BoundaryAssessment.Attempt.Reason.A_ROW_IS_ALREADY_THERE);
+        }
+        if (!worthBuilding(coverage)) {
+            return new BoundaryAssessment.Attempt.NotAttempted(
+                    BoundaryAssessment.Attempt.Reason.NOT_MEASURED);
+        }
+        if (probe == null) {
+            return new BoundaryAssessment.Attempt.NotAttempted(
+                    BoundaryAssessment.Attempt.Reason.NO_CLASSES);
+        }
+        souther.compiler.partition.Generator.BoundaryAttempt made = probe.attempt(obligation);
+        return switch (made) {
+            case null -> new BoundaryAssessment.Attempt.NotAttempted(
+                    BoundaryAssessment.Attempt.Reason.RUNTIME_ABSENT);
+            case souther.compiler.partition.Generator.BoundaryAttempt.Built built ->
+                    new BoundaryAssessment.Attempt.Built(built.row());
+            case souther.compiler.partition.Generator.BoundaryAttempt.Unresolved left ->
+                    new BoundaryAssessment.Attempt.Refused(left.why());
+        };
     }
 
     /** Whether a row sits at one boundary, and whether that could be told. */
@@ -322,43 +358,32 @@ final class Coverages {
     }
 
     /**
-     * What says a row can be written at one boundary.
+     * What says a row can be written at one boundary: the verdict, over the evidence there is.
      *
      * <p>The strongest evidence already in hand first. A row at the value went through the decoder,
-     * which is the whole of what writable means, and costs nothing to read. Otherwise a value is built:
-     * that is the same attempt the generator offers an author, made once here and read by both. The
-     * projection stands behind the attempt rather than in front of it — where it read every rule it
-     * proves the edge inhabited whatever the decoder made of the particular candidates tried, which is
-     * what keeps a refusal from turning into a claim of impossibility.
+     * which is the whole of what writable means, and costs nothing to read. Then the value that was
+     * built, which went through the same decoder. Then the projection, which stands behind both rather
+     * than in front of them: where it read every rule it proves the edge inhabited whatever the search
+     * made of the particular candidates it tried.
      *
-     * <p>Nothing is built where nothing is owed: a boundary a row already sits at needs no candidate,
-     * and one whose measurement never happened is not a piece of work to hand to anybody.
+     * <p>Only the verdict is decided here. What was tried and what came of it is the attempt's to
+     * say, and it is kept whether or not it changed this answer — an edge the projection proves is one
+     * a search can still fail to reach, and a reader that had only this could not tell that it had.
      */
     private static BoundaryAssessment.Writability writabilityOf(
-            BoundaryObligation obligation, BoundaryAssessment.Coverage coverage,
-            boolean knownWritable, Probe probe) {
+            BoundaryAssessment.Coverage coverage, boolean knownWritable,
+            BoundaryAssessment.Attempt attempt) {
         if (coverage instanceof BoundaryAssessment.Coverage.Hit) {
             return new BoundaryAssessment.Writability.WitnessedByRow();
         }
-        if (!worthBuilding(coverage) || probe == null) {
-            return knownWritable ? new BoundaryAssessment.Writability.ProvenByProjection()
-                    : BoundaryAssessment.Writability.Unknown.of(
-                            BoundaryAssessment.Writability.Unknown.Reason.NOT_ATTEMPTED);
+        if (attempt instanceof BoundaryAssessment.Attempt.Built) {
+            return new BoundaryAssessment.Writability.WitnessedByConstruction();
         }
-        souther.compiler.partition.Generator.BoundaryAttempt attempt = probe.attempt(obligation);
-        if (attempt == null) {
-            return knownWritable ? new BoundaryAssessment.Writability.ProvenByProjection()
-                    : BoundaryAssessment.Writability.Unknown.of(
-                            BoundaryAssessment.Writability.Unknown.Reason.NOT_ATTEMPTED);
-        }
-        if (attempt.built()) {
-            return new BoundaryAssessment.Writability.WitnessedByConstruction(attempt.row());
-        }
-        // Every candidate refused. Which does not make the edge unwritable — another value of it may
-        // build — so a projection that read every rule still proves what the attempt could not find.
+        // A refusal and an attempt nobody made leave the same verdict, and a projection that read
+        // every rule proves what neither of them found. Which is where the asymmetry lives: nothing
+        // a search does can take a proof away, because nothing a search does is evidence against.
         return knownWritable ? new BoundaryAssessment.Writability.ProvenByProjection()
-                : new BoundaryAssessment.Writability.Unknown(
-                        reasonOf(attempt.unresolved().reason()), attempt.unresolved().detail());
+                : new BoundaryAssessment.Writability.Unknown();
     }
 
     /**
@@ -373,16 +398,6 @@ final class Coverages {
         return coverage instanceof BoundaryAssessment.Coverage.Missed
                 || (coverage instanceof BoundaryAssessment.Coverage.NotMeasured absent
                         && absent.reason() == BoundaryAssessment.Coverage.Reason.NO_ROWS);
-    }
-
-    private static BoundaryAssessment.Writability.Unknown.Reason reasonOf(
-            souther.compiler.partition.Generator.UnresolvedCombination.Reason reason) {
-        return switch (reason) {
-            case NO_REPRESENTATIVE ->
-                    BoundaryAssessment.Writability.Unknown.Reason.NO_REPRESENTATIVE;
-            case ALL_CANDIDATES_REJECTED -> BoundaryAssessment.Writability.Unknown.Reason.REFUSED;
-            case SEARCH_LIMIT -> BoundaryAssessment.Writability.Unknown.Reason.SEARCH_LIMIT;
-        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/PartitionEvidence.java
@@ -1,8 +1,6 @@
 package souther.compiler.query;
 
-import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.MeasurementStatus;
-import souther.compiler.partition.BoundaryObligation;
 import souther.compiler.partition.Partitions;
 
 import java.util.List;
@@ -24,7 +22,7 @@ import java.util.Set;
  *                     one cost — a position that was carrying a boundary leaves the rows there
  *                     unmeasured rather than covered
  */
-public record PartitionEvidence(List<AxisCoverage> axes, List<BoundaryCoverage> boundaries,
+public record PartitionEvidence(List<AxisCoverage> axes, List<BoundaryAssessment> boundaries,
                                 PairSpace pairs, List<String> notDerivable,
                                 List<Partitions.OmittedAxis> omitted) {
 
@@ -135,35 +133,6 @@ public record PartitionEvidence(List<AxisCoverage> axes, List<BoundaryCoverage> 
 
         public List<String> uncovered() {
             return classes.stream().filter(c -> !covered.contains(c)).toList();
-        }
-    }
-
-    /**
-     * One value a row has to be written at, and whether one was.
-     *
-     * @param reason why it could not be told, where it could not. A guard's line and an invariant's
-     *               are not measured the same way and do not fail to be measured for the same
-     *               reasons, which is why the two are built along separate paths
-     */
-    public record BoundaryCoverage(String axis, String origin, BoundaryObligation.BoundarySide side,
-                                   String value, boolean hit, MeasurementStatus status,
-                                   Reason reason, boolean knownWritable) {
-
-        /** Why a line has no answer. */
-        public enum Reason {
-            /** The build did not ask for the arms, and a guard's line is met by reaching the
-             *  comparison rather than by writing the value. Never a reason for an invariant's line,
-             *  which needs no arms. */
-            ARMS_NOT_ASKED,
-            /** The rows ran without instrumentation, so no row can be shown to have reached the
-             *  comparison. Never a reason for an invariant's line. */
-            ARMS_UNREADABLE,
-            /** No row names this behavior. */
-            NO_ROWS
-        }
-
-        public BoundaryCoverage {
-            Unavailable.check(status, reason);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -10,6 +10,7 @@ import souther.compiler.observe.OutputCaseEvidence;
 import souther.compiler.observe.RowOutcome;
 import souther.compiler.partition.Partitions;
 import souther.compiler.query.Adequacy;
+import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Output;
 import souther.compiler.query.PartitionEvidence;
@@ -493,26 +494,33 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                         ruled.classId(), why(ruled)));
             }
         }
-        List<PartitionEvidence.BoundaryCoverage> measured = partition.boundaries().stream()
-                .filter(b -> b.status() != MeasurementStatus.UNAVAILABLE)
-                .filter(PartitionEvidence.BoundaryCoverage::knownWritable).toList();
-        List<PartitionEvidence.BoundaryCoverage> unpromised = partition.boundaries().stream()
-                .filter(b -> !b.knownWritable()).toList();
-        long met = measured.stream().filter(PartitionEvidence.BoundaryCoverage::hit).count();
+        // Counted where both questions have an answer: the line was measured against the rows, and
+        // something has shown a row can be written at it. The two are separate observations and are
+        // filtered separately — a line nobody measured and a line nothing promises are not the same
+        // absence, and printing them under one sentence said "not known to be writable" about
+        // behaviors whose only problem was that nobody had written a row yet.
+        List<BoundaryAssessment> measured = partition.boundaries().stream()
+                .filter(b -> !(b.coverage() instanceof BoundaryAssessment.Coverage.NotMeasured))
+                .filter(b -> b.writability().known()).toList();
+        List<BoundaryAssessment> unpromised = partition.boundaries().stream()
+                .filter(b -> !b.writability().known()).toList();
+        long met = measured.stream().filter(b -> b.coverage().hit()).count();
         long undecided = measured.stream()
-                .filter(b -> b.status() == MeasurementStatus.PARTIAL).filter(b -> !b.hit()).count();
+                .filter(b -> b.coverage() instanceof BoundaryAssessment.Coverage.Undecided).count();
         out.append(String.format("    boundary    %d/%d%s%s%n", met, measured.size(),
-                notes(partition.boundaries(), b -> b.status() == MeasurementStatus.UNAVAILABLE,
-                        b -> whyNoBoundary(b.reason())),
+                notes(partition.boundaries(),
+                        b -> b.coverage() instanceof BoundaryAssessment.Coverage.NotMeasured,
+                        b -> whyNoBoundary(b.coverage())),
                 undecided == 0 ? "" : "   (" + undecided + " undecided: a value was not read)"));
         for (Adequacy.Finding f : behavior.of(Adequacy.Kind.BOUNDARY_UNMET)) {
             out.append(String.format("      · no row is at %s = %s (%s)%n",
                     f.args().get(0), f.args().get(1), f.args().get(2)));
         }
-        // Said and not counted. The edge is where the rules this could read stop, and a rule it
-        // could not read can refuse that value as readily as the one beyond it — so it is not a row
-        // anybody is owed, and it is still the only thing there is to say about this position.
-        for (PartitionEvidence.BoundaryCoverage b : unpromised) {
+        // Said and not counted. Nothing has shown a row can be written at these — the projection
+        // could not read every rule of the value, and nothing built one either — so they are not
+        // rows anybody is owed, and they are still the only thing there is to say about the
+        // position.
+        for (BoundaryAssessment b : unpromised) {
             out.append(String.format("      · not known to be writable: %s = %s (%s)%n",
                     b.axis(), b.value(), b.origin()));
         }
@@ -621,8 +629,11 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         };
     }
 
-    private static String whyNoBoundary(PartitionEvidence.BoundaryCoverage.Reason reason) {
-        return switch (reason) {
+    private static String whyNoBoundary(BoundaryAssessment.Coverage coverage) {
+        if (!(coverage instanceof BoundaryAssessment.Coverage.NotMeasured absent)) {
+            return "";
+        }
+        return switch (absent.reason()) {
             case ARMS_NOT_ASKED -> "the arms were not asked for";
             case ARMS_UNREADABLE -> "the arms could not be measured";
             case NO_ROWS -> "no row names this behavior";
@@ -717,14 +728,18 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             measured(a, axis.status(), axis.reason());
         }
         ArrayNode boundaries = out.putArray("boundaries");
-        for (PartitionEvidence.BoundaryCoverage boundary : partition.boundaries()) {
+        for (BoundaryAssessment boundary : partition.boundaries()) {
             ObjectNode b = boundaries.addObject();
             b.put("axis", boundary.axis());
             b.put("origin", boundary.origin());
             b.put("side", boundary.side().name().toLowerCase(java.util.Locale.ROOT));
             b.put("value", boundary.value());
-            b.put("hit", boundary.hit());
-            b.put("knownWritable", boundary.knownWritable());
+            // The shape a published schema promises, read off the assessment rather than stored
+            // beside it. What each of these says is unchanged; where it comes from is one answer now
+            // instead of two kept in step. Naming which evidence made a line writable is worth
+            // emitting and would be a different schema, so it waits for one.
+            b.put("hit", boundary.coverage().hit());
+            b.put("knownWritable", boundary.writability().known());
             measured(b, boundary.status(), boundary.reason());
         }
         ObjectNode pairs = out.putObject("pairs");

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -37,9 +37,10 @@ public final class GeneratedRows {
     /**
      * The block for a finished compile, for the modules and behaviors the caller asked about.
      *
-     * <p>Asked here and not with the rest of a compile's questions, because this one builds values
-     * through the derived decoders to find out which of them the model admits. Nobody who only wanted
-     * the report should pay for that.
+     * <p>Asked here and not with the rest of a compile's questions, because filling the combinations
+     * searches the pair space, and nobody who only wanted the report should pay for that. The rows at
+     * the edges cost nothing here: each was built where the boundary was measured, and this reads what
+     * that attempt produced.
      */
     public static String of(Compilation compilation, String module, String behavior,
                             boolean boundaries) {

--- a/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -246,11 +246,16 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
                 """;
         String report = reportOn(dense);
 
-        assertEquals(List.of(), boundariesOf(dense), "none of them is a row anybody is owed");
-        assertTrue(report.contains("boundary    0/0"), () -> report);
+        List<String> owed = boundariesOf(dense);
+
         assertTrue(report.contains("not known to be writable: classify/band.low = 1"), () -> report);
-        assertTrue(report.contains("adequacy: satisfied"),
-                () -> "and no build is refused over it:\n" + report);
+        assertFalse(owed.stream().anyMatch(l -> l.contains("classify/band.low = 1")),
+                () -> "and nobody is owed a row at it: " + owed);
+        // The other end of the same rule, which the projection could not promise either. A value at
+        // it was built, so it is owed — the two edges are told apart by what something managed to
+        // construct and not by how far one reading of the rules got.
+        assertTrue(owed.stream().anyMatch(l -> l.contains("classify/band.high = 1")),
+                () -> "a row at the top of the upper field builds: " + owed);
     }
 
     /**
@@ -284,11 +289,13 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
                 """;
         String report = reportOn(holed);
 
-        assertTrue(report.contains("boundary    1/1"),
-                () -> "the row at 0 counts, and 10 is neither met nor owed:\n" + report);
         assertFalse(report.contains("not known to be writable: f/r.a = 0"),
                 () -> "there is a row at it:\n" + report);
-        assertTrue(report.contains("not known to be writable: f/r.a = 10"), () -> report);
+        // The row settles its own edge without anything being built for it, and the other edge is
+        // settled by building one. Two kinds of witness, and the projection proves neither.
+        assertTrue(report.contains("boundary    1/2"),
+                () -> "the row at 0 is met, and 10 was built and is owed:\n" + report);
+        assertTrue(report.contains("no row is at f/r.a = 10"), () -> report);
     }
 
     /**
@@ -365,8 +372,15 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
 
         String report = reportOn(holed);
 
-        assertEquals(List.of(), boundariesOf(holed), "0 is in the range and no row can write it");
+        List<String> owed = boundariesOf(holed);
+
         assertTrue(report.contains("not known to be writable: f/n = 0"), () -> report);
+        assertFalse(owed.stream().anyMatch(l -> l.contains("f/n = 0")),
+                () -> "0 is in the range and the decoder refuses it: " + owed);
+        // A refusal at one edge says nothing about the other. `value /= 0` leaves the top of the
+        // range alone, and a value was built there, so that one is a row somebody is owed.
+        assertTrue(owed.stream().anyMatch(l -> l.contains("f/n = 10")),
+                () -> "and the top of the same range builds: " + owed);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -6,6 +6,7 @@ import souther.compiler.observe.Incompleteness;
 import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 
@@ -217,10 +218,10 @@ class AMeasureWithNoNumberSaysWhyTest {
      * The two origins are measured along separate paths for exactly this reason. */
     @Test
     void anInvariantsLineIsNeverWaitingOnTheArms() {
-        List<PartitionEvidence.BoundaryCoverage> lines = partitions().get("rated").boundaries();
+        List<BoundaryAssessment> lines = partitions().get("rated").boundaries();
         assertFalse(lines.isEmpty(), "the invariant draws two");
-        for (PartitionEvidence.BoundaryCoverage line : lines) {
-            assertEquals(PartitionEvidence.BoundaryCoverage.Reason.NO_ROWS, line.reason(),
+        for (BoundaryAssessment line : lines) {
+            assertEquals(BoundaryAssessment.Coverage.Reason.NO_ROWS, line.reason(),
                     line.origin() + " at " + line.value());
         }
     }
@@ -307,8 +308,8 @@ class AMeasureWithNoNumberSaysWhyTest {
         PartitionEvidence partition = compilation.db()
                 .ask(new Adequacy.Coverage("example.unseen")).value().get("elsewhere");
         assertFalse(partition.boundaries().isEmpty(), "the invariant and the guard draw lines");
-        for (PartitionEvidence.BoundaryCoverage line : partition.boundaries()) {
-            assertNotEquals(PartitionEvidence.BoundaryCoverage.Reason.NO_ROWS, line.reason(),
+        for (BoundaryAssessment line : partition.boundaries()) {
+            assertNotEquals(BoundaryAssessment.Coverage.Reason.NO_ROWS, line.reason(),
                     line.origin() + " at " + line.value());
             assertEquals(MeasurementStatus.PARTIAL, line.status(),
                     line.origin() + " at " + line.value());

--- a/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AdequacyNeverAssertsFromPartOfTheRowsTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 import souther.compiler.report.GeneratedRows;
@@ -169,8 +170,8 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
                     wrong.add("axis " + axis.path() + ": " + axis.uncovered());
                 }
             }
-            for (PartitionEvidence.BoundaryCoverage boundary : partition.boundaries()) {
-                if (boundary.status() == MeasurementStatus.COMPLETE && !boundary.hit()) {
+            for (BoundaryAssessment boundary : partition.boundaries()) {
+                if (boundary.status() == MeasurementStatus.COMPLETE && !boundary.coverage().hit()) {
                     wrong.add("boundary " + boundary.axis() + " = " + boundary.value());
                 }
             }
@@ -255,7 +256,7 @@ class AdequacyNeverAssertsFromPartOfTheRowsTest {
         assertEquals(MeasurementStatus.COMPLETE, AdequacyReport.of(compilation).status());
         assertTrue(partition.axes().stream().anyMatch(a -> !a.uncovered().isEmpty()),
                 "a class nothing is in");
-        assertTrue(partition.boundaries().stream().anyMatch(b -> !b.hit()),
+        assertTrue(partition.boundaries().stream().anyMatch(b -> !b.coverage().hit()),
                 "a boundary nothing is at");
         assertTrue(partition.pairs().unknown() > 0, "a combination nothing reaches");
         assertFalse(compilation.db().ask(new Adequacy.BranchCoverage(module)).value()

--- a/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
@@ -1,0 +1,195 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BoundaryAssessment;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What says a row can be written at a boundary, and what a refusal is not.
+ *
+ * <p>Three things can say it and one thing cannot. A projection that read every rule of the value
+ * proves it; a row already at the value witnesses it; a value built through the module's own decoder
+ * witnesses it. The decoder refusing every candidate it tried says nothing — another value of the
+ * same edge may build — so a refusal leaves the edge unknown and never closes it.
+ *
+ * <p>Held here rather than through the report, because the report prints only the two ends of this:
+ * a line it counts and a line it says it cannot promise. Which of the three settled a line, and that
+ * a refusal settled nothing, are the facts the counting is derived from, and a test that read them
+ * off the printed line could not tell a witness from a proof.
+ */
+class AnEdgeIsWritableBecauseSomethingSaidSoTest {
+
+    /**
+     * Two edges of one range, one refused by a rule that reaches it and one not.
+     *
+     * <p>{@code value /= 0} is a rule the projection cannot take into a bound, so neither edge is
+     * proven. It reaches the bottom of the range and nothing else: the decoder refuses a 0 and builds
+     * a 10. The pair is the whole point — an answer that turned {@code allRulesRead == false} into
+     * "writable" would settle both, and one that kept it as "not writable" would settle neither.
+     */
+    private static final String HOLED = """
+            module example.holed
+
+            data N = Int
+                invariant within = value >= 0 && value <= 10
+                invariant nonzero = value /= 0
+
+            data Ok
+
+            behavior f : (n: N) -> Ok
+                constructs Ok
+
+            let f (n) = Ok
+
+            example f
+                | "x" : (N(3)) -> Ok
+            """;
+
+    @Test
+    void aRuleTheProjectionCouldNotReadLeavesTheEdgeItRefusesUnknown() {
+        assertInstanceOf(BoundaryAssessment.Writability.Unknown.class,
+                writabilityAt(HOLED, "example.holed", "f", "0"),
+                "the decoder refused every candidate at 0");
+        assertEquals(BoundaryAssessment.Writability.Unknown.Reason.REFUSED,
+                ((BoundaryAssessment.Writability.Unknown)
+                        writabilityAt(HOLED, "example.holed", "f", "0")).reason(),
+                "and refused is not impossible: nothing here says no row can be written");
+    }
+
+    @Test
+    void anEdgeTheSameRuleDoesNotReachIsWitnessedByTheValueThatWasBuilt() {
+        assertInstanceOf(BoundaryAssessment.Writability.WitnessedByConstruction.class,
+                writabilityAt(HOLED, "example.holed", "f", "10"),
+                "a value at 10 went through the decoder");
+    }
+
+    /**
+     * A rule about another position does not disqualify this one.
+     *
+     * <p>{@code String.matches} on the identifier is outside the fragment the projection reads, so
+     * nothing about this value is proven — and it cannot refuse an amount whatever it does to an id.
+     * Which is the shape most of a real model has: one clause somewhere in a record used to leave
+     * every numeric edge in it unpromised.
+     */
+    @Test
+    void anUnreadRuleOnAnotherFieldDoesNotLeaveThisEdgeUnknown() {
+        String model = """
+                module example.order
+
+                data OrderId = String
+                    invariant String.matches("[0-9]{4}", value)
+
+                data Amount = Int
+                    invariant value >= 0
+
+                data Order = { id: OrderId, amount: Amount }
+
+                data Ok
+
+                behavior place : (order: Order) -> Ok
+                    constructs Ok
+
+                let place (order) = Ok
+
+                example place
+                    | "some" : (Order { id = OrderId("0001"), amount = Amount(7) }) -> Ok
+                """;
+        assertInstanceOf(BoundaryAssessment.Writability.WitnessedByConstruction.class,
+                writabilityAt(model, "example.order", "place", "0"),
+                "the id's rule cannot refuse an amount of 0");
+    }
+
+    /** A row at the value settles it, and nothing is built to find out what the row already shows. */
+    @Test
+    void aRowAtTheValueIsTheWitnessAndNothingIsBuilt() {
+        String model = """
+                module example.at
+
+                data N = Int
+                    invariant within = value >= 0 && value <= 10
+                    invariant nonzero = value /= 3
+
+                data Ok
+
+                behavior f : (n: N) -> Ok
+                    constructs Ok
+
+                let f (n) = Ok
+
+                example f
+                    | "bottom" : (N(0)) -> Ok
+                """;
+        BoundaryAssessment at = assessmentAt(model, "example.at", "f", "0");
+        assertInstanceOf(BoundaryAssessment.Coverage.Hit.class, at.coverage());
+        assertInstanceOf(BoundaryAssessment.Writability.WitnessedByRow.class, at.writability(),
+                "the row is the witness; no candidate was built for a value that is already there");
+    }
+
+    /**
+     * A behavior no row names has no coverage answer and may still have a writability one.
+     *
+     * <p>Two observations on two axes, and the report used to print the second as though it were the
+     * first — a behavior whose only problem was that nobody had written a row yet was reported under
+     * "not known to be writable", beside a note saying the line was never measured.
+     */
+    @Test
+    void aBehaviorNoRowNamesIsUnmeasuredAndNotUnwritable() {
+        String model = """
+                module example.unnamed
+
+                data N = Int
+                    invariant within = value >= 0 && value <= 10
+
+                data Ok
+
+                behavior f : (n: N) -> Ok
+                    constructs Ok
+
+                let f (n) = Ok
+
+                data Other
+
+                behavior g : (n: N) -> Other
+                    constructs Other
+
+                let g (n) = Other
+
+                example g
+                    | "some" : (N(4)) -> Other
+                """;
+        BoundaryAssessment at = assessmentAt(model, "example.unnamed", "f", "0");
+        BoundaryAssessment.Coverage.NotMeasured absent = assertInstanceOf(
+                BoundaryAssessment.Coverage.NotMeasured.class, at.coverage());
+        assertEquals(BoundaryAssessment.Coverage.Reason.NO_ROWS, absent.reason());
+        assertTrue(at.writability().known(),
+                "nobody wrote a row, which says nothing about whether one could be written");
+    }
+
+    private static BoundaryAssessment.Writability writabilityAt(String model, String module,
+                                                                String behavior, String value) {
+        return assessmentAt(model, module, behavior, value).writability();
+    }
+
+    private static BoundaryAssessment assessmentAt(String model, String module, String behavior,
+                                                   String value) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, List<BoundaryAssessment>> boundaries =
+                compilation.db().ask(new Adequacy.Boundaries(module)).value();
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries.get(behavior).stream().filter(b -> b.value().equals(value))
+                .findFirst().orElseThrow(
+                        () -> new AssertionError("no boundary at " + value + " of " + behavior));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import org.junit.jupiter.api.Test;
 
+import souther.compiler.partition.Generator;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.Compilation;
@@ -10,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -57,20 +59,89 @@ class AnEdgeIsWritableBecauseSomethingSaidSoTest {
 
     @Test
     void aRuleTheProjectionCouldNotReadLeavesTheEdgeItRefusesUnknown() {
-        assertInstanceOf(BoundaryAssessment.Writability.Unknown.class,
-                writabilityAt(HOLED, "example.holed", "f", "0"),
-                "the decoder refused every candidate at 0");
-        assertEquals(BoundaryAssessment.Writability.Unknown.Reason.REFUSED,
-                ((BoundaryAssessment.Writability.Unknown)
-                        writabilityAt(HOLED, "example.holed", "f", "0")).reason(),
+        BoundaryAssessment at = assessmentAt(HOLED, "example.holed", "f", "0");
+
+        assertInstanceOf(BoundaryAssessment.Writability.Unknown.class, at.writability(),
+                "nothing proved it and nothing built it");
+        BoundaryAssessment.Attempt.Refused refused = assertInstanceOf(
+                BoundaryAssessment.Attempt.Refused.class, at.attempt(),
                 "and refused is not impossible: nothing here says no row can be written");
+        assertEquals(Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
+                refused.why().reason());
     }
 
     @Test
     void anEdgeTheSameRuleDoesNotReachIsWitnessedByTheValueThatWasBuilt() {
+        BoundaryAssessment at = assessmentAt(HOLED, "example.holed", "f", "10");
+
         assertInstanceOf(BoundaryAssessment.Writability.WitnessedByConstruction.class,
-                writabilityAt(HOLED, "example.holed", "f", "10"),
-                "a value at 10 went through the decoder");
+                at.writability(), "a value at 10 went through the decoder");
+        assertInstanceOf(BoundaryAssessment.Attempt.Built.class, at.attempt(),
+                "and the value it built is kept, because it is also the row an author is offered");
+    }
+
+    /**
+     * A projection's proof and a search that came back with nothing are both true at once.
+     *
+     * <p>Two answers about two different things: whether a value at the edge exists, and whether this
+     * run managed to produce one. Reading the second off the first is what left `--generate` silent
+     * about a boundary it could say something useful about — the report named the row as owed and the
+     * block printed neither a row nor a reason.
+     *
+     * <p>Every rule of {@code Amount} was read, so 0 is proven to be a value it holds. The row needs a
+     * second input as well, and nothing can be written for that one — which is a fact about this
+     * search and not about the edge.
+     */
+    private static final String PROVEN_BUT_UNREACHED = """
+            module example.proven
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Code = String
+                invariant String.matches("(?=.*a).*b", value)
+
+            data Ok
+
+            behavior place : (amount: Amount, code: Code) -> Ok
+                constructs Ok
+
+            let place (amount, code) = Ok
+
+            example place
+                | "some" : (Amount(7), Code("ab")) -> Ok
+            """;
+
+    @Test
+    void anEdgeTheProjectionProvesCanStillBeOneNoSearchReached() {
+        BoundaryAssessment at =
+                assessmentAt(PROVEN_BUT_UNREACHED, "example.proven", "place", "0");
+
+        assertInstanceOf(BoundaryAssessment.Coverage.Missed.class, at.coverage());
+        assertInstanceOf(BoundaryAssessment.Writability.ProvenByProjection.class, at.writability(),
+                "every rule of `Amount` was read, so 0 is a value it holds");
+        assertInstanceOf(BoundaryAssessment.Attempt.Refused.class, at.attempt(),
+                "and the search still came back with nothing, which takes nothing away from that");
+    }
+
+    /**
+     * The same boundary, as the block an author reads.
+     *
+     * <p>This is what recovering the attempt from the verdict cost: the report named the row as owed
+     * and the block said nothing at all, because the verdict was "provable" and the attempt that had
+     * failed was no longer anywhere to be read.
+     */
+    @Test
+    void anEdgeNoSearchReachedIsStillSaidInTheBlock() {
+        Compilation compilation = Compilation.ofSource(PROVEN_BUT_UNREACHED, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+
+        String block = souther.compiler.report.GeneratedRows.of(
+                compilation, "example.proven", "place", true);
+
+        assertTrue(block.contains("no row for `amount = 0` in `place`"), block);
+        assertTrue(block.contains("every value tried was refused"), block);
     }
 
     /**
@@ -132,7 +203,11 @@ class AnEdgeIsWritableBecauseSomethingSaidSoTest {
         BoundaryAssessment at = assessmentAt(model, "example.at", "f", "0");
         assertInstanceOf(BoundaryAssessment.Coverage.Hit.class, at.coverage());
         assertInstanceOf(BoundaryAssessment.Writability.WitnessedByRow.class, at.writability(),
-                "the row is the witness; no candidate was built for a value that is already there");
+                "the row is the witness");
+        assertEquals(BoundaryAssessment.Attempt.Reason.A_ROW_IS_ALREADY_THERE,
+                assertInstanceOf(BoundaryAssessment.Attempt.NotAttempted.class, at.attempt())
+                        .reason(),
+                "and no candidate was built for a value that is already there");
     }
 
     /**
@@ -173,6 +248,54 @@ class AnEdgeIsWritableBecauseSomethingSaidSoTest {
         assertEquals(BoundaryAssessment.Coverage.Reason.NO_ROWS, absent.reason());
         assertTrue(at.writability().known(),
                 "nobody wrote a row, which says nothing about whether one could be written");
+        assertInstanceOf(BoundaryAssessment.Attempt.Built.class, at.attempt(),
+                "a value was built here, and what it settles is the writability and not the rows");
+    }
+
+    /**
+     * A line waiting on the arms is a line nothing is built for.
+     *
+     * <p>Meeting a guard's line takes the comparison having run, which nothing measures until the
+     * build asks for the arms. Until then no row there is owed to anybody, and building a candidate
+     * would hand somebody a specific piece of work on the strength of a question nobody put.
+     */
+    @Test
+    void aLineWaitingOnTheArmsIsALineNothingIsBuiltFor() {
+        String model = """
+                module example.waiting
+
+                data N = Int
+                    invariant within = value >= 0 && value <= 10
+
+                data Ok
+                data Big
+
+                behavior f : (n: N) -> Ok | Big
+                    constructs Ok, Big
+
+                let f (n) = if n.value <= 4 then Ok else Big
+
+                example f
+                    | "some" : (N(2)) -> Ok
+                """;
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        // What a guard's line waits on, and this build does not ask for it.
+        compilation.measure(Adequacy.Asked.reportOnly(Adequacy.Level.WITNESS));
+        compilation.answerEverything();
+        Map<String, List<BoundaryAssessment>> boundaries =
+                compilation.db().ask(new Adequacy.Boundaries("example.waiting")).value();
+
+        List<BoundaryAssessment> guards = boundaries.get("f").stream()
+                .filter(b -> b.origin().startsWith("guard")).toList();
+        assertFalse(guards.isEmpty(), "the comparison draws lines: " + boundaries.get("f"));
+        for (BoundaryAssessment at : guards) {
+            assertEquals(BoundaryAssessment.Coverage.Reason.ARMS_NOT_ASKED,
+                    assertInstanceOf(BoundaryAssessment.Coverage.NotMeasured.class, at.coverage())
+                            .reason(), at.label());
+            assertEquals(BoundaryAssessment.Attempt.Reason.NOT_MEASURED,
+                    assertInstanceOf(BoundaryAssessment.Attempt.NotAttempted.class, at.attempt())
+                            .reason(), at.label());
+        }
     }
 
     private static BoundaryAssessment.Writability writabilityAt(String model, String module,

--- a/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEdgeIsWritableBecauseSomethingSaidSoTest.java
@@ -63,11 +63,11 @@ class AnEdgeIsWritableBecauseSomethingSaidSoTest {
 
         assertInstanceOf(BoundaryAssessment.Writability.Unknown.class, at.writability(),
                 "nothing proved it and nothing built it");
-        BoundaryAssessment.Attempt.Refused refused = assertInstanceOf(
-                BoundaryAssessment.Attempt.Refused.class, at.attempt(),
+        BoundaryAssessment.Attempt.Unresolved unresolved = assertInstanceOf(
+                BoundaryAssessment.Attempt.Unresolved.class, at.attempt(),
                 "and refused is not impossible: nothing here says no row can be written");
         assertEquals(Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
-                refused.why().reason());
+                unresolved.why().reason());
     }
 
     @Test
@@ -120,7 +120,7 @@ class AnEdgeIsWritableBecauseSomethingSaidSoTest {
         assertInstanceOf(BoundaryAssessment.Coverage.Missed.class, at.coverage());
         assertInstanceOf(BoundaryAssessment.Writability.ProvenByProjection.class, at.writability(),
                 "every rule of `Amount` was read, so 0 is a value it holds");
-        assertInstanceOf(BoundaryAssessment.Attempt.Refused.class, at.attempt(),
+        assertInstanceOf(BoundaryAssessment.Attempt.Unresolved.class, at.attempt(),
                 "and the search still came back with nothing, which takes nothing away from that");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompileAdequacyShapesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileAdequacyShapesTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.PartitionEvidence;
 
 import java.util.List;
@@ -69,7 +70,7 @@ class CompileAdequacyShapesTest {
         assertEquals(1, evidence.axes().size());
         assertEquals(List.of("rate/x < 0.5", "rate/0.5 <= x"), evidence.axes().get(0).classes());
         assertEquals(List.of("0.5"),
-                evidence.boundaries().stream().map(PartitionEvidence.BoundaryCoverage::value)
+                evidence.boundaries().stream().map(BoundaryAssessment::value)
                         .toList());
     }
 
@@ -228,7 +229,7 @@ class CompileAdequacyShapesTest {
                 """), "classify");
 
         List<String> at = evidence.boundaries().stream()
-                .map(PartitionEvidence.BoundaryCoverage::value).filter(v -> v.equals("0")).toList();
+                .map(BoundaryAssessment::value).filter(v -> v.equals("0")).toList();
         assertEquals(2, at.size(), "one line, and two rules that drew it there");
         assertFalse(evidence.axes().isEmpty());
         assertEquals(List.of("rate/0 <= x <= 0", "rate/0 < x"), evidence.axes().get(0).classes(),

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.PartitionEvidence;
 
 import java.util.List;
@@ -60,7 +61,7 @@ class CompileExampleBoundaryTest {
                 .findFirst().orElseThrow();
     }
 
-    private static List<PartitionEvidence.BoundaryCoverage> at(PartitionEvidence evidence,
+    private static List<BoundaryAssessment> at(PartitionEvidence evidence,
                                                                String value) {
         return evidence.boundaries().stream().filter(b -> b.value().equals(value)).toList();
     }
@@ -94,8 +95,8 @@ class CompileExampleBoundaryTest {
                 example submit
                     | (Draft { cost = Amount(50) }) -> Submitted
                 """);
-        PartitionEvidence.BoundaryCoverage zero = at(away, "0").get(0);
-        assertFalse(zero.hit());
+        BoundaryAssessment zero = at(away, "0").get(0);
+        assertFalse(zero.coverage().hit());
         assertEquals(MeasurementStatus.COMPLETE, zero.status());
         assertTrue(zero.origin().startsWith("invariant"), zero.origin());
 
@@ -104,7 +105,7 @@ class CompileExampleBoundaryTest {
                 example submit
                     | (Draft { cost = Amount(0) }) -> Submitted
                 """);
-        assertTrue(at(edge, "0").get(0).hit(), "a row is written at the edge");
+        assertTrue(at(edge, "0").get(0).coverage().hit(), "a row is written at the edge");
     }
 
     /** A row that writes the value and reaches the comparison meets the line the guard drew. */
@@ -116,9 +117,9 @@ class CompileExampleBoundaryTest {
                     | (Draft { cost = Amount(100) }) -> Submitted
                 """);
 
-        PartitionEvidence.BoundaryCoverage hundred = at(evidence, "100").get(0);
+        BoundaryAssessment hundred = at(evidence, "100").get(0);
         assertEquals(MeasurementStatus.COMPLETE, hundred.status());
-        assertTrue(hundred.hit(), "the row wrote 100 and the guard compared it");
+        assertTrue(hundred.coverage().hit(), "the row wrote 100 and the guard compared it");
         assertTrue(hundred.origin().startsWith("guard"), hundred.origin());
     }
 
@@ -155,13 +156,13 @@ class CompileExampleBoundaryTest {
                     | (Draft { cost = Amount(-1) }) -> Waiting { cost = Amount(-1) }
                 """);
 
-        PartitionEvidence.BoundaryCoverage first = at(evidence, "0").stream()
+        BoundaryAssessment first = at(evidence, "0").stream()
                 .filter(b -> b.origin().startsWith("guard")).findFirst().orElseThrow();
-        PartitionEvidence.BoundaryCoverage second = at(evidence, "100").get(0);
+        BoundaryAssessment second = at(evidence, "100").get(0);
 
         assertEquals(MeasurementStatus.COMPLETE, second.status(), "the arms were measured");
-        assertFalse(second.hit(), "no row was ever compared against 100");
-        assertFalse(first.hit(), "and the row wrote -1, not 0");
+        assertFalse(second.coverage().hit(), "no row was ever compared against 100");
+        assertFalse(first.coverage().hit(), "and the row wrote -1, not 0");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -8,6 +8,7 @@ import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
 import souther.compiler.query.Db;
+import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 import souther.compiler.report.GeneratedRows;
@@ -217,11 +218,11 @@ class CompilePartialAdequacyTest {
         PartitionEvidence partition = measured(budgetSpent("")).db()
                 .ask(new Adequacy.Coverage("example.budget")).value().get("take");
 
-        List<PartitionEvidence.BoundaryCoverage> at = partition.boundaries().stream()
+        List<BoundaryAssessment> at = partition.boundaries().stream()
                 .filter(b -> b.value().equals("0")).toList();
         assertEquals(1, at.size());
         assertEquals(MeasurementStatus.PARTIAL, at.get(0).status());
-        assertFalse(at.get(0).hit(), "nothing was read, so nothing was met either");
+        assertFalse(at.get(0).coverage().hit(), "nothing was read, so nothing was met either");
     }
 
     @Test
@@ -380,9 +381,9 @@ class CompilePartialAdequacyTest {
                 .ask(new Adequacy.Coverage("example.split")).value().get("take");
 
         assertEquals(2, partition.boundaries().size());
-        for (PartitionEvidence.BoundaryCoverage boundary : partition.boundaries()) {
+        for (BoundaryAssessment boundary : partition.boundaries()) {
             assertEquals(MeasurementStatus.PARTIAL, boundary.status(), boundary.value());
-            assertFalse(boundary.hit());
+            assertFalse(boundary.coverage().hit());
         }
     }
 
@@ -586,12 +587,12 @@ class CompilePartialAdequacyTest {
                         DoesNotComeBack.everythingAboutTheRowDescribed("over it")), Adequacy.Asked.reportOnly())
                 .db().ask(new Adequacy.Coverage("example.mix")).value().get("take");
 
-        PartitionEvidence.BoundaryCoverage line = partition.boundaries().stream()
+        BoundaryAssessment line = partition.boundaries().stream()
                 .filter(b -> b.value().equals("100")).findFirst().orElseThrow();
-        assertTrue(line.hit(), "a row wrote 100 and went through the comparison");
+        assertTrue(line.coverage().hit(), "a row wrote 100 and went through the comparison");
         assertEquals(MeasurementStatus.COMPLETE, line.status());
 
-        PartitionEvidence.BoundaryCoverage beyond = partition.boundaries().stream()
+        BoundaryAssessment beyond = partition.boundaries().stream()
                 .filter(b -> b.value().equals("101")).findFirst().orElseThrow();
         assertEquals(MeasurementStatus.PARTIAL, beyond.status(),
                 "and the one nothing was found at is undecided, not missed");

--- a/souther-compiler/src/test/java/souther/compiler/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
@@ -238,7 +238,9 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
                                 new TypeName("example.rate", "Amount"), "value <= 100"),
                         BoundaryObligation.BoundarySide.AT, new ObservedValue.Integer(100)),
                 new BoundaryAssessment.Coverage.Hit(),
-                new BoundaryAssessment.Writability.WitnessedByRow());
+                new BoundaryAssessment.Writability.WitnessedByRow(),
+                new BoundaryAssessment.Attempt.NotAttempted(
+                        BoundaryAssessment.Attempt.Reason.A_ROW_IS_ALREADY_THERE));
 
         assertEquals(AdequacyReport.AdequacyStatus.SATISFIED, verdictOf(partition(met)),
                 "nothing dropped");

--- a/souther-compiler/src/test/java/souther/compiler/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhatStrictRefusesIsWhatTheRowsDoNotCoverTest.java
@@ -8,6 +8,11 @@ import souther.compiler.partition.BoundaryObligation;
 import souther.compiler.partition.Partitions;
 import souther.compiler.query.Adequacy;
 import souther.compiler.query.Compilation;
+import souther.compiler.partition.AxisId;
+import souther.compiler.partition.OriginRef;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.query.BoundaryAssessment;
+import souther.compiler.types.TypeName;
 import souther.compiler.query.PartitionEvidence;
 import souther.compiler.report.AdequacyReport;
 
@@ -18,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -226,9 +232,13 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
      */
     @Test
     void anAxisDroppedPastTheLimitHoldsTheVerdictOpenOnlyWhereItCarriedAnObligation() {
-        PartitionEvidence.BoundaryCoverage met = new PartitionEvidence.BoundaryCoverage(
-                "weigh/w.a", "guard", BoundaryObligation.BoundarySide.AT, "100", true,
-                MeasurementStatus.COMPLETE, null, true);
+        BoundaryAssessment met = new BoundaryAssessment(
+                new BoundaryObligation(new AxisId("weigh", "w.a"),
+                        new OriginRef.InvariantOrigin(Optional.empty(),
+                                new TypeName("example.rate", "Amount"), "value <= 100"),
+                        BoundaryObligation.BoundarySide.AT, new ObservedValue.Integer(100)),
+                new BoundaryAssessment.Coverage.Hit(),
+                new BoundaryAssessment.Writability.WitnessedByRow());
 
         assertEquals(AdequacyReport.AdequacyStatus.SATISFIED, verdictOf(partition(met)),
                 "nothing dropped");
@@ -245,7 +255,7 @@ class WhatStrictRefusesIsWhatTheRowsDoNotCoverTest {
                 Incompleteness.Scope.POSITION, position), carriedAnObligation);
     }
 
-    private static PartitionEvidence partition(PartitionEvidence.BoundaryCoverage boundary,
+    private static PartitionEvidence partition(BoundaryAssessment boundary,
                                                Partitions.OmittedAxis... omitted) {
         return new PartitionEvidence(List.of(), List.of(boundary), PartitionEvidence.PairSpace.NONE,
                 List.of(), List.of(omitted));

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -485,10 +485,18 @@ public final class Analyzer {
         return String.join(" · ", parts);
     }
 
-    /** Whether a line was measured against the rows at all. A line waiting on the arms has no answer
-     * to show beside a declaration, and a count that included it would move when the setting did. */
+    /**
+     * Whether a line came to an answer against the rows.
+     *
+     * <p>Hit or missed, and nothing else. A line waiting on the arms has no answer to show beside a
+     * declaration, and one whose value could not be read has no answer either — a lens counting it
+     * would put a number in front of an author that says a row is missing at a value nothing was able
+     * to look at. The report can afford to include such a line because it writes "undecided" beside
+     * the count; one number on one line has nowhere to put that word.
+     */
     private static boolean settled(souther.compiler.query.BoundaryAssessment.Coverage coverage) {
-        return !(coverage instanceof souther.compiler.query.BoundaryAssessment.Coverage.NotMeasured);
+        return coverage instanceof souther.compiler.query.BoundaryAssessment.Coverage.Hit
+                || coverage instanceof souther.compiler.query.BoundaryAssessment.Coverage.Missed;
     }
 
     /** The caret at one position, as a range of no width. */

--- a/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
+++ b/souther-lsp/src/main/java/souther/lsp/analysis/Analyzer.java
@@ -468,11 +468,10 @@ public final class Analyzer {
                 adequacy.partitions() == null ? null : adequacy.partitions().get(behavior);
         if (partition != null) {
             long measured = partition.boundaries().stream()
-                    .filter(b -> b.status() == souther.compiler.observe.MeasurementStatus.COMPLETE)
-                    .count();
+                    .filter(b -> settled(b.coverage())).count();
             long met = partition.boundaries().stream()
-                    .filter(b -> b.status() == souther.compiler.observe.MeasurementStatus.COMPLETE)
-                    .filter(souther.compiler.query.PartitionEvidence.BoundaryCoverage::hit).count();
+                    .filter(b -> settled(b.coverage()))
+                    .filter(b -> b.coverage().hit()).count();
             if (measured > 0) {
                 parts.add("boundary " + met + "/" + measured);
             }
@@ -484,6 +483,12 @@ public final class Analyzer {
             parts.add("branch " + branch.covered().size() + "/" + branch.all().size());
         }
         return String.join(" · ", parts);
+    }
+
+    /** Whether a line was measured against the rows at all. A line waiting on the arms has no answer
+     * to show beside a declaration, and a count that included it would move when the setting did. */
+    private static boolean settled(souther.compiler.query.BoundaryAssessment.Coverage coverage) {
+        return !(coverage instanceof souther.compiler.query.BoundaryAssessment.Coverage.NotMeasured);
     }
 
     /** The caret at one position, as a range of no width. */

--- a/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/AdequacyLensTest.java
@@ -167,4 +167,57 @@ class AdequacyLensTest {
         assertEquals(List.of(), new Analyzer()
                 .codeActions(MODULE, TRIP, on(9), graphOf(Map.of(MODULE, TRIP))));
     }
+
+    /**
+     * A line whose value could not be read is left out of the ratio.
+     *
+     * <p>A lens is one number on one line and has nowhere to put a word beside it. The report writes
+     * "undecided" next to the count and can afford to include such a line; drawn over a declaration
+     * the same line reads as a row the author has not written, at a value nothing was able to look
+     * at. So the ratio counts the lines that came to an answer, and the rest are absent rather than
+     * counted as missing.
+     *
+     * <p>The row below hands the behavior more nodes than an observation keeps, so the value at
+     * {@code cost} is truncated and the boundaries there are undecided.
+     */
+    @Test
+    void aLineWhoseValueCouldNotBeReadIsNotInTheRatio() {
+        StringBuilder items = new StringBuilder();
+        for (int i = 0; i < 64; i++) {
+            items.append(i == 0 ? "" : ", ")
+                    .append("Item { a = \"").append(i).append("\", b = \"").append(i)
+                    .append("\", c = \"").append(i).append("\" }");
+        }
+        StringBuilder groups = new StringBuilder();
+        for (int i = 0; i < 64; i++) {
+            groups.append(i == 0 ? "" : ", ")
+                    .append("Group { items = [ ").append(items).append(" ] }");
+        }
+        String unread = """
+                module example.wide
+
+                data Amount = Int
+                    invariant value >= 0 && value <= 1000
+
+                data Item = { a: String, b: String, c: String }
+                data Group = { items: List<Item> }
+                data Draft = { groups: List<Group>, cost: Amount }
+                data Ok = { n: Int }
+
+                behavior take : (request: Draft) -> Ok
+                    constructs Ok
+
+                let take (request) = Ok { n = request.cost.value }
+
+                example take
+                    | (Draft { groups = [ %s ], cost = Amount(0) }) -> Ok { n = 0 }
+                """.formatted(groups);
+
+        List<CodeLens> lenses = measuring(Adequacy.Level.ALL)
+                .codeLenses(MODULE, graphOf(Map.of(MODULE, unread)));
+
+        assertEquals(1, lenses.size());
+        assertFalse(lenses.get(0).title().contains("boundary"),
+                "the invariant draws two lines and neither was decided: " + lenses.get(0).title());
+    }
 }


### PR DESCRIPTION
Closes #467.

## What the issue asked, and what turned out to be under it

#467 asks whether `Findings` should read `Generated`, and offers three
shapes for saying yes. None of them is taken here. The generator's witness
being unread is a symptom: coverage, the static projection and runtime
construction were each producing their own answer about the same boundary
obligation, which is the problem `Adequacy.Excluded` already names —
deriving the same fact several times is several chances to disagree.

Two of the issue's premises did not hold up:

- The cost is not "a row search on every adequacy run". `Generator.fill`
  searches the pair space; a boundary witness is one decode per unmet
  obligation. They were bundled in one query, not one computation.
- `Generated` was asking `Output.Linked`, generating a second uncounted
  set of classes, while the rows had already been run against
  `Output.EvaluationLinked`. Those give the same generated bytes, so the
  second codegen bought nothing. (`FixtureReader.constructing` still makes
  its own `MemoryClassLoader`; no `Class<?>` identity is shared with the
  evaluation.)

## What is here

`BoundaryAssessment(obligation, coverage, writability, attempt)`, made
once in the new `Adequacy.Boundaries` query and read by `Findings`, by
`Generated` and by the report.

Three answers, because they are about three things and are established by
three different means:

```
Coverage    — what the rows showed
Writability — what is proven about a value existing there
Attempt     — what the search tried, and what came of it
```

`Writability` is sealed: `ProvenByProjection`, `WitnessedByRow`,
`WitnessedByConstruction`, `Unknown`. There is no case for "cannot be
written". A decoder refusing every candidate it tried says nothing about
the ones it did not, so a refusal leaves the edge unknown — and the
mutation that turns a decode failure into proof of impossibility is not
expressible, not merely tested against.

`Attempt` is `Built | Refused | NotAttempted(reason)`. It is kept whether
or not it changed the verdict, because an edge the projection proves is
still one a search can fail to reach — folding it into the verdict left
`--generate` with nothing to say about exactly that case.

Gone: `Coverages.unmet`, `Generator.forBoundaries`,
`PartitionEvidence.BoundaryCoverage`, and `knownWritable || met == YES`
— which was two evidence sources joined with a boolean `or`.

### Evaluation order

A row at the value settles it first, and nothing is built for a value
that is already there. Otherwise the probe runs, and the projection
stands behind it rather than in front of it. That is one step away from
what was proposed on the issue thread: skipping the probe where the
projection already proves the edge would also skip building the row the
generator offers there, and running one attempt that both readers use is
the point of moving it here.

## Effect on souther-examples

```
not known to be writable   82 -> 32
no row is at              138 -> 166
```

50 edges leave the unknown set. 28 become rows an author is owed. The
other 22 are on behaviors no row names (`returnFromLeave`,
`loseCoverage`, `applyDecision`): writability now has an answer, coverage
still does not, and the report no longer prints the second as though it
were the first.

`sharedAttendees` stays unknown, correctly — nothing can be written at
its `related` position, so no row completes.

Generator output is unchanged from develop: same rows, same notes.

## Tests

`AnEdgeIsWritableBecauseSomethingSaidSoTest` pins the design at the
assessment rather than through the printed line, which cannot tell a
witness from a proof. Its main fixture is one range with `value /= 0` on
it: edge 0 is refused because the unread rule reaches it, edge 10 is
witnessed by construction because it does not. The pair is the point —
reading `allRulesRead == false` as writable would settle both, and
keeping it as unwritable settles neither. A second model covers a proven
edge whose search still came back with nothing, in the assessment and in
the block an author reads.

Three cases in `ABoundaryIsAValueTheRecordCanHoldTest` changed, and are
rewritten to assert both ends. `Band { low, high } invariant low < high`
now distinguishes `band.low = 1`, which stays unknown, from
`band.high = 1`, which is owed.

`AdequacyLensTest.aLineWhoseValueCouldNotBeReadIsNotInTheRatio` holds the
editor lens to counting only what came to an answer.

Full clean build: 3691 + 185 + 109 + 1 tests, no failures.

## Not in this change

- The JSON report keeps its shape. `hit` and `knownWritable` are derived
  from the assessment instead of stored beside it. Naming which evidence
  settled a line is worth emitting and needs a schema version, so it
  waits for one.
- The candidate search is asymmetric: probing `band.low = 0` refuses
  every candidate while probing `band.high = 1` builds `low = 0, high = 1`
  — the same pair, found from one side only. It predates this change and
  is sound here (unknown never means impossible), but it costs coverage.
  Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
