### PR TITLE
What a value carried is written once, by the substitution nothing else is inside

### DIFF
--- a/souther-bench/src/main/java/souther/bench/Bench.java
+++ b/souther-bench/src/main/java/souther/bench/Bench.java
@@ -6,9 +6,9 @@ import java.util.List;
 /**
  * The benchmarks, run from the command line: {@code java -jar souther-bench.jar [measurement...]}.
  *
- * <p>With no argument it runs all four. Naming one runs only that, which is how a change is checked
- * against the thing it was meant to move without waiting for the rest — {@code scale} in particular
- * compiles two hundred modules five times over.
+ * <p>With no argument it runs all of them. Naming one runs only that, which is how a change is
+ * checked against the thing it was meant to move without waiting for the rest — {@code scale} in
+ * particular compiles two hundred modules five times over.
  *
  * <pre>
  *   cold    one compile in a JVM that has not compiled before
@@ -17,6 +17,7 @@ import java.util.List;
  *   edit    what an edit costs a store that already holds the answers
  *   run     what the generated code costs to run, per element
  *   scale   how a whole-workspace compile grows with the number of modules
+ *   values  how one module's compile grows with the number of values it declares
  * </pre>
  *
  * <p>Every corpus is compiled once and checked before anything is timed. A language change that
@@ -30,7 +31,7 @@ public final class Bench {
     public static void main(String[] args) {
         Report report = new Report(System.out);
         List<String> wanted = args.length == 0
-                ? List.of("cold", "warm", "phase", "edit", "run", "scale")
+                ? List.of("cold", "warm", "phase", "edit", "run", "scale", "values")
                 : new ArrayList<>(List.of(args));
 
         List<Corpus> corpora = Corpus.all();
@@ -73,6 +74,10 @@ public final class Bench {
         }
         if (wanted.contains("scale")) {
             Scale.measure(report);
+            report.blank();
+        }
+        if (wanted.contains("values")) {
+            Values.measure(report);
         }
     }
 }

--- a/souther-bench/src/main/java/souther/bench/Values.java
+++ b/souther-bench/src/main/java/souther/bench/Values.java
@@ -1,0 +1,73 @@
+package souther.bench;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+
+/**
+ * How a compile grows with the number of values one module declares.
+ *
+ * <p>{@link Scale} asks the same question of a workspace and this asks it of a module, because the
+ * two have different answers: a value is substituted where it is named, so what a module declares
+ * can cost more than the sum of its declarations while what a workspace holds does not.
+ *
+ * <p>Two shapes, held the same apart from what a value names. Each value of the chain names the one
+ * before it, so the last of them stands for the whole chain and the module's source shares what its
+ * elaboration copies. The flat shape declares as many values naming none of them, which is the same
+ * number of declarations with nothing to share — so the distance between the two lines is what
+ * substitution costs, and the chain's own per-value figure is what says whether that cost is
+ * proportional to what the module declares.
+ *
+ * <p>The per-value figure is the one to read. A total that grows is only the module growing; a
+ * per-value figure that grows with the module is a term above linear, and it is reported at sizes
+ * that double so the ratio between two lines names the exponent.
+ */
+final class Values {
+
+    private Values() {}
+
+    // Doubling from a size the fixed cost of a compile is already small against: below a hundred
+    // values a module costs about what an empty one does, and a per-value figure taken there says
+    // more about that floor than about the curve.
+    private static final int[] SIZES = {100, 200, 400, 800};
+
+    static void measure(Report report) {
+        for (int values : SIZES) {
+            Timing chain = timeOf(chain(values));
+            Timing flat = timeOf(flat(values));
+            report.line("VALUES n=%-4d  chain %7.1f ms (%5.3f ms/value)   "
+                            + "flat %7.1f ms (%5.3f ms/value)",
+                    values, chain.medianMillis(), chain.medianMillis() / values,
+                    flat.medianMillis(), flat.medianMillis() / values);
+        }
+    }
+
+    private static Timing timeOf(String source) {
+        return Timing.of(2, 5, () -> {
+            Compilation compilation = Compilation.ofSources(List.of(source), ModulePath.EMPTY);
+            compilation.answerEverything();
+            compilation.classes();
+        });
+    }
+
+    /** {@code n} values, each naming the one before it, and a behavior naming the last. */
+    private static String chain(int n) {
+        StringBuilder source = new StringBuilder("module chain exposing ( f )\n\nlet v0 = 1\n");
+        for (int i = 1; i < n; i++) {
+            source.append("let v").append(i).append(" = v").append(i - 1).append(" + 1\n");
+        }
+        return source.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v")
+                .append(n - 1).append("\n").toString();
+    }
+
+    /** {@code n} values naming none of them, and a behavior naming the last. */
+    private static String flat(int n) {
+        StringBuilder source = new StringBuilder("module flat exposing ( f )\n\n");
+        for (int i = 0; i < n; i++) {
+            source.append("let v").append(i).append(" = ").append(i).append(" + 1\n");
+        }
+        return source.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v")
+                .append(n - 1).append("\n").toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1315,6 +1315,15 @@ public final class HelperInliner {
      *
      * <p>What it holds is the path and not what it has seen: a value named twice in one body is
      * substituted twice, side by side, and only one inside the other is re-entry.
+     *
+     * <p>The path is also what says whose job the mark is. What a value carried is written over the
+     * whole expansion once it is whole, by the substitution no other substitution is inside — the
+     * outermost one holds every subtree the ones under it produced, and the mark is a flag, so
+     * writing it there says of each node what writing it at every level said. Written at every
+     * level it is written over each subtree once per level that subtree is under, which is the
+     * depth of a chain of values times its length. The walk allocates nothing — rebuilding an
+     * expression hands back what it was given where nothing changed — so what it costs is the
+     * walking, and nothing downstream of it can see that it ran twice.
      */
     private Ast.Expr substituted(String reached, Ast.Expr body) {
         if (!substituting.add(reached)) {
@@ -1323,7 +1332,8 @@ public final class HelperInliner {
                     + " values are not well founded is refused before a body of it is expanded");
         }
         try {
-            return HelperNames.carriedByValue(inline(body));
+            Ast.Expr expanded = inline(body);
+            return substituting.size() == 1 ? HelperNames.carriedByValue(expanded) : expanded;
         } finally {
             substituting.remove(reached);
         }

--- a/souther-compiler/src/test/java/souther/compiler/CompileValueConstructionAuthorityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileValueConstructionAuthorityTest.java
@@ -229,6 +229,54 @@ class CompileValueConstructionAuthorityTest {
         assertEquals("E1002", e.code(), e.getMessage());
     }
 
+    /** A value reached through values of the same module. The mark is written over the whole
+     * expansion by the substitution no other substitution is inside, so what it says of a
+     * construction does not depend on how many names stood between the behavior and it. */
+    @Test
+    void aValueReachedThroughValuesOfThisModuleCarriesTheSameWay() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let baseHours = Hours(20.0m)
+                let namedHours = baseHours
+                let floorHours = namedHours
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """));
+    }
+
+    /** The same, with a helper expanded on the way. A helper call becomes an expansion, whose
+     * `given` is not a slot of the walk that rebuilds an expression, so this is the shape that says
+     * the outermost substitution reaches what the ones under it produced. */
+    @Test
+    void aValueReachedThroughAValueThatExpandsAHelperCarriesTheSameWay() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let floorOf (d) = Hours(d)
+                let baseHours = floorOf(20.0m)
+                let floorHours = baseHours
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """));
+    }
+
     /** A unit data is constructed by being named, so it has no construction node to carry the mark
      * — the name carries it. A value standing for one reaches the reading behavior by that path. */
     @Test


### PR DESCRIPTION
A value's expansion is walked to mark what it built as carried, and the walk ran at the end of
every substitution. A value that names another substitutes inside that expansion, so a subtree the
inner substitution produced was walked again by the one above it, and again by the one above that.
A chain of K values was walked at sizes 1, 2, ..., K, which is N cubed over a module of N.

The mark is a flag set from what a node denotes, so the walk says the same thing however many
times it runs, and the outermost substitution holds every subtree the ones under it produced.
Writing the mark there alone says of each node what writing it at every level said. Which
substitution that is, the path this pass already keeps answers: it is the one the path holds
nothing else beside.

## What it moves

`values` joins the benchmarks: a chain of values against as many values naming none of them,
reported per value so a term above linear reads as a rising figure rather than a bigger total.

Before:

```
VALUES n=100   chain    19.6 ms (0.196 ms/value)   flat     5.6 ms (0.056 ms/value)
VALUES n=200   chain    62.3 ms (0.312 ms/value)   flat     4.8 ms (0.024 ms/value)
VALUES n=400   chain   439.3 ms (1.098 ms/value)   flat     5.8 ms (0.015 ms/value)
VALUES n=800   chain  3471.9 ms (4.340 ms/value)   flat     8.6 ms (0.011 ms/value)
```

After:

```
VALUES n=100   chain     8.5 ms (0.085 ms/value)   flat     6.5 ms (0.065 ms/value)
VALUES n=200   chain    16.7 ms (0.084 ms/value)   flat     4.6 ms (0.023 ms/value)
VALUES n=400   chain    49.1 ms (0.123 ms/value)   flat     5.9 ms (0.015 ms/value)
VALUES n=800   chain   165.7 ms (0.207 ms/value)   flat     8.9 ms (0.011 ms/value)
```

The per-value figure quadrupled per doubling before and now under doubles: cubic against quadratic.

## What it does not move

This does not close #523, and #523 is left open. A module of N values still holds N squared
expression nodes — the source has one `v99` and elaboration has a hundred copies of it — and the
count of elaborations is unchanged at 644,807 for eight hundred values. What this removes is the
cubic term that sat on top of the quadratic one, which had to go before the quadratic one could be
measured at all.

## Tests

Two for the shape the change turns on: a value reached through values of the same module, and one
reached through a value that expands a helper — a helper call becomes an expansion, whose `given`
is not a slot of the walk that rebuilds an expression and is put back by the pass that marks. Both
fail if the mark is dropped rather than moved, along with the eight that already covered it.

Closes #531.
