### PR TITLE
A comment is filed against a place of the canonical form

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/fmt/ADefinitionsBodyOwnsItsCommentTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ADefinitionsBodyOwnsItsCommentTest.java
@@ -1,8 +1,16 @@
 package souther.compiler.fmt;
 
 import org.junit.jupiter.api.Test;
+import souther.compiler.cst.CstParser;
+import souther.compiler.cst.SyntaxKind;
+import souther.compiler.cst.SyntaxNode;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A comment written above what a definition or an {@code if} writes after its keyword stays there.
@@ -102,28 +110,106 @@ class ADefinitionsBodyOwnsItsCommentTest {
     }
 
     /**
-     * A definition written as a lambda is left as it was. Its parameters move to the left of the
-     * {@code =}, so what the canonical form writes after the {@code =} is not the child the source
-     * has there — it is that child's body, a level further down. The comment is about that body and
-     * the construct the source gives it to is the lambda, and until the two are the same question
-     * this is one construct where the comment still travels to the declaration.
-     *
-     * <p>Held here so that it is a stated limit rather than a case nobody tried. Making it right
-     * needs the canonical structure to be something a comment can be filed against, which is
-     * issue #444.
+     * And so does one written as a lambda. Its parameters move to the left of the {@code =}, so what
+     * the canonical form writes after the {@code =} is not the child the source has there — it is
+     * that child's body, a level further down. The comment is about that body, and the body is a
+     * place of the canonical form whether or not the source has a construct in that position.
      */
     @Test
-    void butADefinitionWrittenAsALambdaIsLeftAsItWas() {
+    void andSoDoesOneWrittenAsALambda() {
         assertEquals("""
                 module m
 
-                // about the body
-                let f (x) = x
+                let f (x) =
+                    // about the body
+                    x
                 """, Formatter.format("""
                 module m
                 let f = (x) ->
                     // about the body
                     x
                 """));
+    }
+
+    /** A lambda whose body is another lambda lifts the outer one only, so what is written after the
+     * {@code =} is the inner lambda and the comment is above all of it. */
+    @Test
+    void andOneWhoseBodyIsAnotherLambda() {
+        assertEquals("""
+                module m
+
+                let g (x) =
+                    // about the body
+                    (y) -> x
+                """, Formatter.format("""
+                module m
+                let g = (x) ->
+                    // about the body
+                    (y) -> x
+                """));
+    }
+
+    /**
+     * And the place that carries it is the body's.
+     *
+     * <p>Read from the text alone this case cannot be told from the one it used to be: a comment
+     * carried by the declaration is written on the line before the body too, and the count of
+     * comments is the same either way. What has to be true is that the place handed the comment is
+     * the one the lambda's last expression child was written at — which is not the place the source
+     * has a construct at, and is why asking the source tree a second time answered wrongly here.
+     */
+    @Test
+    void andTheCarrierIsTheBodysPlaceAndNotTheDefinitions() {
+        SyntaxNode root = CstParser.parse("""
+                module m
+                let f = (x) ->
+                    // about the body
+                    x
+                """).root();
+        Formatter.Construction built = Formatter.build(root);
+
+        SyntaxNode lambda = only(root, SyntaxKind.LAMBDA_EXPR);
+        SyntaxNode body = childOf(lambda, SyntaxKind.VAR_EXPR);
+        Place carrier = carrierOf(built, Carrier.ABOVE);
+
+        assertEquals(List.of(new Written.Construct(body)), built.places().sourcesOf(carrier),
+                "the comment is carried by the place the lambda's body was written at");
+        assertNotSame(carrier, built.places().placesOf(new Written.Construct(lambda.parent())).get(0),
+                "and not by the definition's own place, which is where it used to travel to");
+        assertTrue(built.places().sourcesOf(carrier.parent())
+                        .contains(new Written.Construct(lambda.parent())),
+                "the carrier is one of the definition's places: " + carrier.parent());
+    }
+
+    /** The one place a comment was handed in that direction. */
+    private static Place carrierOf(Formatter.Construction built, Carrier which) {
+        List<Place> found = new ArrayList<>();
+        for (var e : built.carriers().entrySet()) {
+            if (!e.getValue().getOrDefault(which, List.of()).isEmpty()) {
+                found.add(e.getKey());
+            }
+        }
+        assertEquals(1, found.size(), "one place carries the fixture's one comment: " + found);
+        return found.get(0);
+    }
+
+    private static SyntaxNode only(SyntaxNode from, SyntaxKind kind) {
+        List<SyntaxNode> out = new ArrayList<>();
+        descend(from, kind, out);
+        assertEquals(1, out.size(), "the fixture writes one " + kind);
+        return out.get(0);
+    }
+
+    private static void descend(SyntaxNode n, SyntaxKind kind, List<SyntaxNode> out) {
+        if (n.kind() == kind) {
+            out.add(n);
+        }
+        for (SyntaxNode c : n.childNodes()) {
+            descend(c, kind, out);
+        }
+    }
+
+    private static SyntaxNode childOf(SyntaxNode n, SyntaxKind kind) {
+        return n.child(kind).orElseThrow();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest.java
@@ -39,14 +39,23 @@ class EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest {
         return out;
     }
 
+    /** Every arm is written out and none of them is a {@code default}: a document that grows a way
+     *  of holding a token has to be answered for here, and a {@code default} would take the new one
+     *  as holding none. */
     private static void collect(TokenDoc doc, List<TokenDoc.Token> out) {
         switch (doc) {
             case TokenDoc.Token t -> out.add(t);
             case TokenDoc.Node n -> collect(n.doc(), out);
+            case TokenDoc.At a -> collect(a.doc(), out);
             case TokenDoc.Nest n -> collect(n.doc(), out);
             case TokenDoc.Group g -> collect(g.doc(), out);
             case TokenDoc.Concat c -> c.parts().forEach(part -> collect(part, out));
-            default -> { }
+            case TokenDoc.Nil _, TokenDoc.Comment _, TokenDoc.Trailing _, TokenDoc.Gap _,
+                    TokenDoc.MustBreak _ -> { }
+            case TokenDoc.Carries c -> throw new IllegalStateException(
+                    "the document under test still holds an unanswered carrier: " + c);
+            case TokenDoc.Vacant v -> throw new IllegalStateException(
+                    "the document under test still holds brackets nobody has filled: " + v);
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
@@ -58,21 +58,50 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
     /** Each of them can say which place it is written under, and which of that place's it is. */
     @Test
     void andEachOfThemSaysWhoseAndWhichItIs() {
-        Correspondence places = placesOf("""
+        Formatter.Construction built = build("""
                 module m
                 let k (flag: Bool, p: Int, q: Int): Int =
                     if flag then p else q
                 """);
         List<SyntaxNode> written = childrenOf(only(SyntaxKind.IF_EXPR), SyntaxKind.VAR_EXPR);
-        Place condition = places.placesOf(new Written.Construct(written.get(0))).get(0);
-        Place then = places.placesOf(new Written.Construct(written.get(1))).get(0);
-        Place otherwise = places.placesOf(new Written.Construct(written.get(2))).get(0);
+        Place condition = built.places().placesOf(new Written.Construct(written.get(0))).get(0);
+        Place then = built.places().placesOf(new Written.Construct(written.get(1))).get(0);
+        Place otherwise = built.places().placesOf(new Written.Construct(written.get(2))).get(0);
 
         assertSame(condition.parent(), then.parent(), "all three are under the `if`");
         assertSame(then.parent(), otherwise.parent());
-        assertEquals(List.of(0, 1, 2),
-                List.of(condition.ordinal(), then.ordinal(), otherwise.ordinal()),
+        assertEquals(List.of(0, 1, 2), List.of(built.order().get(condition),
+                        built.order().get(then), built.order().get(otherwise)),
                 "counted in the order they are written");
+    }
+
+    /**
+     * And it is counted in the order the document writes them, not the order the formatter made
+     * them.
+     *
+     * <p>A declaration builds its {@code invariant} clauses before its body and writes the body
+     * first; an {@code example} builds its rows before the line it opens with and writes that line
+     * first. Counted as they are made, both come back reversed — which is the formatter's
+     * evaluation order recorded as a fact about the canonical form.
+     */
+    @Test
+    void andItIsCountedInTheOrderTheDocumentWritesThem() {
+        Formatter.Construction built = build("""
+                module m
+                data Amount = Int
+                    invariant value > 0
+                """);
+        SyntaxNode data = only(SyntaxKind.DATA_DEF);
+        Place body = built.places()
+                .placesOf(new Written.Construct(childOf(data, SyntaxKind.NEWTYPE_BODY))).get(0);
+        Place invariant = built.places()
+                .placesOf(new Written.Construct(childOf(data, SyntaxKind.INVARIANT_CLAUSE))).get(0);
+
+        assertSame(body.parent(), invariant.parent(), "both are places of the declaration");
+        assertTrue(built.order().get(body) < built.order().get(invariant),
+                "the body is written on the declaration's line and the clause below it, so the body"
+                        + " is the earlier of the two: " + built.order().get(body) + " and "
+                        + built.order().get(invariant));
     }
 
     /**
@@ -152,6 +181,111 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
                 "the default row's input is a place the source has nothing at");
     }
 
+    /**
+     * And every construct of the source has one answer or the other.
+     *
+     * <p>This is what lets the walk that finds a carrier stay on the places. Where a construct had
+     * no answer the walk went to the source tree for one — up to the construct holding it, and then
+     * to that construct's first or last child, which is a guess about where the canonical form put
+     * it. The construction is not guessing: it knows which place it wrote each construct at as it
+     * writes it, and a construct it recorded nothing for is a hole this fails on rather than a case
+     * the walk quietly covers.
+     */
+    @Test
+    void andEveryConstructOfTheSourceIsWrittenSomewhere() {
+        Formatter.Construction built = build(EVERY_FORM);
+
+        List<String> unwritten = new ArrayList<>();
+        for (SyntaxNode n : allOf(root)) {
+            if (n.kind() == SyntaxKind.SOURCE_FILE) {
+                continue;
+            }
+            if (built.places().placesOf(new Written.Construct(n)).isEmpty()
+                    && built.places().spanOf(n) == null) {
+                unwritten.add(n.kind() + " at " + n.start());
+            }
+        }
+
+        assertEquals(List.of(), unwritten,
+                "the construction records a place or a span for every construct it writes");
+    }
+
+    /**
+     * A run the canonical form flattens says where it opens and where it ends.
+     *
+     * <p>{@code 1 |> b} of {@code 1 |> b |> c} is not a construct the canonical form has: what it
+     * has is a head and two stages, and the nesting the parser read is spread over them. So the
+     * construct opens at the head place and ends at the stage its own right operand is written at,
+     * and both are recorded where they are written. Read off the source tree afterwards, the first
+     * and last children of that operand are {@code 1} and {@code b}, and the place of the second is
+     * only the right answer by accident of this shape.
+     */
+    @Test
+    void andARunTheCanonicalFormFlattensSaysWhereItOpensAndWhereItEnds() {
+        Formatter.Construction built = build("""
+                module m
+                let piped = 1 |> b |> c
+                """);
+        List<SyntaxNode> pipes = allOf(SyntaxKind.PIPE_EXPR);
+        SyntaxNode whole = pipes.get(0);
+        SyntaxNode inner = pipes.get(1);
+
+        Correspondence.Span span = built.places().spanOf(inner);
+        Correspondence.Span outer = built.places().spanOf(whole);
+
+        assertSame(outer.from(), span.from(), "both runs open at the head the file writes first");
+        assertNotSame(outer.to(), span.to(), "and they end at different stages");
+        assertEquals(List.of(new Written.Construct(exprsOf(inner).get(1))),
+                built.places().sourcesOf(span.to()),
+                "the inner run ends at the stage its own right operand is written at");
+    }
+
+    /** One of everything, so that the answer above is quantified over the forms rather than over
+     *  the ones someone thought to write down. */
+    private static final String EVERY_FORM = """
+            module m exposing ( A, S, run )
+            import other.mod ( Thing )
+
+            data A =
+                { id: Int
+                , pair: (Int, String)
+                }
+
+            data Small = Int
+                invariant value > 0
+
+            data One
+
+            data Two
+
+            data S = One | Two
+
+            behavior run : (a: A, n: Int) -> A | Small
+                constructs A, other.mod.Thing
+                depends on helper
+
+            let helper (n: Int) = n
+
+            let run (a, n, helper) = {
+                let doubled = helper(n) |> helper |> helper
+                let list = [x | x > 0]
+                guard doubled > 0 else Small(1)
+                match value(a) with
+                    | One -> A { ...a, id = doubled + 1 * 2 }
+                    | Two -> A { ...a, id = 0 }
+            }
+
+            let value (a: A) = if a.id > 0 then One else Two
+
+            let curried = (x) -> (y) -> x
+
+            example helper
+                | "it doubles" : (2) with n = 2 -> 2
+
+            fake helper
+                | (2) -> 4
+            """;
+
     // --- reading the tree ---
     //
     // One parse per fixture, and every lookup goes through that one root. A place says which source
@@ -162,8 +296,30 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
     private SyntaxNode root;
 
     private Correspondence placesOf(String src) {
+        return build(src).places();
+    }
+
+    private Formatter.Construction build(String src) {
         root = CstParser.parse(src).root();
-        return Formatter.placesOf(root);
+        return Formatter.build(root);
+    }
+
+    private static SyntaxNode childOf(SyntaxNode n, SyntaxKind kind) {
+        return n.child(kind).orElseThrow();
+    }
+
+    private static List<SyntaxNode> allOf(SyntaxNode from) {
+        List<SyntaxNode> out = new ArrayList<>();
+        out.add(from);
+        for (SyntaxNode c : from.childNodes()) {
+            out.addAll(allOf(c));
+        }
+        return out;
+    }
+
+    /** The children of {@code n}, which for a run's node are its two operands. */
+    private static List<SyntaxNode> exprsOf(SyntaxNode n) {
+        return n.childNodes();
     }
 
     private SyntaxNode only(SyntaxKind kind) {

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
@@ -1,0 +1,224 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.cst.CstParser;
+import souther.compiler.cst.SyntaxKind;
+import souther.compiler.cst.SyntaxNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The canonical form has places of its own, and they are kept.
+ *
+ * <p>The formatter used to build them and keep neither them nor what the source had at each, so
+ * anything asked afterwards — which construct can carry a comment, which one a rule is about — was
+ * answered by walking the source tree again. Where the two structures differ that walk answers about
+ * a construct the canonical form does not write, and a definition written as a lambda is where they
+ * differ: its parameters move to the left of the {@code =}, and what is written after the {@code =}
+ * is the lambda's body rather than the child the source has there.
+ */
+class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
+
+    /**
+     * Written {@code if flag then p else q} an {@code if}'s three children are all a
+     * {@code VAR_EXPR}, so the kind does not tell them apart. Which of its parent's places each one
+     * is, does.
+     */
+    @Test
+    void twoChildrenWrittenAsTheSameKindOfConstructAreTwoPlaces() {
+        Correspondence places = placesOf("""
+                module m
+                let k (flag: Bool, p: Int, q: Int): Int =
+                    if flag then p else q
+                """);
+        List<SyntaxNode> written = childrenOf(only(SyntaxKind.IF_EXPR), SyntaxKind.VAR_EXPR);
+
+        List<Place> at = new ArrayList<>();
+        for (SyntaxNode c : written) {
+            List<Place> of = places.placesOf(new Written.Construct(c));
+            assertEquals(1, of.size(), "one place is written for " + c);
+            at.add(of.get(0));
+        }
+
+        assertEquals(3, at.size(), "a condition, a then branch and an else branch");
+        assertNotSame(at.get(0), at.get(1));
+        assertNotSame(at.get(1), at.get(2));
+        assertNotSame(at.get(0), at.get(2));
+        assertEquals(List.of(SyntaxKind.VAR_EXPR, SyntaxKind.VAR_EXPR, SyntaxKind.VAR_EXPR),
+                at.stream().map(Place::construct).toList(),
+                "and the kind is the same for all three, which is why it cannot tell them apart");
+    }
+
+    /** Each of them can say which place it is written under, and which of that place's it is. */
+    @Test
+    void andEachOfThemSaysWhoseAndWhichItIs() {
+        Correspondence places = placesOf("""
+                module m
+                let k (flag: Bool, p: Int, q: Int): Int =
+                    if flag then p else q
+                """);
+        List<SyntaxNode> written = childrenOf(only(SyntaxKind.IF_EXPR), SyntaxKind.VAR_EXPR);
+        Place condition = places.placesOf(new Written.Construct(written.get(0))).get(0);
+        Place then = places.placesOf(new Written.Construct(written.get(1))).get(0);
+        Place otherwise = places.placesOf(new Written.Construct(written.get(2))).get(0);
+
+        assertSame(condition.parent(), then.parent(), "all three are under the `if`");
+        assertSame(then.parent(), otherwise.parent());
+        assertEquals(List.of(0, 1, 2),
+                List.of(condition.ordinal(), then.ordinal(), otherwise.ordinal()),
+                "counted in the order they are written");
+    }
+
+    /**
+     * A place is not another name for a source node. The definition below is written back as
+     * {@code let f (x) = x}, and the parameter list there is a place the source tree has no node at:
+     * what the source has in that position is the lambda, which the canonical form writes nowhere.
+     */
+    @Test
+    void oneSourceElementStandsBehindOnePlaceAndItsDescendantBehindAnother() {
+        Correspondence places = placesOf("""
+                module m
+                let f = (x) -> x
+                """);
+        SyntaxNode lambda = only(SyntaxKind.LAMBDA_EXPR);
+        SyntaxNode body = childrenOf(lambda, SyntaxKind.VAR_EXPR).get(0);
+
+        List<Place> ofTheLambda = places.placesOf(new Written.Construct(lambda));
+        List<Place> ofTheBody = places.placesOf(new Written.Construct(body));
+
+        assertEquals(SyntaxKind.FN_PARAM_LIST, ofTheLambda.get(0).construct(),
+                "the lambda supplies the parameter list the definition writes on the left of `=`");
+        assertEquals(SyntaxKind.VAR_EXPR, ofTheBody.get(0).construct(),
+                "and its last expression child supplies what is written after the `=`");
+        assertSame(ofTheLambda.get(0).parent(), ofTheBody.get(0).parent(),
+                "both are places of the definition, which is what the canonical form writes here");
+    }
+
+    /**
+     * And the relation is not one-to-one in either direction. Nothing may read it as if it were:
+     * asking a place for <em>the</em> source element it came from is the question that has no
+     * answer here.
+     */
+    @Test
+    void andOneSourceElementMayStandBehindMoreThanOnePlace() {
+        Correspondence places = placesOf("""
+                module m
+                let g = (x) -> (y) -> x
+                """);
+        List<SyntaxNode> lambdas = allOf(SyntaxKind.LAMBDA_EXPR);
+        SyntaxNode inner = lambdas.get(1);
+
+        List<Place> of = places.placesOf(new Written.Construct(inner));
+
+        assertTrue(of.size() > 1,
+                "the inner lambda is both what the outer one's body place holds and a construct"
+                        + " with places of its own, and it is written at both: " + of);
+    }
+
+    /**
+     * A place the source has nothing at is ordinary. A {@code fake}'s default row is written
+     * {@code | _ -> …}, and the {@code _} is the canonical form's own: the source wrote no input
+     * there at all.
+     */
+    @Test
+    void andAPlaceMayStandForNothingTheSourceWrote() {
+        Formatter.Construction built = Formatter.build(CstParser.parse("""
+                module m
+                data R =
+                    { x: Int
+                    }
+
+                behavior f : () -> R
+                    constructs R
+
+                fake f
+                    | _ -> R { x = 0 }
+                """).root());
+
+        List<Place> empty = new ArrayList<>();
+        for (Place p : placesIn(built.doc())) {
+            if (built.places().sourcesOf(p).isEmpty()) {
+                empty.add(p);
+            }
+        }
+
+        assertTrue(!empty.isEmpty(),
+                "the default row's input is a place the source has nothing at");
+    }
+
+    // --- reading the tree ---
+    //
+    // One parse per fixture, and every lookup goes through that one root. A place says which source
+    // element it was written from by holding the element itself, and the tree hands back one node
+    // per position — so a second parse of the same text is a different tree, and nothing written
+    // from the first is found in it.
+
+    private SyntaxNode root;
+
+    private Correspondence placesOf(String src) {
+        root = CstParser.parse(src).root();
+        return Formatter.placesOf(root);
+    }
+
+    private SyntaxNode only(SyntaxKind kind) {
+        List<SyntaxNode> found = allOf(kind);
+        assertEquals(1, found.size(), "the fixture writes one " + kind);
+        return found.get(0);
+    }
+
+    private List<SyntaxNode> allOf(SyntaxKind kind) {
+        List<SyntaxNode> out = new ArrayList<>();
+        descend(root, kind, out);
+        return out;
+    }
+
+    private static void descend(SyntaxNode n, SyntaxKind kind, List<SyntaxNode> out) {
+        if (n.kind() == kind) {
+            out.add(n);
+        }
+        for (SyntaxNode c : n.childNodes()) {
+            descend(c, kind, out);
+        }
+    }
+
+    private static List<SyntaxNode> childrenOf(SyntaxNode n, SyntaxKind kind) {
+        List<SyntaxNode> out = new ArrayList<>();
+        for (SyntaxNode c : n.childNodes()) {
+            if (c.kind() == kind) {
+                out.add(c);
+            }
+        }
+        return out;
+    }
+
+    private static List<Place> placesIn(TokenDoc doc) {
+        List<Place> out = new ArrayList<>();
+        collect(doc, out);
+        return out;
+    }
+
+    private static void collect(TokenDoc doc, List<Place> out) {
+        switch (doc) {
+            case TokenDoc.At a -> {
+                out.add(a.place());
+                collect(a.doc(), out);
+            }
+            case TokenDoc.Node n -> collect(n.doc(), out);
+            case TokenDoc.Nest n -> collect(n.doc(), out);
+            case TokenDoc.Group g -> collect(g.doc(), out);
+            case TokenDoc.Concat c -> c.parts().forEach(part -> collect(part, out));
+            case TokenDoc.Nil _, TokenDoc.Token _, TokenDoc.Comment _, TokenDoc.Trailing _,
+                    TokenDoc.Gap _, TokenDoc.MustBreak _ -> { }
+            case TokenDoc.Carries c -> throw new IllegalStateException(
+                    "a carrier survived the resolution: " + c);
+            case TokenDoc.Vacant v -> throw new IllegalStateException(
+                    "brackets survived the resolution unfilled: " + v);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
@@ -121,9 +121,11 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
         List<Place> ofTheLambda = places.placesOf(new Written.Construct(lambda));
         List<Place> ofTheBody = places.placesOf(new Written.Construct(body));
 
-        assertEquals(SyntaxKind.FN_PARAM_LIST, ofTheLambda.get(0).construct(),
+        assertEquals(List.of(SyntaxKind.FN_PARAM_LIST),
+                ofTheLambda.stream().map(Place::construct).toList(),
                 "the lambda supplies the parameter list the definition writes on the left of `=`");
-        assertEquals(SyntaxKind.VAR_EXPR, ofTheBody.get(0).construct(),
+        assertEquals(List.of(SyntaxKind.VAR_EXPR),
+                ofTheBody.stream().map(Place::construct).toList(),
                 "and its last expression child supplies what is written after the `=`");
         assertSame(ofTheLambda.get(0).parent(), ofTheBody.get(0).parent(),
                 "both are places of the definition, which is what the canonical form writes here");
@@ -190,24 +192,59 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
      * it. The construction is not guessing: it knows which place it wrote each construct at as it
      * writes it, and a construct it recorded nothing for is a hole this fails on rather than a case
      * the walk quietly covers.
+     *
+     * <p>Asked of the corpus and not of a fixture written here. A fixture is the domain someone
+     * thought of, and this is a statement about every construct the grammar builds — an import's
+     * alias and a definition's modifiers were nodes no fixture held, and each was a legal source
+     * the formatter refused. What holds the corpus to the grammar is
+     * {@link WhatGoesBetweenTwoTokensOnALineTest#thereIsASourceForEveryKindOfNode}, and it is left
+     * there: a second copy of it here would be the same list kept in two places.
      */
     @Test
     void andEveryConstructOfTheSourceIsWrittenSomewhere() {
-        Formatter.Construction built = build(EVERY_FORM);
-
         List<String> unwritten = new ArrayList<>();
-        for (SyntaxNode n : allOf(root)) {
-            if (n.kind() == SyntaxKind.SOURCE_FILE) {
-                continue;
-            }
-            if (built.places().placesOf(new Written.Construct(n)).isEmpty()
-                    && built.places().spanOf(n) == null) {
-                unwritten.add(n.kind() + " at " + n.start());
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            SyntaxNode file = CstParser.parse(source).root();
+            Formatter.Construction built = Formatter.build(file);
+            for (SyntaxNode n : allOf(file)) {
+                if (n.kind() == SyntaxKind.SOURCE_FILE) {
+                    continue;
+                }
+                if (built.places().placesOf(new Written.Construct(n)).isEmpty()
+                        && built.places().spanOf(n) == null) {
+                    unwritten.add(String.valueOf(n.kind()));
+                }
             }
         }
 
-        assertEquals(List.of(), unwritten,
+        assertEquals(List.of(), unwritten.stream().distinct().sorted().toList(),
                 "the construction records a place or a span for every construct it writes");
+    }
+
+    /**
+     * And every place the construction makes is written in the document.
+     *
+     * <p>The places and the document are two halves of one thing, so a place nothing in the
+     * document names is a place with no position: which of its parent's places it is cannot be
+     * read, because that is the order the document writes them. Two structural places were made
+     * that way — a behavior's signature and its pipeline — and each held places of its own while
+     * having no position itself.
+     */
+    @Test
+    void andEveryPlaceTheConstructionMakesIsWrittenInTheDocument() {
+        List<String> unmarked = new ArrayList<>();
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            Formatter.Construction built = Formatter.build(CstParser.parse(source).root());
+            for (Place p : built.places().made()) {
+                if (built.order().get(p) == null) {
+                    unmarked.add(p.construct() + " under "
+                            + (p.parent() == null ? "-" : p.parent().construct()));
+                }
+            }
+        }
+
+        assertEquals(List.of(), unmarked.stream().distinct().sorted().toList(),
+                "every place the construction makes is written somewhere in the document");
     }
 
     /**
@@ -239,52 +276,6 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
                 built.places().sourcesOf(span.to()),
                 "the inner run ends at the stage its own right operand is written at");
     }
-
-    /** One of everything, so that the answer above is quantified over the forms rather than over
-     *  the ones someone thought to write down. */
-    private static final String EVERY_FORM = """
-            module m exposing ( A, S, run )
-            import other.mod ( Thing )
-
-            data A =
-                { id: Int
-                , pair: (Int, String)
-                }
-
-            data Small = Int
-                invariant value > 0
-
-            data One
-
-            data Two
-
-            data S = One | Two
-
-            behavior run : (a: A, n: Int) -> A | Small
-                constructs A, other.mod.Thing
-                depends on helper
-
-            let helper (n: Int) = n
-
-            let run (a, n, helper) = {
-                let doubled = helper(n) |> helper |> helper
-                let list = [x | x > 0]
-                guard doubled > 0 else Small(1)
-                match value(a) with
-                    | One -> A { ...a, id = doubled + 1 * 2 }
-                    | Two -> A { ...a, id = 0 }
-            }
-
-            let value (a: A) = if a.id > 0 then One else Two
-
-            let curried = (x) -> (y) -> x
-
-            example helper
-                | "it doubles" : (2) with n = 2 -> 2
-
-            fake helper
-                | (2) -> 4
-            """;
 
     // --- reading the tree ---
     //

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Carrier.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Carrier.java
@@ -1,0 +1,21 @@
+package souther.compiler.fmt;
+
+/**
+ * What a {@link Place} can be handed.
+ *
+ * <p>Three, because a comment is written in three positions relative to what it is about and the
+ * three are not the same question: above the line a place opens, at the end of the line it ends, and
+ * inside it under its last member.
+ */
+enum Carrier {
+
+    /** On lines of its own, in front of the place. */
+    ABOVE,
+
+    /** At the end of the line the place ends — after whatever the construct holding it writes
+     *  between this place and the next, since that punctuation is on the same line. */
+    TRAILING,
+
+    /** Inside the place, under its last member and before what closes it. */
+    AT_END
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Carriers.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Carriers.java
@@ -1,0 +1,122 @@
+package souther.compiler.fmt;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Puts a file's comments into the document, at the places that carry them.
+ *
+ * <p>It runs between the construction and the layout. After the construction because that is what
+ * makes the places, and a comment is filed against a place of the canonical form rather than against
+ * a construct of the source — where the two structures differ the source answers about something the
+ * canonical form does not write. Before the layout because a comment cannot share the line after it,
+ * so which place owns one decides whether the group holding it can be laid out flat.
+ *
+ * <p>The same shape {@link Gaps} has: the construction leaves a question at each slot, one place
+ * answers all of them, and the document handed on has only answered slots in it.
+ */
+final class Carriers {
+
+    private Carriers() {
+    }
+
+    /** What the places were handed. One implementation answers every slot of a document. */
+    interface Held {
+
+        /** The comments {@code place} carries in that direction, as documents. A comment is taken
+         *  once, so a place asked for one another place has already been given gets nothing. */
+        List<TokenDoc> at(Place place, Carrier which);
+    }
+
+    /** What the construction left room for. */
+    interface Slot {
+        void found(Place place, Carrier which);
+    }
+
+    /** Every carrier slot {@code doc} holds, in the order it is written. What a place can be handed
+     *  is what the construction left room for, so it is read from the document rather than
+     *  declared beside it. */
+    static void slots(TokenDoc doc, Slot into) {
+        switch (doc) {
+            case TokenDoc.Carries c -> into.found(c.place(), c.which());
+            case TokenDoc.Vacant v -> into.found(v.place(), Carrier.AT_END);
+            case TokenDoc.At a -> slots(a.doc(), into);
+            case TokenDoc.Node n -> slots(n.doc(), into);
+            case TokenDoc.Nest n -> slots(n.doc(), into);
+            case TokenDoc.Group g -> slots(g.doc(), into);
+            case TokenDoc.Concat c -> c.parts().forEach(part -> slots(part, into));
+            case TokenDoc.Nil _, TokenDoc.Token _, TokenDoc.Comment _, TokenDoc.Trailing _,
+                    TokenDoc.Gap _, TokenDoc.MustBreak _ -> { }
+        }
+    }
+
+    /** {@code doc} with every carrier slot filled, and none of them left. */
+    static TokenDoc resolve(TokenDoc doc, Held held) {
+        return rewrite(doc, held);
+    }
+
+    private static TokenDoc rewrite(TokenDoc doc, Held held) {
+        return switch (doc) {
+            case TokenDoc.Carries c -> written(c, held);
+            case TokenDoc.Vacant v -> filled(v, held);
+            case TokenDoc.At a -> new TokenDoc.At(a.place(), rewrite(a.doc(), held));
+            case TokenDoc.Node n -> new TokenDoc.Node(n.kind(), rewrite(n.doc(), held));
+            case TokenDoc.Nest n -> new TokenDoc.Nest(n.indent(), rewrite(n.doc(), held));
+            case TokenDoc.Group g -> new TokenDoc.Group(rewrite(g.doc(), held));
+            case TokenDoc.Concat c -> {
+                List<TokenDoc> parts = new ArrayList<>();
+                for (TokenDoc part : c.parts()) {
+                    parts.add(rewrite(part, held));
+                }
+                yield new TokenDoc.Concat(List.copyOf(parts));
+            }
+            case TokenDoc.Nil _, TokenDoc.Token _, TokenDoc.Comment _, TokenDoc.Trailing _,
+                    TokenDoc.Gap _, TokenDoc.MustBreak _ -> doc;
+        };
+    }
+
+    /**
+     * What brackets with no member between them are written as.
+     *
+     * <p>Nothing between them holds one boundary and not two: written as two — one just inside each
+     * bracket — what a construct written open put there was two spaces, and no rule had said so.
+     * With a comment between them the comments stand where a member would have, so they bring no
+     * line of their own; the brackets already open and close one, and the
+     * {@link TokenDoc#MUST_BREAK} is what stops the layout from putting that line back together.
+     */
+    private static TokenDoc filled(TokenDoc.Vacant vacant, Held held) {
+        List<TokenDoc> comments = held.at(vacant.place(), Carrier.AT_END);
+        if (comments.isEmpty()) {
+            return TokenDoc.node(vacant.construct(),
+                    TokenDoc.concat(vacant.open(), TokenDoc.GAP, vacant.close()));
+        }
+        return TokenDoc.node(vacant.construct(), TokenDoc.group(TokenDoc.concat(
+                vacant.open(),
+                TokenDoc.nest(vacant.indent(), TokenDoc.concat(TokenDoc.SOFT_GAP,
+                        TokenDoc.MUST_BREAK, TokenDoc.join(TokenDoc.HARD_GAP, comments))),
+                TokenDoc.SOFT_GAP, vacant.close())));
+    }
+
+    /**
+     * What a filled slot is written as.
+     *
+     * <p>A comment written above the place goes on a line of its own, and the {@link TokenDoc#HARD_GAP}
+     * after it is what makes the enclosing group break: a {@code //} on a line the group had
+     * collapsed would swallow everything after it.
+     */
+    private static TokenDoc written(TokenDoc.Carries slot, Held held) {
+        List<TokenDoc> comments = held.at(slot.place(), slot.which());
+        if (comments.isEmpty()) {
+            return TokenDoc.NIL;
+        }
+        List<TokenDoc> parts = new ArrayList<>();
+        for (TokenDoc c : comments) {
+            switch (slot.which()) {
+                case ABOVE -> parts.add(TokenDoc.concat(c, TokenDoc.HARD_GAP));
+                case TRAILING -> parts.add(c);
+                case AT_END -> parts.add(TokenDoc.concat(TokenDoc.HARD_GAP, c));
+            }
+        }
+        return TokenDoc.concat(parts);
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Correspondence.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Correspondence.java
@@ -1,0 +1,69 @@
+package souther.compiler.fmt;
+
+import souther.compiler.cst.SyntaxKind;
+import souther.compiler.cst.SyntaxNode;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The places of the canonical form, and what the source had at each.
+ *
+ * <p>A relation in both directions, and nothing here assumes otherwise. A place may stand for
+ * nothing the source wrote, and one source element may stand behind several places. Nothing hands
+ * back <em>the</em> source element of a place, because for a definition written as a lambda there
+ * is no such thing: the parameter-list place the canonical form writes stands for the lambda, and
+ * the body place beside it stands for that lambda's last expression child. A single-valued answer
+ * would have to pick one of those, and picking is what asking the source tree again already does.
+ *
+ * <p>Places are made here so that which of its parent's places a place is, is counted once.
+ */
+final class Correspondence {
+
+    private final Place file = new Place(null, 0, SyntaxKind.SOURCE_FILE, Opening.NONE);
+    private final Map<Place, Integer> counts = new IdentityHashMap<>();
+    private final Map<Place, List<Written>> wrote = new IdentityHashMap<>();
+    private final Map<Written, List<Place>> at = new HashMap<>();
+
+    /** Says what the source has at the file's own place. It is made before anything is written, so
+     *  it is the one place that is told rather than asked. */
+    Place fileOf(SyntaxNode source) {
+        wrote.put(file, List.of(new Written.Construct(source)));
+        at.computeIfAbsent(new Written.Construct(source), _ -> new ArrayList<>()).add(file);
+        return file;
+    }
+
+    /**
+     * A place written under {@code parent}, standing as {@code opening} says, for the source
+     * elements in {@code from} — none, one, or several of them.
+     *
+     * <p>Declaring a place is not deciding where a comment goes. That is decided over the places
+     * once they all exist, which is the whole of the difference this makes.
+     */
+    Place under(Place parent, SyntaxKind construct, Opening opening, Written... from) {
+        int ordinal = counts.merge(parent, 1, Integer::sum) - 1;
+        Place place = new Place(parent, ordinal, construct, opening);
+        if (from.length > 0) {
+            wrote.put(place, List.of(from));
+            for (Written w : from) {
+                at.computeIfAbsent(w, _ -> new ArrayList<>()).add(place);
+            }
+        }
+        return place;
+    }
+
+    /** What the source had at {@code place}. Empty where the canonical form writes something the
+     *  source has nothing at. */
+    List<Written> sourcesOf(Place place) {
+        return wrote.getOrDefault(place, List.of());
+    }
+
+    /** The places {@code written} stands behind, in the order they were written. Empty where the
+     *  canonical form does not write it, and more than one where it stands behind more than one. */
+    List<Place> placesOf(Written written) {
+        return at.getOrDefault(written, List.of());
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Correspondence.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Correspondence.java
@@ -23,10 +23,10 @@ import java.util.Map;
  */
 final class Correspondence {
 
-    private final Place file = new Place(null, 0, SyntaxKind.SOURCE_FILE, Opening.NONE);
-    private final Map<Place, Integer> counts = new IdentityHashMap<>();
+    private final Place file = new Place(null, SyntaxKind.SOURCE_FILE, Opening.FILE_BEGINS);
     private final Map<Place, List<Written>> wrote = new IdentityHashMap<>();
     private final Map<Written, List<Place>> at = new HashMap<>();
+    private final Map<SyntaxNode, Span> spans = new IdentityHashMap<>();
 
     /** Says what the source has at the file's own place. It is made before anything is written, so
      *  it is the one place that is told rather than asked. */
@@ -44,8 +44,7 @@ final class Correspondence {
      * once they all exist, which is the whole of the difference this makes.
      */
     Place under(Place parent, SyntaxKind construct, Opening opening, Written... from) {
-        int ordinal = counts.merge(parent, 1, Integer::sum) - 1;
-        Place place = new Place(parent, ordinal, construct, opening);
+        Place place = new Place(parent, construct, opening);
         if (from.length > 0) {
             wrote.put(place, List.of(from));
             for (Written w : from) {
@@ -53,6 +52,29 @@ final class Correspondence {
             }
         }
         return place;
+    }
+
+    /** Where a construct the canonical form writes no place of its own for begins and ends: the
+     *  first place its text is written at and the last. The two are the same place for a construct
+     *  written inside one. */
+    record Span(Place from, Place to) {}
+
+    /** Records that {@code node}'s text is written at {@code at} and nowhere else — a type inside a
+     *  field's line, a name inside an import's. */
+    void within(SyntaxNode node, Place at) {
+        spans.putIfAbsent(node, new Span(at, at));
+    }
+
+    /** Records that {@code node} is written as a run of places, opening at {@code from} and ending
+     *  at {@code to}. This is what a flattened chain leaves: the source's nesting is written as
+     *  siblings, so the construct the parser read is spread over several of them. */
+    void spanning(SyntaxNode node, Place from, Place to) {
+        spans.put(node, new Span(from, to));
+    }
+
+    /** Where {@code node} is written, or null where the construction recorded nothing for it. */
+    Span spanOf(SyntaxNode node) {
+        return spans.get(node);
     }
 
     /** What the source had at {@code place}. Empty where the canonical form writes something the

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Correspondence.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Correspondence.java
@@ -27,10 +27,12 @@ final class Correspondence {
     private final Map<Place, List<Written>> wrote = new IdentityHashMap<>();
     private final Map<Written, List<Place>> at = new HashMap<>();
     private final Map<SyntaxNode, Span> spans = new IdentityHashMap<>();
+    private final List<Place> made = new ArrayList<>();
 
     /** Says what the source has at the file's own place. It is made before anything is written, so
      *  it is the one place that is told rather than asked. */
     Place fileOf(SyntaxNode source) {
+        made.add(file);
         wrote.put(file, List.of(new Written.Construct(source)));
         at.computeIfAbsent(new Written.Construct(source), _ -> new ArrayList<>()).add(file);
         return file;
@@ -45,6 +47,7 @@ final class Correspondence {
      */
     Place under(Place parent, SyntaxKind construct, Opening opening, Written... from) {
         Place place = new Place(parent, construct, opening);
+        made.add(place);
         if (from.length > 0) {
             wrote.put(place, List.of(from));
             for (Written w : from) {
@@ -52,6 +55,12 @@ final class Correspondence {
             }
         }
         return place;
+    }
+
+    /** Every place the construction made, the file's first. Each of them is written somewhere in
+     *  the document, which is what lets which of its parent's places it is be read off. */
+    List<Place> made() {
+        return List.copyOf(made);
     }
 
     /** Where a construct the canonical form writes no place of its own for begins and ends: the
@@ -83,8 +92,15 @@ final class Correspondence {
         return wrote.getOrDefault(place, List.of());
     }
 
-    /** The places {@code written} stands behind, in the order they were written. Empty where the
-     *  canonical form does not write it, and more than one where it stands behind more than one. */
+    /**
+     * The places {@code written} stands behind. Empty where the canonical form does not write it,
+     * and more than one where it stands behind more than one.
+     *
+     * <p>In no order. This is a relation, and the order the places were made is the order the
+     * formatter's methods happened to run in — the implementation trace that a place's own
+     * position was taken off {@link Place#orderedIn} to stop being. A caller that needs the places
+     * in the order they are written asks for that order.
+     */
     List<Place> placesOf(Written written) {
         return at.getOrDefault(written, List.of());
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -803,6 +803,7 @@ public final class Formatter {
                 qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow(), at));
         Optional<SyntaxNode> alias = n.child(SyntaxKind.IMPORT_ALIAS);
         if (alias.isPresent()) {
+            places.within(alias.get(), at);
             d = concat(d, GAP, TokenDoc.node(alias.get().kind(),
                     concat(TokenDoc.token(SyntaxKind.AS_KW, "as"), GAP,
                             token(idents(alias.get()).get(0)))));
@@ -843,6 +844,7 @@ public final class Formatter {
         var product = n.child(SyntaxKind.PRODUCT_BODY);
         if (product.isPresent()) {
             if (isEmptyProduct(product.get())) {
+                places.within(product.get(), at);
                 return TokenDoc.node(n.kind(),
                         concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP,
                         ASSIGN, GAP, TokenDoc.node(product.get().kind(), concat(LBRACE, GAP, RBRACE)),
@@ -1008,8 +1010,9 @@ public final class Formatter {
             }
             return TokenDoc.node(n.kind(),
                     concat(TokenDoc.token(SyntaxKind.BEHAVIOR_KW, "behavior"), GAP, ident(name),
-                            GAP, COLON, GAP, TokenDoc.node(s.kind(), concat(params, GAP, ARROW, GAP,
-                                    ret, nest(INDENT, concat(clauses))))));
+                            GAP, COLON, GAP, TokenDoc.at(ofTheSig,
+                                    TokenDoc.node(s.kind(), concat(params, GAP, ARROW, GAP,
+                                            ret, nest(INDENT, concat(clauses)))))));
         }
         SyntaxNode pipe = n.child(SyntaxKind.PIPE_BEHAVIOR).orElseThrow();
         Place ofThePipe = places.under(at, pipe.kind(), Opening.NONE, Written.of(pipe));
@@ -1034,7 +1037,8 @@ public final class Formatter {
                     last ? declaredOut : TokenDoc.endsTheLineOf(ofTheStage))));
         }
         return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.BEHAVIOR_KW, "behavior"), GAP, ident(name), GAP, ASSIGN,
-                TokenDoc.node(pipe.kind(), group(nest(INDENT, concat(parts))))));
+                TokenDoc.at(ofThePipe,
+                        TokenDoc.node(pipe.kind(), group(nest(INDENT, concat(parts)))))));
     }
 
     private TokenDoc paramList(SyntaxNode n, Place at) {
@@ -1112,11 +1116,15 @@ public final class Formatter {
     private TokenDoc fnDef(SyntaxNode n, Place at) {
         String name = firstIdent(n);
         // The modifiers are written back in the order the parser reads them: `private partial let`.
+        // Each modifier is written at the head of the definition's own line, so that is where it is
+        // written and there is no place of its own to record.
         List<TokenDoc> modifiers = new ArrayList<>();
-        if (n.child(SyntaxKind.PRIVATE_MODIFIER).isPresent()) {
+        for (SyntaxNode modifier : childNodes(n, SyntaxKind.PRIVATE_MODIFIER)) {
+            places.within(modifier, at);
             modifiers.add(concat(ident("private"), GAP));
         }
-        if (n.child(SyntaxKind.PARTIAL_MODIFIER).isPresent()) {
+        for (SyntaxNode modifier : childNodes(n, SyntaxKind.PARTIAL_MODIFIER)) {
+            places.within(modifier, at);
             modifiers.add(concat(ident("partial"), GAP));
         }
         TokenDoc keyword = concat(concat(modifiers), TokenDoc.token(SyntaxKind.LET_KW, "let"), GAP);

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -68,6 +68,11 @@ public final class Formatter {
      * instance formats one file, so this lives exactly as long as the tree it describes. */
     private Attachments comments = Attachments.empty();
 
+    /** The places this formatter writes, and what the source had at each. Built as the document is
+     * and read once it is whole: what a place can carry is decided over the places, not while one
+     * of them is being written. */
+    private final Correspondence places = new Correspondence();
+
     private Formatter() {
     }
 
@@ -102,7 +107,10 @@ public final class Formatter {
     public static String format(SyntaxNode file) {
         try {
             Formatter formatter = new Formatter();
-            TokenDoc doc = formatter.file(file);
+            // The construction, then the carriers, then the boundaries, then the layout. Each stage
+            // is whole before the next begins: a comment goes to a place of the canonical form and
+            // there are no places until the construction has finished making them.
+            TokenDoc resolved = formatter.resolved(formatter.file(file));
             List<SyntaxToken> missing = unconsumed(file, formatter.consumedComments);
             if (!missing.isEmpty()) {
                 throw new IllegalStateException(
@@ -111,7 +119,7 @@ public final class Formatter {
                                 + missing.get(0).start() + ": "
                                 + missing.get(0).text().stripTrailing());
             }
-            return doc.resolve().render(WIDTH);
+            return resolved.resolve().render(WIDTH);
         } catch (StackOverflowError _) {
             throw tooDeep();
         }
@@ -123,7 +131,287 @@ public final class Formatter {
      * them is decided from the document, so a check on that decision reads the document.
      */
     static TokenDoc document(SyntaxNode file) {
-        return new Formatter().file(file);
+        return build(file).doc();
+    }
+
+    /**
+     * What the formatter builds for a file: the document, the places it was written at, and which
+     * place was handed each comment. All three come out of one construction because they are made
+     * by it — the second reconstructed from the first is the reconstruction this is here to stop.
+     *
+     * <p>The carriers are here because two of them can print the same. A comment above a
+     * definition's body and one above the definition itself both come back on the line before the
+     * body, so text is not enough to say which place owns one.
+     */
+    record Construction(TokenDoc doc, Correspondence places,
+            Map<Place, Map<Carrier, List<SyntaxToken>>> carriers) {}
+
+    static Construction build(SyntaxNode file) {
+        Formatter formatter = new Formatter();
+        TokenDoc doc = formatter.file(file);
+        return new Construction(formatter.resolved(doc), formatter.places, formatter.assigned);
+    }
+
+    /** {@code doc} with the comments in it. The one place a carrier is answered. */
+    private TokenDoc resolved(TokenDoc doc) {
+        assigned = assign(doc);
+        return Carriers.resolve(doc, this::heldAt);
+    }
+
+    /** Which comments each place carries, decided once the whole document exists. */
+    private Map<Place, Map<Carrier, List<SyntaxToken>>> assigned = new IdentityHashMap<>();
+
+    /**
+     * Which place carries each comment.
+     *
+     * <p>What a comment was written about is already known and is a fact about the source. This is
+     * the other question: of the places the canonical form has, which one can be handed it. The
+     * answer is found by walking up the places, and the places are the canonical form's — where it
+     * writes something the source has nowhere for, or writes a source construct's child somewhere
+     * the source does not have it, walking the source instead answers about a construct that is not
+     * written here.
+     *
+     * <p>A comment whose source element stands behind several places is carried by whichever place
+     * they converge on. Two places that do not converge are a correspondence that cannot be read,
+     * so it is refused rather than settled by picking one.
+     */
+    private Map<Place, Map<Carrier, List<SyntaxToken>>> assign(TokenDoc doc) {
+        Map<Place, java.util.EnumSet<Carrier>> declared = new IdentityHashMap<>();
+        Carriers.slots(doc, (place, which) ->
+                declared.computeIfAbsent(place, _ -> java.util.EnumSet.noneOf(Carrier.class))
+                        .add(which));
+
+        Map<Place, Map<Carrier, List<SyntaxToken>>> out = new IdentityHashMap<>();
+        // The two ends of a name are tried before the constructs, so a comment written at the end of
+        // a line the canonical form opens a construct with goes to that line and not to wherever the
+        // construct ends.
+        for (var e : comments.aboveToken().entrySet()) {
+            file(out, declared, tokenPlaces(e.getKey(), Carrier.ABOVE, declared), Carrier.ABOVE,
+                    e.getValue());
+        }
+        for (var e : comments.afterToken().entrySet()) {
+            file(out, declared, tokenPlaces(e.getKey(), Carrier.TRAILING, declared),
+                    Carrier.TRAILING, e.getValue());
+        }
+        for (var e : comments.above().entrySet()) {
+            file(out, declared, entryPlaces(e.getKey(), Carrier.ABOVE), Carrier.ABOVE, e.getValue());
+        }
+        for (var e : comments.after().entrySet()) {
+            file(out, declared, endsTheLine(e.getKey(), e.getKey().end(), declared),
+                    Carrier.TRAILING, e.getValue());
+        }
+        for (var e : comments.atEnd().entrySet()) {
+            file(out, declared, entryPlaces(e.getKey(), Carrier.AT_END), Carrier.AT_END, e.getValue());
+        }
+        for (Map<Carrier, List<SyntaxToken>> byCarrier : out.values()) {
+            for (List<SyntaxToken> run : byCarrier.values()) {
+                run.sort(java.util.Comparator.comparingInt(SyntaxToken::start));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The places a comment held against a token reaches.
+     *
+     * <p>A token is a place of the canonical form wherever the canonical form writes it as one: the
+     * name a sum's case is written from, the {@code =} a declaration's first line ends with. That is
+     * asked of the correspondence by the run the token is part of, since a name written as several
+     * identifiers is one thing and a comment anywhere in it is about all of it.
+     *
+     * <p>Where the canonical form writes no place for it, the token is in the middle of a construct
+     * — a {@code module}, an {@code exposing}, a bracket — and what a comment there ends is the line
+     * that construct is on. So the question is asked again of the construct, which is a source
+     * element and reaches the places the ordinary way.
+     */
+    private List<Place> tokenPlaces(SyntaxToken t, Carrier which,
+            Map<Place, java.util.EnumSet<Carrier>> declared) {
+        List<Place> written = places.placesOf(new Written.Run(nameStart(t), nameEnd(t)));
+        if (!written.isEmpty()) {
+            return written;
+        }
+        return which == Carrier.ABOVE
+                ? entryPlaces(beginningAt(t), Carrier.ABOVE)
+                : endsTheLine(endingAt(t), t.end(), declared);
+    }
+
+    /**
+     * The places a source construct was written at, or where the canonical form writes nothing for
+     * it, the nearest places that stand at the end of it — or the start, for a comment written
+     * above.
+     *
+     * <p>A run the source wrote nested is written flat, so {@code 1 |> b} of {@code 1 |> b |> c} is
+     * not a construct the canonical form has: what it has at the end of it is the {@code b} stage,
+     * and that is what a comment written after {@code 1 |> b} is at the end of the line of.
+     *
+     * <p>This is the whole of the walk over the source tree. Past here the walk is over the places,
+     * and the two are kept apart so that the second cannot start answering with the first.
+     */
+    private List<Place> entryPlaces(SyntaxNode node, Carrier which) {
+        for (SyntaxNode c = node; c != null; c = c.parent()) {
+            List<Place> found = places.placesOf(new Written.Construct(c));
+            if (!found.isEmpty()) {
+                return found;
+            }
+            SyntaxNode edge = which == Carrier.ABOVE ? firstChildOf(c) : lastChildOf(c);
+            if (edge != null) {
+                List<Place> atTheEdge = places.placesOf(new Written.Construct(edge));
+                if (!atTheEdge.isEmpty()) {
+                    return atTheEdge;
+                }
+            }
+        }
+        return List.of();
+    }
+
+    /**
+     * The places a comment written at {@code wrote}, inside {@code anchor}, is at the end of the
+     * line of.
+     *
+     * <p>Where the place that would take it goes on past {@code wrote}, the comment was written in
+     * the middle of that place and not at the end of its line: what it ends is the line that place
+     * is on, so the question is asked again of what the place ends inside. A comment after the
+     * condition of an {@code if} is written at the end of the declaration that holds the {@code if},
+     * and this is why.
+     *
+     * <p>Where the comment was written is carried separately from the construct it was written in,
+     * because the two are not the same offset for a comment written in the middle of one: an anchor
+     * that ends past the comment would say the first place asked already ends the line, and the
+     * comment would stay inside a construct whose line runs on after it.
+     */
+    private List<Place> endsTheLine(SyntaxNode anchor, int wrote,
+            Map<Place, java.util.EnumSet<Carrier>> declared) {
+        SyntaxNode at = anchor;
+        int pos = wrote;
+        for (int widened = 0; widened < 16; widened++) {
+            List<Place> entries = entryPlaces(at, Carrier.TRAILING);
+            Place carrier = null;
+            for (Place entry : entries) {
+                Place found = nearestCarrier(entry, Carrier.TRAILING, declared);
+                if (found != null && (carrier == null || isAncestorOf(carrier, found))) {
+                    carrier = found;
+                }
+            }
+            if (carrier == null) {
+                return entries;
+            }
+            SyntaxNode ends = endOfPlace(carrier);
+            if (ends == null || ends.end() <= pos) {
+                return entries;
+            }
+            at = ends;
+            pos = ends.end();
+        }
+        return entryPlaces(at, Carrier.TRAILING);
+    }
+
+    /** The source construct a place ends at, or null where the canonical form writes it from
+     *  nothing the source has. */
+    private SyntaxNode endOfPlace(Place place) {
+        SyntaxNode last = null;
+        for (Written w : places.sourcesOf(place)) {
+            if (w instanceof Written.Construct c && (last == null || c.node().end() > last.end())) {
+                last = c.node();
+            }
+        }
+        return last == null ? null : endingAt(lastCodeTokenOf(last));
+    }
+
+    /** {@code n}'s last child node, whether or not the layout gives it a line. */
+    private static SyntaxNode lastChildOf(SyntaxNode n) {
+        SyntaxNode last = null;
+        for (SyntaxNode c : n.childNodes()) {
+            last = c;
+        }
+        return last;
+    }
+
+    private void file(Map<Place, Map<Carrier, List<SyntaxToken>>> out,
+            Map<Place, java.util.EnumSet<Carrier>> declared, List<Place> entries, Carrier which,
+            List<SyntaxToken> run) {
+        java.util.Set<Place> carriers = java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        for (Place entry : entries) {
+            Place carrier = nearestCarrier(entry, which, declared);
+            if (carrier != null) {
+                carriers.add(carrier);
+            }
+        }
+        for (Place carrier : agreed(carriers, which)) {
+            List<SyntaxToken> held = out
+                    .computeIfAbsent(carrier, _ -> new java.util.EnumMap<>(Carrier.class))
+                    .computeIfAbsent(which, _ -> new ArrayList<>());
+            for (SyntaxToken t : run) {
+                if (!held.contains(t)) {
+                    held.add(t);
+                }
+            }
+        }
+    }
+
+    /**
+     * The one place the carriers found agree on, or none where there were none.
+     *
+     * <p>Several source elements may stand behind one comment's answer, and they agree when the
+     * places they reach lie on one line of descent: an element written under another reaches a
+     * carrier at or below the one its holder reaches, and the deeper of the two is the one that was
+     * asked about. Places on different branches are a correspondence that cannot be read, so it is
+     * refused rather than settled by picking one.
+     */
+    private static List<Place> agreed(java.util.Set<Place> carriers, Carrier which) {
+        Place deepest = null;
+        for (Place c : carriers) {
+            if (deepest == null || isAncestorOf(deepest, c)) {
+                deepest = c;
+            }
+        }
+        for (Place c : carriers) {
+            if (!isAncestorOf(c, deepest)) {
+                throw new IllegalStateException(
+                        "a comment stands behind places that do not agree on which of them carries"
+                                + " it (" + which + "): " + carriers);
+            }
+        }
+        return deepest == null ? List.of() : List.of(deepest);
+    }
+
+    private static boolean isAncestorOf(Place maybe, Place of) {
+        for (Place p = of; p != null; p = p.parent()) {
+            if (p == maybe) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * The nearest place at or above {@code from} that can be handed a comment in that direction.
+     *
+     * <p>A place with no line of its own has nowhere to put one written above it: the rest of that
+     * line would be written inside the comment. Whether it has one is read from the same value the
+     * layout reads to write the boundary in front of it, so the two cannot come apart.
+     */
+    private static Place nearestCarrier(Place from, Carrier which,
+            Map<Place, java.util.EnumSet<Carrier>> declared) {
+        for (Place p = from; p != null; p = p.parent()) {
+            boolean carries = which == Carrier.ABOVE
+                    ? p.opening().opensALine()
+                    : declared.getOrDefault(p, java.util.EnumSet.noneOf(Carrier.class))
+                            .contains(which);
+            if (carries) {
+                return p;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The places {@code file} is written at, and what the source had at each. For a check that has
+     * to see the structure the canonical form has rather than the one the source had — the two are
+     * not the same tree, and where they differ is where asking the source a second time answers
+     * about a construct the canonical form does not write.
+     */
+    static Correspondence placesOf(SyntaxNode file) {
+        return build(file).places();
     }
 
     /**
@@ -158,23 +446,17 @@ public final class Formatter {
      */
     private record Member(TokenDoc doc, TokenDoc trailing) {}
 
-    /** Members that carry no comment of their own. */
-    private static List<Member> plain(List<TokenDoc> docs) {
-        List<Member> out = new ArrayList<>();
-        for (TokenDoc d : docs) {
-            out.add(new Member(d, TokenDoc.NIL));
-        }
-        return out;
-    }
-
-    /** Members with a comma between them, one to a line where they do not fit. The comma stays on
-     * the line its member ends, and a comment written at the end of that line follows the comma. */
+    /**
+     * Members with a comma between them, one to a line where they do not fit. The comma stays on
+     * the line its member ends, and a comment written at the end of that line follows the comma.
+     *
+     * <p>What opens a member's line is the member's own place's and is written from there, so
+     * nothing here says where a line begins. A run that wrote the boundary itself would be saying
+     * it in one place while the members said it in another.
+     */
     private static TokenDoc separated(List<Member> members) {
         List<TokenDoc> parts = new ArrayList<>();
         for (int i = 0; i < members.size(); i++) {
-            if (i > 0) {
-                parts.add(SOFT_GAP);
-            }
             parts.add(members.get(i).doc());
             if (i < members.size() - 1) {
                 parts.add(GAP);
@@ -183,6 +465,34 @@ public final class Formatter {
             parts.add(members.get(i).trailing());
         }
         return concat(parts);
+    }
+
+    /** A member of a run: a place whose line the layout may open with a break. */
+    private Place memberPlace(Place run, SyntaxNode node) {
+        return places.under(run, node.kind(), Opening.breaks(TokenDoc.Break.MAY),
+                Written.of(node));
+    }
+
+    /**
+     * What ends the line a construct opens with — the {@code example j}, the {@code data D =}, the
+     * {@code match … with}, the {@code else}, the {@code {}.
+     *
+     * <p>A construct written over several lines has a first line that none of its members is on, so
+     * that line is a place of its own: what the source wrote at the end of it is about the construct
+     * and belongs there rather than travelling to wherever the construct ends.
+     */
+    private TokenDoc headerLine(Place at, Optional<SyntaxToken> opener) {
+        return opener.map(t -> headerLine(at, t)).orElse(TokenDoc.NIL);
+    }
+
+    private TokenDoc headerLine(Place at, SyntaxToken opener) {
+        return TokenDoc.endsTheLineOf(places.under(at, opener.kind(), Opening.NONE,
+                new Written.Run(opener.start(), opener.end())));
+    }
+
+    /** {@code d}, written at {@code place}, with the comments that construct still hands over. */
+    private Member member(Place place, SyntaxNode node, TokenDoc d) {
+        return new Member(TokenDoc.at(place, d), TokenDoc.endsTheLineOf(place));
     }
 
     /**
@@ -195,48 +505,69 @@ public final class Formatter {
      * source had: a definition written {@code let f = (x) -> x} is written back as
      * {@code let f (x) = x}, and those brackets are a parameter list in what is read back.
      */
-    private static TokenDoc delimited(SyntaxKind construct, TokenDoc open, List<Member> members,
-            TokenDoc close) {
+    private static TokenDoc delimited(Place run, SyntaxKind construct, TokenDoc open,
+            List<Member> members, TokenDoc close) {
         if (members.isEmpty()) {
-            // Brackets with nothing between them hold one boundary and not two. Written as two —
-            // one just inside each bracket — what a construct written open put there was two
-            // spaces, and no rule had said so.
-            return TokenDoc.node(construct, concat(open, GAP, close));
+            // What goes between brackets with no member is one line or none, and which of the two
+            // depends on whether a comment was written there. The construction does not know, so it
+            // hands the brackets over and the pass that answers the carriers says.
+            return new TokenDoc.Vacant(run, construct, open, close, INDENT);
         }
         return TokenDoc.node(construct, group(concat(open,
-                nest(INDENT, concat(SOFT_GAP, separated(members))),
+                nest(INDENT, separated(members)),
                 SOFT_GAP, close)));
     }
 
     /**
-     * One part of a chain, written after the connector that joins it to what came before.
-     * {@code leading} is what goes above the line the part opens — its comments. The connector is
-     * part of that line, so the two are written in this order and not the other: a comment placed
-     * after the connector leaves the part itself starting a line the connector never opened.
+     * The place one part of a chain is written at. The connector that joins it to what came before
+     * opens its line, so the connector is the place's opener: what is written above the part goes
+     * above the connector too, and a comment put after the connector would leave the part itself
+     * starting a line the connector never opened.
+     *
+     * <p>{@code owner} is null only where the source has nothing there — an example row with no
+     * expected value — and such a place stands for nothing, which is ordinary.
      */
-    private record Segment(TokenDoc connector, TokenDoc doc, TokenDoc leading) {}
+    private Place segmentPlace(Place chain, TokenDoc connector, SyntaxNode owner) {
+        return places.under(chain, owner == null ? null : owner.kind(),
+                new Opening.Breaks(TokenDoc.Break.MAY, connector), Written.of(owner));
+    }
+
+
+    private Place segmentPlace(Place chain, TokenDoc connector, SyntaxToken owner) {
+        return places.under(chain, owner.kind(),
+                new Opening.Breaks(TokenDoc.Break.MAY, connector),
+                new Written.Run(nameStart(owner), nameEnd(owner)));
+    }
 
     /**
      * A part of a chain that something in the source stands for. Every segment of every chain is
      * built here: a chain is written from what the source holds, and one built without asking what
-     * was written above and beside it is one whose comments have nowhere to go. {@code owner} is
-     * null only where the source has nothing there — an example row with no expected value.
+     * was written above and beside it is one whose comments have nowhere to go.
      */
-    private Segment segment(TokenDoc connector, SyntaxNode owner, TokenDoc doc) {
+    private TokenDoc segment(Place place, SyntaxNode owner, TokenDoc doc) {
         return owner == null
-                ? new Segment(connector, doc, TokenDoc.NIL)
-                : new Segment(connector, concat(doc, afterOf(owner)), aboveOf(owner));
+                ? TokenDoc.at(place, concat(GAP, doc))
+                : TokenDoc.at(place, concat(GAP, doc, TokenDoc.endsTheLineOf(place)));
+    }
+
+    /**
+     * The last part of a run the canonical form writes flat.
+     *
+     * <p>It ends where the whole run does, and what the run is written inside goes on writing that
+     * line — a condition's {@code then}, a call's {@code )}. So this part is not what ends the line
+     * and carries nothing there; what does is whatever holds the run, whose own place is outside the
+     * group the run is laid out in. Only this shape has it: a match arm's body and an example row's
+     * expected value are the last of their chains and do end their lines.
+     */
+    private TokenDoc lastOfARun(Place place, TokenDoc doc) {
+        return TokenDoc.at(place, concat(GAP, doc));
     }
 
     /** The same for a part the grammar writes as a bare identifier rather than as a node — a sum's
      * cases. It is the only other way a chain's part can stand for something written, so between the
-     * two of them nothing else builds a {@link Segment}. */
-    private Segment segment(TokenDoc connector, SyntaxToken owner, TokenDoc doc) {
-        List<TokenDoc> lead = new ArrayList<>();
-        for (TokenDoc c : aboveCase(owner)) {
-            lead.add(concat(c, HARD_GAP));
-        }
-        return new Segment(connector, concat(doc, afterCase(owner)), concat(lead));
+     * two of them nothing else builds a segment. */
+    private TokenDoc segment(Place place, SyntaxToken owner, TokenDoc doc) {
+        return TokenDoc.at(place, concat(GAP, doc, TokenDoc.endsTheLineOf(place)));
     }
 
     /**
@@ -245,38 +576,37 @@ public final class Formatter {
      * {@code ->}. Broken, each part starts a line one indent in and the connector leads it, so what
      * joins two parts is visible at the front of the second.
      */
-    private static TokenDoc chained(Member head, List<Segment> segments) {
-        List<TokenDoc> parts = new ArrayList<>();
-        for (Segment s : segments) {
-            parts.add(concat(SOFT_GAP, s.leading(), s.connector(), GAP, s.doc()));
-        }
-        return group(concat(head.doc(), head.trailing(), nest(INDENT, concat(parts))));
+    private static TokenDoc chained(Member head, List<TokenDoc> segments) {
+        return group(concat(head.doc(), head.trailing(), nest(INDENT, concat(segments))));
+    }
+
+    /** The place the part of a chain written before the first connector is at. Nothing opens its
+     * line: it is written where the construct holding the chain had already got to. */
+    private Place headPlace(Place chain, SyntaxNode owner) {
+        return places.under(chain, owner == null ? null : owner.kind(), Opening.NONE,
+                Written.of(owner));
     }
 
     /** The part of a chain written before the first connector, from the construct it stands for. A
      * head is a member like a segment is, and the same three things it can stand for: a node, an
      * identifier, or nothing the source wrote. */
-    private Member head(SyntaxNode owner, TokenDoc doc) {
-        return new Member(concat(aboveOf(owner), doc), afterOf(owner));
+    private Member head(Place place, SyntaxNode owner, TokenDoc doc) {
+        return new Member(TokenDoc.at(place, doc), TokenDoc.endsTheLineOf(place));
     }
 
     /** The same for a head the grammar writes as a token — an example row's description, a match
      * arm's pattern. Nothing is read above it: a comment written above one of those, or between the
      * {@code |} and the token itself, is about the row, and the row writes it above its own line. So
      * this head carries only what ends the line it opens. */
-    private Member head(SyntaxToken owner, TokenDoc doc) {
-        return new Member(doc, afterCase(owner));
-    }
-
-    /** A head the source has nothing at — a `fake` row's default `_`. */
-    private static Member synthetic(TokenDoc doc) {
-        return new Member(doc, TokenDoc.NIL);
+    private Member head(Place place, SyntaxToken owner, TokenDoc doc) {
+        return new Member(TokenDoc.at(place, doc), TokenDoc.endsTheLineOf(place));
     }
 
     // --- top level ---
 
     private TokenDoc file(SyntaxNode file) {
         comments = attach(file);
+        Place ofTheFile = places.fileOf(file);
         List<TokenDoc> parts = new ArrayList<>();
         SyntaxKind prev = null;
         for (SyntaxNode item : file.childNodes()) {
@@ -286,19 +616,21 @@ public final class Formatter {
             // A top-level item's comments are read the same way a member's are, and marked written
             // the same way: an `example`'s comment is the item's leading trivia here and the first
             // row's from inside, and it belongs to whichever asks first.
-            TokenDoc lead = aboveOf(item);
-            if (prev != null) {
+            //
+            // The break that separates an item from the one before opens the item's line, so it is
+            // the item's; the first item's line is opened by the start of the file. The blank line
+            // between two of them separates them and belongs to neither, so it stays here.
+            Place at = places.under(ofTheFile, item.kind(),
+                    prev == null ? new Opening.ByOpener(TokenDoc.NIL)
+                            : Opening.breaks(TokenDoc.Break.ALWAYS),
+                    Written.of(item));
+            if (prev != null && blankBetween(prev, item.kind())) {
                 parts.add(HARD_GAP);
-                if (blankBetween(prev, item.kind())) {
-                    parts.add(HARD_GAP);
-                }
             }
-            parts.add(lead);
-            parts.add(item(item));
-            parts.add(afterOf(item));
+            parts.add(TokenDoc.at(at, concat(item(item, at), TokenDoc.endsTheLineOf(at))));
             prev = item.kind();
         }
-        parts.add(endOf(file));
+        parts.add(TokenDoc.carries(ofTheFile, Carrier.AT_END));
         parts.add(HARD_GAP);   // files end with a single newline
         return concat(parts);
     }
@@ -321,16 +653,16 @@ public final class Formatter {
                 || k == SyntaxKind.FAKE_DEF;
     }
 
-    private TokenDoc item(SyntaxNode n) {
+    private TokenDoc item(SyntaxNode n, Place at) {
         return switch (n.kind()) {
-            case MODULE_HEADER -> moduleHeader(n);
-            case IMPORT_DECL -> importDecl(n);
-            case DATA_DEF -> dataDef(n);
-            case BEHAVIOR_DEF -> behaviorDef(n);
-            case FN_DEF -> fnDef(n);
+            case MODULE_HEADER -> moduleHeader(n, at);
+            case IMPORT_DECL -> importDecl(n, at);
+            case DATA_DEF -> dataDef(n, at);
+            case BEHAVIOR_DEF -> behaviorDef(n, at);
+            case FN_DEF -> fnDef(n, at);
             case EXAMPLES_FILE_HEADER -> examplesFileHeader(n);
-            case EXAMPLE_DEF -> exampleDef(n);
-            case FAKE_DEF -> fakeDef(n);
+            case EXAMPLE_DEF -> exampleDef(n, at);
+            case FAKE_DEF -> fakeDef(n, at);
             default -> throw new IllegalStateException("no case writes " + n.kind());
         };
     }
@@ -342,17 +674,18 @@ public final class Formatter {
                 qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow())));
     }
 
-    private TokenDoc exampleDef(SyntaxNode n) {
+    private TokenDoc exampleDef(SyntaxNode n, Place at) {
         List<SyntaxToken> ids = idents(n);   // ["example", target]
         String target = ids.size() >= 2 ? ids.get(1).text() : "";
         List<TokenDoc> rows = new ArrayList<>();
         for (SyntaxNode row : childNodes(n, SyntaxKind.EXAMPLE_ROW)) {
-            rows.add(concat(HARD_GAP, concat(aboveOf(row), exampleRow(row)),
-                    afterOf(row)));
+            Place r = places.under(at, row.kind(), Opening.breaks(TokenDoc.Break.ALWAYS),
+                    Written.of(row));
+            rows.add(TokenDoc.at(r, concat(exampleRow(row, r), TokenDoc.endsTheLineOf(r))));
         }
-        rows.add(endOf(n));
+        rows.add(TokenDoc.carries(at, Carrier.AT_END));
         return TokenDoc.node(n.kind(), concat(ident("example"), GAP, ident(target),
-                afterToken(ids.get(ids.size() - 1), ids.size() >= 2), nest(INDENT, concat(rows))));
+                ids.size() >= 2 ? headerLine(at, ids.get(ids.size() - 1)) : TokenDoc.NIL, nest(INDENT, concat(rows))));
     }
 
     /**
@@ -361,88 +694,122 @@ public final class Formatter {
      * its input instead left {@code ), Amount(100)) -> Accepted} opening a line, and stopped showing
      * which part was which.
      */
-    private TokenDoc exampleRow(SyntaxNode n) {
-        TokenDoc input = n.child(SyntaxKind.ARG_LIST)
-                .map(a -> delimited(SyntaxKind.ARG_LIST, LPAREN, exprDocs(a), RPAREN))
+    private TokenDoc exampleRow(SyntaxNode n, Place at) {
+        var desc = n.token(SyntaxKind.STRING_LIT);
+        var argList = n.child(SyntaxKind.ARG_LIST);
+        // The description opens the row where there is one; otherwise the input does. Either way the
+        // input is written at the place the row's head or its first segment is.
+        Place ofTheHead = desc.isPresent()
+                ? places.under(at, SyntaxKind.STRING_LIT, Opening.NONE,
+                        new Written.Run(desc.get().start(), desc.get().end()))
+                : headPlace(at, argList.orElse(null));
+        Place ofTheInput = desc.isPresent()
+                ? segmentPlace(at, COLON, argList.orElse(null))
+                : ofTheHead;
+
+        TokenDoc input = argList
+                .map(a -> delimited(ofTheInput, SyntaxKind.ARG_LIST, LPAREN,
+                        exprDocs(a, ofTheInput), RPAREN))
                 .orElse(concat(LPAREN, GAP, RPAREN));
         var with = n.child(SyntaxKind.WITH_CLAUSE);
         if (with.isPresent()) {
+            // Written after the input on the input's line, so it is a place of that segment rather
+            // than of the row. A comment about the whole clause then reaches the carrier of the
+            // line the clause is on, which is the line the input ends.
+            Place ofTheWith = places.under(ofTheInput, with.get().kind(), Opening.NONE,
+                    Written.of(with.get()));
             List<Member> binds = new ArrayList<>();
             for (SyntaxNode b : childNodes(with.get(), SyntaxKind.WITH_BINDING)) {
-                binds.add(member(b, TokenDoc.node(b.kind(), concat(ident(firstIdent(b)), GAP,
-                        ASSIGN, GAP, expr(firstExprChildOpt(b).orElseThrow())))));
+                // the first binding is written after the `with` on its line, so nothing opens one
+                Place bind = binds.isEmpty()
+                        ? places.under(ofTheWith, b.kind(), Opening.NONE, Written.of(b))
+                        : memberPlace(ofTheWith, b);
+                binds.add(member(bind, b, TokenDoc.node(b.kind(), concat(ident(firstIdent(b)), GAP,
+                        ASSIGN, GAP,
+                        childAt(bind, firstExprChildOpt(b).orElseThrow(), Opening.NONE)))));
             }
             input = concat(input, GAP, TokenDoc.node(with.get().kind(),
                     concat(TokenDoc.token(SyntaxKind.WITH_KW, "with"), GAP,
-                            group(nest(INDENT, separated(withEndComments(with.get(), binds)))))));
+                            group(nest(INDENT, separated(withEndComments(ofTheWith, binds)))))));
         }
 
-        List<Segment> segs = new ArrayList<>();
-        var desc = n.token(SyntaxKind.STRING_LIT);
+        List<TokenDoc> segs = new ArrayList<>();
         Member head;
         if (desc.isPresent()) {
-            head = head(desc.get(), token(desc.get()));
-            segs.add(segment(COLON, n.child(SyntaxKind.ARG_LIST).orElse(null), input));
+            head = head(ofTheHead, desc.get(), token(desc.get()));
+            segs.add(segment(ofTheInput, argList.orElse(null), input));
         } else {
             // with no description the input opens the row, so the row's head carries its comments
-            SyntaxNode args = n.child(SyntaxKind.ARG_LIST).orElse(null);
-            head = args == null ? synthetic(input) : head(args, input);
+            head = argList.isEmpty() ? new Member(TokenDoc.at(ofTheHead, input), TokenDoc.NIL)
+                    : head(ofTheHead, argList.get(), input);
         }
         List<SyntaxNode> expected = exprChildren(n);   // the row's expr child that is not the ARG_LIST
-        segs.add(segment(ARROW, expected.isEmpty() ? null : expected.get(0),
-                expected.isEmpty() ? TokenDoc.NIL : expr(expected.get(0))));
+        SyntaxNode gives = expected.isEmpty() ? null : expected.get(0);
+        Place ofTheExpected = segmentPlace(at, ARROW, gives);
+        segs.add(segment(ofTheExpected, gives,
+                gives == null ? TokenDoc.NIL : expr(gives, ofTheExpected)));
         return concat(PIPE, GAP, TokenDoc.node(n.kind(), chained(head, segs)));
     }
 
-    private TokenDoc fakeDef(SyntaxNode n) {
+    private TokenDoc fakeDef(SyntaxNode n, Place at) {
         List<SyntaxToken> ids = idents(n);   // ["fake", target]
         String target = ids.size() >= 2 ? ids.get(1).text() : "";
         List<TokenDoc> rows = new ArrayList<>();
         for (SyntaxNode row : childNodes(n, SyntaxKind.FAKE_ROW)) {
-            rows.add(concat(HARD_GAP, concat(aboveOf(row), fakeRow(row)), afterOf(row)));
+            Place r = places.under(at, row.kind(), Opening.breaks(TokenDoc.Break.ALWAYS),
+                    Written.of(row));
+            rows.add(TokenDoc.at(r, concat(fakeRow(row, r), TokenDoc.endsTheLineOf(r))));
         }
-        rows.add(endOf(n));
+        rows.add(TokenDoc.carries(at, Carrier.AT_END));
         return TokenDoc.node(n.kind(), concat(ident("fake"), GAP, ident(target),
-                afterToken(ids.get(ids.size() - 1), ids.size() >= 2), nest(INDENT, concat(rows))));
+                ids.size() >= 2 ? headerLine(at, ids.get(ids.size() - 1)) : TokenDoc.NIL, nest(INDENT, concat(rows))));
     }
 
-    private TokenDoc fakeRow(SyntaxNode n) {
+    private TokenDoc fakeRow(SyntaxNode n, Place at) {
         var args = n.child(SyntaxKind.ARG_LIST);
+        Place ofTheInput = headPlace(at, args.orElse(null));
         TokenDoc input;
         if (args.isPresent()) {
-            input = delimited(SyntaxKind.ARG_LIST, LPAREN, exprDocs(args.get()), RPAREN);
+            input = delimited(ofTheInput, SyntaxKind.ARG_LIST, LPAREN, exprDocs(args.get(), ofTheInput),
+                    RPAREN);
         } else {
             input = ident("_");   // the default row
         }
         List<SyntaxNode> outs = exprChildren(n);
         // the input opens the row, so the head carries what was written above and beside it
-        Member head = args.map(a -> head(a, input)).orElse(synthetic(input));
+        Member head = args.isPresent() ? head(ofTheInput, args.get(), input)
+                : new Member(TokenDoc.at(ofTheInput, input), TokenDoc.NIL);
+        SyntaxNode gives = outs.isEmpty() ? null : outs.get(0);
+        Place ofTheOutput = segmentPlace(at, ARROW, gives);
         return concat(PIPE, GAP, TokenDoc.node(n.kind(), chained(head,
-                List.of(segment(ARROW, outs.isEmpty() ? null : outs.get(0),
-                        outs.isEmpty() ? TokenDoc.NIL : expr(outs.get(0)))))));
+                List.of(segment(ofTheOutput, gives,
+                        gives == null ? TokenDoc.NIL : expr(gives, ofTheOutput))))));
     }
 
-    private TokenDoc moduleHeader(SyntaxNode n) {
+    private TokenDoc moduleHeader(SyntaxNode n, Place at) {
         TokenDoc d = concat(TokenDoc.token(SyntaxKind.MODULE_KW, "module"), GAP,
                 qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow()));
         return TokenDoc.node(n.kind(), n.child(SyntaxKind.EXPOSING_CLAUSE)
-                .map(c -> concat(d, GAP, exposing(c)))
+                .map(c -> concat(d, GAP, exposing(c, at)))
                 .orElse(d));
     }
 
-    private TokenDoc exposing(SyntaxNode clause) {
+    private TokenDoc exposing(SyntaxNode clause, Place at) {
+        Place run = places.under(at, clause.kind(), Opening.NONE, Written.of(clause));
         List<Member> entries = new ArrayList<>();
         for (SyntaxNode e : childNodes(clause, SyntaxKind.EXPOSED_ENTRY)) {
+            Place entry = memberPlace(run, e);
             TokenDoc name = qualifiedName(e.child(SyntaxKind.QUALIFIED_NAME).orElseThrow());
-            entries.add(member(e, TokenDoc.node(e.kind(), e.child(SyntaxKind.RET_TYPE)
-                    .map(rt -> concat(name, GAP, COLON, GAP, retType(rt)))
+            entries.add(member(entry, e, TokenDoc.node(e.kind(), e.child(SyntaxKind.RET_TYPE)
+                    .map(rt -> concat(name, GAP, COLON, GAP, retType(rt, entry)))
                     .orElse(name))));
         }
-        return delimited(SyntaxKind.EXPOSING_CLAUSE, concat(TokenDoc.token(SyntaxKind.EXPOSING_KW, "exposing"), GAP,
-                LPAREN), withEndComments(clause, entries), RPAREN);
+        return TokenDoc.at(run, delimited(run, SyntaxKind.EXPOSING_CLAUSE,
+                concat(TokenDoc.token(SyntaxKind.EXPOSING_KW, "exposing"), GAP, LPAREN),
+                withEndComments(run, entries), RPAREN));
     }
 
-    private TokenDoc importDecl(SyntaxNode n) {
+    private TokenDoc importDecl(SyntaxNode n, Place at) {
         TokenDoc d = concat(TokenDoc.token(SyntaxKind.IMPORT_KW, "import"), GAP,
                 qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow()));
         Optional<SyntaxNode> alias = n.child(SyntaxKind.IMPORT_ALIAS);
@@ -455,27 +822,33 @@ public final class Formatter {
         if (list.isEmpty()) {
             return TokenDoc.node(n.kind(), d);   // one that only renames it, or only names it
         }
+        Place run = places.under(at, list.get().kind(), Opening.NONE, Written.of(list.get()));
         List<Member> names = new ArrayList<>();
         for (SyntaxToken t : idents(list.get())) {
-            names.add(tokenMember(t, t, token(t)));
+            names.add(tokenMember(places.under(run, t.kind(),
+                    Opening.breaks(TokenDoc.Break.MAY),
+                    new Written.Run(nameStart(t), nameEnd(t))), t, t, token(t)));
         }
-        return TokenDoc.node(n.kind(), concat(d, GAP,
-                delimited(SyntaxKind.NAME_LIST, LPAREN, withEndComments(list.get(), names), RPAREN)));
+        return TokenDoc.node(n.kind(), concat(d, GAP, TokenDoc.at(run,
+                delimited(run, SyntaxKind.NAME_LIST, LPAREN, withEndComments(run, names),
+                        RPAREN))));
     }
 
     // --- data ---
 
-    private TokenDoc dataDef(SyntaxNode n) {
+    private TokenDoc dataDef(SyntaxNode n, Place at) {
         String name = firstIdent(n);
         List<TokenDoc> invariants = new ArrayList<>();
         for (SyntaxNode inv : childNodes(n, SyntaxKind.INVARIANT_CLAUSE)) {
             // A named clause keeps its name: it is what an attempt's arm and a boundary issue call it.
             TokenDoc label = inv.token(SyntaxKind.ASSIGN).isPresent()
                     ? concat(ident(firstIdent(inv)), GAP, ASSIGN, GAP) : TokenDoc.NIL;
-            invariants.add(concat(HARD_GAP,
-                    concat(aboveOf(inv), TokenDoc.node(inv.kind(), concat(TokenDoc.token(SyntaxKind.INVARIANT_KW, "invariant"), GAP, label,
-                            expr(onlyExpr(inv))))),
-                    afterOf(inv)));
+            Place clause = places.under(at, inv.kind(), Opening.breaks(TokenDoc.Break.ALWAYS),
+                    Written.of(inv));
+            invariants.add(TokenDoc.at(clause, concat(TokenDoc.node(inv.kind(),
+                            concat(TokenDoc.token(SyntaxKind.INVARIANT_KW, "invariant"), GAP, label,
+                                    childAt(clause, onlyExpr(inv), Opening.NONE))),
+                            TokenDoc.endsTheLineOf(clause))));
         }
 
         var product = n.child(SyntaxKind.PRODUCT_BODY);
@@ -484,77 +857,100 @@ public final class Formatter {
                 return TokenDoc.node(n.kind(),
                         concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP,
                         ASSIGN, GAP, TokenDoc.node(product.get().kind(), concat(LBRACE, GAP, RBRACE)),
-                        afterToken(n.token(SyntaxKind.ASSIGN)),
+                        headerLine(at, n.token(SyntaxKind.ASSIGN)),
                         nest(INDENT, concat(invariants))));
             }
             return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP, ASSIGN,
-                    afterToken(n.token(SyntaxKind.ASSIGN)),
-                    nest(INDENT, concat(concat(HARD_GAP, productBody(product.get())),
+                    headerLine(at, n.token(SyntaxKind.ASSIGN)),
+                    nest(INDENT, concat(concat(HARD_GAP, productBody(product.get(), at)),
                             concat(invariants)))));
         }
         var sum = n.child(SyntaxKind.SUM_BODY);
         if (sum.isPresent()) {
             // A sum's cases are bare idents, not nodes, so a case's comments are held against where
             // its identifier is rather than against a member node.
+            //
+            // The first case shares its line with `data S =`, so a comment written above it has
+            // nowhere to go there without describing the declaration instead: the union moves down
+            // a line, and the line it moves to is the union's own. Which shape the union is written
+            // in is not where the comment goes — it is what the source has above that case, which
+            // the token stream has already said.
+            boolean movesDown = !comments.aboveToken()
+                    .getOrDefault(firstCaseOf(sum.get()), List.of()).isEmpty();
+            Place chainAt = places.under(at, sum.get().kind(),
+                    movesDown ? new Opening.ByOpener(TokenDoc.NIL) : Opening.NONE,
+                    Written.of(sum.get()));
             TokenDoc head = null;
-            List<TokenDoc> headComments = new ArrayList<>();
-            List<Segment> cases = new ArrayList<>();
+            List<TokenDoc> cases = new ArrayList<>();
             for (SyntaxElement e : sum.get().children()) {
                 if (!(e instanceof SyntaxToken t) || t.kind() != SyntaxKind.IDENT) {
                     continue;
                 }
                 if (head == null) {
-                    head = concat(token(t), afterCase(t));
-                    headComments = new ArrayList<>();
-                    for (TokenDoc c : aboveCase(t)) {
-                        headComments.add(concat(c, HARD_GAP));
-                    }
+                    Place first = places.under(chainAt, t.kind(), Opening.NONE,
+                            new Written.Run(nameStart(t), nameEnd(t)));
+                    head = TokenDoc.at(first,
+                            concat(token(t), TokenDoc.endsTheLineOf(first)));
                 } else {
-                    cases.add(segment(PIPE, t, token(t)));
+                    cases.add(segment(segmentPlace(chainAt, PIPE, t), t, token(t)));
                 }
             }
-            TokenDoc chain = TokenDoc.node(sum.get().kind(), chained(synthetic(head), cases));
-            if (headComments.isEmpty()) {
+            TokenDoc chain = TokenDoc.at(chainAt, TokenDoc.node(sum.get().kind(),
+                    chained(new Member(head, TokenDoc.NIL), cases)));
+            if (!movesDown) {
                 return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP, ASSIGN, GAP, chain));
             }
-            // The first case shares its line with `data S =`, so its comments cannot go above that
-            // line without describing the declaration instead. The union moves down a line instead.
             return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP, ASSIGN,
-                    nest(INDENT, concat(HARD_GAP, concat(headComments), chain))));
+                    nest(INDENT, concat(HARD_GAP, chain))));
         }
         var newtype = n.child(SyntaxKind.NEWTYPE_BODY);
         if (newtype.isPresent()) {
-            TokenDoc inner = concat(aboveOf(newtype.get()), typeRef(typeChild(newtype.get())),
-                    afterOf(newtype.get()));
+            // The representation is written after the `=` on the declaration's line, so nothing
+            // opens a line for it. It still ends that line, which is what lets it own the comment
+            // written there.
+            Place ofTheBody = places.under(at, newtype.get().kind(), Opening.NONE,
+                    Written.of(newtype.get()));
+            TokenDoc inner = TokenDoc.at(ofTheBody, concat(typeRef(typeChild(newtype.get()), ofTheBody), TokenDoc.endsTheLineOf(ofTheBody)));
             return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP, ASSIGN, GAP, inner,
                     nest(INDENT, concat(invariants))));
         }
         return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name)));   // unit
     }
 
+    /** The identifier a union's first case is written from, or null for a body with no case in it. */
+    private static SyntaxToken firstCaseOf(SyntaxNode sum) {
+        for (SyntaxElement e : sum.children()) {
+            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
+                return t;
+            }
+        }
+        return null;
+    }
+
     /** The leading-comma product block: {@code { f1: T1\n, f2: T2\n}}. Multi-line wherever it holds
      * anything: the block writes its opening brace on the first member's line, so a body with no
      * members has no line to write one on, and it is written as the empty brackets it is. */
-    private TokenDoc productBody(SyntaxNode body) {
+    private TokenDoc productBody(SyntaxNode body, Place at) {
+        Place run = places.under(at, body.kind(), Opening.NONE, Written.of(body));
         List<TokenDoc> lines = new ArrayList<>();
         for (SyntaxNode m : body.childNodes()) {
-            TokenDoc member;
-            if (m.kind() == SyntaxKind.FIELD) {
-                member = field(m);
-            } else if (m.kind() == SyntaxKind.SPREAD_MEMBER) {
-                member = TokenDoc.node(m.kind(), concat(
-                        TokenDoc.token(SyntaxKind.SPREAD, "..."), GAP,
-                        dottedName(idents(m))));
-            } else {
+            if (m.kind() != SyntaxKind.FIELD && m.kind() != SyntaxKind.SPREAD_MEMBER) {
                 continue;
             }
-            // The opener is part of the member's line, so it is inside what the comments decorate:
-            // a comment written after it would leave the member starting a line of its own, at the
+            // The opener is part of the member's line, so it is what the place is opened with: a
+            // comment written after it would leave the member starting a line of its own, at the
             // block's indent rather than after the comma the rest of the block is written with.
             boolean first = lines.isEmpty();
-            TokenDoc line = concat(concat(aboveOf(m), first ? LBRACE : COMMA, GAP, member),
-                    afterOf(m));
-            lines.add(first ? line : concat(HARD_GAP, line));
+            Place place = places.under(run, m.kind(),
+                    first ? new Opening.ByOpener(LBRACE)
+                            : new Opening.Breaks(TokenDoc.Break.ALWAYS, COMMA),
+                    Written.of(m));
+            TokenDoc written = m.kind() == SyntaxKind.FIELD
+                    ? field(m, place)
+                    : TokenDoc.node(m.kind(), concat(
+                            TokenDoc.token(SyntaxKind.SPREAD, "..."), GAP,
+                            dottedName(idents(m))));
+            lines.add(TokenDoc.at(place, concat(GAP, written, TokenDoc.endsTheLineOf(place))));
         }
         if (lines.isEmpty()) {
             // No member wrote the opening brace, so the block writes it on a line of its own. This
@@ -562,7 +958,7 @@ public final class Formatter {
             // as `{}` and never reaches here.
             lines.add(LBRACE);
         }
-        lines.add(endOf(body));
+        lines.add(TokenDoc.carries(run, Carrier.AT_END));
         lines.add(concat(HARD_GAP, RBRACE));
         return TokenDoc.node(body.kind(), concat(lines));
     }
@@ -583,33 +979,43 @@ public final class Formatter {
         return comments.atEnd().getOrDefault(body, List.of()).isEmpty();
     }
 
-    private TokenDoc field(SyntaxNode n) {
-        TokenDoc d = concat(ident(firstIdent(n)), GAP, COLON, GAP, typeRef(typeChild(n)));
+    private TokenDoc field(SyntaxNode n, Place at) {
+        TokenDoc d = concat(ident(firstIdent(n)), GAP, COLON, GAP, typeRef(typeChild(n), at));
         return TokenDoc.node(n.kind(),
                 n.token(SyntaxKind.QUESTION).isPresent() ? concat(d, GAP, QUESTION) : d);
     }
 
     // --- behavior ---
 
-    private TokenDoc behaviorDef(SyntaxNode n) {
+    private TokenDoc behaviorDef(SyntaxNode n, Place at) {
         String name = firstIdent(n);
         var sig = n.child(SyntaxKind.BEHAVIOR_SIG);
         if (sig.isPresent()) {
             SyntaxNode s = sig.get();
-            TokenDoc params = paramList(s.child(SyntaxKind.PARAM_LIST).orElseThrow());
+            Place ofTheSig = places.under(at, s.kind(), Opening.NONE, Written.of(s));
+            TokenDoc params = paramList(s.child(SyntaxKind.PARAM_LIST).orElseThrow(), ofTheSig);
             SyntaxNode retNode = s.child(SyntaxKind.RET_TYPE).orElseThrow();
-            TokenDoc ret = concat(aboveOf(retNode), retType(retNode), afterOf(retNode));
+            // What is written after the `->` is on the line the `->` is on, so nothing opens a line
+            // for it. It still ends that line, which is what lets it own the comment there.
+            Place ofTheResult = places.under(ofTheSig, retNode.kind(), Opening.NONE,
+                    Written.of(retNode));
+            TokenDoc ret = TokenDoc.at(ofTheResult, concat(retType(retNode, ofTheResult), TokenDoc.endsTheLineOf(ofTheResult)));
             List<TokenDoc> clauses = new ArrayList<>();
             for (SyntaxNode c : s.childNodes()) {
-                if (c.kind() == SyntaxKind.CONSTRUCTS_CLAUSE) {
-                    clauses.add(concat(HARD_GAP, concat(aboveOf(c), TokenDoc.node(c.kind(),
-                            concat(TokenDoc.token(SyntaxKind.CONSTRUCTS_KW, "constructs"), GAP,
-                                    nameList(c, 0)))), afterOf(c)));
-                } else if (c.kind() == SyntaxKind.DEPENDS_CLAUSE) {
-                    clauses.add(concat(HARD_GAP, concat(aboveOf(c), TokenDoc.node(c.kind(),
-                            concat(TokenDoc.token(SyntaxKind.DEPENDS_KW, "depends"), GAP,
-                                    ident("on"), GAP, nameList(c, 1)))), afterOf(c)));
+                if (c.kind() != SyntaxKind.CONSTRUCTS_CLAUSE
+                        && c.kind() != SyntaxKind.DEPENDS_CLAUSE) {
+                    continue;
                 }
+                Place clause = places.under(ofTheSig, c.kind(),
+                        Opening.breaks(TokenDoc.Break.ALWAYS), Written.of(c));
+                TokenDoc listed = c.kind() == SyntaxKind.CONSTRUCTS_CLAUSE
+                        ? TokenDoc.node(c.kind(),
+                                concat(TokenDoc.token(SyntaxKind.CONSTRUCTS_KW, "constructs"), GAP,
+                                        nameList(c, 0, clause)))
+                        : TokenDoc.node(c.kind(),
+                                concat(TokenDoc.token(SyntaxKind.DEPENDS_KW, "depends"), GAP,
+                                        ident("on"), GAP, nameList(c, 1, clause)));
+                clauses.add(TokenDoc.at(clause, concat(listed, TokenDoc.endsTheLineOf(clause))));
             }
             return TokenDoc.node(n.kind(),
                     concat(TokenDoc.token(SyntaxKind.BEHAVIOR_KW, "behavior"), GAP, ident(name),
@@ -617,29 +1023,42 @@ public final class Formatter {
                                     ret, nest(INDENT, concat(clauses))))));
         }
         SyntaxNode pipe = n.child(SyntaxKind.PIPE_BEHAVIOR).orElseThrow();
+        Place ofThePipe = places.under(at, pipe.kind(), Opening.NONE, Written.of(pipe));
         List<SyntaxNode> stages = childNodes(pipe, SyntaxKind.STAGE);
         TokenDoc declaredOut = pipe.child(SyntaxKind.RET_TYPE)
-                .map(rt -> concat(GAP, ARROW, GAP, retType(rt))).orElse(TokenDoc.NIL);
+                .map(rt -> concat(GAP, ARROW, GAP, retType(rt, ofThePipe))).orElse(TokenDoc.NIL);
         List<TokenDoc> parts = new ArrayList<>();
         for (int i = 0; i < stages.size(); i++) {
             SyntaxNode st = stages.get(i);
-            // What the declaration writes after the last stage is on that stage's line, so it comes
-            // before the comment that ends the line rather than after it.
-            parts.add(concat(SOFT_GAP, aboveOf(st),
-                    i == 0 ? TokenDoc.NIL : concat(TokenDoc.token(SyntaxKind.PIPEFWD, ">->"), GAP), stage(st),
-                    i == stages.size() - 1 ? declaredOut : TokenDoc.NIL, afterOf(st)));
+            // What joins a stage to the one before opens the stage's line, so it is the place's
+            // opener. What the declaration writes after the last stage is on that stage's line, so
+            // it comes before the comment that ends the line rather than after it.
+            Place ofTheStage = places.under(ofThePipe, st.kind(),
+                    new Opening.Breaks(TokenDoc.Break.MAY, i == 0 ? TokenDoc.NIL
+                            : concat(TokenDoc.token(SyntaxKind.PIPEFWD, ">->"), GAP)),
+                    Written.of(st));
+            // The declared output is written after the last stage and on that stage's line, so that
+            // stage is not what ends the line and carries nothing there: what ends it is the
+            // declaration, whose own place is outside the group this run is laid out in.
+            boolean last = i == stages.size() - 1;
+            parts.add(TokenDoc.at(ofTheStage, concat(stage(st),
+                    last ? declaredOut : TokenDoc.endsTheLineOf(ofTheStage))));
         }
         return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.BEHAVIOR_KW, "behavior"), GAP, ident(name), GAP, ASSIGN,
                 TokenDoc.node(pipe.kind(), group(nest(INDENT, concat(parts))))));
     }
 
-    private TokenDoc paramList(SyntaxNode n) {
+    private TokenDoc paramList(SyntaxNode n, Place at) {
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
         List<Member> params = new ArrayList<>();
         for (SyntaxNode p : childNodes(n, SyntaxKind.PARAM)) {
-            params.add(member(p, TokenDoc.node(p.kind(), concat(ident(firstIdent(p)), GAP, COLON,
-                    GAP, retType(p.child(SyntaxKind.RET_TYPE).orElseThrow())))));
+            Place param = memberPlace(run, p);
+            params.add(member(param, p, TokenDoc.node(p.kind(),
+                    concat(ident(firstIdent(p)), GAP, COLON, GAP,
+                            retType(p.child(SyntaxKind.RET_TYPE).orElseThrow(), param)))));
         }
-        return delimited(SyntaxKind.PARAM_LIST, LPAREN, withEndComments(n, params), RPAREN);
+        return TokenDoc.at(run,
+                delimited(run, SyntaxKind.PARAM_LIST, LPAREN, withEndComments(run, params), RPAREN));
     }
 
     /** One stage of a pipeline, which is a name and is written as one. */
@@ -650,7 +1069,8 @@ public final class Formatter {
     /** The names a {@code constructs} / {@code depends on} clause lists. {@code skipIdents} drops
      * the leading identifiers that belong to the keyword rather than the list — the {@code on} of
      * {@code depends on}, which lexes as an ordinary identifier. */
-    private TokenDoc nameList(SyntaxNode clause, int skipIdents) {
+    private TokenDoc nameList(SyntaxNode clause, int skipIdents, Place at) {
+        Place run = places.under(at, SyntaxKind.NAME_LIST, Opening.NONE, Written.of(clause));
         // an entry may name through a module, so the dots of one name are kept and only a comma
         // starts the next
         List<Member> names = new ArrayList<>();
@@ -667,33 +1087,40 @@ public final class Formatter {
             switch (t.kind()) {
                 case IDENT -> current.add(t);
                 case COMMA -> {
-                    names.add(named(clause, current));
+                    names.add(named(run, names.isEmpty(), current));
                     current = new ArrayList<>();
                 }
                 default -> { }   // the dots of one name, and the `constructs` / `depends` keyword
             }
         }
         if (!current.isEmpty()) {
-            names.add(named(clause, current));
+            names.add(named(run, names.isEmpty(), current));
         }
-        return TokenDoc.node(clause.kind(),
-                group(nest(INDENT, separated(withEndComments(clause, names)))));
+        return TokenDoc.at(run, TokenDoc.node(clause.kind(),
+                group(nest(INDENT, separated(withEndComments(run, names))))));
     }
 
-    /** One name of such a clause, held against where its identifiers are. */
-    private Member named(SyntaxNode clause, List<SyntaxToken> idents) {
-        return tokenMember(idents.get(0), idents.get(idents.size() - 1), dottedName(idents));
+    /** One name of such a clause, held against where its identifiers are. The first is written
+     * after the keyword on its line, so nothing opens one for it — which is also why a comment
+     * above it is about the clause and not about the name. */
+    private Member named(Place run, boolean first, List<SyntaxToken> idents) {
+        SyntaxToken from = idents.get(0);
+        SyntaxToken to = idents.get(idents.size() - 1);
+        Place place = places.under(run, from.kind(),
+                first ? Opening.NONE : Opening.breaks(TokenDoc.Break.MAY),
+                new Written.Run(nameStart(from), nameEnd(to)));
+        return tokenMember(place, from, to, dottedName(idents));
     }
 
     /** The {@code : T} a node wrote, or nothing — a helper's return type, a local binding's annotation. */
-    private TokenDoc writtenType(SyntaxNode n) {
+    private TokenDoc writtenType(SyntaxNode n, Place at) {
         return n.child(SyntaxKind.RET_TYPE)
-                .map(rt -> concat(GAP, COLON, GAP, retType(rt))).orElse(TokenDoc.NIL);
+                .map(rt -> concat(GAP, COLON, GAP, retType(rt, at))).orElse(TokenDoc.NIL);
     }
 
     // --- fn ---
 
-    private TokenDoc fnDef(SyntaxNode n) {
+    private TokenDoc fnDef(SyntaxNode n, Place at) {
         String name = firstIdent(n);
         // The modifiers are written back in the order the parser reads them: `private partial let`.
         List<TokenDoc> modifiers = new ArrayList<>();
@@ -709,27 +1136,35 @@ public final class Formatter {
         // is written back with its parameters on the left. A definition with neither is a value, and
         // writes no list at all.
         SyntaxNode lifted = written.isPresent() ? null : liftedLambda(n);
-        TokenDoc params = written.isPresent() ? concat(GAP, fnParamList(written.get()))
-                : lifted == null ? TokenDoc.NIL : concat(GAP, lambdaParams(lifted));
-        TokenDoc head = concat(keyword, ident(name), params, writtenType(n));
+        TokenDoc params = written.isPresent() ? concat(GAP, fnParamList(written.get(), at))
+                : lifted == null ? TokenDoc.NIL : concat(GAP, lambdaParams(lifted, at));
+        TokenDoc head = concat(keyword, ident(name), params, writtenType(n, at));
 
         var intrinsic = n.child(SyntaxKind.INTRINSIC_BODY);
         if (intrinsic.isPresent()) {
             SyntaxToken body = intrinsic.get().token(SyntaxKind.STRING_LIT).orElseThrow();
+            Place ofTheBody = places.under(at, intrinsic.get().kind(),
+                    Opening.breaks(TokenDoc.Break.MAY), Written.of(intrinsic.get()));
             return TokenDoc.node(n.kind(), concat(head, GAP, ASSIGN,
-                    group(nest(INDENT, concat(SOFT_GAP, aboveOf(intrinsic.get()),
-                            TokenDoc.node(intrinsic.get().kind(),
+                    group(nest(INDENT, TokenDoc.at(ofTheBody, concat(TokenDoc.node(intrinsic.get().kind(),
                                     concat(ident("intrinsic"), GAP, token(body))),
-                            afterOf(intrinsic.get()))))));
+                                    TokenDoc.endsTheLineOf(ofTheBody)))))));
         }
         var block = n.child(SyntaxKind.BLOCK_EXPR);
         if (block.isPresent()) {
-            return TokenDoc.node(n.kind(), concat(head, GAP, ASSIGN, GAP, block(block.get())));
+            return TokenDoc.node(n.kind(), concat(head, GAP, ASSIGN, GAP, block(block.get(), at)));
         }
+        // What the canonical form writes after the `=` stands for the source's body where nothing
+        // was lifted, and for the lifted lambda's last expression child where something was. The
+        // parameter list on the left stands for the lambda itself. Both are written down here
+        // because here is where they are known: asked of the source tree afterwards, the answer for
+        // either is the lambda, and the canonical form has a lambda at neither position.
         SyntaxNode body = lifted == null ? onlyExpr(n) : lastExprChild(lifted);
+        Place ofTheBody = places.under(at, body.kind(), Opening.breaks(TokenDoc.Break.MAY),
+                Written.of(body));
         return TokenDoc.node(n.kind(),
                 concat(head, GAP, ASSIGN, group(nest(INDENT,
-                        concat(SOFT_GAP, aboveOf(body), expr(body), afterOf(body))))));
+                        TokenDoc.at(ofTheBody, concat(expr(body, ofTheBody), TokenDoc.endsTheLineOf(ofTheBody)))))));
     }
 
     /** The lambda a parameter-less definition was written as, or null when its body is an ordinary
@@ -783,34 +1218,44 @@ public final class Formatter {
     }
 
     /** A lambda's parameters as a definition's parameter list — always parenthesised, which is the
-     * only shape a definition writes. */
-    private TokenDoc lambdaParams(SyntaxNode lambda) {
+     * only shape a definition writes. The list is a place of its own, and what the source has at it
+     * is the lambda: the parameters moved to the left of the {@code =} and the lambda did not. */
+    private TokenDoc lambdaParams(SyntaxNode lambda, Place under) {
+        Place run = places.under(under, SyntaxKind.FN_PARAM_LIST, Opening.NONE,
+                Written.of(lambda));
         List<Member> params = new ArrayList<>();
         for (SyntaxNode c : lambda.childNodes()) {
             if (isPatternNode(c.kind())) {
-                params.add(member(c, pattern(c)));
+                Place param = memberPlace(run, c);
+                params.add(member(param, c, pattern(c, param)));
             }
         }
-        return delimited(SyntaxKind.FN_PARAM_LIST, LPAREN, withEndComments(lambda, params), RPAREN);
+        return TokenDoc.at(run,
+                delimited(run, SyntaxKind.FN_PARAM_LIST, LPAREN, withEndComments(run, params),
+                        RPAREN));
     }
 
-    private TokenDoc fnParamList(SyntaxNode n) {
+    private TokenDoc fnParamList(SyntaxNode n, Place at) {
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
         List<Member> params = new ArrayList<>();
         for (SyntaxNode p : childNodes(n, SyntaxKind.FN_PARAM)) {
+            Place param = memberPlace(run, p);
             SyntaxNode pat = optionalPatternChild(p);
-            TokenDoc d = pat == null ? ident(firstIdent(p)) : pattern(pat);
+            TokenDoc d = pat == null ? ident(firstIdent(p)) : pattern(pat, param);
             var rt = p.child(SyntaxKind.RET_TYPE);
             if (rt.isPresent()) {
-                d = concat(d, GAP, COLON, GAP, retType(rt.get()));
+                d = concat(d, GAP, COLON, GAP, retType(rt.get(), param));
             }
-            params.add(member(p, TokenDoc.node(p.kind(), d)));
+            params.add(member(param, p, TokenDoc.node(p.kind(), d)));
         }
-        return delimited(SyntaxKind.FN_PARAM_LIST, LPAREN, withEndComments(n, params), RPAREN);
+        return TokenDoc.at(run,
+                delimited(run, SyntaxKind.FN_PARAM_LIST, LPAREN, withEndComments(run, params), RPAREN));
     }
 
     // --- types ---
 
-    private TokenDoc fnType(SyntaxNode n) {
+    private TokenDoc fnType(SyntaxNode n, Place at) {
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
         List<Member> params = new ArrayList<>();
         TokenDoc result = TokenDoc.NIL;
         boolean afterArrow = false;
@@ -819,47 +1264,56 @@ public final class Formatter {
                 afterArrow = true;
             } else if (e instanceof SyntaxNode c && c.kind() == SyntaxKind.RET_TYPE) {
                 if (afterArrow) {
-                    result = concat(aboveOf(c), retType(c), afterOf(c));
+                    // written after the `->` on that line, so nothing opens a line for it
+                    Place ofTheResult = places.under(run, c.kind(), Opening.NONE, Written.of(c));
+                    result = TokenDoc.at(ofTheResult, concat(retType(c, ofTheResult), TokenDoc.endsTheLineOf(ofTheResult)));
                 } else {
-                    params.add(member(c, retType(c)));
+                    Place param = memberPlace(run, c);
+                    params.add(member(param, c, retType(c, param)));
                 }
             }
         }
-        return TokenDoc.node(n.kind(),
-                concat(delimited(SyntaxKind.FN_TYPE, LPAREN, withEndComments(n, params), RPAREN),
+        return TokenDoc.node(n.kind(), concat(TokenDoc.at(run,
+                delimited(run, SyntaxKind.FN_TYPE, LPAREN, withEndComments(run, params), RPAREN)),
                         GAP, ARROW, GAP, result));
     }
 
-    private TokenDoc retType(SyntaxNode n) {
+    private TokenDoc retType(SyntaxNode n, Place at) {
         List<TokenDoc> cases = new ArrayList<>();
-        List<Segment> rest = new ArrayList<>();
+        List<TokenDoc> rest = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             if (!isTypeNode(c.kind())) {
                 continue;
             }
-            TokenDoc body = concat(typeTerm(c), afterOf(c));
-            if (cases.isEmpty()) {
-                cases.add(concat(aboveOf(c), body));
+            boolean first = cases.isEmpty();
+            Place place = first ? headPlace(at, c) : segmentPlace(at, PIPE, c);
+            TokenDoc body = concat(typeTerm(c, place), TokenDoc.endsTheLineOf(place));
+            if (first) {
+                cases.add(TokenDoc.at(place, body));
             } else {
-                rest.add(segment(PIPE, c, typeTerm(c)));
+                rest.add(segment(place, c, typeTerm(c, place)));
             }
         }
         TokenDoc d = cases.isEmpty() ? TokenDoc.NIL
-                : TokenDoc.node(n.kind(), chained(synthetic(cases.get(0)), rest));
+                : TokenDoc.node(n.kind(),
+                        chained(new Member(cases.get(0), TokenDoc.NIL), rest));
         // `T?` in a core signature, the same mark a field carries
         return n.token(SyntaxKind.QUESTION).isPresent()
                 ? TokenDoc.node(n.kind(), concat(d, GAP, QUESTION)) : d;
     }
 
-    private TokenDoc typeRef(SyntaxNode n) {
+    private TokenDoc typeRef(SyntaxNode n, Place at) {
         if (n.kind() == SyntaxKind.TUPLE_TYPE) {
+            Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
             List<Member> elems = new ArrayList<>();
             for (SyntaxNode c : n.childNodes()) {
                 if (isTypeNode(c.kind())) {
-                    elems.add(member(c, typeTerm(c)));
+                    Place elem = memberPlace(run, c);
+                    elems.add(member(elem, c, typeTerm(c, elem)));
                 }
             }
-            return delimited(SyntaxKind.TUPLE_TYPE, LPAREN, withEndComments(n, elems), RPAREN);
+            return TokenDoc.at(run,
+                    delimited(run, SyntaxKind.TUPLE_TYPE, LPAREN, withEndComments(run, elems), RPAREN));
         }
         var typevar = n.token(SyntaxKind.TYPEVAR);
         if (typevar.isPresent()) {
@@ -870,14 +1324,16 @@ public final class Formatter {
         if (args.isEmpty()) {
             return name;
         }
+        Place run = places.under(at, args.get().kind(), Opening.NONE, Written.of(args.get()));
         List<Member> typeArgs = new ArrayList<>();
         for (SyntaxNode c : args.get().childNodes()) {
             if (isTypeNode(c.kind())) {
-                typeArgs.add(member(c, typeTerm(c)));
+                Place arg = memberPlace(run, c);
+                typeArgs.add(member(arg, c, typeTerm(c, arg)));
             }
         }
-        return TokenDoc.node(n.kind(), concat(name, GAP,
-                delimited(SyntaxKind.TYPE_ARGS, LT, withEndComments(args.get(), typeArgs), GT)));
+        return TokenDoc.node(n.kind(), concat(name, GAP, TokenDoc.at(run,
+                delimited(run, SyntaxKind.TYPE_ARGS, LT, withEndComments(run, typeArgs), GT))));
     }
 
     private static boolean isTypeNode(SyntaxKind k) {
@@ -885,38 +1341,56 @@ public final class Formatter {
     }
 
     /** One term of a written type. A function type reads as itself wherever a type goes. */
-    private TokenDoc typeTerm(SyntaxNode n) {
-        return n.kind() == SyntaxKind.FN_TYPE ? fnType(n) : typeRef(n);
+    private TokenDoc typeTerm(SyntaxNode n, Place at) {
+        return n.kind() == SyntaxKind.FN_TYPE ? fnType(n, at) : typeRef(n, at);
     }
 
     // --- expressions ---
 
-    private TokenDoc expr(SyntaxNode n) {
+    /** {@code n} written at {@code at}, which is the place the canonical form has it at. What it
+     *  writes under itself is written at places under that one. */
+    private TokenDoc expr(SyntaxNode n, Place at) {
         return switch (n.kind()) {
             case LITERAL_EXPR -> token(firstMeaningfulToken(n));
             case VAR_EXPR -> ident(firstIdent(n));
             case FIELD_ACCESS -> TokenDoc.node(n.kind(),
-                    concat(expr(firstExprChild(n)), GAP, DOT, GAP, ident(lastIdent(n))));
+                    concat(childAt(at, firstExprChild(n), Opening.NONE), GAP, DOT, GAP,
+                            ident(lastIdent(n))));
             case FIELD_GETTER -> TokenDoc.node(n.kind(), concat(DOT, GAP, ident(lastIdent(n))));
-            case APPLY_EXPR -> apply(n);
-            case BINARY_EXPR -> binary(n);
+            case APPLY_EXPR -> apply(n, at);
+            case BINARY_EXPR -> binary(n, at);
             case UNARY_EXPR -> TokenDoc.node(n.kind(),
-                    concat(TokenDoc.token(SyntaxKind.MINUS, "-"), GAP, expr(onlyExpr(n))));
-            case PIPE_EXPR -> pipe(n);
+                    concat(TokenDoc.token(SyntaxKind.MINUS, "-"), GAP,
+                            childAt(at, onlyExpr(n), Opening.NONE)));
+            case PIPE_EXPR -> pipe(n, at);
             case PAREN_EXPR -> TokenDoc.node(n.kind(),
-                    concat(LPAREN, GAP, expr(onlyExpr(n)), GAP, RPAREN));
-            case TUPLE_EXPR -> delimited(SyntaxKind.TUPLE_EXPR, LPAREN, exprDocs(n), RPAREN);
-            case LIST_EXPR -> list(n);
-            case LIST_COMP -> listComp(n);
-            case IF_EXPR -> ifExpr(n);
-            case MATCH_EXPR -> matchExpr(n);
-            case LAMBDA_EXPR -> lambda(n);
-            case NEW_DATA_EXPR -> newData(n);
-            case BLOCK_EXPR -> block(n);
+                    concat(LPAREN, GAP, childAt(at, onlyExpr(n), Opening.NONE), GAP, RPAREN));
+            case TUPLE_EXPR -> tuple(n, at);
+            case LIST_EXPR -> list(n, at);
+            case LIST_COMP -> listComp(n, at);
+            case IF_EXPR -> ifExpr(n, at);
+            case MATCH_EXPR -> matchExpr(n, at);
+            case LAMBDA_EXPR -> lambda(n, at);
+            case NEW_DATA_EXPR -> newData(n, at);
+            case BLOCK_EXPR -> block(n, at);
             case UNREACHABLE_EXPR -> TokenDoc.node(n.kind(), concat(
-                    TokenDoc.token(SyntaxKind.UNREACHABLE_KW, "unreachable"), GAP, expr(onlyExpr(n))));
+                    TokenDoc.token(SyntaxKind.UNREACHABLE_KW, "unreachable"), GAP,
+                    childAt(at, onlyExpr(n), Opening.NONE)));
             default -> throw new IllegalStateException("no case writes " + n.kind());
         };
+    }
+
+    /**
+     * {@code child} written at a place of its own under {@code at}.
+     *
+     * <p>The place, the boundary that opens the line it is on, and what is written there are one
+     * call. A construct that could write the line without saying which place is on it is one where
+     * the two can come to disagree, which is how a comment came to be filed against a construct the
+     * canonical form does not write.
+     */
+    private TokenDoc childAt(Place at, SyntaxNode child, Opening opening) {
+        Place place = places.under(at, child.kind(), opening, Written.of(child));
+        return TokenDoc.at(place, expr(child, place));
     }
 
     /**
@@ -927,29 +1401,33 @@ public final class Formatter {
      * <p>Printed on the line its callee ends on: an argument list that began the next line would be
      * a parenthesised expression rather than an application.
      */
-    private TokenDoc apply(SyntaxNode n) {
-        return TokenDoc.node(n.kind(), concat(expr(firstExprChild(n)), GAP, arguments(n)));
+    private TokenDoc apply(SyntaxNode n, Place at) {
+        return TokenDoc.node(n.kind(),
+                concat(childAt(at, firstExprChild(n), Opening.NONE), GAP, arguments(n, at)));
     }
 
     /** The bracketed argument list of a call or an application. */
-    private TokenDoc arguments(SyntaxNode n) {
+    private TokenDoc arguments(SyntaxNode n, Place at) {
         List<SyntaxNode> args = n.child(SyntaxKind.ARG_LIST).map(Formatter::exprChildren).orElse(List.of());
         SyntaxNode argList = n.child(SyntaxKind.ARG_LIST).orElse(null);
+        Place run = places.under(at, SyntaxKind.ARG_LIST, Opening.NONE, Written.of(argList));
         if (args.isEmpty()) {
-            List<Member> only = argList == null ? List.of() : withEndComments(argList, List.of());
-            return delimited(SyntaxKind.ARG_LIST, LPAREN, only, RPAREN);
+            List<Member> only = withEndComments(run, List.of());
+            return TokenDoc.at(run, delimited(run, SyntaxKind.ARG_LIST, LPAREN, only, RPAREN));
         }
         List<Member> argDocs = new ArrayList<>();
         for (SyntaxNode a : args) {
-            argDocs.add(member(a, expr(a)));
+            Place arg = memberPlace(run, a);
+            argDocs.add(member(arg, a, expr(a, arg)));
         }
-        return delimited(SyntaxKind.ARG_LIST, LPAREN, withEndComments(argList, argDocs), RPAREN);
+        return TokenDoc.at(run, delimited(run, SyntaxKind.ARG_LIST, LPAREN,
+                withEndComments(run, argDocs), RPAREN));
     }
 
-    private TokenDoc binary(SyntaxNode n) {
-        List<Segment> segs = new ArrayList<>();
-        TokenDoc head = collectChain(n, ladderLevel(operatorKind(n)), segs);
-        return TokenDoc.node(n.kind(), chained(synthetic(head), segs));
+    private TokenDoc binary(SyntaxNode n, Place at) {
+        List<TokenDoc> segs = new ArrayList<>();
+        TokenDoc head = collectChain(n, at, ladderLevel(operatorKind(n)), segs, true);
+        return TokenDoc.node(n.kind(), chained(new Member(head, TokenDoc.NIL), segs));
     }
 
     /**
@@ -962,17 +1440,21 @@ public final class Formatter {
      * parenthesised operand is a structure its author wrote — descending into either would show a
      * run the tree does not have.
      */
-    private TokenDoc collectChain(SyntaxNode n, int level, List<Segment> segs) {
+    private TokenDoc collectChain(SyntaxNode n, Place at, int level, List<TokenDoc> segs,
+            boolean last) {
         List<SyntaxNode> ops = exprChildren(n);
         SyntaxNode left = ops.get(0);
         TokenDoc head;
         if (left.kind() == SyntaxKind.BINARY_EXPR && ladderLevel(operatorKind(left)) == level) {
-            head = collectChain(left, level, segs);
+            head = collectChain(left, at, level, segs, false);
         } else {
-            head = concat(aboveOf(left), expr(left), afterOf(left));
+            Place ofTheLeft = headPlace(at, left);
+            head = TokenDoc.at(ofTheLeft, concat(expr(left, ofTheLeft), TokenDoc.endsTheLineOf(ofTheLeft)));
         }
         SyntaxNode right = ops.get(1);
-        segs.add(segment(token(operatorToken(n)), right, expr(right)));
+        Place ofTheRight = segmentPlace(at, token(operatorToken(n)), right);
+        segs.add(last ? lastOfARun(ofTheRight, expr(right, ofTheRight))
+                : segment(ofTheRight, right, expr(right, ofTheRight)));
         return head;
     }
 
@@ -996,73 +1478,113 @@ public final class Formatter {
         };
     }
 
-    private TokenDoc pipe(SyntaxNode n) {
-        List<Segment> stages = new ArrayList<>();
-        TokenDoc head = collectPipe(n, stages);
-        return TokenDoc.node(n.kind(), chained(synthetic(head), stages));
+    private TokenDoc pipe(SyntaxNode n, Place at) {
+        List<TokenDoc> stages = new ArrayList<>();
+        TokenDoc head = collectPipe(n, at, stages, true);
+        return TokenDoc.node(n.kind(), chained(new Member(head, TokenDoc.NIL), stages));
     }
 
     /** Flattens a left-nested {@code |>} chain: returns the head doc and fills {@code stages} with each
      * right-hand stage in source order. */
-    private TokenDoc collectPipe(SyntaxNode n, List<Segment> stages) {
+    private TokenDoc collectPipe(SyntaxNode n, Place at, List<TokenDoc> stages, boolean last) {
         List<SyntaxNode> ops = exprChildren(n);
         SyntaxNode left = ops.get(0);
         SyntaxNode right = ops.get(1);
         TokenDoc head;
         if (left.kind() == SyntaxKind.PIPE_EXPR) {
-            head = collectPipe(left, stages);
+            head = collectPipe(left, at, stages, false);
         } else {
-            head = concat(aboveOf(left), expr(left), afterOf(left));
+            Place ofTheLeft = headPlace(at, left);
+            head = TokenDoc.at(ofTheLeft, concat(expr(left, ofTheLeft), TokenDoc.endsTheLineOf(ofTheLeft)));
         }
-        stages.add(segment(TokenDoc.token(SyntaxKind.VPIPE, "|>"), right, expr(right)));
+        Place ofTheStage = segmentPlace(at, TokenDoc.token(SyntaxKind.VPIPE, "|>"), right);
+        stages.add(last ? lastOfARun(ofTheStage, expr(right, ofTheStage))
+                : segment(ofTheStage, right, expr(right, ofTheStage)));
         return head;
     }
 
-    private TokenDoc list(SyntaxNode n) {
-        return delimited(SyntaxKind.LIST_EXPR, LBRACKET, exprDocs(n), RBRACKET);
+    private TokenDoc tuple(SyntaxNode n, Place at) {
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
+        return TokenDoc.at(run,
+                delimited(run, SyntaxKind.TUPLE_EXPR, LPAREN, exprDocs(n, run), RPAREN));
     }
 
-    private TokenDoc listComp(SyntaxNode n) {
-        List<Member> exprs = exprDocs(n);
-        Member element = exprs.get(0);
-        List<Member> guards = exprs.subList(1, exprs.size());
+    private TokenDoc list(SyntaxNode n, Place at) {
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
+        return TokenDoc.at(run,
+                delimited(run, SyntaxKind.LIST_EXPR, LBRACKET, exprDocs(n, run), RBRACKET));
+    }
+
+    private TokenDoc listComp(SyntaxNode n, Place at) {
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
+        List<SyntaxNode> children = exprChildren(n);
+        // The element is written after the `[` on its line, so nothing opens one for it; each guard
+        // after the `|` has a line the layout may open.
+        List<Member> parts = new ArrayList<>();
+        for (SyntaxNode c : children) {
+            Place p = parts.isEmpty()
+                    ? places.under(run, c.kind(), Opening.NONE, Written.of(c))
+                    : memberPlace(run, c);
+            parts.add(member(p, c, expr(c, p)));
+        }
+        List<Member> all = withEndComments(run, parts);
+        Member element = all.get(0);
+        List<Member> guards = all.subList(1, all.size());
         // The `|` is the comprehension's and it is on the element's line, so it goes before the
         // comment that ends that line — as a comma does for a member of a list.
-        return TokenDoc.node(n.kind(),
+        return TokenDoc.at(run, TokenDoc.node(n.kind(),
                 group(concat(LBRACKET, GAP, element.doc(), GAP, PIPE, element.trailing(),
-                        nest(INDENT, concat(SOFT_GAP, separated(guards))), SOFT_GAP, RBRACKET)));
+                        nest(INDENT, separated(guards)), SOFT_GAP, RBRACKET))));
     }
 
-    private TokenDoc ifExpr(SyntaxNode n) {
+    /**
+     * Three places, and the kinds do not tell them apart: written {@code if flag then p else q} all
+     * three are a {@code VAR_EXPR}. The condition stands between {@code if} and {@code then} with no
+     * boundary the layout can break, so it opens no line; the two branches each open one.
+     */
+    private TokenDoc ifExpr(SyntaxNode n, Place at) {
         List<SyntaxNode> parts = exprChildren(n);
-        TokenDoc departures = elseArms(n);
+        Place condition = places.under(at, parts.get(0).kind(), Opening.NONE,
+                Written.of(parts.get(0)));
+        Place then = places.under(at, parts.get(1).kind(), Opening.breaks(TokenDoc.Break.MAY),
+                Written.of(parts.get(1)));
+        TokenDoc departures = elseArms(n, at);
         return TokenDoc.node(n.kind(), group(concat(TokenDoc.token(SyntaxKind.IF_KW, "if"), GAP,
-                expr(parts.get(0)), attemptBinder(n), GAP, TokenDoc.token(SyntaxKind.THEN_KW, "then"),
-                nest(INDENT, concat(SOFT_GAP, aboveOf(parts.get(1)), expr(parts.get(1)),
-                        afterOf(parts.get(1)))),
+                TokenDoc.at(condition, expr(parts.get(0), condition)),
+                attemptBinder(n), GAP, TokenDoc.token(SyntaxKind.THEN_KW, "then"),
+                nest(INDENT, TokenDoc.at(then, concat(expr(parts.get(1), then), TokenDoc.endsTheLineOf(then)))),
                 SOFT_GAP, TokenDoc.token(SyntaxKind.ELSE_KW, "else"),
                 departures != TokenDoc.NIL
                         ? departures
-                        : nest(INDENT, concat(SOFT_GAP, aboveOf(parts.get(2)), expr(parts.get(2)),
-                                afterOf(parts.get(2)))))));
+                        : otherwise(n, at, parts.get(2)))));
+    }
+
+    private TokenDoc otherwise(SyntaxNode n, Place at, SyntaxNode part) {
+        Place branch = places.under(at, part.kind(), Opening.breaks(TokenDoc.Break.MAY),
+                Written.of(part));
+        return nest(INDENT, TokenDoc.at(branch, concat(expr(part, branch), TokenDoc.endsTheLineOf(branch))));
     }
 
     /** An attempt's per-clause departures, one to a line under the {@code else}, or nothing where the
      * {@code else} took one expression. */
-    private TokenDoc elseArms(SyntaxNode n) {
+    private TokenDoc elseArms(SyntaxNode n, Place at) {
         var arms = n.child(SyntaxKind.ELSE_ARMS);
         if (arms.isEmpty()) {
             return TokenDoc.NIL;
         }
+        Place run = places.under(at, arms.get().kind(), Opening.NONE, Written.of(arms.get()));
         List<TokenDoc> lines = new ArrayList<>();
-        lines.add(afterToken(n.token(SyntaxKind.ELSE_KW)));
+        lines.add(headerLine(run, n.token(SyntaxKind.ELSE_KW)));
         for (SyntaxNode arm : childNodes(arms.get(), SyntaxKind.ELSE_ARM)) {
-            lines.add(concat(HARD_GAP, aboveOf(arm), TokenDoc.node(arm.kind(),
-                    concat(PIPE, GAP, ident(firstIdent(arm)), GAP, ARROW, GAP, expr(onlyExpr(arm)))),
-                    afterOf(arm)));
+            Place place = places.under(run, arm.kind(), Opening.breaks(TokenDoc.Break.ALWAYS),
+                    Written.of(arm));
+            lines.add(TokenDoc.at(place, concat(TokenDoc.node(arm.kind(),
+                            concat(PIPE, GAP, ident(firstIdent(arm)), GAP, ARROW, GAP,
+                                    childAt(place, onlyExpr(arm), Opening.NONE))),
+                            TokenDoc.endsTheLineOf(place))));
         }
-        lines.add(endOf(arms.get()));
-        return TokenDoc.node(arms.get().kind(), nest(INDENT, concat(lines)));
+        lines.add(TokenDoc.carries(run, Carrier.AT_END));
+        return TokenDoc.at(run, TokenDoc.node(arms.get().kind(), nest(INDENT, concat(lines))));
     }
 
     /** The {@code as x} of an attempted construction, or nothing where none was written. It sits
@@ -1080,16 +1602,21 @@ public final class Formatter {
         return TokenDoc.NIL;
     }
 
-    private TokenDoc matchExpr(SyntaxNode n) {
+    private TokenDoc matchExpr(SyntaxNode n, Place at) {
         SyntaxNode scrutinee = exprChildren(n).get(0);
+        Place ofTheScrutinee = places.under(at, scrutinee.kind(), Opening.NONE,
+                Written.of(scrutinee));
         List<TokenDoc> cases = new ArrayList<>();
         for (SyntaxNode c : childNodes(n, SyntaxKind.MATCH_CASE)) {
-            cases.add(concat(HARD_GAP, concat(aboveOf(c), matchCase(c)), afterOf(c)));
+            Place place = places.under(at, c.kind(), Opening.breaks(TokenDoc.Break.ALWAYS),
+                    Written.of(c));
+            cases.add(TokenDoc.at(place, concat(matchCase(c, place), TokenDoc.endsTheLineOf(place))));
         }
-        cases.add(endOf(n));
-        return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.MATCH_KW, "match"), GAP, expr(scrutinee),
+        cases.add(TokenDoc.carries(at, Carrier.AT_END));
+        return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.MATCH_KW, "match"), GAP,
+                TokenDoc.at(ofTheScrutinee, expr(scrutinee, ofTheScrutinee)),
                 GAP, TokenDoc.token(SyntaxKind.WITH_KW, "with"),
-                afterToken(n.token(SyntaxKind.WITH_KW)), nest(INDENT, concat(cases))));
+                headerLine(at, n.token(SyntaxKind.WITH_KW)), nest(INDENT, concat(cases))));
     }
 
     /** The brackets a construct is written between. One place knows which they are. */
@@ -1108,7 +1635,7 @@ public final class Formatter {
      * formatter joined two tokens itself, and it wrote `Some ( x )` where the `let` opening the same
      * value writes `Some(x)`.
      */
-    private TokenDoc matchCase(SyntaxNode n) {
+    private TokenDoc matchCase(SyntaxNode n, Place at) {
         List<TokenDoc> pattern = new ArrayList<>();
         SyntaxNode body = null;
         SyntaxToken patternEnd = null;
@@ -1131,106 +1658,140 @@ public final class Formatter {
             }
         }
         TokenDoc written = concat(pattern);
-        return concat(PIPE, GAP, TokenDoc.node(n.kind(), chained(patternEnd == null
-                        ? synthetic(written) : head(patternEnd, written),
-                List.of(segment(ARROW, body, expr(body))))));
+        Place ofThePattern = places.under(at, patternEnd == null ? null : patternEnd.kind(),
+                Opening.NONE, patternEnd == null ? Written.NONE
+                        : new Written[] {new Written.Run(patternEnd.start(), patternEnd.end())});
+        Member headMember = patternEnd == null
+                ? new Member(TokenDoc.at(ofThePattern, written), TokenDoc.NIL)
+                : head(ofThePattern, patternEnd, written);
+        Place ofTheBody = segmentPlace(at, ARROW, body);
+        return concat(PIPE, GAP, TokenDoc.node(n.kind(), chained(headMember,
+                List.of(segment(ofTheBody, body, expr(body, ofTheBody))))));
     }
 
-    private TokenDoc lambda(SyntaxNode n) {
+    private TokenDoc lambda(SyntaxNode n, Place at) {
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
+        // `x -> e` keeps its bare parameter, and that one is not written between brackets: nothing
+        // opens a line for it, so its place brings no boundary of its own.
+        boolean bracketed = n.token(SyntaxKind.LPAREN).isPresent();
         List<Member> params = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             if (isPatternNode(c.kind())) {
-                params.add(member(c, pattern(c)));
+                Place param = bracketed ? memberPlace(run, c)
+                        : places.under(run, c.kind(), Opening.NONE, Written.of(c));
+                params.add(member(param, c, pattern(c, param)));
             }
         }
         // `x -> e` keeps its bare parameter; anything parenthesised was written that way
         TokenDoc paramsDoc = n.token(SyntaxKind.LPAREN).isPresent()
-                ? delimited(SyntaxKind.LAMBDA_EXPR, LPAREN, withEndComments(n, params), RPAREN)
+                ? delimited(run, SyntaxKind.LAMBDA_EXPR, LPAREN, withEndComments(run, params), RPAREN)
                 : concat(params.get(0).doc(), params.get(0).trailing());
-        return TokenDoc.node(n.kind(), concat(paramsDoc, GAP, ARROW, GAP, expr(lastExprChild(n))));
+        SyntaxNode body = lastExprChild(n);
+        Place ofTheBody = places.under(at, body.kind(), Opening.NONE, Written.of(body));
+        return TokenDoc.node(n.kind(), concat(TokenDoc.at(run, paramsDoc), GAP, ARROW, GAP,
+                TokenDoc.at(ofTheBody, expr(body, ofTheBody))));
     }
 
-    private TokenDoc newData(SyntaxNode n) {
+    private TokenDoc newData(SyntaxNode n, Place at) {
         String typeName = firstIdent(n);
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
         List<Member> members = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
-            TokenDoc member;
+            if (c.kind() != SyntaxKind.SPREAD_MEMBER && c.kind() != SyntaxKind.FIELD_INIT) {
+                continue;
+            }
+            Place place = memberPlace(run, c);
+            TokenDoc written;
             if (c.kind() == SyntaxKind.SPREAD_MEMBER) {
                 // `...c` or `...c.address`
-                member = TokenDoc.node(c.kind(), concat(
+                written = TokenDoc.node(c.kind(), concat(
                         TokenDoc.token(SyntaxKind.SPREAD, "..."), GAP,
                         dottedName(idents(c))));
-            } else if (c.kind() == SyntaxKind.FIELD_INIT) {
-                var value = firstExprChildOpt(c);
-                member = TokenDoc.node(c.kind(),
-                        value.map(v -> concat(ident(firstIdent(c)), GAP, ASSIGN, GAP, expr(v)))
-                                .orElse(ident(firstIdent(c))));   // shorthand `field`
             } else {
-                continue;
+                var value = firstExprChildOpt(c);
+                written = TokenDoc.node(c.kind(),
+                        value.map(v -> concat(ident(firstIdent(c)), GAP, ASSIGN, GAP,
+                                        childAt(place, v, Opening.NONE)))
+                                .orElse(ident(firstIdent(c))));   // shorthand `field`
             }
             // A member's leading comments come before it, each on its own line. The HARD_GAP forces
             // the enclosing group to break, which is what a literal with a comment in it wants
             // anyway: a `//` on a line the group had collapsed would swallow the rest of it.
-            members.add(member(c, member));
+            members.add(member(place, c, written));
         }
-        return TokenDoc.node(n.kind(), concat(ident(typeName), GAP,
-                delimited(SyntaxKind.NEW_DATA_EXPR, LBRACE, withEndComments(n, members), RBRACE)));
+        return TokenDoc.node(n.kind(), concat(ident(typeName), GAP, TokenDoc.at(run,
+                delimited(run, SyntaxKind.NEW_DATA_EXPR, LBRACE, withEndComments(run, members),
+                        RBRACE))));
     }
 
-    private TokenDoc block(SyntaxNode n) {
+    private TokenDoc block(SyntaxNode n, Place at) {
+        Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
         List<TokenDoc> lines = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
             // A statement inside a block carries its leading comments the same way a top-level item
             // does. Walking only the child nodes dropped them, so a comment explaining a step was
             // lost on the first format.
-            TokenDoc lead = aboveOf(c);
+            Place place = places.under(run, c.kind(), Opening.breaks(TokenDoc.Break.ALWAYS),
+                    Written.of(c));
             TokenDoc d = switch (c.kind()) {
                 case LET_STMT -> TokenDoc.node(c.kind(), concat(TokenDoc.token(SyntaxKind.LET_KW, "let"), GAP, ident(firstIdent(c)),
-                        writtenType(c), GAP, ASSIGN, GAP, expr(onlyExpr(c))));
+                        writtenType(c, place), GAP, ASSIGN, GAP,
+                        childAt(place, onlyExpr(c), Opening.NONE)));
                 case LET_DESTRUCTURE -> TokenDoc.node(c.kind(), concat(TokenDoc.token(SyntaxKind.LET_KW, "let"), GAP,
-                        pattern(patternChild(c)), GAP, ASSIGN, GAP, expr(onlyExpr(c))));
-                case GUARD_STMT -> guardStmt(c);
-                default -> expr(c);   // the result expression
+                        pattern(patternChild(c), place), GAP, ASSIGN, GAP,
+                        childAt(place, onlyExpr(c), Opening.NONE)));
+                case GUARD_STMT -> guardStmt(c, place);
+                default -> expr(c, place);   // the result expression
             };
-            lines.add(concat(HARD_GAP, lead, d, afterOf(c)));
+            lines.add(TokenDoc.at(place, concat(d, TokenDoc.endsTheLineOf(place))));
         }
-        lines.add(endOf(n));
-        return TokenDoc.node(n.kind(), concat(LBRACE, afterToken(n.token(SyntaxKind.LBRACE)),
-                nest(INDENT, concat(lines)), HARD_GAP, RBRACE));
+        lines.add(TokenDoc.carries(run, Carrier.AT_END));
+        return TokenDoc.at(run, TokenDoc.node(n.kind(),
+                concat(LBRACE, headerLine(run, n.token(SyntaxKind.LBRACE)),
+                        nest(INDENT, concat(lines)), HARD_GAP, RBRACE)));
     }
 
     /** A binding pattern, written back as it was: a name, a tuple, a newtype opened by its
      * constructor, or a record's fields. */
-    private TokenDoc pattern(SyntaxNode n) {
+    private TokenDoc pattern(SyntaxNode n, Place at) {
         switch (n.kind()) {
             case PATTERN_NAME -> {
                 return ident(firstIdent(n));
             }
             case PATTERN_TUPLE -> {
+                Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
                 List<Member> elems = new ArrayList<>();
                 for (SyntaxNode c : n.childNodes()) {
                     if (isPatternNode(c.kind())) {
-                        elems.add(member(c, pattern(c)));
+                        Place elem = memberPlace(run, c);
+                        elems.add(member(elem, c, pattern(c, elem)));
                     }
                 }
-                return delimited(SyntaxKind.PATTERN_TUPLE, LPAREN, withEndComments(n, elems), RPAREN);
+                return TokenDoc.at(run, delimited(run, SyntaxKind.PATTERN_TUPLE, LPAREN,
+                        withEndComments(run, elems), RPAREN));
             }
             case PATTERN_CTOR -> {
+                SyntaxNode inner = patternChild(n);
+                Place ofTheInner = places.under(at, inner.kind(), Opening.NONE, Written.of(inner));
                 return TokenDoc.node(n.kind(), concat(qualifiedName(n), GAP, LPAREN, GAP,
-                        pattern(patternChild(n)), GAP, RPAREN));
+                        TokenDoc.at(ofTheInner, pattern(inner, ofTheInner)), GAP, RPAREN));
             }
             case PATTERN_RECORD -> {
+                Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
                 List<Member> fields = new ArrayList<>();
                 for (SyntaxNode f : n.childNodes()) {
                     if (f.kind() != SyntaxKind.PATTERN_FIELD) {
                         continue;
                     }
                     List<SyntaxToken> names = idents(f);
-                    fields.add(member(f, TokenDoc.node(f.kind(), names.size() > 1
-                            ? concat(token(names.get(0)), GAP, ASSIGN, GAP, token(names.get(1)))
-                            : token(names.get(0)))));
+                    fields.add(member(memberPlace(run, f), f, TokenDoc.node(f.kind(),
+                            names.size() > 1
+                                    ? concat(token(names.get(0)), GAP, ASSIGN, GAP,
+                                            token(names.get(1)))
+                                    : token(names.get(0)))));
                 }
-                return delimited(SyntaxKind.PATTERN_RECORD, LBRACE, withEndComments(n, fields), RBRACE);
+                return TokenDoc.at(run, delimited(run, SyntaxKind.PATTERN_RECORD, LBRACE,
+                        withEndComments(run, fields), RBRACE));
             }
             default -> {
                 return ident(firstIdent(n));
@@ -1260,15 +1821,22 @@ public final class Formatter {
         return null;
     }
 
-    private TokenDoc guardStmt(SyntaxNode n) {
+    private TokenDoc guardStmt(SyntaxNode n, Place at) {
         List<SyntaxNode> exprs = exprChildren(n);
-        TokenDoc departures = elseArms(n);
+        Place ofTheTest = places.under(at, exprs.get(0).kind(), Opening.NONE,
+                Written.of(exprs.get(0)));
+        TokenDoc departures = elseArms(n, at);
         if (departures != TokenDoc.NIL) {
-            return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.GUARD_KW, "guard"), GAP, expr(exprs.get(0)),
+            return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.GUARD_KW, "guard"), GAP,
+                    TokenDoc.at(ofTheTest, expr(exprs.get(0), ofTheTest)),
                     attemptBinder(n), GAP, TokenDoc.token(SyntaxKind.ELSE_KW, "else"), departures));
         }
-        return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.GUARD_KW, "guard"), GAP, expr(exprs.get(0)),
-                attemptBinder(n), GAP, TokenDoc.token(SyntaxKind.ELSE_KW, "else"), GAP, expr(exprs.get(1))));
+        Place ofTheDeparture = places.under(at, exprs.get(1).kind(), Opening.NONE,
+                Written.of(exprs.get(1)));
+        return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.GUARD_KW, "guard"), GAP,
+                TokenDoc.at(ofTheTest, expr(exprs.get(0), ofTheTest)),
+                attemptBinder(n), GAP, TokenDoc.token(SyntaxKind.ELSE_KW, "else"), GAP,
+                TokenDoc.at(ofTheDeparture, expr(exprs.get(1), ofTheDeparture))));
     }
 
     // --- comments ---
@@ -1294,14 +1862,15 @@ public final class Formatter {
             Map<SyntaxNode, List<SyntaxToken>> after,
             /** Inside the node, under its last member and before it closes. */
             Map<SyntaxNode, List<SyntaxToken>> atEnd,
-            /** Against a bare token rather than a node — a sum's cases, which are identifiers.
-             * Keyed by where the identifier starts, since a token has no identity of its own. */
-            Map<Integer, List<SyntaxToken>> aboveCase,
-            Map<Integer, List<SyntaxToken>> afterCase) {
+            /** Against a token rather than a node — a name the grammar wrote as identifiers, and a
+             * token in the middle of a construct, which is a line of the canonical form without
+             * being a construct of the source. */
+            Map<SyntaxToken, List<SyntaxToken>> aboveToken,
+            Map<SyntaxToken, List<SyntaxToken>> afterToken) {
 
         static Attachments empty() {
             return new Attachments(new IdentityHashMap<>(), new IdentityHashMap<>(),
-                    new IdentityHashMap<>(), new java.util.HashMap<>(), new java.util.HashMap<>());
+                    new IdentityHashMap<>(), new IdentityHashMap<>(), new IdentityHashMap<>());
         }
     }
 
@@ -1321,7 +1890,8 @@ public final class Formatter {
                 lineEnded |= t.text().indexOf('\n') >= 0;
             } else if (t.kind() == SyntaxKind.LINE_COMMENT) {
                 if (lineEnded) {
-                    above(out, nextCode(all, i), t, file);
+                    Follows follows = nextCode(all, i);
+                    above(out, follows.code(), t, file, follows.pastAConnector());
                 } else {
                     after(out, lastCode(code), t);
                 }
@@ -1362,18 +1932,46 @@ public final class Formatter {
         return isOpeningBracket(t.kind());
     }
 
-    /** The code the comment at {@code i} was written above, or null where the file ends first. */
-    private static SyntaxToken nextCode(List<SyntaxToken> all, int i) {
+    /**
+     * Whether {@code n} is what its brackets hold and nothing more.
+     *
+     * <p>Only then does the opening bracket share its line with the first member: a lambda writes
+     * {@code -> x} after its parameters, so a comment above the {@code (} of {@code (y) -> x} is
+     * above the lambda and not above {@code y}. Read the other way, the comment came back between
+     * the brackets and the parameter was pushed onto a line of its own.
+     */
+    private static boolean isBracketed(SyntaxNode n) {
+        SyntaxToken last = lastCodeTokenOf(n);
+        return last != null && closes(last);
+    }
+
+    /**
+     * The code the comment at {@code i} was written above, or null where the file ends first, and
+     * whether a connector stood between the two.
+     *
+     * <p>A connector joins what follows it to what came before, and the canonical form writes it at
+     * the head of the line what follows is on. So a comment written above it is above the whole of
+     * what follows and not above whatever that opens with — read the other way, a comment above an
+     * example row's {@code : (2)} came back inside the brackets.
+     */
+    private record Follows(SyntaxToken code, boolean pastAConnector) {}
+
+    private static Follows nextCode(List<SyntaxToken> all, int i) {
+        boolean past = false;
         for (int j = i + 1; j < all.size(); j++) {
             SyntaxToken t = all.get(j);
-            // what closes a construct is asked about before what separates its members, because a
-            // type's `>` is both: it is the angle bracket here and the comparison everywhere else
-            if (t.isTrivia() || (separates(t) && !closes(t))) {
+            if (t.isTrivia()) {
                 continue;
             }
-            return t.kind() == SyntaxKind.EOF ? null : t;
+            // what closes a construct is asked about before what separates its members, because a
+            // type's `>` is both: it is the angle bracket here and the comparison everywhere else
+            if (separates(t) && !closes(t)) {
+                past = true;
+                continue;
+            }
+            return new Follows(t.kind() == SyntaxKind.EOF ? null : t, past);
         }
-        return null;
+        return new Follows(null, past);
     }
 
     /** The code a comment was written after. */
@@ -1392,27 +1990,31 @@ public final class Formatter {
      * that construct has anywhere to put it — that is the next question, and answering the two
      * together is what turned a comment about a case into a comment about the declaration.
      */
-    private static void above(Attachments out, SyntaxToken next, SyntaxToken comment, SyntaxNode file) {
-        SyntaxNode begins = next == null ? null : beginningAt(next);
-        // What opens a construct is the construct's, and it shares a line with the first member —
-        // unless a member begins at that bracket itself, as a `fake` row does at its `(`, in which
-        // case the comment is above the member and not above what the member opens with.
-        boolean opensSomethingElse = begins != null && begins.parent() != null
-                && !takesALineOf(begins.parent(), begins);
-        if (next != null && opens(next) && opensSomethingElse) {
+    private static void above(Attachments out, SyntaxToken next, SyntaxToken comment, SyntaxNode file,
+            boolean pastAConnector) {
+        if (next == null) {
+            add(out.atEnd(), file, comment);          // nothing follows: it closes the file
+            return;
+        }
+        // What opens a construct is the construct's, and it shares a line with the first member, so
+        // a comment above the bracket was written above that member and not above the bracket —
+        // unless something larger begins at that bracket, as an example row does at its `(`, in
+        // which case the comment is above that and not above what it opens with. Nor where a
+        // connector stands in front of it: the connector opens the line, and what the comment is
+        // above is everything written on that line.
+        if (!pastAConnector && opens(next) && beginningAt(next) == next.parent()
+                && isBracketed(next.parent())) {
             SyntaxElement first = firstMemberOf(next.parent());
             if (first instanceof SyntaxNode node) {
-                place(out, node, comment, true);
+                add(out.above(), node, comment);
                 return;
             }
             if (first instanceof SyntaxToken token) {
-                out.aboveCase().computeIfAbsent(nameStart(token), _ -> new ArrayList<>()).add(comment);
+                add(out.aboveToken(), token, comment);
                 return;
             }
         }
-        if (next == null) {
-            add(out.atEnd(), file, comment);          // nothing follows: it closes the file
-        } else if (isBareMember(next)) {
+        if (isBareMember(next)) {
             // A clause keyword opens the line its first name is on, the way a bracket does, so a
             // comment above that name is above the clause rather than between the two.
             SyntaxElement first = firstMemberOf(next.parent());
@@ -1420,108 +2022,56 @@ public final class Formatter {
                     && (next.parent().kind() == SyntaxKind.CONSTRUCTS_CLAUSE
                             || next.parent().kind() == SyntaxKind.DEPENDS_CLAUSE);
             if (opensTheClause) {
-                place(out, next.parent(), comment, true);
+                add(out.above(), next.parent(), comment);
             } else {
-                out.aboveCase().computeIfAbsent(nameStart(next), _ -> new ArrayList<>()).add(comment);
+                add(out.aboveToken(), next, comment);
             }
-        } else if (closes(next)) {
-            add(out.atEnd(), next.parent(), comment);
-        } else {
-            place(out, begins, comment, true);
+            return;
         }
+        if (closes(next)) {
+            add(out.atEnd(), next.parent(), comment);
+            return;
+        }
+        add(out.above(), beginningAt(next), comment);
     }
 
     /** What a comment written after {@code code} was written about: the outermost construct that
      * ends there. */
-    private static void after(Attachments out, SyntaxToken code, SyntaxToken comment) {
-        if (code == null) {
+    private static void after(Attachments out, SyntaxToken written, SyntaxToken comment) {
+        if (written == null) {
             return;                                   // a comment with no code before it is above
         }
+        // A name written as several identifiers is one thing, so a comment written inside it was
+        // written after all of it. Read from the identifier it happens to follow, the rest of the
+        // name is still to come and the comment looks like one written in the middle of a construct.
+        SyntaxToken code = lastOfName(written);
         // A bare member is only its own line's owner while something follows it. The last case of a
         // sum ends where the declaration does, and what ends on that line is the declaration.
         // Measured from the end of the whole name, not from the identifier the comment happens to
         // follow: a comment inside `other.mod.Thing` and one after it are about the same member, and
         // the last member of a run ends where the run does, which is the run's line and not its own.
         if (isBareMember(code) && nameEnd(code) != code.parent().end()) {
-            out.afterCase().computeIfAbsent(nameEnd(code), _ -> new ArrayList<>()).add(comment);
+            add(out.afterToken(), code, comment);
             return;
         }
         if (isChainHead(code)) {
-            out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
+            add(out.afterToken(), code, comment);
             return;
         }
-        // Of the constructs ending where the comment is, the outermost one the layout gives a line
-        // to. Outermost because `data D = A | B // c` is about the declaration and not about `B`;
-        // only among those that have a line, because a `with` binding has one even though the row
-        // it is in goes on to its expected value — the comment is itself what ends that line.
-        SyntaxNode slot = slotEndingAt(code);
-        if (slot == null) {
-            // Nothing ends here, so the comment was written in the middle of a construct: it ends
-            // the line that construct is on, which is where the same comment written after that
-            // construct's last token would go. Reading the two the same way is what makes the
-            // answer survive a second formatting.
-            slot = slotOf(endingAt(code));
-        }
-        if (slot == null) {
+        // The outermost construct ending where the comment is. Outermost because
+        // `data D = A | B // c` is about the declaration and not about `B`. Whether that construct
+        // is one the canonical form gives a line to is the next question and not this one's:
+        // answering the two together is what made a comment about a member come back describing
+        // whatever held it.
+        SyntaxNode ends = endingAt(code);
+        if (ends.end() != code.end()) {
+            // Nothing ends here, so the comment was written in the middle of a construct — after a
+            // `data D =`, a `match … with`, a `{`. What it ends is the line that token is on, so it
+            // is held against the token rather than against the construct the token is inside.
+            add(out.afterToken(), code, comment);
             return;
         }
-        // A pipeline's declared output is written after its last stage and on that stage's line, so
-        // the stage is not what ends the line: what ends it is the declaration.
-        boolean moreOfTheLineFollows = slot.parent() != null
-                && slot.parent().kind() == SyntaxKind.PIPE_BEHAVIOR
-                && slot.end() != slot.parent().end();
-        if ((slot.end() != code.end() || moreOfTheLineFollows) && !endsAWrittenLine(code)) {
-            SyntaxToken last = lastCodeTokenOf(moreOfTheLineFollows ? slot.parent() : slot);
-            if (last != null && last.end() != code.end()) {
-                SyntaxNode wider = slotOf(endingAt(last));
-                if (wider != null) {
-                    slot = wider;
-                }
-            }
-        }
-        if (slot.end() != code.end() && endsAWrittenLine(code)) {
-            out.afterCase().computeIfAbsent(code.end(), _ -> new ArrayList<>()).add(comment);
-        } else {
-            add(out.after(), slot, comment);
-        }
-    }
-
-    /**
-     * Files {@code comment} against {@code owner}, or against the nearest construct above it that
-     * the layout gives a line of its own. A construct with no line of its own has nowhere to put a
-     * comment: written there, the rest of that line would be written inside it. So the comment
-     * travels — a comment after the condition of an {@code if} is written at the end of the
-     * declaration that holds the {@code if} — and how far it travels is a fact about the layout
-     * rather than about what the comment was written about.
-     */
-    private static void place(Attachments out, SyntaxNode owner, SyntaxToken comment, boolean above) {
-        SyntaxNode slot = slotOf(owner, above);
-        if (slot != null) {
-            add(above ? out.above() : out.after(), slot, comment);
-        }
-    }
-
-    /**
-     * Whether the layout always ends a line at {@code t}. These are the tokens a construct written
-     * over several lines opens with — the {@code =} of a product block, the {@code with} of a match,
-     * the {@code {} of a block — where the line a comment ends is the construct's first and not its
-     * last. Whether a bracketed construct breaks depends on its width, so its brackets are not here:
-     * a comment there goes to the line the whole construct ends.
-     */
-    private static boolean endsAWrittenLine(SyntaxToken t) {
-        SyntaxNode parent = t.parent();
-        return switch (t.kind()) {
-            case ASSIGN -> parent.kind() == SyntaxKind.DATA_DEF
-                    && parent.child(SyntaxKind.PRODUCT_BODY).isPresent();
-            case WITH_KW -> parent.kind() == SyntaxKind.MATCH_EXPR;
-            case LBRACE -> parent.kind() == SyntaxKind.BLOCK_EXPR;
-            case ELSE_KW -> parent.child(SyntaxKind.ELSE_ARMS).isPresent();
-            case IDENT -> (parent.kind() == SyntaxKind.EXAMPLE_DEF
-                        || parent.kind() == SyntaxKind.FAKE_DEF)
-                    // the target, not the `example` that opens the line with it
-                    && lastIdentOf(parent) != null && lastIdentOf(parent).end() == t.end();
-            default -> false;
-        };
+        add(out.after(), ends, comment);
     }
 
     /** {@code n}'s first child node, whether or not the layout gives it a line. */
@@ -1540,114 +2090,6 @@ public final class Formatter {
             }
         }
         return last;
-    }
-
-    private static SyntaxToken lastIdentOf(SyntaxNode n) {
-        SyntaxToken last = null;
-        for (SyntaxElement e : n.children()) {
-            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.IDENT) {
-                last = t;
-            }
-        }
-        return last;
-    }
-
-    /** The outermost construct ending at {@code code} that the layout gives a line of its own, or
-     * nothing where none of them has one. */
-    private static SyntaxNode slotEndingAt(SyntaxToken code) {
-        SyntaxNode best = null;
-        for (SyntaxNode c = code.parent();
-                c != null && c.parent() != null && c.end() == code.end();
-                c = c.parent()) {
-            // The last part of a run has a line only while the run is inside another one. The last
-            // part of the outermost run ends where the run does, and what the run is inside goes on
-            // writing that line — a condition's `then`, a call's `)`.
-            boolean endsTheOutermostRun = isSpine(c.parent()) && c.end() == c.parent().end()
-                    && !isSpine(c.parent().parent());
-            if (takesALineOf(c.parent(), c) && !endsTheOutermostRun) {
-                best = c;
-            }
-        }
-        return best;
-    }
-
-    /** The construct that owns the line {@code owner} is written on. */
-    /**
-     * Whether {@code child} opens a line of {@code parent} as well as ending one. A construct the
-     * parent writes a prefix in front of — a newtype's body after the {@code =}, a signature's
-     * return type after the {@code ->} — ends the line it is on and does not begin it, since the
-     * prefix is already there. A comment above it goes above the line the prefix opens, which
-     * belongs to whatever wrote the prefix.
-     */
-    private static boolean opensALine(SyntaxNode c) {
-        if (!takesALineOf(c.parent(), c)) {
-            return false;
-        }
-        SyntaxKind parent = c.parent().kind();
-        if (parent == SyntaxKind.DATA_DEF && c.kind() == SyntaxKind.NEWTYPE_BODY) {
-            return false;
-        }
-        if (parent == SyntaxKind.BEHAVIOR_SIG && c.kind() == SyntaxKind.RET_TYPE) {
-            return false;
-        }
-        // The first of a run is written after whatever opens it and the rest after a break, so only
-        // the rest have a line of their own to be written above. The head of a chain is the first of
-        // its run, and so is the first binding of a `with`.
-        return !isFirstOfItsRun(c);
-    }
-
-    /** Whether {@code c} is the first member of a run the layout opens with text of its own rather
-     * than with a break — the left of a chain, an example row's input where no description precedes
-     * it, the first binding after a {@code with}. */
-    private static boolean isFirstOfItsRun(SyntaxNode c) {
-        SyntaxNode parent = c.parent();
-        return switch (parent.kind()) {
-            // the left of a run, which is the run's own left where the run nests: `a |> b |> c` is
-            // read as `(a |> b) |> c`, and the part that opens the line is `a`
-            case BINARY_EXPR, PIPE_EXPR, RET_TYPE, WITH_CLAUSE, LIST_COMP -> firstChildOf(parent) == c;
-            case EXAMPLE_ROW -> c.kind() == SyntaxKind.ARG_LIST
-                    && parent.token(SyntaxKind.STRING_LIT).isEmpty();
-            case FAKE_ROW -> c.kind() == SyntaxKind.ARG_LIST;
-            default -> false;
-        };
-    }
-
-    private static SyntaxNode slotOf(SyntaxNode owner) {
-        return slotOf(owner, false);
-    }
-
-    private static SyntaxNode slotOf(SyntaxNode owner, boolean above) {
-        SyntaxNode from = owner;
-        // A run the layout flattens is written as segments, and a part of the spine ends where its
-        // own segment does rather than where the whole run does. Only inside the run, though: the
-        // last segment of the outermost run is followed by whatever the construct holding it writes
-        // — a `then`, a closing bracket — and a comment there would have that written inside it.
-        while (isSpine(from) && from.parent() != null && from.parent().kind() == from.kind()) {
-            from = lastSegmentOf(from);
-        }
-        for (SyntaxNode c = from; c != null && c.parent() != null; c = c.parent()) {
-            if (above ? opensALine(c) : takesALineOf(c.parent(), c)) {
-                return c;
-            }
-        }
-        return null;
-    }
-
-    /** Whether {@code n} is a run the layout writes as one chain of segments rather than as the
-     * nesting the parser read. */
-    private static boolean isSpine(SyntaxNode n) {
-        return n.kind() == SyntaxKind.PIPE_EXPR || n.kind() == SyntaxKind.BINARY_EXPR;
-    }
-
-    /** The part of a flattened run that is written last — the segment whose line the run ends on. */
-    private static SyntaxNode lastSegmentOf(SyntaxNode n) {
-        List<SyntaxNode> parts = new ArrayList<>();
-        for (SyntaxNode c : n.childNodes()) {
-            if (isExprKind(c.kind())) {
-                parts.add(c);
-            }
-        }
-        return parts.get(parts.size() - 1);
     }
 
     /** The outermost construct beginning at {@code t}. */
@@ -1694,11 +2136,17 @@ public final class Formatter {
     }
 
     private static int nameEnd(SyntaxToken ident) {
+        return lastOfName(ident).end();
+    }
+
+    /** The last identifier of the name {@code ident} is part of, which is {@code ident} itself
+     *  wherever the name is one identifier. */
+    private static SyntaxToken lastOfName(SyntaxToken ident) {
         SyntaxToken at = ident;
         for (SyntaxToken after = nextOfName(at); after != null; after = nextOfName(at)) {
             at = after;
         }
-        return at.end();
+        return at;
     }
 
     private static SyntaxToken previousOfName(SyntaxToken ident) {
@@ -1733,7 +2181,7 @@ public final class Formatter {
         return -1;
     }
 
-    private static void add(Map<SyntaxNode, List<SyntaxToken>> to, SyntaxNode key, SyntaxToken c) {
+    private static <K> void add(Map<K, List<SyntaxToken>> to, K key, SyntaxToken c) {
         to.computeIfAbsent(key, _ -> new ArrayList<>()).add(c);
     }
 
@@ -1741,7 +2189,7 @@ public final class Formatter {
      * Nothing where it has no members: an empty construct's brackets open and close one line. */
     private static SyntaxElement firstMemberOf(SyntaxNode container) {
         for (SyntaxElement e : container.children()) {
-            if (e instanceof SyntaxNode c && takesALineOf(container, c)) {
+            if (e instanceof SyntaxNode c) {
                 return c;
             }
             if (e instanceof SyntaxToken t && isBareMember(t)) {
@@ -1808,9 +2256,6 @@ public final class Formatter {
     /** Whether {@code t} is what closes a construct whose members take a line each — the place a
      * comment written under the last member goes. */
     private static boolean closes(SyntaxToken t) {
-        if (!holdsLines(t.parent().kind())) {
-            return false;
-        }
         // Usually a construct's members run to its own end. A function type and a parenthesised
         // lambda are written as one node whose members stop at a bracket in the middle of it —
         // `(Int, String) -> Bool` — and the layout writes that bracketed run as a construct of its
@@ -1825,230 +2270,54 @@ public final class Formatter {
         };
     }
 
-    /**
-     * The construct whose line {@code t} is on: the nearest one at or above it that the layout gives
-     * a line of its own.
-     */
-    private static SyntaxNode hasALine(SyntaxToken t) {
-        for (SyntaxNode c = t.parent(); c != null && c.parent() != null; c = c.parent()) {
-            if (takesALineOf(c.parent(), c)) {
-                return c;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Whether a {@code child} of {@code parent} is written on a line of its own.
-     *
-     * <p>Asked of the two nodes rather than of their kinds, because for two constructs the kinds do
-     * not answer it. An {@code if} writes three expressions and only the two after the condition open
-     * a line — written {@code if flag then p else q} all three are a {@code VAR_EXPR}. And a
-     * definition written as a lambda has its parameters moved to the left of the {@code =}, so what
-     * the canonical form writes after the {@code =} is that lambda's body rather than the child the
-     * source has there; the child here is not what is written, and a comment about the body is not
-     * this construct's to carry. Filing one against what the canonical form writes needs a canonical
-     * structure to file it against, which is issue #444.
-     */
-    private static boolean takesALineOf(SyntaxNode parent, SyntaxNode child) {
-        java.util.function.Predicate<SyntaxKind> children = linesOf(parent.kind());
-        if (children == null || !children.test(child.kind())) {
-            return false;
-        }
-        return switch (parent.kind()) {
-            case IF_EXPR -> !isTheConditionOf(parent, child);
-            case FN_DEF -> liftedLambda(parent) == null;
-            default -> true;
-        };
-    }
-
-    /** Whether {@code child} is the expression an {@code if} tests, which is the one it writes on
-     * its header line. */
-    private static boolean isTheConditionOf(SyntaxNode ifExpr, SyntaxNode child) {
-        List<SyntaxNode> exprs = exprChildren(ifExpr);
-        return !exprs.isEmpty() && exprs.get(0) == child;
-    }
-
-    /** Whether {@code parent} writes any of its children on lines of their own, so that what closes
-     * it opens a line too. Read from the same table as {@link #takesALineOf}: a construct that holds
-     * lines and a construct whose members can be written above are the same construct, and keeping
-     * two lists of them is how a type argument came to have somewhere to put the comment under it
-     * while nothing put one there. */
-    private static boolean holdsLines(SyntaxKind parent) {
-        return linesOf(parent) != null;
-    }
-
-    /**
-     * Which children of {@code parent} are written on lines of their own, or null where none are.
-     * These are the places a construct is asked for its comments; one added here without being asked
-     * is what counting the comments consumed against the comments the tree holds is there to catch.
-     */
-    private static java.util.function.Predicate<SyntaxKind> linesOf(SyntaxKind parent) {
-        return switch (parent) {
-            case SOURCE_FILE -> Formatter::isTopLevel;
-            case PRODUCT_BODY, NEW_DATA_EXPR ->
-                    k -> k == SyntaxKind.FIELD || k == SyntaxKind.FIELD_INIT
-                            || k == SyntaxKind.SPREAD_MEMBER;
-            case MATCH_EXPR -> k -> k == SyntaxKind.MATCH_CASE;
-            case MATCH_CASE -> Formatter::isExprKind;
-            case EXAMPLE_ROW, FAKE_ROW -> k -> k == SyntaxKind.ARG_LIST || isExprKind(k);
-            case EXAMPLE_DEF -> k -> k == SyntaxKind.EXAMPLE_ROW;
-            case FAKE_DEF -> k -> k == SyntaxKind.FAKE_ROW;
-            case EXPOSING_CLAUSE -> k -> k == SyntaxKind.EXPOSED_ENTRY;
-            case PARAM_LIST -> k -> k == SyntaxKind.PARAM;
-            case FN_PARAM_LIST -> k -> k == SyntaxKind.FN_PARAM;
-            case WITH_CLAUSE -> k -> k == SyntaxKind.WITH_BINDING;
-            case ELSE_ARMS -> k -> k == SyntaxKind.ELSE_ARM;
-            case PIPE_BEHAVIOR -> k -> k == SyntaxKind.STAGE;
-            case DATA_DEF -> k -> k == SyntaxKind.INVARIANT_CLAUSE
-                    || k == SyntaxKind.NEWTYPE_BODY;
-            case BEHAVIOR_SIG -> k -> k == SyntaxKind.CONSTRUCTS_CLAUSE
-                    || k == SyntaxKind.DEPENDS_CLAUSE || k == SyntaxKind.RET_TYPE;
-            case RET_TYPE, TYPE_ARGS, TUPLE_TYPE -> Formatter::isTypeNode;
-            case FN_TYPE -> k -> k == SyntaxKind.RET_TYPE;
-            case LAMBDA_EXPR, PATTERN_TUPLE -> Formatter::isPatternNode;
-            case PATTERN_RECORD -> k -> k == SyntaxKind.PATTERN_FIELD;
-            case BINARY_EXPR -> k -> isExprKind(k) && k != SyntaxKind.BINARY_EXPR;
-            case BLOCK_EXPR -> _ -> true;
-            case ARG_LIST, LIST_EXPR, TUPLE_EXPR, LIST_COMP -> Formatter::isExprKind;
-            case PIPE_EXPR -> k -> isExprKind(k) && k != SyntaxKind.PIPE_EXPR;
-            case FN_DEF -> k -> k == SyntaxKind.INTRINSIC_BODY
-                    || isExprKind(k) && k != SyntaxKind.BLOCK_EXPR;
-            case IF_EXPR -> Formatter::isExprKind;
-            default -> null;
-        };
-    }
-
     // --- writing them back ---
 
-    /** {@code run} as documents, each marked consumed as it is taken. A comment is taken once. */
-    private List<TokenDoc> unwritten(List<SyntaxToken> run) {
+    /**
+     * The comments {@code place} carries in that direction.
+     *
+     * <p>Asked once every place exists, and answered here and nowhere else. The construction leaves
+     * a slot; which comments go in it is read from the source elements the place was written from,
+     * which the construction recorded rather than the source tree being asked a second time.
+     */
+    private List<TokenDoc> heldAt(Place place, Carrier which) {
         List<TokenDoc> out = new ArrayList<>();
-        for (SyntaxToken c : run) {
-            if (consumedComments.add(c.start())) {
-                out.add(TokenDoc.comment(c.text().stripTrailing()));
-            }
-        }
+        take(out, assigned.getOrDefault(place, Map.of()).getOrDefault(which, List.of()), which);
         return out;
     }
 
-    /** The comments written above {@code n}, each on its own line in front of it. The
-     * {@link TokenDoc#HARD_GAP} after each forces the enclosing group to break: a {@code //} on a line the
-     * group had collapsed would swallow everything after it. */
-    private TokenDoc aboveOf(SyntaxNode n) {
-        List<TokenDoc> parts = new ArrayList<>();
-        for (TokenDoc c : unwritten(comments.above().getOrDefault(n, List.of()))) {
-            parts.add(concat(c, HARD_GAP));
-        }
-        return concat(parts);
-    }
-
-    /** The comment written at the end of {@code n}'s line. */
-    private TokenDoc afterOf(SyntaxNode n) {
-        List<TokenDoc> parts = new ArrayList<>();
-        for (SyntaxToken c : comments.after().getOrDefault(n, List.of())) {
-            if (consumedComments.add(c.start())) {
-                parts.add(TokenDoc.trailing(c.text().stripTrailing()));
+    private void take(List<TokenDoc> out, List<SyntaxToken> run, Carrier which) {
+        for (SyntaxToken t : run) {
+            if (consumedComments.add(t.start())) {
+                out.add(which == Carrier.TRAILING
+                        ? TokenDoc.trailing(t.text().stripTrailing())
+                        : TokenDoc.comment(t.text().stripTrailing()));
             }
         }
-        return concat(parts);
-    }
-
-    /** The comments written inside {@code n} under its last member, each opening a line. */
-    private TokenDoc endOf(SyntaxNode n) {
-        List<TokenDoc> parts = new ArrayList<>();
-        for (TokenDoc c : endLines(n)) {
-            parts.add(concat(HARD_GAP, c));
-        }
-        return concat(parts);
-    }
-
-    private List<TokenDoc> endLines(SyntaxNode n) {
-        return unwritten(comments.atEnd().getOrDefault(n, List.of()));
-    }
-
-    /** The comments written above a sum's case, which is an identifier and not a node. */
-    private List<TokenDoc> aboveCase(SyntaxToken ident) {
-        return unwritten(comments.aboveCase().getOrDefault(ident.start(), List.of()));
-    }
-
-    /** The comment written at the end of a sum case's line. */
-    private TokenDoc afterCase(SyntaxToken ident) {
-        List<TokenDoc> parts = new ArrayList<>();
-        for (SyntaxToken c : comments.afterCase().getOrDefault(ident.end(), List.of())) {
-            if (consumedComments.add(c.start())) {
-                parts.add(TokenDoc.trailing(c.text().stripTrailing()));
-            }
-        }
-        return concat(parts);
-    }
-
-    /** The comment written at the end of the line {@code t} ends, where that is a line inside a
-     * construct rather than the construct's own last line. */
-    private TokenDoc afterToken(java.util.Optional<SyntaxToken> t) {
-        return t.map(this::afterToken).orElse(TokenDoc.NIL);
-    }
-
-    private TokenDoc afterToken(SyntaxToken t, boolean present) {
-        return present ? afterToken(t) : TokenDoc.NIL;
-    }
-
-    private TokenDoc afterToken(SyntaxToken t) {
-        List<TokenDoc> parts = new ArrayList<>();
-        for (SyntaxToken c : comments.afterCase().getOrDefault(t.end(), List.of())) {
-            if (consumedComments.add(c.start())) {
-                parts.add(TokenDoc.trailing(c.text().stripTrailing()));
-            }
-        }
-        return concat(parts);
     }
 
     /** A member the grammar wrote as an identifier: the same shape as one written as a node, held
      * against where the identifier is. */
-    private Member tokenMember(SyntaxToken above, SyntaxToken end, TokenDoc d) {
-        List<TokenDoc> lead = new ArrayList<>();
-        for (TokenDoc c : unwritten(comments.aboveCase().getOrDefault(nameStart(above), List.of()))) {
-            lead.add(concat(c, HARD_GAP));
-        }
-        List<TokenDoc> parts = new ArrayList<>();
-        for (SyntaxToken c : comments.afterCase().getOrDefault(nameEnd(end), List.of())) {
-            if (consumedComments.add(c.start())) {
-                parts.add(TokenDoc.trailing(c.text().stripTrailing()));
-            }
-        }
-        return new Member(concat(concat(lead), d), concat(parts));
+    private Member tokenMember(Place place, SyntaxToken above, SyntaxToken end, TokenDoc d) {
+        return new Member(TokenDoc.at(place, d), TokenDoc.endsTheLineOf(place));
     }
 
-    /** A member: what is written above its line, the member, and what ends that line — the last kept
-     * apart because whatever the enclosing construct writes between this member and the next belongs
-     * on this line, before the comment. */
-    private Member member(SyntaxNode node, TokenDoc d) {
-        return new Member(concat(aboveOf(node), d), afterOf(node));
-    }
-
-    /** {@code members} of {@code parent} with the comments written under the last of them. A
-     * construct with no members at all still has somewhere to put them: between its brackets, which
-     * is where they were written. */
-    private List<Member> withEndComments(SyntaxNode parent, List<Member> members) {
-        List<TokenDoc> end = endLines(parent);
-        if (end.isEmpty()) {
+    /**
+     * {@code members} of a run, with room under the last of them for the comments written inside
+     * the run and below everything it holds.
+     *
+     * <p>They go after that member's own trailing comment, since the line they are under is the one
+     * that member ends. A run with no members at all is a different shape and not this one's — see
+     * {@link TokenDoc.Vacant}.
+     */
+    private List<Member> withEndComments(Place run, List<Member> members) {
+        if (members.isEmpty()) {
             return members;
         }
-        List<TokenDoc> lines = new ArrayList<>();
-        for (TokenDoc c : end) {
-            lines.add(concat(HARD_GAP, c));
-        }
         List<Member> out = new ArrayList<>(members);
-        if (out.isEmpty()) {
-            // a construct with no members still has between its brackets, which is where they were
-            // written; the comments stand where a member would have, so they bring no line of their
-            // own — the brackets already open and close one
-            out.add(new Member(concat(TokenDoc.MUST_BREAK, TokenDoc.join(HARD_GAP, end)), TokenDoc.NIL));
-            return out;
-        }
         Member last = out.get(out.size() - 1);
-        out.set(out.size() - 1,
-                new Member(concat(last.doc(), last.trailing(), concat(lines)), TokenDoc.NIL));
+        out.set(out.size() - 1, new Member(
+                concat(last.doc(), last.trailing(), TokenDoc.carries(run, Carrier.AT_END)),
+                TokenDoc.NIL));
         return out;
     }
 
@@ -2102,12 +2371,13 @@ public final class Formatter {
         return concat(parts);
     }
 
-    private List<Member> exprDocs(SyntaxNode n) {
+    private List<Member> exprDocs(SyntaxNode n, Place run) {
         List<Member> out = new ArrayList<>();
         for (SyntaxNode c : exprChildren(n)) {
-            out.add(member(c, expr(c)));
+            Place at = memberPlace(run, c);
+            out.add(member(at, c, expr(c, at)));
         }
-        return withEndComments(n, out);
+        return withEndComments(run, out);
     }
 
     private static List<SyntaxNode> exprChildren(SyntaxNode n) {
@@ -2185,10 +2455,6 @@ public final class Formatter {
             }
         }
         return last;
-    }
-
-    private String operatorText(SyntaxNode n) {
-        return operatorToken(n).text();
     }
 
     private SyntaxKind operatorKind(SyntaxNode n) {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -144,12 +144,14 @@ public final class Formatter {
      * body, so text is not enough to say which place owns one.
      */
     record Construction(TokenDoc doc, Correspondence places,
-            Map<Place, Map<Carrier, List<SyntaxToken>>> carriers) {}
+            Map<Place, Map<Carrier, List<SyntaxToken>>> carriers, Map<Place, Integer> order) {}
 
     static Construction build(SyntaxNode file) {
         Formatter formatter = new Formatter();
         TokenDoc doc = formatter.file(file);
-        return new Construction(formatter.resolved(doc), formatter.places, formatter.assigned);
+        Map<Place, Integer> order = Place.orderedIn(doc);
+        return new Construction(formatter.resolved(doc), formatter.places, formatter.assigned,
+                order);
     }
 
     /** {@code doc} with the comments in it. The one place a carrier is answered. */
@@ -186,12 +188,14 @@ public final class Formatter {
         // a line the canonical form opens a construct with goes to that line and not to wherever the
         // construct ends.
         for (var e : comments.aboveToken().entrySet()) {
-            file(out, declared, tokenPlaces(e.getKey(), Carrier.ABOVE, declared), Carrier.ABOVE,
-                    e.getValue());
+            file(out, declared,
+                    namePlaces(e.getKey(), e.getValue(), Carrier.ABOVE, declared),
+                    Carrier.ABOVE, e.getValue().comments());
         }
         for (var e : comments.afterToken().entrySet()) {
-            file(out, declared, tokenPlaces(e.getKey(), Carrier.TRAILING, declared),
-                    Carrier.TRAILING, e.getValue());
+            file(out, declared,
+                    namePlaces(e.getKey(), e.getValue(), Carrier.TRAILING, declared),
+                    Carrier.TRAILING, e.getValue().comments());
         }
         for (var e : comments.above().entrySet()) {
             file(out, declared, entryPlaces(e.getKey(), Carrier.ABOVE), Carrier.ABOVE, e.getValue());
@@ -212,56 +216,51 @@ public final class Formatter {
     }
 
     /**
-     * The places a comment held against a token reaches.
+     * The places a comment held against a name reaches.
      *
-     * <p>A token is a place of the canonical form wherever the canonical form writes it as one: the
-     * name a sum's case is written from, the {@code =} a declaration's first line ends with. That is
-     * asked of the correspondence by the run the token is part of, since a name written as several
-     * identifiers is one thing and a comment anywhere in it is about all of it.
-     *
-     * <p>Where the canonical form writes no place for it, the token is in the middle of a construct
-     * — a {@code module}, an {@code exposing}, a bracket — and what a comment there ends is the line
-     * that construct is on. So the question is asked again of the construct, which is a source
-     * element and reaches the places the ordinary way.
+     * <p>A name is a place of the canonical form wherever the canonical form writes it as one: the
+     * name a sum's case is written from, the {@code =} a declaration's first line ends with. Where
+     * it writes no place for it, the name is in the middle of a construct — a {@code module}, an
+     * {@code exposing}, a bracket — and the construction said which construct that is, so this asks
+     * that construct and not the source tree.
      */
-    private List<Place> tokenPlaces(SyntaxToken t, Carrier which,
+    private List<Place> namePlaces(Written name, Attachments.OnAName held, Carrier which,
             Map<Place, java.util.EnumSet<Carrier>> declared) {
-        List<Place> written = places.placesOf(new Written.Run(nameStart(t), nameEnd(t)));
+        List<Place> written = places.placesOf(name);
         if (!written.isEmpty()) {
             return written;
         }
         return which == Carrier.ABOVE
-                ? entryPlaces(beginningAt(t), Carrier.ABOVE)
-                : endsTheLine(endingAt(t), t.end(), declared);
+                ? entryPlaces(held.inside(), Carrier.ABOVE)
+                : endsTheLine(held.inside(), name.end(), declared);
     }
 
     /**
-     * The places a source construct was written at, or where the canonical form writes nothing for
-     * it, the nearest places that stand at the end of it — or the start, for a comment written
-     * above.
+     * The places a source construct was written at.
      *
-     * <p>A run the source wrote nested is written flat, so {@code 1 |> b} of {@code 1 |> b |> c} is
-     * not a construct the canonical form has: what it has at the end of it is the {@code b} stage,
-     * and that is what a comment written after {@code 1 |> b} is at the end of the line of.
+     * <p>Every construct has an answer and the construction gave it. One the canonical form writes
+     * a place for is written at that place; one it writes inside another construct's line is
+     * written at that construct's place; and a run the canonical form flattens — {@code 1 |> b} of
+     * {@code 1 |> b |> c} — opens at the head place and ends at the stage place its own right
+     * operand is written at, which is what a comment written after it is at the end of the line of.
      *
-     * <p>This is the whole of the walk over the source tree. Past here the walk is over the places,
-     * and the two are kept apart so that the second cannot start answering with the first.
+     * <p>Nothing here walks the source tree. Which canonical place a construct the canonical form
+     * has no construct for contributed to is a fact the construction knew and recorded; worked out
+     * afterwards from the shape of the source it is a guess, and it was one — the first or last
+     * child of whatever held it, which is neither of the two ends of a flattened run.
      */
     private List<Place> entryPlaces(SyntaxNode node, Carrier which) {
-        for (SyntaxNode c = node; c != null; c = c.parent()) {
-            List<Place> found = places.placesOf(new Written.Construct(c));
-            if (!found.isEmpty()) {
-                return found;
-            }
-            SyntaxNode edge = which == Carrier.ABOVE ? firstChildOf(c) : lastChildOf(c);
-            if (edge != null) {
-                List<Place> atTheEdge = places.placesOf(new Written.Construct(edge));
-                if (!atTheEdge.isEmpty()) {
-                    return atTheEdge;
-                }
-            }
+        List<Place> written = places.placesOf(new Written.Construct(node));
+        if (!written.isEmpty()) {
+            return written;
         }
-        return List.of();
+        Correspondence.Span span = places.spanOf(node);
+        if (span == null) {
+            throw new IllegalStateException("the construction recorded no place for " + node.kind()
+                    + " at " + node.start() + ".." + node.end()
+                    + "; every construct it writes is written somewhere");
+        }
+        return List.of(which == Carrier.ABOVE ? span.from() : span.to());
     }
 
     /**
@@ -270,60 +269,60 @@ public final class Formatter {
      *
      * <p>Where the place that would take it goes on past {@code wrote}, the comment was written in
      * the middle of that place and not at the end of its line: what it ends is the line that place
-     * is on, so the question is asked again of what the place ends inside. A comment after the
-     * condition of an {@code if} is written at the end of the declaration that holds the {@code if},
-     * and this is why.
+     * is on, so the question is asked again of the place that one is written under. A comment after
+     * the condition of an {@code if} is written at the end of the declaration that holds the
+     * {@code if}, and this is why.
      *
      * <p>Where the comment was written is carried separately from the construct it was written in,
-     * because the two are not the same offset for a comment written in the middle of one: an anchor
-     * that ends past the comment would say the first place asked already ends the line, and the
-     * comment would stay inside a construct whose line runs on after it.
+     * because for a comment in the middle of one the two are not the same offset: an anchor that
+     * ends past the comment would say the first place asked already ends the line.
+     *
+     * <p>The widening is over the places. It used to read the place's source elements, find what
+     * the source has ending there and ask the source tree again, which is the round trip between
+     * the two structures that having places is meant to end.
      */
     private List<Place> endsTheLine(SyntaxNode anchor, int wrote,
             Map<Place, java.util.EnumSet<Carrier>> declared) {
-        SyntaxNode at = anchor;
+        List<Place> entries = entryPlaces(anchor, Carrier.TRAILING);
+        Place carrier = null;
+        for (Place entry : entries) {
+            Place found = nearestCarrier(entry, Carrier.TRAILING, declared);
+            if (found != null && (carrier == null || isAncestorOf(carrier, found))) {
+                carrier = found;
+            }
+        }
         int pos = wrote;
-        for (int widened = 0; widened < 16; widened++) {
-            List<Place> entries = entryPlaces(at, Carrier.TRAILING);
-            Place carrier = null;
-            for (Place entry : entries) {
-                Place found = nearestCarrier(entry, Carrier.TRAILING, declared);
-                if (found != null && (carrier == null || isAncestorOf(carrier, found))) {
-                    carrier = found;
+        while (carrier != null) {
+            int ends = endsAt(carrier);
+            if (ends <= pos) {
+                break;                        // its line ends where the comment was written
+            }
+            // The comment is inside this place, so what it ends is the line this place is on, and
+            // that line runs to the end of the outermost place ending where this one does.
+            Place outer = carrier;
+            for (Place p = carrier.parent(); p != null && endsAt(p) == ends; p = p.parent()) {
+                Place found = nearestCarrier(p, Carrier.TRAILING, declared);
+                if (found != null && endsAt(found) == ends) {
+                    outer = found;
                 }
             }
-            if (carrier == null) {
-                return entries;
+            pos = ends;
+            if (outer == carrier) {
+                break;                        // nothing wider ends here to hand it to
             }
-            SyntaxNode ends = endOfPlace(carrier);
-            if (ends == null || ends.end() <= pos) {
-                return entries;
-            }
-            at = ends;
-            pos = ends.end();
+            carrier = outer;
         }
-        return entryPlaces(at, Carrier.TRAILING);
+        return carrier == null ? entries : List.of(carrier);
     }
 
-    /** The source construct a place ends at, or null where the canonical form writes it from
-     *  nothing the source has. */
-    private SyntaxNode endOfPlace(Place place) {
-        SyntaxNode last = null;
+    /** Where what {@code place} is written from ends, or the start of the file where the canonical
+     *  form writes it from nothing the source has. */
+    private int endsAt(Place place) {
+        int end = 0;
         for (Written w : places.sourcesOf(place)) {
-            if (w instanceof Written.Construct c && (last == null || c.node().end() > last.end())) {
-                last = c.node();
-            }
+            end = Math.max(end, w.end());
         }
-        return last == null ? null : endingAt(lastCodeTokenOf(last));
-    }
-
-    /** {@code n}'s last child node, whether or not the layout gives it a line. */
-    private static SyntaxNode lastChildOf(SyntaxNode n) {
-        SyntaxNode last = null;
-        for (SyntaxNode c : n.childNodes()) {
-            last = c;
-        }
-        return last;
+        return end;
     }
 
     private void file(Map<Place, Map<Carrier, List<SyntaxToken>>> out,
@@ -402,16 +401,6 @@ public final class Formatter {
             }
         }
         return null;
-    }
-
-    /**
-     * The places {@code file} is written at, and what the source had at each. For a check that has
-     * to see the structure the canonical form has rather than the one the source had — the two are
-     * not the same tree, and where they differ is where asking the source a second time answers
-     * about a construct the canonical form does not write.
-     */
-    static Correspondence placesOf(SyntaxNode file) {
-        return build(file).places();
     }
 
     /**
@@ -621,8 +610,7 @@ public final class Formatter {
             // the item's; the first item's line is opened by the start of the file. The blank line
             // between two of them separates them and belongs to neither, so it stays here.
             Place at = places.under(ofTheFile, item.kind(),
-                    prev == null ? new Opening.ByOpener(TokenDoc.NIL)
-                            : Opening.breaks(TokenDoc.Break.ALWAYS),
+                    prev == null ? Opening.FILE_BEGINS : Opening.breaks(TokenDoc.Break.ALWAYS),
                     Written.of(item));
             if (prev != null && blankBetween(prev, item.kind())) {
                 parts.add(HARD_GAP);
@@ -654,13 +642,14 @@ public final class Formatter {
     }
 
     private TokenDoc item(SyntaxNode n, Place at) {
+        places.within(n, at);
         return switch (n.kind()) {
             case MODULE_HEADER -> moduleHeader(n, at);
             case IMPORT_DECL -> importDecl(n, at);
             case DATA_DEF -> dataDef(n, at);
             case BEHAVIOR_DEF -> behaviorDef(n, at);
             case FN_DEF -> fnDef(n, at);
-            case EXAMPLES_FILE_HEADER -> examplesFileHeader(n);
+            case EXAMPLES_FILE_HEADER -> examplesFileHeader(n, at);
             case EXAMPLE_DEF -> exampleDef(n, at);
             case FAKE_DEF -> fakeDef(n, at);
             default -> throw new IllegalStateException("no case writes " + n.kind());
@@ -669,9 +658,9 @@ public final class Formatter {
 
     // --- example ---
 
-    private TokenDoc examplesFileHeader(SyntaxNode n) {
+    private TokenDoc examplesFileHeader(SyntaxNode n, Place at) {
         return TokenDoc.node(n.kind(), concat(ident("examples"), GAP, ident("for"), GAP,
-                qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow())));
+                qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow(), at)));
     }
 
     private TokenDoc exampleDef(SyntaxNode n, Place at) {
@@ -788,7 +777,7 @@ public final class Formatter {
 
     private TokenDoc moduleHeader(SyntaxNode n, Place at) {
         TokenDoc d = concat(TokenDoc.token(SyntaxKind.MODULE_KW, "module"), GAP,
-                qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow()));
+                qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow(), at));
         return TokenDoc.node(n.kind(), n.child(SyntaxKind.EXPOSING_CLAUSE)
                 .map(c -> concat(d, GAP, exposing(c, at)))
                 .orElse(d));
@@ -799,7 +788,7 @@ public final class Formatter {
         List<Member> entries = new ArrayList<>();
         for (SyntaxNode e : childNodes(clause, SyntaxKind.EXPOSED_ENTRY)) {
             Place entry = memberPlace(run, e);
-            TokenDoc name = qualifiedName(e.child(SyntaxKind.QUALIFIED_NAME).orElseThrow());
+            TokenDoc name = qualifiedName(e.child(SyntaxKind.QUALIFIED_NAME).orElseThrow(), entry);
             entries.add(member(entry, e, TokenDoc.node(e.kind(), e.child(SyntaxKind.RET_TYPE)
                     .map(rt -> concat(name, GAP, COLON, GAP, retType(rt, entry)))
                     .orElse(name))));
@@ -811,7 +800,7 @@ public final class Formatter {
 
     private TokenDoc importDecl(SyntaxNode n, Place at) {
         TokenDoc d = concat(TokenDoc.token(SyntaxKind.IMPORT_KW, "import"), GAP,
-                qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow()));
+                qualifiedName(n.child(SyntaxKind.QUALIFIED_NAME).orElseThrow(), at));
         Optional<SyntaxNode> alias = n.child(SyntaxKind.IMPORT_ALIAS);
         if (alias.isPresent()) {
             d = concat(d, GAP, TokenDoc.node(alias.get().kind(),
@@ -862,8 +851,7 @@ public final class Formatter {
             }
             return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP, ASSIGN,
                     headerLine(at, n.token(SyntaxKind.ASSIGN)),
-                    nest(INDENT, concat(concat(HARD_GAP, productBody(product.get(), at)),
-                            concat(invariants)))));
+                    nest(INDENT, concat(productBody(product.get(), at), concat(invariants)))));
         }
         var sum = n.child(SyntaxKind.SUM_BODY);
         if (sum.isPresent()) {
@@ -875,10 +863,11 @@ public final class Formatter {
             // a line, and the line it moves to is the union's own. Which shape the union is written
             // in is not where the comment goes — it is what the source has above that case, which
             // the token stream has already said.
-            boolean movesDown = !comments.aboveToken()
-                    .getOrDefault(firstCaseOf(sum.get()), List.of()).isEmpty();
+            SyntaxToken firstCase = firstCaseOf(sum.get());
+            boolean movesDown = firstCase != null && comments.aboveToken()
+                    .containsKey(new Written.Run(nameStart(firstCase), nameEnd(firstCase)));
             Place chainAt = places.under(at, sum.get().kind(),
-                    movesDown ? new Opening.ByOpener(TokenDoc.NIL) : Opening.NONE,
+                    movesDown ? Opening.breaks(TokenDoc.Break.ALWAYS) : Opening.NONE,
                     Written.of(sum.get()));
             TokenDoc head = null;
             List<TokenDoc> cases = new ArrayList<>();
@@ -901,7 +890,7 @@ public final class Formatter {
                 return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP, ASSIGN, GAP, chain));
             }
             return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.DATA_KW, "data"), GAP, ident(name), GAP, ASSIGN,
-                    nest(INDENT, concat(HARD_GAP, chain))));
+                    nest(INDENT, chain)));
         }
         var newtype = n.child(SyntaxKind.NEWTYPE_BODY);
         if (newtype.isPresent()) {
@@ -942,7 +931,7 @@ public final class Formatter {
             // block's indent rather than after the comma the rest of the block is written with.
             boolean first = lines.isEmpty();
             Place place = places.under(run, m.kind(),
-                    first ? new Opening.ByOpener(LBRACE)
+                    first ? new Opening.Breaks(TokenDoc.Break.ALWAYS, LBRACE)
                             : new Opening.Breaks(TokenDoc.Break.ALWAYS, COMMA),
                     Written.of(m));
             TokenDoc written = m.kind() == SyntaxKind.FIELD
@@ -956,7 +945,7 @@ public final class Formatter {
             // No member wrote the opening brace, so the block writes it on a line of its own. This
             // is the body that holds only comments: `dataDef` writes a body holding nothing at all
             // as `{}` and never reaches here.
-            lines.add(LBRACE);
+            lines.add(concat(HARD_GAP, LBRACE));
         }
         lines.add(TokenDoc.carries(run, Carrier.AT_END));
         lines.add(concat(HARD_GAP, RBRACE));
@@ -1041,7 +1030,7 @@ public final class Formatter {
             // stage is not what ends the line and carries nothing there: what ends it is the
             // declaration, whose own place is outside the group this run is laid out in.
             boolean last = i == stages.size() - 1;
-            parts.add(TokenDoc.at(ofTheStage, concat(stage(st),
+            parts.add(TokenDoc.at(ofTheStage, concat(stage(st, ofTheStage),
                     last ? declaredOut : TokenDoc.endsTheLineOf(ofTheStage))));
         }
         return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.BEHAVIOR_KW, "behavior"), GAP, ident(name), GAP, ASSIGN,
@@ -1062,8 +1051,8 @@ public final class Formatter {
     }
 
     /** One stage of a pipeline, which is a name and is written as one. */
-    private TokenDoc stage(SyntaxNode n) {
-        return qualifiedName(n);
+    private TokenDoc stage(SyntaxNode n, Place at) {
+        return qualifiedName(n, at);
     }
 
     /** The names a {@code constructs} / {@code depends on} clause lists. {@code skipIdents} drops
@@ -1279,6 +1268,7 @@ public final class Formatter {
     }
 
     private TokenDoc retType(SyntaxNode n, Place at) {
+        places.within(n, at);
         List<TokenDoc> cases = new ArrayList<>();
         List<TokenDoc> rest = new ArrayList<>();
         for (SyntaxNode c : n.childNodes()) {
@@ -1303,6 +1293,7 @@ public final class Formatter {
     }
 
     private TokenDoc typeRef(SyntaxNode n, Place at) {
+        places.within(n, at);
         if (n.kind() == SyntaxKind.TUPLE_TYPE) {
             Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
             List<Member> elems = new ArrayList<>();
@@ -1319,7 +1310,7 @@ public final class Formatter {
         if (typevar.isPresent()) {
             return token(typevar.get());
         }
-        TokenDoc name = qualifiedName(n);   // a type may be named through its module or an import alias
+        TokenDoc name = qualifiedName(n, at);   // a type may be named through its module or an import alias
         var args = n.child(SyntaxKind.TYPE_ARGS);
         if (args.isEmpty()) {
             return name;
@@ -1342,6 +1333,7 @@ public final class Formatter {
 
     /** One term of a written type. A function type reads as itself wherever a type goes. */
     private TokenDoc typeTerm(SyntaxNode n, Place at) {
+        places.within(n, at);
         return n.kind() == SyntaxKind.FN_TYPE ? fnType(n, at) : typeRef(n, at);
     }
 
@@ -1350,6 +1342,7 @@ public final class Formatter {
     /** {@code n} written at {@code at}, which is the place the canonical form has it at. What it
      *  writes under itself is written at places under that one. */
     private TokenDoc expr(SyntaxNode n, Place at) {
+        places.within(n, at);
         return switch (n.kind()) {
             case LITERAL_EXPR -> token(firstMeaningfulToken(n));
             case VAR_EXPR -> ident(firstIdent(n));
@@ -1445,16 +1438,23 @@ public final class Formatter {
         List<SyntaxNode> ops = exprChildren(n);
         SyntaxNode left = ops.get(0);
         TokenDoc head;
+        Place opensAt;
         if (left.kind() == SyntaxKind.BINARY_EXPR && ladderLevel(operatorKind(left)) == level) {
             head = collectChain(left, at, level, segs, false);
+            opensAt = places.spanOf(left).from();
         } else {
             Place ofTheLeft = headPlace(at, left);
+            opensAt = ofTheLeft;
             head = TokenDoc.at(ofTheLeft, concat(expr(left, ofTheLeft), TokenDoc.endsTheLineOf(ofTheLeft)));
         }
         SyntaxNode right = ops.get(1);
         Place ofTheRight = segmentPlace(at, token(operatorToken(n)), right);
         segs.add(last ? lastOfARun(ofTheRight, expr(right, ofTheRight))
                 : segment(ofTheRight, right, expr(right, ofTheRight)));
+        // What the parser read as one operand of the level above is written here as a run of
+        // sibling places. It opens where the run's head is written and ends at the segment its own
+        // right operand is written at, and the construction is the only thing that knows both.
+        places.spanning(n, opensAt, ofTheRight);
         return head;
     }
 
@@ -1491,15 +1491,19 @@ public final class Formatter {
         SyntaxNode left = ops.get(0);
         SyntaxNode right = ops.get(1);
         TokenDoc head;
+        Place opensAt;
         if (left.kind() == SyntaxKind.PIPE_EXPR) {
             head = collectPipe(left, at, stages, false);
+            opensAt = places.spanOf(left).from();
         } else {
             Place ofTheLeft = headPlace(at, left);
+            opensAt = ofTheLeft;
             head = TokenDoc.at(ofTheLeft, concat(expr(left, ofTheLeft), TokenDoc.endsTheLineOf(ofTheLeft)));
         }
         Place ofTheStage = segmentPlace(at, TokenDoc.token(SyntaxKind.VPIPE, "|>"), right);
         stages.add(last ? lastOfARun(ofTheStage, expr(right, ofTheStage))
                 : segment(ofTheStage, right, expr(right, ofTheStage)));
+        places.spanning(n, opensAt, ofTheStage);
         return head;
     }
 
@@ -1754,6 +1758,7 @@ public final class Formatter {
     /** A binding pattern, written back as it was: a name, a tuple, a newtype opened by its
      * constructor, or a record's fields. */
     private TokenDoc pattern(SyntaxNode n, Place at) {
+        places.within(n, at);
         switch (n.kind()) {
             case PATTERN_NAME -> {
                 return ident(firstIdent(n));
@@ -1773,7 +1778,7 @@ public final class Formatter {
             case PATTERN_CTOR -> {
                 SyntaxNode inner = patternChild(n);
                 Place ofTheInner = places.under(at, inner.kind(), Opening.NONE, Written.of(inner));
-                return TokenDoc.node(n.kind(), concat(qualifiedName(n), GAP, LPAREN, GAP,
+                return TokenDoc.node(n.kind(), concat(qualifiedName(n, at), GAP, LPAREN, GAP,
                         TokenDoc.at(ofTheInner, pattern(inner, ofTheInner)), GAP, RPAREN));
             }
             case PATTERN_RECORD -> {
@@ -1862,16 +1867,33 @@ public final class Formatter {
             Map<SyntaxNode, List<SyntaxToken>> after,
             /** Inside the node, under its last member and before it closes. */
             Map<SyntaxNode, List<SyntaxToken>> atEnd,
-            /** Against a token rather than a node — a name the grammar wrote as identifiers, and a
-             * token in the middle of a construct, which is a line of the canonical form without
-             * being a construct of the source. */
-            Map<SyntaxToken, List<SyntaxToken>> aboveToken,
-            Map<SyntaxToken, List<SyntaxToken>> afterToken) {
+            /** Against a name rather than a node — the identifiers a sum's case or a clause's
+             * member is written as, and a token in the middle of a construct, which is a line of
+             * the canonical form without being a construct of the source. */
+            Map<Written, OnAName> aboveToken,
+            Map<Written, OnAName> afterToken) {
+
+        /**
+         * The comments held against one name, and the construct that name is written in.
+         *
+         * <p>Both are read here, where the comment's own position is read. Leaving the second to be
+         * worked out later would have the walk over the places begin by walking the source tree,
+         * which is what recording the places is here to stop.
+         */
+        record OnAName(SyntaxNode inside, List<SyntaxToken> comments) {}
 
         static Attachments empty() {
             return new Attachments(new IdentityHashMap<>(), new IdentityHashMap<>(),
-                    new IdentityHashMap<>(), new IdentityHashMap<>(), new IdentityHashMap<>());
+                    new IdentityHashMap<>(), new java.util.HashMap<>(), new java.util.HashMap<>());
         }
+    }
+
+    /** Files {@code comment} against the name {@code t} is part of, written inside {@code inside}. */
+    private static void onAName(Map<Written, Attachments.OnAName> to, SyntaxToken t,
+            SyntaxNode inside, SyntaxToken comment) {
+        to.computeIfAbsent(new Written.Run(nameStart(t), nameEnd(t)),
+                        _ -> new Attachments.OnAName(inside, new ArrayList<>()))
+                .comments().add(comment);
     }
 
     /**
@@ -2010,7 +2032,7 @@ public final class Formatter {
                 return;
             }
             if (first instanceof SyntaxToken token) {
-                add(out.aboveToken(), token, comment);
+                onAName(out.aboveToken(), token, beginningAt(token), comment);
                 return;
             }
         }
@@ -2024,7 +2046,7 @@ public final class Formatter {
             if (opensTheClause) {
                 add(out.above(), next.parent(), comment);
             } else {
-                add(out.aboveToken(), next, comment);
+                onAName(out.aboveToken(), next, beginningAt(next), comment);
             }
             return;
         }
@@ -2051,11 +2073,11 @@ public final class Formatter {
         // follow: a comment inside `other.mod.Thing` and one after it are about the same member, and
         // the last member of a run ends where the run does, which is the run's line and not its own.
         if (isBareMember(code) && nameEnd(code) != code.parent().end()) {
-            add(out.afterToken(), code, comment);
+            onAName(out.afterToken(), code, endingAt(code), comment);
             return;
         }
         if (isChainHead(code)) {
-            add(out.afterToken(), code, comment);
+            onAName(out.afterToken(), code, endingAt(code), comment);
             return;
         }
         // The outermost construct ending where the comment is. Outermost because
@@ -2068,18 +2090,10 @@ public final class Formatter {
             // Nothing ends here, so the comment was written in the middle of a construct — after a
             // `data D =`, a `match … with`, a `{`. What it ends is the line that token is on, so it
             // is held against the token rather than against the construct the token is inside.
-            add(out.afterToken(), code, comment);
+            onAName(out.afterToken(), code, ends, comment);
             return;
         }
         add(out.after(), ends, comment);
-    }
-
-    /** {@code n}'s first child node, whether or not the layout gives it a line. */
-    private static SyntaxNode firstChildOf(SyntaxNode n) {
-        for (SyntaxNode c : n.childNodes()) {
-            return c;
-        }
-        return null;
     }
 
     private static SyntaxToken lastCodeTokenOf(SyntaxNode n) {
@@ -2337,7 +2351,8 @@ public final class Formatter {
 
     // --- CST navigation ---
 
-    private TokenDoc qualifiedName(SyntaxNode n) {
+    private TokenDoc qualifiedName(SyntaxNode n, Place at) {
+        places.within(n, at);
         return TokenDoc.node(n.kind(), dottedName(idents(n)));
     }
 

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
@@ -158,6 +158,15 @@ final class Gaps {
             case TokenDoc.Gap g -> out.add(new GapSlot(g.policy()));
             case TokenDoc.Node n -> collect(n.doc(),
                     new Within(n.kind(), within, within == null ? 0 : within.depth() + 1), out);
+            // A place names a position and joins nothing, so the construct a boundary belongs to is
+            // found past it: two tokens on either side of a place are joined by whatever holds it.
+            case TokenDoc.At a -> collect(a.doc(), within, out);
+            case TokenDoc.Carries c -> throw new IllegalStateException(
+                    "a carrier reached the layout unresolved (" + c.which() + " of " + c.place()
+                            + "); the comments go in before the boundaries are answered");
+            case TokenDoc.Vacant v -> throw new IllegalStateException(
+                    "brackets reached the layout without being told what is between them ("
+                            + v.construct() + ")");
             case TokenDoc.Nest n -> collect(n.doc(), within, out);
             case TokenDoc.Group g -> collect(g.doc(), within, out);
             case TokenDoc.Concat c -> {
@@ -251,6 +260,9 @@ final class Gaps {
             case TokenDoc.Comment c -> Doc.text(c.text());
             case TokenDoc.Trailing t -> Doc.trailing(t.text());
             case TokenDoc.Node n -> lower(n.doc(), answers, next);
+            case TokenDoc.At a -> lower(a.doc(), answers, next);
+            case TokenDoc.Carries _, TokenDoc.Vacant _ -> throw new IllegalStateException(
+                    "a carrier reached the layout unresolved");
             case TokenDoc.Nest n -> Doc.nest(n.indent(), lower(n.doc(), answers, next));
             case TokenDoc.Group g -> Doc.group(lower(g.doc(), answers, next));
             case TokenDoc.Concat c -> {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Opening.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Opening.java
@@ -1,0 +1,70 @@
+package souther.compiler.fmt;
+
+/**
+ * How the line a {@link Place} is written on begins.
+ *
+ * <p>Written once, where the place is written, and read twice. The layout takes the boundary from
+ * it; comment ownership takes from it whether a comment written above the place is one the place
+ * can carry. Two readers of one value — which a table of lines kept beside the document was not,
+ * and a construct could be entered in one and left out of the other without anything noticing.
+ *
+ * <p>What opens the line is written from here and from nowhere else. A construct that wrote the
+ * opener itself and named it here as well would be saying where the line begins twice.
+ */
+sealed interface Opening {
+
+    Opening NONE = new None();
+
+    /** The boundary that opens this place's line, and what the construct writes after it before
+     *  the place itself — a leading comma, or nothing. */
+    record Breaks(TokenDoc.Break policy, TokenDoc opener) implements Opening {}
+
+    /** The line begins where whatever holds this place opened one — a {@code {}, the start of a
+     *  file — so the boundary is already behind it and only the opener is left to write. */
+    record ByOpener(TokenDoc opener) implements Opening {}
+
+    /** The place does not open a line: what holds it goes on writing the line it is on. */
+    record None() implements Opening {}
+
+    static Opening breaks(TokenDoc.Break policy) {
+        return new Breaks(policy, TokenDoc.NIL);
+    }
+
+    /** The boundary that opens the line, or nothing where the line is already open. */
+    default TokenDoc boundary() {
+        return switch (this) {
+            case Breaks b -> new TokenDoc.Gap(b.policy());
+            case ByOpener _, None _ -> TokenDoc.NIL;
+        };
+    }
+
+    /**
+     * What the construct writes at the head of the line, after the boundary and before the place.
+     *
+     * <p>It is on the place's line, so what is written above the place is written above it too — a
+     * comment put after a leading comma would leave the member starting a line the comma never
+     * opened. That is why this is here and not in front of the whole thing.
+     */
+    default TokenDoc opener() {
+        return switch (this) {
+            case Breaks b -> b.opener();
+            case ByOpener o -> o.opener();
+            case None _ -> TokenDoc.NIL;
+        };
+    }
+
+    /**
+     * Whether the place has a line of its own to be written above.
+     *
+     * <p>A place whose line is opened by a boundary the layout can break has one. A place the
+     * construct runs into has not: a comment written there would have the rest of that line
+     * written inside it, so the comment belongs to whatever opened the line instead.
+     */
+    default boolean opensALine() {
+        return switch (this) {
+            case Breaks b -> b.policy() != TokenDoc.Break.NEVER;
+            case ByOpener _ -> true;
+            case None _ -> false;
+        };
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Opening.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Opening.java
@@ -15,13 +15,21 @@ sealed interface Opening {
 
     Opening NONE = new None();
 
+    /** The one line nothing opens: the first of the file. */
+    Opening FILE_BEGINS = new FileBegins();
+
     /** The boundary that opens this place's line, and what the construct writes after it before
      *  the place itself — a leading comma, or nothing. */
     record Breaks(TokenDoc.Break policy, TokenDoc opener) implements Opening {}
 
-    /** The line begins where whatever holds this place opened one — a {@code {}, the start of a
-     *  file — so the boundary is already behind it and only the opener is left to write. */
-    record ByOpener(TokenDoc opener) implements Opening {}
+    /**
+     * The line is open and no boundary opened it, which is true in one place: the start of a file.
+     *
+     * <p>Anywhere else a place with a line of its own says what opens that line, so that whether
+     * the place has one and what wrote it are one value. A place that claimed a line while
+     * something else wrote the boundary would be the two-table arrangement again, one table deep.
+     */
+    record FileBegins() implements Opening {}
 
     /** The place does not open a line: what holds it goes on writing the line it is on. */
     record None() implements Opening {}
@@ -34,7 +42,7 @@ sealed interface Opening {
     default TokenDoc boundary() {
         return switch (this) {
             case Breaks b -> new TokenDoc.Gap(b.policy());
-            case ByOpener _, None _ -> TokenDoc.NIL;
+            case FileBegins _, None _ -> TokenDoc.NIL;
         };
     }
 
@@ -48,8 +56,7 @@ sealed interface Opening {
     default TokenDoc opener() {
         return switch (this) {
             case Breaks b -> b.opener();
-            case ByOpener o -> o.opener();
-            case None _ -> TokenDoc.NIL;
+            case FileBegins _, None _ -> TokenDoc.NIL;
         };
     }
 
@@ -63,7 +70,7 @@ sealed interface Opening {
     default boolean opensALine() {
         return switch (this) {
             case Breaks b -> b.policy() != TokenDoc.Break.NEVER;
-            case ByOpener _ -> true;
+            case FileBegins _ -> true;
             case None _ -> false;
         };
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Place.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Place.java
@@ -1,0 +1,63 @@
+package souther.compiler.fmt;
+
+import souther.compiler.cst.SyntaxKind;
+
+/**
+ * One place of the canonical form: somewhere the formatter writes something, told apart from every
+ * other place by being it.
+ *
+ * <p>Two siblings written as the same kind of construct are two places. An {@code if} written
+ * {@code if flag then p else q} has three children that are all a {@code VAR_EXPR}, and its
+ * condition, its then branch and its else branch are three places. Identity is the object's — a
+ * place is not equal to another place that happens to look the same, because there is no other
+ * place that is this one.
+ *
+ * <p>A place is not another name for a {@link souther.compiler.cst.SyntaxNode}. A definition
+ * written {@code let f = (x) -> x} is written back as {@code let f (x) = x}, and the parameter list
+ * there is a place the source tree has no node at. What the source had at a place is
+ * {@link Correspondence}'s to say and not a field here: a place with one source element and a place
+ * with none are both ordinary, and a field would make the first of those the only kind.
+ *
+ * <p>Which of its parent's places this is, is the label on the edge from the parent — the parent
+ * and the ordinal together. Nothing else has to name it.
+ */
+final class Place {
+
+    private final Place parent;
+    private final int ordinal;
+    private final SyntaxKind construct;
+    private final Opening opening;
+
+    Place(Place parent, int ordinal, SyntaxKind construct, Opening opening) {
+        this.parent = parent;
+        this.ordinal = ordinal;
+        this.construct = construct;
+        this.opening = opening;
+    }
+
+    /** The place this one is written inside, or null for the file. */
+    Place parent() {
+        return parent;
+    }
+
+    /** Which of its parent's places this is, counted in the order they are written. */
+    int ordinal() {
+        return ordinal;
+    }
+
+    /** What the canonical form writes here, named as it writes it rather than as the source had
+     *  it. Null where what is written is a bare name rather than a construct. */
+    SyntaxKind construct() {
+        return construct;
+    }
+
+    Opening opening() {
+        return opening;
+    }
+
+    @Override
+    public String toString() {
+        return (parent == null ? "file" : parent.construct() + "[" + ordinal + "]")
+                + " " + construct;
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Place.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Place.java
@@ -2,6 +2,11 @@ package souther.compiler.fmt;
 
 import souther.compiler.cst.SyntaxKind;
 
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+
 /**
  * One place of the canonical form: somewhere the formatter writes something, told apart from every
  * other place by being it.
@@ -18,19 +23,17 @@ import souther.compiler.cst.SyntaxKind;
  * {@link Correspondence}'s to say and not a field here: a place with one source element and a place
  * with none are both ordinary, and a field would make the first of those the only kind.
  *
- * <p>Which of its parent's places this is, is the label on the edge from the parent — the parent
- * and the ordinal together. Nothing else has to name it.
+ * <p>Which of its parent's places this is, is the label on the edge from the parent, and it is read
+ * from the document by {@link #orderedIn}. Nothing else has to name it.
  */
 final class Place {
 
     private final Place parent;
-    private final int ordinal;
     private final SyntaxKind construct;
     private final Opening opening;
 
-    Place(Place parent, int ordinal, SyntaxKind construct, Opening opening) {
+    Place(Place parent, SyntaxKind construct, Opening opening) {
         this.parent = parent;
-        this.ordinal = ordinal;
         this.construct = construct;
         this.opening = opening;
     }
@@ -38,11 +41,6 @@ final class Place {
     /** The place this one is written inside, or null for the file. */
     Place parent() {
         return parent;
-    }
-
-    /** Which of its parent's places this is, counted in the order they are written. */
-    int ordinal() {
-        return ordinal;
     }
 
     /** What the canonical form writes here, named as it writes it rather than as the source had
@@ -55,9 +53,56 @@ final class Place {
         return opening;
     }
 
+    /**
+     * Which of its parent's places each place of {@code doc} is, counted in the order the document
+     * writes them.
+     *
+     * <p>Read from the document and not from the order the formatter made them. A declaration
+     * builds its clauses before its body and writes the body first; an {@code example} builds its
+     * rows before the line it opens with and writes that line first. Counting as they are made
+     * records the order the formatter's methods happened to run in and calls it a fact about the
+     * canonical form, which is the kind of thing a place exists to stop being asked of a trace.
+     *
+     * <p>Asked of the document before the carriers are answered, since a slot names the place it
+     * belongs to and an answered one does not.
+     */
+    static Map<Place, Integer> orderedIn(TokenDoc doc) {
+        List<Place> written = new ArrayList<>();
+        Map<Place, Boolean> seen = new IdentityHashMap<>();
+        collect(doc, written, seen);
+        Map<Place, Integer> counts = new IdentityHashMap<>();
+        Map<Place, Integer> out = new IdentityHashMap<>();
+        for (Place p : written) {
+            out.put(p, counts.merge(p.parent(), 1, Integer::sum) - 1);
+        }
+        return out;
+    }
+
+    private static void collect(TokenDoc doc, List<Place> written, Map<Place, Boolean> seen) {
+        switch (doc) {
+            case TokenDoc.At a -> {
+                first(a.place(), written, seen);
+                collect(a.doc(), written, seen);
+            }
+            case TokenDoc.Carries c -> first(c.place(), written, seen);
+            case TokenDoc.Vacant v -> first(v.place(), written, seen);
+            case TokenDoc.Node n -> collect(n.doc(), written, seen);
+            case TokenDoc.Nest n -> collect(n.doc(), written, seen);
+            case TokenDoc.Group g -> collect(g.doc(), written, seen);
+            case TokenDoc.Concat c -> c.parts().forEach(part -> collect(part, written, seen));
+            case TokenDoc.Nil _, TokenDoc.Token _, TokenDoc.Comment _, TokenDoc.Trailing _,
+                    TokenDoc.Gap _, TokenDoc.MustBreak _ -> { }
+        }
+    }
+
+    private static void first(Place place, List<Place> written, Map<Place, Boolean> seen) {
+        if (place != null && seen.put(place, true) == null) {
+            written.add(place);
+        }
+    }
+
     @Override
     public String toString() {
-        return (parent == null ? "file" : parent.construct() + "[" + ordinal + "]")
-                + " " + construct;
+        return (parent == null ? "file" : "under " + parent.construct()) + " " + construct;
     }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/TokenDoc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/TokenDoc.java
@@ -62,6 +62,38 @@ sealed interface TokenDoc {
     /** The construct joining what is under it, named as the canonical form writes it. */
     record Node(SyntaxKind kind, TokenDoc doc) implements TokenDoc {}
 
+    /**
+     * Where in the canonical form this document is written, and what opens the line it is on.
+     *
+     * <p>A {@link Node} names what joins two tokens and is asked of the spacing rule; this names a
+     * position and is asked of nothing. It is what comment ownership addresses when it says which
+     * construct can carry a comment — a question a {@code Node} cannot answer, since two siblings
+     * written as the same kind of construct are one {@code Node} kind and two places.
+     */
+    record At(Place place, TokenDoc doc) implements TokenDoc {}
+
+    /**
+     * Where the comments a place carries in one direction are written.
+     *
+     * <p>A construct leaves the slot and says nothing about what goes in it. What does is decided
+     * once every place exists — which is after the construction and before the layout, because a
+     * comment cannot share the line after it and so decides whether the group holding it can be laid
+     * out flat. A construct that settled it here would be answering from the source tree, which is
+     * the structure the canonical form is not.
+     */
+    record Carries(Place place, Carrier which) implements TokenDoc {}
+
+    /**
+     * Brackets with no member written between them.
+     *
+     * <p>What goes there is one line or none, and which of the two depends on whether the place was
+     * handed any comments — a construct with nothing in it is written {@code ()}, and one holding
+     * only a comment keeps the line the comment is on. The construction does not know which, so it
+     * hands over the brackets and lets the same pass that answers the carriers say.
+     */
+    record Vacant(Place place, SyntaxKind construct, TokenDoc open, TokenDoc close, int indent)
+            implements TokenDoc {}
+
     record Gap(Break policy) implements TokenDoc {}
 
     record Concat(List<TokenDoc> parts) implements TokenDoc {}
@@ -78,6 +110,31 @@ sealed interface TokenDoc {
 
     static TokenDoc node(SyntaxKind kind, TokenDoc doc) {
         return new Node(kind, doc);
+    }
+
+    /**
+     * {@code doc} at {@code place}, behind whatever opens the line that place is written on, with
+     * {@code leading} at the head of that line.
+     *
+     * <p>The boundary and the place are written together because they are one decision: what stands
+     * in front of a place and whether the place has a line of its own to be written above are the
+     * same fact, and a construct able to write one without the other is one where the two can
+     * disagree.
+     */
+    static TokenDoc at(Place place, TokenDoc doc) {
+        Opening opening = place.opening();
+        return concat(opening.boundary(), new Carries(place, Carrier.ABOVE), opening.opener(),
+                new At(place, doc));
+    }
+
+    /** What the place carries at the end of the line it ends. Written where the construct holding
+     *  it has finished writing that line, which is not always straight after the place. */
+    static TokenDoc endsTheLineOf(Place place) {
+        return new Carries(place, Carrier.TRAILING);
+    }
+
+    static TokenDoc carries(Place place, Carrier which) {
+        return new Carries(place, which);
     }
 
     static TokenDoc comment(String text) {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Written.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Written.java
@@ -1,6 +1,8 @@
 package souther.compiler.fmt;
 
+import souther.compiler.cst.SyntaxElement;
 import souther.compiler.cst.SyntaxNode;
+import souther.compiler.cst.SyntaxToken;
 
 /**
  * A source element a place was written from.
@@ -13,9 +15,37 @@ sealed interface Written {
 
     Written[] NONE = new Written[0];
 
+    /**
+     * Where this element's own text ends.
+     *
+     * <p>Past whatever trivia the node carries after its last token, since that trivia is where a
+     * comment written after it is. Asked of the element rather than worked out from the tree it is
+     * in: how far a place reaches is a fact about what was written there.
+     */
+    int end();
+
     /** A construct of the source. Compared by identity, which is what the tree gives: one red node
      *  per position, handed back the same each time its parent is asked for its children. */
-    record Construct(SyntaxNode node) implements Written {}
+    record Construct(SyntaxNode node) implements Written {
+
+        @Override
+        public int end() {
+            SyntaxToken last = lastCodeTokenOf(node);
+            return last == null ? node.end() : last.end();
+        }
+
+        private static SyntaxToken lastCodeTokenOf(SyntaxNode n) {
+            SyntaxToken last = null;
+            for (SyntaxElement e : n.children()) {
+                SyntaxToken found = e instanceof SyntaxNode c ? lastCodeTokenOf(c)
+                        : e instanceof SyntaxToken t && !t.isTrivia() ? t : null;
+                if (found != null) {
+                    last = found;
+                }
+            }
+            return last;
+        }
+    }
 
     /** A name the grammar wrote as identifiers, named by where it begins and ends. */
     record Run(int start, int end) implements Written {}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Written.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Written.java
@@ -1,0 +1,26 @@
+package souther.compiler.fmt;
+
+import souther.compiler.cst.SyntaxNode;
+
+/**
+ * A source element a place was written from.
+ *
+ * <p>A node has an identity of its own, so it names itself. A name written as a run of identifiers
+ * has none — a sum's cases are bare identifiers — so it is named by where it is, which is how the
+ * formatter has always named one.
+ */
+sealed interface Written {
+
+    Written[] NONE = new Written[0];
+
+    /** A construct of the source. Compared by identity, which is what the tree gives: one red node
+     *  per position, handed back the same each time its parent is asked for its children. */
+    record Construct(SyntaxNode node) implements Written {}
+
+    /** A name the grammar wrote as identifiers, named by where it begins and ends. */
+    record Run(int start, int end) implements Written {}
+
+    static Written[] of(SyntaxNode node) {
+        return node == null ? NONE : new Written[] {new Construct(node)};
+    }
+}


### PR DESCRIPTION
The formatter built the canonical form's places while it wrote them, knew which source elements produced them, and kept neither. Comment ownership asked the source tree the same question afterwards, and wherever the two structures differ it got a different answer.

The construction now records the places it writes and what the source had at each, and carriers are answered between the construction and the layout: the construction leaves a slot and says nothing about what goes in it, one pass fills every slot once every place exists, and what reaches the layout is a document with the comments already in it.

## Places exist

A place is told apart from every other by being it — an `if` written `if flag then p else q` has three children that are all a `VAR_EXPR` and three places — and says which of its parent's places it is. It is not another name for a source node: the parameter list of `let f (x) = x` is a place the source tree has no node at.

## The correspondence is a relation

A place stands for none, one or several source elements, and no API offers a single-valued `origin()`. The lambda supplies the parameter list place and its last expression child supplies the body place beside it, so a single-valued answer would have to pick one — and picking is what asking the source tree again already did.

## The counterexample turns over

```souther
let f = (x) ->
    // about the body
    x
```

The body owns the comment now. `butADefinitionWrittenAsALambdaIsLeftAsItWas` stated this as a limit; it requires the ownership instead, with a nested lift beside it, and reads the carrier rather than the rendered position — a comment carried by the declaration prints on the same line, and text alone cannot tell the two apart.

## Four answers did not survive being read back

Three were the classification reading the canonical form it had itself produced: a `with` clause is written on the input's line, so its place is that segment's and not the row's; a connector opens the line what follows is written on, so a comment above the connector is above all of that line and not above whatever it opens with; and a comment written inside a name is written after the whole name. The fourth was the walk that widens a carrier, which compared against the construct the comment is inside rather than against where the comment was written.

A comment held against a token also had no carrier at all in half the boundaries below. It was looked up in an index of places by offset, which only names and header lines are in; it reaches its place through the run the token is part of now, and where the canonical form writes no place for it, through the construct the token is inside.

## One table

The line table the old ownership walked is gone. `linesOf` and the placements said the same thing in two places, which is what #500 found. Nothing reaches it now, and the one representative left is a place's `Opening`: writing `Break.NEVER` where a member's line may break fails the layout fixtures and the ownership fixtures independently of each other.

## Checks

A probe comment written into every boundary of the two sweep fixtures, on a line of its own and at the end of a line, comes back once and formats to itself: 404 variants each way, none moved, refused, or rewritten. `mvn clean install` is green.

Closes #506. Lifts the limit stated in #502. Refs #444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
