### PR TITLE
Propose both edges of a bounded newtype, not only the low one

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -41,9 +41,10 @@ public final class Generator {
      * and pastes, and a model that wants more than this has axes it should be measured at fewer of. */
     static final int MAX_ROWS = 200;
 
-    /** How many assignments of values one parameter is tried at. The choices multiply, so this is a
-     * bound on the search and not on any one position — and reaching it is reported as the search
-     * having stopped, which is a different thing from every assignment having been refused. */
+    /** How many assignments of values one parameter is tried at in one pass. The choices multiply, so
+     * this is a bound on the search and not on any one position — and reaching it is reported as the
+     * search having stopped, which is a different thing from every assignment having been refused. A
+     * parameter with something held in reserve is walked twice, each pass under this bound. */
     private static final int MAX_TUPLES = 256;
 
     /** How deep a record is built. Past this a value stops being anything an author recognises as one
@@ -614,13 +615,34 @@ public final class Generator {
      *
      * @param at        the paths, so that an assignment can be read back as which value went where
      * @param values    what each of those positions can take, never empty
+     * @param reserves  what each holds back for the case where everything above was refused, which is
+     *                  usually nothing. Kept apart rather than appended: the search is over the
+     *                  product of {@code values} and is bounded, so a value added to one position
+     *                  moves the assignments past it further back — and a row that was being reached
+     *                  would stop being reached over a widening at a position it does not involve
      * @param missingAt the position nothing at all can be written at, where there is one — which is
      *                  not a choice to make but a reason there is no row
      */
-    private record Choices(List<String> at, List<List<FixtureTemplate>> values, String missingAt) {
+    private record Choices(List<String> at, List<List<FixtureTemplate>> values,
+                           List<List<FixtureTemplate>> reserves, String missingAt) {
 
         static Choices missing(String at) {
-            return new Choices(List.of(), List.of(), at);
+            return new Choices(List.of(), List.of(), List.of(), at);
+        }
+
+        boolean anythingHeldBack() {
+            return reserves.stream().anyMatch(each -> !each.isEmpty());
+        }
+
+        /** The same positions, each offering what it held back as well. */
+        List<List<FixtureTemplate>> widened() {
+            List<List<FixtureTemplate>> out = new ArrayList<>();
+            for (int i = 0; i < values.size(); i++) {
+                List<FixtureTemplate> here = new ArrayList<>(values.get(i));
+                here.addAll(reserves.get(i));
+                out.add(List.copyOf(here));
+            }
+            return List.copyOf(out);
         }
     }
 
@@ -640,14 +662,18 @@ public final class Generator {
                                      Map<String, BigDecimal> settled) {
         List<String> paths = new ArrayList<>(decided.keySet());
         List<List<FixtureTemplate>> values = new ArrayList<>(decided.values());
+        // A position the caller fixed holds nothing back: it was given the value it is to take.
+        List<List<FixtureTemplate>> reserves = new ArrayList<>(
+                java.util.Collections.nCopies(paths.size(), List.<FixtureTemplate>of()));
         // One reading of the parameter, not one per record inside it. A clause on the outer record
         // says what is left for a position two levels down, and a reading rebuilt at the inner record
         // has never seen it.
         FieldDomains left = type instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()
                 ? FieldDomains.of(ref.name(), data, symbols, under(at, settled)) : FieldDomains.NONE;
-        String missing = choicesUnder(type, at, symbols, 0, paths, values, left, at);
-        return missing != null ? Choices.missing(missing) : new Choices(paths, values, null);
+        String missing = choicesUnder(type, at, symbols, 0, paths, values, reserves, left, at);
+        return missing != null ? Choices.missing(missing)
+                : new Choices(paths, values, reserves, null);
     }
 
     /** The settled positions of one parameter, named the way the reading of that parameter names
@@ -670,6 +696,7 @@ public final class Generator {
      * nothing can be written at, where there is one. */
     private static String choicesUnder(Type type, TermPath at, Symbols symbols, int depth,
                                        List<String> paths, List<List<FixtureTemplate>> values,
+                                       List<List<FixtureTemplate>> reserves,
                                        FieldDomains left, TermPath root) {
         if (paths.contains(at.toString())) {
             return null;   // an axis decides here
@@ -680,7 +707,7 @@ public final class Generator {
             if (!fields.isEmpty()) {
                 for (Map.Entry<String, Type> field : fields.entrySet()) {
                     String missing = choicesUnder(field.getValue(), at.then(field.getKey()), symbols,
-                            depth + 1, paths, values, left, root);
+                            depth + 1, paths, values, reserves, left, root);
                     if (missing != null) {
                         return missing;
                     }
@@ -688,8 +715,9 @@ public final class Generator {
                 return null;
             }
         }
-        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols,
-                at.fields().isEmpty() ? null : left.at(String.join(".", at.fields())));
+        souther.compiler.numeric.NumericDomain.Bounds here =
+                at.fields().isEmpty() ? null : left.at(String.join(".", at.fields()));
+        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols, here);
         if (stands.isEmpty()) {
             // Nothing could be written at all: a position of a type nothing stands for. Which is not
             // the same as a value that was written and refused, and reporting it as one sends the
@@ -698,6 +726,7 @@ public final class Generator {
         }
         paths.add(at.toString());
         values.add(stands);
+        reserves.add(Partitions.inReserve(type, symbols, here));
         return null;
     }
 
@@ -712,9 +741,31 @@ public final class Generator {
      * then every assignment one step from one already tried. Deterministic, because the order the
      * positions were collected in is the order their steps are taken in, and a row is compared against
      * the last run's to see what changed.
+     *
+     * <p>Twice where a position held something back, and the second pass runs only after the first ran
+     * out. What the positions offer ordinarily is searched whole before anything held in reserve is
+     * offered at all, so a row the first pass reaches is reached at the assignment it always was: a
+     * wider set of choices is a longer walk to every assignment in it, and a widening meant for one
+     * position would otherwise take rows away from the rest.
      */
     private static Outcome walk(Subject subject, int p, Choices choices, CandidateCheck check) {
-        int positions = choices.at().size();
+        Outcome tried = over(subject, p, choices.at(), choices.values(), check);
+        // Only where the ordinary assignments ran out. A search that stopped at the bound has not
+        // tried them all, and starting a wider one in front of the ones it never reached would spend
+        // what is left on assignments further from what the model says the row is about, while the
+        // nearer ones stay untried.
+        if (tried.value() != null || !choices.anythingHeldBack()
+                || tried.reason() != UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED) {
+            return tried;
+        }
+        return over(subject, p, choices.at(), choices.widened(), check);
+    }
+
+    /** One pass over one set of choices, from the assignment where every position takes its first
+     * value outward. */
+    private static Outcome over(Subject subject, int p, List<String> at,
+                                List<List<FixtureTemplate>> values, CandidateCheck check) {
+        int positions = at.size();
         ArrayDeque<int[]> next = new ArrayDeque<>();
         Set<String> seen = new LinkedHashSet<>();
         int[] first = new int[positions];
@@ -727,7 +778,7 @@ public final class Generator {
             tried++;
             Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
             for (int i = 0; i < positions; i++) {
-                chosen.put(choices.at().get(i), choices.values().get(i).get(assignment[i]));
+                chosen.put(at.get(i), values.get(i).get(assignment[i]));
             }
             FixtureTemplate built = compose(subject.types().get(p),
                     TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0);
@@ -735,7 +786,7 @@ public final class Generator {
                 return new Outcome(built, null, null);
             }
             for (int i = 0; i < positions; i++) {
-                if (assignment[i] + 1 >= choices.values().get(i).size()) {
+                if (assignment[i] + 1 >= values.get(i).size()) {
                     continue;
                 }
                 int[] stepped = assignment.clone();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -620,9 +620,10 @@ public final class Partitions {
 
         Bounds bounds = narrowed(boundsOf(new Type.Ref(newtype), symbols), within);
         if (bounds != null && !bounds.isEmpty()) {
-            candidates.add(bounds.decimal()
-                    ? FixtureTemplate.decimal(inside(bounds))
-                    : FixtureTemplate.integer(inside(bounds).longValueExact()));
+            for (BigDecimal edge : edgesOf(bounds)) {
+                candidates.add(bounds.decimal() ? FixtureTemplate.decimal(edge)
+                        : FixtureTemplate.integer(edge.longValueExact()));
+            }
         }
         if (base == Type.STRING && symbols.get(newtype) instanceof Ast.Data data) {
             for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
@@ -644,11 +645,26 @@ public final class Partitions {
         return List.copyOf(once.values());
     }
 
-    /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge
-     * there is, and it is the value a boundary wants written anyway. */
-    private static BigDecimal inside(Bounds bounds) {
-        return bounds.min() != null ? bounds.min().value()
-                : bounds.max() != null ? bounds.max().value() : BigDecimal.ZERO;
+    /**
+     * The numbers the bound admits that are worth proposing, in the order to try them.
+     *
+     * <p>The lower edge first: it is inside whatever upper edge there is, and it is the value a
+     * boundary wants written anyway, so an assignment that builds today builds on the same number.
+     *
+     * <p>Then the upper one, which is reached only where the first was refused. What refuses it is a
+     * rule relating this position to another: `low < high` with `low` already fixed leaves `high` a
+     * range starting at the value `low` took, and over decimals that range starts at the one number
+     * the rule will not accept. Offering the far end is not knowing which number the rule wants — it
+     * is having a second number to be refused at, which a range with one edge does not.
+     */
+    private static List<BigDecimal> edgesOf(Bounds bounds) {
+        if (bounds.min() == null) {
+            return List.of(bounds.max().value());
+        }
+        if (bounds.max() == null || bounds.max().value().compareTo(bounds.min().value()) == 0) {
+            return List.of(bounds.min().value());
+        }
+        return List.of(bounds.min().value(), bounds.max().value());
     }
 
     private static boolean isBool(ObservedValue v, boolean expected) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -620,10 +620,9 @@ public final class Partitions {
 
         Bounds bounds = narrowed(boundsOf(new Type.Ref(newtype), symbols), within);
         if (bounds != null && !bounds.isEmpty()) {
-            for (BigDecimal edge : edgesOf(bounds)) {
-                candidates.add(bounds.decimal() ? FixtureTemplate.decimal(edge)
-                        : FixtureTemplate.integer(edge.longValueExact()));
-            }
+            candidates.add(bounds.decimal()
+                    ? FixtureTemplate.decimal(inside(bounds))
+                    : FixtureTemplate.integer(inside(bounds).longValueExact()));
         }
         if (base == Type.STRING && symbols.get(newtype) instanceof Ast.Data data) {
             for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
@@ -645,26 +644,47 @@ public final class Partitions {
         return List.copyOf(once.values());
     }
 
+    /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge
+     * there is, and it is the value a boundary wants written anyway. */
+    private static BigDecimal inside(Bounds bounds) {
+        return bounds.min() != null ? bounds.min().value()
+                : bounds.max() != null ? bounds.max().value() : BigDecimal.ZERO;
+    }
+
     /**
-     * The numbers the bound admits that are worth proposing, in the order to try them.
+     * What a position can offer once everything it ordinarily offers has been refused.
      *
-     * <p>The lower edge first: it is inside whatever upper edge there is, and it is the value a
-     * boundary wants written anyway, so an assignment that builds today builds on the same number.
+     * <p>The far edge of a range, for a position that is a bounded number. A rule relating this
+     * position to another is what refuses the near one: `low < high` with `low` already fixed leaves
+     * `high` a range starting at the value `low` took, and over decimals that range starts at the one
+     * number the rule will not accept, because a strict bound there has no next value to step to. The
+     * far edge is not knowing which number the rule wants — it is having a second number to be
+     * refused at, which a range offering one edge does not.
      *
-     * <p>Then the upper one, which is reached only where the first was refused. What refuses it is a
-     * rule relating this position to another: `low < high` with `low` already fixed leaves `high` a
-     * range starting at the value `low` took, and over decimals that range starts at the one number
-     * the rule will not accept. Offering the far end is not knowing which number the rule wants — it
-     * is having a second number to be refused at, which a range with one edge does not.
+     * <p>Held back rather than offered beside the others, because what a row is searched for is the
+     * product of what its positions offer and that search is bounded. A value added to one position
+     * moves every assignment past it further back, so offering this one among the rest would lose
+     * rows that were being reached at positions this has nothing to do with.
      */
-    private static List<BigDecimal> edgesOf(Bounds bounds) {
-        if (bounds.min() == null) {
-            return List.of(bounds.max().value());
+    static List<FixtureTemplate> inReserve(Type type, Symbols symbols,
+                                           NumericDomain.Bounds within) {
+        if (!(type instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)
+                || !data.newtype()) {
+            return List.of();
         }
-        if (bounds.max() == null || bounds.max().value().compareTo(bounds.min().value()) == 0) {
-            return List.of(bounds.min().value());
+        Bounds bounds = narrowed(boundsOf(type, symbols), within);
+        if (bounds == null || bounds.min() == null || bounds.max() == null
+                || bounds.max().value().compareTo(bounds.min().value()) == 0) {
+            return List.of();
         }
-        return List.of(bounds.min().value(), bounds.max().value());
+        BigDecimal far = bounds.max().value();
+        FixtureTemplate held = FixtureTemplate.newtype(ref.name(), bounds.decimal()
+                ? FixtureTemplate.decimal(far) : FixtureTemplate.integer(far.longValueExact()));
+        // Nothing already on offer: a range whose far edge is the number the base type stands for
+        // would otherwise hold the same value twice, once in each tier.
+        return representativesOf(type, symbols, within).stream()
+                .map(FixtureTemplate::text).anyMatch(held.text()::equals)
+                ? List.of() : List.of(held);
     }
 
     private static boolean isBool(ObservedValue v, boolean expected) {

--- a/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -51,6 +51,31 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
                     -> ShortShift
             """;
 
+    /** Two fields of one record, each bounded at both ends by its own type and related to the other
+     * by a strict rule the decimals give no next value to step to. */
+    private static final String BAND = """
+            module example.band
+
+            data Ratio = Decimal
+                invariant withinOne = value >= 0.0m && value <= 1.0m
+
+            data Band =
+                { low: Ratio
+                , high: Ratio
+                }
+                invariant ordered = low < high
+
+            data Ok
+
+            behavior classify : (band: Band) -> Ok
+                constructs Ok
+
+            let classify (band) = Ok
+
+            example classify
+                | "a" : (Band { low = Ratio(0.1m), high = Ratio(0.9m) }) -> Ok
+            """;
+
     private static List<String> boundariesOf(String model) throws Exception {
         return reportOn(model).lines()
                 .map(String::trim)
@@ -222,31 +247,9 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
      */
     @Test
     void anEdgeNothingPromisesIsSaidAndNotCounted() throws Exception {
-        String dense = """
-                module example.band
+        String report = reportOn(BAND);
 
-                data Ratio = Decimal
-                    invariant withinOne = value >= 0.0m && value <= 1.0m
-
-                data Band =
-                    { low: Ratio
-                    , high: Ratio
-                    }
-                    invariant ordered = low < high
-
-                data Ok
-
-                behavior classify : (band: Band) -> Ok
-                    constructs Ok
-
-                let classify (band) = Ok
-
-                example classify
-                    | "a" : (Band { low = Ratio(0.1m), high = Ratio(0.9m) }) -> Ok
-                """;
-        String report = reportOn(dense);
-
-        List<String> owed = boundariesOf(dense);
+        List<String> owed = boundariesOf(BAND);
 
         assertTrue(report.contains("not known to be writable: classify/band.low = 1"), () -> report);
         assertFalse(owed.stream().anyMatch(l -> l.contains("classify/band.low = 1")),
@@ -256,6 +259,25 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
         // construct and not by how far one reading of the rules got.
         assertTrue(owed.stream().anyMatch(l -> l.contains("classify/band.high = 1")),
                 () -> "a row at the top of the upper field builds: " + owed);
+    }
+
+    /**
+     * One pair of values, reached from either field of the rule that relates them.
+     *
+     * <p>`low < high` is satisfied by `{ 0, 1 }` whichever end is fixed first. Fixing `high` at 1
+     * leaves `low` a range whose bottom the rule takes, and fixing `low` at 0 leaves `high` a range
+     * whose bottom it does not — so a position that proposes one value has nothing left to offer
+     * the moment that value is refused, and the same pair comes back found one way and missing the
+     * other.
+     */
+    @Test
+    void thePairIsFoundFromEitherFieldOfTheRule() throws Exception {
+        List<String> owed = boundariesOf(BAND);
+
+        assertTrue(owed.stream().anyMatch(l -> l.contains("classify/band.low = 0")),
+                () -> "a row at the bottom of the lower field builds: " + owed);
+        assertTrue(owed.stream().anyMatch(l -> l.contains("classify/band.high = 1")),
+                () -> "and so does one at the top of the upper field: " + owed);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -496,6 +496,44 @@ class CompileExampleGenerateTest {
     }
 
     /**
+     * A value held in reserve does not push aside the assignments already being tried.
+     *
+     * <p>The search walks the product of what the positions offer, and it is bounded — so a value
+     * added to one position moves every assignment past it further back, and enough positions
+     * carrying one more value each puts an assignment that used to be reached past the bound. Here
+     * six fields refuse both edges of their type and take the value between them, which is the
+     * sixty-fourth assignment out of sixty-four while each position offers two values and the last
+     * of seven hundred and twenty-nine while each offers three. So a value offered for the case
+     * where the ordinary ones are refused is tried after all of them, and not as one of them.
+     */
+    @Test
+    void aValueHeldInReserveDoesNotDisplaceTheAssignmentsAlreadyTried() {
+        String source = """
+                module example.reserve
+
+                data N = Decimal
+                    invariant bounded = value >= -1.0m && value <= 1.0m
+                    invariant notLow = value /= -1.0m
+                    invariant notHigh = value /= 1.0m
+
+                data R = { a: N, b: N, c: N, d: N, e: N, f: N }
+
+                data Ok = { n: Int }
+
+                behavior take : (request: R, flag: Bool) -> Ok
+                    constructs Ok
+
+                let take (request, flag) = Ok { n = 0 }
+                """;
+
+        Generator.GenerationResult filled = generated(source).get("take").pairs();
+
+        assertEquals(List.of(), filled.unresolved(),
+                () -> "the value between the edges builds: " + filled.unresolved());
+        assertFalse(filled.rows().isEmpty(), "so there are rows");
+    }
+
+    /**
      * A search that stopped says so, rather than saying everything was refused.
      *
      * <p>The choices multiply, so a row is tried at a bounded number of assignments. Past that bound


### PR DESCRIPTION
Closes #473.

`Partitions.insideTheNewtype` proposed the low edge of a bounded newtype
and nothing else. After dedup with the base type's own representative
that is one candidate for a whole range, and `Generator.walk` searches
the product of the candidate lists — so a position holding one value is
not searched: the value is composed, the decoder refuses it, and the
combination comes back with every value having been refused.

With `low < high` over decimals, fixing `low` at 0 leaves `high` a range
starting at 0. Strictness has no next value to step to over the decimals,
so that range starts at the one number the rule will not take, and it is
the only number offered. Fixing `high` first leaves `low` a range whose
bottom the rule does take. The same pair was found from one side and
missed from the other.

The far edge is offered now, and it is held in reserve rather than added
to what the position ordinarily offers.

## Why in reserve

The first commit added it to the candidate list, and that takes rows
away. The search is over the product of what the positions offer and it
stops at a bound, so a value added to one position moves every assignment
past it further back. Six fields whose edges are both refused and whose
interior value builds is the sixty-fourth assignment out of sixty-four
while each position offers two values, and the last of seven hundred and
twenty-nine while each offers three — reached before, past the bound
after. A widening meant for one position was taking rows away from
positions it had nothing to do with.

So `Choices` carries what each position holds back, `Partitions.inReserve`
says what that is, and the walk runs the ordinary product whole before
offering any of it. The first pass is the search as it was, so a row it
reaches is reached at the assignment it always was; the second runs only
where the first ran out. A pass that stopped at the bound does not start a
wider one, because the assignments it never reached are nearer than
anything the wider one would try.

`insideTheNewtype` is therefore unchanged from develop, so a class
representative is still a single value and `settledIn` still settles the
positions it settled.

## What moves

On the `Band` model, `boundary 0/1` becomes `0/2`: `band.low = 0` goes
from an attempt that came back with nothing to a row an author is owed.
`band.low = 1` and `band.high = 0` stay refused, which is right — no
value exists at either.

Generator output over souther-examples is byte-identical to develop's:
198 boundary obligations, 32 not known to be writable, unchanged. Those
32 have other causes, recorded in #479.

## What this does not do

It widens the search; it does not recover what was lost before the search
began. A newtype the model bounds on one side only has no far edge to
offer, because `narrowed` does not take a projected bound onto an end the
type left open — and the first candidate is the refused one for the same
reason it always was. Both belong to #479.

## Checks

`mvn clean test` over the reactor: 3712 + 185 + 109 + 1, all green. Each
test was watched failing first — the boundary one on the missing
`band.low = 0`, the generator one on `SEARCH_LIMIT` where develop builds a
row.

Compared against develop by swapping the two files in and rebuilding: a
model of one to eight bounded newtype fields whose edges are both refused
produces a row at every width on both, and `Band` goes `0/1` to `0/2`.
`anEdgeNothingPromisesIsSaidAndNotCounted` keeps its assertions unchanged;
its model is now a shared constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
