### PR TITLE
A row is chosen from what the rules leave the positions, one position at a time

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -687,7 +687,14 @@ public final class Generator {
         private int left = MAX_TUPLES;
         private boolean cutShort;
 
-        /** Whether there is room to compose one more assignment. */
+        /**
+         * Whether there is room to compose one more assignment.
+         *
+         * <p>The only place the bound is called reached. Spending the last of it is not the same as
+         * being short of it: a search whose last assignment was composed and refused has tried
+         * everything it had, and marking it where the count reaches zero would report the one search
+         * that finished as the one that stopped.
+         */
         boolean spend() {
             if (left <= 0) {
                 cutShort = true;
@@ -735,8 +742,7 @@ public final class Generator {
             }
             chosen.remove(position.path());
             settled.remove(position.path());
-            if (budget.left <= 0) {
-                budget.cutShort = true;   // branches left, and nothing to spend on them
+            if (budget.cutShort) {
                 return null;
             }
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -721,7 +721,7 @@ public final class Generator {
                 : FieldDomains.NONE;
         String under = position.path().equals(at.toString()) ? null
                 : position.path().substring(at.toString().length() + 1);
-        return Partitions.representativesOf(position.type(), subject.symbols(),
+        return Partitions.displacedRepresentativesOf(position.type(), subject.symbols(),
                 under == null ? null : left.at(under));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -625,7 +625,18 @@ public final class Generator {
         // Asked again choosing one position at a time, each from what is left once the ones before it
         // are asserted, which is the only way `a < b` is met in general.
         Outcome conditioned = conditioned(subject, p, decided, settled, check);
-        return conditioned.value() != null ? conditioned : product;
+        if (conditioned.value() != null) {
+            return conditioned;
+        }
+        // A pass that stopped at its bound has not tried everything it had, and neither pass may be
+        // reported as though it had: `ALL_CANDIDATES_REJECTED` is what a reader is told nothing else
+        // can be written at, and a search still holding assignments it never composed has not
+        // established that.
+        if (product.reason() == UnresolvedCombination.Reason.SEARCH_LIMIT
+                || conditioned.reason() == UnresolvedCombination.Reason.SEARCH_LIMIT) {
+            return new Outcome(null, UnresolvedCombination.Reason.SEARCH_LIMIT, null);
+        }
+        return product;
     }
 
     /**
@@ -646,19 +657,45 @@ public final class Generator {
         Type type = subject.types().get(p);
         TermPath at = TermPath.of(subject.parameters().get(p));
         List<Position> found = new ArrayList<>();
-        if (positionsUnder(type, at, subject.symbols(), 0, found, decided.keySet()) != null) {
-            return new Outcome(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
-        }
+        positionsUnder(type, at, subject.symbols(), 0, found, decided.keySet());
         // What the caller fixed goes first, so that everything chosen after it is chosen beside it.
         // A class stands for one value and a boundary is one value, and neither is worth deciding
         // after the positions whose range it settles.
         List<Position> positions = new ArrayList<>(
                 found.stream().filter(each -> decided.containsKey(each.path())).toList());
         positions.addAll(found.stream().filter(each -> !decided.containsKey(each.path())).toList());
+        Budget budget = new Budget();
         FixtureTemplate built = descend(subject, p, positions, 0, new LinkedHashMap<>(),
-                new LinkedHashMap<>(settled), decided, check, new int[] {MAX_TUPLES});
-        return built != null ? new Outcome(built, null, null)
-                : new Outcome(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
+                new LinkedHashMap<>(settled), decided, check, budget);
+        if (built != null) {
+            return new Outcome(built, null, null);
+        }
+        return new Outcome(null, budget.cutShort
+                ? UnresolvedCombination.Reason.SEARCH_LIMIT
+                : UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
+    }
+
+    /**
+     * What is left of the bound on one search, and whether it ran out.
+     *
+     * <p>The two are one fact and are held together. Nothing left is not the same as everything
+     * tried, and a search that stopped at the bound reporting that every value was refused would put
+     * a combination nobody looked at beside the ones that were.
+     */
+    private static final class Budget {
+
+        private int left = MAX_TUPLES;
+        private boolean cutShort;
+
+        /** Whether there is room to compose one more assignment. */
+        boolean spend() {
+            if (left <= 0) {
+                cutShort = true;
+                return false;
+            }
+            left--;
+            return true;
+        }
     }
 
     /** One position of a row: where it is, and what it holds. */
@@ -675,9 +712,9 @@ public final class Generator {
                                            Map<String, FixtureTemplate> chosen,
                                            Map<String, BigDecimal> settled,
                                            Map<String, List<FixtureTemplate>> decided,
-                                           CandidateCheck check, int[] budget) {
+                                           CandidateCheck check, Budget budget) {
         if (index == positions.size()) {
-            if (budget[0]-- <= 0) {
+            if (!budget.spend()) {
                 return null;
             }
             FixtureTemplate whole = compose(subject.types().get(p),
@@ -698,7 +735,8 @@ public final class Generator {
             }
             chosen.remove(position.path());
             settled.remove(position.path());
-            if (budget[0] <= 0) {
+            if (budget.left <= 0) {
+                budget.cutShort = true;   // branches left, and nothing to spend on them
                 return null;
             }
         }
@@ -727,28 +765,24 @@ public final class Generator {
 
     /** The positions under one parameter, in the order they are composed. The same rule
      * {@link #choicesUnder} walks, so that the two agree about where a row chooses anything. */
-    private static String positionsUnder(Type type, TermPath at, Symbols symbols, int depth,
-                                         List<Position> out, java.util.Set<String> decided) {
+    private static void positionsUnder(Type type, TermPath at, Symbols symbols, int depth,
+                                       List<Position> out, java.util.Set<String> decided) {
         if (decided.contains(at.toString())) {
             out.add(new Position(at.toString(), type));
-            return null;
+            return;
         }
         if (depth < MAX_DEPTH && type instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
             Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
             if (!fields.isEmpty()) {
                 for (Map.Entry<String, Type> field : fields.entrySet()) {
-                    String missing = positionsUnder(field.getValue(), at.then(field.getKey()), symbols,
+                    positionsUnder(field.getValue(), at.then(field.getKey()), symbols,
                             depth + 1, out, decided);
-                    if (missing != null) {
-                        return missing;
-                    }
                 }
-                return null;
+                return;
             }
         }
         out.add(new Position(at.toString(), type));
-        return null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -612,10 +612,143 @@ public final class Generator {
                                    CandidateCheck check) {
         Choices choices = choicesOf(subject.types().get(p),
                 TermPath.of(subject.parameters().get(p)), subject.symbols(), decided, settled);
-        return choices.missingAt() != null
-                ? new Outcome(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
-                        choices.missingAt())
-                : walk(subject, p, choices, check);
+        if (choices.missingAt() != null) {
+            return new Outcome(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
+                    choices.missingAt());
+        }
+        Outcome product = walk(subject, p, choices, check);
+        if (product.value() != null) {
+            return product;
+        }
+        // Every position took its value knowing only what the caller had settled, so a rule relating
+        // two of them was satisfied only where the lists happened to already hold a pair that does.
+        // Asked again choosing one position at a time, each from what is left once the ones before it
+        // are asserted, which is the only way `a < b` is met in general.
+        Outcome conditioned = conditioned(subject, p, decided, settled, check);
+        return conditioned.value() != null ? conditioned : product;
+    }
+
+    /**
+     * One parameter's value, chosen a position at a time.
+     *
+     * <p>Depth first, so that a position is chosen against a projection that already has the ones
+     * before it in it. The projection is the same one the whole search started from — what the
+     * record's rules leave each of its fields — asked again with the assignment so far settled into
+     * it, which is what {@link FieldDomains#of(TypeName, Ast.Data, Symbols, Map)} is for.
+     *
+     * <p>Second, and not instead. What it costs is a reading of the record's rules per position per
+     * branch, and the search in front of it answers most rows without any of that; running this one
+     * first would spend it on every row to change none of them.
+     */
+    private static Outcome conditioned(Subject subject, int p,
+                                       Map<String, List<FixtureTemplate>> decided,
+                                       Map<String, BigDecimal> settled, CandidateCheck check) {
+        Type type = subject.types().get(p);
+        TermPath at = TermPath.of(subject.parameters().get(p));
+        List<Position> found = new ArrayList<>();
+        if (positionsUnder(type, at, subject.symbols(), 0, found, decided.keySet()) != null) {
+            return new Outcome(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
+        }
+        // What the caller fixed goes first, so that everything chosen after it is chosen beside it.
+        // A class stands for one value and a boundary is one value, and neither is worth deciding
+        // after the positions whose range it settles.
+        List<Position> positions = new ArrayList<>(
+                found.stream().filter(each -> decided.containsKey(each.path())).toList());
+        positions.addAll(found.stream().filter(each -> !decided.containsKey(each.path())).toList());
+        FixtureTemplate built = descend(subject, p, positions, 0, new LinkedHashMap<>(),
+                new LinkedHashMap<>(settled), decided, check, new int[] {MAX_TUPLES});
+        return built != null ? new Outcome(built, null, null)
+                : new Outcome(null, UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED, null);
+    }
+
+    /** One position of a row: where it is, and what it holds. */
+    private record Position(String path, Type type) {}
+
+    /**
+     * The assignment this branch leads to, or null where none of them builds.
+     *
+     * @param chosen  what the positions before this one took
+     * @param settled the numbers among them, which is what a projection can be asked about
+     * @param budget  assignments left to compose, shared down the whole search
+     */
+    private static FixtureTemplate descend(Subject subject, int p, List<Position> positions, int index,
+                                           Map<String, FixtureTemplate> chosen,
+                                           Map<String, BigDecimal> settled,
+                                           Map<String, List<FixtureTemplate>> decided,
+                                           CandidateCheck check, int[] budget) {
+        if (index == positions.size()) {
+            if (budget[0]-- <= 0) {
+                return null;
+            }
+            FixtureTemplate whole = compose(subject.types().get(p),
+                    TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0);
+            return whole != null && check.refuse(p, whole).isEmpty() ? whole : null;
+        }
+        Position position = positions.get(index);
+        for (FixtureTemplate candidate : candidatesAt(subject, p, position, settled, decided)) {
+            chosen.put(position.path(), candidate);
+            BigDecimal number = writtenNumber(candidate.value());
+            if (number != null) {
+                settled.put(position.path(), number);
+            }
+            FixtureTemplate found = descend(subject, p, positions, index + 1, chosen, settled,
+                    decided, check, budget);
+            if (found != null) {
+                return found;
+            }
+            chosen.remove(position.path());
+            settled.remove(position.path());
+            if (budget[0] <= 0) {
+                return null;
+            }
+        }
+        return null;
+    }
+
+    /** What one position can take, given what the positions before it took. */
+    private static List<FixtureTemplate> candidatesAt(Subject subject, int p, Position position,
+                                                      Map<String, BigDecimal> settled,
+                                                      Map<String, List<FixtureTemplate>> decided) {
+        List<FixtureTemplate> fixed = decided.get(position.path());
+        if (fixed != null) {
+            return fixed;
+        }
+        TermPath at = TermPath.of(subject.parameters().get(p));
+        Type parameter = subject.types().get(p);
+        FieldDomains left = parameter instanceof Type.Ref ref
+                && subject.symbols().get(ref.name()) instanceof Ast.Data data && !data.newtype()
+                ? FieldDomains.of(ref.name(), data, subject.symbols(), under(at, settled))
+                : FieldDomains.NONE;
+        String under = position.path().equals(at.toString()) ? null
+                : position.path().substring(at.toString().length() + 1);
+        return Partitions.representativesOf(position.type(), subject.symbols(),
+                under == null ? null : left.at(under));
+    }
+
+    /** The positions under one parameter, in the order they are composed. The same rule
+     * {@link #choicesUnder} walks, so that the two agree about where a row chooses anything. */
+    private static String positionsUnder(Type type, TermPath at, Symbols symbols, int depth,
+                                         List<Position> out, java.util.Set<String> decided) {
+        if (decided.contains(at.toString())) {
+            out.add(new Position(at.toString(), type));
+            return null;
+        }
+        if (depth < MAX_DEPTH && type instanceof Type.Ref ref
+                && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
+            Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
+            if (!fields.isEmpty()) {
+                for (Map.Entry<String, Type> field : fields.entrySet()) {
+                    String missing = positionsUnder(field.getValue(), at.then(field.getKey()), symbols,
+                            depth + 1, out, decided);
+                    if (missing != null) {
+                        return missing;
+                    }
+                }
+                return null;
+            }
+        }
+        out.add(new Position(at.toString(), type));
+        return null;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardEdge.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardEdge.java
@@ -1,0 +1,75 @@
+package souther.compiler.partition;
+
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.numeric.NumericDomain;
+
+import java.math.BigDecimal;
+
+/**
+ * One side of a guard, and the values of one position that take it.
+ *
+ * <p>Not a {@link Threshold}. A threshold says which side of a line the line's own value belongs to,
+ * which is what decides where one class ends and the next begins. This says which values reach one
+ * arm, which is what decides whether that arm is an arm at all. The two are not the same question and
+ * neither is derivable from the other: {@code x <= c} and {@code x > c} both put {@code c} on the low
+ * side, and their {@code then} arms are opposite halves of the line.
+ *
+ * <p>An absent end is unbounded there. The openness here is exact — it is read off the comparison the
+ * body is written with — and is not the openness a derived bound loses (#483): nothing about it comes
+ * through {@link NumericDomain}.
+ *
+ * @param guard the {@code if} this is one arm of, which is also what says which behavior it is in
+ * @param site  the probe number of that arm, the same identity a branch obligation is counted by
+ */
+public record GuardEdge(CoverageSites.GuardRef guard, int site, TermPath path,
+                        BigDecimal low, boolean lowInclusive,
+                        BigDecimal high, boolean highInclusive) {
+
+    /** The values above {@code value}, including it where {@code inclusive}. */
+    public static GuardEdge above(CoverageSites.GuardRef guard, int site, TermPath path,
+                                  BigDecimal value, boolean inclusive) {
+        return new GuardEdge(guard, site, path, value, inclusive, null, false);
+    }
+
+    /** The values below {@code value}, including it where {@code inclusive}. */
+    public static GuardEdge below(CoverageSites.GuardRef guard, int site, TermPath path,
+                                  BigDecimal value, boolean inclusive) {
+        return new GuardEdge(guard, site, path, null, false, value, inclusive);
+    }
+
+    public String behavior() {
+        return guard.behavior();
+    }
+
+    /**
+     * Whether nothing this edge admits is a value the position can hold.
+     *
+     * <p>The one place the two are compared, so that what changes when a bound learns its own openness
+     * changes here and nowhere else.
+     *
+     * <p>Sound while {@code admissible} is as wide as or wider than the values that can really be
+     * written: an edge disjoint from a superset is disjoint from the set. The other direction is not
+     * claimed — an edge that meets these bounds is not thereby reachable, because a rule they could
+     * not hold can still refuse every value in the overlap. So only this answer excludes anything,
+     * and being unable to prove disjointness costs a report nothing but an obligation nobody can
+     * meet.
+     */
+    public boolean provenDisjoint(NumericDomain.Bounds admissible) {
+        if (admissible == null) {
+            return false;
+        }
+        if (low != null && admissible.max() != null) {
+            int order = low.compareTo(admissible.max());
+            if (order > 0 || (order == 0 && !lowInclusive)) {
+                return true;
+            }
+        }
+        if (high != null && admissible.min() != null) {
+            int order = high.compareTo(admissible.min());
+            if (order < 0 || (order == 0 && !highInclusive)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardReachability.java
@@ -58,6 +58,22 @@ public final class GuardReachability {
         return out.isEmpty() ? NONE : new GuardReachability(Set.copyOf(out));
     }
 
+    /**
+     * The same, with these arms no longer proven.
+     *
+     * <p>What takes a proof away is a row that went through the arm. Nothing about the model is wrong
+     * then — the proof is — and a caller reading this afterwards has to be told the same thing every
+     * other caller is, or the arm leaves one denominator and stays out of another.
+     */
+    public GuardReachability without(Set<Integer> sites) {
+        if (sites.isEmpty() || unreachable.isEmpty()) {
+            return this;
+        }
+        Set<Integer> left = new LinkedHashSet<>(unreachable);
+        left.removeAll(sites);
+        return left.isEmpty() ? NONE : new GuardReachability(Set.copyOf(left));
+    }
+
     /** Whether nothing reaches the arm with this probe number. */
     public boolean provenUnreachable(int site) {
         return unreachable.contains(site);

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardReachability.java
@@ -1,0 +1,74 @@
+package souther.compiler.partition;
+
+import souther.compiler.numeric.NumericDomain;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The arms of a body that the model's own rules prove nothing reaches.
+ *
+ * <p>One fact, derived once, read by every measure. What a position is divided into, which lines are
+ * owed a row, which arms are owed a row and which cases the signature is owed are four projections of
+ * one universe of possible executions, and four derivations of what is possible are four chances to
+ * disagree — which is how a report came to drop the class beyond a cap while still asking for the arm
+ * behind it.
+ *
+ * <p>Independent of the partitioning it happens to be computed beside. A caller with the edges of a
+ * body and what its positions can hold has everything this needs, and nothing about a partition is
+ * involved in the answer.
+ *
+ * <p>Only proof excludes. An arm this does not name may still be unreachable — a rule outside what
+ * the bounds could hold can refuse every value of an overlap — and that direction is the safe one: an
+ * arm left in is one the report asks for, and an author reading an obligation they cannot meet has at
+ * least been told something true about their model.
+ */
+public final class GuardReachability {
+
+    /** Nothing proven: every arm is owed whatever it was owed. */
+    public static final GuardReachability NONE = new GuardReachability(Set.of());
+
+    private final Set<Integer> unreachable;
+
+    private GuardReachability(Set<Integer> unreachable) {
+        this.unreachable = unreachable;
+    }
+
+    /**
+     * <p>Held by probe number, which is what a branch obligation is counted by: the sites of a module
+     * are numbered across all of its bodies, so one number names one arm of one behavior and a caller
+     * matching on it cannot reach another behavior's. Which behavior an edge is in is on the edge
+     * itself, for a caller that needs to say.
+     *
+     * @param edges      both arms of every guard whose comparison could be read
+     * @param admissible what each position can hold, keyed the way a {@link TermPath} prints — which
+     *                   is {@code Partitions.Partitioning#domains()}, and any other reading of the
+     *                   same question
+     */
+    public static GuardReachability of(List<GuardEdge> edges,
+                                       Map<String, NumericDomain.Bounds> admissible) {
+        Set<Integer> out = new LinkedHashSet<>();
+        for (GuardEdge edge : edges) {
+            if (edge.provenDisjoint(admissible.get(edge.path().toString()))) {
+                out.add(edge.site());
+            }
+        }
+        return out.isEmpty() ? NONE : new GuardReachability(Set.copyOf(out));
+    }
+
+    /** Whether nothing reaches the arm with this probe number. */
+    public boolean provenUnreachable(int site) {
+        return unreachable.contains(site);
+    }
+
+    /** The arms nothing reaches, by probe number. */
+    public Set<Integer> unreachableSites() {
+        return unreachable;
+    }
+
+    public boolean isEmpty() {
+        return unreachable.isEmpty();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -33,31 +33,52 @@ import java.util.List;
  */
 public final class GuardThresholds {
 
-    /** The thresholds one behavior's body compares its parameters against. {@code plan} supplies the
-     * guard each one belongs to, so a boundary can later ask whether the comparison ran. */
-    public static List<Threshold> of(String behavior, Core body, CoverageSites.Plan plan,
-                                     List<String> parameters, Symbols symbols) {
+    /**
+     * What one reading of a body says about the comparisons in it.
+     *
+     * <p>Two answers from one walk, because they are read off the same comparison and the operator is
+     * known once. Asked separately they would be two readings of it, and the second would have to
+     * recover from {@link Threshold} which side of the line each arm takes — which a threshold does not
+     * say and cannot be made to say (see {@link GuardEdge}).
+     */
+    public record Guards(List<Threshold> thresholds, List<GuardEdge> edges) {
+
+        public static final Guards NONE = new Guards(List.of(), List.of());
+
+        public Guards {
+            thresholds = List.copyOf(thresholds);
+            edges = List.copyOf(edges);
+        }
+    }
+
+    /** The thresholds one behavior's body compares its parameters against, and both arms of each
+     * comparison. {@code plan} supplies the guard each one belongs to, so a boundary can later ask
+     * whether the comparison ran and an arm can be found by the probe that counts it. */
+    public static Guards of(String behavior, Core body, CoverageSites.Plan plan,
+                            List<String> parameters, Symbols symbols) {
         List<Threshold> found = new ArrayList<>();
-        walk(behavior, body, plan, parameters, symbols, found);
-        return List.copyOf(found);
+        List<GuardEdge> edges = new ArrayList<>();
+        walk(behavior, body, plan, parameters, symbols, found, edges);
+        return new Guards(found, edges);
     }
 
     private static void walk(String behavior, Core e, CoverageSites.Plan plan,
-                             List<String> parameters, Symbols symbols, List<Threshold> out) {
+                             List<String> parameters, Symbols symbols, List<Threshold> out,
+                             List<GuardEdge> edges) {
         if (e instanceof Core.If iff) {
-            read(behavior, iff, plan, parameters, symbols).ifPresent(out::add);
+            read(behavior, iff, plan, parameters, symbols, out, edges);
         }
         // A match case's body and an attempted construction's departure are expression slots, so the
         // generic walk reaches them; only the arms themselves are not children, and this walk does not
         // number arms.
-        Core.forEachChild(e, child -> walk(behavior, child, plan, parameters, symbols, out));
+        Core.forEachChild(e, child -> walk(behavior, child, plan, parameters, symbols, out, edges));
     }
 
-    private static java.util.Optional<Threshold> read(String behavior, Core.If iff,
-                                                      CoverageSites.Plan plan,
-                                                      List<String> parameters, Symbols symbols) {
+    private static void read(String behavior, Core.If iff, CoverageSites.Plan plan,
+                             List<String> parameters, Symbols symbols, List<Threshold> out,
+                             List<GuardEdge> edges) {
         if (!(iff.cond() instanceof Core.Binary comparison)) {
-            return java.util.Optional.empty();
+            return;
         }
         Ast.BinOp op = comparison.op();
         TermPath path = pathOf(comparison.left(), parameters, symbols);
@@ -69,7 +90,7 @@ public final class GuardThresholds {
             op = mirrored(op);
         }
         if (path == null || value == null) {
-            return java.util.Optional.empty();
+            return;
         }
         Boolean below = switch (op) {
             case LE, GT -> Boolean.TRUE;    // the value itself is on the low side
@@ -77,15 +98,50 @@ public final class GuardThresholds {
             default -> null;                // EQ / NE do not order the values, so they draw no cut
         };
         if (below == null) {
-            return java.util.Optional.empty();
+            return;
         }
         CoverageSites.GuardRef guard = guardOf(plan, iff);
         if (guard == null) {
-            return java.util.Optional.empty();   // no site for this `if`: nothing could answer for it
+            return;   // no site for this `if`: nothing could answer for it
         }
-        return java.util.Optional.of(new Threshold(path, value, below,
+        out.add(new Threshold(path, value, below,
                 new OriginRef.GuardOrigin(guard, new SourceRef(guard.at().sourceId(), iff.pos()),
                         below)));
+        // Which side of the line the line's own value is on does not say which arm is which. `x <= c`
+        // and `x > c` agree about the first and take opposite halves, so the arms are read off the
+        // operator here, where it is still known, and not recovered from the threshold later.
+        int then = guard.siteIndexThen();
+        int otherwise = guard.siteIndexElse();
+        switch (op) {
+            case LE -> {
+                edge(edges, guard, then, path, value, true, true);
+                edge(edges, guard, otherwise, path, value, false, false);
+            }
+            case GT -> {
+                edge(edges, guard, then, path, value, false, false);
+                edge(edges, guard, otherwise, path, value, true, true);
+            }
+            case LT -> {
+                edge(edges, guard, then, path, value, true, false);
+                edge(edges, guard, otherwise, path, value, false, true);
+            }
+            case GE -> {
+                edge(edges, guard, then, path, value, false, true);
+                edge(edges, guard, otherwise, path, value, true, false);
+            }
+            default -> { }
+        }
+    }
+
+    /** One arm's edge, where that arm has a probe. An arm answering nothing has none, and it is owed
+     * no row whether anything reaches it or not. */
+    private static void edge(List<GuardEdge> edges, CoverageSites.GuardRef guard, int site,
+                             TermPath path, BigDecimal value, boolean below, boolean inclusive) {
+        if (site == CoverageSites.NO_SITE) {
+            return;
+        }
+        edges.add(below ? GuardEdge.below(guard, site, path, value, inclusive)
+                : GuardEdge.above(guard, site, path, value, inclusive));
     }
 
     private static CoverageSites.GuardRef guardOf(CoverageSites.Plan plan, Core.If iff) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -607,10 +607,10 @@ public final class Partitions {
             return List.of();
         }
         if (type == Type.INT) {
-            return List.of(FixtureTemplate.integer(0));
+            return List.of(FixtureTemplate.integer(admissible(within, true).longValueExact()));
         }
         if (type == Type.DECIMAL) {
-            return List.of(FixtureTemplate.decimal(BigDecimal.ZERO));
+            return List.of(FixtureTemplate.decimal(admissible(within, false)));
         }
         if (type == Type.STRING) {
             return List.of(FixtureTemplate.string("x"));
@@ -698,6 +698,30 @@ public final class Partitions {
             once.putIfAbsent(each.text(), each);
         }
         return List.copyOf(once.values());
+    }
+
+    /**
+     * A number the position can hold, for a position whose type says nothing about which one.
+     *
+     * <p>The lower end where there is one, the upper where there is only that, and zero where the
+     * position is left open — which is what a type with no rules has always offered here. The same
+     * order a newtype's own candidate is chosen in: the low end is inside whatever high end there is,
+     * so one rule picks a value for both shapes of range.
+     *
+     * <p>{@code whole} takes an end in to the nearest whole number inside it. A projection divides,
+     * so what it leaves an {@code Int} can have a fraction on it that no {@code Int} has.
+     */
+    private static BigDecimal admissible(NumericDomain.Bounds within, boolean whole) {
+        if (within == null) {
+            return BigDecimal.ZERO;
+        }
+        if (within.min() != null) {
+            return whole ? within.min().setScale(0, java.math.RoundingMode.CEILING) : within.min();
+        }
+        if (within.max() != null) {
+            return whole ? within.max().setScale(0, java.math.RoundingMode.FLOOR) : within.max();
+        }
+        return BigDecimal.ZERO;
     }
 
     /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -666,15 +666,23 @@ public final class Partitions {
      */
     static List<FixtureTemplate> displacedRepresentativesOf(Type type, Symbols symbols,
                                                             NumericDomain.Bounds within) {
-        List<FixtureTemplate> base = representativesOf(type, symbols, within);
+        List<FixtureTemplate> base = new ArrayList<>(representativesOf(type, symbols, within));
+        // What a position holds back for the product search's second pass is on offer here from the
+        // start. This pass runs only where both of those have already failed, and a position keeping
+        // a value from the last search there is a value nothing will ever be tried at.
+        for (FixtureTemplate held : inReserve(type, symbols, within)) {
+            if (base.stream().noneMatch(each -> each.text().equals(held.text()))) {
+                base.add(held);
+            }
+        }
         Type numeric = TypeOps.numericBase(type, symbols);
         if (numeric == null) {
-            return base;
+            return List.copyOf(base);
         }
         NumericDomain.Bounds range = admissibleBounds(boundsOf(type, symbols), within);
         BigDecimal step = displaced(range, numeric == Type.INT);
         if (step == null) {
-            return base;
+            return List.copyOf(base);
         }
         FixtureTemplate bare = numeric == Type.DECIMAL ? FixtureTemplate.decimal(step)
                 : FixtureTemplate.integer(step.longValueExact());
@@ -682,11 +690,10 @@ public final class Partitions {
                 && symbols.get(ref.name()) instanceof Ast.Data data && data.newtype()
                 ? FixtureTemplate.newtype(ref.name(), bare) : bare;
         if (base.stream().anyMatch(each -> each.text().equals(value.text()))) {
-            return base;
+            return List.copyOf(base);
         }
-        List<FixtureTemplate> out = new ArrayList<>(base);
-        out.add(value);
-        return List.copyOf(out);
+        base.add(value);
+        return List.copyOf(base);
     }
 
     /** A second number of a range, or null where the type has none to give. */
@@ -810,13 +817,14 @@ public final class Partitions {
                 || !data.newtype()) {
             return List.of();
         }
-        Bounds bounds = narrowed(boundsOf(type, symbols), within);
+        Bounds own = boundsOf(type, symbols);
+        NumericDomain.Bounds bounds = admissibleBounds(own, within);
         if (bounds == null || bounds.min() == null || bounds.max() == null
-                || bounds.max().value().compareTo(bounds.min().value()) == 0) {
+                || bounds.max().compareTo(bounds.min()) == 0) {
             return List.of();
         }
-        BigDecimal far = bounds.max().value();
-        FixtureTemplate held = FixtureTemplate.newtype(ref.name(), bounds.decimal()
+        BigDecimal far = bounds.max();
+        FixtureTemplate held = FixtureTemplate.newtype(ref.name(), own.decimal()
                 ? FixtureTemplate.decimal(far) : FixtureTemplate.integer(far.longValueExact()));
         // Nothing already on offer: a range whose far edge is the number the base type stands for
         // would otherwise hold the same value twice, once in each tier.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -209,7 +209,8 @@ public final class Partitions {
      * the edge is the only row there is to write. A guard's line has values on both sides, so it wants
      * the value and its neighbour — and the neighbour only where the type has one to give.
      */
-    public static List<BoundaryObligation> obligationsOf(Axis axis, Symbols symbols) {
+    public static List<BoundaryObligation> obligationsOf(Axis axis, Symbols symbols,
+                                                         NumericDomain.Bounds within) {
         boolean decimal = TypeOps.base(axis.type(), symbols) == Type.DECIMAL;
         BoundaryDomain domain = decimal ? BoundaryDomain.DECIMAL : BoundaryDomain.INT;
         List<BoundaryObligation> out = new ArrayList<>();
@@ -218,13 +219,20 @@ public final class Partitions {
                 out.add(new BoundaryObligation(axis.id(), origin,
                         BoundaryObligation.BoundarySide.AT, cut.value()));
                 if (origin instanceof OriginRef.GuardOrigin guard) {
-                    // The other class's edge is the neighbour on the side the cut value is not on.
+                    // The other class's edge is the neighbour on the side the cut value is not on —
+                    // where that class has values. A guard at the end of what the position can hold
+                    // has nothing on one side of it, and a step off the end is a row nobody can write:
+                    // `value >= 10` under `x < 10` would be owed a 9. The cut itself stays either way,
+                    // because the comparison is still reached by a row written at the line.
                     if (guard.valueBelongsBelow()) {
-                        domain.successor(cut.value()).ifPresent(next -> out.add(new BoundaryObligation(
-                                axis.id(), origin, BoundaryObligation.BoundarySide.ABOVE, next)));
+                        domain.successor(cut.value()).filter(next -> holds(within, next))
+                                .ifPresent(next -> out.add(new BoundaryObligation(
+                                        axis.id(), origin,
+                                        BoundaryObligation.BoundarySide.ABOVE, next)));
                     } else {
-                        domain.predecessor(cut.value()).ifPresent(before ->
-                                out.add(new BoundaryObligation(axis.id(), origin,
+                        domain.predecessor(cut.value()).filter(before -> holds(within, before))
+                                .ifPresent(before -> out.add(new BoundaryObligation(
+                                        axis.id(), origin,
                                         BoundaryObligation.BoundarySide.BELOW, before)));
                     }
                 }
@@ -233,6 +241,22 @@ public final class Partitions {
         return List.copyOf(out);
     }
 
+    /** Whether a value invented one step off a line is one the position can hold. */
+    private static boolean holds(NumericDomain.Bounds within, ObservedValue value) {
+        if (within == null) {
+            return true;
+        }
+        BigDecimal number = switch (value) {
+            case ObservedValue.Integer i -> BigDecimal.valueOf(i.value());
+            case ObservedValue.Decimal d -> d.value();
+            case null, default -> null;
+        };
+        if (number == null) {
+            return true;
+        }
+        return (within.min() == null || number.compareTo(within.min()) >= 0)
+                && (within.max() == null || number.compareTo(within.max()) <= 0);
+    }
 
     /** One position: measured where the model divides it or bounds it, taken apart where it is a
      * record, and recorded as not derivable where it is neither. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -233,6 +233,7 @@ public final class Partitions {
         return List.copyOf(out);
     }
 
+
     /** One position: measured where the model divides it or bounds it, taken apart where it is a
      * record, and recorded as not derivable where it is neither. */
     private static void walk(String behavior, TermPath path, Type type, int depth, Symbols symbols,
@@ -245,14 +246,17 @@ public final class Partitions {
         // A value whose rules contradict has no positions to cover: every edge of every field of it
         // is a row nobody can write, which is not the same answer as a field nothing bounds.
         boolean nothingExists = placed != null && placed.domains().infeasible();
-        Bounds here = nothingExists ? null : narrowed(own, placed == null ? null : placed.at(path));
-        if (here != null && !here.isEmpty()) {
-            domains.put(path.toString(), new NumericDomain.Bounds(
-                    here.min() == null ? null : here.min().value(),
-                    here.max() == null ? null : here.max().value()));
+        NumericDomain.Bounds projected = placed == null ? null : placed.at(path);
+        // Two questions of one pair of readings, and they do not have one answer. What the position
+        // can hold is every rule about it intersected; where it is divided is only where its own type
+        // draws a line, because a clause relating two fields is not a partition of one of them.
+        NumericDomain.Bounds admissible = nothingExists ? null : admissibleBounds(own, projected);
+        if (admissible != null && !admissible.isEmpty()) {
+            domains.put(path.toString(), admissible);
         }
+        Bounds axis = nothingExists ? null : axisBounds(own, projected);
         List<Cut> cuts = nothingExists ? List.of()
-                : cutsOf(type, here, own, placed == null ? null : placed.value());
+                : cutsOf(type, axis, own, placed == null ? null : placed.value());
         // Whether a row can be written at an edge is a question about the whole value the position
         // sits in, so it is answered once for the parameter. A rule this could not read is a way that
         // value can be refused, wherever in it the rule is written.
@@ -296,14 +300,18 @@ public final class Partitions {
     }
 
     /**
-     * The type's own bound, taken in to where the record it sits in stops.
+     * Where the position is divided: the type's own bound, taken in to where the record it sits in
+     * stops.
      *
      * <p>Only taken in. A record's rule moves an edge the type already has; it does not put one on a
      * position the type left open. An {@code Int} nobody bounded stays a position the model draws no
      * line through, which is what a report says of it (ADR-0090) — giving it an edge here would make
      * a rule relating two fields into a partition of one of them.
+     *
+     * <p>So this is not what the position can hold, and reading it as that is how a cap written on
+     * the record alone became invisible: see {@link #admissibleBounds}.
      */
-    private static Bounds narrowed(Bounds own, NumericDomain.Bounds projected) {
+    private static Bounds axisBounds(Bounds own, NumericDomain.Bounds projected) {
         if (own == null || projected == null) {
             return own;
         }
@@ -315,6 +323,29 @@ public final class Partitions {
                 own.max() == null ? null
                         : new End(lowest(own.max().value(), projected.max()), own.max().from()),
                 own.decimal());
+    }
+
+    /**
+     * What the position can hold: every rule reaching it, intersected.
+     *
+     * <p>An end survives from whichever side has one, because a value outside it is refused whether
+     * the type said so or the record did. That is the difference from {@link #axisBounds}: a cap the
+     * record alone imposes is not a line dividing this position, and it is still where its values
+     * stop — so a guard beyond it divides nothing and is no edge either.
+     *
+     * <p>Numbers and no names. An end here says where the values stop; which rule put it there is a
+     * cut's question, and answering it from a projection would name a rule that never mentioned this
+     * position on its own.
+     */
+    private static NumericDomain.Bounds admissibleBounds(Bounds own, NumericDomain.Bounds projected) {
+        if (own == null) {
+            return null;   // not a number, so nothing bounds it either way
+        }
+        BigDecimal min = own.min() == null ? null : own.min().value();
+        BigDecimal max = own.max() == null ? null : own.max().value();
+        return projected == null ? new NumericDomain.Bounds(min, max)
+                : new NumericDomain.Bounds(highest(min, projected.min()),
+                        lowest(max, projected.max()));
     }
 
     /** A record's fields, or nothing where the type is not one. A newtype is not taken apart: its
@@ -618,9 +649,10 @@ public final class Partitions {
         Type base = TypeOps.newtypeInner(newtype, symbols);
         List<FixtureTemplate> candidates = new ArrayList<>();
 
-        Bounds bounds = narrowed(boundsOf(new Type.Ref(newtype), symbols), within);
+        Bounds own = boundsOf(new Type.Ref(newtype), symbols);
+        NumericDomain.Bounds bounds = admissibleBounds(own, within);
         if (bounds != null && !bounds.isEmpty()) {
-            candidates.add(bounds.decimal()
+            candidates.add(own.decimal()
                     ? FixtureTemplate.decimal(inside(bounds))
                     : FixtureTemplate.integer(inside(bounds).longValueExact()));
         }
@@ -646,9 +678,9 @@ public final class Partitions {
 
     /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge
      * there is, and it is the value a boundary wants written anyway. */
-    private static BigDecimal inside(Bounds bounds) {
-        return bounds.min() != null ? bounds.min().value()
-                : bounds.max() != null ? bounds.max().value() : BigDecimal.ZERO;
+    private static BigDecimal inside(NumericDomain.Bounds bounds) {
+        return bounds.min() != null ? bounds.min()
+                : bounds.max() != null ? bounds.max() : BigDecimal.ZERO;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -650,6 +650,64 @@ public final class Partitions {
     }
 
     /**
+     * The same, with a second value offered at a numeric position.
+     *
+     * <p>One value is enough only where the rules that decide it are the rules the projection holds.
+     * A disequality is a hole no range keeps, a strict bound over the decimals is recorded as the
+     * non-strict one, and a form that is neither an interval nor a difference is not recorded at all —
+     * so the end a projection names can be the one value the rules refuse, and a position offering
+     * only that has nothing left to try.
+     *
+     * <p>Displaced and not invented. A whole number has a next one; a decimal between two ends has a
+     * midpoint, and where it has no second end it gets no second value, because an epsilon is a value
+     * the type does not name. A candidate is a proposal the decoder answers — it carries no promise
+     * that the value is writable, which is what separates this from a boundary a person is asked to
+     * write.
+     */
+    static List<FixtureTemplate> displacedRepresentativesOf(Type type, Symbols symbols,
+                                                            NumericDomain.Bounds within) {
+        List<FixtureTemplate> base = representativesOf(type, symbols, within);
+        Type numeric = TypeOps.numericBase(type, symbols);
+        if (numeric == null) {
+            return base;
+        }
+        NumericDomain.Bounds range = admissibleBounds(boundsOf(type, symbols), within);
+        BigDecimal step = displaced(range, numeric == Type.INT);
+        if (step == null) {
+            return base;
+        }
+        FixtureTemplate bare = numeric == Type.DECIMAL ? FixtureTemplate.decimal(step)
+                : FixtureTemplate.integer(step.longValueExact());
+        FixtureTemplate value = type instanceof Type.Ref ref
+                && symbols.get(ref.name()) instanceof Ast.Data data && data.newtype()
+                ? FixtureTemplate.newtype(ref.name(), bare) : bare;
+        if (base.stream().anyMatch(each -> each.text().equals(value.text()))) {
+            return base;
+        }
+        List<FixtureTemplate> out = new ArrayList<>(base);
+        out.add(value);
+        return List.copyOf(out);
+    }
+
+    /** A second number of a range, or null where the type has none to give. */
+    private static BigDecimal displaced(NumericDomain.Bounds range, boolean whole) {
+        BigDecimal from = admissible(range, whole);
+        BigDecimal min = range == null ? null : range.min();
+        BigDecimal max = range == null ? null : range.max();
+        if (!whole) {
+            // No smallest step, so the only second value a range names is one inside both its ends.
+            return min == null || max == null || min.compareTo(max) >= 0 ? null
+                    : min.add(max).divide(BigDecimal.valueOf(2));
+        }
+        BigDecimal up = from.add(BigDecimal.ONE);
+        if (max == null || up.compareTo(max) <= 0) {
+            return up;
+        }
+        BigDecimal down = from.subtract(BigDecimal.ONE);
+        return min == null || down.compareTo(min) >= 0 ? down : null;
+    }
+
+    /**
      * What a newtype wraps: every value for it this can think of, in the order to try them.
      *
      * <p>Candidates, not an answer. Whether a newtype accepts a value is decided by its own

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -1,0 +1,124 @@
+package souther.compiler.partition;
+
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.types.TypeName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * The cases of its output a body may answer with.
+ *
+ * <p>Asked because a case is owed a row only where something can produce it. An arm nothing reaches
+ * produces nothing, and a case produced nowhere else is then a case the signature would ask for and
+ * no row could give — the same obligation the classes and the lines have already stopped asking for.
+ *
+ * <p>A may-analysis, so the answer is only ever too wide. What one producer contributes is
+ *
+ * <pre>
+ * nothing               where an arm it sits under is proven unreachable
+ * the case it builds    where the value it builds names one
+ * every declared case   otherwise
+ * </pre>
+ *
+ * and the answer is their union. The last line is the top of the lattice and it is where everything
+ * this cannot read goes: a call, a value bound elsewhere, a body that is a function. So a helper that
+ * might answer anything keeps every case owed, which is the safe direction — a case left in is a case
+ * the report asks for, and an author reading a gap they cannot fill has at least been told something
+ * true about their model.
+ *
+ * <p>Only guards take an arm away, because only a guard's arm has a reachability proof behind it. A
+ * {@code match} arm is left alone: which cases of a sum can arrive is a different question and
+ * {@link Exclusions} is where it is asked.
+ */
+public final class ProducedCases {
+
+    /**
+     * @param declared what the output type's cases are, which is both the answer where nothing can be
+     *                 read and the set every unresolved producer contributes
+     */
+    public static Set<TypeName> of(Core body, CoverageSites.Plan plan, GuardReachability reachable,
+                                   Set<TypeName> declared) {
+        if (body == null || declared.isEmpty() || reachable.isEmpty()) {
+            return declared;   // nothing to take away, so nothing is worth walking for
+        }
+        Set<TypeName> found = new LinkedHashSet<>();
+        walk(body, List.of(), plan, reachable, declared, found);
+        return found;
+    }
+
+    /**
+     * One tail position, and the arms it sits under.
+     *
+     * <p>Tail positions only. A construction evaluated on the way to somewhere else — an argument, the
+     * value a {@code let} binds — is not what the behavior answers with, and counting it would keep a
+     * case owed because the body happened to build one on its way past.
+     */
+    private static void walk(Core e, List<Integer> under, CoverageSites.Plan plan,
+                             GuardReachability reachable, Set<TypeName> declared,
+                             Set<TypeName> found) {
+        if (found.size() == declared.size()) {
+            return;   // already the whole set; nothing further can widen it
+        }
+        switch (e) {
+            case Core.Unreachable _ -> { }   // answers nothing, so it produces nothing
+            case Core.LetIn li -> walk(li.body(), under, plan, reachable, declared, found);
+            case Core.If iff -> {
+                int[] arms = plan.probesOf(iff);
+                walk(iff.then(), beneath(under, arms, 0), plan, reachable, declared, found);
+                walk(iff.els(), beneath(under, arms, 1), plan, reachable, declared, found);
+            }
+            case Core.Match m -> {
+                int[] arms = plan.probesOf(m);
+                for (int i = 0; i < m.cases().size(); i++) {
+                    walk(m.cases().get(i).body(), beneath(under, arms, i), plan, reachable, declared,
+                            found);
+                }
+            }
+            case Core.IfConstructed ic -> {
+                int[] arms = plan.probesOf(ic);
+                walk(ic.then(), beneath(under, arms, 0), plan, reachable, declared, found);
+                for (int i = 0; i < ic.els().size(); i++) {
+                    walk(ic.els().get(i).body(), beneath(under, arms, i + 1), plan, reachable,
+                            declared, found);
+                }
+            }
+            case Core.UnitValue u -> produce(u.data(), under, reachable, declared, found);
+            case Core.NewData nd -> produce(nd.typeName(), under, reachable, declared, found);
+            // Everything else answers something this cannot name: a call, a name read from a binding,
+            // a function value. The top of the lattice, which keeps every case owed.
+            case null, default -> produce(null, under, reachable, declared, found);
+        }
+    }
+
+    /** What one producer contributes, which is nothing at all where an arm above it is unreachable. */
+    private static void produce(TypeName built, List<Integer> under, GuardReachability reachable,
+                                Set<TypeName> declared, Set<TypeName> found) {
+        for (int site : under) {
+            if (reachable.provenUnreachable(site)) {
+                return;
+            }
+        }
+        if (built != null && declared.contains(built)) {
+            found.add(built);
+            return;
+        }
+        found.addAll(declared);
+    }
+
+    /** The arms of an inner fork, added to the ones already above it. An arm with no probe adds
+     * nothing: there is no site for a proof to have been about. */
+    private static List<Integer> beneath(List<Integer> under, int[] arms, int index) {
+        if (arms == null || index >= arms.length || arms[index] == CoverageSites.NO_SITE) {
+            return under;
+        }
+        List<Integer> out = new ArrayList<>(under);
+        out.add(arms[index]);
+        return List.copyOf(out);
+    }
+
+    private ProducedCases() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -10,25 +10,26 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * The cases of its output a body may answer with.
+ * The cases of a behavior's output that no row could carry, because everything answering with them is
+ * behind an arm nothing reaches.
  *
- * <p>Asked because a case is owed a row only where something can produce it. An arm nothing reaches
- * produces nothing, and a case produced nowhere else is then a case the signature would ask for and
- * no row could give — the same obligation the classes and the lines have already stopped asking for.
- *
- * <p>A may-analysis, so the answer is only ever too wide. What one producer contributes is
+ * <p>Taken away and not counted up. A case a body has no producer for stays owed: that a signature
+ * says {@code A | B} and an implementation never answers {@code B} is a gap between the two, and it is
+ * the kind of gap a coverage measure is for. What is not a gap is a case something does answer with,
+ * at a place the model's own rules prove nothing reaches — nobody can write that row, and asking is
+ * asking for work nobody can do.
  *
  * <pre>
- * nothing               where an arm it sits under is proven unreachable
- * the case it builds    where the value it builds names one
- * every declared case   otherwise
+ * a reachable producer, or one this cannot read   keep
+ * producers, and every one of them unreachable    take away
+ * no producer at all                              keep
  * </pre>
  *
- * and the answer is their union. The last line is the top of the lattice and it is where everything
- * this cannot read goes: a call, a value bound elsewhere, a body that is a function. So a helper that
- * might answer anything keeps every case owed, which is the safe direction — a case left in is a case
- * the report asks for, and an author reading a gap they cannot fill has at least been told something
- * true about their model.
+ * <p>The middle line is the only one that takes anything, and it is the one #479 is about. The first
+ * covers everything unreadable — a call, a value bound elsewhere, a body that is a function — so a
+ * helper that might answer anything keeps every case owed, which is the safe direction: a case left in
+ * is a case the report asks for, and an author reading a gap they cannot fill has at least been told
+ * something true about their model.
  *
  * <p>Only guards take an arm away, because only a guard's arm has a reachability proof behind it. A
  * {@code match} arm is left alone: which cases of a sum can arrive is a different question and
@@ -37,22 +38,38 @@ import java.util.Set;
 public final class ProducedCases {
 
     /**
-     * <p>Asked of every body, and not only of one with an arm this can rule out. What a body may
-     * answer with is a fact about the body: reading it only where a guard happens to be provable
-     * would make the same two bodies answer differently, and adding a guard nothing reaches to a
-     * behavior would change what its signature is owed.
-     *
-     * @param declared what the output type's cases are, which is both the answer where nothing can be
-     *                 read and the set every unresolved producer contributes
+     * @param declared what the output type's cases are, which is what this answers where nothing is
+     *                 taken away
      */
     public static Set<TypeName> of(Core body, CoverageSites.Plan plan, GuardReachability reachable,
                                    Set<TypeName> declared) {
-        if (body == null || declared.isEmpty()) {
-            return declared;   // nothing to read, so every case the type has stays owed
+        // Nothing proven is nothing to take away: what this returns is `declared` less the cases whose
+        // every producer is behind a proven arm, and with no such arm there are none. Skipped rather
+        // than walked to the same answer.
+        if (body == null || declared.isEmpty() || reachable.isEmpty()) {
+            return declared;
         }
-        Set<TypeName> found = new LinkedHashSet<>();
-        walk(body, List.of(), plan, reachable, declared, found);
-        return found;
+        Seen seen = new Seen();
+        walk(body, List.of(), plan, reachable, declared, seen);
+        if (seen.anythingUnreadable) {
+            return declared;   // something reachable answers with what this cannot name
+        }
+        Set<TypeName> out = new LinkedHashSet<>(declared);
+        seen.behindAProvenArm.stream().filter(each -> !seen.reachable.contains(each)).toList()
+                .forEach(out::remove);
+        return Set.copyOf(out);
+    }
+
+    /** Where a case was answered with, which is what decides whether it can be answered at all. */
+    private static final class Seen {
+
+        /** Answered with somewhere no proof rules out. */
+        private final Set<TypeName> reachable = new LinkedHashSet<>();
+        /** Answered with behind an arm nothing reaches, which is only worth acting on where the case
+         * is answered with nowhere else. */
+        private final Set<TypeName> behindAProvenArm = new LinkedHashSet<>();
+        /** A producer that could answer with anything, at a place something reaches. */
+        private boolean anythingUnreadable;
     }
 
     /**
@@ -63,55 +80,56 @@ public final class ProducedCases {
      * case owed because the body happened to build one on its way past.
      */
     private static void walk(Core e, List<Integer> under, CoverageSites.Plan plan,
-                             GuardReachability reachable, Set<TypeName> declared,
-                             Set<TypeName> found) {
-        if (found.size() == declared.size()) {
-            return;   // already the whole set; nothing further can widen it
+                             GuardReachability reachable, Set<TypeName> declared, Seen seen) {
+        if (seen.anythingUnreadable) {
+            return;   // nothing further can be taken away
         }
         switch (e) {
             case Core.Unreachable _ -> { }   // answers nothing, so it produces nothing
-            case Core.LetIn li -> walk(li.body(), under, plan, reachable, declared, found);
+            case Core.LetIn li -> walk(li.body(), under, plan, reachable, declared, seen);
             case Core.If iff -> {
                 int[] arms = plan.probesOf(iff);
-                walk(iff.then(), beneath(under, arms, 0), plan, reachable, declared, found);
-                walk(iff.els(), beneath(under, arms, 1), plan, reachable, declared, found);
+                walk(iff.then(), beneath(under, arms, 0), plan, reachable, declared, seen);
+                walk(iff.els(), beneath(under, arms, 1), plan, reachable, declared, seen);
             }
             case Core.Match m -> {
                 int[] arms = plan.probesOf(m);
                 for (int i = 0; i < m.cases().size(); i++) {
                     walk(m.cases().get(i).body(), beneath(under, arms, i), plan, reachable, declared,
-                            found);
+                            seen);
                 }
             }
             case Core.IfConstructed ic -> {
                 int[] arms = plan.probesOf(ic);
-                walk(ic.then(), beneath(under, arms, 0), plan, reachable, declared, found);
+                walk(ic.then(), beneath(under, arms, 0), plan, reachable, declared, seen);
                 for (int i = 0; i < ic.els().size(); i++) {
                     walk(ic.els().get(i).body(), beneath(under, arms, i + 1), plan, reachable,
-                            declared, found);
+                            declared, seen);
                 }
             }
-            case Core.UnitValue u -> produce(u.data(), under, reachable, declared, found);
-            case Core.NewData nd -> produce(nd.typeName(), under, reachable, declared, found);
+            case Core.UnitValue u -> produce(u.data(), under, reachable, declared, seen);
+            case Core.NewData nd -> produce(nd.typeName(), under, reachable, declared, seen);
             // Everything else answers something this cannot name: a call, a name read from a binding,
             // a function value. The top of the lattice, which keeps every case owed.
-            case null, default -> produce(null, under, reachable, declared, found);
+            case null, default -> produce(null, under, reachable, declared, seen);
         }
     }
 
-    /** What one producer contributes, which is nothing at all where an arm above it is unreachable. */
+    /** Where one producer puts the case it answers with. */
     private static void produce(TypeName built, List<Integer> under, GuardReachability reachable,
-                                Set<TypeName> declared, Set<TypeName> found) {
-        for (int site : under) {
-            if (reachable.provenUnreachable(site)) {
-                return;
-            }
-        }
-        if (built != null && declared.contains(built)) {
-            found.add(built);
+                                Set<TypeName> declared, Seen seen) {
+        boolean proven = under.stream().anyMatch(reachable::provenUnreachable);
+        if (built == null || !declared.contains(built)) {
+            // Not a case this can name. Reachable, it could be any of them and nothing is taken away;
+            // behind a proven arm it answers nothing and says nothing about any case either.
+            seen.anythingUnreadable |= !proven;
             return;
         }
-        found.addAll(declared);
+        if (proven) {
+            seen.behindAProvenArm.add(built);
+        } else {
+            seen.reachable.add(built);
+        }
     }
 
     /** The arms of an inner fork, added to the ones already above it. An arm with no probe adds

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -57,7 +57,10 @@ public final class ProducedCases {
         Set<TypeName> out = new LinkedHashSet<>(declared);
         seen.behindAProvenArm.stream().filter(each -> !seen.reachable.contains(each)).toList()
                 .forEach(out::remove);
-        return Set.copyOf(out);
+        // The order the cases were declared in, which is the order they are named in. `Set.copyOf`
+        // keeps the values and not the order, so a case taken out here would have reordered the ones
+        // left — and what a report lists is read against the declaration it came from.
+        return java.util.Collections.unmodifiableSet(out);
     }
 
     /** Where a case was answered with, which is what decides whether it can be answered at all. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ProducedCases.java
@@ -37,13 +37,18 @@ import java.util.Set;
 public final class ProducedCases {
 
     /**
+     * <p>Asked of every body, and not only of one with an arm this can rule out. What a body may
+     * answer with is a fact about the body: reading it only where a guard happens to be provable
+     * would make the same two bodies answer differently, and adding a guard nothing reaches to a
+     * behavior would change what its signature is owed.
+     *
      * @param declared what the output type's cases are, which is both the answer where nothing can be
      *                 read and the set every unresolved producer contributes
      */
     public static Set<TypeName> of(Core body, CoverageSites.Plan plan, GuardReachability reachable,
                                    Set<TypeName> declared) {
-        if (body == null || declared.isEmpty() || reachable.isEmpty()) {
-            return declared;   // nothing to take away, so nothing is worth walking for
+        if (body == null || declared.isEmpty()) {
+            return declared;   // nothing to read, so every case the type has stays owed
         }
         Set<TypeName> found = new LinkedHashSet<>();
         walk(body, List.of(), plan, reachable, declared, found);

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -362,7 +362,8 @@ public final class Adequacy {
                     continue;
                 }
                 out.addAll(Coverages.assess(axis, parameters, observed, symbols, armsAsked,
-                        partitioning.edgeIsKnownWritable(axis.path().toString()), probe));
+                        partitioning.edgeIsKnownWritable(axis.path().toString()), probe,
+                        partitioning.domains().get(axis.path().toString())));
             }
             return List.copyOf(out);
         }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -102,6 +102,10 @@ public final class Adequacy {
                      Map<String, PartitionEvidence> partitions,
                      Map<String, BranchEvidence> branches) {}
 
+    /** Nothing proven and nothing disproved, for a module whose reachability could not be asked. */
+    static final Effective NOTHING_PROVEN =
+            new Effective(souther.compiler.partition.GuardReachability.NONE, Set.of());
+
     static Asked askedOf(Db db) {
         Asked asked = db.ask(new Requested()).value();
         return asked == null ? Asked.NOTHING : asked;
@@ -246,6 +250,61 @@ public final class Adequacy {
     }
 
     /**
+     * What is proven about a behavior's arms once the rows have run.
+     *
+     * <p>A proof is about the model's own rules and the rows are about what happened, so a row that
+     * went through an arm nothing was supposed to reach settles it: the proof was wrong. Recorded
+     * rather than dropped, because that is a disagreement between an analysis and an execution and
+     * not a gap in anybody's rows.
+     *
+     * @param reachable  the arms still proven unreachable, which is what every measure excludes by
+     * @param contradicted the ones a row reached anyway
+     */
+    public record Effective(souther.compiler.partition.GuardReachability reachable, Set<Integer> contradicted) {
+
+        public Effective {
+            contradicted = Set.copyOf(contradicted);
+        }
+    }
+
+    /**
+     * The effective reachability of every behavior of one module.
+     *
+     * <p>Derived once and read by both of the measures that exclude by it. Asked separately they
+     * would disagree exactly where it matters most: an arm put back into the branch measure by a row
+     * that reached it would still be taken out of the signature's, and the case behind it would stay
+     * unowed over a proof already known to be wrong.
+     */
+    public record Reached(String name) implements Key<Map<String, Effective>> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, Effective>> compute(Db db) {
+            Answer<Map<String, souther.compiler.partition.GuardReachability>> proven = db.ask(new Reachable(name));
+            if (!proven.present()) {
+                return Answer.absent();
+            }
+            Set<Integer> lit = new LinkedHashSet<>();
+            for (Observed observed : rowsOf(db, name).values()) {
+                for (RowOutcome row : observed.rows()) {
+                    lit.addAll(row.hits());
+                }
+            }
+            Map<String, Effective> out = new LinkedHashMap<>();
+            proven.value().forEach((behavior, reachable) -> {
+                Set<Integer> contradicted = new LinkedHashSet<>(reachable.unreachableSites());
+                contradicted.retainAll(lit);
+                out.put(behavior, new Effective(reachable.without(contradicted), contradicted));
+            });
+            return Answer.of(Ordered.map(out));
+        }
+    }
+
+    /**
      * The signature evidence for every behavior of one module.
      *
      * <p>A module's question, not a source's, although the rows are evaluated per source. A behavior's
@@ -279,7 +338,7 @@ public final class Adequacy {
             souther.compiler.coverage.CoverageSites.Plan producingPlan =
                     souther.compiler.coverage.CoverageSites.of(
                             Coverage.sourceIdOf(db, name), producing);
-            Map<String, souther.compiler.partition.GuardReachability> reachableArms = db.ask(new Reachable(name)).value();
+            Map<String, Effective> reachableArms = db.ask(new Reached(name)).value();
             Map<String, SignatureEvidence> out = new LinkedHashMap<>();
             for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
                 Sig sig = sigs.value().get(behavior.name());
@@ -293,8 +352,8 @@ public final class Adequacy {
                         excluded == null ? Exclusions.NONE
                                 : excluded.getOrDefault(behavior.name(), Exclusions.NONE),
                         producing.get(behavior.name()), producingPlan,
-                        reachableArms == null ? souther.compiler.partition.GuardReachability.NONE
-                                : reachableArms.getOrDefault(behavior.name(), souther.compiler.partition.GuardReachability.NONE)));
+                        reachableArms == null ? NOTHING_PROVEN
+                                : reachableArms.getOrDefault(behavior.name(), NOTHING_PROVEN)));
             }
             return Answer.of(Ordered.map(out));
         }
@@ -533,24 +592,18 @@ public final class Adequacy {
          * probe could never disprove the reachability it was excluded by.
          */
         public static BranchEvidence measured(List<souther.compiler.coverage.CoverageSites.Site> all,
-                                              Set<Integer> covered,
-                                              souther.compiler.partition.GuardReachability reachable,
+                                              Set<Integer> covered, Effective reachable,
                                               MeasurementStatus status) {
-            Set<Integer> contradicted = new LinkedHashSet<>();
-            List<souther.compiler.coverage.CoverageSites.Site> owed = new ArrayList<>();
-            for (souther.compiler.coverage.CoverageSites.Site site : all) {
-                boolean proven = reachable.provenUnreachable(site.index());
-                if (proven && covered.contains(site.index())) {
-                    contradicted.add(site.index());
-                }
-                if (!proven || contradicted.contains(site.index())) {
-                    owed.add(site);
-                }
-            }
+            List<souther.compiler.coverage.CoverageSites.Site> owed = all.stream()
+                    .filter(site -> !reachable.reachable().provenUnreachable(site.index())).toList();
             Set<Integer> counted = new LinkedHashSet<>(covered);
             counted.retainAll(owed.stream()
                     .map(souther.compiler.coverage.CoverageSites.Site::index).toList());
-            return new BranchEvidence(owed, counted, contradicted, status, null);
+            // A proof a row has already disproved is not something to report a complete measurement
+            // over. What is wrong is this analysis, not the model's rows, and a number given as though
+            // nothing had happened is the one thing that must not come out of it.
+            return new BranchEvidence(owed, counted, reachable.contradicted(),
+                    reachable.contradicted().isEmpty() ? status : MeasurementStatus.PARTIAL, null);
         }
 
         public BranchEvidence {
@@ -619,8 +672,7 @@ public final class Adequacy {
                 }
             }
 
-            Map<String, souther.compiler.partition.GuardReachability> reachable =
-                    db.ask(new Reachable(name)).value();
+            Map<String, Effective> reachable = db.ask(new Reached(name)).value();
 
             Map<String, BranchEvidence> out = new LinkedHashMap<>();
             for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
@@ -642,9 +694,8 @@ public final class Adequacy {
                 boolean partial = !observed.complete() || observed.rows().stream()
                         .anyMatch(row -> row.disposition() == Disposition.INCOMPLETE);
                 out.put(behavior.name(), BranchEvidence.measured(arms, covered,
-                        reachable == null ? souther.compiler.partition.GuardReachability.NONE
-                                : reachable.getOrDefault(behavior.name(),
-                                        souther.compiler.partition.GuardReachability.NONE),
+                        reachable == null ? NOTHING_PROVEN
+                                : reachable.getOrDefault(behavior.name(), NOTHING_PROVEN),
                         partial ? MeasurementStatus.PARTIAL : MeasurementStatus.COMPLETE));
             }
             return Answer.of(Ordered.map(out));
@@ -1331,12 +1382,12 @@ public final class Adequacy {
                                         List<String> parameters, Exclusions excluded,
                                         souther.compiler.core.Core body,
                                         souther.compiler.coverage.CoverageSites.Plan plan,
-                                        souther.compiler.partition.GuardReachability reachable) {
+                                        Effective reachable) {
         List<RowOutcome> rows = seen.rows();
         // The cases the output type has, less the ones only an arm nothing reaches produces. A case
         // no reachable producer answers with is not a gap in the rows.
         Set<TypeName> declaredOut = souther.compiler.partition.ProducedCases.of(
-                body, plan, reachable, coverableCases(sig.outputType(), symbols));
+                body, plan, reachable.reachable(), coverableCases(sig.outputType(), symbols));
         Set<TypeName> specified = new LinkedHashSet<>();
         Set<TypeName> observed = new LinkedHashSet<>();
         Set<TypeName> verified = new LinkedHashSet<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -270,6 +270,16 @@ public final class Adequacy {
             }
             Map<String, Observed> byTarget = rowsOf(db, name);
             Map<String, Exclusions> excluded = db.ask(new Excluded(name)).value();
+            // What each body can answer with, so that a case only an unreachable arm produces is not
+            // counted. Read from the same reachability the arms are counted by.
+            souther.compiler.check.TypeChecker.Checked checkedBodies =
+                    db.ask(new Bodies.Checked(name)).value();
+            Map<String, souther.compiler.core.Core> producing =
+                    checkedBodies == null ? Map.of() : checkedBodies.behaviorBodies();
+            souther.compiler.coverage.CoverageSites.Plan producingPlan =
+                    souther.compiler.coverage.CoverageSites.of(
+                            Coverage.sourceIdOf(db, name), producing);
+            Map<String, souther.compiler.partition.GuardReachability> reachableArms = db.ask(new Reachable(name)).value();
             Map<String, SignatureEvidence> out = new LinkedHashMap<>();
             for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
                 Sig sig = sigs.value().get(behavior.name());
@@ -281,7 +291,10 @@ public final class Adequacy {
                         behavior instanceof Ast.SpecBehavior spec ? spec.params().stream()
                                 .map(Ast.Param::name).toList() : List.of(),
                         excluded == null ? Exclusions.NONE
-                                : excluded.getOrDefault(behavior.name(), Exclusions.NONE)));
+                                : excluded.getOrDefault(behavior.name(), Exclusions.NONE),
+                        producing.get(behavior.name()), producingPlan,
+                        reachableArms == null ? souther.compiler.partition.GuardReachability.NONE
+                                : reachableArms.getOrDefault(behavior.name(), souther.compiler.partition.GuardReachability.NONE)));
             }
             return Answer.of(Ordered.map(out));
         }
@@ -1315,9 +1328,15 @@ public final class Adequacy {
      *                   at an input position is matched to the position this counts
      */
     static SignatureEvidence evidenceOf(Sig sig, Symbols symbols, Observed seen,
-                                        List<String> parameters, Exclusions excluded) {
+                                        List<String> parameters, Exclusions excluded,
+                                        souther.compiler.core.Core body,
+                                        souther.compiler.coverage.CoverageSites.Plan plan,
+                                        souther.compiler.partition.GuardReachability reachable) {
         List<RowOutcome> rows = seen.rows();
-        Set<TypeName> declaredOut = coverableCases(sig.outputType(), symbols);
+        // The cases the output type has, less the ones only an arm nothing reaches produces. A case
+        // no reachable producer answers with is not a gap in the rows.
+        Set<TypeName> declaredOut = souther.compiler.partition.ProducedCases.of(
+                body, plan, reachable, coverableCases(sig.outputType(), symbols));
         Set<TypeName> specified = new LinkedHashSet<>();
         Set<TypeName> observed = new LinkedHashSet<>();
         Set<TypeName> verified = new LinkedHashSet<>();

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -182,6 +182,70 @@ public final class Adequacy {
     }
 
     /**
+     * The arms of every behavior of one module that the model's own rules prove nothing reaches.
+     *
+     * <p>Asked once, for the same reason {@link Excluded} is: what a position is divided into, which
+     * lines are owed a row, which arms are owed a row and which cases the signature is owed are
+     * projections of one universe of possible executions. Derived per measure they disagreed — the
+     * class beyond a cap was dropped while the arm behind it was still asked for.
+     *
+     * <p>A guard whose comparison this cannot read leaves both of its arms owed, and so does a position
+     * nothing bounds. Only a proof takes an arm away.
+     */
+    public record Reachable(String name)
+            implements Key<Map<String, souther.compiler.partition.GuardReachability>> {
+
+        @Override
+        public String module() {
+            return name;
+        }
+
+        @Override
+        public Answer<Map<String, souther.compiler.partition.GuardReachability>> compute(Db db) {
+            Answer<Ast.Module> prepared = db.ask(new Shapes.Prepared(name));
+            Answer<Symbols> scope = db.ask(new Shapes.Scope(name));
+            Answer<Map<String, Sig>> sigs = db.ask(new Bodies.Signatures(name));
+            if (!prepared.present() || !scope.present() || !sigs.present()) {
+                return Answer.absent();
+            }
+            souther.compiler.check.TypeChecker.Checked checked =
+                    db.ask(new Bodies.Checked(name)).value();
+            Map<String, souther.compiler.core.Core> bodies =
+                    checked == null ? Map.of() : checked.behaviorBodies();
+            souther.compiler.coverage.CoverageSites.Plan plan =
+                    souther.compiler.coverage.CoverageSites.of(
+                            Coverage.sourceIdOf(db, name), bodies);
+            Map<String, Exclusions> excluded = db.ask(new Excluded(name)).value();
+            Symbols symbols = scope.value();
+            Map<String, souther.compiler.partition.GuardReachability> out = new LinkedHashMap<>();
+            for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
+                if (!(behavior instanceof Ast.SpecBehavior spec)) {
+                    continue;   // a composition has no body of its own, so no arms of its own
+                }
+                souther.compiler.core.Core body = bodies.get(spec.name());
+                Sig sig = sigs.value().get(spec.name());
+                if (body == null || sig == null) {
+                    continue;
+                }
+                List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
+                souther.compiler.partition.GuardThresholds.Guards guards =
+                        souther.compiler.partition.GuardThresholds.of(
+                                spec.name(), body, plan, parameters, symbols);
+                // What the positions can hold, read before any threshold is applied: a guard's own line
+                // is not what says whether that line is reachable.
+                Map<String, souther.compiler.numeric.NumericDomain.Bounds> admissible =
+                        souther.compiler.partition.Partitions.of(spec, sig, symbols,
+                                excluded == null ? Exclusions.NONE
+                                        : excluded.getOrDefault(spec.name(), Exclusions.NONE))
+                                .domains();
+                out.put(spec.name(), souther.compiler.partition.GuardReachability.of(
+                        guards.edges(), admissible));
+            }
+            return Answer.of(Ordered.map(out));
+        }
+    }
+
+    /**
      * The signature evidence for every behavior of one module.
      *
      * <p>A module's question, not a source's, although the rows are evaluated per source. A behavior's
@@ -406,11 +470,20 @@ public final class Adequacy {
      * conditions is four arms and says nothing about whether their combinations were tried, so nothing
      * here calls this covering the paths a body has.
      *
-     * @param all     every arm the behavior has
+     * @param all     every arm the behavior is owed a row for. An arm the model's own rules prove
+     *                nothing reaches is not one of them: it is instrumented, because a probe is what
+     *                would show the proof wrong, and it is not owed, because no row can light it.
+     *                Which arms those are is {@link GuardReachability}'s answer, asked once for the
+     *                module and read by every measure.
      * @param covered the ones a row went through
+     * @param contradicted arms proven unreachable that a row went through anyway. Nothing in the model
+     *                is wrong here — the proof is. Kept rather than dropped, and the arm is left in
+     *                {@link #all} beside it, because a measure that quietly counted such an arm as
+     *                covered would report a full denominator and hide the one fact worth acting on.
      */
     public record BranchEvidence(List<souther.compiler.coverage.CoverageSites.Site> all,
-                                 Set<Integer> covered, MeasurementStatus status, Reason reason) {
+                                 Set<Integer> covered, Set<Integer> contradicted,
+                                 MeasurementStatus status, Reason reason) {
 
         /**
          * Why a behavior's arms have no number, in the order the measurement asks.
@@ -435,17 +508,42 @@ public final class Adequacy {
         }
 
         public static BranchEvidence unavailable(Reason reason) {
-            return new BranchEvidence(List.of(), Set.of(), MeasurementStatus.UNAVAILABLE, reason);
+            return new BranchEvidence(List.of(), Set.of(), Set.of(),
+                    MeasurementStatus.UNAVAILABLE, reason);
         }
 
+        /**
+         * The arms of one behavior, with the ones nothing reaches taken out of what it is owed.
+         *
+         * <p>Taken out here and not where the probes are numbered. The plan says where instrumentation
+         * is; this says which of it is owed a row, and the two are different questions — a site with no
+         * probe could never disprove the reachability it was excluded by.
+         */
         public static BranchEvidence measured(List<souther.compiler.coverage.CoverageSites.Site> all,
-                                              Set<Integer> covered, MeasurementStatus status) {
-            return new BranchEvidence(all, covered, status, null);
+                                              Set<Integer> covered,
+                                              souther.compiler.partition.GuardReachability reachable,
+                                              MeasurementStatus status) {
+            Set<Integer> contradicted = new LinkedHashSet<>();
+            List<souther.compiler.coverage.CoverageSites.Site> owed = new ArrayList<>();
+            for (souther.compiler.coverage.CoverageSites.Site site : all) {
+                boolean proven = reachable.provenUnreachable(site.index());
+                if (proven && covered.contains(site.index())) {
+                    contradicted.add(site.index());
+                }
+                if (!proven || contradicted.contains(site.index())) {
+                    owed.add(site);
+                }
+            }
+            Set<Integer> counted = new LinkedHashSet<>(covered);
+            counted.retainAll(owed.stream()
+                    .map(souther.compiler.coverage.CoverageSites.Site::index).toList());
+            return new BranchEvidence(owed, counted, contradicted, status, null);
         }
 
         public BranchEvidence {
             all = List.copyOf(all);
             covered = Set.copyOf(covered);
+            contradicted = Set.copyOf(contradicted);
             Unavailable.check(status, reason);
         }
 
@@ -508,6 +606,9 @@ public final class Adequacy {
                 }
             }
 
+            Map<String, souther.compiler.partition.GuardReachability> reachable =
+                    db.ask(new Reachable(name)).value();
+
             Map<String, BranchEvidence> out = new LinkedHashMap<>();
             for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
                 List<souther.compiler.coverage.CoverageSites.Site> arms = plan.sites().stream()
@@ -528,6 +629,9 @@ public final class Adequacy {
                 boolean partial = !observed.complete() || observed.rows().stream()
                         .anyMatch(row -> row.disposition() == Disposition.INCOMPLETE);
                 out.put(behavior.name(), BranchEvidence.measured(arms, covered,
+                        reachable == null ? souther.compiler.partition.GuardReachability.NONE
+                                : reachable.getOrDefault(behavior.name(),
+                                        souther.compiler.partition.GuardReachability.NONE),
                         partial ? MeasurementStatus.PARTIAL : MeasurementStatus.COMPLETE));
             }
             return Answer.of(Ordered.map(out));

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -273,10 +273,11 @@ final class Coverages {
      */
     static List<BoundaryAssessment> assess(
             Axis axis, List<String> parameters, souther.compiler.query.Adequacy.Observed observed,
-            Symbols symbols, boolean armsAsked, boolean knownWritable, Probe probe) {
+            Symbols symbols, boolean armsAsked, boolean knownWritable, Probe probe,
+            souther.compiler.numeric.NumericDomain.Bounds within) {
         List<RowOutcome> rows = observed.rows();
         List<BoundaryAssessment> out = new ArrayList<>();
-        for (BoundaryObligation each : Partitions.obligationsOf(axis, symbols)) {
+        for (BoundaryObligation each : Partitions.obligationsOf(axis, symbols, within)) {
             BoundaryAssessment.Coverage coverage =
                     coverageOf(each, axis, parameters, observed, armsAsked);
             BoundaryAssessment.Attempt attempt = attemptAt(each, coverage, probe);

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -49,7 +49,8 @@ final class Coverages {
             return partitioning;
         }
         return Partitions.withThresholds(partitioning,
-                GuardThresholds.of(behavior.name(), body, plan, parameters, symbols), symbols);
+                GuardThresholds.of(behavior.name(), body, plan, parameters, symbols).thresholds(),
+                symbols);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -168,6 +168,54 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
     }
 
     /**
+     * An end only the record imposes rules out a line beyond it as much as one the type repeats.
+     *
+     * <p>Above, both fields carry an end of their own and the record moves one of them. Here
+     * {@code Count} bounds its value below and nothing above, and the cap on {@code b} is written on
+     * the record alone. What a position can hold is the whole of what its rules leave it, whichever
+     * of them said so — read off the type's own ends, the cap is invisible, and a guard at 50 is left
+     * dividing a range that stops at 10.
+     */
+    @Test
+    void anEndOnlyTheRecordImposesRulesOutALineBeyondIt() throws Exception {
+        String report = reportOn("""
+                module example.capped
+
+                data Count = Int
+                    invariant lower = value >= 0
+
+                data Pair =
+                    { a: Count
+                    , b: Count
+                    }
+                    invariant cap = b <= 10
+                    invariant ordered = a < b
+
+                data Small
+                data Big
+
+                behavior classify : (pair: Pair) -> Small | Big
+                    constructs Small, Big
+
+                let classify (pair) =
+                    if pair.b.value >= 50
+                        then Big
+                        else Small
+                """, "--generate", "--boundaries");
+
+        assertFalse(report.contains("pair.b = 50"),
+                () -> "no pair holds a `b` of 50, so the guard draws no line there:\n" + report);
+        assertFalse(report.contains("pair.b = 49"),
+                () -> "and none holds the value below it either:\n" + report);
+        assertFalse(report.contains("pair.b=50 <= x"),
+                () -> "a class nothing can be in is not a class:\n" + report);
+        assertTrue(report.contains("pair.b = 1"),
+                () -> "the end the record moved is still asked for:\n" + report);
+        assertFalse(report.contains("every value tried was refused"),
+                () -> "and everything left is writable:\n" + report);
+    }
+
+    /**
      * A row filling a class picks the rest of the record beside the value it settled on.
      *
      * <p>The boundary filler and the class filler are two searches over one record, and only one of

--- a/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -216,6 +216,40 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
     }
 
     /**
+     * A guard at the end of what a position holds is a line, and the step off it is not a row.
+     *
+     * <p>The neighbour is invented rather than read: a guard has values on both sides, so the class
+     * beyond it wants its own edge. Where the guard sits at the end of the range there is no class
+     * beyond it, and the neighbour is a value the type refuses. The line itself stays owed — a row
+     * written at it reaches the comparison, which is what a guard's boundary is about.
+     */
+    @Test
+    void aStepOffTheEndOfTheRangeIsNotABoundary() throws Exception {
+        List<String> asked = boundariesOf("""
+                module example.floor
+
+                data Level = Int
+                    invariant lower = value >= 10
+
+                data Answer = { n: Int }
+
+                behavior classify : (level: Level) -> Answer
+                    constructs Answer
+
+                let classify (level) =
+                    if level.value < 10 then Answer { n = 1 } else Answer { n = 2 }
+
+                example classify
+                    | "twenty" : (Level(20)) -> Answer { n = 2 }
+                """);
+
+        assertTrue(asked.stream().anyMatch(l -> l.contains("level = 10")),
+                () -> "the line is still owed a row: " + asked);
+        assertFalse(asked.stream().anyMatch(l -> l.contains("level = 9")),
+                () -> "and no level is 9, so no row can be written there: " + asked);
+    }
+
+    /**
      * A row filling a class picks the rest of the record beside the value it settled on.
      *
      * <p>The boundary filler and the class filler are two searches over one record, and only one of

--- a/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AMeasureWithNoNumberSaysWhyTest.java
@@ -369,10 +369,11 @@ class AMeasureWithNoNumberSaysWhyTest {
     @Test
     void aMeasureCannotBeBuiltWithoutKeepingThatContract() {
         assertThrows(IllegalArgumentException.class, () -> new Adequacy.BranchEvidence(
-                List.of(), java.util.Set.of(), MeasurementStatus.UNAVAILABLE, null));
+                List.of(), java.util.Set.of(), java.util.Set.of(),
+                MeasurementStatus.UNAVAILABLE, null));
         assertThrows(IllegalArgumentException.class, () -> new Adequacy.BranchEvidence(
-                List.of(), java.util.Set.of(), MeasurementStatus.COMPLETE,
-                Adequacy.BranchEvidence.Reason.NO_BODY));
+                List.of(), java.util.Set.of(), java.util.Set.of(),
+                MeasurementStatus.COMPLETE, Adequacy.BranchEvidence.Reason.NO_BODY));
         assertThrows(IllegalArgumentException.class, () -> new PartitionEvidence.AxisCoverage(
                 "a", "a", List.of(), java.util.Set.of(), List.of(), 0,
                 MeasurementStatus.UNAVAILABLE, null));

--- a/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
@@ -1,0 +1,134 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A rule relating two positions is met by choosing one of them knowing the other.
+ *
+ * <p>Every position took its value from what the rules leave it on its own, and the search then went
+ * through the product of those lists. A clause relating two of them was satisfied only where the
+ * lists happened to already hold a pair that does — so two bare {@code Int}s under {@code a < b} were
+ * offered a zero each, and the one assignment there was is the one the record refuses. Nothing about
+ * it is a boundary, a newtype or a decimal: it is ordinary partition fill finding no row at all.
+ */
+class APairIsChosenOnePositionAtATimeTest {
+
+    private static String rowsFor(String clauses) throws Exception {
+        String model = """
+                module example.paired
+
+                data R =
+                    { a: Int
+                    , b: Int
+                    }
+                    invariant ordered = CLAUSE
+
+                data Ok
+
+                behavior f : (r: R, flag: Bool) -> Ok
+                    constructs Ok
+
+                let f (r, flag) = Ok
+                """.replace("CLAUSE", clauses);
+        Path file = Files.createTempDirectory("souther-paired").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--generate", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void twoFieldsAnOrderingRelatesAreFilledInThatOrder() throws Exception {
+        String rows = rowsFor("a < b");
+
+        assertTrue(rows.contains("R { a = 0, b = 1 }"),
+                () -> "0 leaves 1 for the other end:\n" + rows);
+        assertFalse(rows.contains("every value tried was refused"), () -> rows);
+    }
+
+    /**
+     * The reason widening the lists is not the answer.
+     *
+     * <p>No pair drawn from two lists chosen in ignorance of each other satisfies this, however many
+     * values each list holds. Asserting the first choice into the domain leaves the second bounded at
+     * 101, and there is only ever one list to draw from.
+     */
+    @Test
+    void aRelationWithAnOffsetIsMetTheSameWay() throws Exception {
+        String rows = rowsFor("a + 100 < b");
+
+        assertTrue(rows.contains("R { a = 0, b = 101 }"),
+                () -> "101 is the least `b` a zero leaves:\n" + rows);
+    }
+
+    /** Nothing is invented for a relation this cannot read. The rows stay unfilled and the report says
+     * what it always said about them. */
+    @Test
+    void aRelationOutsideWhatTheDomainHoldsFillsNothing() throws Exception {
+        String rows = rowsFor("a * b < 10");
+
+        assertTrue(rows.contains("R { a = 0, b = 0 }"),
+                () -> "the pair each field's own range offers, which this one happens to admit:\n"
+                        + rows);
+    }
+
+    /**
+     * A dense strict bound is a different gap.
+     *
+     * <p>Choosing {@code low} first leaves {@code high} at zero and above, because {@code low < high}
+     * over the decimals is recorded as {@code low - high <= 0} — so the one value the rule refuses is
+     * the one the projection offers. No amount of choosing in order reaches past that, which is why
+     * the openness of an end is tracked separately (#483).
+     */
+    @Test
+    void aStrictBoundOverDecimalsIsNotClosedByChoosingInOrder() throws Exception {
+        String model = """
+                module example.band
+
+                data Ratio = Decimal
+                    invariant range = value >= 0.0m && value <= 1.0m
+
+                data Band =
+                    { low: Ratio
+                    , high: Ratio
+                    }
+                    invariant ordered = low < high
+
+                data Ok
+
+                behavior f : (band: Band, flag: Bool) -> Ok
+                    constructs Ok
+
+                let f (band, flag) = Ok
+                """;
+        Path file = Files.createTempDirectory("souther-band").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--generate", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        String rows = out.toString(StandardCharsets.UTF_8);
+
+        assertTrue(rows.contains("every value tried was refused"),
+                () -> "still nothing here, and it is the bound that is approximate:\n" + rows);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
@@ -92,7 +92,7 @@ class APairIsChosenOnePositionAtATimeTest {
      *
      * <p>Choosing {@code low} first leaves {@code high} at zero and above, because {@code low < high}
      * over the decimals is recorded as {@code low - high <= 0} — so the end the projection offers is
-     * the one value the rule refuses. What gets past it is a second value inside the range, and the
+     * the one value the rule refuses. What gets past it is a second value from the range, and the
      * ends themselves stay where they were: the report still cannot say that a {@code high} of zero
      * is impossible rather than untried, because the bound it would have to read that off is the
      * weakened one (#483).
@@ -130,9 +130,8 @@ class APairIsChosenOnePositionAtATimeTest {
         }
         String rows = out.toString(StandardCharsets.UTF_8);
 
-        assertTrue(rows.contains("high = Ratio(0.5m)"),
-                () -> "a value between the ends, which the range names and an epsilon would not:\n"
-                        + rows);
+        assertTrue(rows.contains("high = Ratio(1m)"),
+                () -> "the far end of what `high` can hold, which the range names:\n" + rows);
         assertTrue(rows.contains("no row for `band.high = 0`"),
                 () -> "and the end itself is still where nothing can be written:\n" + rows);
     }

--- a/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
@@ -88,15 +88,17 @@ class APairIsChosenOnePositionAtATimeTest {
     }
 
     /**
-     * A dense strict bound is a different gap.
+     * A dense strict bound is reached by a value off the end, and not by the order of choosing.
      *
      * <p>Choosing {@code low} first leaves {@code high} at zero and above, because {@code low < high}
-     * over the decimals is recorded as {@code low - high <= 0} — so the one value the rule refuses is
-     * the one the projection offers. No amount of choosing in order reaches past that, which is why
-     * the openness of an end is tracked separately (#483).
+     * over the decimals is recorded as {@code low - high <= 0} — so the end the projection offers is
+     * the one value the rule refuses. What gets past it is a second value inside the range, and the
+     * ends themselves stay where they were: the report still cannot say that a {@code high} of zero
+     * is impossible rather than untried, because the bound it would have to read that off is the
+     * weakened one (#483).
      */
     @Test
-    void aStrictBoundOverDecimalsIsNotClosedByChoosingInOrder() throws Exception {
+    void aStrictBoundOverDecimalsIsReachedOffTheEnd() throws Exception {
         String model = """
                 module example.band
 
@@ -122,13 +124,16 @@ class APairIsChosenOnePositionAtATimeTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
         try {
-            Main.main(new String[] {"examples", "--generate", file.toString()});
+            Main.main(new String[] {"examples", "--generate", "--boundaries", file.toString()});
         } finally {
             System.setOut(was);
         }
         String rows = out.toString(StandardCharsets.UTF_8);
 
-        assertTrue(rows.contains("every value tried was refused"),
-                () -> "still nothing here, and it is the bound that is approximate:\n" + rows);
+        assertTrue(rows.contains("high = Ratio(0.5m)"),
+                () -> "a value between the ends, which the range names and an epsilon would not:\n"
+                        + rows);
+        assertTrue(rows.contains("no row for `band.high = 0`"),
+                () -> "and the end itself is still where nothing can be written:\n" + rows);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
@@ -136,6 +136,51 @@ class APairIsChosenOnePositionAtATimeTest {
     }
 
     /**
+     * Spending the last of the bound is not being short of it.
+     *
+     * <p>Eight positions of two values each is exactly what the search is allowed to compose. Every
+     * one of them is refused, and every one of them was tried — so what the reader is owed is that
+     * nothing here builds, and not that the search gave up one assignment early.
+     */
+    @Test
+    void aSearchThatSpentItsLastAssignmentSaysEverythingWasRefused() throws Exception {
+        StringBuilder fields = new StringBuilder("    { a1: Int\n");
+        for (int i = 2; i <= 8; i++) {
+            fields.append("    , a").append(i).append(": Int\n");
+        }
+        String model = """
+                module example.exact
+
+                data R =
+                FIELDS    }
+                    invariant rule = a1 * a2 >= 5
+
+                data Ok
+
+                behavior f : (r: R, flag: Bool) -> Ok
+                    constructs Ok
+
+                let f (r, flag) = Ok
+                """.replace("FIELDS", fields.toString());
+        Path file = Files.createTempDirectory("souther-exact").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--generate", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        String rows = out.toString(StandardCharsets.UTF_8);
+
+        assertTrue(rows.contains("every value tried was refused"),
+                () -> "256 assignments, all composed and all refused:\n" + rows);
+        assertFalse(rows.contains("the search stopped before reaching it"),
+                () -> "and none of them was left untried:\n" + rows);
+    }
+
+    /**
      * A dense strict bound is reached by a value off the end, and not by the order of choosing.
      *
      * <p>Choosing {@code low} first leaves {@code high} at zero and above, because {@code low < high}

--- a/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
@@ -88,6 +88,54 @@ class APairIsChosenOnePositionAtATimeTest {
     }
 
     /**
+     * A search that stopped at its bound has not tried everything it had.
+     *
+     * <p>Eleven positions, each with a hole in its range, and the assignment that satisfies all of
+     * them is the last the walk would reach. What the reader is owed is which of the two happened:
+     * that everything was refused is a stronger claim than that the search ran out, and it is the one
+     * a later reader would take for an impossibility.
+     */
+    @Test
+    void aSearchThatRanOutSaysSoRatherThanThatEverythingWasRefused() throws Exception {
+        StringBuilder fields = new StringBuilder("    { a1: Int\n");
+        StringBuilder rule = new StringBuilder("a1 /= 0");
+        for (int i = 2; i <= 11; i++) {
+            fields.append("    , a").append(i).append(": Int\n");
+            rule.append(" && a").append(i).append(" /= 0");
+        }
+        String model = """
+                module example.budget
+
+                data R =
+                FIELDS    }
+                    invariant rule = RULE
+
+                data Ok
+
+                behavior f : (r: R, flag: Bool) -> Ok
+                    constructs Ok
+
+                let f (r, flag) = Ok
+                """.replace("FIELDS", fields.toString()).replace("RULE", rule.toString());
+        Path file = Files.createTempDirectory("souther-budget").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--generate", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        String rows = out.toString(StandardCharsets.UTF_8);
+
+        assertTrue(rows.contains("the search stopped before reaching it"),
+                () -> "it ran out of assignments to compose:\n" + rows);
+        assertFalse(rows.contains("every value tried was refused"),
+                () -> "and it did not try them all:\n" + rows);
+    }
+
+    /**
      * A dense strict bound is reached by a value off the end, and not by the order of choosing.
      *
      * <p>Choosing {@code low} first leaves {@code high} at zero and above, because {@code low < high}

--- a/souther-compiler/src/test/java/souther/compiler/APositionOffersASecondValueWhereItsRangeIsApproximateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APositionOffersASecondValueWhereItsRangeIsApproximateTest.java
@@ -1,0 +1,135 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * One value is enough only where the range a position is chosen from is the whole of its rules.
+ *
+ * <p>Three ways it is not. A disequality is a hole no range keeps; a form that is neither an interval
+ * nor a difference is not recorded at all; a strict bound over the decimals is recorded as the
+ * non-strict one. In each of them the end a projection names can be the one value the rules refuse,
+ * and a position offering only that has nothing left to try — however the choosing is ordered, because
+ * ordering it changes which range is read and not how many values come out of one.
+ */
+class APositionOffersASecondValueWhereItsRangeIsApproximateTest {
+
+    private static String rowsFor(String clause) throws Exception {
+        String model = """
+                module example.approximate
+
+                data R =
+                    { a: Int
+                    , b: Int
+                    }
+                    invariant rule = CLAUSE
+
+                data Ok
+
+                behavior f : (r: R, flag: Bool) -> Ok
+                    constructs Ok
+
+                let f (r, flag) = Ok
+                """.replace("CLAUSE", clause);
+        Path file = Files.createTempDirectory("souther-approximate").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--generate", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    /** A hole in a range, which a range cannot hold. The projection says nothing, so the position is
+     * offered the zero it would have been offered anyway, and the rule refuses exactly that. */
+    @Test
+    void aDisequalityIsMetByTheValueBesideTheHole() throws Exception {
+        String rows = rowsFor("a /= 0");
+
+        assertTrue(rows.contains("a = 1"), () -> "one step off the value the rule rules out:\n" + rows);
+        assertFalse(rows.contains("every value tried was refused"), () -> rows);
+    }
+
+    /** The same where the bound is real and the hole sits on it. */
+    @Test
+    void aHoleOnTheEndOfARangeIsSteppedOff() throws Exception {
+        String rows = rowsFor("a >= 0 && a /= 0");
+
+        assertTrue(rows.contains("a = 1"), () -> rows);
+        assertFalse(rows.contains("every value tried was refused"), () -> rows);
+    }
+
+    /** A sum of two atoms is neither an interval nor a difference, so nothing about it reaches the
+     * range either position is chosen from. */
+    @Test
+    void aFormTheDomainCannotHoldIsMetByTheSecondValue() throws Exception {
+        String rows = rowsFor("a + b >= 1");
+
+        assertTrue(rows.contains("R { a = 0, b = 1 }"), () -> rows);
+        assertFalse(rows.contains("every value tried was refused"), () -> rows);
+    }
+
+    /** A product needs both positions off their ends, which is what a search rather than a rule does. */
+    @Test
+    void aProductNeedsBothPositionsMoved() throws Exception {
+        String rows = rowsFor("a * b >= 1");
+
+        assertTrue(rows.contains("R { a = 1, b = 1 }"), () -> rows);
+    }
+
+    /**
+     * A decimal gets a second value only between two ends.
+     *
+     * <p>A whole number has a next one. A decimal does not, and an epsilon is a value the type does
+     * not name — inventing one would propose a row against a rule the model never stated. Between two
+     * ends there is an ordinary decimal, and that is the only second value there is to give.
+     */
+    @Test
+    void aDecimalWithOneEndKeepsTheOneValueItHas() throws Exception {
+        String model = """
+                module example.halfopen
+
+                data Rate = Decimal
+                    invariant lower = value >= 0.0m
+
+                data Pair =
+                    { low: Rate
+                    , high: Rate
+                    }
+                    invariant ordered = low < high
+
+                data Ok
+
+                behavior f : (pair: Pair, flag: Bool) -> Ok
+                    constructs Ok
+
+                let f (pair, flag) = Ok
+                """;
+        Path file = Files.createTempDirectory("souther-halfopen").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--generate", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        String rows = out.toString(StandardCharsets.UTF_8);
+
+        assertTrue(rows.contains("every value tried was refused"),
+                () -> "nothing above zero is named by a range that only starts there:\n" + rows);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/APositionOffersASecondValueWhereItsRangeIsApproximateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APositionOffersASecondValueWhereItsRangeIsApproximateTest.java
@@ -90,6 +90,49 @@ class APositionOffersASecondValueWhereItsRangeIsApproximateTest {
     }
 
     /**
+     * A bare decimal between two ends is offered the one between them.
+     *
+     * <p>A newtype holds its far end back for the search that runs before this one; a bare number has
+     * no such reserve, and the end it is offered first is the one a weakened strict bound puts it at.
+     * The midpoint is an ordinary decimal the range names.
+     */
+    @Test
+    void aBareDecimalIsOfferedTheValueBetweenItsEnds() throws Exception {
+        String model = """
+                module example.bare
+
+                data R =
+                    { a: Decimal
+                    , b: Decimal
+                    }
+                    invariant aRange = a >= 0.0m && a <= 1.0m
+                    invariant bRange = b >= 0.0m && b <= 1.0m
+                    invariant ordered = a < b
+
+                data Ok
+
+                behavior f : (r: R, flag: Bool) -> Ok
+                    constructs Ok
+
+                let f (r, flag) = Ok
+                """;
+        Path file = Files.createTempDirectory("souther-bare").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--generate", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        String rows = out.toString(StandardCharsets.UTF_8);
+
+        assertTrue(rows.contains("R { a = 0m, b = 0.5m }"),
+                () -> "half way between the ends `b` has:\n" + rows);
+    }
+
+    /**
      * A decimal gets a second value only between two ends.
      *
      * <p>A whole number has a next one. A decimal does not, and an epsilon is a value the type does

--- a/souther-compiler/src/test/java/souther/compiler/AValueOfferedAtAPositionIsOneTheRecordLeavesItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AValueOfferedAtAPositionIsOneTheRecordLeavesItTest.java
@@ -1,0 +1,121 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A value offered at a position comes from what the record leaves that position.
+ *
+ * <p>A newtype's candidate has been read from there for a while. A bare {@code Int} or {@code Decimal}
+ * had not: every primitive branch answered from the type and returned before what was left of the
+ * position was looked at, so a field a clause bounds from below was offered a zero the record refuses
+ * and the row it was part of never built.
+ */
+class AValueOfferedAtAPositionIsOneTheRecordLeavesItTest {
+
+    private static String rowsFor(String model) throws Exception {
+        Path file = Files.createTempDirectory("souther-offered").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--generate", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    private static String model(String clauses, String field) {
+        return """
+                module example.offered
+
+                data R =
+                    { a: FIELD
+                    , b: FIELD
+                    }
+                CLAUSES
+
+                data Ok
+
+                behavior f : (r: R, flag: Bool) -> Ok
+                    constructs Ok
+
+                let f (r, flag) = Ok
+                """.replace("CLAUSES", clauses).replace("FIELD", field);
+    }
+
+    /**
+     * The projection exists and was being discarded.
+     *
+     * <p>{@code a >= 0} beside {@code a < b} leaves {@code b} at 1 and above. Read, the row builds;
+     * discarded, both fields are offered a zero and {@code a < b} refuses the only pair there was.
+     */
+    @Test
+    void aFieldTheRecordBoundsFromBelowIsOfferedAValueAboveIt() throws Exception {
+        String rows = rowsFor(model("""
+                    invariant lower = a >= 0
+                    invariant ordered = a < b""", "Int"));
+
+        assertTrue(rows.contains("R { a = 0, b = 1 }"),
+                () -> "1 is the least `b` a pair can hold:\n" + rows);
+        assertFalse(rows.contains("every value tried was refused"), () -> rows);
+    }
+
+    /** The same the other way up: a field capped below zero is offered the cap and not a zero it
+     * cannot hold. */
+    @Test
+    void aFieldTheRecordCapsBelowZeroIsOfferedTheCap() throws Exception {
+        String rows = rowsFor(model("""
+                    invariant negative = a <= -3
+                    invariant ordered = b < a""", "Int"));
+
+        assertTrue(rows.contains("a = -3"), () -> "the greatest `a` there is:\n" + rows);
+        assertFalse(rows.contains("every value tried was refused"), () -> rows);
+    }
+
+    /**
+     * A range that starts below zero starts where it starts.
+     *
+     * <p>Zero is a value both fields hold here, and offering it to both is what the pair refuses:
+     * `a < b` relates them and no value chosen for one in ignorance of the other satisfies it. The
+     * ends do, because they are a step apart — which is the low end of each, not a zero that happens
+     * to be inside both.
+     */
+    @Test
+    void aRangeThatStartsBelowZeroIsOfferedItsOwnStart() throws Exception {
+        String rows = rowsFor(model("""
+                    invariant span = a >= -10
+                    invariant ordered = a < b""", "Int"));
+
+        assertTrue(rows.contains("R { a = -10, b = -9 }"),
+                () -> "the pair the ends make:\n" + rows);
+    }
+
+    /** A decimal position is read the same way, and its end is not taken in to a whole number. */
+    @Test
+    void aDecimalFieldIsOfferedTheEndAsItIs() throws Exception {
+        String rows = rowsFor(model("""
+                    invariant lower = a >= 0.5m""", "Decimal"));
+
+        assertTrue(rows.contains("a = 0.5m"), () -> "0.5 is where the position starts:\n" + rows);
+    }
+
+    /** Nothing is offered from a range this cannot read, and the position keeps what it had. */
+    @Test
+    void aFieldNothingBoundsIsStillOfferedZero() throws Exception {
+        String rows = rowsFor(model("", "Int"));
+
+        assertTrue(rows.contains("R { a = 0, b = 0 }"), () -> rows);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
@@ -152,17 +152,17 @@ class AnArmNothingReachesIsNotOwedARowTest {
     }
 
     /**
-     * What a body may answer with is a fact about the body.
+     * A case nothing answers with is not the same as a case nothing can answer with.
      *
-     * <p>Two behaviors that can answer with the same cases are owed the same rows. Read only where a
-     * guard happens to be provable, adding an arm nothing reaches to a behavior would change what its
-     * signature is owed — a case would leave the denominator because a guard beside it was written,
-     * not because anything about the answers had changed.
+     * <p>What is taken away here is a case something does answer with, at a place the rules prove
+     * nothing reaches. A case the body has no producer for stays: that a signature says {@code A | B}
+     * and the implementation never answers `B` is a gap between the two, and it is the kind of gap
+     * this measure is for.
      */
     @Test
-    void aDeadGuardDoesNotChangeWhatTheSignatureIsOwed() throws Exception {
+    void onlyACaseSomethingAnswersWithBehindAProvenArmIsTakenAway() throws Exception {
         String model = """
-                module example.passthrough
+                module example.threeways
 
                 data N = Int
                     invariant cap = value <= 10
@@ -170,24 +170,26 @@ class AnArmNothingReachesIsNotOwedARowTest {
                 data A
                 data B
 
-                behavior f : (n: N, b: B) -> A | B
-                    constructs A
+                behavior f : (n: N) -> A | B
+                    constructs BUILDS
 
-                let f (n, b) = BODY
+                let f (n) = BODY
 
                 example f
-                    | "one" : (N(1), B) -> A
+                    | "one" : (N(1)) -> A
                 """;
-        String dead = reportOn(model.replace("BODY", "if n.value > 100 then b else A"));
-        String plain = reportOn(model.replace("BODY", "A"));
-        String live = reportOn(model.replace("BODY", "if n.value > 5 then b else A"));
+        String dead = reportOn(model.replace("BODY", "if n.value > 100 then B else A")
+                .replace("BUILDS", "A, B"));
+        String none = reportOn(model.replace("BODY", "A").replace("BUILDS", "A"));
+        String live = reportOn(model.replace("BODY", "if n.value > 5 then B else A")
+                .replace("BUILDS", "A, B"));
 
         assertTrue(dead.contains("out specified 1/1"),
-                () -> "no pair holds an `n` above 100, so nothing here answers `B`:\n" + dead);
-        assertTrue(plain.contains("out specified 1/1"),
-                () -> "and the same body without the guard answers the same cases:\n" + plain);
+                () -> "`B` is answered only where nothing reaches:\n" + dead);
+        assertTrue(none.contains("out specified 1/2"),
+                () -> "nothing answers `B` here, which is a gap and not an impossibility:\n" + none);
         assertTrue(live.contains("out specified 1/2"),
-                () -> "where the guard is one a row can take, `B` is owed again:\n" + live);
+                () -> "and here a row can take the arm that answers it:\n" + live);
     }
 
     // --- what happens if the proof is wrong -------------------------------------------------------

--- a/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
@@ -1,0 +1,149 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.observe.MeasurementStatus;
+import souther.compiler.partition.GuardEdge;
+import souther.compiler.partition.GuardReachability;
+import souther.compiler.partition.TermPath;
+import souther.compiler.query.Adequacy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An arm the model's own rules prove nothing reaches is not a row anybody is owed.
+ *
+ * <p>The cap on {@code b} is written on the record, so {@code Count} alone says nothing about it and a
+ * guard at 50 sits outside what any pair can hold. What a position is divided into and which lines are
+ * owed a row already knew that; the arms did not, and a report asking for a row through an arm nothing
+ * can reach is asking for work nobody can do.
+ *
+ * <p>Instrumented is not the same as owed. The probe on that arm stays, because a probe is the only
+ * thing that could show the reachability wrong.
+ */
+class AnArmNothingReachesIsNotOwedARowTest {
+
+    private static final String CAPPED = """
+            module example.capped
+
+            data Count = Int
+                invariant lower = value >= 0
+
+            data Pair =
+                { a: Count
+                , b: Count
+                }
+                invariant cap = b <= 10
+                invariant ordered = a < b
+
+            data Small
+            data Big
+
+            behavior classify : (pair: Pair) -> Small | Big
+                constructs Small, Big
+
+            let classify (pair) =
+                if pair.b.value >= 50
+                    then Big
+                    else Small
+
+            example classify
+                | "small" : (Pair { a = Count(0), b = Count(1) }) -> Small
+            """;
+
+    private static String reportOn(String model) throws Exception {
+        Path file = Files.createTempDirectory("souther-arms").resolve("model.sou");
+        Files.writeString(file, model);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", "--boundaries", file.toString()});
+        } finally {
+            System.setOut(was);
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void anArmBeyondTheRecordsCapIsNotCounted() throws Exception {
+        String report = reportOn(CAPPED);
+
+        assertTrue(report.contains("branch      1/1"),
+                () -> "the `else` arm is the only one a pair can take:\n" + report);
+        assertFalse(report.contains("no row goes through"),
+                () -> "and it was taken:\n" + report);
+    }
+
+    /** The same guard one value lower, which a pair can hold. Without this the assertion above would
+     * pass on a measure that had stopped counting arms at all. */
+    @Test
+    void anArmWithinItStillIs() throws Exception {
+        String report = reportOn(CAPPED.replace("pair.b.value >= 50", "pair.b.value >= 5"));
+
+        assertTrue(report.contains("branch      1/2"),
+                () -> "a `b` of 5 is a value some pair holds, so both arms are owed:\n" + report);
+        assertTrue(report.contains("no row goes through `then`"),
+                () -> "and no row went through this one:\n" + report);
+    }
+
+    // --- what happens if the proof is wrong -------------------------------------------------------
+
+    private static CoverageSites.Site arm(int index) {
+        return new CoverageSites.Site("classify", CoverageSites.Site.Kind.THEN, "then", null,
+                index, index, "f" + index);
+    }
+
+    /** A reachability that proves arm 0 unreachable: nothing at or above 50 is a value of [0, 10]. */
+    private static GuardReachability proving() {
+        GuardEdge edge = GuardEdge.above(new CoverageSites.GuardRef("classify", 0, 1, null),
+                0, TermPath.of("pair"), BigDecimal.valueOf(50), true);
+        return GuardReachability.of(List.of(edge),
+                Map.of("pair", new NumericDomain.Bounds(BigDecimal.ZERO, BigDecimal.TEN)));
+    }
+
+    @Test
+    void aProvenArmLeavesTheDenominator() {
+        Adequacy.BranchEvidence measured = Adequacy.BranchEvidence.measured(
+                List.of(arm(0), arm(1)), Set.of(1), proving(), MeasurementStatus.COMPLETE);
+
+        assertEquals(List.of(1), measured.all().stream().map(CoverageSites.Site::index).toList());
+        assertEquals(Set.of(1), measured.covered());
+        assertTrue(measured.contradicted().isEmpty());
+        assertTrue(measured.unreached().isEmpty());
+    }
+
+    /**
+     * A row through an arm nothing was supposed to reach.
+     *
+     * <p>Then the model is fine and the proof is not. The arm stays in the denominator and the fact is
+     * kept, because the alternative is a measure that reports {@code 1/1} over a proof it has just been
+     * shown to have broken.
+     */
+    @Test
+    void anArmObservedAgainstTheProofIsKeptAndSaidSo() {
+        Adequacy.BranchEvidence measured = Adequacy.BranchEvidence.measured(
+                List.of(arm(0), arm(1)), Set.of(0, 1), proving(), MeasurementStatus.COMPLETE);
+
+        assertEquals(Set.of(0), measured.contradicted(),
+                "arm 0 was proven unreachable and a row went through it");
+        assertEquals(List.of(0, 1),
+                measured.all().stream().map(CoverageSites.Site::index).toList(),
+                "so it is still an arm this behavior has");
+        assertEquals(Set.of(0, 1), measured.covered());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
@@ -192,6 +192,49 @@ class AnArmNothingReachesIsNotOwedARowTest {
                 () -> "and here a row can take the arm that answers it:\n" + live);
     }
 
+    /**
+     * The cases left are named in the order they were declared in.
+     *
+     * <p>A report is read against the declaration it came from, so the list has to run the way that
+     * declaration does. Taking a case out of the middle is where the order is easiest to lose: what
+     * is left is a new set, and a set that keeps the values is not one that keeps their order.
+     */
+    @Test
+    void whatIsLeftKeepsTheOrderItWasDeclaredIn() throws Exception {
+        String report = reportOn("""
+                module example.order
+
+                data N = Int
+                    invariant cap = value <= 10
+
+                data Alpha
+                data Beta
+                data Gamma
+                data Delta
+                data Epsilon
+                data Zeta
+                data Kind = Alpha | Beta | Gamma | Delta | Epsilon | Zeta
+
+                behavior f : (n: N) -> Kind
+                    constructs Alpha, Beta
+
+                let f (n) =
+                    if n.value > 100 then Beta else Alpha
+
+                example f
+                    | "one" : (N(1)) -> Alpha
+                """);
+
+        assertTrue(report.contains("out specified 1/5"),
+                () -> "`Beta` is answered only where nothing reaches:\n" + report);
+        List<String> named = report.lines().map(String::trim)
+                .filter(line -> line.startsWith("· no row expects"))
+                .map(line -> line.substring(line.indexOf('`') + 1, line.lastIndexOf('`')))
+                .toList();
+        assertEquals(List.of("Gamma", "Delta", "Epsilon", "Zeta"), named,
+                () -> "the order `Kind` lists them in:\n" + report);
+    }
+
     // --- what happens if the proof is wrong -------------------------------------------------------
 
     private static CoverageSites.Site arm(int index) {

--- a/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
@@ -101,6 +101,56 @@ class AnArmNothingReachesIsNotOwedARowTest {
                 () -> "and no row went through this one:\n" + report);
     }
 
+    // --- the cases behind such an arm -------------------------------------------------------------
+
+    @Test
+    void aCaseOnlyThatArmProducesIsNotOwedEither() throws Exception {
+        String report = reportOn(CAPPED);
+
+        assertTrue(report.contains("out specified 1/1"),
+                () -> "`Big` is answered only where nothing reaches:\n" + report);
+        assertFalse(report.contains("no row expects `Big`"), () -> report);
+        assertTrue(report.contains("adequacy: satisfied"),
+                () -> "and everything left is covered:\n" + report);
+    }
+
+    /** The same case built somewhere a row can get to. One producer proving nothing about the others
+     * is the whole reason this is a union over producers rather than a fact about the case. */
+    @Test
+    void aCaseAReachableArmAlsoProducesStaysOwed() throws Exception {
+        String report = reportOn(CAPPED.replace("        else Small",
+                "        else if pair.a.value >= 1 then Big else Small"));
+
+        assertTrue(report.contains("no row expects `Big`"),
+                () -> "an `a` of 1 is a value some pair holds:\n" + report);
+    }
+
+    /**
+     * A producer this cannot read keeps every case owed.
+     *
+     * <p>The body answers with a name rather than with a value built in a tail position, and what that
+     * name holds is not followed. That is the top of the analysis, and it is where anything unreadable
+     * goes: taking a case away on a guess is how an author stops being asked for a row they could have
+     * written.
+     */
+    @Test
+    void aCaseWhoseProducerCannotBeReadStaysOwed() throws Exception {
+        String report = reportOn(CAPPED.replace("""
+                let classify (pair) =
+                    if pair.b.value >= 50
+                        then Big
+                        else Small
+                """, """
+                let classify (pair) = {
+                    let answer = if pair.b.value >= 50 then Big else Small
+                    answer
+                }
+                """));
+
+        assertTrue(report.contains("no row expects `Big`"),
+                () -> "nothing here says what `answer` holds:\n" + report);
+    }
+
     // --- what happens if the proof is wrong -------------------------------------------------------
 
     private static CoverageSites.Site arm(int index) {

--- a/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
@@ -169,7 +169,8 @@ class AnArmNothingReachesIsNotOwedARowTest {
     @Test
     void aProvenArmLeavesTheDenominator() {
         Adequacy.BranchEvidence measured = Adequacy.BranchEvidence.measured(
-                List.of(arm(0), arm(1)), Set.of(1), proving(), MeasurementStatus.COMPLETE);
+                List.of(arm(0), arm(1)), Set.of(1),
+                new Adequacy.Effective(proving(), Set.of()), MeasurementStatus.COMPLETE);
 
         assertEquals(List.of(1), measured.all().stream().map(CoverageSites.Site::index).toList());
         assertEquals(Set.of(1), measured.covered());
@@ -180,14 +181,17 @@ class AnArmNothingReachesIsNotOwedARowTest {
     /**
      * A row through an arm nothing was supposed to reach.
      *
-     * <p>Then the model is fine and the proof is not. The arm stays in the denominator and the fact is
-     * kept, because the alternative is a measure that reports {@code 1/1} over a proof it has just been
-     * shown to have broken.
+     * <p>Then the model is fine and the proof is not. The arm is back in the denominator before this
+     * measure sees it, and what is left to do here is to refuse to report a complete measurement over
+     * a proof already known to be wrong.
      */
     @Test
     void anArmObservedAgainstTheProofIsKeptAndSaidSo() {
+        GuardReachability proven = proving();
+        Adequacy.Effective effective = new Adequacy.Effective(
+                proven.without(Set.of(0)), Set.of(0));
         Adequacy.BranchEvidence measured = Adequacy.BranchEvidence.measured(
-                List.of(arm(0), arm(1)), Set.of(0, 1), proving(), MeasurementStatus.COMPLETE);
+                List.of(arm(0), arm(1)), Set.of(0, 1), effective, MeasurementStatus.COMPLETE);
 
         assertEquals(Set.of(0), measured.contradicted(),
                 "arm 0 was proven unreachable and a row went through it");
@@ -195,5 +199,20 @@ class AnArmNothingReachesIsNotOwedARowTest {
                 measured.all().stream().map(CoverageSites.Site::index).toList(),
                 "so it is still an arm this behavior has");
         assertEquals(Set.of(0, 1), measured.covered());
+        assertEquals(MeasurementStatus.PARTIAL, measured.status(),
+                "and no number here is given as though nothing had happened");
+    }
+
+    /** The same fact both measures read. Taking the arm back for one of them and not the other is how
+     * the case behind it would stay unowed over a proof already disproved. */
+    @Test
+    void theSameArmIsBackForEveryMeasure() {
+        Adequacy.Effective effective = new Adequacy.Effective(
+                proving().without(Set.of(0)), Set.of(0));
+
+        assertFalse(effective.reachable().provenUnreachable(0),
+                "a row went through it, so nothing about it is proven any more");
+        assertTrue(effective.reachable().isEmpty(),
+                "and what the signature reads is the same set the arms are counted by");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
@@ -151,6 +151,45 @@ class AnArmNothingReachesIsNotOwedARowTest {
                 () -> "nothing here says what `answer` holds:\n" + report);
     }
 
+    /**
+     * What a body may answer with is a fact about the body.
+     *
+     * <p>Two behaviors that can answer with the same cases are owed the same rows. Read only where a
+     * guard happens to be provable, adding an arm nothing reaches to a behavior would change what its
+     * signature is owed — a case would leave the denominator because a guard beside it was written,
+     * not because anything about the answers had changed.
+     */
+    @Test
+    void aDeadGuardDoesNotChangeWhatTheSignatureIsOwed() throws Exception {
+        String model = """
+                module example.passthrough
+
+                data N = Int
+                    invariant cap = value <= 10
+
+                data A
+                data B
+
+                behavior f : (n: N, b: B) -> A | B
+                    constructs A
+
+                let f (n, b) = BODY
+
+                example f
+                    | "one" : (N(1), B) -> A
+                """;
+        String dead = reportOn(model.replace("BODY", "if n.value > 100 then b else A"));
+        String plain = reportOn(model.replace("BODY", "A"));
+        String live = reportOn(model.replace("BODY", "if n.value > 5 then b else A"));
+
+        assertTrue(dead.contains("out specified 1/1"),
+                () -> "no pair holds an `n` above 100, so nothing here answers `B`:\n" + dead);
+        assertTrue(plain.contains("out specified 1/1"),
+                () -> "and the same body without the guard answers the same cases:\n" + plain);
+        assertTrue(live.contains("out specified 1/2"),
+                () -> "where the guard is one a row can take, `B` is owed again:\n" + live);
+    }
+
     // --- what happens if the proof is wrong -------------------------------------------------------
 
     private static CoverageSites.Site arm(int index) {

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -432,18 +432,13 @@ class CompilePartialAdequacyTest {
      * The lines say what the summary says.
      *
      * <p>A `(partial)` in the margin and a flat assertion under it read as a finding with a footnote.
-     * Under partial the honest sentence is that nothing *seen* claims the class.
-     *
-     * <p>Read at a position and not at the output. `take` answers with `Ok` and nothing else, so
-     * `Refused` is not a case any row could carry and the signature stops counting it — which is a
-     * different question from how a gap is worded, and the wording is what this holds.
+     * Under partial the honest sentence is that nothing *seen* claims the case.
      */
     @Test
-    void aMeasureLineUnderPartialDoesNotAssert() {
+    void aSignatureLineUnderPartialDoesNotAssert() {
         String human = AdequacyReport.of(split()).human();
 
-        assertTrue(human.contains("undecided whether a row is in `No`"), human);
-        assertFalse(human.contains("· no row is in"), human);
+        assertTrue(human.contains("undecided whether a row expects `Refused`"), human);
         assertFalse(human.contains("· no row expects"), human);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompilePartialAdequacyTest.java
@@ -432,13 +432,18 @@ class CompilePartialAdequacyTest {
      * The lines say what the summary says.
      *
      * <p>A `(partial)` in the margin and a flat assertion under it read as a finding with a footnote.
-     * Under partial the honest sentence is that nothing *seen* claims the case.
+     * Under partial the honest sentence is that nothing *seen* claims the class.
+     *
+     * <p>Read at a position and not at the output. `take` answers with `Ok` and nothing else, so
+     * `Refused` is not a case any row could carry and the signature stops counting it — which is a
+     * different question from how a gap is worded, and the wording is what this holds.
      */
     @Test
-    void aSignatureLineUnderPartialDoesNotAssert() {
+    void aMeasureLineUnderPartialDoesNotAssert() {
         String human = AdequacyReport.of(split()).human();
 
-        assertTrue(human.contains("undecided whether a row expects `Refused`"), human);
+        assertTrue(human.contains("undecided whether a row is in `No`"), human);
+        assertFalse(human.contains("· no row is in"), human);
         assertFalse(human.contains("· no row expects"), human);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGuardsArmsAreNotItsThresholdTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGuardsArmsAreNotItsThresholdTest.java
@@ -1,0 +1,210 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeChecker;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Which values reach one arm of a guard, which is not which side of the line its value belongs to.
+ *
+ * <p>A {@link Threshold} answers the second, and that is what decides where one class ends and the
+ * next begins. It cannot answer the first: {@code x <= c} and {@code x > c} both put {@code c} on the
+ * low side and their {@code then} arms are opposite halves of the line. So the arms are read off the
+ * operator where it is still known, and a measure that recovered them from a threshold would have
+ * counted the wrong arm.
+ */
+class AGuardsArmsAreNotItsThresholdTest {
+
+    private static GuardThresholds.Guards read(String condition) {
+        String source = """
+                module example.guarded
+
+                data Count = Int
+                    invariant range = value >= 0 && value <= 10
+
+                data Low
+                data High
+
+                behavior pick : (n: Count) -> Low | High
+                    constructs Low, High
+
+                let pick (n) =
+                    if CONDITION
+                        then High
+                        else Low
+                """.replace("CONDITION", condition);
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Ast.Module prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        TypeChecker.Checked checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, () -> "the model under test compiles: " + condition);
+        Ast.SpecBehavior spec = (Ast.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("pick")).findFirst().orElseThrow();
+        Core body = checked.behaviorBodies().get("pick");
+        assertNotNull(body);
+        CoverageSites.Plan plan = CoverageSites.of("m.sou", checked.behaviorBodies());
+        return GuardThresholds.of("pick", body, plan,
+                spec.params().stream().map(Ast.Param::name).toList(), symbols);
+    }
+
+    /** The arm taken when the condition holds, which the plan numbers first. */
+    private static GuardEdge thenArm(GuardThresholds.Guards guards) {
+        int site = guards.edges().get(0).guard().siteIndexThen();
+        return guards.edges().stream().filter(e -> e.site() == site).findFirst().orElseThrow();
+    }
+
+    private static GuardEdge elseArm(GuardThresholds.Guards guards) {
+        int site = guards.edges().get(0).guard().siteIndexElse();
+        return guards.edges().stream().filter(e -> e.site() == site).findFirst().orElseThrow();
+    }
+
+    private static String shown(GuardEdge edge) {
+        return (edge.low() == null ? "(-inf" : (edge.lowInclusive() ? "[" : "(") + edge.low())
+                + ", " + (edge.high() == null ? "+inf)"
+                        : edge.high() + (edge.highInclusive() ? "]" : ")"));
+    }
+
+    @Test
+    void thereAreTwoArmsAndBothAreRead() {
+        GuardThresholds.Guards guards = read("n.value <= 5");
+
+        assertEquals(1, guards.thresholds().size(), () -> "one line: " + guards.thresholds());
+        assertEquals(2, guards.edges().size(), () -> "and two arms of it: " + guards.edges());
+        assertEquals("n", thenArm(guards).path().toString());
+    }
+
+    /**
+     * The finding this test exists for.
+     *
+     * <p>Both operators put 5 on the low side, so a threshold cannot tell them apart. Their arms are
+     * the two halves of the line the other way round, and anything reading the arms off
+     * {@code valueBelongsBelow} would have taken one for the other.
+     */
+    @Test
+    void twoOperatorsAgreeAboutTheValueAndTakeOppositeArms() {
+        GuardThresholds.Guards atOrBelow = read("n.value <= 5");
+        GuardThresholds.Guards above = read("n.value > 5");
+
+        assertTrue(atOrBelow.thresholds().get(0).valueBelongsBelow(),
+                "`x <= 5` puts 5 on the low side");
+        assertTrue(above.thresholds().get(0).valueBelongsBelow(),
+                "and so does `x > 5`");
+
+        assertEquals("(-inf, 5]", shown(thenArm(atOrBelow)));
+        assertEquals("(5, +inf)", shown(thenArm(above)));
+        assertEquals(shown(thenArm(atOrBelow)), shown(elseArm(above)),
+                "the arms are the same two halves, swapped");
+        assertEquals(shown(thenArm(above)), shown(elseArm(atOrBelow)));
+    }
+
+    @Test
+    void theOtherTwoOperatorsPutTheValueHighAndAlsoTakeOppositeArms() {
+        GuardThresholds.Guards below = read("n.value < 5");
+        GuardThresholds.Guards atOrAbove = read("n.value >= 5");
+
+        assertFalse(below.thresholds().get(0).valueBelongsBelow(),
+                "`x < 5` puts 5 on the high side");
+        assertFalse(atOrAbove.thresholds().get(0).valueBelongsBelow(),
+                "and so does `x >= 5`");
+
+        assertEquals("(-inf, 5)", shown(thenArm(below)));
+        assertEquals("[5, +inf)", shown(thenArm(atOrAbove)));
+        assertEquals(shown(thenArm(below)), shown(elseArm(atOrAbove)));
+        assertEquals(shown(thenArm(atOrAbove)), shown(elseArm(below)));
+    }
+
+    /** A comparison written the other way round says what the first one says, arms included. */
+    @Test
+    void aMirroredComparisonHasTheSameArms() {
+        assertEquals(shown(thenArm(read("n.value <= 5"))), shown(thenArm(read("5 >= n.value"))));
+        assertEquals(shown(elseArm(read("n.value <= 5"))), shown(elseArm(read("5 >= n.value"))));
+    }
+
+    // --- what the bounds prove about an arm --------------------------------------------------------
+
+    private static final CoverageSites.GuardRef ONE_GUARD =
+            new CoverageSites.GuardRef("pick", 0, 1, null);
+
+    private static GuardEdge above(long value, boolean inclusive) {
+        return GuardEdge.above(ONE_GUARD, 0, TermPath.of("n"), BigDecimal.valueOf(value), inclusive);
+    }
+
+    private static GuardEdge below(long value, boolean inclusive) {
+        return GuardEdge.below(ONE_GUARD, 1, TermPath.of("n"), BigDecimal.valueOf(value), inclusive);
+    }
+
+    private static NumericDomain.Bounds holds(Long min, Long max) {
+        return new NumericDomain.Bounds(min == null ? null : BigDecimal.valueOf(min),
+                max == null ? null : BigDecimal.valueOf(max));
+    }
+
+    @Test
+    void anArmBeyondWhatThePositionHoldsIsProvenUnreachable() {
+        assertTrue(above(50, true).provenDisjoint(holds(0L, 10L)),
+                "nothing at or above 50 is a value of [0, 10]");
+        assertTrue(below(-1, true).provenDisjoint(holds(0L, 10L)));
+    }
+
+    @Test
+    void anArmThatMeetsThemIsNotProven() {
+        assertFalse(above(10, true).provenDisjoint(holds(0L, 10L)),
+                "10 is a value of [0, 10], so this arm is not ruled out");
+        assertFalse(above(5, true).provenDisjoint(holds(0L, 10L)));
+        assertFalse(below(0, true).provenDisjoint(holds(0L, 10L)));
+    }
+
+    /** The edge that touches the end without including it. Read as closed it would be called
+     * reachable, and the arm behind it would stay in a denominator nothing can fill. */
+    @Test
+    void anArmOpenAtTheEndItTouchesIsProvenUnreachable() {
+        assertTrue(above(10, false).provenDisjoint(holds(0L, 10L)),
+                "there is no value of [0, 10] above 10");
+        assertTrue(below(0, false).provenDisjoint(holds(0L, 10L)));
+    }
+
+    /** Nothing is proven where nothing is known. An unbounded position rules out no arm, and neither
+     * does a position nobody bounded in the direction the arm goes. */
+    @Test
+    void nothingIsProvenWhereThePositionIsUnbounded() {
+        assertFalse(above(50, true).provenDisjoint(null));
+        assertFalse(above(50, true).provenDisjoint(holds(0L, null)));
+        assertFalse(below(-1, true).provenDisjoint(holds(null, 10L)));
+    }
+
+    @Test
+    void reachabilityNamesTheArmsItProvesAndNoOthers() {
+        List<GuardEdge> edges = List.of(above(50, true), below(50, false));
+        GuardReachability reach = GuardReachability.of(edges, Map.of("n", holds(0L, 10L)));
+
+        assertTrue(reach.provenUnreachable(0), "the arm above 50 is unreachable");
+        assertFalse(reach.provenUnreachable(1), "the arm below it is the whole of the range");
+        assertEquals(java.util.Set.of(0), reach.unreachableSites());
+    }
+
+    @Test
+    void aPositionWithNoBoundsProvesNothingAboutEitherArm() {
+        GuardReachability reach = GuardReachability.of(
+                List.of(above(50, true), below(50, false)), Map.of());
+
+        assertTrue(reach.isEmpty(), () -> "proved " + reach.unreachableSites());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
@@ -76,7 +76,8 @@ class RowClassesTest {
         List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
         Partitions.Partitioning partitioning = Partitions.withThresholds(
                 Partitions.of(spec, sigs.get("submit"), symbols, Exclusions.NONE),
-                GuardThresholds.of("submit", body, plan, parameters, symbols), symbols);
+                GuardThresholds.of("submit", body, plan, parameters, symbols).thresholds(),
+                symbols);
 
         Output.Examples.Of observed = compilation.db()
                 .ask(Output.Examples.asked(compilation.db(), module,

--- a/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
@@ -204,7 +204,8 @@ class ThresholdNormalizationTest {
         Read read = read(CEILING, "submit");
         Axis cost = axis(read.partitioning(), "request.cost");
 
-        List<BoundaryObligation> obligations = Partitions.obligationsOf(cost, Symbols.none());
+        List<BoundaryObligation> obligations = Partitions.obligationsOf(cost, Symbols.none(),
+                read.partitioning().domains().get("request.cost"));
         List<String> described = obligations.stream()
                 .map(o -> o.side() + " " + Intervals.numberOf(o.value())).toList();
 
@@ -240,7 +241,8 @@ class ThresholdNormalizationTest {
         Axis amount = axis(read.partitioning(), "amount");
         assertEquals(List.of("0 <= x < 3000", "3000 <= x"), labels(amount));
 
-        List<String> described = Partitions.obligationsOf(amount, Symbols.none()).stream()
+        List<String> described = Partitions.obligationsOf(amount, Symbols.none(),
+                read.partitioning().domains().get(amount.path().toString())).stream()
                 .map(o -> o.side() + " " + Intervals.numberOf(o.value())).toList();
         assertTrue(described.contains("AT 3000"), described.toString());
         assertTrue(described.contains("BELOW 2999"), described.toString());

--- a/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ThresholdNormalizationTest.java
@@ -48,8 +48,9 @@ class ThresholdNormalizationTest {
         Core body = checked.behaviorBodies().get(behavior);
         assertNotNull(body);
         CoverageSites.Plan plan = CoverageSites.of("m.sou", checked.behaviorBodies());
-        List<Threshold> thresholds = GuardThresholds.of(behavior, body, plan,
+        GuardThresholds.Guards guards = GuardThresholds.of(behavior, body, plan,
                 spec.params().stream().map(Ast.Param::name).toList(), symbols);
+        List<Threshold> thresholds = guards.thresholds();
         Partitions.Partitioning base = Partitions.of(spec, sigs.get(behavior), symbols, Exclusions.NONE);
         return new Read(Partitions.withThresholds(base, thresholds, symbols), thresholds);
     }


### PR DESCRIPTION
Closes #479.

Candidate generation fixed what each position may take before knowing what any
other position took, so a rule relating two positions was satisfied only where
the lists happened to already hold a pair that satisfies it. Two bare `Int`s
under `a < b` had one assignment to try and it is the one the record refuses —
ordinary partition fill finding no row at all.

Four changes, in the order they can be read. The first three are small fixes to
what was there; the fourth changes when the projection is asked.

## What a position can hold is not where it is divided

`narrowed` answered two questions with one type. Deriving an axis, a record's rule
moves an edge the type already has and does not put one on a position the type
left open (ADR-0090). Choosing a value, every rule reaching the position bounds
it, whichever of them said so.

Read as the second, the first lost a cap the record alone imposes — and the same
bounds decide which of a behavior's thresholds are reachable, so a guard beyond
the cap was left dividing a range that stops short of it. Split into `axisBounds`
and `admissibleBounds`.

The second answers in numbers rather than in ends carrying the names that put them
there: where the values stop is not the same fact as which rule a row is owed to.

## A step off the end of a range is not a row anybody can write

A guard's neighbour is invented one step off the line rather than read from
anything, and where the guard sits at the end of what the position can hold, the
step lands outside the type. `value >= 10` under a guard of `x < 10` was owed a
row at 9. The line itself stays owed.

## An arm nothing reaches is not owed a row, and neither are the cases only it
produces

Three measures had stopped asking about a guard beyond a cap; the arms and the
signature had not, so the report said in one place that the guard divides nothing
and in another that a row is owed through it.

`GuardEdge` is one side of a guard and the values that take it. It is not a
`Threshold` and cannot be derived from one: `x <= c` and `x > c` both put `c` on
the low side and their `then` arms are opposite halves of the line, so the arms
are read where the operator still is. `GuardReachability` answers which arms the
model's own rules prove nothing reaches, derived once for the module the way
`Excluded` already is.

Arms leave the denominator where the measure is assembled and not where the probes
are numbered — the plan says where instrumentation is, and a site with no probe
could never disprove the reachability it was excluded by. A probe on an excluded
arm that lights means the proof is wrong rather than the model, so the arm goes
back into the denominator and the contradiction is kept beside it.

The signature is read per producer: nothing where an arm above it is proven
unreachable, the case it builds where the value names one, and every declared case
otherwise. So a case a reachable arm also produces stays owed, and so does one
behind a producer this cannot read.

## A value comes from what is left of the position, and a position is chosen
knowing the ones before it

Every primitive branch of `representativesOf` answered from the type and returned
before `within` was looked at. A newtype's candidate had been read from there for
a while; a bare `Int` had not.

Then the positions are chosen one at a time, each from the projection asked again
with the ones before it settled into it. The reading is the one that was already
there — `FieldDomains.of(name, data, symbols, settled)` — and what changes is when
it is asked. Second and not instead: it costs a reading of the record's rules per
position per branch, and the search in front of it answers most rows without any
of that.

One value is still not enough where the range a position is chosen from is
approximate: a disequality is a hole no range keeps, a form that is neither an
interval nor a difference is not recorded at all, and a strict bound over the
decimals is recorded as the non-strict one. A second value is displaced rather
than invented — a whole number has a next one, a decimal between two ends has a
midpoint, and a decimal with one end gets nothing, because an epsilon is a value
the type does not name.

## Measured

| model | before | after |
|---|---|---|
| `a: Int, b: Int`, `a < b` | no row | `R { a = 0, b = 1 }` |
| `a + 100 < b` | no row | `R { a = 0, b = 101 }` |
| `a /= 0` | no row | `a = 1` |
| `a + b >= 1` | no row | `R { a = 0, b = 1 }` |
| `a * b >= 1` | no row | `R { a = 1, b = 1 }` |
| `Ratio = Decimal` band, `low < high` | 5 unfilled | 2 unfilled |
| record cap 10 with a guard at 50 | class, 2 boundaries, arm and case all owed | none owed |

The two that remain in the decimal band are `low = 1` and `high = 0`, and both are
refused by a rule: `low = 1` wants a `high` above `Ratio`'s own maximum.

`souther-examples`, 41 files across 14 modules, moves in one place against
`develop`: hr's `office.insuredCount` gains the lower bound its record always had,
so its class is `0 <= x < 51` rather than `x < 51` and its representative is 0
rather than 50. Every report line is otherwise identical.

## Meeting the reserve

`develop` grew a second pass over the product while this was being written, and a
position that is a bounded newtype holds its far end back for it. Two things had
to meet.

`inReserve` asks what the position can hold, so it now reads the admissible bounds
rather than the ones an axis is derived from — the same split the first commit
makes, which also means an end only the record imposes is one of the values held
back. And the pass that chooses a position at a time runs only after both product
passes have failed, so what a position held back is on offer there among the rest:
keeping a value from the last search there is keeping it from every search.

A displaced value still earns its place beside the reserve. `inReserve` answers for
a bounded newtype; a bare `Int` under `a /= 0` and a bare `Decimal` between two
ends have no reserve, and those are exactly the positions whose range is
approximate.

## Review

Three findings, each with a regression test that fails without its fix.

A dead guard changed what the signature was owed. The cause was the walk counting
up what a body may answer with: a case with no producer at all then left the
denominator beside a case whose every producer is behind an arm nothing reaches,
and those are not the same fact. That a signature says `A | B` and the
implementation never answers `B` is a gap between the two, and it is what the
measure is for. The walk takes away instead, and takes away one thing — a case
something answers with, where every producer of it is proven unreachable. A case
nothing answers with stays, and so does one behind a producer this cannot read.

The pass that chooses a position at a time reported running out of its bound as
every value having been refused, and then reported a search that spent its last
assignment as one short of it. The bound and whether it ran out are one fact now,
`spend` is the only place the bound is called reached, and a failure from either
pass carries the weaker answer where either stopped short.

A proof a row disproved was taken back for the arms and left standing for the
signature. `Reached` is the derivation both read: what the rules prove, less what
the rows reached. A measurement over a contradicted proof reports partial, so a
module cannot come back `adequacy: satisfied` over an analysis a row has already
shown to be wrong. There is no report line naming the contradicted arm — a
user-visible diagnostic for a disagreement between an analysis and an execution
wants its own code, and this leaves it at partial.

## Left open

`NumericDomain` records a strict bound over the decimals as the non-strict one, so
the domain cannot tell `[0` from `(0`. That is #483, and it is independent in both
directions: openness recorded exactly leaves `a + 100 < b` where it was, and the
projection under a partial assignment leaves the approximation where it was. What
it would buy is a report that can say which of the two remaining band edges is
refused by a rule rather than merely untried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
