### PR TITLE
An operator reads each operand once

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
@@ -19,35 +19,41 @@ public final class BinaryElaborator {
 
     private BinaryElaborator() {}
 
-    /** Whether either side of {@code bin} has a type the compiler could not work out. */
-    private static boolean erroneousOperand(Ast.Binary bin, Scope env,
-                                            CheckContext ctx) {
-        return erroneous(bin.left(), env, ctx) || erroneous(bin.right(), env, ctx);
-    }
-
-    private static boolean erroneous(Ast.Expr operand, Scope env, CheckContext ctx) {
-        try {
-            return Elaborator.elaborate(operand, env, ctx).type() instanceof Type.Erroneous;
-        } catch (CompileException _) {
-            return false;   // it has its own error; the operator's check will raise it as before
+    /**
+     * Reads one operand, and gives up on the definition where its type is one the compiler could not
+     * work out.
+     *
+     * <p>An operator wants a particular shape of type — Int or Decimal to add, two lists or two
+     * strings to append — and an operand the compiler could not work out has no shape. Absorbing is
+     * for a comparison, which can answer "no disagreement"; there is no answer to give here, so the
+     * definition is abandoned and the name that denoted nothing stands as what was wrong. Left alone,
+     * the operand's type reaches the message as `?`, which names nothing the author could go looking
+     * for.
+     *
+     * <p>What this answers with is what the operator's rule then reads. Asking the question of a
+     * reading of its own cost the expression twice its own subtree, and an operand of an operand
+     * twice again, so a chain of operators nested one inside the last cost two to the power of its
+     * length: twenty-six links took ten seconds and a hundred did not finish.
+     */
+    private static Core operand(Ast.Expr e, Ast.Binary bin, Scope env, CheckContext ctx) {
+        Core read = Elaborator.elaborate(e, env, ctx);
+        if (read.type() instanceof Type.Erroneous) {
+            throw new Unanswerable(bin.pos());
         }
+        return read;
     }
 
     static Core elaborateBinary(Ast.Binary bin, Scope env, CheckContext ctx) {
-        // An operator wants a particular shape of type — Int or Decimal to add, two lists or two
-        // strings to append — and an operand the compiler could not work out has no shape. Absorbing
-        // is for a comparison, which can answer "no disagreement"; there is no answer to give here, so
-        // the definition is abandoned and the name that denoted nothing stands as what was wrong.
-        // Left alone, the operand's type reaches the message as `?`, which names nothing the author
-        // could go looking for.
-        if (erroneousOperand(bin, env, ctx)) {
-            throw new Unanswerable(bin.pos());
-        }
+        // Left to right, and the first operand that failed is the one reported: an operand that says
+        // what is wrong with it has said it, and what stands beside it is not read at all where this
+        // one left nothing to check against.
+        Core left = operand(bin.left(), bin, env, ctx);
+        Core right = operand(bin.right(), bin, env, ctx);
         return switch (bin.op()) {
             case AND, OR -> {
-                Core left = Elaborator.requireTyped(bin.left(), Type.BOOL, env, ctx,
+                Elaborator.requireType(bin.left(), left.type(), Type.BOOL, ctx.symbols(),
                         "operand of logical operator");
-                Core right = Elaborator.requireTyped(bin.right(), Type.BOOL, env, ctx,
+                Elaborator.requireType(bin.right(), right.type(), Type.BOOL, ctx.symbols(),
                         "operand of logical operator");
                 yield new Core.Binary(bin.op(), left, right, Type.BOOL, bin.pos());
             }
@@ -58,8 +64,6 @@ public final class BinaryElaborator {
                 // LocalDateTime are Comparable, so it orders them too. A single-value newtype over an
                 // ordered type is ordered by that value; the operands stay the same newtype (nominal),
                 // except that a bare literal takes the other side's newtype from context.
-                Core left = Elaborator.elaborate(bin.left(), env, ctx);
-                Core right = Elaborator.elaborate(bin.right(), env, ctx);
                 Type lt = left.type();
                 Type rt = right.type();
                 if (!orderedComparable(lt, rt, bin.left(), bin.right(), ctx.symbols())) {
@@ -76,8 +80,6 @@ public final class BinaryElaborator {
                 // `+ - * /` work on two Int or two Decimal operands (spec 18.1). Int aborts on
                 // overflow and `/` aborts on a zero divisor; Decimal `/` rounds by the default
                 // scale/mode. Case handling for a zero divisor is the `divide`/`remainder` functions.
-                Core left = Elaborator.elaborate(bin.left(), env, ctx);
-                Core right = Elaborator.elaborate(bin.right(), env, ctx);
                 Type lt = left.type();
                 Type rt = right.type();
                 // The rules live in ArithmeticCheck, which answers with the type the operator gives
@@ -100,8 +102,6 @@ public final class BinaryElaborator {
             case CONCAT -> {
                 // `++` is Elm's appendable operator: two strings concatenate to a string, two lists to
                 // a list (spec 18.1). Strings are checked first, before the empty-list absorption below.
-                Core left = Elaborator.elaborate(bin.left(), env, ctx);
-                Core right = Elaborator.elaborate(bin.right(), env, ctx);
                 Type lraw = left.type();
                 Type rraw = right.type();
                 if (lraw == Type.STRING && rraw == Type.STRING) {
@@ -129,8 +129,6 @@ public final class BinaryElaborator {
                         Type.list(BottomInfer.unifyElem(lo.element(), ro.element(), bin.pos())), bin.pos());
             }
             case EQ, NE -> {
-                Core left = Elaborator.elaborate(bin.left(), env, ctx);
-                Core right = Elaborator.elaborate(bin.right(), env, ctx);
                 Type lt = left.type();
                 Type rt = right.type();
                 // two values of the same data compare by their fields (spec 16.2); across different

--- a/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
@@ -30,6 +30,10 @@ public final class BinaryElaborator {
      * the operand's type reaches the message as `?`, which names nothing the author could go looking
      * for.
      *
+     * <p>{@code &&} and {@code ||} are the operators that ask something of an operand on its own,
+     * and that is asked here, before the operand beside it is read: an operand is finished where it
+     * stands. The rest ask about the pair and cannot answer until both have been read.
+     *
      * <p>What this answers with is what the operator's rule then reads. Asking the question of a
      * reading of its own cost the expression twice its own subtree, and an operand of an operand
      * twice again, so a chain of operators nested one inside the last cost two to the power of its
@@ -39,6 +43,10 @@ public final class BinaryElaborator {
         Core read = Elaborator.elaborate(e, env, ctx);
         if (read.type() instanceof Type.Erroneous) {
             throw new Unanswerable(bin.pos());
+        }
+        if (bin.op() == Ast.BinOp.AND || bin.op() == Ast.BinOp.OR) {
+            Elaborator.requireType(e, read.type(), Type.BOOL, ctx.symbols(),
+                    "operand of logical operator");
         }
         return read;
     }
@@ -50,13 +58,8 @@ public final class BinaryElaborator {
         Core left = operand(bin.left(), bin, env, ctx);
         Core right = operand(bin.right(), bin, env, ctx);
         return switch (bin.op()) {
-            case AND, OR -> {
-                Elaborator.requireType(bin.left(), left.type(), Type.BOOL, ctx.symbols(),
-                        "operand of logical operator");
-                Elaborator.requireType(bin.right(), right.type(), Type.BOOL, ctx.symbols(),
-                        "operand of logical operator");
-                yield new Core.Binary(bin.op(), left, right, Type.BOOL, bin.pos());
-            }
+            // both operands were asked for a Bool where they were read
+            case AND, OR -> new Core.Binary(bin.op(), left, right, Type.BOOL, bin.pos());
             case LT, LE, GT, GE -> {
                 // The ordered primitives: Int numerically, String lexicographically, Decimal by
                 // value, Date/DateTime in time. Unlike Elm (which orders only Int/Float/Char/String

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorReadsEachOperandOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorReadsEachOperandOnceTest.java
@@ -92,6 +92,11 @@ class AnOperatorReadsEachOperandOnceTest {
      * Compiles {@code source} on a thread of its own and fails where it took longer than
      * {@link #BUDGET_MS}. The wait is bounded well above the budget: a compile that never comes back
      * is the failure this is about, and it fails with a name on it rather than sitting there.
+     *
+     * <p>The thread is a daemon and is interrupted where the wait ran out, because a run that
+     * regressed leaves five of these behind and the cases after them would be timed against a
+     * machine those are still using. The compiler does not read the interruption, so what actually
+     * bounds them is that the JVM does not wait for a daemon to finish.
      */
     private static void compilesWithinTheBudget(String source) {
         AtomicReference<Throwable> thrown = new AtomicReference<>();
@@ -102,6 +107,7 @@ class AnOperatorReadsEachOperandOnceTest {
                 thrown.set(x);
             }
         }, "operand-cost");
+        work.setDaemon(true);
         long started = System.nanoTime();
         work.start();
         try {
@@ -111,8 +117,12 @@ class AnOperatorReadsEachOperandOnceTest {
             throw new AssertionError("interrupted while waiting for the compile", interrupted);
         }
         long took = (System.nanoTime() - started) / 1_000_000;
+        boolean stillRunning = work.isAlive();
+        if (stillRunning) {
+            work.interrupt();
+        }
 
-        assertFalse(work.isAlive(), "the compile did not come back within " + (6 * BUDGET_MS) + "ms");
+        assertFalse(stillRunning, "the compile did not come back within " + (6 * BUDGET_MS) + "ms");
         assertNull(thrown.get(), "this source is correct and should compile");
         assertTrue(took < BUDGET_MS, "compiling took " + took + "ms, which is what reading an operand"
                 + " more than once costs at this depth");

--- a/souther-compiler/src/test/java/souther/compiler/check/AnOperatorReadsEachOperandOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnOperatorReadsEachOperandOnceTest.java
@@ -1,0 +1,120 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Elaborating a binary expression reads each operand once, so what it costs is the size of the
+ * expression and not two to the power of its nesting depth (issue #507).
+ *
+ * <p>An operand read twice costs twice its own subtree, and an operand of an operand costs twice
+ * again: a chain of {@code N} operators nested one inside the last cost {@code 2^N}. Twenty-six
+ * links took ten seconds and a hundred did not finish. Nothing said so — the operand check that
+ * read them is the same check that reports, and it reports nothing until it comes back.
+ *
+ * <p>The reading is one place for every operator, so a chain of any one of them measures it. The
+ * depth below is where the two costs are far enough apart that neither the machine nor the run
+ * decides the answer: at 26 links a second reading takes tens of seconds, and one reading takes
+ * milliseconds.
+ */
+class AnOperatorReadsEachOperandOnceTest {
+
+    /** Deep enough that a second reading is tens of seconds, shallow enough that one is not
+     *  measurable. */
+    private static final int LINKS = 26;
+
+    /** Far above what one reading costs at {@link #LINKS} and far below what two cost. */
+    private static final long BUDGET_MS = 10_000;
+
+    /** A chain of values, each written from the one before it — the shape the nesting ceiling
+     *  (E2104) tells an author to break a deep expression into. A value is substituted where it is
+     *  named (ADR-0072), so the last one's body is as deep as the chain is long. */
+    @Test
+    void aChainOfNamedValuesCostsWhatItsLengthSays() {
+        StringBuilder source = new StringBuilder("module m\n\nlet v0 = 1\n");
+        for (int i = 1; i <= 100; i++) {
+            source.append("let v").append(i).append(" = v").append(i - 1).append(" + 1\n");
+        }
+        source.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v100\n");
+
+        compilesWithinTheBudget(source.toString());
+    }
+
+    @Test
+    void aChainOfArithmeticCostsWhatItsLengthSays() {
+        compilesWithinTheBudget("""
+                module m
+
+                behavior f : (x: Int) -> Int
+                let f (x) = x%s
+                """.formatted(" + 1".repeat(LINKS)));
+    }
+
+    @Test
+    void aChainOfAppendsCostsWhatItsLengthSays() {
+        compilesWithinTheBudget("""
+                module m
+
+                behavior f : (s: String) -> String
+                let f (s) = s%s
+                """.formatted(" ++ \"a\"".repeat(LINKS)));
+    }
+
+    @Test
+    void aChainOfLogicalOperatorsCostsWhatItsLengthSays() {
+        compilesWithinTheBudget("""
+                module m
+
+                behavior f : (b: Bool) -> Bool
+                let f (b) = b%s
+                """.formatted(" && true".repeat(LINKS)));
+    }
+
+    /** `==` does not associate, so the nesting is written out. */
+    @Test
+    void aChainOfEqualitiesCostsWhatItsLengthSays() {
+        compilesWithinTheBudget("""
+                module m
+
+                behavior f : (b: Bool) -> Bool
+                let f (b) = %sb%s
+                """.formatted("(".repeat(LINKS), " == true)".repeat(LINKS)));
+    }
+
+    /**
+     * Compiles {@code source} on a thread of its own and fails where it took longer than
+     * {@link #BUDGET_MS}. The wait is bounded well above the budget: a compile that never comes back
+     * is the failure this is about, and it fails with a name on it rather than sitting there.
+     */
+    private static void compilesWithinTheBudget(String source) {
+        AtomicReference<Throwable> thrown = new AtomicReference<>();
+        Thread work = new Thread(() -> {
+            try {
+                Compiler.compile(source);
+            } catch (Throwable x) {
+                thrown.set(x);
+            }
+        }, "operand-cost");
+        long started = System.nanoTime();
+        work.start();
+        try {
+            work.join(6 * BUDGET_MS);
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            throw new AssertionError("interrupted while waiting for the compile", interrupted);
+        }
+        long took = (System.nanoTime() - started) / 1_000_000;
+
+        assertFalse(work.isAlive(), "the compile did not come back within " + (6 * BUDGET_MS) + "ms");
+        assertNull(thrown.get(), "this source is correct and should compile");
+        assertTrue(took < BUDGET_MS, "compiling took " + took + "ms, which is what reading an operand"
+                + " more than once costs at this depth");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/TheOperandThatFailedFirstIsTheOneReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheOperandThatFailedFirstIsTheOneReportedTest.java
@@ -50,6 +50,40 @@ class TheOperandThatFailedFirstIsTheOneReportedTest {
                 "the operand that said what was wrong with it is reported: " + keys);
     }
 
+    /**
+     * `&&` and `||` are the operators that ask something of an operand on its own, so an operand
+     * they refuse has failed where it stands and the operand beside it is not reached. The rest ask
+     * about the pair, and cannot answer until both have been read.
+     */
+    @Test
+    void anOperandTheOperatorRefusesOnItsOwnComesBeforeWhatStandsBesideIt() {
+        List<String> keys = messageKeys("""
+                behavior f : (a: A) -> Bool
+                let f (a) = 1 && ("x" ++ 1)
+                """);
+
+        assertTrue(keys.contains("check.type.mismatch.msg"),
+                "`1` is not a Bool, and that is what `&&` was given first: " + keys);
+        assertFalse(keys.contains("check.concat.msg"),
+                "the operand beside it was never read: " + keys);
+    }
+
+    /**
+     * The same rule where what stands beside it is an operand with no type. Abandoning the
+     * definition is for what follows from a name that denotes nothing, and an operand the operator
+     * refuses before reaching that name does not follow from it.
+     */
+    @Test
+    void anOperandTheOperatorRefusesIsReportedThoughTheOneBesideItHasNoType() {
+        List<String> keys = messageKeys("""
+                behavior f : (a: A) -> Bool
+                let f (a) = 1 && a.n
+                """);
+
+        assertTrue(keys.contains("check.type.mismatch.msg"),
+                "`1` is not a Bool, whatever stands beside it: " + keys);
+    }
+
     @Test
     void anOperandWithNoTypeStopsTheOneBesideItFromBeingRead() {
         List<String> keys = messageKeys("""

--- a/souther-compiler/src/test/java/souther/compiler/check/TheOperandThatFailedFirstIsTheOneReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheOperandThatFailedFirstIsTheOneReportedTest.java
@@ -1,0 +1,74 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.Located;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An operator reads its operands left to right and reports the first one that failed.
+ *
+ * <p>An operand whose type the compiler could not work out gives the operator no shape to check
+ * against, so the definition is abandoned rather than told what {@code ?} is not. That is about the
+ * operand it is read from: an operand of its own that already said what was wrong with it has been
+ * reported, and the operand beside it does not take that back.
+ */
+class TheOperandThatFailedFirstIsTheOneReportedTest {
+
+    /** `n` is declared at a type nothing declares, so `a.n` is the type the compiler could not work
+     *  out; `"x" ++ 1` is an operand that says what is wrong with it. */
+    private static final String NOWHERE = """
+            data A = { n: Nowhere }
+            """;
+
+    private static List<String> messageKeys(String body) {
+        Map<String, List<Located>> found = Compiler.diagnoseModules(Map.of("demo", """
+                module demo
+
+                %s
+                %s
+                """.formatted(NOWHERE, body)));
+        return found.getOrDefault("demo", List.of()).stream()
+                .map(l -> l.diagnostic().messageKey()).toList();
+    }
+
+    @Test
+    void theOperandBesideOneThatFailedDoesNotCoverIt() {
+        List<String> keys = messageKeys("""
+                behavior f : (a: A) -> Int
+                let f (a) = ("x" ++ 1) + a.n
+                """);
+
+        assertTrue(keys.contains("check.concat.msg"),
+                "the operand that said what was wrong with it is reported: " + keys);
+    }
+
+    @Test
+    void anOperandWithNoTypeStopsTheOneBesideItFromBeingRead() {
+        List<String> keys = messageKeys("""
+                behavior f : (a: A) -> Int
+                let f (a) = a.n + ("x" ++ 1)
+                """);
+
+        assertFalse(keys.contains("check.concat.msg"),
+                "reading stopped at the operand with no type, so nothing beside it was read: " + keys);
+    }
+
+    @Test
+    void anOperandWithNoTypeIsNotReportedAsTheWrongTypeForTheOperator() {
+        List<String> keys = messageKeys("""
+                behavior f : (a: A) -> Int
+                let f (a) = 1 + a.n
+                """);
+
+        assertEquals(List.of("check.unknown.type.msg"), keys,
+                "the name that denotes nothing, and nothing about adding it: " + keys);
+    }
+}


### PR DESCRIPTION
Closes #507.

## What was wrong

`BinaryElaborator.elaborateBinary` read each operand twice: once in `erroneousOperand`, to ask whether the operand's type was one the compiler could not work out, and again in the rule for the operator. An operand of an operand was read twice again, so an expression whose operators nest N deep cost 2^N.

Counting the calls to `Elaborator.elaborate`:

| N | before | after |
|---|---|---|
| 10 | 24,533 | 167 |
| 14 | 393,161 | 287 |
| 18 | 6,291,389 | 439 |
| 22 | 100,663,217 | 623 |

Exactly twice per link. A value is substituted where it is named (ADR-0072), so a chain of values written one from the last nests that deep — which is the shape an author is told to write a deep expression in.

The nesting ceiling never covered this. E2104 bounds the parser's frame stack, not the depth of the tree it builds, and a left-associated operator chain does not grow that stack: `let f (x) = x + 1 + 1 + ...` written thirty times took 96 s with no names involved at all.

| | before | after |
|---|---|---|
| chain N=26 | 9.70 s | 0.45 s |
| chain N=100 | killed after 120 s | 0.46 s |
| 30 literal `+` | 96.3 s | 0.43 s |

## What changed

The operands are read once, and the Core each reading answers with is what the rule reads.

Reading twice also decided which operand was reported, and decided it wrongly: `erroneous` swallowed an operand's own `CompileException` on the assumption that the second reading would raise it again, but where the operand beside it had no type the definition was abandoned first and that diagnostic was never raised at all — `("x" ++ 1) + a.n` said nothing about `++`. Left to right is a rule now: an operand that says what is wrong with it is reported, and what stands beside it is not read where this one left nothing to check against.

`&&` and `||` are the operators that ask something of an operand on its own, so that is asked where the operand is read, before the one beside it is read. Everything else is about the pair and is answered once both have been read. That keeps `1 && ("x" ++ 1)` reporting that `1` is not a Bool, as it did before.

## The diagnostics that change

Two, both of them the rule above rather than a consequence of how many times an operand is read:

- `("x" ++ 1) + a.n`, where `a.n` has no type — the append is reported. Before, `erroneous` swallowed it and the definition was then abandoned for `a.n`, so nothing about `++` was said at all.
- `1 && a.n` — that `1` is not a Bool is reported. Before, the definition was abandoned for `a.n`. Giving up on a definition is for what follows from a name that denotes nothing, and an operand refused before that name is reached does not follow from it.

## Tests

`AnOperatorReadsEachOperandOnceTest` measures a chain of 100 named values and a 26-deep chain of each operator that nests into itself (`+`, `++`, `&&`, `==`), against a 10 s budget on a thread whose wait is bounded. Before this change all five failed — three at 27–32 s and two by not coming back within 60 s, 206.6 s for the class. After it, 0.229 s.

The reading is one place ahead of the switch, so every arm goes through it; the comparisons cannot nest into themselves and are covered by that rather than by a chain of their own.

`TheOperandThatFailedFirstIsTheOneReportedTest` fixes the order: the operand beside one that failed does not cover it, an operand `&&` refuses on its own comes before what stands beside it (whether that is an error of its own or an operand with no type), an operand with no type stops the one beside it from being read, and an operand with no type is still not reported as the wrong type for the operator.

`mvn clean install` is green (4,406 + 315 tests).

## Left out

Two things this investigation turned up, split out because they have different causes:

- #523 — with the doubling gone the same chain still costs O(N²), because substitution copies each body rather than sharing it.
- #524 — a chain of 3000 ends in a `StackOverflowError` from the substitution walk, with no diagnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
