### PR TITLE
Every comma-separated list carries a trailing comma, this one too

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACanonicalFormCanRewriteCodeTokensTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACanonicalFormCanRewriteCodeTokensTest.java
@@ -28,7 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  *
  * <ul>
  *   <li>a token is <b>removed</b> — a trailing comma, which every comma-separated list may carry and
- *       the canonical form writes none of;
+ *       the canonical form writes none of. Each of those lists is a row here: the grammar admits one
+ *       in fourteen constructs, which is every loop in {@code CstParser} that reads a comma;
  *   <li>a token is <b>added</b> — the {@code |} in front of a match's first arm, which the grammar
  *       makes optional and the canonical form always writes;
  *   <li>tokens are <b>rewritten</b> — a definition whose right-hand side is a lambda is written with
@@ -78,6 +79,43 @@ class ACanonicalFormCanRewriteCodeTokensTest {
                 new Rewrite("a trailing comma in a product's fields", REMOVED,
                         "module m\n\ndata R =\n    { a: Int,\n    }\n",
                         "module m\n\ndata R =\n    { a: Int\n    }\n"),
+                new Rewrite("a trailing comma in a tuple", REMOVED,
+                        "module m\n\nlet t = (1, 2,)\n",
+                        "module m\n\nlet t = (1, 2)\n"),
+                new Rewrite("a trailing comma in a tuple type", REMOVED,
+                        "module m\n\nlet f (a: (Int, Int,)): Int = 1\n",
+                        "module m\n\nlet f (a: (Int, Int)): Int = 1\n"),
+                new Rewrite("a trailing comma in a record literal's fields", REMOVED,
+                        "module m\n\ndata R =\n    { a: Int\n    }\n\nlet r = R { a = 1, }\n",
+                        "module m\n\ndata R =\n    { a: Int\n    }\n\nlet r = R { a = 1 }\n"),
+                new Rewrite("a trailing comma in a type argument list", REMOVED,
+                        "module m\n\nlet f (a: Map<String, Int,>): Int = 1\n",
+                        "module m\n\nlet f (a: Map<String, Int>): Int = 1\n"),
+                new Rewrite("a trailing comma in a lambda's parameters", REMOVED,
+                        "module m\n\nlet f: (Int, Int) -> Int = (x, y,) -> x\n",
+                        "module m\n\nlet f: (Int, Int) -> Int = (x, y) -> x\n"),
+                new Rewrite("a trailing comma in a `constructs` name list", REMOVED,
+                        "module m exposing (b)\n\ndata R =\n    { a: Int\n    }\n\nbehavior b : (n: Int)"
+                                + " -> R\n    constructs R,\n\nlet b (n) = R { a = n }\n",
+                        "module m exposing ( b )\n\ndata R =\n    { a: Int\n    }\n\nbehavior b :"
+                                + " (n: Int) -> R\n    constructs R\n\nlet b (n) = R { a = n }\n"),
+                new Rewrite("a trailing comma in a behavior's parameters", REMOVED,
+                        "module m exposing (b)\n\ndata R =\n    { a: Int\n    }\n\nbehavior b :"
+                                + " (n: Int,) -> R\n    constructs R\n\nlet b (n) = R { a = n }\n",
+                        "module m exposing ( b )\n\ndata R =\n    { a: Int\n    }\n\nbehavior b :"
+                                + " (n: Int) -> R\n    constructs R\n\nlet b (n) = R { a = n }\n"),
+                new Rewrite("a trailing comma in an example row's arguments", REMOVED,
+                        "module m exposing (b)\n\ndata R =\n    { a: Int\n    }\n\nbehavior b :"
+                                + " (n: Int) -> R\n    constructs R\n\nlet b (n) = R { a = n }\n\n"
+                                + "example b\n    | (1,) -> R { a = 1 }\n",
+                        "module m exposing ( b )\n\ndata R =\n    { a: Int\n    }\n\nbehavior b :"
+                                + " (n: Int) -> R\n    constructs R\n\nlet b (n) = R { a = n }\n\n"
+                                + "example b\n    | (1) -> R { a = 1 }\n"),
+                new Rewrite("a trailing comma in an example row's `with` bindings", REMOVED,
+                        "examples for m\n\nexample helper\n"
+                                + "    | (1) with dep = two, other = three, -> 2\n",
+                        "examples for m\n\nexample helper\n"
+                                + "    | (1) with dep = two, other = three -> 2\n"),
 
                 new Rewrite("the bar in front of a match's first arm", ADDED,
                         "module m\n\nlet f (a: Int): Int =\n    match a with\n        A -> 1\n        | B -> 2\n",

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstParser.java
@@ -659,6 +659,9 @@ public final class CstParser {
         bump();   // with
         withBinding();
         while (eat(SyntaxKind.COMMA)) {
+            if (!at(SyntaxKind.IDENT)) {
+                break;   // a trailing comma is consumed and ends the clause
+            }
             withBinding();
         }
         finish();


### PR DESCRIPTION
§466 says every `,`-separated list may carry a single trailing `,`, and names no exception. The
parser had one: an `example` row's `with` bindings.

```
| "a row" : (1) with dep = two, other = three, -> 2
                                             ^ expected IDENT but found ARROW
```

It reads as an oversight rather than a rule. The two comma lists written without brackets end where
the next token is not an item — `constructs` / `depends on` does it with `if (!at(IDENT)) break;` and
the comment "a trailing comma is consumed and ends the list" — and the seventeen bracketed ones peek
their closing bracket. `withClause` had neither, so the comma was eaten and a binding demanded after
it. Nothing in the specification, in the parser, or in that method's history says the clause is
different.

It now ends the same way. The canonical form drops the comma there as it does everywhere else,
without a formatter change: the formatter spells its own separators, and never read the source's.

### The pinning table

`ACanonicalFormCanRewriteCodeTokensTest` held five of the constructs that admit a trailing comma. All
fourteen are there now — a tuple and a tuple type, a record literal's fields, a type argument list, a
lambda's parameters, a `constructs` name list, a behavior's parameters, an `example` row's arguments,
and its `with` bindings, alongside the five that were already written down. Fourteen is every loop in
`CstParser` that reads a comma, so what the canonical form does to one is now asked of every list that
can write one.

Each row is also read by `TheCanonicalFormMeansWhatTheSourceMeantTest`, so every one of them says both
what the canonical form writes and that it builds the same module.

Refs #480 — the issue stays open for the normative-status question.
