### PR TITLE
A classifier says why it could not read the value

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Classifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Classifier.java
@@ -2,6 +2,8 @@ package souther.compiler.partition;
 
 import souther.compiler.observe.ObservedValue;
 
+import java.util.function.Predicate;
+
 /**
  * Whether a value an {@code example} row was given belongs to one equivalence class.
  *
@@ -9,14 +11,33 @@ import souther.compiler.observe.ObservedValue;
  * author already wrote while nothing can generate a representative for it — a type whose invariant is
  * a pattern, a record whose fields constrain each other — and treating those as unmeasurable would
  * throw away coverage that is already there.
+ *
+ * <p>The answer is a {@link Membership} and not a {@code boolean} because a classifier may have to
+ * read the value before it can say anything about it, and reading can fail. What did the reading
+ * says why it failed; nothing downstream is in a position to work it out.
  */
 @FunctionalInterface
 public interface Classifier {
 
-    boolean matches(ObservedValue value);
+    Membership membershipOf(ObservedValue value);
+
+    /**
+     * One that answers by looking at the value it is given.
+     *
+     * <p>For the classes told apart by shape — a case of a sum, a {@code Bool}, whether an optional
+     * holds anything — where the value at the position is the value to look at. An observation that
+     * did not arrive is answered before the predicate is asked, because that is a fact about the
+     * observation rather than a thing the class declines.
+     */
+    static Classifier byShape(Predicate<ObservedValue> holds) {
+        return value -> {
+            Membership.Incomplete unread = Membership.unread(value);
+            return unread != null ? unread : Membership.of(holds.test(value));
+        };
+    }
 
     /** Recognises nothing: a class that exists but cannot be told from another by looking. */
     static Classifier none() {
-        return _ -> false;
+        return _ -> Membership.NO_MATCH;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -122,9 +122,9 @@ final class Intervals {
         for (Interval range : intervals) {
             String id = path + "/" + range.label();
             BigDecimal inside = representative(range, decimal);
-            Classifier is = v -> {
-                BigDecimal number = numberOf(v);
-                return number != null && range.holds(number);
+            Classifier is = v -> switch (read(v)) {
+                case Read.Number number -> Membership.of(range.holds(number.value()));
+                case Read.Missing missing -> new Membership.Incomplete(missing.code());
             };
             classes.add(inside == null
                     ? PartitionClass.ungeneratable(id, range.label(), is,
@@ -144,13 +144,38 @@ final class Intervals {
                 decimal ? Granularity.DENSE : Granularity.DISCRETE);
     }
 
-    static BigDecimal numberOf(ObservedValue v) {
+    /** The number a value holds, or why it holds none. */
+    private sealed interface Read {
+
+        record Number(BigDecimal value) implements Read {}
+
+        record Missing(souther.compiler.observe.Incompleteness.Code code) implements Read {}
+    }
+
+    /**
+     * The number at a value, keeping why there is none where there is none.
+     *
+     * <p>A newtype is not a step in a path, so the value at a position may be the construction and
+     * the number one inside it. Which is why this walk exists, and why the reason it stops has to
+     * come back with it: read as a bare {@code null}, an observation a limit stopped is the same
+     * answer as a value that is not a number.
+     */
+    private static Read read(ObservedValue v) {
+        Membership.Incomplete unread = Membership.unread(v);
+        if (unread != null) {
+            return new Read.Missing(unread.code());
+        }
         return switch (v) {
-            case ObservedValue.Integer i -> BigDecimal.valueOf(i.value());
-            case ObservedValue.Decimal d -> d.value();
-            case ObservedValue.Constructed c when c.field("value") != null -> numberOf(c.field("value"));
-            case null, default -> null;
+            case ObservedValue.Integer i -> new Read.Number(BigDecimal.valueOf(i.value()));
+            case ObservedValue.Decimal d -> new Read.Number(d.value());
+            case ObservedValue.Constructed c when c.field("value") != null -> read(c.field("value"));
+            default -> new Read.Missing(souther.compiler.observe.Incompleteness.Code.VALUE_UNREADABLE);
         };
+    }
+
+    /** The number at a value, for a caller that has nothing to say about why there is none. */
+    static BigDecimal numberOf(ObservedValue v) {
+        return read(v) instanceof Read.Number number ? number.value() : null;
     }
 
     private static FixtureTemplate written(BigDecimal value, souther.compiler.types.TypeName wrapper,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -125,6 +125,7 @@ final class Intervals {
             Classifier is = v -> switch (read(v)) {
                 case Read.Number number -> Membership.of(range.holds(number.value()));
                 case Read.Missing missing -> new Membership.Incomplete(missing.code());
+                case Read.NotNumber _ -> Membership.NO_MATCH;
             };
             classes.add(inside == null
                     ? PartitionClass.ungeneratable(id, range.label(), is,
@@ -144,12 +145,19 @@ final class Intervals {
                 decimal ? Granularity.DENSE : Granularity.DISCRETE);
     }
 
-    /** The number a value holds, or why it holds none. */
+    /** The number a value holds, or why it holds none — and those are two different reasons. */
     private sealed interface Read {
 
         record Number(BigDecimal value) implements Read {}
 
+        /** There was no value to read, and this is what stopped there being one. */
         record Missing(souther.compiler.observe.Incompleteness.Code code) implements Read {}
+
+        /** The value was read and is not a number. Which is an answer about the value and not about
+         * the observation: a {@code Text} at a numeric position is a class this does not hold, and
+         * calling it unreadable would report a partition that does not fit its position as a row
+         * nobody could read. */
+        record NotNumber() implements Read {}
     }
 
     /**
@@ -169,7 +177,7 @@ final class Intervals {
             case ObservedValue.Integer i -> new Read.Number(BigDecimal.valueOf(i.value()));
             case ObservedValue.Decimal d -> new Read.Number(d.value());
             case ObservedValue.Constructed c when c.field("value") != null -> read(c.field("value"));
-            default -> new Read.Missing(souther.compiler.observe.Incompleteness.Code.VALUE_UNREADABLE);
+            default -> new Read.NotNumber();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Membership.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Membership.java
@@ -1,0 +1,53 @@
+package souther.compiler.partition;
+
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.ObservedValue;
+
+/**
+ * What one class makes of one value: it holds it, it does not, or it could not tell.
+ *
+ * <p>The third is why this is not a {@code boolean}. A class is told from a value by a classifier
+ * that may read through it — a number at a position is the number inside the newtype named there,
+ * and the walk that finds positions never steps into one — so a classifier is entitled to decode,
+ * and decoding can fail. Answered as a yes or a no, a value it could not read comes back as a value
+ * it does not hold, and whoever has to say why the row could not be placed has neither the reason
+ * nor the knowledge to work one out.
+ *
+ * <p>The rule is the interpreter's: what read the value says why it could not.
+ */
+public sealed interface Membership {
+
+    /** The class holds this value. */
+    record Match() implements Membership {}
+
+    /** The class does not hold it, which is an answer about a value that was read. */
+    record NoMatch() implements Membership {}
+
+    /** There was no value to hold, and this is what stopped there being one. */
+    record Incomplete(Incompleteness.Code code) implements Membership {}
+
+    Membership MATCH = new Match();
+
+    Membership NO_MATCH = new NoMatch();
+
+    static Membership of(boolean holds) {
+        return holds ? MATCH : NO_MATCH;
+    }
+
+    /**
+     * What an observation that did not arrive says, whichever class is asking.
+     *
+     * <p>Null where there is a value to look at, so a classifier can go on to its own question. Here
+     * rather than at each classifier because it is one fact about the observation and not a
+     * judgement any class makes: a limit stopped it, or the walk could not read it back, and both
+     * are true before any class is consulted.
+     */
+    static Incomplete unread(ObservedValue value) {
+        return switch (value) {
+            case null -> new Incomplete(Incompleteness.Code.VALUE_UNREADABLE);
+            case ObservedValue.Truncated _ -> new Incomplete(Incompleteness.Code.VALUE_TRUNCATED);
+            case ObservedValue.Unknown _ -> new Incomplete(Incompleteness.Code.VALUE_UNREADABLE);
+            default -> null;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -393,22 +393,24 @@ public final class Partitions {
     static List<PartitionClass> classesOf(Type type, Symbols symbols) {
         if (type == Type.BOOL) {
             return List.of(
-                    PartitionClass.of("true", "true", v -> isBool(v, true),
+                    PartitionClass.of("true", "true", Classifier.byShape(v -> isBool(v, true)),
                             RepresentativeSource.of(FixtureTemplate.bool(true))),
-                    PartitionClass.of("false", "false", v -> isBool(v, false),
+                    PartitionClass.of("false", "false", Classifier.byShape(v -> isBool(v, false)),
                             RepresentativeSource.of(FixtureTemplate.bool(false))));
         }
         if (type instanceof Type.OptionOf option) {
             List<FixtureTemplate> some = representativesOf(option.element(), symbols);
             return List.of(
-                    PartitionClass.of("None", "None", v -> v instanceof ObservedValue.Absent,
+                    PartitionClass.of("None", "None",
+                            Classifier.byShape(v -> v instanceof ObservedValue.Absent),
                             RepresentativeSource.of(FixtureTemplate.none())),
                     some.isEmpty()
                             ? PartitionClass.ungeneratable("Some", "Some",
-                                    v -> !(v instanceof ObservedValue.Absent),
+                                    Classifier.byShape(v -> !(v instanceof ObservedValue.Absent)),
                                     "no value of " + option.element() + " can be written")
                             : PartitionClass.of("Some", "Some",
-                                    v -> !(v instanceof ObservedValue.Absent), () -> some));
+                                    Classifier.byShape(v -> !(v instanceof ObservedValue.Absent)),
+                                    () -> some));
         }
         if (TypeOps.isSumType(type, symbols)) {
             List<PartitionClass> cases = new ArrayList<>();
@@ -425,11 +427,11 @@ public final class Partitions {
     }
 
     private static PartitionClass caseClass(TypeName leaf, Symbols symbols) {
-        Classifier is = v -> switch (v) {
+        Classifier is = Classifier.byShape(v -> switch (v) {
             case ObservedValue.Unit u -> leaf.equals(u.type());
             case ObservedValue.Constructed c -> leaf.equals(c.type());
-            case null, default -> false;
-        };
+            default -> false;
+        });
         if (!(symbols.get(leaf) instanceof Ast.Data data)) {
             return PartitionClass.of(leaf.name(), leaf.name(), is,
                     RepresentativeSource.of(FixtureTemplate.unitCase(leaf)));   // naming it builds it

--- a/souther-compiler/src/main/java/souther/compiler/partition/RowClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RowClasses.java
@@ -63,30 +63,36 @@ public final class RowClasses {
                     axis.id().behavior(), axis.id().path());
         }
         ObservedValue value = walk(row.inputs().get(at), axis.path().fields());
-        Membership.Incomplete incomplete = null;
+        // Kept rather than returned on, and not acted on either. A class may read less of a value
+        // than the one after it, so one saying it could not read says nothing about the rest —
+        // including that the rest cannot hold it. An incompleteness is what is left once no class
+        // has claimed the value, so nothing about it is decided until every class has answered.
+        Incompleteness.Code incomplete = null;
+        boolean disagreed = false;
         for (PartitionClass each : axis.classes()) {
             switch (each.classifier().membershipOf(value)) {
                 case Membership.Match _ -> {
                     return Classification.in(each.id());
                 }
-                // Kept rather than returned on: a class may read less of a value than the one after
-                // it, so one saying it could not read says nothing about the rest. Two of them
-                // disagreeing about why is two readings of one value, which is not an answer to
-                // pick between.
                 case Membership.Incomplete why -> {
                     if (incomplete == null) {
-                        incomplete = why;
-                    } else if (incomplete.code() != why.code()) {
-                        throw new IllegalStateException("two classes of " + axis.id()
-                                + " disagree about why the value could not be read: "
-                                + incomplete.code() + " and " + why.code());
+                        incomplete = why.code();
+                    } else if (incomplete != why.code()) {
+                        disagreed = true;
                     }
                 }
                 case Membership.NoMatch _ -> { }
             }
         }
+        // Two readings of one value that disagree about whether it is there. Held to rather than
+        // picked between: today every class of a numeric position reads through the same reader,
+        // so nothing produces one.
+        if (disagreed) {
+            throw new IllegalStateException("classes of " + axis.id()
+                    + " disagree about why the value could not be read");
+        }
         if (incomplete != null) {
-            return Classification.unreadable(incomplete.code(),
+            return Classification.unreadable(incomplete,
                     axis.id().behavior(), axis.id().path());
         }
         // Every class read the value and none holds it, which `Axis` says cannot happen: its classes

--- a/souther-compiler/src/main/java/souther/compiler/partition/RowClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RowClasses.java
@@ -46,6 +46,16 @@ public final class RowClasses {
         return walk(row.inputs().get(at), path.fields());
     }
 
+    /**
+     * Which class the row's value at {@code axis} fell in, or why none of them could say.
+     *
+     * <p>The classes answer for themselves, including about a value none of them could read. This
+     * used to test the value's shape here first, which is the same question asked in a second place
+     * and answered from a different node: a classifier may read through the value — a number at a
+     * position is the number inside the newtype named there — so a limit reached one level in left
+     * a construction this saw nothing wrong with, and the reason came out as the one the last line
+     * had to guess.
+     */
     private static Classification classify(RowOutcome row, List<String> parameters, Axis axis) {
         int at = parameters.indexOf(axis.path().head());
         if (at < 0 || at >= row.inputs().size()) {
@@ -53,27 +63,38 @@ public final class RowClasses {
                     axis.id().behavior(), axis.id().path());
         }
         ObservedValue value = walk(row.inputs().get(at), axis.path().fields());
-        if (value == null) {
-            return Classification.unreadable(Incompleteness.Code.VALUE_UNREADABLE,
-                    axis.id().behavior(), axis.id().path());
-        }
-        if (value instanceof ObservedValue.Unknown) {
-            return Classification.unreadable(Incompleteness.Code.VALUE_UNREADABLE,
-                    axis.id().behavior(), axis.id().path());
-        }
-        if (value instanceof ObservedValue.Truncated) {
-            return Classification.unreadable(Incompleteness.Code.VALUE_TRUNCATED,
-                    axis.id().behavior(), axis.id().path());
-        }
+        Membership.Incomplete incomplete = null;
         for (PartitionClass each : axis.classes()) {
-            if (each.classifier().matches(value)) {
-                return Classification.in(each.id());
+            switch (each.classifier().membershipOf(value)) {
+                case Membership.Match _ -> {
+                    return Classification.in(each.id());
+                }
+                // Kept rather than returned on: a class may read less of a value than the one after
+                // it, so one saying it could not read says nothing about the rest. Two of them
+                // disagreeing about why is two readings of one value, which is not an answer to
+                // pick between.
+                case Membership.Incomplete why -> {
+                    if (incomplete == null) {
+                        incomplete = why;
+                    } else if (incomplete.code() != why.code()) {
+                        throw new IllegalStateException("two classes of " + axis.id()
+                                + " disagree about why the value could not be read: "
+                                + incomplete.code() + " and " + why.code());
+                    }
+                }
+                case Membership.NoMatch _ -> { }
             }
         }
-        // The classes are exhaustive over the position, so a value in none of them is one this could
-        // not read rather than one outside the partition.
-        return Classification.unreadable(Incompleteness.Code.VALUE_UNREADABLE,
-                axis.id().behavior(), axis.id().path());
+        if (incomplete != null) {
+            return Classification.unreadable(incomplete.code(),
+                    axis.id().behavior(), axis.id().path());
+        }
+        // Every class read the value and none holds it, which `Axis` says cannot happen: its classes
+        // are exhaustive over the position's values. So this is that contract broken rather than
+        // anything about the row, and saying the value could not be read would be reporting a
+        // measurement failure for a defect in the partition.
+        throw new IllegalStateException("no class of " + axis.id() + " holds a value it read: "
+                + value);
     }
 
     /** The value at the end of a field chain, or null where the chain does not lead anywhere. A

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -152,7 +152,7 @@ class GeneratorTest {
         for (long each : candidates) {
             values.add(FixtureTemplate.integer(each));
         }
-        return PartitionClass.of(id, id, _ -> false, () -> values);
+        return PartitionClass.of(id, id, _ -> Membership.NO_MATCH, () -> values);
     }
 
     /**
@@ -208,7 +208,7 @@ class GeneratorTest {
     void aClassWithNoValueIsNamedRatherThanDropped() {
         Symbols symbols = modelOf(TRIP, "submit").symbols();
         Generator.Subject subject = twoNumbers(symbols,
-                List.of(PartitionClass.ungeneratable("opaque", "opaque", _ -> false, "no value")),
+                List.of(PartitionClass.ungeneratable("opaque", "opaque", _ -> Membership.NO_MATCH, "no value")),
                 List.of(number("high", 10)));
 
         Generator.GenerationResult filled =
@@ -230,7 +230,7 @@ class GeneratorTest {
     void whatHadNoValueIsNamedRatherThanTheCombinationsThatWantedIt() {
         Symbols symbols = modelOf(TRIP, "submit").symbols();
         Generator.Subject subject = twoNumbers(symbols,
-                List.of(PartitionClass.ungeneratable("opaque", "opaque", _ -> false, "no value"),
+                List.of(PartitionClass.ungeneratable("opaque", "opaque", _ -> Membership.NO_MATCH, "no value"),
                         number("low", 1)),
                 List.of(number("high", 10), number("higher", 20)));
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/PartitionsTest.java
@@ -244,18 +244,21 @@ class PartitionsTest {
     void classifiersRecogniseTheValuesRowsCarry() {
         Partitions.Partitioning partitioning = partitioningOf(KINDS, "submit");
         Axis kind = axis(partitioning, "request.kind");
-        TypeName domestic = kind.classes().get(0).classifier().matches(
-                new ObservedValue.Unit(new TypeName("example.trip", "Domestic")))
-                ? new TypeName("example.trip", "Domestic") : null;
-        assertNotNull(domestic, "a unit case is recognised by the type it names");
+        assertEquals(Membership.MATCH, kind.classes().get(0).classifier().membershipOf(
+                        new ObservedValue.Unit(new TypeName("example.trip", "Domestic"))),
+                "a unit case is recognised by the type it names");
 
         Axis urgent = axis(partitioning, "request.urgent");
-        assertTrue(urgent.classOf("true").classifier().matches(new ObservedValue.Bool(true)));
-        assertFalse(urgent.classOf("true").classifier().matches(new ObservedValue.Bool(false)));
+        assertEquals(Membership.MATCH,
+                urgent.classOf("true").classifier().membershipOf(new ObservedValue.Bool(true)));
+        assertEquals(Membership.NO_MATCH,
+                urgent.classOf("true").classifier().membershipOf(new ObservedValue.Bool(false)));
 
         Axis memo = axis(partitioning, "request.memo");
-        assertTrue(memo.classOf("None").classifier().matches(new ObservedValue.Absent()));
-        assertFalse(memo.classOf("None").classifier().matches(new ObservedValue.Text("x")));
+        assertEquals(Membership.MATCH,
+                memo.classOf("None").classifier().membershipOf(new ObservedValue.Absent()));
+        assertEquals(Membership.NO_MATCH,
+                memo.classOf("None").classifier().membershipOf(new ObservedValue.Text("x")));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
@@ -1,0 +1,232 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeChecker;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.observe.Classification;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.observe.RowOutcome;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+import souther.compiler.query.Shapes;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Why a row could not be placed at a position, and who is entitled to say.
+ *
+ * <p>A classifier may read through the value it is given: a number at a position is the number
+ * inside the newtype named there, because a newtype is not a step in a path. So the value the walk
+ * finds and the value a class is about are not always the same node, and only the classifier knows
+ * which one it read.
+ *
+ * <p>Held here because the difference is invisible half the time. A limit reached one wrapper in
+ * used to come back as a value that could not be read — right about the row and wrong about what
+ * happened to it — while the same failure at the node itself came back correctly, and an unreadable
+ * value one wrapper in came back correctly by accident. Which is why nothing noticed.
+ */
+class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
+
+    private static final String MODEL = """
+            module example.trip
+
+            data Domestic
+            data Overseas
+            data Kind = Domestic | Overseas
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Request = { kind: Kind, cost: Amount, plain: Int }
+            data Submitted = { cost: Amount }
+            data Waiting = { cost: Amount }
+
+            behavior submit : (request: Request) -> Submitted | Waiting
+                constructs Submitted, Waiting
+
+            let submit (request) = {
+                guard request.cost.value <= 100 else Waiting { cost = request.cost }
+                guard request.plain <= 10 else Waiting { cost = request.cost }
+                Submitted { cost = request.cost }
+            }
+
+            example submit
+                | (Request { kind = Domestic, cost = Amount(50), plain = 1 }) -> Submitted
+            """;
+
+    private record Read(List<Axis> axes, List<String> parameters, RowOutcome row) {}
+
+    private static Read read() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Ast.Module prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        TypeChecker.Checked checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, "the model under test compiles");
+        Ast.SpecBehavior spec = (Ast.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("submit")).findFirst().orElseThrow();
+        Core body = checked.behaviorBodies().get("submit");
+        CoverageSites.Plan plan = CoverageSites.of("m.sou", checked.behaviorBodies());
+        List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
+        Partitions.Partitioning partitioning = Partitions.withThresholds(
+                Partitions.of(spec, sigs.get("submit"), symbols, Exclusions.NONE),
+                GuardThresholds.of("submit", body, plan, parameters, symbols).thresholds(), symbols);
+        Output.Examples.Of observed = compilation.db()
+                .ask(Output.Examples.asked(compilation.db(), module,
+                        compilation.sourceIds().get(0))).value();
+        assertNotNull(observed);
+        return new Read(partitioning.axes(), parameters, observed.rows().get(0));
+    }
+
+    /** The row it read, with one of the request's fields replaced. */
+    private static RowOutcome giving(Read read, String field, ObservedValue value) {
+        ObservedValue.Constructed request = (ObservedValue.Constructed) read.row().inputs().get(0);
+        Map<String, ObservedValue> fields = new LinkedHashMap<>(request.fields());
+        fields.put(field, value);
+        return new RowOutcome(read.row().at(), read.row().target(), read.row().description(),
+                read.row().stage(), read.row().disposition(), read.row().failurePhase(),
+                read.row().expectedArm(), read.row().resultArm(), read.row().inputCases(),
+                List.of(new ObservedValue.Constructed(request.type(), fields)), read.row().hits(),
+                read.row().stepsSpent());
+    }
+
+    /** The newtype the row wrote at {@code cost}, holding {@code inner} where its number was. */
+    private static ObservedValue wrapping(Read read, ObservedValue inner) {
+        ObservedValue.Constructed request = (ObservedValue.Constructed) read.row().inputs().get(0);
+        ObservedValue.Constructed amount = (ObservedValue.Constructed) request.field("cost");
+        Map<String, ObservedValue> value = new LinkedHashMap<>(amount.fields());
+        value.put("value", inner);
+        return new ObservedValue.Constructed(amount.type(), value);
+    }
+
+    private static Classification at(Read read, RowOutcome row, String path) {
+        Map<AxisId, Classification> classes = RowClasses.of(row, read.parameters(), read.axes());
+        return classes.entrySet().stream().filter(e -> e.getKey().path().equals(path))
+                .map(Map.Entry::getValue).findFirst()
+                .orElseThrow(() -> new AssertionError("no axis at " + path));
+    }
+
+    private static Incompleteness.Code why(Classification where) {
+        return assertInstanceOf(Classification.Unclassified.class, where).reason().code();
+    }
+
+    @Test
+    void aValueTheLimitStoppedSaysSoWhereItIsTheValueItself() {
+        Read read = read();
+
+        assertEquals(Incompleteness.Code.VALUE_TRUNCATED,
+                why(at(read, giving(read, "plain", new ObservedValue.Truncated()), "request.plain")));
+    }
+
+    @Test
+    void aValueTheWalkCouldNotReadSaysSoWhereItIsTheValueItself() {
+        Read read = read();
+
+        assertEquals(Incompleteness.Code.VALUE_UNREADABLE,
+                why(at(read, giving(read, "plain", new ObservedValue.Unknown("gone")),
+                        "request.plain")));
+    }
+
+    /** The one this issue is about. A newtype is not a step, so the limit was reached at a node the
+     * walk never names — and the class that reads through it is the only thing that knows. */
+    @Test
+    void aValueTheLimitStoppedInsideANewtypeSaysSoTo() {
+        Read read = read();
+
+        assertEquals(Incompleteness.Code.VALUE_TRUNCATED,
+                why(at(read, giving(read, "cost", wrapping(read, new ObservedValue.Truncated())),
+                        "request.cost")));
+    }
+
+    @Test
+    void aValueTheWalkCouldNotReadInsideANewtypeSaysSoTo() {
+        Read read = read();
+
+        assertEquals(Incompleteness.Code.VALUE_UNREADABLE,
+                why(at(read, giving(read, "cost", wrapping(read, new ObservedValue.Unknown("gone"))),
+                        "request.cost")));
+    }
+
+    /** And a value every class could read still lands where it did. */
+    @Test
+    void aReadableValueIsStillPlacedInTheClassThatHoldsIt() {
+        Read read = read();
+
+        assertEquals(new Classification.Classified("request.cost/0 <= x <= 100"),
+                at(read, read.row(), "request.cost"));
+        assertEquals(new Classification.Classified("request.plain/x <= 10"),
+                at(read, read.row(), "request.plain"));
+        assertEquals(new Classification.Classified("Domestic"),
+                at(read, read.row(), "request.kind"));
+    }
+
+    // --- what the contract says cannot happen ---------------------------------------------------
+
+    /** The same axis, with classes that answer however this asks them to. */
+    private static List<Axis> answering(Read read, String path, Classifier... classifiers) {
+        Axis real = read.axes().stream().filter(a -> a.path().toString().equals(path))
+                .findFirst().orElseThrow();
+        List<PartitionClass> classes = new java.util.ArrayList<>();
+        for (int i = 0; i < classifiers.length; i++) {
+            classes.add(PartitionClass.of("c" + i, "c" + i, classifiers[i],
+                    RepresentativeSource.none()));
+        }
+        return List.of(new Axis(real.id(), real.path(), real.type(), classes, real.cuts()));
+    }
+
+    /**
+     * A readable value in none of the classes is the partition's contract broken.
+     *
+     * <p>{@code Axis} says its classes are exclusive and exhaustive over the position's values, so a
+     * value every class read and none holds is not a third thing a row can be. Reporting it as a row
+     * that could not be read would answer a defect in the partition with a measurement failure, and
+     * the report would name the row.
+     */
+    @Test
+    void everyClassReadingTheValueAndNoneHoldingItIsNotAnAnswer() {
+        Read read = read();
+        List<Axis> axes = answering(read, "request.plain",
+                _ -> Membership.NO_MATCH, _ -> Membership.NO_MATCH);
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> RowClasses.of(read.row(), read.parameters(), axes));
+        org.junit.jupiter.api.Assertions.assertTrue(
+                thrown.getMessage().contains("holds a value it read"), thrown.getMessage());
+    }
+
+    /**
+     * And two classes disagreeing about why they could not read it is the same kind of thing.
+     *
+     * <p>One value, two readings of whether it is there. Picking between them would be inventing a
+     * precedence for a question nothing has asked: today every class of a numeric position reads
+     * through the same reader and they cannot disagree.
+     */
+    @Test
+    void twoClassesDisagreeingAboutWhyIsNotAnAnswerEither() {
+        Read read = read();
+        List<Axis> axes = answering(read, "request.plain",
+                _ -> new Membership.Incomplete(Incompleteness.Code.VALUE_TRUNCATED),
+                _ -> new Membership.Incomplete(Incompleteness.Code.VALUE_UNREADABLE));
+
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                () -> RowClasses.of(read.row(), read.parameters(), axes));
+        org.junit.jupiter.api.Assertions.assertTrue(
+                thrown.getMessage().contains("disagree about why"), thrown.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
@@ -163,6 +163,35 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
                         "request.cost")));
     }
 
+    /** A class told apart by shape says it too, which is where that test moved to. */
+    @Test
+    void aShapeClassSaysWhenTheObservationWasStopped() {
+        Read read = read();
+
+        assertEquals(Incompleteness.Code.VALUE_TRUNCATED,
+                why(at(read, giving(read, "kind", new ObservedValue.Truncated()), "request.kind")));
+        assertEquals(Incompleteness.Code.VALUE_UNREADABLE,
+                why(at(read, giving(read, "kind", new ObservedValue.Unknown("gone")),
+                        "request.kind")));
+    }
+
+    /**
+     * A value that was read and is not a number is a class this position does not hold.
+     *
+     * <p>Not an incompleteness. `VALUE_UNREADABLE` is a value that could not be read back into an
+     * observed form at all, and a `Text` was read — it is the partition that does not fit it. So the
+     * classes all decline, and declining together is the contract below, not a row nobody could
+     * read.
+     */
+    @Test
+    void aReadableValueThatIsNotANumberIsNotAnIncompleteness() {
+        Read read = read();
+        RowOutcome row = giving(read, "plain", new ObservedValue.Text("x"));
+
+        assertThrows(IllegalStateException.class,
+                () -> RowClasses.of(row, read.parameters(), read.axes()));
+    }
+
     /** And a value every class could read still lands where it did. */
     @Test
     void aReadableValueIsStillPlacedInTheClassThatHoldsIt() {
@@ -188,6 +217,26 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
                     RepresentativeSource.none()));
         }
         return List.of(new Axis(real.id(), real.path(), real.type(), classes, real.cuts()));
+    }
+
+    /**
+     * A class that holds the value wins over classes that could not read it, wherever it sits.
+     *
+     * <p>One class saying it could not read says nothing about the rest — that is why the answers
+     * are collected rather than returned on — and it says nothing about whether one of them holds
+     * the value either. An incompleteness is what is left once nothing has claimed it, so it cannot
+     * be acted on before every class has answered.
+     */
+    @Test
+    void aClassThatHoldsTheValueWinsOverOnesThatCouldNotReadIt() {
+        Read read = read();
+        List<Axis> axes = answering(read, "request.plain",
+                _ -> new Membership.Incomplete(Incompleteness.Code.VALUE_TRUNCATED),
+                _ -> new Membership.Incomplete(Incompleteness.Code.VALUE_UNREADABLE),
+                _ -> Membership.MATCH);
+
+        assertEquals(new Classification.Classified("c2"),
+                RowClasses.of(read.row(), read.parameters(), axes).values().iterator().next());
     }
 
     /**


### PR DESCRIPTION
Closes #499.

`Classifier` answers a `Membership` instead of a `boolean`, and the numeric
reader stops writing two kinds of nothing as one.

## What was wrong

A newtype is not a step in a path, so the value at `request.cost` is the
construction and the number is one node inside it. `Intervals` reads through it;
`classify` tested the node the walk found. A limit reached inside left a
construction with nothing visibly wrong, and the last line named a failure it had
not observed:

```text
plain = Truncated                -> VALUE_TRUNCATED
plain = Unknown                  -> VALUE_UNREADABLE
cost  = Amount{value=Truncated}  -> VALUE_UNREADABLE     wrong
cost  = Amount{value=Unknown}    -> VALUE_UNREADABLE     right, by accident
```

Two losses, not one: `numberOf` answered `null` both for a value it could not
read and for a value that is not a number, and `matches` folded that into the
same `false` as a number outside the range.

## What it is now

```text
any Match                 ->  that class
else Incomplete, agreeing ->  that incompleteness
else                      ->  internal failure
```

The shape tests in `classify` are gone. They were the same question asked in a
second place and answered from a different node, which is what let the two come
apart.

`Incomplete` answers are not returned on as they arrive: a class may read less of
a value than the one after it, so one saying it could not read says nothing about
the rest.

## The last line

`Axis` says its classes are *exclusive and exhaustive over the position's
values*, so every class reading a value and none holding it is that contract
broken, not a third thing a row can be. Answering it with `VALUE_UNREADABLE`
would report a defect in the partition as a measurement failure and name the row
for it.

Walked, and nothing produces it: a parameter is a single named type so no
anonymous union reaches an input axis; a fixture that would not build never
reaches `inputs`; the case classes are built from every leaf; the decoder refuses
a number outside its newtype's invariant; and `Intervals` divides a domain end to
end, thresholds adding boundaries rather than holes. The whole existing suite
runs without reaching it.

Two classes disagreeing about why they could not read one value is held to the
same line, rather than given a precedence nobody has asked for.

## Checks

Eight cases, including the two contract ones as unit tests rather than
reproductions. Dropping the reason on the way back out of the numeric reader
fails two of them, so they are not passing on the shape alone.

Full reactor `clean test` green.

## Noted, not done here

`numberOf` is written four times — `Intervals`, `Coverages`, `BoundaryAssessment`,
`Generator` — each its own copy of the same walk through a newtype. Only the
first is touched here, and `numberOf` is kept on top of the new reader so this
does not add a fifth.
