### PR TITLE
A selector that names nothing is refused before a report is made of it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -392,6 +392,14 @@ public final class Main {
                     ? Compiler.compiled(texts.get(0), Runner.moduleName(sources.get(0)), warnings,
                             measure)
                     : Compiler.compiledModules(texts, path, warnings, measure);
+            // Before the report, because a name that names nothing is not something a report can
+            // say. Filtering one after the fact leaves an empty document whose every word is about
+            // what was measured, and nothing measured anything.
+            Selection.Refusal refused = new Selection(module, behavior).unresolved(compilation);
+            if (refused != null) {
+                System.err.println(Messages.get(refused.key(), render.locale(), refused.args()));
+                return 2;
+            }
             AdequacyReport report = AdequacyReport.of(compilation).only(module, behavior);
             report(warnings, sources, render);
             String rendered = render.json() ? report.json() + System.lineSeparator() : report.human();

--- a/souther-compiler/src/main/java/souther/compiler/Selection.java
+++ b/souther-compiler/src/main/java/souther/compiler/Selection.java
@@ -1,0 +1,78 @@
+package souther.compiler;
+
+import souther.compiler.query.Compilation;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Which subjects {@code souther examples} was asked to report on.
+ *
+ * <p>Resolving the names is a separate question from measuring what they name, and it is asked
+ * first. A name that resolves to nothing is a fact about the command line, and a report is not
+ * where a fact about the command line can be written down: a report says how much of a subject the
+ * rows cover, and there is no subject to say it of. Filtering the report instead put the two on one
+ * scale, and the empty selection came out reading like a measurement that went through and found no
+ * gap — which is what {@code --strict} is entitled to accept.
+ *
+ * <p>The names are resolved together and not one at a time. What the command was given is a pair,
+ * and two names that each name something and hold nothing between them select nothing.
+ *
+ * <p>Asked of what the sources declare rather than of what reached the report. A module that was
+ * declared and could not be prepared shows up nowhere in the report, and refusing the name over it
+ * would answer an absent measurement with a usage error.
+ */
+record Selection(String module, String behavior) {
+
+    /** What a selection that names no subject is refused with: a catalog key and what fills it. */
+    record Refusal(String key, Object... args) {}
+
+    /**
+     * Why this selection names no subject, or null where it names one.
+     *
+     * <p>Null is also the answer wherever the declarations themselves could not be read. Nothing
+     * there says the name missed, and this only ever says that.
+     */
+    Refusal unresolved(Compilation compilation) {
+        if (module == null && behavior == null) {
+            return null;
+        }
+        List<String> declared = compilation.modules();
+        if (declared.isEmpty()) {
+            return null;
+        }
+        if (module != null && !declared.contains(module)) {
+            return new Refusal("cli.examples.selector.module", module, named(declared));
+        }
+        if (behavior == null) {
+            return null;
+        }
+        // A module the selection named is the only one searched; with none named, every module is,
+        // because that is what the report would have shown the behavior from.
+        Set<String> available = new LinkedHashSet<>();
+        for (String name : module == null ? declared : List.of(module)) {
+            Set<String> behaviors = compilation.declaredBehaviors(name);
+            if (behaviors == null) {
+                return null;
+            }
+            if (behaviors.contains(behavior)) {
+                return null;
+            }
+            available.addAll(behaviors);
+        }
+        if (module != null) {
+            return available.isEmpty()
+                    ? new Refusal("cli.examples.selector.pair.none", module, behavior)
+                    : new Refusal("cli.examples.selector.pair", module, behavior, named(available));
+        }
+        return available.isEmpty()
+                ? new Refusal("cli.examples.selector.behavior.none", behavior)
+                : new Refusal("cli.examples.selector.behavior", behavior, named(available));
+    }
+
+    /** The names a reader could have written instead, in the order the sources give them. */
+    private static String named(java.util.Collection<String> names) {
+        return String.join(", ", names);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -163,6 +163,20 @@ public final class Compilation {
         return db.ask(new Shapes.Scope(module)).value();
     }
 
+    /**
+     * The names of the behaviors {@code module} declares, or null where its declarations could not
+     * be read.
+     *
+     * <p>What the source says rather than what got as far as being measured. A caller resolving a
+     * name that arrived from outside needs the first: a behavior that was declared and could not be
+     * prepared is a measurement that is missing, and answering "no such name" over it would report
+     * the one as the other. Which is also why the unreadable case is null rather than empty — an
+     * empty set is a module that declares no behavior, and that is an answer.
+     */
+    public Set<String> declaredBehaviors(String module) {
+        return db.ask(new Front.Behaviors(module)).value();
+    }
+
     /** The signatures of the behaviors {@code module} declares — what each takes and what it
      * answers, as the shapes a decoder and an encoder are built for. */
     public Map<String, Sig> signatures(String module) {

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -18,6 +18,11 @@ diag.suggestion=did you mean `{0}`?
 # --- what the command line says about the build, rather than about the source ---
 cli.warnings.refused=No classes were written: warnings are treated as errors.
 cli.examples.strict.refused={0} gap(s) named above: the rows do not cover the model.
+cli.examples.selector.module=no module named `{0}`. These sources declare: {1}.
+cli.examples.selector.behavior=no behavior named `{0}`. These sources declare: {1}.
+cli.examples.selector.behavior.none=no behavior named `{0}`. These sources declare no behavior at all.
+cli.examples.selector.pair=`{0}` declares no behavior named `{1}`. It declares: {2}.
+cli.examples.selector.pair.none=`{0}` declares no behavior named `{1}`. It declares no behavior at all.
 
 # --- error titles (spec section 22) ---
 e1002.title=INSUFFICIENT CONSTRUCTION AUTHORITY

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -16,6 +16,11 @@ diag.suggestion=`{0}` の間違いではありませんか？
 # --- ソースではなくビルドについてコマンドラインが言うこと ---
 cli.warnings.refused=警告をエラーとして扱う設定のため、クラスを出力しませんでした。
 cli.examples.strict.refused=上に挙げた {0} 件を行が覆っていません。
+cli.examples.selector.module=`{0}` というモジュールはありません。これらのソースが宣言しているのは {1} です。
+cli.examples.selector.behavior=`{0}` という behavior はありません。これらのソースが宣言しているのは {1} です。
+cli.examples.selector.behavior.none=`{0}` という behavior はありません。これらのソースは behavior を1つも宣言していません。
+cli.examples.selector.pair=`{0}` に `{1}` という behavior はありません。`{0}` が宣言しているのは {2} です。
+cli.examples.selector.pair.none=`{0}` に `{1}` という behavior はありません。`{0}` は behavior を1つも宣言していません。
 
 # --- エラー見出し（仕様 22 章） ---
 e1002.title=構築権限の不足

--- a/souther-compiler/src/test/java/souther/compiler/ASelectorThatResolvesToNothingIsRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ASelectorThatResolvesToNothingIsRefusedTest.java
@@ -1,0 +1,195 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What {@code souther examples --module} and {@code --behavior} do with a name nothing answers to.
+ *
+ * <p>They used to report on the empty selection they had made, and a report of nothing says the
+ * measurement went through and found no gap: {@code status} folded over no modules kept the word it
+ * started at, the verdict over no measures was {@code undetermined}, and {@code --strict} lets that
+ * through because a measure that was not made is not a gap. Every one of those steps is right about
+ * the question it answers. The one that is not asked anywhere is whether the name resolved.
+ *
+ * <p>So it is asked before a report exists. Whether a selector names a subject is a fact about the
+ * command line and what the sources declare, and it is settled against the declarations rather than
+ * against what reached the report — a module that was declared and could not be measured is an
+ * absent measurement, and refusing the name over it would report the one as the other.
+ */
+class ASelectorThatResolvesToNothingIsRefusedTest {
+
+    /** A model with a behavior and a gap: without a selector this exits non-zero under
+     *  {@code --strict}, which is what a misspelled selector used to hide. */
+    private static final String RATE = """
+            module example.rate
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Charged = { cost: Amount }
+            data Refused = { reason: String }
+
+            behavior submit : (cost: Amount) -> Charged | Refused
+                constructs Charged, Refused
+
+            let submit (cost) = {
+                guard cost.value <= 100 else Refused { reason = "over" }
+                Charged { cost = cost }
+            }
+
+            example submit
+                | "within" : (Amount(50)) -> Charged
+            """;
+
+    /** A second module, so that two names can each resolve and still select nothing together. */
+    private static final String AUDIT = """
+            module example.audit
+
+            data Entry = { what: String }
+
+            behavior record : (what: String) -> Entry
+                constructs Entry
+
+            let record (what) = Entry { what = what }
+
+            example record
+                | "one" : ("a") -> Entry { what = "a" }
+            """;
+
+    /** A module that declares no behavior at all, which is what an empty selection looks like once
+     *  the report is made. The name resolves, so this is not the same answer. */
+    private static final String NO_BEHAVIOR = """
+            module example.empty
+
+            data Amount = Int
+                invariant value >= 0
+            """;
+
+    @Test
+    void aModuleNameNothingDeclaresIsRefusedInsteadOfReportedOn() throws Exception {
+        Run run = examples(List.of(RATE), "--module", "example.nosuch", "--strict");
+
+        assertEquals(2, run.code(), run.out() + run.err());
+        assertTrue(run.err().contains("example.nosuch"), run.err());
+        assertTrue(run.err().contains("example.rate"), run.err());
+        assertFalse(run.out().contains("adequacy"), run.out());
+    }
+
+    @Test
+    void aBehaviorNameNothingDeclaresIsRefusedInsteadOfReportedOn() throws Exception {
+        Run run = examples(List.of(RATE), "--behavior", "nosuch", "--strict");
+
+        assertEquals(2, run.code(), run.out() + run.err());
+        assertTrue(run.err().contains("nosuch"), run.err());
+        assertTrue(run.err().contains("submit"), run.err());
+        assertFalse(run.out().contains("adequacy"), run.out());
+    }
+
+    /**
+     * Two names that each name something, and nothing that is both.
+     *
+     * <p>Resolving them one at a time would pass this: {@code example.rate} is a module and
+     * {@code record} is a behavior. What the command was asked for is the pair, and the pair holds
+     * nothing.
+     */
+    @Test
+    void selectorsAreResolvedTogetherAndNotOneAtATime() throws Exception {
+        Run run = examples(List.of(RATE, AUDIT),
+                "--module", "example.rate", "--behavior", "record", "--strict");
+
+        assertEquals(2, run.code(), run.out() + run.err());
+        assertTrue(run.err().contains("record"), run.err());
+        assertTrue(run.err().contains("submit"), run.err());
+        assertFalse(run.out().contains("adequacy"), run.out());
+    }
+
+    /** The gap the misspelled selector used to hide, still refused where the name resolves. */
+    @Test
+    void aSelectorThatResolvesReportsAndStrictStillRefusesTheGap() throws Exception {
+        Run run = examples(List.of(RATE), "--module", "example.rate", "--behavior", "submit",
+                "--strict");
+
+        assertEquals(1, run.code(), run.out() + run.err());
+        assertTrue(run.out().contains("adequacy: not satisfied"), run.out());
+    }
+
+    /**
+     * A module that declares no behavior is selected, not refused.
+     *
+     * <p>This is the case the empty selection was indistinguishable from: the report it produces has
+     * the same shape either way. Nothing here was misspelled, so the answer is the report — the same
+     * one the command gives with no selector at all.
+     */
+    @Test
+    void aModuleThatDeclaresNoBehaviorResolves() throws Exception {
+        Run selected = examples(List.of(NO_BEHAVIOR), "--module", "example.empty", "--strict");
+        Run whole = examples(List.of(NO_BEHAVIOR), "--strict");
+
+        assertEquals(0, selected.code(), selected.out() + selected.err());
+        assertEquals(whole.out(), selected.out());
+    }
+
+    /** A selector naming a module in a compilation of several, with the other left out. */
+    @Test
+    void oneModuleOfSeveralResolves() throws Exception {
+        Run run = examples(List.of(RATE, AUDIT), "--module", "example.audit");
+
+        assertEquals(0, run.code(), run.out() + run.err());
+        assertTrue(run.out().contains("example.audit"), run.out());
+        assertFalse(run.out().contains("example.rate"), run.out());
+    }
+
+    /** A behavior named without a module is looked for across all of them. */
+    @Test
+    void aBehaviorNameResolvesAgainstEveryModuleWhenNoneIsNamed() throws Exception {
+        Run run = examples(List.of(RATE, AUDIT), "--behavior", "record");
+
+        assertEquals(0, run.code(), run.out() + run.err());
+        assertTrue(run.out().contains("record"), run.out());
+        assertFalse(run.out().contains("submit"), run.out());
+    }
+
+    private record Run(int code, String out, String err) {}
+
+    private static Run examples(List<String> models, String... extraArgs) throws Exception {
+        Path dir = Files.createTempDirectory("souther-selector");
+        List<String> args = new ArrayList<>(List.of("examples"));
+        for (int i = 0; i < models.size(); i++) {
+            Path file = dir.resolve("m" + i + ".sou");
+            Files.writeString(file, models.get(i));
+            args.add(file.toString());
+        }
+        args.addAll(List.of(extraArgs));
+        return cli(args.toArray(String[]::new));
+    }
+
+    private static Run cli(String... args) {
+        PrintStream originalOut = System.out;
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        int code;
+        try {
+            code = Main.dispatch(args);
+        } finally {
+            System.setOut(originalOut);
+            System.setErr(originalErr);
+        }
+        return new Run(code, out.toString(StandardCharsets.UTF_8),
+                err.toString(StandardCharsets.UTF_8));
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -2620,6 +2620,8 @@ Which measures could have found a gap is what was asked for and what the model h
 
 *What refuses a build.* A gap a measure came to an answer about, whichever of the two ways a build asks: `+souther compile --adequacy all --warnings error+` and `+souther examples --strict+` refuse the same findings. How many rows are waiting for a `+let+` refuses nothing. A build that failed on one would fail on the record of what an injected behavior owes, which is what <<example-pending>> says a model being migrated onto is made of.
 
+*A selector names a subject or the command is refused.* `+souther examples --module+` and `+--behavior+` narrow what is reported, and a name that resolves to no subject is a usage error rather than a report of nothing. A report of nothing says the measurement was made and found no gap, which is what a build reading it is entitled to accept. The two names are resolved together, so names that each resolve and hold nothing between them select nothing; and they are resolved against what the sources declare rather than against what reached the report, so a subject that resolves and then cannot be measured is reported as `+partial+` and is not a selector that named nothing.
+
 *The question is asked of a module, not of a source.* A behavior's rows are written in the module's own source and in any number of attached files (<<example-placement>>), so a source-by-source reading would report what another file covers as uncovered.
 
 [#example-partition]


### PR DESCRIPTION
Fixes #484.

`souther examples --module example.nosuch --strict model.sou` reported
`status: complete`, `adequacy: undetermined`, and exited 0 on a model that
answers `not_satisfied` without the selector. `--behavior nosuch` did the same
one level down. The build gate that exists to refuse a gap let it through over a
misspelling.

## What the defect is

`AdequacyReport.only` drops the miss at the `continue` and the `.filter`, and
every fold that follows starts at `COMPLETE`. Each of those is right about its
own question — an empty selection was completely assessed, and no measure that
could find a gap was asked — and none of them is asked whether the name
resolved.

Which is not a question a report can answer. `complete` and `partial` say how
much of a measurement was made, `satisfied`/`not_satisfied`/`undetermined` say
what the rows cover, and a name that matches nothing is neither: it is what the
command line was given held against what the sources declare. Adding a word for
it to either enum would put a resolution failure on the scale that measurement
results are read on, so the report and the schema are left alone and the
question is asked before a report exists.

`--strict` is left alone too. What it refuses is what
`compile --adequacy all --warnings error` refuses, stated in the specification
and in `adequacy-schema-1.json`, and accepting `undetermined` is that rule
working rather than the defect.

The two are indistinguishable once the report is made: `--behavior nosuch` on a
model with behaviors and a module that declares none produce the same document.

## What changed

`Selection` resolves the selector against the compilation and answers with a
`Refusal` — a catalog key and its arguments — or with nothing.
`Main.examplesSubcommand` asks it before `AdequacyReport.of` and returns 2 with
the reason on stderr, which is the code its other argument errors return.
`--generate` stops at the same gate.

Resolution is asked of what the sources declare rather than of what reached the
report. `Compilation.declaredBehaviors` carries `Front.Behaviors` through, which
answers absent where a module could not be read: null is a module whose
declarations are unreadable and an empty set is a module that declares no
behavior, and only the second is an answer about the name. A subject that
resolves and then cannot be measured stays `partial`.

The names are resolved together. `--module A --behavior bar` where `bar` is
declared in `B` is refused, and each name on its own resolves.

Five messages in both catalogs, and a paragraph in the specification beside the
one that says what refuses a build.

## Verification

`ASelectorThatResolvesToNothingIsRefusedTest`, seven cases. The three refusals
fail on the parent commit; the four that resolve — a selector that names a
subject, a module that declares no behavior, one module of several, a behavior
name searched across every module — pass before and after, which is what holds
the gate to the names that miss.

`mvn clean test` at the root is green. The CLI was run for each of the five
messages, for `--lang ja`, for `--generate`, and for `--module example.rate
--strict`, which still exits 1 on the gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
