### PR TITLE
A truncated observation says that it was, and nothing else

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ObservedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/ObservedValues.java
@@ -75,9 +75,10 @@ final class ObservedValues {
     }
 
     /** A collection past the element limit is dropped whole rather than kept as a prefix. A prefix
-     * read back is a collection nobody wrote, and it arrives looking like one that was: a measure
-     * would classify it, and be answering about a value that was never there. Saying the
-     * observation was stopped is the one thing that stays true. */
+     * is not the value that was written, and returned as a {@link ObservedValue.Sequence} it would
+     * be the same thing as a complete observation of a shorter collection — nothing about the two
+     * would differ. {@link ObservedValue.Truncated} keeps the one fact that stays true: the
+     * observation stopped. */
     private ObservedValue sequence(Iterable<?> it, int depth) {
         List<ObservedValue> out = new ArrayList<>();
         for (Object e : it) {

--- a/souther-compiler/src/main/java/souther/compiler/ObservedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/ObservedValues.java
@@ -74,8 +74,10 @@ final class ObservedValues {
                 : new ObservedValue.Truncated();
     }
 
-    /** A collection past the element limit is dropped whole rather than kept as a prefix: its size is
-     * what a rule over it reads, and a prefix would answer a length question with the wrong number. */
+    /** A collection past the element limit is dropped whole rather than kept as a prefix. A prefix
+     * read back is a collection nobody wrote, and it arrives looking like one that was: a measure
+     * would classify it, and be answering about a value that was never there. Saying the
+     * observation was stopped is the one thing that stays true. */
     private ObservedValue sequence(Iterable<?> it, int depth) {
         List<ObservedValue> out = new ArrayList<>();
         for (Object e : it) {

--- a/souther-compiler/src/main/java/souther/compiler/ObservedValues.java
+++ b/souther-compiler/src/main/java/souther/compiler/ObservedValues.java
@@ -20,11 +20,11 @@ import java.util.Map;
  * one {@link NeutralForm#of} makes in the other direction: that one produces the form a decoder reads,
  * this one produces the form a measure reads.
  *
- * <p>The walk never fails. A value it cannot read becomes {@link ObservedValue.Unknown} and an
- * observation {@link Limits} stopped becomes {@link ObservedValue.Truncated}, both carrying why,
- * because a measure that cannot classify a row has to say so rather than count the row as covering
- * nothing. The second is not the same as a large value: the node budget is one for the whole walk,
- * so a small value observed after a large sibling is truncated as well.
+ * <p>The walk never fails. A value it cannot read becomes {@link ObservedValue.Unknown}, which says
+ * why, and an observation {@link Limits} stopped becomes {@link ObservedValue.Truncated}, which says
+ * only that — a measure that cannot classify a row has to say so rather than count the row as
+ * covering nothing. The second is not the same as a large value: the node budget is one for the
+ * whole walk, so a small value observed after a large sibling is truncated as well.
  */
 final class ObservedValues {
 
@@ -48,10 +48,10 @@ final class ObservedValues {
 
     private ObservedValue walk(Object live, int depth) {
         if (budget-- <= 0) {
-            return new ObservedValue.Truncated(-1, "node-limit");
+            return new ObservedValue.Truncated();
         }
         if (depth > limits.maxDepth()) {
-            return new ObservedValue.Truncated(-1, "depth-limit:" + NeutralForm.simpleName(live));
+            return new ObservedValue.Truncated();
         }
         return switch (live) {
             case null -> new ObservedValue.Unknown("a null reached the observer");
@@ -71,8 +71,7 @@ final class ObservedValues {
     private ObservedValue text(String s) {
         return s.length() <= limits.maxText()
                 ? new ObservedValue.Text(s)
-                : new ObservedValue.Truncated(s.length(),
-                        java.lang.Integer.toHexString(s.hashCode()));
+                : new ObservedValue.Truncated();
     }
 
     /** A collection past the element limit is dropped whole rather than kept as a prefix: its size is
@@ -81,7 +80,7 @@ final class ObservedValues {
         List<ObservedValue> out = new ArrayList<>();
         for (Object e : it) {
             if (out.size() >= limits.maxElements()) {
-                return new ObservedValue.Truncated(size(it), "elements");
+                return new ObservedValue.Truncated();
             }
             out.add(walk(e, depth + 1));
         }
@@ -90,7 +89,7 @@ final class ObservedValues {
 
     private ObservedValue mapping(Map<?, ?> m, int depth) {
         if (m.size() > limits.maxElements()) {
-            return new ObservedValue.Truncated(m.size(), "entries");
+            return new ObservedValue.Truncated();
         }
         List<ObservedValue.Entry> out = new ArrayList<>(m.size());
         for (Map.Entry<?, ?> e : m.entrySet()) {
@@ -154,14 +153,4 @@ final class ObservedValues {
         }
     }
 
-    private static int size(Iterable<?> it) {
-        if (it instanceof java.util.Collection<?> c) {
-            return c.size();
-        }
-        int n = 0;
-        for (Object _ : it) {
-            n++;
-        }
-        return n;
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/observe/ObservedValue.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/ObservedValue.java
@@ -85,11 +85,21 @@ public sealed interface ObservedValue {
      * rather than reporting a gap it did not see. */
     record Unknown(String reason) implements ObservedValue {}
 
-    /** An observation {@link Limits} stopped. Not the same as a large value: the node budget is one
-     * for the whole walk, so a small value observed after a large sibling arrives here too. What is
-     * kept is the size and a digest, which is enough to tell two of these apart without holding
-     * either. */
-    record Truncated(int observedSize, String digest) implements ObservedValue {}
+    /**
+     * An observation {@link Limits} stopped. Not the same as a large value: the node budget is one
+     * for the whole walk, so a small value observed after a large sibling arrives here too.
+     *
+     * <p>Nothing about it but that it happened. It carried the size and a fingerprint, for a rule
+     * over the value's size to read and for telling two of these apart — and a position is divided
+     * by the cases of its type or by where a rule cuts its range, never by how large a value is, so
+     * a size was written only where nothing classifies and was {@code -1} wherever anything did.
+     * Nothing compares two observations either.
+     *
+     * <p>Which leaves the case, and the case is read: a row this stands in is one no class holds,
+     * and the report says an observation was stopped by a limit. Two of these being equal is Java
+     * saying they carry the same nothing, and is not two observations being the same value.
+     */
+    record Truncated() implements ObservedValue {}
 
     /** An empty map with a stable iteration order, for building a {@link Constructed}. */
     static Map<String, ObservedValue> fields() {

--- a/souther-compiler/src/test/java/souther/compiler/ObservedValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ObservedValuesTest.java
@@ -71,32 +71,31 @@ class ObservedValuesTest {
         assertInstanceOf(ObservedValue.Unknown.class, observe(null));
     }
 
+    /** The content goes with it, which is the whole reason the walk is bounded. */
     @Test
-    void textPastTheLimitKeepsItsLengthAndNotItsContent() {
+    void textPastTheLimitDoesNotKeepItsContent() {
         String long_ = "x".repeat(50);
-        ObservedValue.Truncated t = assertInstanceOf(ObservedValue.Truncated.class,
+
+        assertInstanceOf(ObservedValue.Truncated.class,
                 observe(long_, new Limits(16, 10_000, 64, 10)));
-        assertEquals(50, t.observedSize());
     }
 
     /** A prefix would answer a length question with the wrong number, so the collection goes whole. */
     @Test
-    void aCollectionPastTheLimitIsDroppedWholeAndKeepsItsSize() {
+    void aCollectionPastTheLimitIsDroppedWhole() {
         List<Long> many = new ArrayList<>();
         for (long i = 0; i < 20; i++) {
             many.add(i);
         }
-        ObservedValue.Truncated t = assertInstanceOf(ObservedValue.Truncated.class,
+        assertInstanceOf(ObservedValue.Truncated.class,
                 observe(many, new Limits(16, 10_000, 4, 1024)));
-        assertEquals(20, t.observedSize());
-        assertEquals("elements", t.digest());
 
         Map<Object, Object> big = new LinkedHashMap<>();
         for (long i = 0; i < 20; i++) {
             big.put("k" + i, i);
         }
-        assertEquals(20, assertInstanceOf(ObservedValue.Truncated.class,
-                observe(big, new Limits(16, 10_000, 4, 1024))).observedSize());
+        assertInstanceOf(ObservedValue.Truncated.class,
+                observe(big, new Limits(16, 10_000, 4, 1024)));
     }
 
     @Test
@@ -116,9 +115,7 @@ class ObservedValuesTest {
         ObservedValue.Sequence observed = assertInstanceOf(ObservedValue.Sequence.class,
                 observe(List.of(1L, 2L, 3L, 4L), new Limits(16, 3, 64, 1024)));
         assertEquals(new ObservedValue.Integer(1L), observed.elements().get(0));
-        ObservedValue.Truncated stopped = assertInstanceOf(ObservedValue.Truncated.class,
-                observed.elements().get(2));
-        assertEquals("node-limit", stopped.digest());
+        assertInstanceOf(ObservedValue.Truncated.class, observed.elements().get(2));
     }
 
     /** Being a record is not being immutable: what an answer reported must not change under it. */

--- a/souther-compiler/src/test/java/souther/compiler/ObservedValuesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ObservedValuesTest.java
@@ -80,7 +80,8 @@ class ObservedValuesTest {
                 observe(long_, new Limits(16, 10_000, 64, 10)));
     }
 
-    /** A prefix would answer a length question with the wrong number, so the collection goes whole. */
+    /** Whole, because a prefix read back is a collection nobody wrote and nothing downstream could
+     * tell it from one somebody did. */
     @Test
     void aCollectionPastTheLimitIsDroppedWhole() {
         List<Long> many = new ArrayList<>();

--- a/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
@@ -155,7 +155,7 @@ class RowClassesTest {
         ObservedValue.Constructed request =
                 assertInstanceOf(ObservedValue.Constructed.class, row.inputs().get(0));
         Map<String, ObservedValue> broken = new java.util.LinkedHashMap<>(request.fields());
-        broken.put("cost", new ObservedValue.Truncated(9, "x"));
+        broken.put("cost", new ObservedValue.Truncated());
         RowOutcome damaged = new RowOutcome(row.at(), row.target(), row.description(), row.stage(),
                 row.disposition(), row.failurePhase(), row.expectedArm(), row.resultArm(),
                 row.inputCases(),


### PR DESCRIPTION
Closes #498.

`ObservedValue.Truncated` becomes a case with no payload. The two fields it
carried were each written for a reader named at the time, and the model has no
way to build either — which is what the investigation on #498 turned up, and why
this is not a dead-field cleanup.

## What the fields were for, and why nothing could read them

The size was for *a rule over that value*, in the words of the commit that
introduced the type. A position gets classes from the cases of its type or from
where a rule cuts its range, and `RowClasses` skips a position with no classes
before looking at any value. A collection, a string, and a newtype over one have
neither:

```text
· not derivable: request.memo      (String)
· not derivable: request.who       (a newtype over String)
· not derivable: request.items     (List<Item>)
```

So the size was informative exactly where nothing looks: the three producers that
knew a real one wrote at those positions, and the two that reach a classified
position — the shared node budget and the depth limit — both passed `-1`.

The fingerprint was for telling two truncated values apart. Two observations are
compared in one place, and `readable()` drops a truncated one before the
comparison because it is not a number. Nothing asks whether two observations are
the same. And only one of the five producers put a fingerprint there; the other
four put the name of the limit they hit, so the field was an identity at one and
a cause at four.

## What is not in this

Nothing about how a truncation is classified. A truncation one wrapper in is
still reported as a value that could not be read — that is #499, and mixing it in
here would join the payload question back to the classification vocabulary the
investigation separated it from.

No `equals` of its own. Two of these now compare equal, which is Java saying they
carry the same nothing. Structural equality of an `ObservedValue` is not read
anywhere; writing an identity back in would restore by another route exactly the
semantics this removes.

## Checks

```text
git grep -nE 'observedSize|new Truncated\('   nothing
git grep -n digest                            only CoverageSites and Continuation, other concepts
git diff --check                              clean
mvn clean test                                full reactor green
```

Four files: the record, its five producers, and the two tests that asserted
payload values rather than the case.
