### PR TITLE
The report is what was observed, not whether it compiled

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -219,6 +219,44 @@ public final class Compiler {
         return compilation;
     }
 
+    /**
+     * The compilation of one source, driven as far as it goes, with nothing raised.
+     *
+     * <p>Beside {@link #compiled} rather than in place of it. A caller about to write classes out has
+     * to stop at the first error, there being nothing to write; a caller about to say what the rows
+     * cover has an answer either way. The specification puts the two apart — an example report
+     * "changes what compiles" not at all — and this is the half of that the entry points did not
+     * have. What refused the compilation is refused still: it is in the reports, and the caller reads
+     * it there rather than catching it.
+     */
+    public static Compilation analyzed(String source, String defaultModuleName,
+                                       List<Located> warningsOut, Adequacy.Asked measure) {
+        return answered(Compilation.ofSource(source, defaultModuleName), warningsOut, measure);
+    }
+
+    /** As {@link #analyzed}, for a module set resolved against {@code path} — what
+     *  {@link #compiledModules} is to {@link #compiled}. */
+    public static Compilation analyzedModules(List<String> sources, ModulePath path,
+                                              List<Located> warningsOut, Adequacy.Asked measure) {
+        return answered(Compilation.ofSources(sources, path), warningsOut, measure);
+    }
+
+    /**
+     * Asks the whole compilation and collects its warnings.
+     *
+     * <p>The warnings are collected whatever the compilation came to, which is where this parts from
+     * the raising entry points: they reach the collection only by getting past every error, so a
+     * compilation with one reports no warnings at all. Nothing about a warning depends on the errors
+     * beside it.
+     */
+    private static Compilation answered(Compilation compilation, List<Located> warningsOut,
+                                        Adequacy.Asked measure) {
+        compilation.measure(measure);
+        compilation.answerEverything();
+        warningsOut.addAll(compilation.warnings(compilation.db().allReports()));
+        return compilation;
+    }
+
     private static Map<String, byte[]> classesOf(Compilation compilation) {
         return new LinkedHashMap<>(compilation.classes());
     }
@@ -272,8 +310,8 @@ public final class Compiler {
      * The compilation of a module set, driven to completion, with the first error raised — what
      * {@link #linking} returns the classes of, for a caller that wants more than the classes.
      *
-     * <p>{@code souther examples} is such a caller: it asks how well the rows cover the model, which
-     * is read off the same compile that would have written the classes out.
+     * <p>For a caller that has to have a compilation there is nothing to go on with. A caller that
+     * can say something either way takes {@link #analyzedModules} instead.
      */
     public static Compilation compiledModules(List<String> sources, ModulePath path,
                                               List<Located> warningsOut) {

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -316,9 +316,17 @@ public final class Main {
      * {@code souther examples <file.sou>...}: how well the model's {@code example}s cover it.
      *
      * <p>Its own command rather than a flag on {@code compile}, because the two answer different
-     * questions. {@code compile} writes classes out and stops at the first error; this asks a model
-     * that already compiles how much of it the rows have pinned down. Mixing them would put a report
-     * on stdout next to {@code wrote <path>} and make a failing build the only way to see it.
+     * questions. {@code compile} writes classes out and stops at the first error; this asks how much
+     * of a model the rows have pinned down, which is a question about what was observed and not
+     * about whether anything can be written out. Mixing them would put a report on stdout next to
+     * {@code wrote <path>} and make a failing build the only way to see it.
+     *
+     * <p>So the three things this answers with are decided apart. The report goes to stdout wherever
+     * there is a subject to report on; the diagnostics go to stderr as they always did; the exit code
+     * says whether the command succeeded, and an error still means it did not. Reading the report off
+     * a compile that had to survive every error is what left the whole {@code incompleteness} channel
+     * unreachable — all but one of the reasons that field carries arrive with a diagnostic beside
+     * them, so the fail-fast path hid the whole of it.
      */
     private static int examplesSubcommand(String[] rawArgs) {
         RenderOptions render = new RenderOptions();
@@ -388,10 +396,20 @@ public final class Main {
             }
             ModulePath path = classPath.isEmpty() ? ModulePath.EMPTY
                     : ModulePath.ofClassPath(classPath);
+            // The analysing entry points, not the compiling ones. What the rows cover is a question
+            // this command answers from whatever was observed, and taking the compilation from an
+            // entry point that raises the first error made every failure the report describes the
+            // one thing that stopped it being written.
             Compilation compilation = texts.size() == 1 && classPath.isEmpty()
-                    ? Compiler.compiled(texts.get(0), Runner.moduleName(sources.get(0)), warnings,
+                    ? Compiler.analyzed(texts.get(0), Runner.moduleName(sources.get(0)), warnings,
                             measure)
-                    : Compiler.compiledModules(texts, path, warnings, measure);
+                    : Compiler.analyzedModules(texts, path, warnings, measure);
+            // Said first, and whatever the command answers with after. What is wrong with the source
+            // is the same news whether the rest of this reports, refuses, or succeeds.
+            List<Located> errors = compilation.errors(compilation.db().allReports());
+            List<Located> said = new ArrayList<>(errors);
+            said.addAll(warnings);
+            report(said, sources, render);
             // Before the report, because a name that names nothing is not something a report can
             // say. Filtering one after the fact leaves an empty document whose every word is about
             // what was measured, and nothing measured anything.
@@ -400,16 +418,29 @@ public final class Main {
                 System.err.println(Messages.get(refused.key(), render.locale(), refused.args()));
                 return 2;
             }
-            AdequacyReport report = AdequacyReport.of(compilation).only(module, behavior);
-            report(warnings, sources, render);
-            String rendered = render.json() ? report.json() + System.lineSeparator() : report.human();
-            System.out.print(rendered);
-            // After the report, because the rows are what to do about what the report just said.
-            // Beside it rather than in it where the report is JSON: the rows are source, and source in
-            // the middle of a JSON document is not a document.
-            if (generate) {
-                String rows = GeneratedRows.of(compilation, module, behavior, boundaries);
-                (render.json() ? System.err : System.out).print(rows);
+            AdequacyReport assessed = AdequacyReport.of(compilation);
+            // Whether there is anything to report on is a question about the compilation, and what
+            // the report shows is a question about the selection. They are asked of different things
+            // — this of everything that formed, `only` of what was named — so that neither can come
+            // to stand for the other. That is the shape of the defect this command had.
+            boolean assessable = !assessed.modules().isEmpty();
+            AdequacyReport report = assessed.only(module, behavior);
+            if (assessable) {
+                String rendered = render.json() ? report.json() + System.lineSeparator()
+                        : report.human();
+                System.out.print(rendered);
+                // After the report, because the rows are what to do about what the report just said.
+                // Beside it rather than in it where the report is JSON: the rows are source, and
+                // source in the middle of a JSON document is not a document.
+                if (generate) {
+                    String rows = GeneratedRows.of(compilation, module, behavior, boundaries);
+                    (render.json() ? System.err : System.out).print(rows);
+                }
+            }
+            // The report is written either way; whether the command succeeded is a separate answer,
+            // and an error is an error whatever could still be said about the rows.
+            if (!errors.isEmpty()) {
+                return 1;
             }
             // What the report just named, and nothing else. A row waiting for a `let` is not one of
             // them: waiting is the normal state of a model being written, and a gate on it refuses the

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -518,4 +518,22 @@ public final class Compilation {
         }
         return warnings;
     }
+
+    /**
+     * The errors among {@code found}, tagged as {@link #warnings} tags a warning.
+     *
+     * <p>All of them, where {@link #firstError} answers with one. A caller that stops at the first
+     * error wants the first; one that goes on to say something about the whole compilation has
+     * already read past it, and showing a reader one error beside an account of everything else
+     * would leave them to wonder what the rest of the errors were.
+     */
+    public List<Located> errors(List<Db.Found> found) {
+        List<Located> errors = new ArrayList<>();
+        for (Db.Found f : found) {
+            if (f.report().isError()) {
+                errors.add(new Located(f.report().diagnostic(), sourceIdOf(f)));
+            }
+        }
+        return errors;
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/ACompilationThatFailedStillReportsWhatItsRowsCoverTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACompilationThatFailedStillReportsWhatItsRowsCoverTest.java
@@ -1,0 +1,240 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * How well the rows cover a model is a different question from whether the model compiles, and
+ * {@code souther examples} answers the first one.
+ *
+ * <p>The specification says so — "Nothing here changes what compiles; it reports" — and the command
+ * read it one way round only. It took its compilation from the entry point a batch compile uses,
+ * which raises the first error it finds, so every failure the report exists to describe stopped the
+ * report from being written at all.
+ */
+class ACompilationThatFailedStillReportsWhatItsRowsCoverTest {
+
+    /** One behavior that checks and one that does not, so there is something to report and a reason
+     * the command still refuses. */
+    private static final String ONE_BEHAVIOR_DOES_NOT_CHECK = """
+            module example.partly
+
+            data Amount = Int
+                invariant value >= 0 && value <= 1000
+
+            data Draft = { cost: Amount }
+            data Ok = { n: Int }
+            data Refused = { why: String }
+
+            behavior take : (request: Draft) -> Ok | Refused
+                constructs Ok
+
+            let take (request) = Ok { n = request.cost.value }
+
+            behavior other : (request: Draft) -> Ok
+                constructs Ok
+
+            let other (request) = Ok { n = request.cost.nope }
+
+            example take
+                | (Draft { cost = Amount(7) }) -> Ok { n = 7 }
+            """;
+
+    /** A module, and an attached file declaring a value the module already declares — so the rows in
+     * the attached file are never evaluated and nothing knows what they covered. */
+    private static final String MODULE_WITH_A_SHARED_VALUE = """
+            module example.split
+
+            data Amount = Int
+                invariant value >= 0 && value <= 1000
+
+            data Draft = { cost: Amount }
+            data Ok = { n: Int }
+
+            let shared = Draft { cost = Amount(7) }
+
+            behavior take : (request: Draft) -> Ok
+                constructs Ok
+
+            let take (request) = Ok { n = request.cost.value }
+
+            example take
+                | (Draft { cost = Amount(7) }) -> Ok { n = 7 }
+            """;
+
+    private static final String ATTACHED_DECLARING_IT_AGAIN = """
+            examples for example.split
+
+            let shared = Draft { cost = Amount(0) }
+
+            example take
+                | (Draft { cost = Amount(0) }) -> Ok { n = 0 }
+            """;
+
+    /** Two behaviors, each reading a field its input has not got: two problems, neither behind the
+     * other. */
+    private static final String TWO_BEHAVIORS_DO_NOT_CHECK = """
+            module example.twice
+
+            data Draft = { cost: Int }
+            data Ok = { n: Int }
+
+            behavior take : (request: Draft) -> Ok
+                constructs Ok
+
+            let take (request) = Ok { n = request.nope }
+
+            behavior other : (request: Draft) -> Ok
+                constructs Ok
+
+            let other (request) = Ok { n = request.alsoNope }
+            """;
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    private record Streams(int code, String out, String err) {}
+
+    private static Streams run(String source, String... extraArgs) throws Exception {
+        return ran(List.of(source), extraArgs);
+    }
+
+    /** The module and its attached file, given to the command together as an author gives them. */
+    private static Streams runBoth(String... extraArgs) throws Exception {
+        return ran(List.of(MODULE_WITH_A_SHARED_VALUE, ATTACHED_DECLARING_IT_AGAIN), extraArgs);
+    }
+
+    private static Streams ran(List<String> texts, String... extraArgs) throws Exception {
+        Path dir = Files.createTempDirectory("souther-examples");
+        List<String> args = new ArrayList<>(List.of("examples"));
+        args.addAll(List.of(extraArgs));
+        for (int i = 0; i < texts.size(); i++) {
+            Path file = dir.resolve(i == 0 ? "model.sou" : "attached" + i + ".sou");
+            Files.writeString(file, texts.get(i));
+            args.add(file.toString());
+        }
+
+        PrintStream originalOut = System.out;
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        int code;
+        try {
+            // `dispatch` rather than `main`, which turns a non-zero answer into a dead JVM.
+            code = Main.dispatch(args.toArray(String[]::new));
+        } finally {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+        }
+        return new Streams(code, out.toString(StandardCharsets.UTF_8),
+                err.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void theReportIsWrittenForAModuleOneOfWhoseBehaviorsDidNotCheck() throws Exception {
+        Streams ran = run(ONE_BEHAVIOR_DOES_NOT_CHECK, "--format", "json");
+
+        assertFalse(ran.out().isBlank(),
+                "the report is what this command answers with; stderr said: " + ran.err());
+        JsonNode report = JSON.readTree(ran.out());
+        assertEquals("example.partly", report.get("modules").get(0).get("module").asString(),
+                "the module is there to be reported on, whatever else did not check");
+    }
+
+    @Test
+    void theDiagnosticIsStillSaidAndTheCommandStillRefuses() throws Exception {
+        Streams ran = run(ONE_BEHAVIOR_DOES_NOT_CHECK, "--format", "json");
+
+        assertEquals(1, ran.code(), "a compilation with an error is still a failed command");
+        assertTrue(ran.err().contains("E1321"),
+                "the diagnostic goes where it always went: " + ran.err());
+    }
+
+    /**
+     * And the field that says what the assessment did without is finally written.
+     *
+     * <p>The whole of {@code incompleteness} was unreachable: all but one of the reasons it carries
+     * arrive with a diagnostic beside them — the exception is the runtime not being reachable — so a
+     * report only a clean compile produced could carry almost nothing the field is for. Here a
+     * source declares a value the module already declares, so its rows are never evaluated and
+     * whatever they covered is unknown.
+     *
+     * <p>The word is not asserted. Which code a source that produced no observation should carry is
+     * its own question, and this test is about the entry existing at all.
+     */
+    @Test
+    void aSourceThatWasNeverEvaluatedIsSaidToBeMissingFromTheAssessment() throws Exception {
+        Streams ran = runBoth("--format", "json");
+
+        assertEquals(1, ran.code());
+        JsonNode gaps = JSON.readTree(ran.out()).get("modules").get(0).get("incompleteness");
+        assertEquals(1, gaps.size(), "the attached source went unread: " + ran.out());
+        assertEquals("source", gaps.get(0).get("scope").asString(),
+                "what could not be read is the source, so it counts against everything in it");
+    }
+
+    /**
+     * Every error, where the raising entry point said the first one.
+     *
+     * <p>A command that goes on to describe the whole compilation has read past the first error
+     * already, and showing one beside an account of everything else leaves a reader to wonder what
+     * the rest of them were.
+     */
+    @Test
+    void bothProblemsAreSaidRatherThanTheFirstOfThem() throws Exception {
+        Streams ran = run(TWO_BEHAVIORS_DO_NOT_CHECK, "--format", "json");
+
+        assertEquals(1, ran.code());
+        assertTrue(ran.err().contains("nope") && ran.err().contains("alsoNope"),
+                "neither problem is behind the other, so both are said: " + ran.err());
+    }
+
+    /**
+     * A selector that resolves, on a compilation that did not.
+     *
+     * <p>Where the two rules meet. A name that names nothing is refused before a report is made of
+     * it, and a name that names something is not — so a subject that resolves and then could not be
+     * fully measured comes back as the partial report it is, with the error said beside it, rather
+     * than as a usage error about a name that was perfectly good.
+     */
+    @Test
+    void aSelectorThatResolvesStillGetsItsReportFromACompilationThatDidNot() throws Exception {
+        Streams ran = run(ONE_BEHAVIOR_DOES_NOT_CHECK, "--format", "json",
+                "--module", "example.partly", "--behavior", "take");
+
+        assertEquals(1, ran.code(), "the compilation failed, and the selector was not why");
+        assertTrue(ran.err().contains("E1321"), ran.err());
+        JsonNode report = JSON.readTree(ran.out());
+        assertEquals("example.partly", report.get("modules").get(0).get("module").asString());
+        assertEquals(1, report.get("modules").get(0).get("behaviors").size(),
+                "the selector narrowed it to the one behavior it named: " + ran.out());
+    }
+
+    @Test
+    void nothingIsReportedWhereNoModuleFormed() throws Exception {
+        Streams ran = run("""
+                module example.broken
+
+                data Ok = { n: Int
+                """, "--format", "json");
+
+        assertEquals(1, ran.code());
+        assertTrue(ran.out().isBlank(),
+                "a source that declares no module has no subject to assess: " + ran.out());
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -2587,7 +2587,7 @@ The base form is written inline, in the same source as the behavior. To keep fix
 [#example-adequacy]
 === What the rows establish
 
-An `+example+` fixes the value rule for one input. Whether a model's rows together say enough about it is a different question, and `+souther examples+` answers it from what evaluating them observed. Nothing here changes what compiles; it reports.
+An `+example+` fixes the value rule for one input. Whether a model's rows together say enough about it is a different question, and `+souther examples+` answers it from what evaluating them observed. Nothing here changes what compiles; it reports. And what compiles does not decide whether it reports: a compilation that raised a diagnostic observed whatever it observed, and the rows covered whatever they covered (<<example-report-emission>>).
 
 These are the questions the dial asks of a model's rows, each answered where the measurement was complete:
 
@@ -2707,6 +2707,25 @@ That difference is the one worth reading. `+not applicable+` asks nothing of an 
 *A measure's reason is the measure's own.* It is not worked out from the numbers beside it, from how many rows a behavior has, or from whether the behavior is injected. Those correlate with the reason and are not it.
 
 *The JSON form carries the same two.* Every measure emits `+status+`, and emits `+reason+` exactly where `+status+` is `+unavailable+`. `+schemaVersion+` is raised when a field is removed or renamed, and not when one is added: a document written before a field existed is still a document of this version. That holds one way only. Every object in the schema is closed, so an older copy of it refuses a document carrying a field added since; a reader that has to accept newer documents wants the newer schema rather than a higher number.
+
+*What the rows could not be observed doing.* Beside the measures, the report carries the reasons the rows were not observed — what happened, and what it happened to: a behavior, a source, the module, or a position in a value. A row that did not come back, a source none of whose rows were evaluated, a run whose instrumentation could not be tied back to the body. The JSON writes them as `+incompleteness+`.
+
+This is not the whole account of what an assessment went without, and an empty list does not say that everything was read. What stopped a measure from reading what was observed is said by that measure instead: a position dropped for being past the axis limit, a combination count that stopped at its own limit, a value too large to be read back. Those carry no entry here, and a report may say `+partial+` with this list empty. The division is which half of the work did not happen — the rows not observed, or the observations not read — and `+status+` is what a reader asks about completeness either way.
+
+These are not the compilation's diagnostics restated. A diagnostic says what is wrong with the source and where; one of these says which evidence the assessment went without, which is a fact about the measurement. Most of them will sit beside a diagnostic that accounts for it — a source that would not evaluate is a source something was wrong with — and one of them never does: the runtime not being reachable is a fact about the host that no source can be corrected for. Neither substitutes for the other: a reader wanting to know what to fix reads the diagnostics, and one wanting to know how far the report's own numbers can be trusted reads these.
+
+[#example-report-emission]
+=== When the report is written
+
+What the command answers with, what it says went wrong, and whether it succeeded are three results, decided apart:
+
+* [[a-diagnostic-does-not-withhold-the-report]]a diagnostic MUST NOT on its own withhold the report. The rows covered what they covered, and that is the question this command was asked;
+* [[no-subject-leaves-no-report]]where nothing the compilation produced can be measured — no module formed at all — there is no subject for a measure to be about, and no report is written;
+* [[an-error-still-refuses-the-command]]an error MUST still be reported, and MUST still leave a non-zero exit status. `+--strict+` decides the exit status of a compilation that raised none (<<example-adequacy>>).
+
+This is what makes the reasons above reportable. All but one of them arrive with a diagnostic beside them, so a report written only for a compilation that raised none could carry almost nothing that field is for — the exception being the runtime not being reachable, which no source is at fault for.
+
+A reader that took an empty stdout for a refused command reads the exit status instead: a failing invocation may write a report and a non-zero status together.
 
 [#control-flow]
 == Control structures


### PR DESCRIPTION
Fixes #482.

`souther examples` took its compilation from `Compiler.compiled` /
`compiledModules`, which raise the first error they find. Those entry points
are `Compilation.answerEverything()` plus three throws, so the command got
the work it needed and a contract it did not: the specification says
"Nothing here changes what compiles; it reports", and the converse was
never implemented.

What that cost is the `incompleteness` field. It carries what stopped the
rows from being observed, and run through the CLI each of those exits 1
with the diagnostic and prints no report:

```text
duplicate declaration in an attached file   E1906
a module that did not type-check            E1321 and its neighbours
a composition that reaches itself           E1608
a row that did not come back                E1923
classes that could not be generated         the backend's own CompileException
```

One producer carries no diagnostic — the runtime not being reachable,
which no source is at fault for — and it needs the runtime off the
classpath while the compiler runs, which is the annotation processor's
situation, and that path builds no report. So the field a report could
carry and the report a compilation could produce excluded each other, and
`AdequacyReport.adequacy` — which refuses `satisfied` where the field is
not empty — has never had the chance to fire in a published report.

What stopped a *measure* from reading what was observed is a separate half,
said by that measure: an axis past the limit, a combination count that
stopped at its own, a value too large to read back. Those reach the report
today, carry no `incompleteness` entry, and are why `partial` was never in
the same position. An empty `incompleteness` has therefore never meant that
everything was read, and the specification now says which half is which.

## What changed

`Compiler.analyzed` / `analyzedModules` drive the same compilation and
raise nothing. `Compilation.errors(...)` sits beside `warnings(...)` and
answers with all of them where `firstError` answers with one.
`examplesSubcommand` routes through those and decides its three results
apart: the report to stdout wherever the compilation formed something to
assess, the diagnostics to stderr as before, the exit code unchanged — an
error is still 1, and `--strict` still decides the exit code of a
compilation that raised none.

Whether there is anything to report on and what the report shows are asked
of different things — the first of everything that formed, the second of
what the selection named. Reading the first off the filtered report would
put them back under one condition, which is the shape of the defect this
change is about, and would leave the emission gate depending on the
selector having been resolved somewhere else first.

`Compiler.linked` and `compiled` keep their fail-fast contract. `souther
compile` is untouched.

The specification gains `[#example-report-emission]` and a normative
account of `incompleteness`, which it had never described at all — its
description of the JSON form covered `status` and `reason` only.

## Behaviour that changes

- A failing invocation now writes a report to stdout alongside a non-zero
  exit status. A consumer treating empty stdout as "no report" reads the
  exit status instead. This is a change to the process I/O contract, not to
  the schema: `incompleteness[]` has never been emitted, so no document
  shape a consumer has seen is altered.
- `souther examples` now prints every error rather than the first. A
  command that goes on to describe the whole compilation should not show
  one error beside an account of everything else.
- A source that declares no module gets no report. It has no subject for a
  measure to be about.

## Not in this change

A selector that matches nothing is refused ahead of the report, with its own
exit code. That landed in #487 while this was open, and this rebases onto it:
the two rules meet in a test here, where a selector that resolves gets its
report from a compilation that did not.

The test asserts that the entry exists and is about the source, not which
word it carries. `runtime_absent` at source scope does not mean the runtime
is absent, and that is #474's to fix now that the field is reachable.

Evidence is still recovered per module: `Bodies.Checked` is absent for the
whole module, so one behavior that does not type-check costs every row
observation in it. A report that says `partial` and carries little is
honest and not yet worth much. That is the next piece of work and wants its
own issue.

## Verification

`mvn clean test` — BUILD SUCCESS across all eight modules.

Six tests in `ACompilationThatFailedStillReportsWhatItsRowsCoverTest`, and
`ASelectorThatResolvesToNothingIsRefusedTest` still green beside them. The
emission and `incompleteness` tests were watched failing against the old
routing before this was written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
