### PR TITLE
The methods the server answers are the methods it advertises

### DIFF
--- a/souther-lsp/src/main/java/souther/lsp/Advertisement.java
+++ b/souther-lsp/src/main/java/souther/lsp/Advertisement.java
@@ -1,0 +1,54 @@
+package souther.lsp;
+
+/**
+ * What tells a client that a {@link LspMethod} can be called.
+ *
+ * <p>Not every method is announced the same way, and some are announced by nothing at all, so this
+ * is a set of alternatives rather than a capability name. A method whose absence from the handshake
+ * is deliberate carries {@link None} with the reason it is absent, which is what separates a
+ * decision from an omission — the two look identical in a hand-written capability map.
+ *
+ * <p>One advertisement may be shared by several methods: full document sync is one capability that
+ * three notifications rely on, and no method holds it alone.
+ */
+public sealed interface Advertisement {
+
+    /**
+     * A field of the {@code capabilities} object the initialize result answers with.
+     *
+     * <p>The value is the field's whole value, not a flag: some capabilities are a boolean and
+     * others an options object, and which one a capability takes is part of the capability rather
+     * than something a caller decides.
+     */
+    record StaticCapability(String key, Object value) implements Advertisement {
+    }
+
+    /**
+     * Announced after the handshake by {@code client/registerCapability} rather than by a field of
+     * the capabilities object.
+     *
+     * <p>The method being registered is the one holding this, so it is not written here.
+     */
+    record DynamicRegistration(String id, Object registerOptions) implements Advertisement {
+    }
+
+    /** Nothing in the handshake tells a client about this method. */
+    record None(Reason reason) implements Advertisement {
+    }
+
+    /** Why a method is answered without being announced. */
+    enum Reason {
+
+        /**
+         * The handshake and its teardown. These are answered before any capability has been agreed,
+         * and a server that could not answer them would never be asked anything else.
+         */
+        LIFECYCLE,
+
+        /**
+         * Defined by the protocol for every server, with no field in the capabilities object to
+         * carry it. A client sends these knowing they may be ignored.
+         */
+        UNADVERTISED_PROTOCOL_METHOD
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/LspMethod.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspMethod.java
@@ -1,0 +1,171 @@
+package souther.lsp;
+
+import souther.lsp.analysis.Analyzer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Every request and notification this server answers, and what tells a client about each.
+ *
+ * <p>The set lives here rather than in the case labels of a switch because the rest of the server
+ * has to read it. What the handshake advertises and what is registered after it are both built from
+ * these values, so the two cannot say something the server does not answer; and a method cannot be
+ * answered without being one of these values, because {@link LspServer} reaches its handlers only
+ * through {@link #of}. A method nobody was told about is then not something to test for — it is
+ * something there is no way to write.
+ *
+ * <p>What a method is advertised by is not a name derived from the method's own: three notifications
+ * share one capability, one method is registered after the handshake instead, and the lifecycle is
+ * announced by nothing. Each of those is a value here rather than a row missing from a table.
+ */
+public enum LspMethod {
+
+    INITIALIZE("initialize", Announced.LIFECYCLE),
+    INITIALIZED("initialized", Announced.LIFECYCLE),
+    SET_TRACE("$/setTrace", Announced.PROTOCOL_DEFINED),
+    DID_CHANGE_CONFIGURATION("workspace/didChangeConfiguration", Announced.PROTOCOL_DEFINED),
+    DID_OPEN("textDocument/didOpen", Announced.TEXT_DOCUMENT_SYNC),
+    DID_CHANGE("textDocument/didChange", Announced.TEXT_DOCUMENT_SYNC),
+    DID_CLOSE("textDocument/didClose", Announced.TEXT_DOCUMENT_SYNC),
+    DID_CHANGE_WATCHED_FILES("workspace/didChangeWatchedFiles", Announced.SOU_FILE_WATCHER),
+    DOCUMENT_SYMBOL("textDocument/documentSymbol",
+            new Advertisement.StaticCapability("documentSymbolProvider", true)),
+    SEMANTIC_TOKENS_FULL("textDocument/semanticTokens/full", Announced.SEMANTIC_TOKENS),
+    HOVER("textDocument/hover", new Advertisement.StaticCapability("hoverProvider", true)),
+    DEFINITION("textDocument/definition", new Advertisement.StaticCapability("definitionProvider", true)),
+    REFERENCES("textDocument/references", new Advertisement.StaticCapability("referencesProvider", true)),
+    // invoked completion; no trigger characters
+    COMPLETION("textDocument/completion", new Advertisement.StaticCapability("completionProvider", Map.of())),
+    CODE_ACTION("textDocument/codeAction", new Advertisement.StaticCapability("codeActionProvider", true)),
+    CODE_LENS("textDocument/codeLens",
+            new Advertisement.StaticCapability("codeLensProvider", Map.of("resolveProvider", false))),
+    RENAME("textDocument/rename", new Advertisement.StaticCapability("renameProvider", true)),
+    FORMATTING("textDocument/formatting",
+            new Advertisement.StaticCapability("documentFormattingProvider", true)),
+    SHUTDOWN("shutdown", Announced.LIFECYCLE),
+    EXIT("exit", Announced.LIFECYCLE);
+
+    /** Advertisements shared by more than one method, or whose value is built rather than written. */
+    private static final class Announced {
+
+        static final Advertisement LIFECYCLE =
+                new Advertisement.None(Advertisement.Reason.LIFECYCLE);
+
+        static final Advertisement PROTOCOL_DEFINED =
+                new Advertisement.None(Advertisement.Reason.UNADVERTISED_PROTOCOL_METHOD);
+
+        /** 1 = full document sync. Opening, changing and closing a document are the three
+         * notifications this one capability admits, and none of them names it. */
+        static final Advertisement TEXT_DOCUMENT_SYNC =
+                new Advertisement.StaticCapability("textDocumentSync", 1);
+
+        static final Advertisement SEMANTIC_TOKENS =
+                new Advertisement.StaticCapability("semanticTokensProvider", semanticTokens());
+
+        static final Advertisement SOU_FILE_WATCHER = new Advertisement.DynamicRegistration(
+                "souther-sou-watcher",
+                Map.of("watchers", List.of(Map.of("globPattern", "**/*.sou"))));
+
+        private static Map<String, Object> semanticTokens() {
+            Map<String, Object> options = new LinkedHashMap<>();
+            options.put("legend", Map.of("tokenTypes", Analyzer.TOKEN_TYPES,
+                    "tokenModifiers", List.of()));
+            options.put("full", true);
+            return options;
+        }
+
+        private Announced() {
+        }
+    }
+
+    private static final Map<String, LspMethod> BY_WIRE = byWire();
+
+    private final String wire;
+    private final Advertisement advertisement;
+
+    LspMethod(String wire, Advertisement advertisement) {
+        this.wire = wire;
+        this.advertisement = advertisement;
+    }
+
+    /** How this method is spelled in a JSON-RPC {@code method} field. */
+    public String wire() {
+        return wire;
+    }
+
+    /** What tells a client this method can be called. */
+    public Advertisement advertisement() {
+        return advertisement;
+    }
+
+    /** The method a client named, or empty when the server answers no such method. */
+    public static Optional<LspMethod> of(String wire) {
+        return Optional.ofNullable(BY_WIRE.get(wire));
+    }
+
+    /**
+     * The {@code capabilities} object of the initialize result.
+     *
+     * <p>Built from the methods rather than beside them, so a client is told about what is answered
+     * and nothing else. A capability several methods share is one field, and one they disagree
+     * about is a contradiction rather than a last-writer-wins.
+     */
+    public static Map<String, Object> serverCapabilities() {
+        Map<String, Object> capabilities = new LinkedHashMap<>();
+        for (LspMethod method : values()) {
+            if (!(method.advertisement instanceof Advertisement.StaticCapability capability)) {
+                continue;
+            }
+            Object already = capabilities.put(capability.key(), capability.value());
+            if (already != null && !already.equals(capability.value())) {
+                throw new IllegalStateException(
+                        "two values advertised under " + capability.key() + ": " + already
+                                + " and " + capability.value());
+            }
+        }
+        return capabilities;
+    }
+
+    /**
+     * The registrations to send once the client reports {@code initialized}, in the shape the
+     * protocol's {@code Registration} takes. The method each one registers is the method that holds
+     * it, so what is registered and what is answered cannot name different things.
+     */
+    public static List<Map<String, Object>> dynamicRegistrations() {
+        List<Map<String, Object>> registrations = new ArrayList<>();
+        for (LspMethod method : values()) {
+            if (!(method.advertisement instanceof Advertisement.DynamicRegistration registration)) {
+                continue;
+            }
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("id", registration.id());
+            entry.put("method", method.wire);
+            entry.put("registerOptions", registration.registerOptions());
+            registrations.add(entry);
+        }
+        return registrations;
+    }
+
+    /**
+     * Indexes the methods by their spelling, refusing two that are spelled the same.
+     *
+     * <p>A repeated spelling would leave one of the two unreachable and say nothing about it, and
+     * the one left out would be the one that keeps its advertisement — a capability announcing a
+     * method that answers as something else.
+     */
+    private static Map<String, LspMethod> byWire() {
+        Map<String, LspMethod> index = new LinkedHashMap<>();
+        for (LspMethod method : values()) {
+            LspMethod clash = index.put(method.wire, method);
+            if (clash != null) {
+                throw new IllegalStateException(
+                        clash + " and " + method + " are both spelled " + method.wire);
+            }
+        }
+        return index;
+    }
+}

--- a/souther-lsp/src/main/java/souther/lsp/LspMethod.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspMethod.java
@@ -3,6 +3,7 @@ package souther.lsp;
 import souther.lsp.analysis.Analyzer;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,18 @@ public enum LspMethod {
         }
     }
 
+    /**
+     * Everything derived from the table is derived once, as the class is loaded.
+     *
+     * <p>A table that contradicts itself is not a request's failure to be reported to whoever
+     * happened to ask first — it is this server being unable to say what it does, and it says so
+     * before it has answered anything.
+     */
     private static final Map<String, LspMethod> BY_WIRE = byWire();
+
+    private static final Map<String, Object> CAPABILITIES = capabilities();
+
+    private static final List<Map<String, Object>> REGISTRATIONS = registrations();
 
     private final String wire;
     private final Advertisement advertisement;
@@ -107,35 +119,50 @@ public enum LspMethod {
         return Optional.ofNullable(BY_WIRE.get(wire));
     }
 
-    /**
-     * The {@code capabilities} object of the initialize result.
-     *
-     * <p>Built from the methods rather than beside them, so a client is told about what is answered
-     * and nothing else. A capability several methods share is one field, and one they disagree
-     * about is a contradiction rather than a last-writer-wins.
-     */
+    /** The {@code capabilities} object of the initialize result. */
     public static Map<String, Object> serverCapabilities() {
+        return CAPABILITIES;
+    }
+
+    /**
+     * The registrations to send once the client reports {@code initialized}, in the shape the
+     * protocol's {@code Registration} takes.
+     */
+    public static List<Map<String, Object>> dynamicRegistrations() {
+        return REGISTRATIONS;
+    }
+
+    /**
+     * The capabilities, built from the methods rather than beside them, so a client is told about
+     * what is answered and nothing else.
+     *
+     * <p>One field may announce several methods, and then it is the one advertisement all of them
+     * hold — not one written out again under the same key. Two methods reaching the same field by
+     * different advertisements are refused even where both spell the same value: the field would
+     * announce one of them, and the other would be answered without being announced, which is the
+     * whole of what a capability rules out.
+     */
+    private static Map<String, Object> capabilities() {
+        Map<String, LspMethod> announcedBy = new LinkedHashMap<>();
         Map<String, Object> capabilities = new LinkedHashMap<>();
         for (LspMethod method : values()) {
             if (!(method.advertisement instanceof Advertisement.StaticCapability capability)) {
                 continue;
             }
-            Object already = capabilities.put(capability.key(), capability.value());
-            if (already != null && !already.equals(capability.value())) {
-                throw new IllegalStateException(
-                        "two values advertised under " + capability.key() + ": " + already
-                                + " and " + capability.value());
+            LspMethod first = announcedBy.putIfAbsent(capability.key(), method);
+            if (first == null) {
+                capabilities.put(capability.key(), capability.value());
+            } else if (first.advertisement != method.advertisement) {
+                throw new IllegalStateException(first + " and " + method + " both advertise "
+                        + capability.key() + " without sharing one advertisement");
             }
         }
-        return capabilities;
+        return Collections.unmodifiableMap(capabilities);
     }
 
-    /**
-     * The registrations to send once the client reports {@code initialized}, in the shape the
-     * protocol's {@code Registration} takes. The method each one registers is the method that holds
-     * it, so what is registered and what is answered cannot name different things.
-     */
-    public static List<Map<String, Object>> dynamicRegistrations() {
+    /** The registrations, whose {@code method} is the method holding each one, so what is registered
+     * and what is answered cannot name different things. */
+    private static List<Map<String, Object>> registrations() {
         List<Map<String, Object>> registrations = new ArrayList<>();
         for (LspMethod method : values()) {
             if (!(method.advertisement instanceof Advertisement.DynamicRegistration registration)) {
@@ -145,9 +172,9 @@ public enum LspMethod {
             entry.put("id", registration.id());
             entry.put("method", method.wire);
             entry.put("registerOptions", registration.registerOptions());
-            registrations.add(entry);
+            registrations.add(Collections.unmodifiableMap(entry));
         }
-        return registrations;
+        return Collections.unmodifiableList(registrations);
     }
 
     /**

--- a/souther-lsp/src/main/java/souther/lsp/LspServer.java
+++ b/souther-lsp/src/main/java/souther/lsp/LspServer.java
@@ -91,41 +91,69 @@ public final class LspServer {
                 "the request could not be completed (" + cause.getClass().getSimpleName() + ")");
     }
 
-    /** Returns true when the server should stop (on {@code exit}). */
+    /**
+     * Returns true when the server should stop (on {@code exit}).
+     *
+     * <p>Naming the method is where a client learns the server does not answer it: nothing below
+     * this point takes a spelling, so there is no second place a method could be refused, and none
+     * where one could be answered without being declared.
+     */
     private boolean dispatch(String method, JsonNode id, JsonNode params) {
-        switch (method) {
-            case "initialize" -> { captureRoots(params); respond(id, initializeResult()); }
-            case "initialized" -> registerFileWatchers();
-            case "$/setTrace", "workspace/didChangeConfiguration" -> { /* no-op */ }
-            case "textDocument/didOpen" -> InboundDecoders.decode(InboundDecoders.DID_OPEN, params)
-                    .ifPresent(p -> { documents.open(p.uri(), p.text()); publishAll(); });
-            case "textDocument/didChange" -> InboundDecoders.decode(InboundDecoders.DID_CHANGE, params)
-                    .ifPresent(p -> { documents.change(p.uri(), p.text()); publishAll(); });
-            case "textDocument/didClose" -> InboundDecoders.decode(InboundDecoders.DOC_REF, params)
-                    .ifPresent(p -> { documents.close(p.uri()); clearDiagnostics(p.uri()); });
-            case "workspace/didChangeWatchedFiles" -> {
+        LspMethod named = LspMethod.of(method).orElse(null);
+        if (named == null) {
+            if (id != null && !id.isNull()) {
+                respondError(id, -32601, "method not found: " + method);
+            }
+            return false;   // a notification has no reply, so an unknown one is simply dropped
+        }
+        return answer(named, id, params);
+    }
+
+    /**
+     * Carries out one method.
+     *
+     * <p>A switch expression with no {@code default}: a method added to {@link LspMethod} and left
+     * unhandled here does not compile. That is what makes the set of methods the server answers the
+     * set written there, and so the set the handshake is built from.
+     */
+    private boolean answer(LspMethod method, JsonNode id, JsonNode params) {
+        return switch (method) {
+            case INITIALIZE -> { captureRoots(params); respond(id, initializeResult()); yield false; }
+            case INITIALIZED -> { registerDynamically(); yield false; }
+            case SET_TRACE, DID_CHANGE_CONFIGURATION -> false;   // no-op
+            case DID_OPEN -> {
+                InboundDecoders.decode(InboundDecoders.DID_OPEN, params)
+                        .ifPresent(p -> { documents.open(p.uri(), p.text()); publishAll(); });
+                yield false;
+            }
+            case DID_CHANGE -> {
+                InboundDecoders.decode(InboundDecoders.DID_CHANGE, params)
+                        .ifPresent(p -> { documents.change(p.uri(), p.text()); publishAll(); });
+                yield false;
+            }
+            case DID_CLOSE -> {
+                InboundDecoders.decode(InboundDecoders.DOC_REF, params)
+                        .ifPresent(p -> { documents.close(p.uri()); clearDiagnostics(p.uri()); });
+                yield false;
+            }
+            case DID_CHANGE_WATCHED_FILES -> {
                 workspace.markChanged();   // a file changed on disk; drop the cached scan and re-read
                 publishAll();
+                yield false;
             }
-            case "textDocument/documentSymbol" -> respond(id, documentSymbols(params));
-            case "textDocument/semanticTokens/full" -> respond(id, semanticTokens(params));
-            case "textDocument/hover" -> respond(id, hover(params));
-            case "textDocument/definition" -> respond(id, definition(params));
-            case "textDocument/references" -> respond(id, references(params));
-            case "textDocument/completion" -> respond(id, completion(params));
-            case "textDocument/codeAction" -> respond(id, codeActions(params));
-            case "textDocument/codeLens" -> respond(id, codeLenses(params));
-            case "textDocument/rename" -> respond(id, rename(params));
-            case "textDocument/formatting" -> respond(id, formatting(params));
-            case "shutdown" -> respond(id, null);
-            case "exit" -> { return true; }
-            default -> {
-                if (id != null && !id.isNull()) {
-                    respondError(id, -32601, "method not found: " + method);
-                }
-            }
-        }
-        return false;
+            case DOCUMENT_SYMBOL -> { respond(id, documentSymbols(params)); yield false; }
+            case SEMANTIC_TOKENS_FULL -> { respond(id, semanticTokens(params)); yield false; }
+            case HOVER -> { respond(id, hover(params)); yield false; }
+            case DEFINITION -> { respond(id, definition(params)); yield false; }
+            case REFERENCES -> { respond(id, references(params)); yield false; }
+            case COMPLETION -> { respond(id, completion(params)); yield false; }
+            case CODE_ACTION -> { respond(id, codeActions(params)); yield false; }
+            case CODE_LENS -> { respond(id, codeLenses(params)); yield false; }
+            case RENAME -> { respond(id, rename(params)); yield false; }
+            case FORMATTING -> { respond(id, formatting(params)); yield false; }
+            case SHUTDOWN -> { respond(id, null); yield false; }
+            case EXIT -> true;
+        };
     }
 
     // --- capabilities ---
@@ -177,25 +205,10 @@ public final class LspServer {
         };
     }
 
+    /** What the client is told it may call, drawn from the methods that are answered. */
     private Map<String, Object> initializeResult() {
-        Map<String, Object> capabilities = new LinkedHashMap<>();
-        capabilities.put("textDocumentSync", 1);   // 1 = full document sync
-        capabilities.put("documentSymbolProvider", true);
-        capabilities.put("hoverProvider", true);
-        capabilities.put("definitionProvider", true);
-        capabilities.put("referencesProvider", true);
-        capabilities.put("renameProvider", true);
-        capabilities.put("completionProvider", Map.of());   // invoked completion; no trigger characters
-        capabilities.put("codeActionProvider", true);
-        capabilities.put("codeLensProvider", Map.of("resolveProvider", false));
-        capabilities.put("documentFormattingProvider", true);
-        Map<String, Object> semanticTokens = new LinkedHashMap<>();
-        semanticTokens.put("legend", Map.of("tokenTypes", Analyzer.TOKEN_TYPES,
-                "tokenModifiers", List.of()));
-        semanticTokens.put("full", true);
-        capabilities.put("semanticTokensProvider", semanticTokens);
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("capabilities", capabilities);
+        result.put("capabilities", LspMethod.serverCapabilities());
         result.put("serverInfo", Map.of("name", "souther-lsp", "version", "0.1.0"));
         return result;
     }
@@ -526,18 +539,19 @@ public final class LspServer {
         conn.write(JSON.writeValueAsString(message));
     }
 
-    /** Asks the client to watch the workspace's {@code .sou} files and report on-disk changes via
-     * {@code workspace/didChangeWatchedFiles}, so the cached disk scan is invalidated when a file is
-     * created, edited, or deleted outside the editor rather than relying on the client watching by
-     * default. The registration response is a no-op here (dropped by {@link #run}); a client without
-     * dynamic registration simply ignores the request. */
-    private void registerFileWatchers() {
-        Map<String, Object> registration = new LinkedHashMap<>();
-        registration.put("id", "souther-sou-watcher");
-        registration.put("method", "workspace/didChangeWatchedFiles");
-        registration.put("registerOptions",
-                Map.of("watchers", List.of(Map.of("globPattern", "**/*.sou"))));
-        sendRequest("client/registerCapability", Map.of("registrations", List.of(registration)));
+    /** Announces the methods no capability carries — asking the client to watch the workspace's
+     * {@code .sou} files and report on-disk changes via {@code workspace/didChangeWatchedFiles}, so
+     * the cached disk scan is dropped when a file is created, edited, or deleted outside the editor
+     * rather than relying on the client watching by default. What is registered comes from the same
+     * methods the capabilities do, so this and the handshake describe one server between them. The
+     * registration response is a no-op here (dropped by {@link #run}); a client without dynamic
+     * registration simply ignores the request. */
+    private void registerDynamically() {
+        List<Map<String, Object>> registrations = LspMethod.dynamicRegistrations();
+        if (registrations.isEmpty()) {
+            return;
+        }
+        sendRequest("client/registerCapability", Map.of("registrations", registrations));
     }
 
     private void sendRequest(String method, Object params) {

--- a/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/LspServerTest.java
@@ -264,6 +264,129 @@ class LspServerTest {
         assertEquals(0, actions.size(), "with no context diagnostics the server skips the compile");
     }
 
+    /**
+     * A module with a type, a use of it, and a behavior, so the navigation requests below have
+     * somewhere to go.
+     *
+     * <p>`data X` is at line 1 character 5; the `X` in the signature is at line 2 character 17.
+     */
+    private static final String NAVIGABLE =
+            "module demo\ndata X = { a: Int }\nbehavior f : (x: X) -> X\nlet f (x) = x\n";
+
+    /** Opens {@code NAVIGABLE} and asks one request of it, answering with that request's result. */
+    private static JsonNode askOf(String uri, String method, Map<String, Object> params) {
+        byte[] input = frames(
+                message(1, "initialize", Map.of()),
+                message(null, "initialized", Map.of()),
+                message(null, "textDocument/didOpen", Map.of(
+                        "textDocument", Map.of("uri", uri, "text", NAVIGABLE))),
+                message(2, method, params));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
+        return responseFor(readFrames(out.toByteArray()), 2);
+    }
+
+    @Test
+    void documentSymbolsNameWhatTheModuleDeclares() {
+        String uri = "file:///s.sou";
+        JsonNode symbols = askOf(uri, "textDocument/documentSymbol",
+                Map.of("textDocument", Map.of("uri", uri)));
+
+        List<String> names = new ArrayList<>();
+        for (JsonNode symbol : symbols) {
+            names.add(symbol.get("name").asString());
+        }
+        assertTrue(names.contains("X"), names.toString());
+        assertTrue(names.contains("f"), names.toString());
+    }
+
+    @Test
+    void semanticTokensComeBackAsFiveNumbersEach() {
+        String uri = "file:///t.sou";
+        JsonNode data = askOf(uri, "textDocument/semanticTokens/full",
+                Map.of("textDocument", Map.of("uri", uri))).get("data");
+
+        assertTrue(data.size() > 0, "the module is highlighted");
+        assertEquals(0, data.size() % 5, "line, start, length, type, modifiers: " + data);
+    }
+
+    @Test
+    void hoverOverATypeShowsHowItIsDeclared() {
+        String uri = "file:///h.sou";
+        JsonNode hover = askOf(uri, "textDocument/hover", Map.of(
+                "textDocument", Map.of("uri", uri),
+                "position", Map.of("line", 1, "character", 5)));   // on `data X`
+
+        assertNotNull(hover, "a declaration says something about itself");
+        String contents = hover.get("contents").get("value").asString();
+        assertTrue(contents.contains("data X"), contents);
+    }
+
+    @Test
+    void definitionGoesFromAUseToTheDeclaration() {
+        String uri = "file:///d.sou";
+        JsonNode location = askOf(uri, "textDocument/definition", Map.of(
+                "textDocument", Map.of("uri", uri),
+                "position", Map.of("line", 2, "character", 17)));   // the `X` in the signature
+
+        assertNotNull(location, "the use resolves");
+        assertEquals(uri, location.get("uri").asString());
+        assertEquals(1, location.get("range").get("start").get("line").asInt(),
+                "the `data X` line, zero-based");
+    }
+
+    @Test
+    void referencesAnswerWithTheDeclarationAndItsUses() {
+        String uri = "file:///r2.sou";
+        JsonNode locations = askOf(uri, "textDocument/references", Map.of(
+                "textDocument", Map.of("uri", uri),
+                "position", Map.of("line", 1, "character", 5),   // on `data X`
+                "context", Map.of("includeDeclaration", true)));
+
+        assertEquals(3, locations.size(),
+                "the declaration plus its two type uses: " + locations);
+    }
+
+    @Test
+    void aCodeLensIsDrawnOverABehaviorTheClientAskedToMeasure() throws Exception {
+        Path dir = Files.createTempDirectory("lens");
+        String text = """
+                module demo
+
+                data Draft = { cost: Int }
+                data Submitted = { cost: Int }
+
+                behavior submit : (request: Draft) -> Submitted
+                let submit (request) = Submitted { cost = request.cost }
+
+                example submit
+                    | (Draft { cost = 1 }) -> Submitted { cost = 1 }
+                """;
+        Path source = dir.resolve("demo.sou");
+        Files.writeString(source, text);
+        String uri = source.toUri().toString();
+
+        byte[] input = frames(
+                message(1, "initialize", Map.of(
+                        "rootUri", dir.toUri().toString(),
+                        "initializationOptions", Map.of("souther", Map.of("adequacy", "witness")))),
+                message(null, "initialized", Map.of()),
+                message(null, "textDocument/didOpen", Map.of(
+                        "textDocument", Map.of("uri", uri, "text", text))),
+                message(2, "textDocument/codeLens", Map.of("textDocument", Map.of("uri", uri))));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(input), out)).run();
+
+        JsonNode lenses = responseFor(readFrames(out.toByteArray()), 2);
+        assertEquals(1, lenses.size(), "one behavior, so one line: " + lenses);
+        assertEquals(5, lenses.get(0).get("range").get("start").get("line").asInt(),
+                "the `behavior` line, zero-based");
+        assertTrue(lenses.get(0).get("command").get("title").asString().contains("row"),
+                lenses.get(0).toString());
+    }
+
     // --- helpers: build and read framed JSON-RPC messages ---
 
     /** The {@code result} array of the response to request {@code id}. */

--- a/souther-lsp/src/test/java/souther/lsp/WhatTheServerAdvertisesIsWhatItAnswersTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/WhatTheServerAdvertisesIsWhatItAnswersTest.java
@@ -130,9 +130,47 @@ class WhatTheServerAdvertisesIsWhatItAnswersTest {
     private static final Predicate<JsonNode> TRUE_OR_OPTIONS =
             value -> (value.isBoolean() && value.booleanValue()) || value.isObject();
 
-    /** A sync kind other than {@code None}, or options saying which notifications are wanted. */
-    private static final Predicate<JsonNode> SYNCING =
-            value -> value.isObject() || (value.isNumber() && value.intValue() != 0);
+    /** An options object and nothing else — these two capabilities have no boolean form. */
+    private static final Predicate<JsonNode> OPTIONS = JsonNode::isObject;
+
+    /**
+     * The shorthand form of {@code textDocumentSync}, when it says documents are synced at all.
+     *
+     * <p>{@code TextDocumentSyncKind} is {@code None}, {@code Full} or {@code Incremental}, so a
+     * number outside those three says nothing rather than something permissive.
+     */
+    private static boolean syncedByKind(JsonNode value) {
+        return value.isNumber() && (value.intValue() == 1 || value.intValue() == 2);
+    }
+
+    /**
+     * Opening and closing a document, which the options form puts behind its own {@code openClose}.
+     *
+     * <p>The shorthand carries it; the long form does not unless it says so, and a client reading
+     * options without {@code openClose} sends neither notification.
+     */
+    private static final Predicate<JsonNode> OPEN_CLOSE_SYNC = value -> {
+        if (syncedByKind(value)) {
+            return true;
+        }
+        JsonNode openClose = value.isObject() ? value.get("openClose") : null;
+        return openClose != null && openClose.isBoolean() && openClose.booleanValue();
+    };
+
+    /**
+     * Changing a document, which the options form puts behind its own {@code change}.
+     *
+     * <p>A sync that opens and closes documents is not one that reports edits: {@code change} is
+     * absent or {@code None} in options that say nothing about them, and either way no
+     * {@code didChange} arrives.
+     */
+    private static final Predicate<JsonNode> CHANGE_SYNC = value -> {
+        if (syncedByKind(value)) {
+            return true;
+        }
+        JsonNode change = value.isObject() ? value.get("change") : null;
+        return change != null && syncedByKind(change);
+    };
 
     /** Semantic tokens for a whole document are behind the options' own {@code full}. */
     private static final Predicate<JsonNode> FULL_DOCUMENT_TOKENS = value -> {
@@ -170,11 +208,14 @@ class WhatTheServerAdvertisesIsWhatItAnswersTest {
             protocolNotification(LspMethod.DID_CHANGE_CONFIGURATION,
                     "workspace/didChangeConfiguration"),
             new Protocol(LspMethod.DID_OPEN, "textDocument/didOpen",
-                    new Told.Capability("textDocumentSync", SYNCING, "a sync kind other than None")),
+                    new Told.Capability("textDocumentSync", OPEN_CLOSE_SYNC,
+                            "a sync kind that syncs, or options whose `openClose` is on")),
             new Protocol(LspMethod.DID_CHANGE, "textDocument/didChange",
-                    new Told.Capability("textDocumentSync", SYNCING, "a sync kind other than None")),
+                    new Told.Capability("textDocumentSync", CHANGE_SYNC,
+                            "a sync kind that syncs, or options whose `change` is not None")),
             new Protocol(LspMethod.DID_CLOSE, "textDocument/didClose",
-                    new Told.Capability("textDocumentSync", SYNCING, "a sync kind other than None")),
+                    new Told.Capability("textDocumentSync", OPEN_CLOSE_SYNC,
+                            "a sync kind that syncs, or options whose `openClose` is on")),
             new Protocol(LspMethod.DID_CHANGE_WATCHED_FILES, "workspace/didChangeWatchedFiles",
                     new Told.Registration()),
             offered(LspMethod.DOCUMENT_SYMBOL, "textDocument/documentSymbol",
@@ -185,9 +226,11 @@ class WhatTheServerAdvertisesIsWhatItAnswersTest {
             offered(LspMethod.HOVER, "textDocument/hover", "hoverProvider"),
             offered(LspMethod.DEFINITION, "textDocument/definition", "definitionProvider"),
             offered(LspMethod.REFERENCES, "textDocument/references", "referencesProvider"),
-            offered(LspMethod.COMPLETION, "textDocument/completion", "completionProvider"),
+            new Protocol(LspMethod.COMPLETION, "textDocument/completion",
+                    new Told.Capability("completionProvider", OPTIONS, "an options object")),
             offered(LspMethod.CODE_ACTION, "textDocument/codeAction", "codeActionProvider"),
-            offered(LspMethod.CODE_LENS, "textDocument/codeLens", "codeLensProvider"),
+            new Protocol(LspMethod.CODE_LENS, "textDocument/codeLens",
+                    new Told.Capability("codeLensProvider", OPTIONS, "an options object")),
             offered(LspMethod.RENAME, "textDocument/rename", "renameProvider"),
             offered(LspMethod.FORMATTING, "textDocument/formatting", "documentFormattingProvider"));
 

--- a/souther-lsp/src/test/java/souther/lsp/WhatTheServerAdvertisesIsWhatItAnswersTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/WhatTheServerAdvertisesIsWhatItAnswersTest.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -16,6 +17,8 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -29,9 +32,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * that the property survives the wire — that a method the handshake invites is not met with
  * {@code method not found} at the connection, which is what a client actually depends on.
  *
- * <p>The methods are read from {@link LspMethod} rather than listed here on purpose. A list written
- * in this file would be a third copy of the set, agreeing with neither side by construction and
- * silently going stale exactly when the other two change.
+ * <p>Which method a capability announces is a different question, and one the server cannot answer
+ * about itself: that {@code hoverProvider} is the field a client reads before sending
+ * {@code textDocument/hover} is the protocol's, not ours. {@link #everyMethodIsAnnouncedTheWayTheProtocolSaysItIs}
+ * writes that relation out. It is deliberately a second copy of what {@link LspMethod} declares,
+ * for the reason the protocol-facing tests keep their method literals: one side says what this
+ * server believes and the other says what the protocol defines, and only holding them together
+ * catches a capability announcing a method it does not name.
+ *
+ * <p>Everywhere else the methods are read from {@link LspMethod} rather than listed. Which methods
+ * exist is settled there, and a list of them written here would be a third copy of that set.
  */
 class WhatTheServerAdvertisesIsWhatItAnswersTest {
 
@@ -58,8 +68,17 @@ class WhatTheServerAdvertisesIsWhatItAnswersTest {
         return params;
     }
 
+    /**
+     * No method a capability announces comes back as one the server does not have.
+     *
+     * <p>Only that. What a handler answers with, and whether it answers at all rather than failing
+     * on the way, is each method's own behaviour and is tested where that behaviour is. A
+     * notification has no reply to be refused in, so for the three that share full document sync
+     * there is nothing here to observe; they are walked with the rest because which methods a
+     * capability announces is not this test's to decide.
+     */
     @Test
-    void everyAdvertisedMethodIsAnsweredAtTheConnection() {
+    void noAdvertisedMethodIsRefusedAsNotFound() {
         for (LspMethod method : LspMethod.values()) {
             if (!(method.advertisement() instanceof Advertisement.StaticCapability capability)) {
                 continue;
@@ -70,8 +89,78 @@ class WhatTheServerAdvertisesIsWhatItAnswersTest {
                     message(null, "textDocument/didOpen", Map.of(
                             "textDocument", Map.of("uri", URI, "text", TEXT))),
                     message(2, method.wire(), everyShape())), 2);
-            assertNull(error, capability.key() + " invites " + method.wire()
-                    + ", which answers: " + error);
+            if (error != null) {
+                assertNotEquals(METHOD_NOT_FOUND, error.get("code").asInt(),
+                        capability.key() + " invites " + method.wire() + ", which is refused");
+            }
+        }
+    }
+
+    /**
+     * How each method is announced, written from the protocol rather than read from the server.
+     *
+     * <p>A capability key is what the protocol says a client reads before sending that method. The
+     * value under the key is not here: whether a provider is spelled {@code true} or an options
+     * object is this server's to decide, and repeating it would copy a decision rather than witness
+     * an agreement.
+     */
+    @Test
+    void everyMethodIsAnnouncedTheWayTheProtocolSaysItIs() {
+        Map<LspMethod, String> byCapability = new LinkedHashMap<>();
+        byCapability.put(LspMethod.DID_OPEN, "textDocumentSync");
+        byCapability.put(LspMethod.DID_CHANGE, "textDocumentSync");
+        byCapability.put(LspMethod.DID_CLOSE, "textDocumentSync");
+        byCapability.put(LspMethod.DOCUMENT_SYMBOL, "documentSymbolProvider");
+        byCapability.put(LspMethod.SEMANTIC_TOKENS_FULL, "semanticTokensProvider");
+        byCapability.put(LspMethod.HOVER, "hoverProvider");
+        byCapability.put(LspMethod.DEFINITION, "definitionProvider");
+        byCapability.put(LspMethod.REFERENCES, "referencesProvider");
+        byCapability.put(LspMethod.COMPLETION, "completionProvider");
+        byCapability.put(LspMethod.CODE_ACTION, "codeActionProvider");
+        byCapability.put(LspMethod.CODE_LENS, "codeLensProvider");
+        byCapability.put(LspMethod.RENAME, "renameProvider");
+        byCapability.put(LspMethod.FORMATTING, "documentFormattingProvider");
+
+        Set<LspMethod> registeredAfterTheHandshake = EnumSet.of(LspMethod.DID_CHANGE_WATCHED_FILES);
+
+        Map<LspMethod, Advertisement.Reason> announcedByNothing = new LinkedHashMap<>();
+        announcedByNothing.put(LspMethod.INITIALIZE, Advertisement.Reason.LIFECYCLE);
+        announcedByNothing.put(LspMethod.INITIALIZED, Advertisement.Reason.LIFECYCLE);
+        announcedByNothing.put(LspMethod.SHUTDOWN, Advertisement.Reason.LIFECYCLE);
+        announcedByNothing.put(LspMethod.EXIT, Advertisement.Reason.LIFECYCLE);
+        announcedByNothing.put(LspMethod.SET_TRACE,
+                Advertisement.Reason.UNADVERTISED_PROTOCOL_METHOD);
+        announcedByNothing.put(LspMethod.DID_CHANGE_CONFIGURATION,
+                Advertisement.Reason.UNADVERTISED_PROTOCOL_METHOD);
+
+        Set<LspMethod> written = EnumSet.noneOf(LspMethod.class);
+        for (LspMethod method : byCapability.keySet()) {
+            assertTrue(written.add(method), method + " is written more than once");
+        }
+        for (LspMethod method : registeredAfterTheHandshake) {
+            assertTrue(written.add(method), method + " is written more than once");
+        }
+        for (LspMethod method : announcedByNothing.keySet()) {
+            assertTrue(written.add(method), method + " is written more than once");
+        }
+        assertEquals(EnumSet.allOf(LspMethod.class), written,
+                "every method the server answers says here how a client hears about it");
+
+        for (Map.Entry<LspMethod, String> row : byCapability.entrySet()) {
+            Advertisement.StaticCapability capability = assertInstanceOf(
+                    Advertisement.StaticCapability.class, row.getKey().advertisement(),
+                    row.getKey() + " is announced by a capability");
+            assertEquals(row.getValue(), capability.key(),
+                    "the capability a client reads before sending " + row.getKey().wire());
+        }
+        for (LspMethod method : registeredAfterTheHandshake) {
+            assertInstanceOf(Advertisement.DynamicRegistration.class, method.advertisement(),
+                    method + " is registered rather than carried by a capability");
+        }
+        for (Map.Entry<LspMethod, Advertisement.Reason> row : announcedByNothing.entrySet()) {
+            Advertisement.None none = assertInstanceOf(Advertisement.None.class,
+                    row.getKey().advertisement(), row.getKey() + " is announced by nothing");
+            assertEquals(row.getValue(), none.reason(), "why " + row.getKey() + " is not announced");
         }
     }
 

--- a/souther-lsp/src/test/java/souther/lsp/WhatTheServerAdvertisesIsWhatItAnswersTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/WhatTheServerAdvertisesIsWhatItAnswersTest.java
@@ -1,0 +1,197 @@
+package souther.lsp;
+
+import souther.lsp.transport.MessageConnection;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a client is told it may call, held against what the server does when it calls it.
+ *
+ * <p>That the two describe one set is a property of {@link LspMethod}: the handshake is built from
+ * the methods and there is no way to answer one that is not among them. What is left to observe is
+ * that the property survives the wire — that a method the handshake invites is not met with
+ * {@code method not found} at the connection, which is what a client actually depends on.
+ *
+ * <p>The methods are read from {@link LspMethod} rather than listed here on purpose. A list written
+ * in this file would be a third copy of the set, agreeing with neither side by construction and
+ * silently going stale exactly when the other two change.
+ */
+class WhatTheServerAdvertisesIsWhatItAnswersTest {
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    private static final int METHOD_NOT_FOUND = -32601;
+
+    private static final String URI = "file:///a.sou";
+
+    private static final String TEXT = "module demo\ndata X = { a: Int }\n";
+
+    /** Enough of every request shape for any handler's decoder to read what it looks for, so that a
+     * method answering nothing in particular still answers rather than failing to be understood. */
+    private static Map<String, Object> everyShape() {
+        Map<String, Object> params = new LinkedHashMap<>();
+        params.put("textDocument", Map.of("uri", URI, "text", TEXT));
+        params.put("contentChanges", List.of(Map.of("text", TEXT)));
+        params.put("position", Map.of("line", 1, "character", 5));
+        params.put("range", Map.of("start", Map.of("line", 1, "character", 5),
+                "end", Map.of("line", 1, "character", 6)));
+        params.put("context", Map.of("diagnostics", List.of()));
+        params.put("newName", "y");
+        params.put("options", Map.of("tabSize", 4, "insertSpaces", true));
+        return params;
+    }
+
+    @Test
+    void everyAdvertisedMethodIsAnsweredAtTheConnection() {
+        for (LspMethod method : LspMethod.values()) {
+            if (!(method.advertisement() instanceof Advertisement.StaticCapability capability)) {
+                continue;
+            }
+            JsonNode error = errorFrom(exchange(
+                    message(1, "initialize", Map.of()),
+                    message(null, "initialized", Map.of()),
+                    message(null, "textDocument/didOpen", Map.of(
+                            "textDocument", Map.of("uri", URI, "text", TEXT))),
+                    message(2, method.wire(), everyShape())), 2);
+            assertNull(error, capability.key() + " invites " + method.wire()
+                    + ", which answers: " + error);
+        }
+    }
+
+    @Test
+    void theHandshakeCarriesEveryAdvertisedCapabilityAndNoOther() {
+        JsonNode capabilities = responseFor(
+                exchange(message(1, "initialize", Map.of())), 1).get("capabilities");
+
+        Set<String> announced = new LinkedHashSet<>();
+        for (LspMethod method : LspMethod.values()) {
+            if (method.advertisement() instanceof Advertisement.StaticCapability capability) {
+                announced.add(capability.key());
+            }
+        }
+
+        Set<String> sent = new LinkedHashSet<>();
+        for (String key : capabilities.propertyNames()) {
+            sent.add(key);
+        }
+
+        assertEquals(announced, sent,
+                "the handshake is the methods' advertisements and nothing written beside them");
+    }
+
+    @Test
+    void theRegistrationNamesTheMethodThatCarriesIt() {
+        for (Map<String, Object> registration : LspMethod.dynamicRegistrations()) {
+            String registered = (String) registration.get("method");
+            assertTrue(LspMethod.of(registered).isPresent(),
+                    "registers a method the server answers: " + registered);
+            assertSame(LspMethod.of(registered).orElseThrow().advertisement().getClass(),
+                    Advertisement.DynamicRegistration.class,
+                    registered + " is registered, so that is how it is announced");
+        }
+    }
+
+    @Test
+    void aMethodIsFoundByTheSpellingItDeclares() {
+        for (LspMethod method : LspMethod.values()) {
+            assertSame(method, LspMethod.of(method.wire()).orElse(null),
+                    method + " is what its own spelling names");
+        }
+    }
+
+    @Test
+    void anUnknownRequestIsRefusedAsNotFound() {
+        JsonNode error = errorFrom(exchange(
+                message(1, "initialize", Map.of()),
+                message(2, "textDocument/inlayHint", Map.of())), 2);
+        assertNotNull(error, "a request naming no method is refused");
+        assertEquals(METHOD_NOT_FOUND, error.get("code").asInt());
+    }
+
+    @Test
+    void anUnknownNotificationIsDroppedRatherThanRefused() {
+        List<JsonNode> answers = exchange(
+                message(1, "initialize", Map.of()),
+                message(null, "textDocument/willSave", Map.of()),
+                message(2, "shutdown", Map.of()));
+
+        assertNull(errorFrom(answers, 2), "the session reads on past a notification it does not know");
+        assertNotNull(responseFor(answers, 2), "and still answers what comes after it");
+        for (JsonNode answer : answers) {
+            assertTrue(!answer.has("error") || answer.get("error").get("code").asInt() != METHOD_NOT_FOUND,
+                    "a notification has no reply to be refused in: " + answer);
+        }
+    }
+
+    // --- helpers: run one session over an in-memory connection ---
+
+    private static List<JsonNode> exchange(String... requests) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new LspServer(new MessageConnection(new ByteArrayInputStream(frames(requests)), out)).run();
+        return readFrames(out.toByteArray());
+    }
+
+    /** The {@code error} of the reply to request {@code id}, or null when it was not refused. */
+    private static JsonNode errorFrom(List<JsonNode> messages, int id) {
+        return messages.stream()
+                .filter(m -> m.has("id") && m.get("id").isNumber() && m.get("id").asInt() == id)
+                .filter(m -> m.has("error"))
+                .findFirst().map(m -> m.get("error")).orElse(null);
+    }
+
+    /** The {@code result} of the reply to request {@code id}, or null when there was none. */
+    private static JsonNode responseFor(List<JsonNode> messages, int id) {
+        return messages.stream()
+                .filter(m -> m.has("result") && m.has("id") && m.get("id").isNumber()
+                        && m.get("id").asInt() == id)
+                .findFirst().map(m -> m.get("result")).orElse(null);
+    }
+
+    private static String message(Integer id, String method, Object params) {
+        Map<String, Object> m = new LinkedHashMap<>();
+        m.put("jsonrpc", "2.0");
+        if (id != null) {
+            m.put("id", id);
+        }
+        m.put("method", method);
+        m.put("params", params);
+        return JSON.writeValueAsString(m);
+    }
+
+    private static byte[] frames(String... messages) {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        MessageConnection writer = new MessageConnection(new ByteArrayInputStream(new byte[0]), buffer);
+        for (String m : messages) {
+            writer.write(m);
+        }
+        return buffer.toByteArray();
+    }
+
+    private static List<JsonNode> readFrames(byte[] bytes) {
+        MessageConnection reader = new MessageConnection(
+                new ByteArrayInputStream(bytes), OutputStream.nullOutputStream());
+        List<JsonNode> out = new ArrayList<>();
+        String s;
+        while ((s = reader.read()) != null) {
+            out.add(JSON.readTree(s));
+        }
+        return out;
+    }
+}

--- a/souther-lsp/src/test/java/souther/lsp/WhatTheServerAdvertisesIsWhatItAnswersTest.java
+++ b/souther-lsp/src/test/java/souther/lsp/WhatTheServerAdvertisesIsWhatItAnswersTest.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -96,72 +97,135 @@ class WhatTheServerAdvertisesIsWhatItAnswersTest {
         }
     }
 
+    /** What a client must read under a capability's key to be told the method is offered. */
+    private sealed interface Told {
+
+        /**
+         * A field of the capabilities object, and what its value has to say.
+         *
+         * <p>Which value to send is this server's to choose — a bare {@code true} and an options
+         * object are both legitimate answers, and copying the one we chose would witness nothing.
+         * Whether the value offers the method is not a choice: {@code hoverProvider: false} and
+         * {@code semanticTokensProvider: { full: false }} are well-formed capabilities that decline
+         * the very request behind them, and a server sending one while answering that request is
+         * back to answering what it did not advertise.
+         */
+        record Capability(String key, Predicate<JsonNode> offers, String offering) implements Told {
+        }
+
+        /** Announced after the handshake by {@code client/registerCapability}. */
+        record Registration() implements Told {
+        }
+
+        /** Announced by nothing, for the reason given. */
+        record Nothing(Advertisement.Reason reason) implements Told {
+        }
+    }
+
+    /** One method as the protocol defines it: the name a client sends, and how it is told. */
+    private record Protocol(LspMethod method, String wire, Told told) {
+    }
+
+    /** {@code true}, or an options object; {@code false} or an absent field declines the request. */
+    private static final Predicate<JsonNode> TRUE_OR_OPTIONS =
+            value -> (value.isBoolean() && value.booleanValue()) || value.isObject();
+
+    /** A sync kind other than {@code None}, or options saying which notifications are wanted. */
+    private static final Predicate<JsonNode> SYNCING =
+            value -> value.isObject() || (value.isNumber() && value.intValue() != 0);
+
+    /** Semantic tokens for a whole document are behind the options' own {@code full}. */
+    private static final Predicate<JsonNode> FULL_DOCUMENT_TOKENS = value -> {
+        JsonNode full = value.isObject() ? value.get("full") : null;
+        return full != null && (full.isObject() || (full.isBoolean() && full.booleanValue()));
+    };
+
+    private static Protocol offered(LspMethod method, String wire, String key) {
+        return new Protocol(method, wire,
+                new Told.Capability(key, TRUE_OR_OPTIONS, "true or an options object"));
+    }
+
+    private static Protocol lifecycle(LspMethod method, String wire) {
+        return new Protocol(method, wire, new Told.Nothing(Advertisement.Reason.LIFECYCLE));
+    }
+
+    private static Protocol protocolNotification(LspMethod method, String wire) {
+        return new Protocol(method, wire,
+                new Told.Nothing(Advertisement.Reason.UNADVERTISED_PROTOCOL_METHOD));
+    }
+
     /**
-     * How each method is announced, written from the protocol rather than read from the server.
+     * The protocol, written out rather than read from the server.
      *
-     * <p>A capability key is what the protocol says a client reads before sending that method. The
-     * value under the key is not here: whether a provider is spelled {@code true} or an options
-     * object is this server's to decide, and repeating it would copy a decision rather than witness
-     * an agreement.
+     * <p>Every method has a row, so a method added to {@link LspMethod} is one this file has to say
+     * something about. What a row says is what the specification says: the name a client sends, and
+     * what a client reads to know it may send it.
      */
+    private static final List<Protocol> PROTOCOL = List.of(
+            lifecycle(LspMethod.INITIALIZE, "initialize"),
+            lifecycle(LspMethod.INITIALIZED, "initialized"),
+            lifecycle(LspMethod.SHUTDOWN, "shutdown"),
+            lifecycle(LspMethod.EXIT, "exit"),
+            protocolNotification(LspMethod.SET_TRACE, "$/setTrace"),
+            protocolNotification(LspMethod.DID_CHANGE_CONFIGURATION,
+                    "workspace/didChangeConfiguration"),
+            new Protocol(LspMethod.DID_OPEN, "textDocument/didOpen",
+                    new Told.Capability("textDocumentSync", SYNCING, "a sync kind other than None")),
+            new Protocol(LspMethod.DID_CHANGE, "textDocument/didChange",
+                    new Told.Capability("textDocumentSync", SYNCING, "a sync kind other than None")),
+            new Protocol(LspMethod.DID_CLOSE, "textDocument/didClose",
+                    new Told.Capability("textDocumentSync", SYNCING, "a sync kind other than None")),
+            new Protocol(LspMethod.DID_CHANGE_WATCHED_FILES, "workspace/didChangeWatchedFiles",
+                    new Told.Registration()),
+            offered(LspMethod.DOCUMENT_SYMBOL, "textDocument/documentSymbol",
+                    "documentSymbolProvider"),
+            new Protocol(LspMethod.SEMANTIC_TOKENS_FULL, "textDocument/semanticTokens/full",
+                    new Told.Capability("semanticTokensProvider", FULL_DOCUMENT_TOKENS,
+                            "options whose `full` offers whole-document tokens")),
+            offered(LspMethod.HOVER, "textDocument/hover", "hoverProvider"),
+            offered(LspMethod.DEFINITION, "textDocument/definition", "definitionProvider"),
+            offered(LspMethod.REFERENCES, "textDocument/references", "referencesProvider"),
+            offered(LspMethod.COMPLETION, "textDocument/completion", "completionProvider"),
+            offered(LspMethod.CODE_ACTION, "textDocument/codeAction", "codeActionProvider"),
+            offered(LspMethod.CODE_LENS, "textDocument/codeLens", "codeLensProvider"),
+            offered(LspMethod.RENAME, "textDocument/rename", "renameProvider"),
+            offered(LspMethod.FORMATTING, "textDocument/formatting", "documentFormattingProvider"));
+
     @Test
     void everyMethodIsAnnouncedTheWayTheProtocolSaysItIs() {
-        Map<LspMethod, String> byCapability = new LinkedHashMap<>();
-        byCapability.put(LspMethod.DID_OPEN, "textDocumentSync");
-        byCapability.put(LspMethod.DID_CHANGE, "textDocumentSync");
-        byCapability.put(LspMethod.DID_CLOSE, "textDocumentSync");
-        byCapability.put(LspMethod.DOCUMENT_SYMBOL, "documentSymbolProvider");
-        byCapability.put(LspMethod.SEMANTIC_TOKENS_FULL, "semanticTokensProvider");
-        byCapability.put(LspMethod.HOVER, "hoverProvider");
-        byCapability.put(LspMethod.DEFINITION, "definitionProvider");
-        byCapability.put(LspMethod.REFERENCES, "referencesProvider");
-        byCapability.put(LspMethod.COMPLETION, "completionProvider");
-        byCapability.put(LspMethod.CODE_ACTION, "codeActionProvider");
-        byCapability.put(LspMethod.CODE_LENS, "codeLensProvider");
-        byCapability.put(LspMethod.RENAME, "renameProvider");
-        byCapability.put(LspMethod.FORMATTING, "documentFormattingProvider");
-
-        Set<LspMethod> registeredAfterTheHandshake = EnumSet.of(LspMethod.DID_CHANGE_WATCHED_FILES);
-
-        Map<LspMethod, Advertisement.Reason> announcedByNothing = new LinkedHashMap<>();
-        announcedByNothing.put(LspMethod.INITIALIZE, Advertisement.Reason.LIFECYCLE);
-        announcedByNothing.put(LspMethod.INITIALIZED, Advertisement.Reason.LIFECYCLE);
-        announcedByNothing.put(LspMethod.SHUTDOWN, Advertisement.Reason.LIFECYCLE);
-        announcedByNothing.put(LspMethod.EXIT, Advertisement.Reason.LIFECYCLE);
-        announcedByNothing.put(LspMethod.SET_TRACE,
-                Advertisement.Reason.UNADVERTISED_PROTOCOL_METHOD);
-        announcedByNothing.put(LspMethod.DID_CHANGE_CONFIGURATION,
-                Advertisement.Reason.UNADVERTISED_PROTOCOL_METHOD);
+        JsonNode capabilities = responseFor(
+                exchange(message(1, "initialize", Map.of())), 1).get("capabilities");
 
         Set<LspMethod> written = EnumSet.noneOf(LspMethod.class);
-        for (LspMethod method : byCapability.keySet()) {
-            assertTrue(written.add(method), method + " is written more than once");
-        }
-        for (LspMethod method : registeredAfterTheHandshake) {
-            assertTrue(written.add(method), method + " is written more than once");
-        }
-        for (LspMethod method : announcedByNothing.keySet()) {
-            assertTrue(written.add(method), method + " is written more than once");
+        for (Protocol row : PROTOCOL) {
+            assertTrue(written.add(row.method()), row.method() + " is written more than once");
+            assertEquals(row.wire(), row.method().wire(),
+                    "the name a client sends for " + row.method());
+            switch (row.told()) {
+                case Told.Capability told -> {
+                    Advertisement.StaticCapability declared = assertInstanceOf(
+                            Advertisement.StaticCapability.class, row.method().advertisement(),
+                            row.method() + " is announced by a capability");
+                    assertEquals(told.key(), declared.key(),
+                            "the capability a client reads before sending " + row.wire());
+                    JsonNode sent = capabilities.get(told.key());
+                    assertNotNull(sent, told.key() + " is in the handshake");
+                    assertTrue(told.offers().test(sent), told.key() + " has to be "
+                            + told.offering() + " to offer " + row.wire() + ", and is " + sent);
+                }
+                case Told.Registration _ -> assertInstanceOf(
+                        Advertisement.DynamicRegistration.class, row.method().advertisement(),
+                        row.method() + " is registered rather than carried by a capability");
+                case Told.Nothing told -> {
+                    Advertisement.None none = assertInstanceOf(Advertisement.None.class,
+                            row.method().advertisement(), row.method() + " is announced by nothing");
+                    assertEquals(told.reason(), none.reason(),
+                            "why " + row.method() + " is not announced");
+                }
+            }
         }
         assertEquals(EnumSet.allOf(LspMethod.class), written,
                 "every method the server answers says here how a client hears about it");
-
-        for (Map.Entry<LspMethod, String> row : byCapability.entrySet()) {
-            Advertisement.StaticCapability capability = assertInstanceOf(
-                    Advertisement.StaticCapability.class, row.getKey().advertisement(),
-                    row.getKey() + " is announced by a capability");
-            assertEquals(row.getValue(), capability.key(),
-                    "the capability a client reads before sending " + row.getKey().wire());
-        }
-        for (LspMethod method : registeredAfterTheHandshake) {
-            assertInstanceOf(Advertisement.DynamicRegistration.class, method.advertisement(),
-                    method + " is registered rather than carried by a capability");
-        }
-        for (Map.Entry<LspMethod, Advertisement.Reason> row : announcedByNothing.entrySet()) {
-            Advertisement.None none = assertInstanceOf(Advertisement.None.class,
-                    row.getKey().advertisement(), row.getKey() + " is announced by nothing");
-            assertEquals(row.getValue(), none.reason(), "why " + row.getKey() + " is not announced");
-        }
     }
 
     @Test


### PR DESCRIPTION
Closes #478.

## What the defect was

Not a disagreement between the two lists — they agreed. The set of methods `LspServer` answers
existed only as the case labels of a `switch`, and `-32601` came from that switch's `default`. Since
no other code could read the set, `initializeResult()` restated it by hand, and a test relating the
two would have had to restate it a third time.

That third copy is why the issue's proposal only half works. A table in the test catches a provider
advertised with no row, because the advertised set can be read off the initialize response. It
cannot catch a method answered with no row — the quieter direction the issue is actually about —
because there is no way for a test to enumerate the case labels. The table would be the third
hand-written copy, and adding a case to `dispatch` would not make it fail.

So the supported set belongs in the model. Once it is there, a test-side table stops being a third
copy of that set and can be what it should have been: an oracle for the protocol.

## What changed

`LspMethod` names each method once: the spelling it is called by, and an `Advertisement` saying what
tells a client it can be called.

```
LspMethod
  ├─ wire spelling
  └─ Advertisement
       ├─ StaticCapability     a field of the capabilities object
       ├─ DynamicRegistration  registered after the handshake
       └─ None(reason)         LIFECYCLE | UNADVERTISED_PROTOCOL_METHOD
```

Two projections come off it:

```
initialize   -> LspMethod.values() -> StaticCapability     -> capabilities
initialized  -> LspMethod.values() -> DynamicRegistration  -> client/registerCapability
```

`initialized` itself is `None(LIFECYCLE)`; it is `workspace/didChangeWatchedFiles` that carries the
`DynamicRegistration`. What triggers an announcement and what is announced are separate.

`dispatch` parses the wire string to an `LspMethod` and refuses only a parse failure. The switch over
the result is an **expression with no `default`**, which is what makes the guarantee hold — a
`switch` *statement* over an enum is not checked for exhaustiveness, and a `default` arm would
silently absorb new constants.

One capability field may announce several methods, and then the methods share one advertisement
rather than each writing the value out. Two methods arriving at one key by different advertisements
are refused, by identity and not by equality: writing the same value twice and sharing one value are
different intentions, and only the second leaves every method announced. Everything derived from the
table is derived as the class loads, so a table that contradicts itself stops the server rather than
becoming an internal error at some client's handshake.

## What the production model cannot settle

That `hoverProvider` is the field a client reads before sending `textDocument/hover` is the
protocol's to say, not this server's. `everyMethodIsAnnouncedTheWayTheProtocolSaysItIs` writes that
relation out, with every method named — including those announced by nothing, and why. It is a
second copy on purpose, for the reason the protocol-facing tests keep their method literals:

```
LspMethod                      what this server declares
test-side protocol witness     what LSP defines
```

Only holding the two together catches a capability that announces a method it does not name.

Each row carries three things: the name a client sends, the capability key it reads, and what that
key's value has to say for the method to be offered. The last one matters because the value is only
half this server's to choose. *Which* value to send is a decision — a bare `true` and an options
object are both legitimate, and copying ours would witness nothing. Whether the value offers the
method is not: `hoverProvider: false` and `semanticTokensProvider: { full: false }` are well-formed
capabilities that decline the request behind them, and a server answering that request anyway is
back to answering what it did not advertise, without a key or a spelling having moved.

So the row says "true or an options object", "an options object" for the two capabilities with no
boolean form, "options whose `full` offers whole-document tokens" — and is checked against the
handshake as it goes over the wire. The semantic tokens legend is not witnessed: which token types
this server names is its own to say.

One field can answer differently to different methods. `textDocumentSync` announces three
notifications, and in its options form each is behind its own key: `openClose` for opening and
closing, `change` for edits. So the three rows ask their own question of the same field —
`{ openClose: true, change: 0 }` syncs documents and declines edits, and only the `didChange` row
should accept it. The shorthand form carries all three, but only where it is a kind that syncs.

## The invariants, and the mutant that kills each

| invariant | mutant | result |
| --- | --- | --- |
| a known method is always dispatched | add `WILL_SAVE` to `LspMethod` | compile error: switch expression does not cover all possible input values |
| a spelling names one method | `HOVER` spelled `textDocument/definition` | `HOVER and DEFINITION are both spelled ...` at class load |
| a shared field is a shared advertisement | `HOVER` advertised as `definitionProvider: true` | `HOVER and DEFINITION both advertise definitionProvider without sharing one advertisement` |
| the same, by an equal but separate value | `DID_CHANGE` given its own `StaticCapability("textDocumentSync", 1)` | `DID_OPEN and DID_CHANGE both advertise textDocumentSync without sharing one advertisement` |
| a capability announces the method the protocol says | `HOVER` advertised as `inlayHintProvider` | `the capability a client reads before sending textDocument/hover ==> expected: <hoverProvider> but was: <inlayHintProvider>` |
| a capability's value offers the request behind it | `semanticTokensProvider` sent with `full: false` | `semanticTokensProvider has to be options whose `full` offers whole-document tokens to offer textDocument/semanticTokens/full` |
| — the same, one level up | `hoverProvider` sent as `false` | `hoverProvider has to be true or an options object to offer textDocument/hover, and is false` |
| one field answers per method | `textDocumentSync` sent as `{ openClose: true, change: 0 }` | only `didChange` fails: `... options whose \`change\` is not None to offer textDocument/didChange` |
| — and the other way round | `textDocumentSync` sent as `{ change: 1 }` | only `didOpen`/`didClose` fail: `... options whose \`openClose\` is on` |
| a shorthand kind that declines | `textDocumentSync` sent as `0` | `... to offer textDocument/didOpen, and is 0` (and `2`, a real sync kind, still passes) |
| an options-only capability is an object | `completionProvider` sent as `true` | `completionProvider has to be an options object to offer textDocument/completion, and is true` |
| the handshake is the table's projection | `inlayHintProvider` written into `initializeResult` | `theHandshakeCarriesEveryAdvertisedCapabilityAndNoOther` fails |
| a method is spelled the way the protocol spells it | `HOVER` spelled `textDocument/hoverr` | `the name a client sends for HOVER ==> expected: <textDocument/hover> but was: <textDocument/hoverr>` |
| — including one no behaviour can witness | `SET_TRACE` spelled `$/setTracee` | `the name a client sends for SET_TRACE ==> expected: <$/setTrace> but was: <$/setTracee>` |
| a method answers under that name at the connection | `HOVER` spelled `textDocument/hoverr` | `hoverOverATypeShowsHowItIsDeclared`: no response for id 2 |

Together: adding to `LspMethod` without dispatching does not compile, dispatching without adding to
`LspMethod` cannot be written, and neither the name a method is called by, nor the capability that
announces it, nor whether that capability's value actually offers it can drift from the protocol
without a test saying so.

## Tests

`WhatTheServerAdvertisesIsWhatItAnswersTest` (7) reads the methods from `LspMethod` everywhere except
the protocol witness above. `noAdvertisedMethodIsRefusedAsNotFound` checks only that — whether a
handler survives an ordinary call is that method's own behaviour.

`LspServerTest` gains six behaviour tests, for the request methods that had no literal spelling
anywhere: `documentSymbol`, `semanticTokens/full`, `hover`, `definition`, `references`, `codeLens`.
Each asks a real question and checks a real answer. The spelling is now witnessed twice over — by
the protocol oracle, and by these calling the method under the name a client would use.

`$/setTrace` and `workspace/didChangeConfiguration` get no behaviour test. Both are accepted and do
nothing, and an unknown notification is dropped, so nothing on the wire tells the two apart; the
oracle row is the only place their spelling can be witnessed.

`mvn -o clean test -pl souther-lsp`: 198 tests, no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
