### PR TITLE
An observation says the same thing wherever the path meets it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/observe/ObservedValue.java
+++ b/souther-compiler/src/main/java/souther/compiler/observe/ObservedValue.java
@@ -101,6 +101,31 @@ public sealed interface ObservedValue {
      */
     record Truncated() implements ObservedValue {}
 
+    /**
+     * Why nothing can be read here, or null where there is a value to read.
+     *
+     * <p>Two of these cases stand where a value would have been rather than being one, and what they
+     * say is a fact about the observation: a limit stopped it, or it could not be read back. Neither
+     * is a judgement anything downstream makes, and the case that is left over is the whole of what
+     * a reader further on is entitled to interpret.
+     *
+     * <p>So the cases are named once, here, where they are declared. A reader that meets one is at
+     * the end of what it can do with the value and says this; a walk that meets one on the way to
+     * somewhere else hands it on unchanged, because where along a path an observation stopped is not
+     * something it stopped differently for.
+     *
+     * <p>Nothing readable answers here. A value the limits shortened is not kept — a text past its
+     * length and a collection past its count are replaced whole — so no case is a value and a reason
+     * at once, and this can stay the narrow question it is.
+     */
+    default Incompleteness.Code unread() {
+        return switch (this) {
+            case Truncated _ -> Incompleteness.Code.VALUE_TRUNCATED;
+            case Unknown _ -> Incompleteness.Code.VALUE_UNREADABLE;
+            default -> null;
+        };
+    }
+
     /** An empty map with a stable iteration order, for building a {@link Constructed}. */
     static Map<String, ObservedValue> fields() {
         return new LinkedHashMap<>();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Membership.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Membership.java
@@ -39,15 +39,13 @@ public sealed interface Membership {
      *
      * <p>Null where there is a value to look at, so a classifier can go on to its own question. Here
      * rather than at each classifier because it is one fact about the observation and not a
-     * judgement any class makes: a limit stopped it, or the walk could not read it back, and both
-     * are true before any class is consulted.
+     * judgement any class makes — and by the same reading it is not this layer's to state either, so
+     * which cases are a reason instead of a value is {@link ObservedValue#unread()}'s to say. What
+     * is left here is the absence a walk answers with, which is not an observation at all.
      */
     static Incomplete unread(ObservedValue value) {
-        return switch (value) {
-            case null -> new Incomplete(Incompleteness.Code.VALUE_UNREADABLE);
-            case ObservedValue.Truncated _ -> new Incomplete(Incompleteness.Code.VALUE_TRUNCATED);
-            case ObservedValue.Unknown _ -> new Incomplete(Incompleteness.Code.VALUE_UNREADABLE);
-            default -> null;
-        };
+        Incompleteness.Code why = value == null
+                ? Incompleteness.Code.VALUE_UNREADABLE : value.unread();
+        return why == null ? null : new Incomplete(why);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/RowClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RowClasses.java
@@ -103,12 +103,27 @@ public final class RowClasses {
                 + value);
     }
 
-    /** The value at the end of a field chain, or null where the chain does not lead anywhere. A
+    /**
+     * The value at the end of a field chain, or null where the chain does not lead anywhere. A
      * newtype is never a step — the path never names its {@code value} — so what is walked here is
-     * only a record's fields. */
+     * only a record's fields.
+     *
+     * <p>An observation that stopped is handed on rather than walked into. It is not a record and
+     * there is nothing under it, but it is also not a chain that leads nowhere: it is the reason
+     * this position has no value, and it says that itself. Read as somewhere the walk could not go,
+     * a limit that ran out one field short of a position came back as a value nobody could read —
+     * the same observation the walk returns as it stands when the path happens to end on it.
+     *
+     * <p>Which leaves null for the walk's own answer, and only that: a record that does not hold the
+     * field named next, or a value that was read and is not a record at all. The path and the shape
+     * disagree, and no observation says why because nothing went wrong with one.
+     */
     private static ObservedValue walk(ObservedValue from, List<String> fields) {
         ObservedValue at = from;
         for (String field : fields) {
+            if (at.unread() != null) {
+                return at;
+            }
             if (!(at instanceof ObservedValue.Constructed constructed)) {
                 return null;
             }

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
@@ -1,0 +1,202 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeChecker;
+import souther.compiler.core.Core;
+import souther.compiler.coverage.CoverageSites;
+import souther.compiler.observe.Classification;
+import souther.compiler.observe.Incompleteness;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.observe.RowOutcome;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Output;
+import souther.compiler.query.Shapes;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a walk to a position inside a record says about not getting there.
+ *
+ * <p>An observation that did not arrive is already the reason it did not: {@link ObservedValue}
+ * carries a case for a limit that stopped it and a case for a value it could not read, and both
+ * stand where the value would have been. So the walk is not asked to work anything out. It is asked
+ * not to throw away what it ran into.
+ *
+ * <p>Which it did, in one place only. A record the node budget did not reach stands at the position
+ * itself and comes back as a limit that stopped it, and stands one field short of the position and
+ * comes back as a value nobody could read. One value, two answers, told apart by nothing but how
+ * many fields were left to walk.
+ */
+class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
+
+    private static final String MODEL = """
+            module example.booking
+
+            data Amount = Int
+                invariant value >= 0
+
+            data Interval = { startsAt: Int, endsAt: Int }
+
+            data Request = { cost: Amount, interval: Interval }
+            data Booked = { cost: Amount }
+            data Waiting = { cost: Amount }
+
+            behavior book : (request: Request) -> Booked | Waiting
+                constructs Booked, Waiting
+
+            let book (request) = {
+                guard request.interval.startsAt <= 10 else Waiting { cost = request.cost }
+                Booked { cost = request.cost }
+            }
+
+            example book
+                | (Request { cost = Amount(50),
+                             interval = Interval { startsAt = 1, endsAt = 2 } }) -> Booked
+            """;
+
+    private static final String POSITION = "request.interval.startsAt";
+
+    private record Read(List<Axis> axes, List<String> parameters, RowOutcome row) {}
+
+    private static Read read() {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Ast.Module prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        TypeChecker.Checked checked = compilation.db().ask(new Bodies.Checked(module)).value();
+        assertNotNull(checked, "the model under test compiles");
+        Ast.SpecBehavior spec = (Ast.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals("book")).findFirst().orElseThrow();
+        Core body = checked.behaviorBodies().get("book");
+        CoverageSites.Plan plan = CoverageSites.of("m.sou", checked.behaviorBodies());
+        List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
+        Partitions.Partitioning partitioning = Partitions.withThresholds(
+                Partitions.of(spec, sigs.get("book"), symbols, Exclusions.NONE),
+                GuardThresholds.of("book", body, plan, parameters, symbols).thresholds(), symbols);
+        Output.Examples.Of observed = compilation.db()
+                .ask(Output.Examples.asked(compilation.db(), module,
+                        compilation.sourceIds().get(0))).value();
+        assertNotNull(observed);
+        return new Read(partitioning.axes(), parameters, observed.rows().get(0));
+    }
+
+    /** The row it read, with the request's {@code interval} replaced by whatever stands there. */
+    private static RowOutcome givingInterval(Read read, ObservedValue value) {
+        ObservedValue.Constructed request = (ObservedValue.Constructed) read.row().inputs().get(0);
+        Map<String, ObservedValue> fields = new LinkedHashMap<>(request.fields());
+        fields.put("interval", value);
+        return new RowOutcome(read.row().at(), read.row().target(), read.row().description(),
+                read.row().stage(), read.row().disposition(), read.row().failurePhase(),
+                read.row().expectedArm(), read.row().resultArm(), read.row().inputCases(),
+                List.of(new ObservedValue.Constructed(request.type(), fields)), read.row().hits(),
+                read.row().stepsSpent());
+    }
+
+    /** The interval the row wrote, with {@code inner} where the position's number was. */
+    private static ObservedValue intervalHolding(Read read, ObservedValue inner) {
+        ObservedValue.Constructed interval = (ObservedValue.Constructed)
+                ((ObservedValue.Constructed) read.row().inputs().get(0)).field("interval");
+        Map<String, ObservedValue> fields = new LinkedHashMap<>(interval.fields());
+        fields.put("startsAt", inner);
+        return new ObservedValue.Constructed(interval.type(), fields);
+    }
+
+    private static Incompleteness.Code why(Read read, RowOutcome row) {
+        Map<AxisId, Classification> classes = RowClasses.of(row, read.parameters(), read.axes());
+        Classification where = classes.entrySet().stream()
+                .filter(e -> e.getKey().path().equals(POSITION))
+                .map(Map.Entry::getValue).findFirst()
+                .orElseThrow(() -> new AssertionError("no axis at " + POSITION));
+        return assertInstanceOf(Classification.Unclassified.class, where).reason().code();
+    }
+
+    private static TermPath position(Read read) {
+        return read.axes().stream().filter(a -> a.path().toString().equals(POSITION))
+                .findFirst().orElseThrow().path();
+    }
+
+    /**
+     * A limit that stopped the observation says so from either place on the path.
+     *
+     * <p>Both, in one test, because neither is the claim on its own. The position itself was already
+     * right and the field above it was already wrong, and what was wrong is that they differed.
+     */
+    @Test
+    void aLimitThatStoppedTheObservationSaysSoFromAnywhereOnThePath() {
+        Read read = read();
+
+        assertEquals(Incompleteness.Code.VALUE_TRUNCATED,
+                why(read, givingInterval(read, intervalHolding(read, new ObservedValue.Truncated()))),
+                "the limit was reached at the position");
+        assertEquals(Incompleteness.Code.VALUE_TRUNCATED,
+                why(read, givingInterval(read, new ObservedValue.Truncated())),
+                "the limit was reached one field above the position");
+    }
+
+    /** And so does a value the observer could not read, which was right in both places by accident:
+     * the answer the walk invented for everything happened to be this one. */
+    @Test
+    void aValueTheObserverCouldNotReadSaysSoFromAnywhereOnThePath() {
+        Read read = read();
+
+        assertEquals(Incompleteness.Code.VALUE_UNREADABLE,
+                why(read, givingInterval(read,
+                        intervalHolding(read, new ObservedValue.Unknown("gone")))));
+        assertEquals(Incompleteness.Code.VALUE_UNREADABLE,
+                why(read, givingInterval(read, new ObservedValue.Unknown("gone"))));
+    }
+
+    /**
+     * A record that was observed and does not hold the field the path names is the other thing, and
+     * stays the other thing.
+     *
+     * <p>Nothing was stopped here: the walk arrived, read what was there, and the path asked for a
+     * field of it that the observation does not have. There is no reason to keep because the
+     * observation has none to give, which is what is left for the walk to answer on its own.
+     */
+    @Test
+    void aFieldTheObservationDoesNotHoldIsStillTheWalksOwnAnswer() {
+        Read read = read();
+        ObservedValue.Constructed interval = (ObservedValue.Constructed)
+                ((ObservedValue.Constructed) read.row().inputs().get(0)).field("interval");
+
+        assertEquals(Incompleteness.Code.VALUE_UNREADABLE,
+                why(read, givingInterval(read,
+                        new ObservedValue.Constructed(interval.type(), Map.of()))));
+    }
+
+    /**
+     * What the boundary's caller sees, which is why this changes nothing for it.
+     *
+     * <p>{@code valueAt} already hands back a stopped observation where the path ends on one — the
+     * loop runs out of fields and returns what it is holding — so a caller that asks it for a number
+     * already meets one and reads it as no number. Keeping the same value from one field earlier
+     * gives that caller a value it already handles rather than a new one.
+     */
+    @Test
+    void theValueAtAPositionIsTheStoppedObservationItself() {
+        Read read = read();
+
+        assertInstanceOf(ObservedValue.Truncated.class,
+                RowClasses.valueAt(givingInterval(read, intervalHolding(read,
+                        new ObservedValue.Truncated())), read.parameters(), position(read)),
+                "the limit was reached at the position");
+        assertInstanceOf(ObservedValue.Truncated.class,
+                RowClasses.valueAt(givingInterval(read, new ObservedValue.Truncated()),
+                        read.parameters(), position(read)),
+                "the limit was reached one field above the position");
+    }
+}


### PR DESCRIPTION
Closes #504.

`RowClasses.walk` collapsed every way of not reaching a position into `null`, including the
two that already carry their reason. It returns a `Truncated` or an `Unknown` unchanged
where the path ends on one, and replaced the same observation with `null` where it sat one
field earlier — so a limit that ran out one field short of a position was reported as a
value nobody could read.

Measured over `request.interval.startsAt`:

```text
interval.startsAt = Truncated      (the path ends on it)  -> VALUE_TRUNCATED
interval          = Truncated      (one field above)      -> VALUE_UNREADABLE
interval          = Unknown        (one field above)      -> VALUE_UNREADABLE
interval          = Constructed{}  (no such field)        -> VALUE_UNREADABLE
```

The third line is right by accident, which is why nothing noticed. #499 hid the same way.

The walk now hands those on. `null` stays for its own answer and only that: a record that
does not hold the field named next, or a value that was read and is not a record.

Which cases are a reason rather than a value moves from `Membership.unread` to
`ObservedValue`, on that method's own reading — it is a fact about the observation, so it
is not the partition's to state either, and the walk needs it without being a classifier.

`valueAt` is unchanged: its callers ask whether `numberOf` found a number, which is no for
a `Truncated` and no for a `null` alike.

Four tests, in pairs — the position itself and one field above it — so the claim is that
the two agree and not that either one is right on its own. Two of the four failed before
the change, both the one-field-above halves. Full `mvn clean test` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
