### PR TITLE
A construct the width could keep on one line still owns its comment

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/fmt/ADefinitionsBodyOwnsItsCommentTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ADefinitionsBodyOwnsItsCommentTest.java
@@ -1,0 +1,129 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A comment written above what a definition or an {@code if} writes after its keyword stays there.
+ * The construct is given a line by the layout — the boundary before it breaks where the body does
+ * not fit — and a comment is about what it was written above whether or not the width would have
+ * kept that on one line. Owning one is then what puts it on a line of its own, since a comment
+ * cannot share the line after it.
+ *
+ * <p>{@link ACommentKeepsItsMemberHoweverItIsWrittenTest} sweeps the ways a member can be written,
+ * and the survival sweep cannot ask either of them: a comment handed to the enclosing construct is
+ * one comment in and one comment out, and only which construct it is about has changed.
+ */
+class ADefinitionsBodyOwnsItsCommentTest {
+
+    @Test
+    void aDefinitionsBody() {
+        assertEquals("""
+                module m
+
+                let g (x: Int): Int =
+                    // about the body
+                    x
+                """, Formatter.format("""
+                module m
+                let g (x: Int): Int =
+                    // about the body
+                    x
+                """));
+    }
+
+    @Test
+    void aBranchOfAnIf() {
+        assertEquals("""
+                module m
+
+                let k (x: Int): Int =
+                    if x > 0 then
+                        // about the then branch
+                        1
+                    else
+                        0
+                """, Formatter.format("""
+                module m
+                let k (x: Int): Int =
+                    if x > 0 then
+                        // about the then branch
+                        1
+                    else
+                        0
+                """));
+    }
+
+    @Test
+    void andItsOtherBranch() {
+        assertEquals("""
+                module m
+
+                let k (x: Int): Int =
+                    if x > 0 then
+                        1
+                    else
+                        // about the else branch
+                        0
+                """, Formatter.format("""
+                module m
+                let k (x: Int): Int =
+                    if x > 0 then
+                        1
+                    else
+                        // about the else branch
+                        0
+                """));
+    }
+
+    /**
+     * And what an {@code if} writes on its header line owns nothing. The condition stands between
+     * {@code if} and {@code then} with no boundary the layout can break, so a comment above it is a
+     * comment about the {@code if} — which is why holding children is not what makes a construct
+     * able to carry one.
+     */
+    @Test
+    void butNotWhatTheHeaderLineHolds() {
+        assertEquals("""
+                module m
+
+                let k (x: Int): Int =
+                    // about the test
+                    if x > 0 then 1 else 0
+                """, Formatter.format("""
+                module m
+                let k (x: Int): Int =
+                    if
+                        // about the test
+                        x > 0
+                    then 1 else 0
+                """));
+    }
+
+    /**
+     * A definition written as a lambda is left as it was. Its parameters move to the left of the
+     * {@code =}, so what the canonical form writes after the {@code =} is not the child the source
+     * has there — it is that child's body, a level further down. The comment is about that body and
+     * the construct the source gives it to is the lambda, and until the two are the same question
+     * this is one construct where the comment still travels to the declaration.
+     *
+     * <p>Held here so that it is a stated limit rather than a case nobody tried. Making it right
+     * needs the canonical structure to be something a comment can be filed against, which is
+     * issue #444.
+     */
+    @Test
+    void butADefinitionWrittenAsALambdaIsLeftAsItWas() {
+        assertEquals("""
+                module m
+
+                // about the body
+                let f (x) = x
+                """, Formatter.format("""
+                module m
+                let f = (x) ->
+                    // about the body
+                    x
+                """));
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -717,8 +717,10 @@ public final class Formatter {
         if (intrinsic.isPresent()) {
             SyntaxToken body = intrinsic.get().token(SyntaxKind.STRING_LIT).orElseThrow();
             return TokenDoc.node(n.kind(), concat(head, GAP, ASSIGN,
-                    group(nest(INDENT, concat(SOFT_GAP, TokenDoc.node(intrinsic.get().kind(),
-                            concat(ident("intrinsic"), GAP, token(body))))))));
+                    group(nest(INDENT, concat(SOFT_GAP, aboveOf(intrinsic.get()),
+                            TokenDoc.node(intrinsic.get().kind(),
+                                    concat(ident("intrinsic"), GAP, token(body))),
+                            afterOf(intrinsic.get()))))));
         }
         var block = n.child(SyntaxKind.BLOCK_EXPR);
         if (block.isPresent()) {
@@ -726,12 +728,13 @@ public final class Formatter {
         }
         SyntaxNode body = lifted == null ? onlyExpr(n) : lastExprChild(lifted);
         return TokenDoc.node(n.kind(),
-                concat(head, GAP, ASSIGN, group(nest(INDENT, concat(SOFT_GAP, expr(body))))));
+                concat(head, GAP, ASSIGN, group(nest(INDENT,
+                        concat(SOFT_GAP, aboveOf(body), expr(body), afterOf(body))))));
     }
 
     /** The lambda a parameter-less definition was written as, or null when its body is an ordinary
      * expression and the definition is a value. */
-    private SyntaxNode liftedLambda(SyntaxNode n) {
+    private static SyntaxNode liftedLambda(SyntaxNode n) {
         if (n.child(SyntaxKind.BLOCK_EXPR).isPresent() || n.child(SyntaxKind.INTRINSIC_BODY).isPresent()) {
             return null;
         }
@@ -930,7 +933,7 @@ public final class Formatter {
 
     /** The bracketed argument list of a call or an application. */
     private TokenDoc arguments(SyntaxNode n) {
-        List<SyntaxNode> args = n.child(SyntaxKind.ARG_LIST).map(this::exprChildren).orElse(List.of());
+        List<SyntaxNode> args = n.child(SyntaxKind.ARG_LIST).map(Formatter::exprChildren).orElse(List.of());
         SyntaxNode argList = n.child(SyntaxKind.ARG_LIST).orElse(null);
         if (args.isEmpty()) {
             List<Member> only = argList == null ? List.of() : withEndComments(argList, List.of());
@@ -1035,11 +1038,13 @@ public final class Formatter {
         TokenDoc departures = elseArms(n);
         return TokenDoc.node(n.kind(), group(concat(TokenDoc.token(SyntaxKind.IF_KW, "if"), GAP,
                 expr(parts.get(0)), attemptBinder(n), GAP, TokenDoc.token(SyntaxKind.THEN_KW, "then"),
-                nest(INDENT, concat(SOFT_GAP, expr(parts.get(1)))),
+                nest(INDENT, concat(SOFT_GAP, aboveOf(parts.get(1)), expr(parts.get(1)),
+                        afterOf(parts.get(1)))),
                 SOFT_GAP, TokenDoc.token(SyntaxKind.ELSE_KW, "else"),
                 departures != TokenDoc.NIL
                         ? departures
-                        : nest(INDENT, concat(SOFT_GAP, expr(parts.get(2)))))));
+                        : nest(INDENT, concat(SOFT_GAP, aboveOf(parts.get(2)), expr(parts.get(2)),
+                                afterOf(parts.get(2)))))));
     }
 
     /** An attempt's per-clause departures, one to a line under the {@code else}, or nothing where the
@@ -1393,7 +1398,7 @@ public final class Formatter {
         // unless a member begins at that bracket itself, as a `fake` row does at its `(`, in which
         // case the comment is above the member and not above what the member opens with.
         boolean opensSomethingElse = begins != null && begins.parent() != null
-                && !takesALineOf(begins.parent().kind(), begins.kind());
+                && !takesALineOf(begins.parent(), begins);
         if (next != null && opens(next) && opensSomethingElse) {
             SyntaxElement first = firstMemberOf(next.parent());
             if (first instanceof SyntaxNode node) {
@@ -1559,7 +1564,7 @@ public final class Formatter {
             // writing that line — a condition's `then`, a call's `)`.
             boolean endsTheOutermostRun = isSpine(c.parent()) && c.end() == c.parent().end()
                     && !isSpine(c.parent().parent());
-            if (takesALineOf(c.parent().kind(), c.kind()) && !endsTheOutermostRun) {
+            if (takesALineOf(c.parent(), c) && !endsTheOutermostRun) {
                 best = c;
             }
         }
@@ -1575,7 +1580,7 @@ public final class Formatter {
      * belongs to whatever wrote the prefix.
      */
     private static boolean opensALine(SyntaxNode c) {
-        if (!takesALineOf(c.parent().kind(), c.kind())) {
+        if (!takesALineOf(c.parent(), c)) {
             return false;
         }
         SyntaxKind parent = c.parent().kind();
@@ -1621,7 +1626,7 @@ public final class Formatter {
             from = lastSegmentOf(from);
         }
         for (SyntaxNode c = from; c != null && c.parent() != null; c = c.parent()) {
-            if (above ? opensALine(c) : takesALineOf(c.parent().kind(), c.kind())) {
+            if (above ? opensALine(c) : takesALineOf(c.parent(), c)) {
                 return c;
             }
         }
@@ -1736,7 +1741,7 @@ public final class Formatter {
      * Nothing where it has no members: an empty construct's brackets open and close one line. */
     private static SyntaxElement firstMemberOf(SyntaxNode container) {
         for (SyntaxElement e : container.children()) {
-            if (e instanceof SyntaxNode c && takesALineOf(container.kind(), c.kind())) {
+            if (e instanceof SyntaxNode c && takesALineOf(container, c)) {
                 return c;
             }
             if (e instanceof SyntaxToken t && isBareMember(t)) {
@@ -1826,17 +1831,42 @@ public final class Formatter {
      */
     private static SyntaxNode hasALine(SyntaxToken t) {
         for (SyntaxNode c = t.parent(); c != null && c.parent() != null; c = c.parent()) {
-            if (takesALineOf(c.parent().kind(), c.kind())) {
+            if (takesALineOf(c.parent(), c)) {
                 return c;
             }
         }
         return null;
     }
 
-    /** Whether a {@code child} of {@code parent} is written on a line of its own. */
-    private static boolean takesALineOf(SyntaxKind parent, SyntaxKind child) {
-        java.util.function.Predicate<SyntaxKind> children = linesOf(parent);
-        return children != null && children.test(child);
+    /**
+     * Whether a {@code child} of {@code parent} is written on a line of its own.
+     *
+     * <p>Asked of the two nodes rather than of their kinds, because for two constructs the kinds do
+     * not answer it. An {@code if} writes three expressions and only the two after the condition open
+     * a line — written {@code if flag then p else q} all three are a {@code VAR_EXPR}. And a
+     * definition written as a lambda has its parameters moved to the left of the {@code =}, so what
+     * the canonical form writes after the {@code =} is that lambda's body rather than the child the
+     * source has there; the child here is not what is written, and a comment about the body is not
+     * this construct's to carry. Filing one against what the canonical form writes needs a canonical
+     * structure to file it against, which is issue #444.
+     */
+    private static boolean takesALineOf(SyntaxNode parent, SyntaxNode child) {
+        java.util.function.Predicate<SyntaxKind> children = linesOf(parent.kind());
+        if (children == null || !children.test(child.kind())) {
+            return false;
+        }
+        return switch (parent.kind()) {
+            case IF_EXPR -> !isTheConditionOf(parent, child);
+            case FN_DEF -> liftedLambda(parent) == null;
+            default -> true;
+        };
+    }
+
+    /** Whether {@code child} is the expression an {@code if} tests, which is the one it writes on
+     * its header line. */
+    private static boolean isTheConditionOf(SyntaxNode ifExpr, SyntaxNode child) {
+        List<SyntaxNode> exprs = exprChildren(ifExpr);
+        return !exprs.isEmpty() && exprs.get(0) == child;
     }
 
     /** Whether {@code parent} writes any of its children on lines of their own, so that what closes
@@ -1882,6 +1912,9 @@ public final class Formatter {
             case BLOCK_EXPR -> _ -> true;
             case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> Formatter::isExprKind;
             case PIPE_EXPR -> k -> isExprKind(k) && k != SyntaxKind.PIPE_EXPR;
+            case FN_DEF -> k -> k == SyntaxKind.INTRINSIC_BODY
+                    || isExprKind(k) && k != SyntaxKind.BLOCK_EXPR;
+            case IF_EXPR -> Formatter::isExprKind;
             default -> null;
         };
     }
@@ -2077,7 +2110,7 @@ public final class Formatter {
         return withEndComments(n, out);
     }
 
-    private List<SyntaxNode> exprChildren(SyntaxNode n) {
+    private static List<SyntaxNode> exprChildren(SyntaxNode n) {
         List<SyntaxNode> out = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             if (isExprKind(c.kind())) {
@@ -2087,7 +2120,7 @@ public final class Formatter {
         return out;
     }
 
-    private SyntaxNode firstExprChild(SyntaxNode n) {
+    private static SyntaxNode firstExprChild(SyntaxNode n) {
         return exprChildren(n).get(0);
     }
 
@@ -2101,7 +2134,7 @@ public final class Formatter {
         return c.get(c.size() - 1);
     }
 
-    private SyntaxNode onlyExpr(SyntaxNode n) {
+    private static SyntaxNode onlyExpr(SyntaxNode n) {
         return firstExprChild(n);
     }
 


### PR DESCRIPTION
A comment written above a definition's body came back above the declaration, and so did one above either branch of an `if`.

```diff
 let g (x: Int): Int =
-    // about the body
     x
```

The comment was about the body. The reader is left with one describing the declaration and no way to see it once said something else. This is #455 in another place — there a trailing comment handed to the next declaration, here a leading comment handed to the enclosing one.

## Why

Which construct a comment is about is decided before any of the document is built, so it cannot be read off the layout. It is read from `linesOf` (`Formatter.java`), a table of which children a construct writes on lines of their own, and that table had no row for a definition or for an `if` — while `fnDef` and `ifExpr` both write a boundary before those children that the layout may break. `slotOf` walked past them to the enclosing construct.

Nothing caught it. The count of comments consumed against comments held sees one comment in and one comment out, and `ACommentKeepsItsMemberHoweverItIsWrittenTest` says so of itself:

> A comment moved from one member to the next is one comment in and one comment out, and the code around it is unchanged; what changed is the only thing a comment is for.

## What is here

The table is asked of the two nodes rather than of their kinds, because for these two constructs the kinds do not answer it.

An `if` writes three expressions and only the two after the condition open a line: written `if flag then p else q` all three are a `VAR_EXPR`, so which of them has a line is a fact about where it stands. The condition keeps its comment travelling, and there is a fixture saying so — holding children is not what makes a construct able to carry one.

A definition written as a lambda has its parameters moved to the left of the `=`, so what the canonical form writes after the `=` is that lambda's body rather than the child the source has there. The comment is about the body, the source gives it to the lambda, and the two are not the same construct. **That case keeps the behaviour it had**, with a fixture stating it as a limit rather than leaving it as a case nobody tried.

## What is deliberately not here

An earlier version of this branch tried to make the layout and the comment attachment read one relation — the same relation, since both need to know which children a construct writes down the page. Measuring it found that they do not want the same answer:

- `DATA_DEF` writes `data Positive = Int` with no boundary before the representation, while the representation owns the trailing comment of that header line. `BEHAVIOR_SIG` and its return type are the same shape. So *what goes before a place* and *whether a place can own a comment* are different questions, and the existing code already knew: both of those are excluded from `opensALine`.
- A slot is a position in the canonical structure, not in the source. Where a definition's lambda is lifted, two different source elements name one canonical place and the canonical body is a descendant rather than a child, so no function of the source tree identifies it.

Merging one relation over those would move the duplication one level down rather than remove it, so this PR does not claim it. The findings belong to #444, which is where the model that has to account for them lives.

## What holds it

`ADefinitionsBodyOwnsItsCommentTest`: a definition's body, both branches of an `if`, the condition that owns nothing, and the lifted lambda that is left as it was. 4353 tests pass.

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)
