### PR TITLE
A module of values costs what it declares

### DIFF
--- a/souther-bench/src/main/java/souther/bench/Bench.java
+++ b/souther-bench/src/main/java/souther/bench/Bench.java
@@ -6,9 +6,9 @@ import java.util.List;
 /**
  * The benchmarks, run from the command line: {@code java -jar souther-bench.jar [measurement...]}.
  *
- * <p>With no argument it runs all four. Naming one runs only that, which is how a change is checked
- * against the thing it was meant to move without waiting for the rest — {@code scale} in particular
- * compiles two hundred modules five times over.
+ * <p>With no argument it runs all of them. Naming one runs only that, which is how a change is
+ * checked against the thing it was meant to move without waiting for the rest — {@code scale} in
+ * particular compiles two hundred modules five times over.
  *
  * <pre>
  *   cold    one compile in a JVM that has not compiled before
@@ -17,6 +17,7 @@ import java.util.List;
  *   edit    what an edit costs a store that already holds the answers
  *   run     what the generated code costs to run, per element
  *   scale   how a whole-workspace compile grows with the number of modules
+ *   values  how one module's compile grows with the number of values it declares
  * </pre>
  *
  * <p>Every corpus is compiled once and checked before anything is timed. A language change that
@@ -30,7 +31,7 @@ public final class Bench {
     public static void main(String[] args) {
         Report report = new Report(System.out);
         List<String> wanted = args.length == 0
-                ? List.of("cold", "warm", "phase", "edit", "run", "scale")
+                ? List.of("cold", "warm", "phase", "edit", "run", "scale", "values")
                 : new ArrayList<>(List.of(args));
 
         List<Corpus> corpora = Corpus.all();
@@ -73,6 +74,10 @@ public final class Bench {
         }
         if (wanted.contains("scale")) {
             Scale.measure(report);
+            report.blank();
+        }
+        if (wanted.contains("values")) {
+            Values.measure(report);
         }
     }
 }

--- a/souther-bench/src/main/java/souther/bench/Values.java
+++ b/souther-bench/src/main/java/souther/bench/Values.java
@@ -14,14 +14,14 @@ import java.util.List;
  * two have different answers: a value is substituted where it is named, so what a module declares
  * can cost more than the sum of its declarations while what a workspace holds does not.
  *
- * <p>Three shapes, held the same apart from what a value names and where it is written. Each value
- * of the chain names the one before it, so the last of them stands for the whole chain and the
- * module's source shares what its elaboration copies. The reversed chain is that module written
- * bottom to top, where no value is settled by the time the one naming it is read unless the check
- * puts them in an order of its own. The flat shape declares as many values naming none of them,
- * which is the same number of declarations with nothing to share — so the distance from it is what
- * substitution costs, and a chain's own per-value figure is what says whether that cost is
- * proportional to what the module declares.
+ * <p>The shapes differ in what a value reaches and in where the thing it reaches is written, which
+ * is what the answer turns on. A chain has each value name the one before it. A chain through
+ * helpers has each value call a helper that names the one before it, so the same reaching is there
+ * and no value writes another's name. Either written bottom to top is the module where nothing a
+ * value reaches has been read yet by the time the value is. The fan-out has one value reach every
+ * other, which is the shape a walk that re-reads a name's edges once per edge is quadratic in and a
+ * chain says nothing about. The flat shape declares as many values reaching none of them: the same
+ * number of declarations with nothing to share, and so the floor the rest are read against.
  *
  * <p>The per-value figure is the one to read. A total that grows is only the module growing; a
  * per-value figure that grows with the module is a term above linear, and it is reported at sizes
@@ -38,15 +38,19 @@ final class Values {
 
     static void measure(Report report) {
         for (int values : SIZES) {
-            Timing chain = timeOf(chain(values, false));
-            Timing reversed = timeOf(chain(values, true));
-            Timing flat = timeOf(flat(values));
-            report.line("VALUES n=%-4d  chain %7.1f ms (%5.3f)   reversed %7.1f ms (%5.3f)   "
-                            + "flat %7.1f ms (%5.3f)   ms/value",
-                    values, chain.medianMillis(), chain.medianMillis() / values,
-                    reversed.medianMillis(), reversed.medianMillis() / values,
-                    flat.medianMillis(), flat.medianMillis() / values);
+            line(report, values, "chain", chain(values, false));
+            line(report, values, "chain bottom-up", chain(values, true));
+            line(report, values, "chain via helpers", throughHelpers(values, false));
+            line(report, values, "same, bottom-up", throughHelpers(values, true));
+            line(report, values, "fan-out", fanOut(values));
+            line(report, values, "flat", flat(values));
         }
+    }
+
+    private static void line(Report report, int values, String shape, String source) {
+        Timing timing = timeOf(source);
+        report.line("VALUES n=%-4d %-18s %7.1f ms (%5.3f ms/value)",
+                values, shape, timing.medianMillis(), timing.medianMillis() / values);
     }
 
     private static Timing timeOf(String source) {
@@ -57,32 +61,64 @@ final class Values {
         });
     }
 
-    /** {@code n} values, each naming the one before it, and a behavior naming the last —
-     * {@code bottomUp} writing the one that names before the one it names. */
+    /** {@code n} values, each naming the one before it — {@code bottomUp} writing the one that
+     * names before the one it names. */
     private static String chain(int n, boolean bottomUp) {
         List<String> declarations = new ArrayList<>();
         declarations.add("let v0 = 1");
         for (int i = 1; i < n; i++) {
             declarations.add("let v" + i + " = v" + (i - 1) + " + 1");
         }
-        if (bottomUp) {
-            Collections.reverse(declarations);
+        return module("chain", declarations, bottomUp, n - 1);
+    }
+
+    /** The same reaching with none of the names: each value calls a helper, and the helper is what
+     * names the value before it. */
+    private static String throughHelpers(int n, boolean bottomUp) {
+        List<String> declarations = new ArrayList<>();
+        declarations.add("let v0 = 1");
+        for (int i = 1; i < n; i++) {
+            declarations.add("let step" + i + " (x: Int) = v" + (i - 1) + " + x");
+            declarations.add("let v" + i + " = step" + i + "(1)");
         }
-        StringBuilder source = new StringBuilder("module chain exposing ( f )\n\n");
-        for (String declaration : declarations) {
+        return module("helpers", declarations, bottomUp, n - 1);
+    }
+
+    /** One value reaching every other, written as a list so that reaching many is not also nesting
+     * deeply. */
+    private static String fanOut(int n) {
+        List<String> declarations = new ArrayList<>();
+        StringBuilder hub = new StringBuilder("let hub = [ ");
+        for (int i = 0; i < n; i++) {
+            declarations.add("let v" + i + " = " + i + " + 1");
+            hub.append(i == 0 ? "" : ", ").append("v").append(i);
+        }
+        declarations.add(hub.append(" ]").toString());
+        return module("fanout", declarations, false, 0);
+    }
+
+    /** {@code n} values reaching none of them. */
+    private static String flat(int n) {
+        List<String> declarations = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            declarations.add("let v" + i + " = " + i + " + 1");
+        }
+        return module("flat", declarations, false, n - 1);
+    }
+
+    /** The module {@code declarations} make, with a behavior naming {@code named} — reversed first
+     * where the point is that nothing a value reaches is written above it. */
+    private static String module(String name, List<String> declarations, boolean bottomUp,
+                                 int named) {
+        List<String> written = new ArrayList<>(declarations);
+        if (bottomUp) {
+            Collections.reverse(written);
+        }
+        StringBuilder source = new StringBuilder("module " + name + " exposing ( f )\n\n");
+        for (String declaration : written) {
             source.append(declaration).append('\n');
         }
         return source.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v")
-                .append(n - 1).append("\n").toString();
-    }
-
-    /** {@code n} values naming none of them, and a behavior naming the last. */
-    private static String flat(int n) {
-        StringBuilder source = new StringBuilder("module flat exposing ( f )\n\n");
-        for (int i = 0; i < n; i++) {
-            source.append("let v").append(i).append(" = ").append(i).append(" + 1\n");
-        }
-        return source.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v")
-                .append(n - 1).append("\n").toString();
+                .append(named).append("\n").toString();
     }
 }

--- a/souther-bench/src/main/java/souther/bench/Values.java
+++ b/souther-bench/src/main/java/souther/bench/Values.java
@@ -3,6 +3,8 @@ package souther.bench;
 import souther.compiler.meta.ModulePath;
 import souther.compiler.query.Compilation;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -12,11 +14,13 @@ import java.util.List;
  * two have different answers: a value is substituted where it is named, so what a module declares
  * can cost more than the sum of its declarations while what a workspace holds does not.
  *
- * <p>Two shapes, held the same apart from what a value names. Each value of the chain names the one
- * before it, so the last of them stands for the whole chain and the module's source shares what its
- * elaboration copies. The flat shape declares as many values naming none of them, which is the same
- * number of declarations with nothing to share — so the distance between the two lines is what
- * substitution costs, and the chain's own per-value figure is what says whether that cost is
+ * <p>Three shapes, held the same apart from what a value names and where it is written. Each value
+ * of the chain names the one before it, so the last of them stands for the whole chain and the
+ * module's source shares what its elaboration copies. The reversed chain is that module written
+ * bottom to top, where no value is settled by the time the one naming it is read unless the check
+ * puts them in an order of its own. The flat shape declares as many values naming none of them,
+ * which is the same number of declarations with nothing to share — so the distance from it is what
+ * substitution costs, and a chain's own per-value figure is what says whether that cost is
  * proportional to what the module declares.
  *
  * <p>The per-value figure is the one to read. A total that grows is only the module growing; a
@@ -34,11 +38,13 @@ final class Values {
 
     static void measure(Report report) {
         for (int values : SIZES) {
-            Timing chain = timeOf(chain(values));
+            Timing chain = timeOf(chain(values, false));
+            Timing reversed = timeOf(chain(values, true));
             Timing flat = timeOf(flat(values));
-            report.line("VALUES n=%-4d  chain %7.1f ms (%5.3f ms/value)   "
-                            + "flat %7.1f ms (%5.3f ms/value)",
+            report.line("VALUES n=%-4d  chain %7.1f ms (%5.3f)   reversed %7.1f ms (%5.3f)   "
+                            + "flat %7.1f ms (%5.3f)   ms/value",
                     values, chain.medianMillis(), chain.medianMillis() / values,
+                    reversed.medianMillis(), reversed.medianMillis() / values,
                     flat.medianMillis(), flat.medianMillis() / values);
         }
     }
@@ -51,11 +57,20 @@ final class Values {
         });
     }
 
-    /** {@code n} values, each naming the one before it, and a behavior naming the last. */
-    private static String chain(int n) {
-        StringBuilder source = new StringBuilder("module chain exposing ( f )\n\nlet v0 = 1\n");
+    /** {@code n} values, each naming the one before it, and a behavior naming the last —
+     * {@code bottomUp} writing the one that names before the one it names. */
+    private static String chain(int n, boolean bottomUp) {
+        List<String> declarations = new ArrayList<>();
+        declarations.add("let v0 = 1");
         for (int i = 1; i < n; i++) {
-            source.append("let v").append(i).append(" = v").append(i - 1).append(" + 1\n");
+            declarations.add("let v" + i + " = v" + (i - 1) + " + 1");
+        }
+        if (bottomUp) {
+            Collections.reverse(declarations);
+        }
+        StringBuilder source = new StringBuilder("module chain exposing ( f )\n\n");
+        for (String declaration : declarations) {
+            source.append(declaration).append('\n');
         }
         return source.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v")
                 .append(n - 1).append("\n").toString();

--- a/souther-bench/src/main/java/souther/bench/Values.java
+++ b/souther-bench/src/main/java/souther/bench/Values.java
@@ -1,0 +1,73 @@
+package souther.bench;
+
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+
+/**
+ * How a compile grows with the number of values one module declares.
+ *
+ * <p>{@link Scale} asks the same question of a workspace and this asks it of a module, because the
+ * two have different answers: a value is substituted where it is named, so what a module declares
+ * can cost more than the sum of its declarations while what a workspace holds does not.
+ *
+ * <p>Two shapes, held the same apart from what a value names. Each value of the chain names the one
+ * before it, so the last of them stands for the whole chain and the module's source shares what its
+ * elaboration copies. The flat shape declares as many values naming none of them, which is the same
+ * number of declarations with nothing to share — so the distance between the two lines is what
+ * substitution costs, and the chain's own per-value figure is what says whether that cost is
+ * proportional to what the module declares.
+ *
+ * <p>The per-value figure is the one to read. A total that grows is only the module growing; a
+ * per-value figure that grows with the module is a term above linear, and it is reported at sizes
+ * that double so the ratio between two lines names the exponent.
+ */
+final class Values {
+
+    private Values() {}
+
+    // Doubling from a size the fixed cost of a compile is already small against: below a hundred
+    // values a module costs about what an empty one does, and a per-value figure taken there says
+    // more about that floor than about the curve.
+    private static final int[] SIZES = {100, 200, 400, 800};
+
+    static void measure(Report report) {
+        for (int values : SIZES) {
+            Timing chain = timeOf(chain(values));
+            Timing flat = timeOf(flat(values));
+            report.line("VALUES n=%-4d  chain %7.1f ms (%5.3f ms/value)   "
+                            + "flat %7.1f ms (%5.3f ms/value)",
+                    values, chain.medianMillis(), chain.medianMillis() / values,
+                    flat.medianMillis(), flat.medianMillis() / values);
+        }
+    }
+
+    private static Timing timeOf(String source) {
+        return Timing.of(2, 5, () -> {
+            Compilation compilation = Compilation.ofSources(List.of(source), ModulePath.EMPTY);
+            compilation.answerEverything();
+            compilation.classes();
+        });
+    }
+
+    /** {@code n} values, each naming the one before it, and a behavior naming the last. */
+    private static String chain(int n) {
+        StringBuilder source = new StringBuilder("module chain exposing ( f )\n\nlet v0 = 1\n");
+        for (int i = 1; i < n; i++) {
+            source.append("let v").append(i).append(" = v").append(i - 1).append(" + 1\n");
+        }
+        return source.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v")
+                .append(n - 1).append("\n").toString();
+    }
+
+    /** {@code n} values naming none of them, and a behavior naming the last. */
+    private static String flat(int n) {
+        StringBuilder source = new StringBuilder("module flat exposing ( f )\n\n");
+        for (int i = 0; i < n; i++) {
+            source.append("let v").append(i).append(" = ").append(i).append(" + 1\n");
+        }
+        return source.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v")
+                .append(n - 1).append("\n").toString();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -231,6 +231,13 @@ public final class Elaborator {
                     }
                     yield value;
                 }
+                // A value this representation kept standing, read as the type its own check
+                // settled. What the value is a constant of is not asked here: that is folded into
+                // the reference where the reference is written, so nothing downstream of this has
+                // to learn that a name can stand for one.
+                case ValueName.Helper _ when ctx.preserved().valueKept(v.denotes()) != null ->
+                        new Core.PreservedCall(v.denotes(), List.of(),
+                                ctx.preserved().valueKept(v.denotes()), v.pos());
                 default -> throw notAValue(v, env);
             };
             case Ast.FieldAccess fa -> elaborateFieldAccess(fa, env, ctx);

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -63,6 +63,17 @@ public final class HelperInliner {
      * a fact about the module rather than about any one body.
      */
     private Map<String, Integer> callableBehaviors = Map.of();
+    /**
+     * The values whose own answer this expansion was given, so that a reference to one need not
+     * copy its body. Empty for every expansion that has no such answer — the tree the backend emits
+     * from is one, and it copies every value as it always did.
+     *
+     * <p>Two answers rather than one, and they are read in {@link #settled}: the type a reference
+     * stands under, and the constant a reference is written out as. A value has the first and may
+     * have the second.
+     */
+    private Preserved settledValues = Preserved.NONE;
+    private java.util.function.Function<ValueName, Object> settledConstants = _ -> null;
     /** What each declaration this table reaches calls, and which of them recurse. A function of the
      * table, so a narrowed table does not narrow it: what recurses was settled over the table as it
      * was built. */
@@ -244,6 +255,24 @@ public final class HelperInliner {
      */
     public HelperInliner namingBehaviors(Map<String, Integer> arities) {
         this.callableBehaviors = Map.copyOf(arities);
+        return this;
+    }
+
+    /**
+     * The same, told what the values named in {@code settled} were settled as, so that a reference
+     * to one of them is not copied.
+     *
+     * <p>For the checks that read a definition on its own. A definition is checked against what the
+     * definitions it names were settled as, which is what a check of each of them already worked
+     * out; copying the body instead re-derives that answer once per name that reaches it, so a
+     * chain of values costs the chain again per link. What the backend emits is the other question
+     * and unchanged: a value is substituted where it is named (ADR-0072), and the tree it is
+     * substituted into is not built here.
+     */
+    public HelperInliner readingSettledValues(Preserved settled,
+                                             java.util.function.Function<ValueName, Object> constants) {
+        this.settledValues = settled;
+        this.settledConstants = constants;
         return this;
     }
 
@@ -1301,7 +1330,46 @@ public final class HelperInliner {
         if (value == null || value.body() == null || graph.recurses(v.reaches())) {
             return v;
         }
-        return substituted(v.reaches(), value.writtenBody());
+        Ast.Expr settled = settled(v);
+        return settled != null ? settled : substituted(v.reaches(), value.writtenBody());
+    }
+
+    /**
+     * What {@code v} stands for where this expansion was told the value's own answer, or null where
+     * it was not and the body has to be copied.
+     *
+     * <p>Two answers, because two things read a substituted value. What it types as is read by the
+     * check, and a reference standing under the settled type says it. What it is a constant of is
+     * read by everything that asks whether an expression is known at compile time — a
+     * {@code String.matches} pattern, the argument a construction proves its invariant against —
+     * and those fold a tree rather than resolve a name ({@link ConstEval}), so a constant is written
+     * out as the literal it folded to and they go on reading a literal. Where the value is neither
+     * — a construction, a collection, anything a fold does not reach — the reference stands and the
+     * check reads its type.
+     *
+     * <p>The literal is written at the reference. A value is substituted at each of its references
+     * (ADR-0072), so what stands there is this reference's, and a report about it belongs where the
+     * name was written rather than in the body it came from.
+     */
+    private Ast.Expr settled(Ast.Var v) {
+        Type type = settledValues.valueKept(v.denotes());
+        if (type == null) {
+            return null;
+        }
+        Object constant = settledConstants.apply(v.denotes());
+        return constant == null ? v : literal(constant, v.pos());
+    }
+
+    /** {@code constant} as the expression a fold would read it back out of, or null for a value no
+     * literal spells. */
+    private static Ast.Expr literal(Object constant, SourcePos pos) {
+        return switch (constant) {
+            case Long i -> new Ast.IntLit(i, pos);
+            case java.math.BigDecimal d -> new Ast.DecimalLit(d, pos);
+            case String s -> new Ast.StringLit(s, pos);
+            case Boolean b -> new Ast.BoolLit(b, pos);
+            default -> null;
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -1318,6 +1318,15 @@ public final class HelperInliner {
      *
      * <p>What it holds is the path and not what it has seen: a value named twice in one body is
      * substituted twice, side by side, and only one inside the other is re-entry.
+     *
+     * <p>The path is also what says whose job the mark is. What a value carried is written over the
+     * whole expansion once it is whole, by the substitution no other substitution is inside — the
+     * outermost one holds every subtree the ones under it produced, and the mark is a flag, so
+     * writing it there says of each node what writing it at every level said. Written at every
+     * level it is written over each subtree once per level that subtree is under, which is the
+     * depth of a chain of values times its length. The walk allocates nothing — rebuilding an
+     * expression hands back what it was given where nothing changed — so what it costs is the
+     * walking, and nothing downstream of it can see that it ran twice.
      */
     private Ast.Expr substituted(String reached, Ast.Expr body) {
         if (!substituting.add(reached)) {
@@ -1326,7 +1335,8 @@ public final class HelperInliner {
                     + " values are not well founded is refused before a body of it is expanded");
         }
         try {
-            return HelperNames.carriedByValue(inline(body));
+            Ast.Expr expanded = inline(body);
+            return substituting.size() == 1 ? HelperNames.carriedByValue(expanded) : expanded;
         } finally {
             substituting.remove(reached);
         }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -10,6 +10,9 @@ import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Deque;
+import java.util.ArrayDeque;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -42,8 +45,21 @@ public final class HelperTyping {
                                      Map<String, ReqSig> reqSigs, Map<String, Type> recursiveHelperFns,
                                      Map<String, Ast.Expr> loweredBodies,
                                      TypeChecker.Elaborated elaborated) {
-        for (Ast.FnDef h : inliner.held().values()) {
+        // What each value of this module was settled as, filled in as they are checked. A value is
+        // checked against these rather than against a copy of the body each of them stands for,
+        // which is the same answer worked out once instead of once per name that reaches it.
+        Map<ValueName, Type> settledTypes = new HashMap<>();
+        Map<ValueName, Object> settledConstants = new HashMap<>();
+        Preserved standing = Preserved.valuesAlreadySettled(settledTypes::get);
+        for (Ast.FnDef h : valuesBeforeTheValuesThatNameThem(inliner)) {
             boolean recursive = recursiveHelperFns.containsKey(h.name());
+            // Only while checking a value, because only a value is settled here: a helper is
+            // checked as though its body had been written inline, and what it names is expanded
+            // into it exactly as before.
+            boolean settling = h.params().isEmpty() && !recursive
+                    && h.declaredBy(inliner.moduleName());
+            ValueName settles = settling
+                    ? new ValueName.Helper(inliner.moduleName(), h.name()) : null;
             Scope env = Scope.NONE;
             List<Integer> inferred = new ArrayList<>();
             for (int i = 0; i < h.params().size(); i++) {
@@ -74,7 +90,13 @@ public final class HelperTyping {
             // expansion runs (foldFrom's `step` is a parameter, not a same-named user helper).
             // Expanded once: the body an un-annotated parameter takes its type from is the same tree.
             Ast.Expr emitted = loweredBodies.get(h.name());
-            Ast.Expr body = emitted != null ? emitted : inliner.inline(h.writtenBody(), inliner.bodyOf(h.name()));
+            Ast.Expr body = emitted != null ? emitted
+                    : inliner.readingSettledValues(settling ? standing : Preserved.NONE,
+                                    settling ? settledConstants::get : _ -> null)
+                            .inline(h.writtenBody(), inliner.bodyOf(h.name()));
+            // Back for everything below, which reads a body with every value copied into it as it
+            // always was: the checks of a helper, and the arguments checked against the surface.
+            inliner.readingSettledValues(Preserved.NONE, _ -> null);
             if (recursive && body == null) {
                 // Lower keeps every recursive helper as a fn of the lowered module, and the backend
                 // emits from that same list, so a recursive helper without a lowered body would leave
@@ -113,9 +135,19 @@ public final class HelperTyping {
             // push a declared return type into the body so an empty-collection body (Map.empty, [])
             // takes the declared element/value type rather than a bottom
             Type declaredReturn = h.declaredReturn() == null ? null : TypeOps.successType(h.declaredReturn(), symbols);
-            Core elaboratedBody = Elaborator.elaborate(body, tenv, new CheckContext(symbols, null, reqSigs), declaredReturn);
+            Core elaboratedBody = Elaborator.elaborate(body, tenv,
+                    new CheckContext(symbols, null, reqSigs)
+                            .preserving(settling ? standing : Preserved.NONE),
+                    declaredReturn);
             Type bodyType = elaboratedBody.type();
             elaborated.definitionTypes.put(h.name(), bodyType);
+            if (settles != null) {
+                settledTypes.put(settles, bodyType);
+                // What it is a constant of, read off the body it was checked as. A reference to it
+                // is written out as that constant, so every position that asks whether an
+                // expression is known at compile time goes on reading a literal.
+                ConstEval.eval(body).ifPresent(c -> settledConstants.put(settles, c));
+            }
             if (emitted != null) {
                 elaborated.helpers.put(h.name(), elaboratedBody);   // the backend emits this
             }
@@ -133,6 +165,74 @@ public final class HelperTyping {
                 }
             }
         }
+    }
+
+    /**
+     * The declarations this pass checks, each value after the values it names.
+     *
+     * <p>A value is checked against what the values it names were settled as, so those have to be
+     * settled first. The source may write them the other way round — nothing says a value must be
+     * declared above the one that reads it — and the order they are checked in is not the order
+     * they are written in for that reason alone.
+     *
+     * <p>Stable otherwise: two values that name neither the other stay in the order the module
+     * wrote them, and a helper stays where it was. What is checked does not depend on the order —
+     * a value not yet settled is copied, as it was before any of this — so this decides what is
+     * worked out twice and nothing else.
+     *
+     * <p>A cycle has no such order, and there is none to find: {@link ValueCycles} refuses a value
+     * that reaches itself before a body of this module is expanded. What a cycle would do here is
+     * leave its members in the order they were written, each copying the other, which is the answer
+     * this pass gave before there was an order at all.
+     */
+    private static List<Ast.FnDef> valuesBeforeTheValuesThatNameThem(HelperInliner inliner) {
+        Map<String, Ast.FnDef> held = inliner.held();
+        Map<String, Set<String>> names = new LinkedHashMap<>();
+        for (Map.Entry<String, Ast.FnDef> e : held.entrySet()) {
+            if (!e.getValue().params().isEmpty()
+                    || !(e.getValue().body() instanceof Ast.FnBody.Written written)) {
+                continue;
+            }
+            Set<String> read = new LinkedHashSet<>();
+            ValueCycles.valuesRead(written.expr(), held, read);
+            read.retainAll(held.keySet());
+            names.put(e.getKey(), read);
+        }
+        // Depth-first with its own stack. A module's values chain as deeply as the author wrote
+        // them, and the chain is what this is for, so the call stack is the wrong one to walk it on.
+        List<Ast.FnDef> ordered = new ArrayList<>();
+        Set<String> placed = new LinkedHashSet<>();
+        for (String root : held.keySet()) {
+            if (placed.contains(root)) {
+                continue;
+            }
+            Deque<String> pending = new ArrayDeque<>();
+            pending.push(root);
+            Set<String> opened = new LinkedHashSet<>();
+            while (!pending.isEmpty()) {
+                String at = pending.peek();
+                if (placed.contains(at)) {
+                    pending.pop();
+                    continue;
+                }
+                // Opened once: its names go on the stack above it, and when it comes round again
+                // every one of them has been placed. A name already open is one this walk came
+                // through, which is a cycle — refused elsewhere, and left in place here so that
+                // this terminates whatever it is handed.
+                if (opened.add(at)) {
+                    for (String read : names.getOrDefault(at, Set.of())) {
+                        if (!placed.contains(read) && !opened.contains(read)) {
+                            pending.push(read);
+                        }
+                    }
+                    continue;
+                }
+                pending.pop();
+                placed.add(at);
+                ordered.add(held.get(at));
+            }
+        }
+        return ordered;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -53,12 +53,15 @@ public final class HelperTyping {
         Preserved standing = Preserved.valuesAlreadySettled(settledTypes::get);
         for (Ast.FnDef h : valuesBeforeTheValuesThatNameThem(inliner)) {
             boolean recursive = recursiveHelperFns.containsKey(h.name());
-            // Only while checking a value, because only a value is settled here: a helper is
-            // checked as though its body had been written inline, and what it names is expanded
-            // into it exactly as before.
-            boolean settling = h.params().isEmpty() && !recursive
-                    && h.declaredBy(inliner.moduleName());
-            ValueName settles = settling
+            // A helper reads a settled value as a value does. A helper's body is expanded into
+            // whoever calls it, and a value it names is expanded into that expansion, so a chain of
+            // values written through helpers reaches every link exactly as one written without them
+            // — and would copy every link, once per helper, for the same reason.
+            //
+            // What settles one is narrower: a value of this module, which is what has an answer to
+            // read. A helper settles nothing, and neither does a value the module took on to emit.
+            boolean settles = h.params().isEmpty() && h.declaredBy(inliner.moduleName());
+            ValueName settled = settles
                     ? new ValueName.Helper(inliner.moduleName(), h.name()) : null;
             Scope env = Scope.NONE;
             List<Integer> inferred = new ArrayList<>();
@@ -90,12 +93,15 @@ public final class HelperTyping {
             // expansion runs (foldFrom's `step` is a parameter, not a same-named user helper).
             // Expanded once: the body an un-annotated parameter takes its type from is the same tree.
             Ast.Expr emitted = loweredBodies.get(h.name());
+            // Not what the backend emits, and not a recursive helper's own body: a value is
+            // substituted at each of its references, and those two are trees that run.
+            boolean reading = emitted == null && !recursive;
             Ast.Expr body = emitted != null ? emitted
-                    : inliner.readingSettledValues(settling ? standing : Preserved.NONE,
-                                    settling ? settledConstants::get : _ -> null)
+                    : inliner.readingSettledValues(reading ? standing : Preserved.NONE,
+                                    reading ? settledConstants::get : _ -> null)
                             .inline(h.writtenBody(), inliner.bodyOf(h.name()));
             // Back for everything below, which reads a body with every value copied into it as it
-            // always was: the checks of a helper, and the arguments checked against the surface.
+            // always was: the arguments checked against the surface, and every other reader.
             inliner.readingSettledValues(Preserved.NONE, _ -> null);
             if (recursive && body == null) {
                 // Lower keeps every recursive helper as a fn of the lowered module, and the backend
@@ -137,16 +143,16 @@ public final class HelperTyping {
             Type declaredReturn = h.declaredReturn() == null ? null : TypeOps.successType(h.declaredReturn(), symbols);
             Core elaboratedBody = Elaborator.elaborate(body, tenv,
                     new CheckContext(symbols, null, reqSigs)
-                            .preserving(settling ? standing : Preserved.NONE),
+                            .preserving(reading ? standing : Preserved.NONE),
                     declaredReturn);
             Type bodyType = elaboratedBody.type();
             elaborated.definitionTypes.put(h.name(), bodyType);
-            if (settles != null) {
-                settledTypes.put(settles, bodyType);
+            if (settled != null) {
+                settledTypes.put(settled, bodyType);
                 // What it is a constant of, read off the body it was checked as. A reference to it
                 // is written out as that constant, so every position that asks whether an
                 // expression is known at compile time goes on reading a literal.
-                ConstEval.eval(body).ifPresent(c -> settledConstants.put(settles, c));
+                ConstEval.eval(body).ifPresent(c -> settledConstants.put(settled, c));
             }
             if (emitted != null) {
                 elaborated.helpers.put(h.name(), elaboratedBody);   // the backend emits this
@@ -175,28 +181,39 @@ public final class HelperTyping {
      * declared above the one that reads it — and the order they are checked in is not the order
      * they are written in for that reason alone.
      *
-     * <p>Stable otherwise: two values that name neither the other stay in the order the module
-     * wrote them, and a helper stays where it was. What is checked does not depend on the order —
-     * a value not yet settled is copied, as it was before any of this — so this decides what is
-     * worked out twice and nothing else.
+     * <p>Reaching is not only writing the name. A value reaches another by reading it and by
+     * calling a helper that reads it — the two kinds of edge {@link ValueCycles} follows together,
+     * for the same reason: a body's expansion goes through the helpers it calls, so what is behind
+     * one is reached exactly as a name written outright is. Following only the first would leave a
+     * chain written through helpers settling in the order it was declared, and a chain written
+     * bottom to top copied again per link.
+     *
+     * <p>Every declaration is a node, a helper as much as a value, because a helper is what carries
+     * the second kind of edge and is itself checked against what it reaches.
+     *
+     * <p>Stable otherwise: two declarations that reach neither the other stay in the order the
+     * module wrote them. What is checked does not depend on the order — what is not yet settled is
+     * copied, as it was before any of this — so this decides what is worked out twice and nothing
+     * else.
      *
      * <p>A cycle has no such order, and there is none to find: {@link ValueCycles} refuses a value
-     * that reaches itself before a body of this module is expanded. What a cycle would do here is
-     * leave its members in the order they were written, each copying the other, which is the answer
-     * this pass gave before there was an order at all.
+     * that reaches itself before a body of this module is expanded, and a cycle of helpers alone is
+     * a recursion the language allows. Either way its members are left in the order they were
+     * written, each copying the other, which is the answer this pass gave before there was an order
+     * at all.
      */
     private static List<Ast.FnDef> valuesBeforeTheValuesThatNameThem(HelperInliner inliner) {
         Map<String, Ast.FnDef> held = inliner.held();
         Map<String, Set<String>> names = new LinkedHashMap<>();
         for (Map.Entry<String, Ast.FnDef> e : held.entrySet()) {
-            if (!e.getValue().params().isEmpty()
-                    || !(e.getValue().body() instanceof Ast.FnBody.Written written)) {
+            if (!(e.getValue().body() instanceof Ast.FnBody.Written written)) {
                 continue;
             }
-            Set<String> read = new LinkedHashSet<>();
-            ValueCycles.valuesRead(written.expr(), held, read);
-            read.retainAll(held.keySet());
-            names.put(e.getKey(), read);
+            Set<String> reached = new LinkedHashSet<>();
+            HelperInliner.helperCallsIn(written.expr(), held, reached);
+            ValueCycles.valuesRead(written.expr(), held, reached);
+            reached.retainAll(held.keySet());
+            names.put(e.getKey(), reached);
         }
         // Depth-first with its own stack. A module's values chain as deeply as the author wrote
         // them, and the chain is what this is for, so the call stack is the wrong one to walk it on.

--- a/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/PartialReachability.java
@@ -11,6 +11,7 @@ import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -58,10 +59,28 @@ final class PartialReachability {
      * module's fns hold both under names of one shape. */
     private final Map<String, List<String>> calls;
 
+    /**
+     * The names of this graph from which a {@code partial} one is reachable, and the {@code partial}
+     * ones themselves. Worked out once, backwards from those, so that asking whether a declaration
+     * reaches one is a lookup.
+     *
+     * <p>The search below is what a report's path comes from and is unchanged. What this saves is the
+     * search that finds nothing: it walks everything the declaration reaches before it can say so,
+     * and every declaration is asked, so over a chain that is the chain again per link. Where the
+     * answer is no, no path was going to be built.
+     *
+     * <p>Backwards from every {@code partial} name reaches exactly the names the forward search
+     * would: the forward one stops at the first {@code partial} node and does not expand it, and a
+     * path that ran on through one would be a longer path to a node this already holds.
+     */
+    private final Set<String> reachingPartial;
+
     private final HelperInliner inliner;
 
-    private PartialReachability(Map<String, List<String>> calls, HelperInliner inliner) {
+    private PartialReachability(Map<String, List<String>> calls, Set<String> reachingPartial,
+                                HelperInliner inliner) {
         this.calls = calls;
+        this.reachingPartial = reachingPartial;
         this.inliner = inliner;
     }
 
@@ -80,7 +99,37 @@ final class PartialReachability {
             }
             // an intrinsic declares no body to read what it reaches out of
         }
-        return new PartialReachability(calls, inliner);
+        return new PartialReachability(calls, reachingPartial(calls, inliner), inliner);
+    }
+
+    /** Every name of {@code calls} from which a {@code partial} one is reachable, the
+     * {@code partial} ones included. */
+    private static Set<String> reachingPartial(Map<String, List<String>> calls,
+                                               HelperInliner inliner) {
+        Map<String, List<String>> back = new LinkedHashMap<>();
+        Set<String> nodes = new LinkedHashSet<>(calls.keySet());
+        calls.forEach((from, tos) -> {
+            for (String to : tos) {
+                nodes.add(to);
+                back.computeIfAbsent(to, _ -> new ArrayList<>()).add(from);
+            }
+        });
+        Set<String> reaching = new LinkedHashSet<>();
+        Deque<String> work = new ArrayDeque<>();
+        for (String node : nodes) {
+            Ast.FnDef declared = inliner.helper(node);
+            if (declared != null && declared.partial() && reaching.add(node)) {
+                work.add(node);
+            }
+        }
+        while (!work.isEmpty()) {
+            for (String previous : back.getOrDefault(work.poll(), List.of())) {
+                if (reaching.add(previous)) {
+                    work.add(previous);
+                }
+            }
+        }
+        return reaching;
     }
 
     /**
@@ -134,6 +183,12 @@ final class PartialReachability {
      * about the caller. A node is visited once, so a cycle is walked once.
      */
     private Optional<List<String>> search(List<String> seeds) {
+        // Whether one is reachable at all is a lookup; the marker is still read off the declaration
+        // beside it, because a name this graph never saw — one an invariant clause alone reaches —
+        // is in no set built from the graph.
+        if (seeds.stream().noneMatch(seed -> reachingPartial.contains(seed) || isPartial(seed))) {
+            return Optional.empty();
+        }
         Map<String, String> from = new HashMap<>();
         Set<String> seen = new HashSet<>();
         Deque<String> work = new ArrayDeque<>();

--- a/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Preserved.java
@@ -1,13 +1,15 @@
 package souther.compiler.check;
 
 import souther.compiler.Prelude;
+import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * The calls the representation being typed keeps standing, and the signature each was declared with.
+ * The names the representation being typed keeps standing, and what each of them is known to be: a
+ * signature for a call, a settled type for a reference to a value.
  *
  * <p>Which calls a representation keeps is the representation's to decide
  * ({@link InliningPolicy}), so it is decided once, where that representation is built, and handed to
@@ -25,11 +27,59 @@ import java.util.Map;
  * one this representation never said it would keep, is this compiler having failed to expand it, and
  * is reported as that rather than typed.
  */
-public record Preserved(Map<ValueName, CompleteSignature> operations) {
+public record Preserved(Map<ValueName, CompleteSignature> operations, SettledValues values) {
+
+    /**
+     * What a value's own check settled it as, asked by the name it was resolved to.
+     *
+     * <p>A lookup rather than a map, because the answers arrive while the representation is being
+     * read: a module's values are checked one after another, each against what the ones it names
+     * were settled as, and a snapshot taken per definition would copy the whole set once per
+     * definition — the cost this was for.
+     */
+    @FunctionalInterface
+    public interface SettledValues {
+
+        /** Nothing settled: every value is substituted, which is what every representation but the
+         * standalone check of a value does. */
+        SettledValues NONE = _ -> null;
+
+        /** The type {@code name} was settled as, or null where nothing settled it. */
+        Type typeOf(ValueName name);
+    }
 
     /** Every representation that keeps nothing standing — the tree the backend emits from, and every
      *  expression checked outside one. */
-    public static final Preserved NONE = new Preserved(Map.of());
+    public static final Preserved NONE = new Preserved(Map.of(), SettledValues.NONE);
+
+    public Preserved(Map<ValueName, CompleteSignature> operations) {
+        this(operations, SettledValues.NONE);
+    }
+
+    /**
+     * A representation that keeps a reference to each of {@code settled} standing, under the type
+     * that value's own check settled for it.
+     *
+     * <p>What a value means is settled where it is declared and is the same wherever it is named
+     * (ADR-0072), so a check that has that answer already needs nothing from the value's body. The
+     * one it does not have is what the value is a constant of: that is folded into the reference
+     * where the reference is written, so everything downstream reads a literal exactly as it did
+     * when the whole body was copied there.
+     */
+    public static Preserved valuesAlreadySettled(SettledValues settled) {
+        return new Preserved(Map.of(), settled);
+    }
+
+    /**
+     * The type {@code name} was settled as, or null where this representation does not keep a
+     * reference to it standing.
+     *
+     * <p>Asked of what the name was resolved to, as an operation is: a binding spelled like a value
+     * is a binding, and two modules' same-named values are two values.
+     */
+    public Type valueKept(ValueName name) {
+        return name == null ? null : values.typeOf(name);
+    }
 
     /**
      * What {@link InliningPolicy#DISCHARGE} keeps: the language's own operations, each under the

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -76,6 +76,12 @@ public final class ValueCycles {
             valuesRead(e.getValue().writtenBody(), own, out);
             edges.put(e.getKey(), out);
         }
+        // Which names lie on a cycle, worked out once over the whole graph. What is asked of each
+        // value below is whether it reaches itself, and a search per value answers it by walking
+        // everything that value reaches — over a chain of values that is the chain again per link.
+        // The path a report names is still found by the search below, which runs for the one value
+        // that is refused and for no other.
+        Set<String> reachesItself = onACycle(edges);
         for (Map.Entry<String, Ast.FnDef> e : own.entrySet()) {
             if (!e.getValue().params().isEmpty()) {
                 continue;   // a helper's own recursion is the call graph's business
@@ -93,6 +99,9 @@ public final class ValueCycles {
                                 .at(block.pos()).build(),
                         "a block is not a value: `let " + e.getKey() + "` writes no parameters, so it"
                                 + " defines a value, and a block cannot be one (spec 12.5)");
+            }
+            if (!reachesItself.contains(e.getKey())) {
+                continue;
             }
             List<String> path = new ArrayList<>();
             if (pathBackTo(e.getKey(), e.getKey(), edges, new LinkedHashSet<>(), path)) {
@@ -130,6 +139,78 @@ public final class ValueCycles {
             }
         }
         Ast.forEachChild(e, c -> valuesRead(c, reachable, out));
+    }
+
+    /**
+     * The names of {@code edges} that reach themselves: the ones in a strongly connected group of
+     * more than one, and the ones with an edge to themselves.
+     *
+     * <p>Tarjan's, written with its own stack rather than the call stack. A module's definitions
+     * nest as deeply as they are chained, and this walk is over the same chain that made the walk
+     * worth doing — a recursive one would answer by running out of stack on the input it was added
+     * for.
+     */
+    private static Set<String> onACycle(Map<String, Set<String>> edges) {
+        Map<String, Integer> index = new LinkedHashMap<>();
+        Map<String, Integer> low = new LinkedHashMap<>();
+        Set<String> open = new LinkedHashSet<>();       // on the component stack
+        List<String> component = new ArrayList<>();
+        Set<String> found = new LinkedHashSet<>();
+        int[] next = {0};
+        for (String root : edges.keySet()) {
+            if (index.containsKey(root)) {
+                continue;
+            }
+            // Each frame is a node and how far its edges have been walked. Pushed with the edge
+            // count at zero and popped once every edge has been taken, which is what a recursion
+            // would have done between two statements.
+            List<Object[]> frames = new ArrayList<>();
+            frames.add(new Object[]{root, 0});
+            index.put(root, next[0]);
+            low.put(root, next[0]++);
+            open.add(root);
+            component.add(root);
+            while (!frames.isEmpty()) {
+                Object[] frame = frames.get(frames.size() - 1);
+                String at = (String) frame[0];
+                List<String> out = new ArrayList<>(edges.getOrDefault(at, Set.of()));
+                int taken = (Integer) frame[1];
+                if (taken < out.size()) {
+                    frame[1] = taken + 1;
+                    String to = out.get(taken);
+                    if (!index.containsKey(to)) {
+                        index.put(to, next[0]);
+                        low.put(to, next[0]++);
+                        open.add(to);
+                        component.add(to);
+                        frames.add(new Object[]{to, 0});
+                    } else if (open.contains(to)) {
+                        low.put(at, Math.min(low.get(at), index.get(to)));
+                    }
+                    continue;
+                }
+                frames.remove(frames.size() - 1);
+                if (!frames.isEmpty()) {
+                    String under = (String) frames.get(frames.size() - 1)[0];
+                    low.put(under, Math.min(low.get(under), low.get(at)));
+                }
+                if (low.get(at).equals(index.get(at))) {
+                    List<String> group = new ArrayList<>();
+                    String popped;
+                    do {
+                        popped = component.remove(component.size() - 1);
+                        open.remove(popped);
+                        group.add(popped);
+                    } while (!popped.equals(at));
+                    // One name is a group of its own unless it names itself: a group of one has no
+                    // way round except an edge back to where it started.
+                    if (group.size() > 1 || edges.getOrDefault(at, Set.of()).contains(at)) {
+                        found.addAll(group);
+                    }
+                }
+            }
+        }
+        return found;
     }
 
     /** Records into {@code path} a route from {@code from} back to {@code target}, or answers false. */

--- a/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ValueCycles.java
@@ -156,34 +156,28 @@ public final class ValueCycles {
         Set<String> open = new LinkedHashSet<>();       // on the component stack
         List<String> component = new ArrayList<>();
         Set<String> found = new LinkedHashSet<>();
-        int[] next = {0};
+        int next = 0;
         for (String root : edges.keySet()) {
             if (index.containsKey(root)) {
                 continue;
             }
-            // Each frame is a node and how far its edges have been walked. Pushed with the edge
-            // count at zero and popped once every edge has been taken, which is what a recursion
-            // would have done between two statements.
-            List<Object[]> frames = new ArrayList<>();
-            frames.add(new Object[]{root, 0});
-            index.put(root, next[0]);
-            low.put(root, next[0]++);
+            List<Walking> frames = new ArrayList<>();
+            frames.add(new Walking(root, edges.getOrDefault(root, Set.of()).iterator()));
+            index.put(root, next);
+            low.put(root, next++);
             open.add(root);
             component.add(root);
             while (!frames.isEmpty()) {
-                Object[] frame = frames.get(frames.size() - 1);
-                String at = (String) frame[0];
-                List<String> out = new ArrayList<>(edges.getOrDefault(at, Set.of()));
-                int taken = (Integer) frame[1];
-                if (taken < out.size()) {
-                    frame[1] = taken + 1;
-                    String to = out.get(taken);
+                Walking frame = frames.get(frames.size() - 1);
+                String at = frame.node();
+                if (frame.edges().hasNext()) {
+                    String to = frame.edges().next();
                     if (!index.containsKey(to)) {
-                        index.put(to, next[0]);
-                        low.put(to, next[0]++);
+                        index.put(to, next);
+                        low.put(to, next++);
                         open.add(to);
                         component.add(to);
-                        frames.add(new Object[]{to, 0});
+                        frames.add(new Walking(to, edges.getOrDefault(to, Set.of()).iterator()));
                     } else if (open.contains(to)) {
                         low.put(at, Math.min(low.get(at), index.get(to)));
                     }
@@ -191,7 +185,7 @@ public final class ValueCycles {
                 }
                 frames.remove(frames.size() - 1);
                 if (!frames.isEmpty()) {
-                    String under = (String) frames.get(frames.size() - 1)[0];
+                    String under = frames.get(frames.size() - 1).node();
                     low.put(under, Math.min(low.get(under), low.get(at)));
                 }
                 if (low.get(at).equals(index.get(at))) {
@@ -212,6 +206,16 @@ public final class ValueCycles {
         }
         return found;
     }
+
+    /**
+     * A node the walk is inside, and the edges of it that are left.
+     *
+     * <p>The iterator is the frame's, taken once when the frame is pushed. A frame is resumed once
+     * per edge it has, so a frame that worked out where it had got to would read the node's edges
+     * once per edge — which over a name that reaches many is that name's edges squared, and a chain
+     * says nothing about it because every name there reaches one.
+     */
+    private record Walking(String node, java.util.Iterator<String> edges) {}
 
     /** Records into {@code path} a route from {@code from} back to {@code target}, or answers false. */
     private static boolean pathBackTo(String from, String target, Map<String, Set<String>> edges,

--- a/souther-compiler/src/main/java/souther/compiler/core/Core.java
+++ b/souther-compiler/src/main/java/souther/compiler/core/Core.java
@@ -159,8 +159,10 @@ public sealed interface Core {
     }
 
     /**
-     * A call a representation kept standing on purpose: resolved to the declaration it names, typed
-     * from that declaration's signature, and deliberately not expanded.
+     * A name a representation kept standing on purpose: resolved to the declaration it names, typed
+     * from what that declaration settled, and deliberately not expanded. A call is one, with its
+     * arguments; a reference to a value is one with none, since reading a value's name is running
+     * its body (ADR-0072) and a representation that did not substitute it kept that.
      *
      * <p>Not a call this compiler failed to expand. Which calls survive is a representation's to
      * decide ({@link souther.compiler.check.InliningPolicy}): an analysis that has rules about an

--- a/souther-compiler/src/test/java/souther/compiler/AValueIsCheckedAgainstWhatTheOnesItNamesSettledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AValueIsCheckedAgainstWhatTheOnesItNamesSettledTest.java
@@ -1,0 +1,179 @@
+package souther.compiler;
+
+import souther.compiler.diag.CompileException;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A value is substituted where it is named, and its own check does not need the copy.
+ *
+ * <p>What that check needs of a value it names is what that value's own check settled: the type it
+ * stands under, and the constant it is one of where a fold reaches it. Both are worked out once and
+ * read, rather than derived again out of a copy of the body — a chain of values would otherwise
+ * cost the chain again per link.
+ *
+ * <p>What the backend emits is the other question and is unchanged: a value is substituted at each
+ * of its references, and every test here that runs the emitted code says so.
+ */
+class AValueIsCheckedAgainstWhatTheOnesItNamesSettledTest {
+
+    private BytesClassLoader loader(String source) {
+        return new BytesClassLoader(Compiler.compile(source), getClass().getClassLoader());
+    }
+
+    /** A chain of values still computes what it says. The check reads each one's settled answer;
+     *  the emitted body reads the substitution, and the two have to agree. */
+    @Test
+    void aChainOfValuesIsStillSubstitutedIntoWhatTheBackendEmits() throws Exception {
+        BytesClassLoader loader = loader("""
+                module demo
+
+                data In = { n: Int }
+                data Out = { n: Int }
+
+                let one = 1
+                let two = one + 1
+                let four = two + two
+
+                behavior bump : (i: In) -> Out constructs Out
+                let bump (i) = Out { n = i.n + four }
+                """);
+        Object behavior = loader.loadClass("demo.Bump$Impl").getConstructor().newInstance();
+        Object out = Codecs.apply(behavior, Codecs.decoded(loader, "demo.In", Map.of("n", 10L)));
+        assertEquals(14L, ((Map<?, ?>) Codecs.encode(loader, "demo.Out", out)).get("n"));
+    }
+
+    /** The order the module wrote them in is not the order they have to be settled in: a value may
+     *  be written above the one it names. */
+    @Test
+    void aValueMayBeWrittenAboveTheOneItNames() throws Exception {
+        BytesClassLoader loader = loader("""
+                module demo
+
+                data In = { n: Int }
+                data Out = { n: Int }
+
+                let four = two + two
+                let two = one + 1
+                let one = 1
+
+                behavior bump : (i: In) -> Out constructs Out
+                let bump (i) = Out { n = i.n + four }
+                """);
+        Object behavior = loader.loadClass("demo.Bump$Impl").getConstructor().newInstance();
+        Object out = Codecs.apply(behavior, Codecs.decoded(loader, "demo.In", Map.of("n", 10L)));
+        assertEquals(14L, ((Map<?, ?>) Codecs.encode(loader, "demo.Out", out)).get("n"));
+    }
+
+    /** A mis-typed value is reported at the value, and reported once. Its own check is what reads
+     *  the body; the values that name it read the answer. */
+    @Test
+    void aValueThatDoesNotTypeIsReportedAtItself() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data In = { n: Int }
+                data Out = { n: Int }
+
+                let text = "no"
+                let sum = text + 1
+                let more = sum + 1
+
+                behavior bump : (i: In) -> Out constructs Out
+                let bump (i) = Out { n = i.n + more }
+                """));
+        assertTrue(e.getMessage().contains("sum") || e.getMessage().contains("String"),
+                e.getMessage());
+    }
+
+    /** A value the fold does not reach stands under its type, and what it is still types. A
+     *  construction is one: nothing folds it to a literal. */
+    @Test
+    void aValueNoFoldReachesIsStillTypedThroughAChain() throws Exception {
+        BytesClassLoader loader = loader("""
+                module demo
+
+                data In = { n: Int }
+                data Out = { n: Int }
+                data Hours = Int
+
+                let base = Hours(3)
+                let same = base
+                let again = same
+
+                behavior bump : (i: In) -> Out constructs Out
+                let bump (i) = Out { n = i.n + again.value }
+                """);
+        Object behavior = loader.loadClass("demo.Bump$Impl").getConstructor().newInstance();
+        Object out = Codecs.apply(behavior, Codecs.decoded(loader, "demo.In", Map.of("n", 10L)));
+        assertEquals(13L, ((Map<?, ?>) Codecs.encode(loader, "demo.Out", out)).get("n"));
+    }
+
+    /** Naming a value in a position that demands a compile-time string still reaches the string.
+     *  The value is written out as the constant it folded to, so the fold reads a literal — and it
+     *  reaches through a chain of values, each of which folded before the next was checked. */
+    @Test
+    void aChainOfValuesStillComposesACompileTimePattern() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data In = { s: String }
+                data Out = Bool
+
+                let digits = "[0-9]"
+                let three = digits ++ digits ++ digits
+                let code = three ++ "-" ++ digits
+
+                behavior check : (i: In) -> Out constructs Out
+                let check (i) = Out(String.matches(code, i.s))
+                """));
+    }
+
+    /**
+     * The same demand inside a value's own body, which is the check that reads a value by its
+     * settled answer rather than by a copy. The pattern names another value, and the fold has to
+     * reach the string through it — which is what writing a constant out at the reference is for.
+     */
+    @Test
+    void aValueMayItselfDemandACompileTimePatternOfAnotherValue() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module demo
+
+                data In = { s: String }
+                data Out = Bool
+
+                let digits = "[0-9]"
+                let code = digits ++ digits
+                let matched = String.matches(code, "42")
+
+                behavior check : (i: In) -> Out constructs Out
+                let check (i) = Out(matched)
+                """));
+    }
+
+    /** And a malformed one there is still refused as a regex, rather than as an expression nothing
+     *  could evaluate at compile time. */
+    @Test
+    void aMalformedPatternInsideAValueIsStillARegexError() {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile("""
+                module demo
+
+                data In = { s: String }
+                data Out = Bool
+
+                let digits = "[0-9]"
+                let broken = String.matches(digits ++ "[", "42")
+
+                behavior check : (i: In) -> Out constructs Out
+                let check (i) = Out(broken)
+                """));
+        assertTrue(e.getMessage().contains("not a valid regular expression"), e.getMessage());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/CompileValueConstructionAuthorityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileValueConstructionAuthorityTest.java
@@ -229,6 +229,54 @@ class CompileValueConstructionAuthorityTest {
         assertEquals("E1002", e.code(), e.getMessage());
     }
 
+    /** A value reached through values of the same module. The mark is written over the whole
+     * expansion by the substitution no other substitution is inside, so what it says of a
+     * construction does not depend on how many names stood between the behavior and it. */
+    @Test
+    void aValueReachedThroughValuesOfThisModuleCarriesTheSameWay() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let baseHours = Hours(20.0m)
+                let namedHours = baseHours
+                let floorHours = namedHours
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """));
+    }
+
+    /** The same, with a helper expanded on the way. A helper call becomes an expansion, whose
+     * `given` is not a slot of the walk that rebuilds an expression, so this is the shape that says
+     * the outermost substitution reaches what the ones under it produced. */
+    @Test
+    void aValueReachedThroughAValueThatExpandsAHelperCarriesTheSameWay() {
+        assertDoesNotThrow(() -> Compiler.compile("""
+                module m
+
+                data Hours = Decimal invariant value >= 0.0m
+                data TooShort
+
+                let floorOf (d) = Hours(d)
+                let baseHours = floorOf(20.0m)
+                let floorHours = baseHours
+
+                behavior judge : (h: Hours) -> Hours | TooShort
+                    constructs TooShort
+                let judge (h) = {
+                    guard h >= floorHours else TooShort
+                    h
+                }
+                """));
+    }
+
     /** A unit data is constructed by being named, so it has no construction node to carry the mark
      * — the name carries it. A value standing for one reaches the reading behavior by that path. */
     @Test


### PR DESCRIPTION
A module of N values cost more than N, in three separate ways. All three are here, and #531 is
folded in rather than left to merge first — PR #532 is closed in favour of this one.

## What was costing what

Measured on the chain of the issue, one module, a whole compile:

| N | before | after |
|---|---|---|
| 200 | 23.8 ms | 11.7 ms |
| 400 | 52.2 ms | 17.0 ms |
| 800 | 130.2 ms | 28.8 ms |
| 1600 | 449.6 ms | 50.0 ms |

The cost per value now falls with the module (0.058 → 0.031 ms) where it rose with it
(0.119 → 0.281 ms).

**The mark on what a value carried was written once per level of substitution** (#531). The walk is
idempotent, so a chain of K values was walked at sizes 1, 2, ..., K — N cubed, and the term that
answered for the time. At eight hundred values, 172,270,002 node visits against 644,807
elaborations.

**Two checks searched the whole graph once per declaration**, and both were at their most expensive
when they found nothing. `ValueCycles` asked each value whether it reaches itself; which names lie
on a cycle is now worked out once, by Tarjan's. `PartialReachability` searched forward from every
declaration for a `partial` one; which names can reach one is now worked out once, backwards from
them. Both keep the search that a report's path comes from, and run it only where the answer is
yes, so nothing reported changes.

**A value's own check read a copy of every value it names.** That is the issue's own term: the
source has one `v99` and the check had a hundred copies of it, so N answers cost N squared nodes.

## What a value's check now reads

What it needs of a value it names is what that value's own check settled, and there are two such
things.

The type it stands under. A reference is kept standing and read as that, which is what a
representation keeping a name standing already means, so it is said through `Preserved` — the
capability belongs to that representation and not to elaboration at large.

The constant it is one of, where a fold reaches one. That is written out at the reference as the
literal it folded to, because everything that asks whether an expression is known at compile time
folds a tree rather than resolves a name (`ConstEval`, and it says so). A `String.matches` pattern
composed out of values goes on reading a literal.

Values are therefore checked each after the ones it names, which is not the order the module wrote
them. The order decides what is worked out twice and nothing else: a value not yet settled is
copied exactly as it was before.

Only while checking a value. A helper is checked as though its body had been written inline, and
what it names is expanded into it as before; so is every tree the backend emits from, because a
value is substituted at each of its references and that is what runs.

## What does not change

No program that compiled stops compiling and none that was refused is accepted. A value whose body
is an empty collection still takes its element type from each place that names it — the behavior
that names it substitutes, as it always did — so this settles nothing about that and leaves it
exactly where it was.

Diagnostics are the one thing that can differ in count: checking `v100` used to re-report what was
already reported at `v99`, and not doing that twice is what the change is. Nothing changes in what
is reported first, or in how anything is worded.

## Tests

Nine, over the two changes that could have altered an answer.

For the mark: a value reached through values of the same module, and one reached through a value
that expands a helper — a helper call becomes an expansion, whose `given` is not a slot of the walk
that rebuilds an expression. Both fail if the mark is dropped rather than moved.

For the settled answer: a chain still computing what it says once emitted, a value written above
the one it names, a value the fold does not reach standing under its type, a mis-typed value
reported at itself, and a compile-time pattern composed through a chain — inside a value's own
body, which is the check that reads a settled answer, and refused as a regex rather than as an
expression nothing could evaluate. The last two fail if the constant is not written out.

The benchmark grows a `values` measurement: a chain of values, the same chain written bottom to
top, and as many values naming none of them. Per value, so a term above linear reads as a rising
figure rather than a bigger total, and an order lost shows up in the reversed column alone.

Closes #523. Closes #531.
