### PR TITLE
The words the schema allows are the words the compiler writes

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -642,22 +642,46 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
 
+    /**
+     * How this report spells an enumerated value on the wire.
+     *
+     * <p>Here rather than at each field, so that the words a consumer reads have one origin. The
+     * shipped schema names the same words in its own file and is held against this — against what is
+     * written, not against a second reading of the enum, because those are different things and only
+     * one of them is what a consumer sees. A spelling rule applied at ten call sites is ten places for
+     * the schema to stop describing the output while every one of them still agrees with the enum.
+     */
+    public static String word(Enum<?> value) {
+        return value.name().toLowerCase(java.util.Locale.ROOT);
+    }
+
+    /**
+     * The same, for the one field with no enum behind it.
+     *
+     * <p>Whether a behavior has a {@code let} is a boolean, and these are the two words it is written
+     * as. Having no enum is why it needs this more than the others rather than less: nothing else in
+     * the compiler says what these words are.
+     */
+    public static String implementationWord(boolean injected) {
+        return injected ? "injected" : "implemented";
+    }
+
     public String json() {
         ObjectNode root = JSON.createObjectNode();
         root.put("schemaVersion", schemaVersion);
         root.put("compilerVersion", compilerVersion);
-        root.put("status", status.name().toLowerCase(java.util.Locale.ROOT));
-        root.put("adequacy", adequacy().name().toLowerCase(java.util.Locale.ROOT));
+        root.put("status", word(status));
+        root.put("adequacy", word(adequacy()));
         ArrayNode modulesOut = root.putArray("modules");
         for (ModuleReport module : modules) {
             ObjectNode m = modulesOut.addObject();
             m.put("module", module.module());
-            m.put("status", module.status().name().toLowerCase(java.util.Locale.ROOT));
+            m.put("status", word(module.status()));
             ArrayNode gaps = m.putArray("incompleteness");
             for (Incompleteness gap : module.incompleteness()) {
                 ObjectNode g = gaps.addObject();
-                g.put("code", gap.code().name().toLowerCase(java.util.Locale.ROOT));
-                g.put("scope", gap.scope().name().toLowerCase(java.util.Locale.ROOT));
+                g.put("code", word(gap.code()));
+                g.put("scope", word(gap.scope()));
                 g.put("subject", gap.subject());
                 gap.at().ifPresent(where -> {
                     ObjectNode at = g.putObject("at");
@@ -670,10 +694,10 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             for (BehaviorReport behavior : module.behaviors()) {
                 ObjectNode b = behaviors.addObject();
                 b.put("name", behavior.name());
-                b.put("implementation", behavior.injected() ? "injected" : "implemented");
+                b.put("implementation", implementationWord(behavior.injected()));
                 b.put("rows", behavior.rows());
                 b.put("pending", behavior.pending());
-                b.put("status", behavior.status().name().toLowerCase(java.util.Locale.ROOT));
+                b.put("status", word(behavior.status()));
                 signature(b, behavior.signature());
                 partition(b, behavior.partition());
                 branch(b, behavior.branch());
@@ -732,7 +756,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             ObjectNode b = boundaries.addObject();
             b.put("axis", boundary.axis());
             b.put("origin", boundary.origin());
-            b.put("side", boundary.side().name().toLowerCase(java.util.Locale.ROOT));
+            b.put("side", word(boundary.side()));
             b.put("value", boundary.value());
             // The shape a published schema promises, read off the assessment rather than stored
             // beside it. What each of these says is unchanged; where it comes from is one answer now
@@ -772,7 +796,7 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
         for (souther.compiler.coverage.CoverageSites.Site arm : named) {
             ObjectNode a = unreached.addObject();
             a.put("label", arm.label());
-            a.put("kind", arm.kind().name().toLowerCase(java.util.Locale.ROOT));
+            a.put("kind", word(arm.kind()));
             ObjectNode at = a.putObject("at");
             at.put("sourceId", arm.at().sourceId());
             at.put("line", arm.at().pos().line());
@@ -789,9 +813,9 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
      * measure that failed no longer has to work it out from the numbers beside it.
      */
     private static void measured(ObjectNode of, MeasurementStatus status, Enum<?> reason) {
-        of.put("status", status.name().toLowerCase(java.util.Locale.ROOT));
+        of.put("status", word(status));
         if (reason != null) {
-            of.put("reason", reason.name().toLowerCase(java.util.Locale.ROOT));
+            of.put("reason", word(reason));
         }
     }
 

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
@@ -290,7 +290,7 @@
           "description": "What `subject` names, and so what the reason counts against. Anything larger than a behavior counts against every behavior inside it."
         },
         "code": {
-          "enum": ["value_unreadable", "value_truncated", "row_timed_out", "runtime_absent",
+          "enum": ["value_unreadable", "value_truncated", "row_undecided", "runtime_absent",
                    "probe_mapping_lost", "search_limit", "axis_omitted"]
         },
         "subject": { "type": "string" },

--- a/souther-compiler/src/test/java/souther/compiler/EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest.java
@@ -1,0 +1,231 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.MeasurementStatus;
+import souther.compiler.partition.BoundaryObligation;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BoundaryAssessment;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.report.AdequacyReport;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The words the shipped schema allows are the words the compiler writes.
+ *
+ * <p>Every enumerated field of {@code adequacy-schema-1.json} is a second spelling of a Java enum.
+ * The two are edited in different files by different hands, and until this test nothing noticed when
+ * one moved: `ROW_TIMED_OUT` became `ROW_UNDECIDED` when a row stopped being held to a clock, the
+ * rename was right, and the schema went on promising a word that had not been emitted since.
+ *
+ * <p>Held as a correspondence rather than by generating one side from the other. A published contract
+ * generated from an internal enum would change whenever the internal enum did, which is the opposite
+ * mistake: renaming a constant is a decision about the compiler, and widening what a consumer must
+ * handle is a decision about the contract. This makes the second decision impossible to take by
+ * accident, and leaves both deliberate.
+ */
+class EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest {
+
+    private static final String SCHEMA = "/souther/adequacy-schema-1.json";
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /**
+     * One enumerated field, and the enum whose constants it spells.
+     *
+     * @param at the field, as the keys leading to it from the root of the schema
+     */
+    private record Vocabulary(String label, List<String> at, Class<? extends Enum<?>> source) {}
+
+    /**
+     * Every enumerated field the schema has.
+     *
+     * <p>Written out rather than discovered. A test that walked the schema for `enum` and looked for
+     * something to compare each against would pass over a field it could not place, which is the
+     * field most worth knowing about — one nobody has said where the words come from.
+     */
+    private static final List<Vocabulary> VOCABULARIES = List.of(
+            new Vocabulary("adequacy", List.of("properties", "adequacy"),
+                    AdequacyReport.AdequacyStatus.class),
+            new Vocabulary("status", List.of("$defs", "status"),
+                    MeasurementStatus.class),
+            new Vocabulary("branch.reason", List.of("$defs", "branch", "properties", "reason"),
+                    Adequacy.BranchEvidence.Reason.class),
+            new Vocabulary("branch.unreached[].kind",
+                    List.of("$defs", "branch", "properties", "unreached", "items", "properties",
+                            "kind"),
+                    CoverageSites.Site.Kind.class),
+            new Vocabulary("partition.axes[].reason",
+                    List.of("$defs", "partition", "properties", "axes", "items", "properties",
+                            "reason"),
+                    PartitionEvidence.AxisCoverage.Reason.class),
+            new Vocabulary("partition.boundaries[].side",
+                    List.of("$defs", "partition", "properties", "boundaries", "items", "properties",
+                            "side"),
+                    BoundaryObligation.BoundarySide.class),
+            new Vocabulary("partition.boundaries[].reason",
+                    List.of("$defs", "partition", "properties", "boundaries", "items", "properties",
+                            "reason"),
+                    BoundaryAssessment.Coverage.Reason.class),
+            new Vocabulary("partition.pairs.reason",
+                    List.of("$defs", "partition", "properties", "pairs", "properties", "reason"),
+                    PartitionEvidence.PairSpace.Reason.class),
+            new Vocabulary("signature.reason", List.of("$defs", "signature", "properties", "reason"),
+                    Adequacy.SignatureEvidence.Reason.class),
+            new Vocabulary("incompleteness.scope",
+                    List.of("$defs", "incompleteness", "properties", "scope"),
+                    Incompleteness.Scope.class),
+            new Vocabulary("incompleteness.code",
+                    List.of("$defs", "incompleteness", "properties", "code"),
+                    Incompleteness.Code.class));
+
+    @Test
+    void everyEnumeratedFieldSpellsTheEnumItComesFrom() {
+        JsonNode schema = schema();
+        for (Vocabulary each : VOCABULARIES) {
+            assertEquals(constantsOf(each.source()), allowedAt(schema, each.at()),
+                    each.label() + ": the schema and " + each.source().getSimpleName()
+                            + " name different words");
+        }
+    }
+
+    /**
+     * The one enumerated field with no enum behind it.
+     *
+     * <p>{@code implementation} is written from a boolean — a behavior has a {@code let} or it does
+     * not — so there is nothing to hold it against. Named here rather than left out, because a field
+     * absent from the table above and absent from the schema are indistinguishable to a reader, and
+     * only one of them is deliberate.
+     */
+    @Test
+    void theFieldWithNoEnumBehindItIsTheOneThatIsWrittenFromABoolean() {
+        assertEquals(Set.of("implemented", "injected"),
+                allowedAt(schema(), List.of("$defs", "behavior", "properties", "implementation")));
+    }
+
+    /** Every enumerated field of the schema is either held above or named as the exception. */
+    @Test
+    void noEnumeratedFieldIsUnaccountedFor() {
+        List<String> paths = new ArrayList<>();
+        collectEnums(schema(), "", paths);
+        Set<String> held = new LinkedHashSet<>();
+        for (Vocabulary each : VOCABULARIES) {
+            held.add("/" + String.join("/", each.at()));
+        }
+        held.add("/$defs/behavior/properties/implementation");
+
+        List<String> unaccounted = paths.stream().filter(p -> !held.contains(p)).toList();
+        assertEquals(List.of(), unaccounted,
+                "an enumerated field nothing says where the words come from");
+    }
+
+    /**
+     * A report that carries an incompleteness says it in a word the schema allows.
+     *
+     * <p>The end of the same defect, from the other side. What the schema promised and what the
+     * compiler wrote could disagree for as long as they did partly because the report the schema is
+     * checked against is a clean compile: `incompleteness` is an empty array in it, so the field
+     * where the two had come apart was never written at all.
+     */
+    @Test
+    void anUndecidedRowIsReportedInAWordTheSchemaAllows() {
+        Compilation compilation = Compilation.ofSource("""
+                module example.loop
+
+                data N = Int
+                    invariant value >= 0
+
+                data Ok = { n: Int }
+
+                behavior go : (n: N) -> Ok
+                    constructs Ok
+
+                let go (n) = Ok { n = n.value }
+
+                example go
+                    | "one" : (N(1)) -> Ok { n = 1 }
+                """, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.withDeadline(
+                DoesNotComeBack.overrunningOn(DoesNotComeBack.everythingAboutRowsOf("go")));
+        compilation.answerEverything();
+
+        JsonNode report = JSON.readTree(AdequacyReport.of(compilation).json());
+        Set<String> allowed =
+                allowedAt(schema(), List.of("$defs", "incompleteness", "properties", "code"));
+
+        List<String> written = new ArrayList<>();
+        for (JsonNode module : report.get("modules")) {
+            for (JsonNode gap : module.get("incompleteness")) {
+                written.add(gap.get("code").asString());
+            }
+        }
+        assertFalse(written.isEmpty(), "the row did not come back, so the report says so");
+        for (String code : written) {
+            assertTrue(allowed.contains(code),
+                    "`" + code + "` is written and the schema allows " + allowed);
+        }
+    }
+
+    private static Set<String> constantsOf(Class<? extends Enum<?>> source) {
+        return Arrays.stream(source.getEnumConstants())
+                .map(each -> each.name().toLowerCase(Locale.ROOT))
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    private static Set<String> allowedAt(JsonNode schema, List<String> at) {
+        JsonNode node = schema;
+        for (String key : at) {
+            node = node.get(key);
+            assertNotNull(node, "the schema has no " + String.join("/", at));
+        }
+        Set<String> out = new LinkedHashSet<>();
+        for (JsonNode each : node.get("enum")) {
+            out.add(each.asString());
+        }
+        return out;
+    }
+
+    /** Every path in the schema that constrains a field to a list of words. */
+    private static void collectEnums(JsonNode node, String path, List<String> out) {
+        if (node.isObject()) {
+            if (node.has("enum")) {
+                out.add(path);
+            }
+            for (String name : node.propertyNames()) {
+                collectEnums(node.get(name), path + "/" + name, out);
+            }
+        } else if (node.isArray()) {
+            for (int i = 0; i < node.size(); i++) {
+                collectEnums(node.get(i), path + "/" + i, out);
+            }
+        }
+    }
+
+    private static JsonNode schema() {
+        try (InputStream in = Main.class.getResourceAsStream(SCHEMA)) {
+            assertNotNull(in, "adequacy-schema-1.json ships beside the compiler");
+            return JSON.readTree(new String(in.readAllBytes(), StandardCharsets.UTF_8));
+        } catch (java.io.IOException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest.java
@@ -101,7 +101,7 @@ class EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest {
     void everyEnumeratedFieldSpellsTheEnumItComesFrom() {
         JsonNode schema = schema();
         for (Vocabulary each : VOCABULARIES) {
-            assertEquals(constantsOf(each.source()), allowedAt(schema, each.at()),
+            assertEquals(wordsOf(each.source()), allowedAt(schema, each.at()),
                     each.label() + ": the schema and " + each.source().getSimpleName()
                             + " name different words");
         }
@@ -117,7 +117,8 @@ class EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest {
      */
     @Test
     void theFieldWithNoEnumBehindItIsTheOneThatIsWrittenFromABoolean() {
-        assertEquals(Set.of("implemented", "injected"),
+        assertEquals(Set.of(AdequacyReport.implementationWord(false),
+                        AdequacyReport.implementationWord(true)),
                 allowedAt(schema(), List.of("$defs", "behavior", "properties", "implementation")));
     }
 
@@ -178,16 +179,26 @@ class EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest {
                 written.add(gap.get("code").asString());
             }
         }
-        assertFalse(written.isEmpty(), "the row did not come back, so the report says so");
-        for (String code : written) {
-            assertTrue(allowed.contains(code),
-                    "`" + code + "` is written and the schema allows " + allowed);
-        }
+        // The word itself, and not merely a word the schema happens to allow. This is here to keep
+        // one reproduction alive: a fixture that stopped producing an undecided row and produced
+        // some other legitimate gap instead would go on passing while covering nothing.
+        assertEquals(List.of("row_undecided"), written,
+                "the row did not come back, and this is what the report says about it");
+        assertTrue(allowed.containsAll(written),
+                "the schema allows " + allowed + " and the report writes " + written);
     }
 
-    private static Set<String> constantsOf(Class<? extends Enum<?>> source) {
+    /**
+     * The words the report writes for one enum, put through the writer's own encoder.
+     *
+     * <p>{@link AdequacyReport#word} rather than a second spelling rule written here. A rule written
+     * here would agree with the schema while the report wrote something else entirely: what a
+     * consumer reads is what the encoder produces, so that is the side a contract has to be held
+     * against.
+     */
+    private static Set<String> wordsOf(Class<? extends Enum<?>> source) {
         return Arrays.stream(source.getEnumConstants())
-                .map(each -> each.name().toLowerCase(Locale.ROOT))
+                .map(AdequacyReport::word)
                 .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/MainExamplesSubcommandTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/MainExamplesSubcommandTest.java
@@ -171,12 +171,16 @@ class MainExamplesSubcommandTest {
     }
 
     /**
-     * The shipped schema and what is actually emitted have to agree. Not a full validation — that
-     * would want a library — but every key the schema requires is present and no key is emitted that
-     * the schema does not declare, which is what drifts.
+     * The shape: every key the schema requires is present, and no key is emitted that the schema does
+     * not declare.
+     *
+     * <p>Named for what it does. It is not a validation — that would want a library — and the words a
+     * field is allowed to take are not checked here at all; a name promising more than that is how a
+     * schema came to allow a word the compiler had stopped writing while this went on passing.
+     * {@link EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest} holds the vocabularies.
      */
     @Test
-    void theEmittedJsonMatchesTheShippedSchema() throws Exception {
+    void theEmittedJsonHasTheShippedSchemaShape() throws Exception {
         JsonNode schema;
         try (var in = Main.class.getResourceAsStream("/souther/adequacy-schema-1.json")) {
             assertNotNull(in, "adequacy-schema-1.json ships beside the compiler");


### PR DESCRIPTION
Closes #472.

## The defect

`adequacy-schema-1.json` allows `row_timed_out` for
`incompleteness[].code`. The compiler writes `row_undecided`. A report
carrying an undecided row fails validation against the schema shipped
beside it.

Reproduced end to end, not read off the source: a compile whose row does
not come back emits

```
emitted code : row_undecided   allowed=false
```

`f1f42ecf` renamed `ROW_TIMED_OUT` to `ROW_UNDECIDED` when a row stopped
being held to a clock and the code widened to cover an evaluation that
did not answer at all. The rename was right. The schema was not part of
the change and has promised the old word since.

## The fix, and why it is not a version

The schema is corrected. `row_timed_out` has never been emitted, so no
consumer has read it and none needs telling: the file described something
that was never true.

## What let it happen

The vocabulary is spelled twice — a Java enum, and a hand-written list in
the schema — with nothing tying them. There are twelve such fields.

I checked all twelve against the compiled enums. Eleven agree. That is
eleven pieces of luck rather than eleven pieces of evidence: the same
rename in any of them would have gone the same way.

`EveryWordTheSchemaAllowsIsOneTheCompilerWritesTest` holds the
correspondence, one entry per field naming the enum its words come from,
plus a third case holding the table complete so a new enumerated field
arrives as a failure rather than an omission. `implementation` is named
as the exception — it is written from a boolean and has no enum behind
it.

Not generated from the enums. A contract generated from an internal type
changes whenever the type does, and widening what a consumer must handle
is a decision about the contract rather than about the compiler. Both
decisions stay deliberate; only the accidental one is now impossible.

This is the shape `Adequacy.Kind` already describes — "the agreement is
held by a test rather than by reading one off the other" — and that
`CstLexer.keywords()` → `souther.tmLanguage.json` and
`Main.knownOptions()` → the usage text already follow.

## The second hole

Only one of the two things that hid this is the missing correspondence.
The report the schema is checked against is a clean compile, so
`incompleteness` is an empty array in it: even a value-checking version
of the existing test would not have produced `row_undecided`. A report
that carries one is now emitted and read.

## The rename

`theEmittedJsonMatchesTheShippedSchema` →
`theEmittedJsonHasTheShippedSchemaShape`. It checks required keys and
declared keys and has never checked a value. A name claiming to match the
schema is how a reader concludes validation is already covered — which is
roughly how this defect survived.

No JSON Schema validator dependency is added. The defect mechanism is
caught by the correspondence, and the fixture gap by the emitted report.

## Where else this could be

I swept the repository with the two questions — must a human remember to
change a second file, and does the build fail if they disagree. Eight
boundaries: six already protected (keyword highlighting, the message
catalogs, diagnostic codes against the specification, message keys
against the catalog, CLI options against the usage text, the doc set
index), and two not. This schema is one. The other is the ADR index, 99
files and 99 entries, in step by hand.

Two more were raised and checked: the stdlib's intrinsic keys against the
backend table turn out to be held in both directions by
`EveryKernelIsDeclaredTest`, and the LSP's advertised capabilities
against its dispatch are not held by anything — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
