### PR TITLE
An end says whether the value it stops at is one of the range's own

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
@@ -13,8 +13,10 @@ import java.util.Optional;
  * <p>Read off the comparison. What a report measures a position at is where the rules about it stop,
  * and that is not the same question as which runtime check the rule becomes: the runtime states a
  * decimal above zero directly and has no word for a decimal above five, so a reader written for it
- * answers "no bound" to a rule that plainly draws one. Asked here of {@code value OP literal} and of
- * nothing else, which is the whole of what a range can hold anyway.
+ * answers "no bound" to a rule that plainly draws one. Asked here of an ordering of
+ * {@code value} against a literal, and of one end at a time. An equality states both ends at once
+ * and is not read: it was not read before either, and giving a position one value is a different
+ * answer from bounding it, which the report has nowhere to put yet.
  *
  * <p>Over whole numbers a strict comparison names the adjacent value, and the end lands on a value
  * the rule admits. Over decimals there is no adjacent value, so the end stays on the literal and says

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantBound.java
@@ -1,0 +1,117 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.types.Type;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/**
+ * Where one conjunct of a numeric newtype's invariant leaves its value able to stop.
+ *
+ * <p>Read off the comparison. What a report measures a position at is where the rules about it stop,
+ * and that is not the same question as which runtime check the rule becomes: the runtime states a
+ * decimal above zero directly and has no word for a decimal above five, so a reader written for it
+ * answers "no bound" to a rule that plainly draws one. Asked here of {@code value OP literal} and of
+ * nothing else, which is the whole of what a range can hold anyway.
+ *
+ * <p>Over whole numbers a strict comparison names the adjacent value, and the end lands on a value
+ * the rule admits. Over decimals there is no adjacent value, so the end stays on the literal and says
+ * that the literal is not one of its own.
+ *
+ * @param lower whether this bounds the value below; otherwise above
+ */
+public record InvariantBound(boolean lower, Endpoint end) {
+
+    private static final String VALUE = "value";
+    private static final BigDecimal LONG_MIN = BigDecimal.valueOf(Long.MIN_VALUE);
+    private static final BigDecimal LONG_MAX = BigDecimal.valueOf(Long.MAX_VALUE);
+
+    /** What {@code clause} says about a value carried as {@code base}, or empty where it says
+     * nothing a range can hold. */
+    public static Optional<InvariantBound> of(Ast.Expr clause, Type base) {
+        if (base != Type.INT && base != Type.DECIMAL) {
+            return Optional.empty();
+        }
+        if (!(clause instanceof Ast.Binary bin)) {
+            return Optional.empty();
+        }
+        // `0 <= value` says what `value >= 0` says: read the value-bearing side as the left one.
+        Ast.Expr left = bin.left();
+        Ast.Expr right = bin.right();
+        Ast.BinOp op = bin.op();
+        if (!isValue(left) && isValue(right)) {
+            Ast.Expr swap = left;
+            left = right;
+            right = swap;
+            op = mirrored(op);
+        }
+        if (!isValue(left)) {
+            return Optional.empty();
+        }
+        BigDecimal bound = literal(right);
+        if (bound == null || (base == Type.INT && bound.stripTrailingZeros().scale() > 0)) {
+            return Optional.empty();
+        }
+        boolean whole = base == Type.INT;
+        return switch (op) {
+            case GE -> Optional.of(new InvariantBound(true, Endpoint.inclusive(bound)));
+            case LE -> Optional.of(new InvariantBound(false, Endpoint.inclusive(bound)));
+            case GT -> whole ? stepped(true, bound.add(BigDecimal.ONE))
+                    : Optional.of(new InvariantBound(true, Endpoint.exclusive(bound)));
+            case LT -> whole ? stepped(false, bound.subtract(BigDecimal.ONE))
+                    : Optional.of(new InvariantBound(false, Endpoint.exclusive(bound)));
+            default -> Optional.empty();
+        };
+    }
+
+    /** A whole number's strict bound moved onto the value beside it — where the type has one. At the
+     * ends of what an {@code Int} holds there is nothing to move onto, and nothing is claimed. */
+    private static Optional<InvariantBound> stepped(boolean lower, BigDecimal onto) {
+        return onto.compareTo(LONG_MIN) < 0 || onto.compareTo(LONG_MAX) > 0
+                ? Optional.empty() : Optional.of(new InvariantBound(lower, Endpoint.inclusive(onto)));
+    }
+
+    private static boolean isValue(Ast.Expr e) {
+        return e instanceof Ast.Var v && v.name().equals(VALUE);
+    }
+
+    private static Ast.BinOp mirrored(Ast.BinOp op) {
+        return switch (op) {
+            case LT -> Ast.BinOp.GT;
+            case LE -> Ast.BinOp.GE;
+            case GT -> Ast.BinOp.LT;
+            case GE -> Ast.BinOp.LE;
+            default -> op;
+        };
+    }
+
+    /** A numeric literal, negation included. A bare integer counts against a decimal, since a literal
+     * takes the other side's type. */
+    private static BigDecimal literal(Ast.Expr e) {
+        return switch (e) {
+            case Ast.IntLit lit -> BigDecimal.valueOf(lit.value());
+            case Ast.DecimalLit lit -> normalized(lit.value());
+            case Ast.Neg neg -> negated(literal(neg.operand()));
+            case null, default -> null;
+        };
+    }
+
+    /**
+     * The number a literal names, without how many places it was written to.
+     *
+     * <p>{@code 5.0m} and {@code 5.00m} are one constraint, so they have to reach a range as one
+     * number: two spellings of an end would be two lines through a position, both holding the same
+     * values, and one boundary owed twice under one printed figure. Trailing zeros left of the point
+     * are put back, so a hundred is written as one.
+     */
+    private static BigDecimal normalized(BigDecimal value) {
+        BigDecimal bare = value.stripTrailingZeros();
+        return bare.scale() < 0 ? bare.setScale(0) : bare;
+    }
+
+    private static BigDecimal negated(BigDecimal value) {
+        return value == null ? null : value.negate();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -397,6 +397,10 @@ public final class InvariantChecker {
      * <p>The same reader, so the same answer: a conjunct that gave the position a bound was read, and
      * one that gave none — {@code isOdd(value)} beside {@code value >= 0} — is a way the type refuses
      * a value that the bounds do not express.
+     *
+     * <p>Which reader that is depends on what the value is carried as. A number's range comes from
+     * the comparison itself; anything else — a length, a pattern, a size — is read as the runtime
+     * check it becomes, which is the only reading of those there is.
      */
     private static boolean everyRuleBecameABound(TypeName named, Ast.Data data, Symbols symbols) {
         Type carried = TypeOps.numericBase(Type.ref(named), symbols);
@@ -406,9 +410,12 @@ public final class InvariantChecker {
         // declares rather than against the number underneath makes every such rule unreadable.
         for (TypeOps.Layer layer : TypeOps.newtypeChain(Type.ref(named), symbols)) {
             for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
+                boolean numeric = base == Type.INT || base == Type.DECIMAL;
                 for (Ast.Expr each
                         : souther.compiler.codegen.InvariantConstraints.clauses(clause.expr())) {
-                    if (souther.compiler.codegen.InvariantConstraints.of(each, base).isEmpty()) {
+                    boolean read = numeric ? InvariantBound.of(each, base).isPresent()
+                            : souther.compiler.codegen.InvariantConstraints.of(each, base).isPresent();
+                    if (!read) {
                         return false;
                     }
                 }

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Endpoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Endpoint.java
@@ -53,6 +53,62 @@ public record Endpoint(BigDecimal value, boolean inclusive) {
         return order < 0 || (low.inclusive() && high.inclusive());
     }
 
+    /**
+     * A value between a lower bound and an upper one, or {@code null} where they hold none.
+     *
+     * <p>The one way a pair of ends gives up a number, so that nothing deciding what to write reads
+     * an end's value and loses whether the range holds it. An end the range holds is the value taken:
+     * it is inside whatever other end there is, and it is the value a boundary wants written anyway.
+     * An end the range stops short of is not one, and over a dense order there is no value beside it
+     * to take instead — so the value comes from inside, between the ends where both are known and a
+     * step in from the only one where there is one. Nothing about that step is the nearest value the
+     * range holds; over a dense order there is no such thing. It is a value the range holds, chosen
+     * the same way every time.
+     *
+     * <p>Over whole numbers each end moves onto the nearest whole number inside it first, which is
+     * where a strict bound and a fractional one both become a value the type has.
+     */
+    public static BigDecimal valueBetween(Endpoint low, Endpoint high, Granularity spacing) {
+        if (spacing == Granularity.DISCRETE) {
+            Endpoint lo = whole(low, true);
+            Endpoint hi = whole(high, false);
+            if (!someValueLiesBetween(lo, hi)) {
+                return null;
+            }
+            return lo != null ? lo.value() : hi != null ? hi.value() : BigDecimal.ZERO;
+        }
+        if (!someValueLiesBetween(low, high)) {
+            return null;
+        }
+        if (low == null) {
+            return high == null ? BigDecimal.ZERO
+                    : high.inclusive() ? high.value() : high.value().subtract(BigDecimal.ONE);
+        }
+        if (low.inclusive()) {
+            return low.value();
+        }
+        // Open below, so the value is not the end. Halfway to the other end where there is one — an
+        // ordinary decimal, and inside both — and a step in where there is not.
+        return high == null ? low.value().add(BigDecimal.ONE)
+                : low.value().add(high.value()).divide(BigDecimal.valueOf(2));
+    }
+
+    /** An end moved onto the nearest whole number the range holds, which is always one it holds. */
+    private static Endpoint whole(Endpoint end, boolean lower) {
+        if (end == null) {
+            return null;
+        }
+        java.math.RoundingMode away = lower ? java.math.RoundingMode.CEILING
+                : java.math.RoundingMode.FLOOR;
+        if (end.inclusive()) {
+            return inclusive(end.value().setScale(0, away));
+        }
+        java.math.RoundingMode into = lower ? java.math.RoundingMode.FLOOR
+                : java.math.RoundingMode.CEILING;
+        BigDecimal step = end.value().setScale(0, into);
+        return inclusive(lower ? step.add(BigDecimal.ONE) : step.subtract(BigDecimal.ONE));
+    }
+
     /** The tighter of two upper bounds, the same way. */
     public static Endpoint upper(Endpoint a, Endpoint b) {
         if (a == null) {

--- a/souther-compiler/src/main/java/souther/compiler/numeric/Endpoint.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/Endpoint.java
@@ -1,0 +1,70 @@
+package souther.compiler.numeric;
+
+import java.math.BigDecimal;
+
+/** Where a range stops, and whether the value it stops at is one of its own. */
+public record Endpoint(BigDecimal value, boolean inclusive) {
+
+    public static Endpoint inclusive(BigDecimal value) {
+        return new Endpoint(value, true);
+    }
+
+    public static Endpoint exclusive(BigDecimal value) {
+        return new Endpoint(value, false);
+    }
+
+    /**
+     * The tighter of two lower bounds, where a {@code null} is no bound and so never the tighter.
+     *
+     * <p>At one value the two are the same edge asked of two rules, and a conjunction cannot admit
+     * what either conjunct refuses — so the value survives only where both admit it.
+     */
+    public static Endpoint lower(Endpoint a, Endpoint b) {
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+        int order = b.value().compareTo(a.value());
+        if (order == 0) {
+            return a.inclusive() && !b.inclusive() ? b : a;
+        }
+        return order > 0 ? b : a;
+    }
+
+    /**
+     * Whether anything at all lies between a lower bound and an upper one, either of which may be
+     * {@code null} for no bound.
+     *
+     * <p>Not a comparison of the two numbers. At one value they are equal whichever way they are
+     * written, and what decides it is whether both admit that value — over a dense atom there is
+     * nothing else between them to fall back on. A discrete atom never reaches here open: its strict
+     * bounds are sharpened onto the adjacent value where they are recorded.
+     */
+    public static boolean someValueLiesBetween(Endpoint low, Endpoint high) {
+        if (low == null || high == null) {
+            return true;
+        }
+        int order = low.value().compareTo(high.value());
+        if (order > 0) {
+            return false;
+        }
+        return order < 0 || (low.inclusive() && high.inclusive());
+    }
+
+    /** The tighter of two upper bounds, the same way. */
+    public static Endpoint upper(Endpoint a, Endpoint b) {
+        if (a == null) {
+            return b;
+        }
+        if (b == null) {
+            return a;
+        }
+        int order = b.value().compareTo(a.value());
+        if (order == 0) {
+            return a.inclusive() && !b.inclusive() ? b : a;
+        }
+        return order < 0 ? b : a;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
+++ b/souther-compiler/src/main/java/souther/compiler/numeric/NumericDomain.java
@@ -72,16 +72,16 @@ public final class NumericDomain {
     private record Asserted(LinearForm f, boolean strict) {}
 
     private final boolean bottom;                              // an infeasible path (guards contradict)
-    private final Map<String, BigDecimal> lo;                  // atom -> lower bound (null key absent = -inf)
-    private final Map<String, BigDecimal> hi;                  // atom -> upper bound (absent = +inf)
-    private final Map<String, Map<String, BigDecimal>> diff;   // diff[a][b] = tightest known (a - b)
+    private final Map<String, Endpoint> lo;                    // atom -> lower bound (absent = -inf)
+    private final Map<String, Endpoint> hi;                    // atom -> upper bound (absent = +inf)
+    private final Map<String, Map<String, Endpoint>> diff;     // diff[a][b] = tightest known (a - b)
     private final List<Asserted> kept;                         // forms outside both shapes, as written
     private final Map<String, Granularity> kinds;              // atom -> how its values are spaced
     private final Map<String, Set<Loss>> losses;               // atom -> what was not recorded of it
-    private Map<String, Map<String, BigDecimal>> closed;       // diff closed transitively, on first ask
+    private Map<String, Map<String, Endpoint>> closed;         // diff closed transitively, on first ask
 
-    private NumericDomain(boolean bottom, Map<String, BigDecimal> lo, Map<String, BigDecimal> hi,
-                          Map<String, Map<String, BigDecimal>> diff, List<Asserted> kept,
+    private NumericDomain(boolean bottom, Map<String, Endpoint> lo, Map<String, Endpoint> hi,
+                          Map<String, Map<String, Endpoint>> diff, List<Asserted> kept,
                           Map<String, Granularity> kinds, Map<String, Set<Loss>> losses) {
         this.bottom = bottom;
         this.lo = lo;
@@ -105,11 +105,6 @@ public final class NumericDomain {
      * rules stop and not merely where this stopped reading them.
      */
     public enum Loss {
-
-        /** A strict bound on an atom with no smallest step. {@code x < 1} over the decimals admits
-         * everything under 1 and no largest of them, so the bound recorded is {@code x <= 1} and the
-         * edge it names is a value the rule refuses. */
-        WEAKENED_STRICT,
 
         /** A disequality. {@code x /= 0} is a hole in a range, and a range is all this holds. */
         DROPPED_DISEQUALITY,
@@ -189,9 +184,9 @@ public final class NumericDomain {
      *
      * <p>What strictness is worth depends on what the atoms are made of. Over whole numbers there is
      * a next value to step to, so {@code a < 3} is {@code a <= 2} and {@code a - b < 0} is
-     * {@code a - b <= -1}; over decimals there is not, and a strict bound is recorded as the
-     * non-strict one, which is weaker and therefore still sound. A form of neither shape keeps its
-     * strictness as written.
+     * {@code a - b <= -1}, and the end that lands there is one the rule admits. Over decimals there
+     * is no step, and the end stays where the constraint put it and says that the value is not its
+     * own. A form of neither shape keeps its strictness as written.
      */
     private NumericDomain addLe(LinearForm g, boolean strict) {
         Map<String, BigDecimal> c = g.coefs();
@@ -211,28 +206,22 @@ public final class NumericDomain {
             java.math.MathContext mc = new java.math.MathContext(
                     34, upper ? java.math.RoundingMode.CEILING : java.math.RoundingMode.FLOOR);
             BigDecimal bound = g.constant().negate().divide(k, mc);
-            NumericDomain into = this;
-            if (kinds.get(a) == Granularity.DISCRETE) {
-                bound = whole(bound, upper, strict);
-            } else if (strict) {
-                into = losing(Loss.WEAKENED_STRICT, Set.of(a));
-            }
-            return upper ? into.withHi(a, bound) : into.withLo(a, bound);
+            Endpoint end = kinds.get(a) == Granularity.DISCRETE
+                    ? Endpoint.inclusive(whole(bound, upper, strict))
+                    : new Endpoint(bound, !strict);
+            return upper ? withHi(a, end) : withLo(a, end);
         }
         String[] ab = unitDiffAtoms(c);
         if (ab != null) {
             // a - b <= -const. A difference of two whole numbers is a whole number, and only then:
             // one dense atom on either side leaves the difference with no smallest step, so the
-            // bound stays where the constant put it.
+            // bound stays where the constant put it and says the value is outside it.
             BigDecimal bound = g.constant().negate();
-            NumericDomain into = this;
-            if (kinds.get(ab[0]) == Granularity.DISCRETE
-                    && kinds.get(ab[1]) == Granularity.DISCRETE) {
-                bound = whole(bound, true, strict);
-            } else if (strict) {
-                into = losing(Loss.WEAKENED_STRICT, Set.of(ab[0], ab[1]));
-            }
-            return into.withDiff(ab[0], ab[1], bound);
+            Endpoint end = kinds.get(ab[0]) == Granularity.DISCRETE
+                    && kinds.get(ab[1]) == Granularity.DISCRETE
+                    ? Endpoint.inclusive(whole(bound, true, strict))
+                    : new Endpoint(bound, !strict);
+            return withDiff(ab[0], ab[1], end);
         }
         // Neither shape holds it — a sum of two lengths, say. Keeping the form as written is what lets
         // a guard restating an invariant discharge it, which is the promise the flagging rests on.
@@ -326,20 +315,22 @@ public final class NumericDomain {
 
     /** Whether {@code g <= 0} (or {@code g < 0} when strict) follows from the domain. */
     private boolean proveLe(LinearForm g, boolean strict) {
-        BigDecimal hiG = upperBound(g);
+        Endpoint hiG = upperBound(g);
         if (hiG != null) {
-            int s = hiG.signum();
-            if (strict ? s < 0 : s <= 0) {
+            int s = hiG.value().signum();
+            // An end at zero the form's own bounds do not reach proves the strict form: nothing the
+            // domain admits gets there, which is what `g < 0` asks.
+            if (s < 0 || (s == 0 && (!strict || !hiG.inclusive()))) {
                 return true;
             }
         }
         String[] ab = unitDiffAtoms(g.coefs());
         if (ab != null) {
-            BigDecimal diffBound = closedDiff(ab[0], ab[1]);   // proven upper bound on (a - b)
+            Endpoint diffBound = closedDiff(ab[0], ab[1]);     // proven upper bound on (a - b)
             if (diffBound != null) {
                 BigDecimal bound = g.constant().negate();      // want a - b <= -const
-                int s = diffBound.compareTo(bound);
-                if (s < 0 || (!strict && s == 0)) {
+                int s = diffBound.value().compareTo(bound);
+                if (s < 0 || (s == 0 && (!strict || !diffBound.inclusive()))) {
                     return true;
                 }
             }
@@ -359,53 +350,62 @@ public final class NumericDomain {
         return false;
     }
 
-    /** The interval upper bound of {@code f}, or {@code null} if unbounded above. */
-    private BigDecimal upperBound(LinearForm f) {
+    /**
+     * The interval upper bound of {@code f}, or {@code null} if unbounded above.
+     *
+     * <p>The end is the form's own only where every end it was added from is. One term that cannot
+     * reach its edge is one the sum cannot reach either, so a single exclusive contribution makes the
+     * total exclusive.
+     */
+    private Endpoint upperBound(LinearForm f) {
         BigDecimal acc = f.constant();
+        boolean inclusive = true;
         for (Map.Entry<String, BigDecimal> e : f.coefs().entrySet()) {
             BigDecimal k = e.getValue();
-            BigDecimal b = k.signum() > 0 ? bestHi(e.getKey()) : bestLo(e.getKey());
+            Endpoint b = k.signum() > 0 ? bestHi(e.getKey()) : bestLo(e.getKey());
             if (b == null) {
                 return null;   // unbounded in the contributing direction
             }
-            acc = acc.add(k.multiply(b));
+            acc = acc.add(k.multiply(b.value()));
+            inclusive &= b.inclusive();
         }
-        return acc;
+        return new Endpoint(acc, inclusive);
     }
 
     /** The tightest upper bound on an atom: its own, or one reached through a difference —
      * {@code a - b <= d} and {@code b <= c} give {@code a <= c + d}, which is what relates the size of
-     * a filtered list to a bound on the list it came from. */
-    private BigDecimal bestHi(String a) {
-        BigDecimal best = hi.get(a);
-        for (Map.Entry<String, BigDecimal> b : hi.entrySet()) {
+     * a filtered list to a bound on the list it came from. A value at the end reached that way needs
+     * every end on the way to be reachable, so the derived end is its own only where both are. */
+    private Endpoint bestHi(String a) {
+        Endpoint best = hi.get(a);
+        for (Map.Entry<String, Endpoint> b : hi.entrySet()) {
             if (b.getKey().equals(a)) {
                 continue;
             }
-            BigDecimal d = closedDiff(a, b.getKey());
+            Endpoint d = closedDiff(a, b.getKey());
             if (d == null) {
                 continue;
             }
-            BigDecimal through = b.getValue().add(d);
-            best = best == null ? through : min(best, through);
+            best = Endpoint.upper(best, new Endpoint(b.getValue().value().add(d.value()),
+                    b.getValue().inclusive() && d.inclusive()));
         }
         return best;
     }
 
     /** The tightest lower bound on an atom, the same way: {@code b - a <= d} and {@code b >= c} give
      * {@code a >= c - d}. */
-    private BigDecimal bestLo(String a) {
-        BigDecimal best = lo.get(a);
-        for (Map.Entry<String, BigDecimal> b : lo.entrySet()) {
+    private Endpoint bestLo(String a) {
+        Endpoint best = lo.get(a);
+        for (Map.Entry<String, Endpoint> b : lo.entrySet()) {
             if (b.getKey().equals(a)) {
                 continue;
             }
-            BigDecimal d = closedDiff(b.getKey(), a);
+            Endpoint d = closedDiff(b.getKey(), a);
             if (d == null) {
                 continue;
             }
-            BigDecimal through = b.getValue().subtract(d);
-            best = best == null ? through : max(best, through);
+            best = Endpoint.lower(best, new Endpoint(b.getValue().value().subtract(d.value()),
+                    b.getValue().inclusive() && d.inclusive()));
         }
         return best;
     }
@@ -424,10 +424,17 @@ public final class NumericDomain {
     }
 
     /** What an atom's values are known to lie between. A {@code null} end is unbounded there. */
-    public record Bounds(BigDecimal min, BigDecimal max) {
+    public record Bounds(Endpoint min, Endpoint max) {
 
         public boolean isEmpty() {
             return min == null && max == null;
+        }
+
+        /** Whether {@code value} is inside both ends — asked of the ends, because whether an end is
+         * one of the values is what the number alone does not say. */
+        public boolean admits(BigDecimal value) {
+            return (min == null || Endpoint.someValueLiesBetween(min, Endpoint.inclusive(value)))
+                    && (max == null || Endpoint.someValueLiesBetween(Endpoint.inclusive(value), max));
         }
     }
 
@@ -494,8 +501,8 @@ public final class NumericDomain {
             return known;
         }
         NumericDomain d = known.forget(atom);
-        BigDecimal up = d.upperBound(f);
-        BigDecimal down = negOrNull(d.upperBound(f.negate()));
+        Endpoint up = d.upperBound(f);
+        Endpoint down = negOrNull(d.upperBound(f.negate()));
         NumericDomain r = d;
         if (up != null) {
             r = r.withHi(atom, up);
@@ -506,8 +513,10 @@ public final class NumericDomain {
         return r;
     }
 
-    private static BigDecimal negOrNull(BigDecimal v) {
-        return v == null ? null : v.negate();
+    /** An upper bound on {@code -f} read as a lower bound on {@code f}. Turning it around moves the
+     * value and not whether it is reached. */
+    private static Endpoint negOrNull(Endpoint v) {
+        return v == null ? null : new Endpoint(v.value().negate(), v.inclusive());
     }
 
     /** The domain with every fact about {@code atom} dropped — what an assignment leaves behind of
@@ -516,14 +525,14 @@ public final class NumericDomain {
         if (bottom) {
             return this;
         }
-        Map<String, BigDecimal> nlo = new HashMap<>(lo);
-        Map<String, BigDecimal> nhi = new HashMap<>(hi);
+        Map<String, Endpoint> nlo = new HashMap<>(lo);
+        Map<String, Endpoint> nhi = new HashMap<>(hi);
         nlo.remove(atom);
         nhi.remove(atom);
-        Map<String, Map<String, BigDecimal>> nd = new HashMap<>();
+        Map<String, Map<String, Endpoint>> nd = new HashMap<>();
         diff.forEach((a, row) -> {
             if (!a.equals(atom)) {
-                Map<String, BigDecimal> nr = new HashMap<>(row);
+                Map<String, Endpoint> nr = new HashMap<>(row);
                 nr.remove(atom);
                 if (!nr.isEmpty()) {
                     nd.put(a, nr);
@@ -541,24 +550,24 @@ public final class NumericDomain {
         return new NumericDomain(true, Map.of(), Map.of(), Map.of(), List.of(), kinds, losses);
     }
 
-    private NumericDomain withHi(String a, BigDecimal bound) {
-        Map<String, BigDecimal> nhi = new HashMap<>(hi);
-        nhi.merge(a, bound, NumericDomain::min);
+    private NumericDomain withHi(String a, Endpoint bound) {
+        Map<String, Endpoint> nhi = new HashMap<>(hi);
+        nhi.merge(a, bound, Endpoint::upper);
         NumericDomain d = new NumericDomain(false, lo, nhi, diff, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
 
-    private NumericDomain withLo(String a, BigDecimal bound) {
-        Map<String, BigDecimal> nlo = new HashMap<>(lo);
-        nlo.merge(a, bound, NumericDomain::max);
+    private NumericDomain withLo(String a, Endpoint bound) {
+        Map<String, Endpoint> nlo = new HashMap<>(lo);
+        nlo.merge(a, bound, Endpoint::lower);
         NumericDomain d = new NumericDomain(false, nlo, hi, diff, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
 
-    private NumericDomain withDiff(String a, String b, BigDecimal bound) {
-        Map<String, Map<String, BigDecimal>> nd = new HashMap<>();
+    private NumericDomain withDiff(String a, String b, Endpoint bound) {
+        Map<String, Map<String, Endpoint>> nd = new HashMap<>();
         diff.forEach((k, v) -> nd.put(k, new HashMap<>(v)));
-        nd.computeIfAbsent(a, k -> new HashMap<>()).merge(b, bound, NumericDomain::min);
+        nd.computeIfAbsent(a, k -> new HashMap<>()).merge(b, bound, Endpoint::upper);
         NumericDomain d = new NumericDomain(false, lo, hi, nd, kept, kinds, losses);
         return d.feasible() ? d : bottom();
     }
@@ -575,16 +584,17 @@ public final class NumericDomain {
      * about {@code a} — so both are asked here rather than at the atom the assertion happened to name.
      */
     private boolean feasible() {
-        for (Map.Entry<String, Map<String, BigDecimal>> row : closed().entrySet()) {
-            BigDecimal cycle = row.getValue().get(row.getKey());
-            if (cycle != null && cycle.signum() < 0) {
+        for (Map.Entry<String, Map<String, Endpoint>> row : closed().entrySet()) {
+            Endpoint cycle = row.getValue().get(row.getKey());
+            // `a - a` is zero, so a cycle bounding it below zero is a contradiction — and so is one
+            // bounding it at zero without admitting it.
+            if (cycle != null && (cycle.value().signum() < 0
+                    || (cycle.value().signum() == 0 && !cycle.inclusive()))) {
                 return false;
             }
         }
         for (String a : lo.keySet()) {
-            BigDecimal l = bestLo(a);
-            BigDecimal h = bestHi(a);
-            if (l != null && h != null && l.compareTo(h) > 0) {
+            if (!Endpoint.someValueLiesBetween(bestLo(a), bestHi(a))) {
                 return false;
             }
         }
@@ -592,47 +602,50 @@ public final class NumericDomain {
     }
 
     /** The tightest proven upper bound on {@code a - b}, or {@code null} if none is known. */
-    private BigDecimal closedDiff(String a, String b) {
+    private Endpoint closedDiff(String a, String b) {
         if (a.equals(b)) {
-            return BigDecimal.ZERO;
+            return Endpoint.inclusive(BigDecimal.ZERO);
         }
-        Map<String, BigDecimal> row = closed().get(a);
+        Map<String, Endpoint> row = closed().get(a);
         return row == null ? null : row.get(b);
     }
 
     /** The difference facts closed transitively — {@code a - b <= c} with {@code b - d <= e} gives
      * {@code a - d <= c + e} — computed once for the domain and read by every query it answers, since
      * a bound on one atom is derived through the differences to every other. */
-    private Map<String, Map<String, BigDecimal>> closed() {
+    private Map<String, Map<String, Endpoint>> closed() {
         if (closed == null) {
             closed = close(diff);
         }
         return closed;
     }
 
-    private static Map<String, Map<String, BigDecimal>> close(Map<String, Map<String, BigDecimal>> diff) {
+    private static Map<String, Map<String, Endpoint>> close(Map<String, Map<String, Endpoint>> diff) {
         Set<String> atoms = new HashSet<>(diff.keySet());
         diff.values().forEach(r -> atoms.addAll(r.keySet()));
-        Map<String, Map<String, BigDecimal>> d = new HashMap<>();
+        Map<String, Map<String, Endpoint>> d = new HashMap<>();
         diff.forEach((a, row) -> d.put(a, new HashMap<>(row)));
         for (String through : atoms) {
-            Map<String, BigDecimal> from = d.get(through);
+            Map<String, Endpoint> from = d.get(through);
             if (from == null) {
                 continue;
             }
-            List<Map.Entry<String, BigDecimal>> hops = List.copyOf(from.entrySet());
+            List<Map.Entry<String, Endpoint>> hops = List.copyOf(from.entrySet());
             for (String a : atoms) {
                 if (a.equals(through)) {
                     continue;   // a hop from an atom to itself only repeats a cycle already recorded
                 }
-                BigDecimal toThrough = edge(d, a, through);
+                Endpoint toThrough = edge(d, a, through);
                 if (toThrough == null) {
                     continue;
                 }
-                for (Map.Entry<String, BigDecimal> hop : hops) {
-                    BigDecimal candidate = toThrough.add(hop.getValue());
-                    BigDecimal known = edge(d, a, hop.getKey());
-                    if (known == null || candidate.compareTo(known) < 0) {
+                for (Map.Entry<String, Endpoint> hop : hops) {
+                    // A path reaches its end only where every hop on it does.
+                    Endpoint candidate = new Endpoint(
+                            toThrough.value().add(hop.getValue().value()),
+                            toThrough.inclusive() && hop.getValue().inclusive());
+                    Endpoint known = edge(d, a, hop.getKey());
+                    if (known == null || Endpoint.upper(known, candidate) == candidate) {
                         d.computeIfAbsent(a, k -> new HashMap<>()).put(hop.getKey(), candidate);
                     }
                 }
@@ -641,16 +654,8 @@ public final class NumericDomain {
         return d;
     }
 
-    private static BigDecimal edge(Map<String, Map<String, BigDecimal>> d, String a, String b) {
-        Map<String, BigDecimal> row = d.get(a);
+    private static Endpoint edge(Map<String, Map<String, Endpoint>> d, String a, String b) {
+        Map<String, Endpoint> row = d.get(a);
         return row == null ? null : row.get(b);
-    }
-
-    private static BigDecimal min(BigDecimal x, BigDecimal y) {
-        return x.compareTo(y) <= 0 ? x : y;
-    }
-
-    private static BigDecimal max(BigDecimal x, BigDecimal y) {
-        return x.compareTo(y) >= 0 ? x : y;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardEdge.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardEdge.java
@@ -59,13 +59,13 @@ public record GuardEdge(CoverageSites.GuardRef guard, int site, TermPath path,
             return false;
         }
         if (low != null && admissible.max() != null) {
-            int order = low.compareTo(admissible.max());
+            int order = low.compareTo(admissible.max().value());
             if (order > 0 || (order == 0 && !lowInclusive)) {
                 return true;
             }
         }
         if (high != null && admissible.min() != null) {
-            int order = high.compareTo(admissible.min());
+            int order = high.compareTo(admissible.min().value());
             if (order < 0 || (order == 0 && !highInclusive)) {
                 return true;
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardEdge.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardEdge.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 
 import java.math.BigDecimal;
@@ -58,18 +59,16 @@ public record GuardEdge(CoverageSites.GuardRef guard, int site, TermPath path,
         if (admissible == null) {
             return false;
         }
-        if (low != null && admissible.max() != null) {
-            int order = low.compareTo(admissible.max().value());
-            if (order > 0 || (order == 0 && !lowInclusive)) {
-                return true;
-            }
-        }
-        if (high != null && admissible.min() != null) {
-            int order = high.compareTo(admissible.min().value());
-            if (order < 0 || (order == 0 && !highInclusive)) {
-                return true;
-            }
-        }
-        return false;
+        // Two half-lines meeting at one number share it only where both hold it, and either side may
+        // be the one that does not. Asked of the pair rather than of the edge, because reading the
+        // arm's openness alone would call an arm at the top of a range reachable in a position whose
+        // rules stop short of it.
+        return !Endpoint.someValueLiesBetween(end(low, lowInclusive), admissible.max())
+                || !Endpoint.someValueLiesBetween(admissible.min(), end(high, highInclusive));
+    }
+
+    /** An end of this edge, or no end at all where the edge is open in that direction. */
+    private static Endpoint end(BigDecimal value, boolean inclusive) {
+        return value == null ? null : new Endpoint(value, inclusive);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -2,6 +2,8 @@ package souther.compiler.partition;
 
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.Granularity;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;
 
@@ -68,18 +70,21 @@ final class Intervals {
     private record Split(BigDecimal value, boolean valueBelongsBelow) {}
 
     /**
-     * The ranges {@code thresholds} leave, inside the domain {@code min}..{@code max} the type allows.
-     * Thresholds outside that domain are dropped: they cut a range no row can reach.
+     * The ranges {@code thresholds} leave, inside what the position holds.
+     *
+     * <p>The outer ends are the position's own, and they are taken as they are: an end the position
+     * stops short of is an end of the first range too, and rebuilding it as one the range holds puts
+     * the value back that the rules had taken away. Thresholds outside what the position holds are
+     * dropped — they cut a range no row can reach — and the end itself is outside it as much as
+     * anything past it is.
      */
-    static List<Interval> of(List<Threshold> thresholds, BigDecimal min, BigDecimal max) {
+    static List<Interval> of(List<Threshold> thresholds, Endpoint min, Endpoint max) {
         // Keyed by the number and not by the BigDecimal: `0.00` and `0` are one line, and
         // BigDecimal's own equality says they are two, which would leave two ranges holding zero.
         Map<String, Split> distinct = new LinkedHashMap<>();
         for (Threshold each : thresholds) {
-            if (min != null && each.value().compareTo(min) < 0) {
-                continue;
-            }
-            if (max != null && each.value().compareTo(max) > 0) {
+            if (!Endpoint.someValueLiesBetween(min, Endpoint.inclusive(each.value()))
+                    || !Endpoint.someValueLiesBetween(Endpoint.inclusive(each.value()), max)) {
                 continue;
             }
             distinct.putIfAbsent(each.value().stripTrailingZeros().toPlainString(),
@@ -89,8 +94,8 @@ final class Intervals {
         splits.sort(Comparator.comparing(Split::value));
 
         List<Interval> out = new ArrayList<>();
-        BigDecimal lo = min;
-        boolean loInclusive = true;
+        BigDecimal lo = min == null ? null : min.value();
+        boolean loInclusive = min == null || min.inclusive();
         for (Split split : splits) {
             Interval range = new Interval(lo, loInclusive, split.value(), split.valueBelongsBelow());
             if (range.inhabited()) {
@@ -99,7 +104,8 @@ final class Intervals {
             lo = split.value();
             loInclusive = !split.valueBelongsBelow();
         }
-        Interval last = new Interval(lo, loInclusive, max, true);
+        Interval last = new Interval(lo, loInclusive, max == null ? null : max.value(),
+                max == null || max.inclusive());
         if (last.inhabited()) {
             out.add(last);
         }
@@ -129,32 +135,13 @@ final class Intervals {
         return List.copyOf(classes);
     }
 
-    /** A value inside a range, or null where the type cannot name one — a decimal range open at the
-     * end it would have to step away from. */
+    /** A value inside a range, or null where it holds none. Asked of the ends, which is where whether
+     * the range holds the value it stops at is written down. */
     private static BigDecimal representative(Interval range, boolean decimal) {
-        BoundaryDomain domain = decimal ? BoundaryDomain.DECIMAL : BoundaryDomain.INT;
-        if (range.lo() != null && range.hi() != null) {
-            BigDecimal lo = range.loInclusive() ? range.lo() : step(range.lo(), domain, decimal, true);
-            if (lo == null) {
-                return null;
-            }
-            return range.holds(lo) ? lo : null;
-        }
-        if (range.lo() != null) {
-            return range.loInclusive() ? range.lo() : step(range.lo(), domain, decimal, true);
-        }
-        if (range.hi() != null) {
-            return range.hiInclusive() ? range.hi() : step(range.hi(), domain, decimal, false);
-        }
-        return BigDecimal.ZERO;
-    }
-
-    private static BigDecimal step(BigDecimal from, BoundaryDomain domain, boolean decimal,
-                                   boolean up) {
-        ObservedValue at = decimal ? new ObservedValue.Decimal(from)
-                : new ObservedValue.Integer(from.longValueExact());
-        return (up ? domain.successor(at) : domain.predecessor(at))
-                .map(Intervals::numberOf).orElse(null);
+        return Endpoint.valueBetween(
+                range.lo() == null ? null : new Endpoint(range.lo(), range.loInclusive()),
+                range.hi() == null ? null : new Endpoint(range.hi(), range.hiInclusive()),
+                decimal ? Granularity.DENSE : Granularity.DISCRETE);
     }
 
     static BigDecimal numberOf(ObservedValue v) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -151,8 +151,6 @@ public final class Partitions {
             // the record it sits in says about it. Reading the type again here would put a threshold
             // back inside a range the record has no values in.
             NumericDomain.Bounds domain = base.domains().get(axis.path().toString());
-            BigDecimal min = domain == null || domain.min() == null ? null : domain.min().value();
-            BigDecimal max = domain == null || domain.max() == null ? null : domain.max().value();
             // Filtered once, and both answers read the filtered list. A line outside what the
             // position holds divides nothing, and it is not a boundary either: leaving it in the
             // cuts while the intervals dropped it asks for a row at a value the record refuses,
@@ -162,7 +160,9 @@ public final class Partitions {
                     .filter(t -> domain == null || domain.admits(t.value()))
                     .toList();
             List<PartitionClass> classes = Intervals.classesOf(
-                    Intervals.of(reachable, min, max), axis.path(), axis.type(), symbols);
+                    Intervals.of(reachable, domain == null ? null : domain.min(),
+                            domain == null ? null : domain.max()),
+                    axis.path(), axis.type(), symbols);
             // What the position is, not what an invariant said about it. There is a bound to read
             // only where the type is a newtype carrying one, and a plain `Decimal` has none — read
             // off the bound, every such position would be called an integer and a threshold of
@@ -562,7 +562,10 @@ public final class Partitions {
         if (end == null) {
             return;
         }
-        boolean moved = own != null && own.value().compareTo(end.value()) != 0;
+        // Taken in, which a record can do by moving the end or by taking away the value it stops
+        // at. `low < high` under one `[0, 1]` leaves `low` the same 1 and no longer holding it, and
+        // that is the record's doing as much as a smaller number would have been.
+        boolean moved = own != null && !own.at().equals(end.at());
         for (TypeName from : end.from()) {
             put(into, numeric(end.value(), decimal), from, clause, moved ? within : null);
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -5,6 +5,7 @@ import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.check.FieldDomains;
+import souther.compiler.check.InvariantBound;
 import souther.compiler.codegen.InvariantConstraints;
 import souther.compiler.diag.SourceRef;
 import souther.compiler.observe.Incompleteness;
@@ -350,11 +351,9 @@ public final class Partitions {
         // from the rule that put one there, and which record did the narrowing is said beside it.
         return new Bounds(
                 own.min() == null ? null
-                        : new End(highest(own.min().value(), valueOf(projected.min())),
-                                own.min().from()),
+                        : new End(Endpoint.lower(own.min().at(), projected.min()), own.min().from()),
                 own.max() == null ? null
-                        : new End(lowest(own.max().value(), valueOf(projected.max())),
-                                own.max().from()),
+                        : new End(Endpoint.upper(own.max().at(), projected.max()), own.max().from()),
                 own.decimal());
     }
 
@@ -374,8 +373,8 @@ public final class Partitions {
         if (own == null) {
             return null;   // not a number, so nothing bounds it either way
         }
-        Endpoint min = own.min() == null ? null : Endpoint.inclusive(own.min().value());
-        Endpoint max = own.max() == null ? null : Endpoint.inclusive(own.max().value());
+        Endpoint min = own.min() == null ? null : own.min().at();
+        Endpoint max = own.max() == null ? null : own.max().at();
         return projected == null ? new NumericDomain.Bounds(min, max)
                 : new NumericDomain.Bounds(Endpoint.lower(min, projected.min()),
                         Endpoint.upper(max, projected.max()));
@@ -466,9 +465,20 @@ public final class Partitions {
      * they are two rules a row could be owed to, which is the accounting a cut already keeps. Holding
      * one would drop an obligation rather than a line of text.
      */
-    private record End(BigDecimal value, List<TypeName> from) {
+    private record End(Endpoint at, List<TypeName> from) {
 
-        /** This end, or {@code other} where it is the stronger, or both where they agree. */
+        BigDecimal value() {
+            return at.value();
+        }
+
+        /**
+         * This end, or {@code other} where it is the stronger, or both where they agree.
+         *
+         * <p>Which number survives and whether the value is one of the range's own are the same
+         * question asked of {@link Endpoint}, so that this and the domain cannot disagree about it.
+         * Where the two are at one number both names are kept: each is a rule the line is owed to,
+         * however far into the range each of them reaches.
+         */
         static End tighter(End had, End one, boolean upper) {
             if (one == null) {
                 return had;
@@ -476,13 +486,13 @@ public final class Partitions {
             if (had == null) {
                 return one;
             }
-            int order = one.value().compareTo(had.value());
-            if (order == 0) {
-                List<TypeName> both = new ArrayList<>(had.from());
-                one.from().stream().filter(n -> !both.contains(n)).forEach(both::add);
-                return new End(had.value(), List.copyOf(both));
+            Endpoint at = upper ? Endpoint.upper(had.at(), one.at()) : Endpoint.lower(had.at(), one.at());
+            if (had.value().compareTo(one.value()) != 0) {
+                return at == had.at() ? had : one;
             }
-            return (upper ? order < 0 : order > 0) ? one : had;
+            List<TypeName> both = new ArrayList<>(had.from());
+            one.from().stream().filter(n -> !both.contains(n)).forEach(both::add);
+            return new End(at, List.copyOf(both));
         }
     }
 
@@ -516,42 +526,20 @@ public final class Partitions {
         for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
             for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
                 for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
-                    InvariantConstraints.Constraint read =
-                            InvariantConstraints.of(each, base).orElse(null);
-                    min = End.tighter(min, endOf(lowerOf(read), layer), false);
-                    max = End.tighter(max, endOf(upperOf(read), layer), true);
+                    InvariantBound read = InvariantBound.of(each, base).orElse(null);
+                    if (read == null) {
+                        continue;
+                    }
+                    End end = new End(read.end(), List.of(layer.named()));
+                    if (read.lower()) {
+                        min = End.tighter(min, end, false);
+                    } else {
+                        max = End.tighter(max, end, true);
+                    }
                 }
             }
         }
         return new Bounds(min, max, base == Type.DECIMAL);
-    }
-
-    private static End endOf(BigDecimal value, TypeOps.Layer layer) {
-        return value == null ? null : new End(value, List.of(layer.named()));
-    }
-
-
-
-    /** The lower bound a constraint states, or null where it states none. */
-    private static BigDecimal lowerOf(InvariantConstraints.Constraint read) {
-        return switch (read) {
-            case InvariantConstraints.Min m -> BigDecimal.valueOf(m.n());
-            case InvariantConstraints.Positive _, InvariantConstraints.DecimalPositive _ ->
-                    BigDecimal.ONE;
-            case InvariantConstraints.NonNegative _, InvariantConstraints.DecimalNonNegative _ ->
-                    BigDecimal.ZERO;
-            case InvariantConstraints.DecimalMin m -> m.n();
-            case null, default -> null;   // length, pattern, size, or a rule this cannot read
-        };
-    }
-
-    /** The upper bound a constraint states, or null where it states none. */
-    private static BigDecimal upperOf(InvariantConstraints.Constraint read) {
-        return switch (read) {
-            case InvariantConstraints.Max m -> BigDecimal.valueOf(m.n());
-            case InvariantConstraints.DecimalMax m -> m.n();
-            case null, default -> null;
-        };
     }
 
     /** The cuts of a position, each carrying the rule that drew it. */
@@ -856,22 +844,6 @@ public final class Partitions {
     private static ObservedValue numeric(BigDecimal value, boolean decimal) {
         return decimal ? new ObservedValue.Decimal(value)
                 : new ObservedValue.Integer(value.longValueExact());
-    }
-
-    /** The higher of two bounds, where a null is no bound at all and so never the higher. */
-    private static BigDecimal highest(BigDecimal had, BigDecimal one) {
-        if (one == null) {
-            return had;
-        }
-        return had == null || one.compareTo(had) > 0 ? one : had;
-    }
-
-    /** The lower of two, the same way. */
-    private static BigDecimal lowest(BigDecimal had, BigDecimal one) {
-        if (one == null) {
-            return had;
-        }
-        return had == null || one.compareTo(had) < 0 ? one : had;
     }
 
     private Partitions() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -10,6 +10,7 @@ import souther.compiler.codegen.InvariantConstraints;
 import souther.compiler.diag.SourceRef;
 import souther.compiler.observe.Incompleteness;
 import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.Granularity;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;
@@ -380,11 +381,6 @@ public final class Partitions {
                         Endpoint.upper(max, projected.max()));
     }
 
-    /** An end's number, or null where there is no end. */
-    private static BigDecimal valueOf(Endpoint end) {
-        return end == null ? null : end.value();
-    }
-
     /** A record's fields, or nothing where the type is not one. A newtype is not taken apart: its
      * {@code value} is the same position it is. */
     private static Map<String, Type> productFields(Type type, Symbols symbols) {
@@ -608,11 +604,11 @@ public final class Partitions {
         if (type == null) {
             return List.of();
         }
-        if (type == Type.INT) {
-            return List.of(FixtureTemplate.integer(admissible(within, true).longValueExact()));
-        }
-        if (type == Type.DECIMAL) {
-            return List.of(FixtureTemplate.decimal(admissible(within, false)));
+        if (type == Type.INT || type == Type.DECIMAL) {
+            BigDecimal value = inside(within, type == Type.DECIMAL);
+            return value == null ? List.of()
+                    : List.of(type == Type.INT ? FixtureTemplate.integer(value.longValueExact())
+                            : FixtureTemplate.decimal(value));
         }
         if (type == Type.STRING) {
             return List.of(FixtureTemplate.string("x"));
@@ -655,10 +651,9 @@ public final class Partitions {
      * The same, with a second value offered at a numeric position.
      *
      * <p>One value is enough only where the rules that decide it are the rules the projection holds.
-     * A disequality is a hole no range keeps, a strict bound over the decimals is recorded as the
-     * non-strict one, and a form that is neither an interval nor a difference is not recorded at all —
-     * so the end a projection names can be the one value the rules refuse, and a position offering
-     * only that has nothing left to try.
+     * A disequality is a hole no range keeps, and a form that is neither an interval nor a difference
+     * is not recorded at all — so the value a range gives up can be one those rules refuse, and a
+     * position offering only that has nothing left to try.
      *
      * <p>Displaced and not invented. A whole number has a next one; a decimal between two ends has a
      * midpoint, and where it has no second end it gets no second value, because an epsilon is a value
@@ -700,19 +695,29 @@ public final class Partitions {
 
     /** A second number of a range, or null where the type has none to give. */
     private static BigDecimal displaced(NumericDomain.Bounds range, boolean whole) {
-        BigDecimal from = admissible(range, whole);
-        BigDecimal min = range == null ? null : valueOf(range.min());
-        BigDecimal max = range == null ? null : valueOf(range.max());
+        BigDecimal from = inside(range, !whole);
+        if (from == null) {
+            return null;
+        }
+        Endpoint min = range == null ? null : range.min();
+        Endpoint max = range == null ? null : range.max();
         if (!whole) {
-            // No smallest step, so the only second value a range names is one inside both its ends.
-            return min == null || max == null ? null : midpoint(min, max);
+            // No smallest step, so the only second value a range names is one inside both its ends —
+            // and the one already on offer is that value where the range is open below.
+            return min == null || max == null || !min.inclusive() ? null
+                    : Endpoint.valueBetween(Endpoint.exclusive(min.value()), max, Granularity.DENSE);
         }
         BigDecimal up = from.add(BigDecimal.ONE);
-        if (max == null || up.compareTo(max) <= 0) {
+        if (holdsNumber(range, up)) {
             return up;
         }
         BigDecimal down = from.subtract(BigDecimal.ONE);
-        return min == null || down.compareTo(min) >= 0 ? down : null;
+        return holdsNumber(range, down) ? down : null;
+    }
+
+    /** Whether a range holds a number, with no range holding everything. */
+    private static boolean holdsNumber(NumericDomain.Bounds range, BigDecimal value) {
+        return range == null || range.admits(value);
     }
 
     /**
@@ -741,10 +746,10 @@ public final class Partitions {
 
         Bounds own = boundsOf(new Type.Ref(newtype), symbols);
         NumericDomain.Bounds bounds = admissibleBounds(own, within);
-        if (bounds != null && !bounds.isEmpty()) {
-            candidates.add(own.decimal()
-                    ? FixtureTemplate.decimal(inside(bounds))
-                    : FixtureTemplate.integer(inside(bounds).longValueExact()));
+        BigDecimal held = bounds == null || bounds.isEmpty() ? null : inside(bounds, own.decimal());
+        if (held != null) {
+            candidates.add(own.decimal() ? FixtureTemplate.decimal(held)
+                    : FixtureTemplate.integer(held.longValueExact()));
         }
         if (base == Type.STRING && symbols.get(newtype) instanceof Ast.Data data) {
             for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(data, symbols)) {
@@ -766,59 +771,12 @@ public final class Partitions {
         return List.copyOf(once.values());
     }
 
-    /**
-     * A number the position can hold, for a position whose type says nothing about which one.
-     *
-     * <p>The lower end where there is one, the upper where there is only that, and zero where the
-     * position is left open — which is what a type with no rules has always offered here. The same
-     * order a newtype's own candidate is chosen in: the low end is inside whatever high end there is,
-     * so one rule picks a value for both shapes of range.
-     *
-     * <p>{@code whole} takes an end in to the nearest whole number inside it. A projection divides,
-     * so what it leaves an {@code Int} can have a fraction on it that no {@code Int} has.
-     */
-    private static BigDecimal admissible(NumericDomain.Bounds within, boolean whole) {
-        if (within == null) {
-            return BigDecimal.ZERO;
-        }
-        if (within.min() != null) {
-            BigDecimal min = within.min().value();
-            return whole ? min.setScale(0, java.math.RoundingMode.CEILING) : min;
-        }
-        if (within.max() != null) {
-            BigDecimal max = within.max().value();
-            return whole ? max.setScale(0, java.math.RoundingMode.FLOOR) : max;
-        }
-        return BigDecimal.ZERO;
-    }
-
-    /**
-     * A number the bound admits.
-     *
-     * <p>An edge the range holds is the value taken, because it is inside whatever other edge there
-     * is and it is the value a boundary wants written anyway. An edge the range stops short of is not
-     * one, and over a dense order there is no value beside it to take instead — so what is taken is a
-     * value from inside: between the two ends where both are known, and a step in from the only one
-     * where there is only one. Nothing about that step is the nearest admitted value; it is one the
-     * rules admit, chosen the same way every time, which is all a candidate has to be.
-     */
-    private static BigDecimal inside(NumericDomain.Bounds bounds) {
-        Endpoint min = bounds.min();
-        Endpoint max = bounds.max();
-        if (min != null && min.inclusive()) {
-            return min.value();
-        }
-        if (min == null) {
-            return max == null ? BigDecimal.ZERO
-                    : max.inclusive() ? max.value() : max.value().subtract(BigDecimal.ONE);
-        }
-        BigDecimal between = max == null ? null : midpoint(min.value(), max.value());
-        return between != null ? between : min.value().add(BigDecimal.ONE);
-    }
-
-    /** The value halfway between two, which every decimal range with two ends has. */
-    private static BigDecimal midpoint(BigDecimal min, BigDecimal max) {
-        return min.compareTo(max) >= 0 ? null : min.add(max).divide(BigDecimal.valueOf(2));
+    /** A number the position holds, or null where it holds none. The ends decide it, so nothing here
+     * reads one of them as a number and loses whether the range reaches it. */
+    private static BigDecimal inside(NumericDomain.Bounds within, boolean decimal) {
+        Granularity spacing = decimal ? Granularity.DENSE : Granularity.DISCRETE;
+        return within == null ? BigDecimal.ZERO
+                : Endpoint.valueBetween(within.min(), within.max(), spacing);
     }
 
     /**
@@ -844,7 +802,11 @@ public final class Partitions {
         }
         Bounds own = boundsOf(type, symbols);
         NumericDomain.Bounds bounds = admissibleBounds(own, within);
+        // The far end has to be a value the position holds. Where the range stops short of it there
+        // is nothing there to hold back, and a dense order has no value beside it to hold back
+        // instead — what is inside is already what the first tier offers.
         if (bounds == null || bounds.min() == null || bounds.max() == null
+                || !bounds.max().inclusive()
                 || bounds.max().value().compareTo(bounds.min().value()) == 0) {
             return List.of();
         }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -705,8 +705,7 @@ public final class Partitions {
         BigDecimal max = range == null ? null : valueOf(range.max());
         if (!whole) {
             // No smallest step, so the only second value a range names is one inside both its ends.
-            return min == null || max == null || min.compareTo(max) >= 0 ? null
-                    : min.add(max).divide(BigDecimal.valueOf(2));
+            return min == null || max == null ? null : midpoint(min, max);
         }
         BigDecimal up = from.add(BigDecimal.ONE);
         if (max == null || up.compareTo(max) <= 0) {
@@ -793,11 +792,33 @@ public final class Partitions {
         return BigDecimal.ZERO;
     }
 
-    /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge
-     * there is, and it is the value a boundary wants written anyway. */
+    /**
+     * A number the bound admits.
+     *
+     * <p>An edge the range holds is the value taken, because it is inside whatever other edge there
+     * is and it is the value a boundary wants written anyway. An edge the range stops short of is not
+     * one, and over a dense order there is no value beside it to take instead — so what is taken is a
+     * value from inside: between the two ends where both are known, and a step in from the only one
+     * where there is only one. Nothing about that step is the nearest admitted value; it is one the
+     * rules admit, chosen the same way every time, which is all a candidate has to be.
+     */
     private static BigDecimal inside(NumericDomain.Bounds bounds) {
-        return bounds.min() != null ? bounds.min().value()
-                : bounds.max() != null ? bounds.max().value() : BigDecimal.ZERO;
+        Endpoint min = bounds.min();
+        Endpoint max = bounds.max();
+        if (min != null && min.inclusive()) {
+            return min.value();
+        }
+        if (min == null) {
+            return max == null ? BigDecimal.ZERO
+                    : max.inclusive() ? max.value() : max.value().subtract(BigDecimal.ONE);
+        }
+        BigDecimal between = max == null ? null : midpoint(min.value(), max.value());
+        return between != null ? between : min.value().add(BigDecimal.ONE);
+    }
+
+    /** The value halfway between two, which every decimal range with two ends has. */
+    private static BigDecimal midpoint(BigDecimal min, BigDecimal max) {
+        return min.compareTo(max) >= 0 ? null : min.add(max).divide(BigDecimal.valueOf(2));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -8,6 +8,7 @@ import souther.compiler.check.FieldDomains;
 import souther.compiler.codegen.InvariantConstraints;
 import souther.compiler.diag.SourceRef;
 import souther.compiler.observe.Incompleteness;
+import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.observe.ObservedValue;
 import souther.compiler.types.Type;
@@ -148,8 +149,8 @@ public final class Partitions {
             // the record it sits in says about it. Reading the type again here would put a threshold
             // back inside a range the record has no values in.
             NumericDomain.Bounds domain = base.domains().get(axis.path().toString());
-            BigDecimal min = domain == null ? null : domain.min();
-            BigDecimal max = domain == null ? null : domain.max();
+            BigDecimal min = domain == null || domain.min() == null ? null : domain.min().value();
+            BigDecimal max = domain == null || domain.max() == null ? null : domain.max().value();
             // Filtered once, and both answers read the filtered list. A line outside what the
             // position holds divides nothing, and it is not a boundary either: leaving it in the
             // cuts while the intervals dropped it asks for a row at a value the record refuses,
@@ -215,9 +216,16 @@ public final class Partitions {
         BoundaryDomain domain = decimal ? BoundaryDomain.DECIMAL : BoundaryDomain.INT;
         List<BoundaryObligation> out = new ArrayList<>();
         for (Cut cut : axis.cuts()) {
+            // A line the position does not reach. The rule that drew it did so about the type, and
+            // what is left of the type here may stop short of it or leave the value out — `low < high`
+            // under one `[0, 1]` leaves `low` every value up to 1 and not 1 itself. Writing the value
+            // is how an edge is met, so where the value is refused there is nothing to write.
+            boolean reachable = holds(within, cut.value());
             for (OriginRef origin : cut.origins()) {
-                out.add(new BoundaryObligation(axis.id(), origin,
-                        BoundaryObligation.BoundarySide.AT, cut.value()));
+                if (reachable) {
+                    out.add(new BoundaryObligation(axis.id(), origin,
+                            BoundaryObligation.BoundarySide.AT, cut.value()));
+                }
                 if (origin instanceof OriginRef.GuardOrigin guard) {
                     // The other class's edge is the neighbour on the side the cut value is not on —
                     // where that class has values. A guard at the end of what the position can hold
@@ -254,8 +262,7 @@ public final class Partitions {
         if (number == null) {
             return true;
         }
-        return (within.min() == null || number.compareTo(within.min()) >= 0)
-                && (within.max() == null || number.compareTo(within.max()) <= 0);
+        return within.admits(number);
     }
 
     /** One position: measured where the model divides it or bounds it, taken apart where it is a
@@ -343,9 +350,11 @@ public final class Partitions {
         // from the rule that put one there, and which record did the narrowing is said beside it.
         return new Bounds(
                 own.min() == null ? null
-                        : new End(highest(own.min().value(), projected.min()), own.min().from()),
+                        : new End(highest(own.min().value(), valueOf(projected.min())),
+                                own.min().from()),
                 own.max() == null ? null
-                        : new End(lowest(own.max().value(), projected.max()), own.max().from()),
+                        : new End(lowest(own.max().value(), valueOf(projected.max())),
+                                own.max().from()),
                 own.decimal());
     }
 
@@ -365,11 +374,16 @@ public final class Partitions {
         if (own == null) {
             return null;   // not a number, so nothing bounds it either way
         }
-        BigDecimal min = own.min() == null ? null : own.min().value();
-        BigDecimal max = own.max() == null ? null : own.max().value();
+        Endpoint min = own.min() == null ? null : Endpoint.inclusive(own.min().value());
+        Endpoint max = own.max() == null ? null : Endpoint.inclusive(own.max().value());
         return projected == null ? new NumericDomain.Bounds(min, max)
-                : new NumericDomain.Bounds(highest(min, projected.min()),
-                        lowest(max, projected.max()));
+                : new NumericDomain.Bounds(Endpoint.lower(min, projected.min()),
+                        Endpoint.upper(max, projected.max()));
+    }
+
+    /** An end's number, or null where there is no end. */
+    private static BigDecimal valueOf(Endpoint end) {
+        return end == null ? null : end.value();
     }
 
     /** A record's fields, or nothing where the type is not one. A newtype is not taken apart: its
@@ -699,8 +713,8 @@ public final class Partitions {
     /** A second number of a range, or null where the type has none to give. */
     private static BigDecimal displaced(NumericDomain.Bounds range, boolean whole) {
         BigDecimal from = admissible(range, whole);
-        BigDecimal min = range == null ? null : range.min();
-        BigDecimal max = range == null ? null : range.max();
+        BigDecimal min = range == null ? null : valueOf(range.min());
+        BigDecimal max = range == null ? null : valueOf(range.max());
         if (!whole) {
             // No smallest step, so the only second value a range names is one inside both its ends.
             return min == null || max == null || min.compareTo(max) >= 0 ? null
@@ -781,10 +795,12 @@ public final class Partitions {
             return BigDecimal.ZERO;
         }
         if (within.min() != null) {
-            return whole ? within.min().setScale(0, java.math.RoundingMode.CEILING) : within.min();
+            BigDecimal min = within.min().value();
+            return whole ? min.setScale(0, java.math.RoundingMode.CEILING) : min;
         }
         if (within.max() != null) {
-            return whole ? within.max().setScale(0, java.math.RoundingMode.FLOOR) : within.max();
+            BigDecimal max = within.max().value();
+            return whole ? max.setScale(0, java.math.RoundingMode.FLOOR) : max;
         }
         return BigDecimal.ZERO;
     }
@@ -792,8 +808,8 @@ public final class Partitions {
     /** A number the bound admits. The lower edge where there is one: it is inside whatever upper edge
      * there is, and it is the value a boundary wants written anyway. */
     private static BigDecimal inside(NumericDomain.Bounds bounds) {
-        return bounds.min() != null ? bounds.min()
-                : bounds.max() != null ? bounds.max() : BigDecimal.ZERO;
+        return bounds.min() != null ? bounds.min().value()
+                : bounds.max() != null ? bounds.max().value() : BigDecimal.ZERO;
     }
 
     /**
@@ -820,10 +836,10 @@ public final class Partitions {
         Bounds own = boundsOf(type, symbols);
         NumericDomain.Bounds bounds = admissibleBounds(own, within);
         if (bounds == null || bounds.min() == null || bounds.max() == null
-                || bounds.max().compareTo(bounds.min()) == 0) {
+                || bounds.max().value().compareTo(bounds.min().value()) == 0) {
             return List.of();
         }
-        BigDecimal far = bounds.max();
+        BigDecimal far = bounds.max().value();
         FixtureTemplate held = FixtureTemplate.newtype(ref.name(), own.decimal()
                 ? FixtureTemplate.decimal(far) : FixtureTemplate.integer(far.longValueExact()));
         // Nothing already on offer: a range whose far edge is the number the base type stands for

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -155,10 +155,10 @@ public final class Partitions {
             // Filtered once, and both answers read the filtered list. A line outside what the
             // position holds divides nothing, and it is not a boundary either: leaving it in the
             // cuts while the intervals dropped it asks for a row at a value the record refuses,
-            // which is the thing being fixed here happening again one field over.
+            // which is the thing being fixed here happening again one field over. The end the
+            // position stops short of is outside it as much as anything past it is.
             List<Threshold> reachable = here.stream()
-                    .filter(t -> (min == null || t.value().compareTo(min) >= 0)
-                            && (max == null || t.value().compareTo(max) <= 0))
+                    .filter(t -> domain == null || domain.admits(t.value()))
                     .toList();
             List<PartitionClass> classes = Intervals.classesOf(
                     Intervals.of(reachable, min, max), axis.path(), axis.type(), symbols);

--- a/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ABoundaryIsAValueTheRecordCanHoldTest.java
@@ -319,28 +319,26 @@ class ABoundaryIsAValueTheRecordCanHoldTest {
     }
 
     /**
-     * An edge nothing promises is writable is reported and not counted.
+     * An edge a rule refuses is not a row anybody is owed.
      *
-     * <p>Over decimals a strict rule takes nothing off either end — there is no next value to step to
-     * — so both ends read `[0, 1]` while the true ranges are `[0, 1)` and `(0, 1]`. The edge is where
-     * the reading stopped and not where the model does. Falling back to the type's own edge is no
-     * better: the rule that could not be read refuses that value just as readily. So it is said and
-     * owed to nobody, which is the account ADR-0091 already gives a combination nothing has settled.
+     * <p>`low < high` under a shared `[0, 1]` leaves `low` in `[0, 1)` and `high` in `(0, 1]`. The
+     * line at 1 is one `Ratio` draws and both fields carry, and only one of them reaches it: a `low`
+     * of 1 would need a `high` above 1, which `Ratio` has no room for. The two edges of one rule come
+     * out differently because the record says so, and asking for the other is asking for a row nobody
+     * can write.
      */
     @Test
-    void anEdgeNothingPromisesIsSaidAndNotCounted() throws Exception {
-        String report = reportOn(BAND);
-
+    void anEdgeThePositionCannotReachIsNotOwedARow() throws Exception {
         List<String> owed = boundariesOf(BAND);
 
-        assertTrue(report.contains("not known to be writable: classify/band.low = 1"), () -> report);
-        assertFalse(owed.stream().anyMatch(l -> l.contains("classify/band.low = 1")),
-                () -> "and nobody is owed a row at it: " + owed);
-        // The other end of the same rule, which the projection could not promise either. A value at
-        // it was built, so it is owed — the two edges are told apart by what something managed to
-        // construct and not by how far one reading of the rules got.
+        assertTrue(owed.stream().anyMatch(l -> l.contains("classify/band.low = 0")),
+                () -> "the bottom of the lower field is its own: " + owed);
         assertTrue(owed.stream().anyMatch(l -> l.contains("classify/band.high = 1")),
-                () -> "a row at the top of the upper field builds: " + owed);
+                () -> "and the top of the upper field is: " + owed);
+        assertFalse(owed.stream().anyMatch(l -> l.contains("classify/band.low = 1")),
+                () -> "a low of 1 leaves no room for a high above it: " + owed);
+        assertFalse(owed.stream().anyMatch(l -> l.contains("classify/band.high = 0")),
+                () -> "and a high of 0 leaves none for a low below it: " + owed);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APairIsChosenOnePositionAtATimeTest.java
@@ -181,17 +181,16 @@ class APairIsChosenOnePositionAtATimeTest {
     }
 
     /**
-     * A dense strict bound is reached by a value off the end, and not by the order of choosing.
+     * A dense strict relation leaves each field an end it does not reach, and no row is asked for
+     * there.
      *
-     * <p>Choosing {@code low} first leaves {@code high} at zero and above, because {@code low < high}
-     * over the decimals is recorded as {@code low - high <= 0} — so the end the projection offers is
-     * the one value the rule refuses. What gets past it is a second value from the range, and the
-     * ends themselves stay where they were: the report still cannot say that a {@code high} of zero
-     * is impossible rather than untried, because the bound it would have to read that off is the
-     * weakened one (#483).
+     * <p>{@code low < high} under one {@code [0, 1]} leaves {@code low} up to 1 without 1 and
+     * {@code high} from 0 without 0. Two of the four edges the type draws are values the record
+     * refuses, and what the report says about them is nothing at all — an edge nobody can write is
+     * not a gap, and calling it untried would send an author looking for a row that does not exist.
      */
     @Test
-    void aStrictBoundOverDecimalsIsReachedOffTheEnd() throws Exception {
+    void aStrictRelationOverDecimalsAsksForNoRowAtTheEndItRefuses() throws Exception {
         String model = """
                 module example.band
 
@@ -223,9 +222,13 @@ class APairIsChosenOnePositionAtATimeTest {
         }
         String rows = out.toString(StandardCharsets.UTF_8);
 
-        assertTrue(rows.contains("high = Ratio(1m)"),
-                () -> "the far end of what `high` can hold, which the range names:\n" + rows);
-        assertTrue(rows.contains("no row for `band.high = 0`"),
-                () -> "and the end itself is still where nothing can be written:\n" + rows);
+        assertTrue(rows.contains("\"band.low = 0\""),
+                () -> "the bottom of `low` is a row it can write:\n" + rows);
+        assertTrue(rows.contains("\"band.high = 1\""),
+                () -> "and so is the top of `high`:\n" + rows);
+        assertFalse(rows.contains("band.high = 0"),
+                () -> "a high of zero is refused by the record, so nothing is owed there:\n" + rows);
+        assertFalse(rows.contains("band.low = 1"),
+                () -> "nor at a low of one:\n" + rows);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/APositionOffersASecondValueWhereItsRangeIsApproximateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APositionOffersASecondValueWhereItsRangeIsApproximateTest.java
@@ -133,14 +133,15 @@ class APositionOffersASecondValueWhereItsRangeIsApproximateTest {
     }
 
     /**
-     * A decimal gets a second value only between two ends.
+     * A decimal open at its only end is offered a value from inside it.
      *
-     * <p>A whole number has a next one. A decimal does not, and an epsilon is a value the type does
-     * not name — inventing one would propose a row against a rule the model never stated. Between two
-     * ends there is an ordinary decimal, and that is the only second value there is to give.
+     * <p>`low < high` with both at zero and above leaves `high` starting at zero without holding it,
+     * and a dense order has no next value to move onto. What the position offers is a value the range
+     * admits rather than the number it stops at — chosen the same way every time and carrying no claim
+     * to be the nearest one, which is what a candidate is for.
      */
     @Test
-    void aDecimalWithOneEndKeepsTheOneValueItHas() throws Exception {
+    void aDecimalOpenAtItsOnlyEndOffersAValueInsideIt() throws Exception {
         String model = """
                 module example.halfopen
 
@@ -172,7 +173,9 @@ class APositionOffersASecondValueWhereItsRangeIsApproximateTest {
         }
         String rows = out.toString(StandardCharsets.UTF_8);
 
-        assertTrue(rows.contains("every value tried was refused"),
-                () -> "nothing above zero is named by a range that only starts there:\n" + rows);
+        assertTrue(rows.contains("Pair { low = Rate(0m), high = Rate(1m) }"),
+                () -> "`low` reaches its end and `high` starts a step past it:\n" + rows);
+        assertFalse(rows.contains("every value tried was refused"),
+                () -> "and nothing had to be refused to get there:\n" + rows);
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
@@ -3,6 +3,7 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.observe.MeasurementStatus;
 import souther.compiler.partition.GuardEdge;
@@ -247,7 +248,8 @@ class AnArmNothingReachesIsNotOwedARowTest {
         GuardEdge edge = GuardEdge.above(new CoverageSites.GuardRef("classify", 0, 1, null),
                 0, TermPath.of("pair"), BigDecimal.valueOf(50), true);
         return GuardReachability.of(List.of(edge),
-                Map.of("pair", new NumericDomain.Bounds(BigDecimal.ZERO, BigDecimal.TEN)));
+                Map.of("pair", new NumericDomain.Bounds(Endpoint.inclusive(BigDecimal.ZERO),
+                        Endpoint.inclusive(BigDecimal.TEN))));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
@@ -99,6 +99,49 @@ class AnEndIsWhereItsRuleStopsTest {
     }
 
     /**
+     * A value offered for an open end is one inside it.
+     *
+     * <p>Over the decimals there is no value beside the end to step onto, so what a position can
+     * offer is a value from inside the range and not one next to its edge — a midpoint where both
+     * ends are known, and a step where only one is. Nothing about the choice is the nearest value
+     * the rule admits, because over a dense order there is no such thing; what it has to be is one
+     * the rule admits at all, decided the same way every time.
+     */
+    @Test
+    void aPositionOpenAtAnEndOffersAValueFromInsideIt() throws Exception {
+        String rows = reportOn("""
+                module example.probe
+
+                data AboveFive = Decimal
+                    invariant above = value > 5.0m
+
+                data UnderOne = Decimal
+                    invariant under = value < 1.0m
+
+                data Between = Decimal
+                    invariant between = value > 5.0m && value < 6.0m
+
+                data Holder = { a: AboveFive, u: UnderOne, b: Between, flag: Bool }
+
+                data Ok
+
+                behavior take : (h: Holder) -> Ok
+                    constructs Ok
+
+                let take (h) = Ok
+                """, "--generate");
+
+        assertTrue(rows.contains("a = AboveFive(6m)"),
+                () -> "a step up from an end nothing sits on:\n" + rows);
+        assertTrue(rows.contains("u = UnderOne(0m)"),
+                () -> "and a step down from the other:\n" + rows);
+        assertTrue(rows.contains("b = Between(5.5m)"),
+                () -> "and between two of them, the value between them:\n" + rows);
+        assertFalse(rows.contains("every value tried was refused"),
+                () -> "none of which the rules refuse:\n" + rows);
+    }
+
+    /**
      * A comparison against a value the position cannot hold divides nothing.
      *
      * <p>A guard draws a line and both sides of it ordinarily hold values a row can write. Where the

--- a/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
@@ -1,0 +1,116 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An end is read off the rule that drew it.
+ *
+ * <p>The bounds a position is measured at used to be read from the constraints codegen emits, which
+ * are the shapes the runtime has a check for. That list answers a different question. It has a case
+ * for a decimal above zero because the runtime states that one directly, and none for a decimal above
+ * five — so a rule that draws a line at five was read as drawing none, and one that draws a line at
+ * zero was read as drawing it at one, which is the whole number a positive integer starts at and a
+ * value no decimal rule here mentions.
+ */
+class AnEndIsWhereItsRuleStopsTest {
+
+    private static final String MODEL = """
+            module example.probe
+
+            data Positive = Decimal
+                invariant positive = value > 0m
+
+            data AboveFive = Decimal
+                invariant above = value > 5.0m
+
+            data Holder = { p: Positive, a: AboveFive }
+
+            data Ok
+
+            behavior take : (h: Holder) -> Ok
+                constructs Ok
+
+            let take (h) = Ok
+            """;
+
+    /** A boundary is at a value some rule wrote. Nothing here writes a one. */
+    @Test
+    void anEdgeIsNotAtAValueNoRuleNamed() throws Exception {
+        String report = reportOn(MODEL);
+
+        assertFalse(report.contains("take/h.p = 1"),
+                () -> "`value > 0m` says nothing about one:\n" + report);
+    }
+
+    /** And a line five is drawn at is a line, though the runtime has no word for it. */
+    @Test
+    void aStrictBoundAwayFromZeroIsALineTheModelDraws() throws Exception {
+        String report = reportOn(MODEL);
+
+        assertFalse(report.contains("not derivable: h.a"),
+                () -> "`value > 5.0m` divides the position at five:\n" + report);
+    }
+
+    /**
+     * A rule this reads is a rule the value's edges are promised against.
+     *
+     * <p>Whether every rule was taken in is asked once for the whole value, so one clause nobody
+     * could read leaves every edge beside it unpromised. The clause here is `value > 5.0m`, which is
+     * read now, and the edge is the other field's — which has nothing to do with it and was being
+     * held back all the same.
+     */
+    @Test
+    void anEdgeIsPromisedWhereEveryRuleBesideItWasRead() throws Exception {
+        String report = reportOn("""
+                module example.probe
+
+                data AboveFive = Decimal
+                    invariant above = value > 5.0m
+
+                data AtMostTen = Decimal
+                    invariant capped = value <= 10.0m
+
+                data Holder = { a: AboveFive, b: AtMostTen }
+
+                data Ok
+
+                behavior take : (h: Holder) -> Ok
+                    constructs Ok
+
+                let take (h) = Ok
+
+                example take
+                    | "a" : (Holder { a = AboveFive(6m), b = AtMostTen(1m) }) -> Ok
+                """);
+
+        assertFalse(report.contains("not known to be writable: take/h.b = 10"), () -> report);
+        assertTrue(report.contains("no row is at take/h.b = 10"),
+                () -> "and the edge is one a row is owed at:\n" + report);
+    }
+
+    private static String reportOn(String model, String... extra) throws Exception {
+        Path file = Files.createTempDirectory("souther-ends").resolve("model.sou");
+        Files.writeString(file, model);
+        List<String> args = new java.util.ArrayList<>(List.of("examples", file.toString()));
+        args.addAll(List.of(extra));
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(args.toArray(String[]::new));
+        } finally {
+            System.setOut(was);
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
@@ -208,6 +208,42 @@ class AnEndIsWhereItsRuleStopsTest {
                 () -> "a low above zero is a row that builds:\n" + rows);
     }
 
+    /**
+     * A guard on a position open at its end leaves ranges that are open there too.
+     *
+     * <p>The ranges a comparison leaves are cut out of what the position holds, and one of their ends
+     * is that position's own. Rebuilt as closed, the first of them holds the value the invariant
+     * refuses and offers it as the value standing for the whole class.
+     */
+    @Test
+    void aRangeCutOutOfAnOpenEndIsOpenThere() throws Exception {
+        String report = reportOn("""
+                module example.probe
+
+                data AboveFive = Decimal
+                    invariant above = value > 5m
+
+                data Ok
+                data No
+
+                behavior pick : (r: AboveFive) -> Ok | No
+                    constructs Ok, No
+
+                let pick (r) = {
+                    guard r.value < 10m else No
+                    Ok
+                }
+
+                example pick
+                    | "over" : (AboveFive(20m)) -> No
+                """, "--generate");
+
+        assertFalse(report.contains("5 <= x"),
+                () -> "nothing of `value > 5m` is five:\n" + report);
+        assertFalse(report.contains("AboveFive(5m)"),
+                () -> "so five stands for no class of it:\n" + report);
+    }
+
     private static String reportOn(String model, String... extra) throws Exception {
         Path file = Files.createTempDirectory("souther-ends").resolve("model.sou");
         Files.writeString(file, model);

--- a/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
@@ -177,6 +177,37 @@ class AnEndIsWhereItsRuleStopsTest {
                 () -> "so no row is asked for there:\n" + report);
     }
 
+    /**
+     * A position of no type but {@code Decimal} is offered a value from inside its range too.
+     *
+     * <p>What is left of a position once the rest of the assignment is settled is read off the record
+     * either way — `low < high` leaves `high` above whatever `low` took, and above it without holding
+     * it. A value offered at the number the range stops at is refused whether or not somebody wrapped
+     * a name round the position.
+     */
+    @Test
+    void aBareDecimalIsOfferedAValueItsRangeHolds() throws Exception {
+        String rows = reportOn("""
+                module example.probe
+
+                data Pair =
+                    { low: Decimal
+                    , high: Decimal
+                    }
+                    invariant lower = low > 0m
+
+                data Ok
+
+                behavior take : (p: Pair, flag: Bool) -> Ok
+                    constructs Ok
+
+                let take (p, flag) = Ok
+                """, "--generate");
+
+        assertFalse(rows.contains("every value tried was refused"),
+                () -> "a low above zero is a row that builds:\n" + rows);
+    }
+
     private static String reportOn(String model, String... extra) throws Exception {
         Path file = Files.createTempDirectory("souther-ends").resolve("model.sou");
         Files.writeString(file, model);

--- a/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEndIsWhereItsRuleStopsTest.java
@@ -98,6 +98,42 @@ class AnEndIsWhereItsRuleStopsTest {
                 () -> "and the edge is one a row is owed at:\n" + report);
     }
 
+    /**
+     * A comparison against a value the position cannot hold divides nothing.
+     *
+     * <p>A guard draws a line and both sides of it ordinarily hold values a row can write. Where the
+     * line is the end the position stops short of, one side holds nothing — and a class nothing can
+     * be written in is a gap no author can close.
+     */
+    @Test
+    void aGuardAtAnEndThePositionDoesNotReachDividesNothing() throws Exception {
+        String report = reportOn("""
+                module example.probe
+
+                data Ratio = Decimal
+                    invariant above = value > 5.0m
+
+                data Ok
+                data No
+
+                behavior pick : (r: Ratio) -> Ok | No
+                    constructs Ok, No
+
+                let pick (r) = {
+                    guard r.value > 5.0m else No
+                    Ok
+                }
+
+                example pick
+                    | "a" : (Ratio(6m)) -> Ok
+                """, "--generate");
+
+        assertFalse(report.contains("5 <= x <= 5"),
+                () -> "nothing of `value > 5.0m` is five:\n" + report);
+        assertFalse(report.contains("every value tried was refused"),
+                () -> "so no row is asked for there:\n" + report);
+    }
+
     private static String reportOn(String model, String... extra) throws Exception {
         Path file = Files.createTempDirectory("souther-ends").resolve("model.sou");
         Files.writeString(file, model);

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsRangeIsTheRecordsRuleProjectedOntoItTest.java
@@ -41,8 +41,10 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
 
     private static void assertBounds(NumericDomain.Bounds bounds, long min, long max) {
         assertNotNull(bounds, "nothing bounds this field");
-        assertEquals(0, BigDecimal.valueOf(min).compareTo(bounds.min()), "min was " + bounds.min());
-        assertEquals(0, BigDecimal.valueOf(max).compareTo(bounds.max()), "max was " + bounds.max());
+        assertEquals(0, BigDecimal.valueOf(min).compareTo(bounds.min().value()),
+                "min was " + bounds.min());
+        assertEquals(0, BigDecimal.valueOf(max).compareTo(bounds.max().value()),
+                "max was " + bounds.max());
     }
 
     private static final String TIMESHEET = """
@@ -108,9 +110,16 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
         assertBounds(domains.at("lateNight"), 0, 24);
     }
 
-    /** Over decimals there is no next value, so a strict rule takes nothing off either end. */
+    /**
+     * Over decimals a strict rule moves no end and takes the value at one of them away.
+     *
+     * <p>There is no next value to step onto, so both ends stay where {@code Ratio} put them. What
+     * {@code low < high} does is leave {@code low} everything up to 1 without 1 itself, and
+     * {@code high} everything from 0 without 0 — which is the whole of the rule and not an
+     * approximation of it.
+     */
     @Test
-    void aStrictRuleOverDecimalsNarrowsNothing() {
+    void aStrictRuleOverDecimalsLeavesTheEndsWhereTheyAreAndOutsideTheRange() {
         FieldDomains domains = domainsIn("""
                 module example.band
 
@@ -126,9 +135,11 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
 
         assertBounds(domains.at("low"), 0, 1);
         assertBounds(domains.at("high"), 0, 1);
-        assertFalse(domains.allRulesRead(),
-                "the true ranges are open at one end, which these bounds cannot hold, so neither 1"
-                        + " nor 0 is promised to be writable");
+        assertTrue(domains.at("low").min().inclusive(), "a low of 0 needs no room under it");
+        assertFalse(domains.at("low").max().inclusive(), "a low of 1 leaves no room above it");
+        assertFalse(domains.at("high").min().inclusive(), "nor a high of 0 below it");
+        assertTrue(domains.at("high").max().inclusive(), "and a high of 1 needs none");
+        assertTrue(domains.allRulesRead(), "and every rule of the record was taken into these");
     }
 
     /** A rule that skips a value is a hole in a range, and a range is all the domain holds. The bound
@@ -291,7 +302,7 @@ class AFieldsRangeIsTheRecordsRuleProjectedOntoItTest {
 
         assertTrue(domains.allRulesRead(),
                 "the rule is `value >= 0.0m` wherever it is declared");
-        assertEquals(0, BigDecimal.ZERO.compareTo(domains.at("total").min()),
+        assertEquals(0, BigDecimal.ZERO.compareTo(domains.at("total").min().value()),
                 "and it reaches the domain from there too");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/numeric/EndpointTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/EndpointTest.java
@@ -1,0 +1,80 @@
+package souther.compiler.numeric;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a range stops, and whether the value it stops at is one of its own.
+ *
+ * <p>The algebra is written here once because two carriers derive it: the domain, which computes
+ * with the numbers, and a partition's end, which also says which rule put it there. Two inventions
+ * of the same rule is the disagreement this exists to keep out.
+ */
+class EndpointTest {
+
+    private static final BigDecimal FIVE = new BigDecimal("5");
+
+    /**
+     * Two lower bounds at the same value leave the value out where either of them does.
+     *
+     * <p>{@code x >= 5} and {@code x > 5} together are {@code x > 5}: the second refuses the value,
+     * and a conjunction cannot admit what one of its conjuncts refuses.
+     */
+    @Test
+    void theExclusiveOfTwoLowerBoundsAtOneValueWins() {
+        Endpoint open = Endpoint.exclusive(FIVE);
+        Endpoint closed = Endpoint.inclusive(FIVE);
+
+        assertEquals(open, Endpoint.lower(closed, open));
+        assertEquals(open, Endpoint.lower(open, closed));
+    }
+
+    /** The same of two upper bounds, which differ only in which way the values run. */
+    @Test
+    void theExclusiveOfTwoUpperBoundsAtOneValueWins() {
+        Endpoint open = Endpoint.exclusive(FIVE);
+        Endpoint closed = Endpoint.inclusive(FIVE);
+
+        assertEquals(open, Endpoint.upper(closed, open));
+        assertEquals(open, Endpoint.upper(open, closed));
+    }
+
+    /**
+     * An end is not moved by one that says the same thing.
+     *
+     * <p>Two readings of one range reach it by different routes and write their numbers to different
+     * places — a rule read off the declaration says zero, the same rule projected through the record
+     * says zero to one place. Neither is tighter, so neither replaces the other, and what a report
+     * prints does not depend on which reading was asked second.
+     */
+    @Test
+    void anEndIsKeptWhereTheOtherIsNoTighter() {
+        Endpoint had = Endpoint.inclusive(new BigDecimal("0"));
+        Endpoint same = Endpoint.inclusive(new BigDecimal("0.0"));
+
+        assertEquals(had, Endpoint.lower(had, same));
+        assertEquals(had, Endpoint.upper(had, same));
+    }
+
+    /**
+     * Ends at one value leave that value where either of them refuses it, and nothing else is there.
+     *
+     * <p>Asked here rather than of the two numbers, which are equal in all four and say nothing about
+     * whether anything is left. Over a dense atom there is nothing between them to fall back on.
+     */
+    @Test
+    void endsAtOneValueAdmitItOnlyWhereBothDo() {
+        Endpoint open = Endpoint.exclusive(FIVE);
+        Endpoint closed = Endpoint.inclusive(FIVE);
+
+        assertTrue(Endpoint.someValueLiesBetween(closed, closed));
+        assertFalse(Endpoint.someValueLiesBetween(open, closed));
+        assertFalse(Endpoint.someValueLiesBetween(closed, open));
+        assertFalse(Endpoint.someValueLiesBetween(open, open));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/numeric/NumericDomainTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/numeric/NumericDomainTest.java
@@ -141,6 +141,20 @@ class NumericDomainTest {
         assertFalse(provesAtLeast(d, A, 5), "a = 4 satisfies it");
     }
 
+    /**
+     * {@code a > 0} over a dense atom stops at zero without admitting it.
+     *
+     * <p>The value is where the rule stops and is not one of the values it leaves. Reading the number
+     * alone cannot tell that from {@code a >= 0}, and a caller turning a bound into a value somebody
+     * has to write needs the difference: zero is what the rule refuses.
+     */
+    @Test
+    void aStrictLowerBoundOnADenseAtomKeepsTheValueOutOfItsOwnRange() {
+        NumericDomain d = NumericDomain.top().assume(atom(A), Rel.GT, dense(A));
+
+        assertEquals(Endpoint.exclusive(BigDecimal.ZERO), d.boundsOf(A).min());
+    }
+
     // --- strictness on a difference, which is the part a record's invariant writes -----------------
 
     /**
@@ -243,26 +257,25 @@ class NumericDomainTest {
         assertFalse(d.projectionIsLossless(), "and the domain is not all of what it was told");
     }
 
-    /** A strict bound over decimals is recorded as the non-strict one, so the edge it names is a
-     * value the rule refuses. Sound as a bound, and not an edge anybody can write. */
+    /** A strict bound over decimals is kept as an end the range stops at without reaching, which is
+     * the whole of what was asserted and so no loss. */
     @Test
-    void aStrictBoundOnADenseAtomIsRecordedAsALoss() {
+    void aStrictBoundOnADenseAtomIsKeptAsAnEndTheRangeDoesNotReach() {
         NumericDomain interval = NumericDomain.top()
                 .assume(atom(A).minus(num(3)), Rel.LT, dense(A));
-        NumericDomain difference = NumericDomain.top()
-                .assume(atom(A).minus(atom(B)), Rel.LT, dense(A, B));
 
-        assertFalse(interval.projectionIsLossless());
-        assertEquals(Set.of(NumericDomain.Loss.WEAKENED_STRICT), interval.lossesAt(A));
-        assertEquals(Set.of(A, B), difference.lossyAtoms(),
-                "a difference is a rule about both of its ends");
+        assertEquals(Endpoint.exclusive(BigDecimal.valueOf(3)), interval.boundsOf(A).max());
+        assertTrue(interval.projectionIsLossless());
     }
 
-    /** The same over whole numbers keeps everything: there the strictness became a step. */
+    /** The same over whole numbers keeps everything too: there the strictness became a step, and the
+     * value it steps onto is one the rule admits. */
     @Test
     void aStrictBoundOnAWholeNumberIsNoLoss() {
-        assertTrue(NumericDomain.top().assume(atom(A).minus(num(3)), Rel.LT, whole(A))
-                .projectionIsLossless());
+        NumericDomain d = NumericDomain.top().assume(atom(A).minus(num(3)), Rel.LT, whole(A));
+
+        assertEquals(Endpoint.inclusive(BigDecimal.valueOf(2)), d.boundsOf(A).max());
+        assertTrue(d.projectionIsLossless());
     }
 
     /** A disequality is a hole in a range, and a range is all this holds. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGuardsArmsAreNotItsThresholdTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGuardsArmsAreNotItsThresholdTest.java
@@ -7,6 +7,7 @@ import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeChecker;
 import souther.compiler.core.Core;
 import souther.compiler.coverage.CoverageSites;
+import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.NumericDomain;
 import souther.compiler.query.Bodies;
 import souther.compiler.query.Compilation;
@@ -153,8 +154,9 @@ class AGuardsArmsAreNotItsThresholdTest {
     }
 
     private static NumericDomain.Bounds holds(Long min, Long max) {
-        return new NumericDomain.Bounds(min == null ? null : BigDecimal.valueOf(min),
-                max == null ? null : BigDecimal.valueOf(max));
+        return new NumericDomain.Bounds(
+                min == null ? null : Endpoint.inclusive(BigDecimal.valueOf(min)),
+                max == null ? null : Endpoint.inclusive(BigDecimal.valueOf(max)));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/AGuardsArmsAreNotItsThresholdTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AGuardsArmsAreNotItsThresholdTest.java
@@ -183,6 +183,27 @@ class AGuardsArmsAreNotItsThresholdTest {
         assertTrue(below(0, false).provenDisjoint(holds(0L, 10L)));
     }
 
+    /**
+     * The position's own end is open at the value the arm starts at.
+     *
+     * <p>Two half-lines meeting at one number share it only where both hold it, and either side can
+     * be the one that does not. A rule that reaches an end without including it — `low < high` over
+     * decimals leaves `low` short of the top of its type — leaves the arm at that number nothing to
+     * be taken by, however the arm itself is written.
+     */
+    @Test
+    void anArmAtAnEndThePositionDoesNotReachIsProvenUnreachable() {
+        NumericDomain.Bounds under = new NumericDomain.Bounds(
+                Endpoint.inclusive(BigDecimal.ZERO), Endpoint.exclusive(BigDecimal.TEN));
+        NumericDomain.Bounds over = new NumericDomain.Bounds(
+                Endpoint.exclusive(BigDecimal.ZERO), Endpoint.inclusive(BigDecimal.TEN));
+
+        assertTrue(above(10, true).provenDisjoint(under), "no value of [0, 10) is 10 or above");
+        assertTrue(below(0, true).provenDisjoint(over), "and none of (0, 10] is 0 or below");
+        assertFalse(above(10, true).provenDisjoint(over), "10 is a value of (0, 10]");
+        assertFalse(below(0, true).provenDisjoint(under), "and 0 is one of [0, 10)");
+    }
+
     /** Nothing is proven where nothing is known. An unbounded position rules out no arm, and neither
      * does a position nobody bounded in the direction the arm goes. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -206,9 +206,9 @@ class PartitionsTest {
                 """, "classify");
 
         assertEquals(List.of(new ObservedValue.Decimal(java.math.BigDecimal.ZERO),
-                        new ObservedValue.Decimal(new java.math.BigDecimal("1.0"))),
+                        new ObservedValue.Decimal(java.math.BigDecimal.ONE)),
                 axis(share, "s").cuts().stream().map(Cut::value).toList(),
-                "`>= 0.0m` is read as non-negative, which is the zero the reader already normalises to");
+                "how many places a literal was written to is not where the line is");
     }
 
     @Test


### PR DESCRIPTION
Closes #483.

Where a rule stops was recorded as a value the rule admits. Over whole numbers
there is always such a value, so the representation cost nothing and read as
exact. Over decimals there is no value beside the line, and each reader that
needed one invented it somewhere else:

| declaration | where the rule stops | what was reported |
| --- | --- | --- |
| `value > 0m` | 0, not its own | a row asked for at 1, a value no rule mentions |
| `value > 5.0m` | 5, not its own | `not derivable` |
| `value < 1.0m` | 1, not its own | `not derivable` |

They compounded. A position whose only candidates were `5m` and `0m` — one
refused by its own rule and one outside it — left the record with no assignment
at all, so **every** edge of it came back as `every value tried was refused at
construction`, including the ones read correctly.

## What is here

An end is a value and whether the range holds it. The algebra is written once, in
`numeric.Endpoint`, because two carriers derive it: the domain, which computes
with the numbers, and a partition's end, which also says which rule put it there.
A lower bound takes the greater value and, at one value, the end that leaves it
out; a range is empty where its ends meet and either of them does.

`NumericDomain` keeps strictness where it records it instead of widening and
tagging the widening as a loss, so `WEAKENED_STRICT` has no producer left and is
gone. An end reached through a difference is reached only where every end on the
way is, which `bestLo`/`bestHi`, the transitive closure and `upperBound` carry
along. `proveLe` gets the precision back and `feasible` sees a contradiction the
numbers alone do not show.

The bounds a position is measured at are read off the comparison rather than off
`codegen.InvariantConstraints`, which is the list of checks the runtime has a word
for. That list has a case for a decimal above zero and none for a decimal above
five, and `Partitions` had one absence for a type that draws no line and a type
that draws one it could not spell. A literal's scale is not part of what it says,
so `5.0m` and `5.00m` reach a range as one number.

A cut is where a rule drew its line; whether a row is owed there is whether the
position holds the value. The two places that compare a guard against a position
ask it as one question — two half-lines meeting at a number share it only where
both hold it, and either side can be the one that does not.

A position offers a value from inside its range where the end is not one of its
own: between the ends where both are known, and a step in from the only one where
there is one. Deliberately not the literal's scale — `5.0m` to `5.1m` would let
how a rule was written decide the value proposed for it, and an end reached
through a difference has no literal to take a scale from.

## Evidence

One record with seven numeric positions and one row written against its edges:

```
before  boundary 0/0 (5 not measured)
          · not known to be writable: take/h.p = 1 (invariant Positive (min))
          · not known to be writable: take/h.z = 0 / h.f = 5 / h.m = 1 / h.i = 1
          · not derivable: h.a        (value > 5.0m)
          · not derivable: h.b        (value < 1.0m)
        // no row for ... every value tried was refused at construction  (x5)

after   boundary 4/4
        adequacy: satisfied
```

`souther examples` over every model in `souther-examples`, before and after,
differs in one place:

```
-     boundary    0/2
-       · no row is at quotaGap/quota = 1 (invariant Quota (min))
+     boundary    0/1
```

`crm`'s `data Quota = Decimal invariant value > 0.0m` was being asked for a row at
1. The real edge of that rule is a value nothing can be constructed at, and the
other obligation on that behavior — an inclusive edge — is untouched.

Each of the five commits builds and its tests pass on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
