### PR TITLE
The invariant diagnostics name the clause they judged

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Clauses.java
@@ -63,6 +63,8 @@ final class Clauses {
                 TypeOps.effectiveInvariants(name, data, symbols, inTheAnalysisRepresentation::get));
     }
 
+    private final Map<TypeName, List<TypeOps.Declared>> declaredClauses = new HashMap<>();
+
     /** What {@code data}'s fields are. */
     Map<String, Type> fieldsOf(Ast.Data data) {
         return fields.computeIfAbsent(data, d -> TypeOps.fieldTypes(d, symbols));
@@ -128,15 +130,31 @@ final class Clauses {
      * it owes where one is being built are the same clauses read the same way, and they differ only
      * in what the fields are given — a read of each field, or the value each is being handed.
      */
-    List<Core> statedAt(TypeName named, Ast.Data data, Map<BindingId, Core> given) {
-        List<Core> stated = new ArrayList<>();
-        for (Ast.InvariantClause inv : of(named, data)) {
-            Core one = statedAt(inv.expr(), named, data, given);
+    List<Stated> statedAt(TypeName named, Ast.Data data, Map<BindingId, Core> given) {
+        List<Stated> stated = new ArrayList<>();
+        for (TypeOps.Declared inv : declared(named, data)) {
+            Core one = statedAt(inv.clause().expr(), named, data, given);
             if (one != null) {
-                stated.add(one);
+                stated.add(new Stated(inv.clause().name().orElse(null), inv.declaredOn(), one));
             }
         }
         return stated;
+    }
+
+    /**
+     * One clause as it reads at a construction, with the name the author gave it and the declaration
+     * it was written on.
+     *
+     * <p>A check that judges the clauses one at a time has something to say about the one it could
+     * not settle, and what it says it by is the name — which the clauses were flattened out of
+     * before reaching here, leaving every unproven clause reported as "the invariant".
+     */
+    record Stated(String name, TypeName declaredOn, Core expr) {}
+
+    /** Every clause of {@code named}, each with the declaration that wrote it. */
+    List<TypeOps.Declared> declared(TypeName named, Ast.Data data) {
+        return declaredClauses.computeIfAbsent(named, name ->
+                TypeOps.declaredInvariants(name, data, symbols, inTheAnalysisRepresentation::get));
     }
 
     /** Which of {@code data}'s own fields {@code clause} reads, remembered: a clause is read at every

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -8,6 +8,7 @@ import souther.compiler.numeric.NumericDomain.LinearForm;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.msg.InvariantMessage;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
@@ -22,6 +23,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.SequencedSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -633,7 +636,7 @@ public final class InvariantChecker {
      * reaches here: the walk opens it before anything is checked, so what a field is given is a
      * value and not a choice of two.
      */
-    private Verdict verdictOf(Core.NewData nd, Ast.Data type, Known k, Denotations at) {
+    private Judgment verdictOf(Core.NewData nd, Ast.Data type, Known k, Denotations at) {
         Map<String, BindingId> fields = clauses.bindingsOf(nd.typeName(), type);
         Map<BindingId, Core> given = new HashMap<>();
         for (Core.FieldInit fi : nd.inits()) {
@@ -725,13 +728,24 @@ public final class InvariantChecker {
 
     /** The discharge verdict for a construction of {@code type} whose fields are being given
      * {@code given}. */
-    private Verdict verdictOf(TypeName named, Ast.Data type, Map<BindingId, Core> given, Known k,
-                              Denotations at, boolean decidesFalse) {
+    private Judgment verdictOf(TypeName named, Ast.Data type, Map<BindingId, Core> given, Known k,
+                               Denotations at, boolean decidesFalse) {
         // What the construction hands over that no clause may be read against. A clause naming one of
         // them is left to the run-time check, and one that is decided outright is still decided: what
         // cannot be guarded is not the same as what cannot be computed.
         Set<Core> unnamed = unnamed(given.values(), k, at);
-        List<Predicates.Clause> owed = new ArrayList<>();
+        List<Owing> owed = new ArrayList<>();
+        // Which clauses came out settled and which did not, in the order they were declared. What is
+        // reported of a construction that may abort is the clause the guards did not establish, and
+        // the invariant is the conjunction of its clauses — so every one of them is read before the
+        // answer is decided, and each is remembered by the name its author gave it.
+        SequencedSet<String> unsettled = new LinkedHashSet<>();
+        SequencedSet<String> settled = new LinkedHashSet<>();
+        boolean refutedAlone = false;
+        // Whether any clause is unsettled, which is not the same as whether any named one is: a
+        // clause MAY be written without a name, and one that was is still a clause the guards did
+        // not establish. Reading the answer off the names alone made an unnamed clause discharge.
+        boolean unknown = false;
         // A clause the check cannot read here owes nothing and proves nothing, and the two are not
         // the same answer. Kept apart: a clause that owes nothing because it folded to what it is read
         // with is discharged, and one that owes nothing because nothing here could be asked of it is
@@ -740,21 +754,24 @@ public final class InvariantChecker {
         // A newtype construction from a value written out is the constant check's to report: it names
         // the clause that failed. It reads the construction as written, so a name given the value is
         // not one it sees, and this check says it instead — which is what `decidesFalse` carries.
-        for (Core stated : clauses.statedAt(named, type, given)) {
-            Predicates.Owed o = predicates.obligations(stated, k, at, unnamed, decidesFalse);
+        for (Clauses.Stated stated : clauses.statedAt(named, type, given)) {
+            Predicates.Owed o = predicates.obligations(stated.expr(), k, at, unnamed, decidesFalse);
             unreadable |= o.unreadable();
-            owed.addAll(o.clauses());
+            for (Predicates.Clause one : o.clauses()) {
+                owed.add(new Owing(stated, one));
+            }
         }
         if (owed.isEmpty()) {
-            return unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED;
+            return new Judgment(unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED,
+                    unsettled, settled);
         }
         NumericDomain dom = k.numbers();
         // The same clauses read against the same site, under what would be known here had no
         // condition on the path settled anything. What each clause states of the sizes it names holds
         // either way, so both readings take it.
         NumericDomain alone = k.unguarded().numbers();
-        for (Predicates.Clause c : owed) {
-            for (Predicates.Constraint known : c.known()) {
+        for (Owing owing : owed) {
+            for (Predicates.Constraint known : owing.clause().known()) {
                 Map<String, Granularity> kinds = terms.kindsOf(known.form());
                 dom = dom.assume(known.form(), known.rel(), kinds);
                 alone = alone.assume(known.form(), known.rel(), kinds);
@@ -765,29 +782,76 @@ public final class InvariantChecker {
         // invariant refuted on the values alone, whatever another clause needed to be refuted —
         // stopping at the first refutation would answer with whichever clause was declared first.
         boolean alongside = false;
-        boolean unknown = false;
-        for (Predicates.Clause c : owed) {
+        for (Owing owing : owed) {
+            Predicates.Clause c = owing.clause();
             if (c.dischargedBy(dom, k.facts())) {
+                if (owing.said() != null) {
+                    settled.add(owing.said());
+                }
                 continue;
             }
             if (!c.refutedBy(dom, k.facts())) {
                 unknown = true;
+                if (owing.said() != null) {
+                    unsettled.add(owing.said());
+                }
                 continue;
             }
             if (c.refutedBy(alone, k.unguarded().facts())) {
-                return Verdict.REFUTED_ALONE;
+                refutedAlone = true;
             }
             alongside = true;
+            if (owing.said() != null) {
+                unsettled.add(owing.said());
+            }
+        }
+        if (refutedAlone) {
+            return new Judgment(Verdict.REFUTED_ALONE, unsettled, settled);
         }
         if (alongside) {
-            return Verdict.REFUTED_NOT_ALONE;
+            return new Judgment(Verdict.REFUTED_NOT_ALONE, unsettled, settled);
         }
         if (unknown) {
-            return Verdict.UNKNOWN;
+            return new Judgment(Verdict.UNKNOWN, unsettled, settled);
         }
         // Every clause that could be read is discharged. One that could not be read still stands, so
         // this is not the whole invariant proven.
-        return unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED;
+        return new Judgment(unreadable ? Verdict.UNREPRESENTABLE : Verdict.PROVED, unsettled,
+                settled);
+    }
+
+    /** One obligation and the clause it was owed by. */
+    private record Owing(Clauses.Stated from, Predicates.Clause clause) {
+
+        /** The name the author gave this clause, or null where they gave it none. A clause MAY be
+         * named, and one that is not is one a reader cannot be sent to by name. */
+        String said() {
+            return from.name();
+        }
+    }
+
+    /**
+     * What the check found, and of which clauses.
+     *
+     * <p>The verdict alone is what used to come back, and it is the conjunction's answer: a reader
+     * told that a construction may violate "its invariant" is told nothing they can act on where the
+     * type declares five clauses and four of them are settled.
+     */
+    record Judgment(Verdict verdict, SequencedSet<String> unsettled, SequencedSet<String> settled) {
+
+        /**
+         * What two readings of one construction found, together.
+         *
+         * <p>A clause is unsettled here if either reading left it so — what one branch established
+         * is not established where the other did not — and settled only where both settled it.
+         */
+        static Judgment of(Judgment a, Judgment b) {
+            SequencedSet<String> unsettled = new LinkedHashSet<>(a.unsettled());
+            unsettled.addAll(b.unsettled());
+            SequencedSet<String> settled = new LinkedHashSet<>(a.settled());
+            settled.retainAll(b.settled());
+            return new Judgment(Verdict.of(a.verdict(), b.verdict()), unsettled, settled);
+        }
     }
 
     /** Whether the constant check reads this construction: a newtype's, over a value written where
@@ -801,24 +865,32 @@ public final class InvariantChecker {
      * warning; a discharged or non-expressible invariant says nothing. An {@code attempted}
      * construction raises no warning: what the warning reports is a possible abort, and an attempt
      * takes its else branch instead. */
-    private void report(Core at, Ast.Data type, SourcePos pos, boolean attempted, Verdict verdict) {
+    private void report(Core at, Ast.Data type, SourcePos pos, boolean attempted,
+                        Judgment judgment) {
+        Verdict verdict = judgment.verdict();
         List<Said> watching = WATCHING;
         if (watching != null && capturing == null) {
             watching.add(new Said(type.name(), pos, verdict));
         }
         if (capturing != null) {
             capturing.found().put(new Occurrence(asWritten(at)),
-                    new Reported(type, pos, verdict, attempted));
+                    new Reported(type, pos, judgment, attempted));
             return;
         }
         switch (verdict) {
-            case REFUTED_ALONE -> reportViolation(type, pos, "check.invariant.violation.alone");
-            case REFUTED_NOT_ALONE ->
-                    reportViolation(type, pos, "check.invariant.violation.assumed");
+            case REFUTED_ALONE -> reportViolation(type, pos, judgment, false);
+            case REFUTED_NOT_ALONE -> reportViolation(type, pos, judgment, true);
             case UNKNOWN -> {
                 if (!attempted) {
-                    warnings.add(Diagnostic.of(DiagnosticCode.E2011, "check.invariant.unproven").at(pos).args(type.name())
-                            .hint("check.invariant.reify", type.name()).build());
+                    String named = String.join(", ", judgment.unsettled());
+                    warnings.add(Diagnostic.at(pos)
+                            .say(named.isEmpty()
+                                    ? new InvariantMessage.TheGuardsDoNotEstablishTheInvariant(
+                                            type.name())
+                                    : new InvariantMessage.TheGuardsDoNotEstablish(type.name(),
+                                            named, String.join(", ", judgment.settled())))
+                            .hint(new InvariantMessage.ReifyTheRelationOntoAnInput(type.name()))
+                            .build());
                 }
             }
             // Nothing was asked here, so nothing is said. Whether that is the right thing to say of a
@@ -830,7 +902,12 @@ public final class InvariantChecker {
     }
 
     /** What a construction came out as where it is being read on a branch rather than said. */
-    private record Reported(Ast.Data type, SourcePos pos, Verdict verdict, boolean attempted) {}
+    private record Reported(Ast.Data type, SourcePos pos, Judgment judgment, boolean attempted) {
+
+        Verdict verdict() {
+            return judgment.verdict();
+        }
+    }
 
     /**
      * Which construction a reading found: the one in the body as it was written. A reading is that
@@ -1098,11 +1175,11 @@ public final class InvariantChecker {
                 // Written inside one branch, so the other reading did not discharge it — it was not
                 // there to discharge. What the reading that reached it found is what it is.
                 Reported said = x != null ? x : y;
-                report(one.of(), said.type(), said.pos(), said.attempted(), said.verdict());
+                report(one.of(), said.type(), said.pos(), said.attempted(), said.judgment());
                 continue;
             }
             report(one.of(), x.type(), x.pos(), x.attempted(),
-                    Verdict.of(x.verdict(), y.verdict()));
+                    Judgment.of(x.judgment(), y.judgment()));
         }
     }
 
@@ -1110,9 +1187,22 @@ public final class InvariantChecker {
      * fails the invariant on its own, or it fails under what else is known where it stands. The check
      * knows which of the two decided it and not what within the second did, so neither message names
      * a guard. */
-    private void reportViolation(Ast.Data type, SourcePos pos, String reason) {
-        errors.add(CompileException.of(Diagnostic.of(DiagnosticCode.E2010, reason)
-                        .at(pos).args(type.name()).build()));
+    private void reportViolation(Ast.Data type, SourcePos pos, Judgment judgment,
+                                 boolean onAPath) {
+        String named = String.join(", ", judgment.unsettled());
+        errors.add(CompileException.of(Diagnostic.at(pos)
+                .say(onAPath
+                        ? named.isEmpty()
+                                ? new InvariantMessage.TheValueIsRejectedOnAReachablePathUnnamed(
+                                        type.name())
+                                : new InvariantMessage.TheValueIsRejectedOnAReachablePath(
+                                        type.name(), named)
+                        : named.isEmpty()
+                                ? new InvariantMessage.TheValueIsOneTheInvariantRejectsUnnamed(
+                                        type.name())
+                                : new InvariantMessage.TheValueIsOneTheInvariantRejects(
+                                        type.name(), named))
+                .build()));
     }
 
     // --- introducing a binding -----------------------------------------------------------------
@@ -1237,9 +1327,9 @@ public final class InvariantChecker {
         });
         Known out = k;
         List<Quantified> quantified = new ArrayList<>();
-        for (Core stated : clauses.statedAt(ref.name(), data, given)) {
-            predicates.quantifiedBy(stated, at, true, quantified);
-            out = predicates.assume(predicates.obligations(stated, out, at, false), out,
+        for (Clauses.Stated stated : clauses.statedAt(ref.name(), data, given)) {
+            predicates.quantifiedBy(stated.expr(), at, true, quantified);
+            out = predicates.assume(predicates.obligations(stated.expr(), out, at, false), out,
                     Known.Held.OF_THE_VALUE);
         }
         out = out.and(quantified);

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -1028,14 +1028,44 @@ public final class TypeOps {
             TypeName named, Ast.Data data, Symbols symbols,
             Function<TypeName, List<Ast.InvariantClause>> form) {
         List<Ast.InvariantClause> invs = new ArrayList<>();
+        for (Declared one : declaredInvariants(named, data, symbols, form)) {
+            invs.add(one.clause());
+        }
+        return invs;
+    }
+
+    /**
+     * A clause and the declaration that wrote it.
+     *
+     * <p>A clause reaching a type through a spread is that type's to hold and the other type's to
+     * have written, and a reader told which clause failed on a data that declares none of its own is
+     * told about a declaration they would not find. {@code declaredOn} is null where the walk was
+     * not given a name to start from.
+     */
+    public record Declared(TypeName declaredOn, Ast.InvariantClause clause) {}
+
+    /**
+     * The same clauses {@link #effectiveInvariants} answers, each with the declaration it was written
+     * on.
+     *
+     * <p>Flattening them loses which spread brought which, and what is reported of an unproven clause
+     * is the name the author wrote — so what is asked for here is the pair, and the flat list is
+     * taken from it rather than walked again.
+     */
+    public static List<Declared> declaredInvariants(
+            TypeName named, Ast.Data data, Symbols symbols,
+            Function<TypeName, List<Ast.InvariantClause>> form) {
+        List<Declared> invs = new ArrayList<>();
         for (Ast.Name inc : data.includes()) {
             Ast.Data id = spreadTarget(inc, symbols);
             if (id != null) {
-                invs.addAll(effectiveInvariants(inc.denotes(), id, symbols, form));
+                invs.addAll(declaredInvariants(inc.denotes(), id, symbols, form));
             }
         }
         List<Ast.InvariantClause> own = named == null ? null : form.apply(named);
-        invs.addAll(own != null ? own : data.invariants());
+        for (Ast.InvariantClause clause : own != null ? own : data.invariants()) {
+            invs.add(new Declared(named, clause));
+        }
         return invs;
     }
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -419,6 +419,13 @@ check.module.publishedincomplete.hint=The jar `{0}` came from is incomplete. Reb
 check.import.unknownmodule=Unknown module `{0}`.
 check.import.notexposed=`{0}` is not exposed by `{1}`.
 check.import.notdefined=`{0}` is not defined in `{1}`.
+invariant.the-guards-do-not-establish=Constructing `{data}` here may violate `{unsettled}`: the guards do not establish it. Guard it with `guard`, or reify the relation into `{data}`'s (or an input's) invariant so it is assumed here. Established here: {settled}.
+invariant.the-guards-do-not-establish-the-invariant=Constructing `{data}` here may violate its invariant: the guards do not establish it. Guard it with `guard`, or reify the relation into `{data}`'s (or an input's) invariant so it is assumed here.
+invariant.reify-the-relation-onto-an-input=If a relation between inputs guarantees `{data}`'s clause, declare it as an `invariant` on the input data so it is checked once at its boundary and assumed here.
+invariant.the-value-is-one-the-invariant-rejects=Constructing `{data}` here violates `{unsettled}`: the value being built is one that clause rejects. Fix the value.
+invariant.the-value-is-one-the-invariant-rejects-unnamed=Constructing `{data}` here violates its invariant: the value being built is one the invariant rejects. Fix the value.
+invariant.the-value-is-rejected-on-a-reachable-path=Constructing `{data}` here violates `{unsettled}` on a reachable path: under what is assumed where it stands, the value being built is one that clause rejects. Fix the value, or guard the path so the violating case cannot reach here.
+invariant.the-value-is-rejected-on-a-reachable-path-unnamed=Constructing `{data}` here violates its invariant on a reachable path: under what is assumed where it stands, the value being built is one the invariant rejects. Fix the value, or guard the path so the violating case cannot reach here.
 import.imported-name-collides-with-a-declaration=Imported `{name}` conflicts with a definition of the same name in this module.
 import.rename-or-qualify-the-colliding-name=One name cannot stand for two things. Rename the local definition, drop the import and name the imported one through its module, or drop the local definition and use the imported one.
 check.import.duplicate=`{0}` is imported from both `{1}` and `{2}`.
@@ -540,10 +547,6 @@ check.totality.partialasvalue=The `partial` helper `{0}` is written where a valu
 
 # --- invariant discharge (E2010 error, E2011 warning) ---
 check.invariant.title=INVARIANT
-check.invariant.violation.alone=Constructing `{0}` here violates its invariant: the value being built is one the invariant rejects. Fix the value.
-check.invariant.violation.assumed=Constructing `{0}` here violates its invariant on a reachable path: under what is assumed where it stands, the value being built is one the invariant rejects. Fix the value, or guard the path so the violating case cannot reach here.
-check.invariant.unproven=Constructing `{0}` here may violate its invariant: the guards do not establish it. Guard it with `guard`, or reify the relation into `{0}`''s (or an input''s) invariant so it is assumed here.
-check.invariant.reify=If a relation between inputs guarantees this, declare it as an `invariant` on the input data so it is checked once at its boundary and assumed here.
 
 # --- fake (E1908-E1909, E1921, test doubles for injected dependencies) ---
 check.fake.missing=`{0}` depends on `{1}`, but no fake was supplied for it.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -416,6 +416,13 @@ check.module.publishedincomplete.hint=`{0}` の jar が不完全です。ビル�
 check.import.unknownmodule=未知のモジュール `{0}` です。
 check.import.notexposed=`{0}` は `{1}` から公開されていません。
 check.import.notdefined=`{0}` は `{1}` に定義されていません。
+invariant.the-guards-do-not-establish=ここでの `{data}` の構築は `{unsettled}` に違反する可能性があります。ガードがそれを確立していません。`guard` でガードするか、関係を `{data}`（または入力）の `invariant` に宣言してここで仮定させてください。ここで確立済み: {settled}。
+invariant.the-guards-do-not-establish-the-invariant=ここでの `{data}` の構築は不変条件に違反する可能性があります。ガードが不変条件を確立していません。`guard` でガードするか、関係を `{data}`（または入力）の `invariant` に宣言してここで仮定させてください。
+invariant.reify-the-relation-onto-an-input=入力間の関係が `{data}` の句を保証するなら、入力データの `invariant` として宣言してください。境界で一度検査され、ここでは仮定されます。
+invariant.the-value-is-one-the-invariant-rejects=ここでの `{data}` の構築は `{unsettled}` に違反します。組み立てている値をその句が拒みます。値を直してください。
+invariant.the-value-is-one-the-invariant-rejects-unnamed=ここでの `{data}` の構築は不変条件に違反します。組み立てている値を不変条件が拒みます。値を直してください。
+invariant.the-value-is-rejected-on-a-reachable-path=ここでの `{data}` の構築は、到達可能な経路で `{unsettled}` に違反します。ここで仮定されていることの下では、組み立てている値をその句が拒みます。値を直すか、違反ケースがここに届かないよう経路をガードしてください。
+invariant.the-value-is-rejected-on-a-reachable-path-unnamed=ここでの `{data}` の構築は、到達可能な経路で不変条件に違反します。ここで仮定されていることの下では、組み立てている値を不変条件が拒みます。値を直すか、違反ケースがここに届かないよう経路をガードしてください。
 import.imported-name-collides-with-a-declaration=import した `{name}` が、このモジュールの同名の定義と衝突しています。
 import.rename-or-qualify-the-colliding-name=1つの名前が2つのものを指すことはできません。ローカルの定義をリネームするか、import をやめて import 先をモジュール名で修飾して参照するか、ローカルの定義を削除して import した方を使ってください。
 check.import.duplicate=`{0}` を `{1}` と `{2}` の両方から import しています。
@@ -537,10 +544,6 @@ check.totality.partialasvalue=`partial` ヘルパ `{0}` が値の位置に書か
 
 # --- invariant discharge (E2010 error, E2011 warning) ---
 check.invariant.title=INVARIANT
-check.invariant.violation.alone=ここでの `{0}` の構築は不変条件に違反します。組み立てている値を不変条件が拒みます。値を直してください。
-check.invariant.violation.assumed=ここでの `{0}` の構築は、到達可能な経路で不変条件に違反します。ここで仮定されていることの下では、組み立てている値を不変条件が拒みます。値を直すか、違反ケースがここに届かないよう経路をガードしてください。
-check.invariant.unproven=ここでの `{0}` の構築は不変条件に違反する可能性があります。ガードが不変条件を確立していません。`guard` でガードするか、関係を `{0}`（または入力）の `invariant` に宣言してここで仮定させてください。
-check.invariant.reify=入力間の関係がこれを保証するなら、入力データの `invariant` として宣言してください。境界で一度検査され、ここでは仮定されます。
 
 # --- fake (E1908-E1909, E1921, 注入依存のテストダブル) ---
 check.fake.missing=`{0}` は `{1}` に依存しますが、その fake が与えられていません。

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantDischargeTest.java
@@ -19,6 +19,76 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class CompileInvariantDischargeTest {
 
+    /**
+     * The warning names the clauses it could not establish, and the ones it did.
+     *
+     * <p>An invariant is the conjunction of its clauses and the check judges them one at a time, so
+     * it knows which of them the guards left standing. Saying only that "its invariant" may be
+     * violated leaves an author to find that out by writing one guard at a time and recompiling —
+     * which is what it cost when this said nothing: three clauses here, one of them established.
+     */
+    @Test
+    void theWarningNamesTheClauseItCouldNotEstablish() {
+        Compiler.Compiled c = Compiler.compileWithWarnings("""
+                module demo
+
+                data Yen = Decimal
+                    invariant nonNegative = value >= 0m
+
+                data Installment =
+                    { payment: Yen
+                    , interest: Decimal
+                    , principalPortion: Decimal
+                    }
+                    invariant interestNotNegative = interest >= 0m
+                    invariant principalPortionNotNegative = principalPortion >= 0m
+                    invariant portionsMakeThePayment = interest + principalPortion == payment.value
+
+                behavior split : (payment: Yen, interest: Decimal) -> Installment
+                    constructs Installment
+
+                let split (payment, interest) =
+                    Installment {
+                        payment = payment,
+                        interest = interest,
+                        principalPortion = payment.value - interest
+                    }
+                """);
+        String said = c.warnings().stream()
+                .filter(d -> "E2011".equals(d.code()))
+                .map(d -> souther.compiler.diag.Messages.render(d.said(), java.util.Locale.ENGLISH))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected an E2011"));
+        assertTrue(said.contains("interestNotNegative"), said);
+        assertTrue(said.contains("principalPortionNotNegative"), said);
+        assertTrue(said.contains("portionsMakeThePayment"), said);
+    }
+
+    /** A clause written without a name cannot be named, and the warning says what it can. */
+    @Test
+    void anUnnamedClauseLeavesTheWarningSayingTheInvariant() {
+        Compiler.Compiled c = Compiler.compileWithWarnings("""
+                module demo
+
+                data Bound =
+                    { low: Int
+                    , high: Int
+                    }
+                    invariant low <= high
+
+                behavior widen : (low: Int, high: Int) -> Bound
+                    constructs Bound
+
+                let widen (low, high) = Bound { low = low, high = high }
+                """);
+        String said = c.warnings().stream()
+                .filter(d -> "E2011".equals(d.code()))
+                .map(d -> souther.compiler.diag.Messages.render(d.said(), java.util.Locale.ENGLISH))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("expected an E2011"));
+        assertTrue(said.contains("its invariant"), said);
+    }
+
     private static long warnings(Compiler.Compiled c) {
         return c.warnings().stream()
                 .filter(d -> d.severity() == Severity.WARNING).count();

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantViolationReasonTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantViolationReasonTest.java
@@ -32,7 +32,7 @@ class CompileInvariantViolationReasonTest {
                 behavior mk : () -> Range constructs Range
                 let mk = Range { lo = 5, hi = 1 }
                 """;
-        assertEquals("check.invariant.violation.alone", reasonOf(m),
+        assertEquals("invariant.the-value-is-one-the-invariant-rejects-unnamed", reasonOf(m),
                 "nothing is guarded here — the values written decide it");
     }
 
@@ -45,7 +45,7 @@ class CompileInvariantViolationReasonTest {
                 behavior calc : (m: Money) -> Money constructs Money
                 let calc (m) = Money(0m) - Money(1m)
                 """;
-        assertEquals("check.invariant.violation.alone", reasonOf(m),
+        assertEquals("invariant.the-value-is-one-the-invariant-rejects-unnamed", reasonOf(m),
                 "0 - 1 is negative wherever it stands");
     }
 
@@ -61,7 +61,7 @@ class CompileInvariantViolationReasonTest {
                 behavior conv : (p: Pos) -> Neg constructs Neg
                 let conv (p) = Neg(p.value)
                 """;
-        assertEquals("check.invariant.violation.alone", reasonOf(m),
+        assertEquals("invariant.the-value-is-one-the-invariant-rejects-unnamed", reasonOf(m),
                 "an input's type carries its invariant everywhere the input does");
     }
 
@@ -77,7 +77,7 @@ class CompileInvariantViolationReasonTest {
                     Amount(bad)
                 }
                 """;
-        assertEquals("check.invariant.violation.alone", reasonOf(m),
+        assertEquals("invariant.the-value-is-one-the-invariant-rejects-unnamed", reasonOf(m),
                 "a name is an alias for what it was given, and no guard was written");
     }
 
@@ -92,7 +92,7 @@ class CompileInvariantViolationReasonTest {
                     if n < 0 then Amount(n)
                     else Amount(0)
                 """;
-        assertEquals("check.invariant.violation.assumed", reasonOf(m),
+        assertEquals("invariant.the-value-is-rejected-on-a-reachable-path-unnamed", reasonOf(m),
                 "without `n < 0` nothing here refutes the invariant");
     }
 
@@ -108,7 +108,7 @@ class CompileInvariantViolationReasonTest {
                     if p.a < p.b then Money(0m) - Money(1m)
                     else p.a
                 """;
-        assertEquals("check.invariant.violation.alone", reasonOf(m),
+        assertEquals("invariant.the-value-is-one-the-invariant-rejects-unnamed", reasonOf(m),
                 "the guard settles something, and the violation does not need it");
     }
 
@@ -124,7 +124,7 @@ class CompileInvariantViolationReasonTest {
                 behavior mk : (n: Int) -> Amount constructs Amount
                 let mk (n) = Amount(if n < 0 then n else 0 - 1)
                 """;
-        assertEquals("check.invariant.violation.assumed", reasonOf(m),
+        assertEquals("invariant.the-value-is-rejected-on-a-reachable-path-unnamed", reasonOf(m),
                 "one reading needed the path, so the two together are said to");
     }
 
@@ -143,14 +143,14 @@ class CompileInvariantViolationReasonTest {
     @Test
     void aClauseRefutedOnTheValuesAloneDecidesTheReasonForTheWholeInvariant() {
         // `x >= 0` fails only under the guard; `y >= 0` fails on `y = -1` wherever it is written
-        assertEquals("check.invariant.violation.alone",
+        assertEquals("invariant.the-value-is-one-the-invariant-rejects-unnamed",
                 reasonOf(TWO_CLAUSES.formatted("    invariant x >= 0\n    invariant y >= 0")),
                 "the invariant is already false without the guard, by its second clause");
     }
 
     @Test
     void whichClauseIsWrittenFirstIsNotTheReason() {
-        assertEquals("check.invariant.violation.alone",
+        assertEquals("invariant.the-value-is-one-the-invariant-rejects-unnamed",
                 reasonOf(TWO_CLAUSES.formatted("    invariant y >= 0\n    invariant x >= 0")),
                 "the same two clauses in the other order are the same invariant");
     }

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/InvariantMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/InvariantMessage.java
@@ -1,0 +1,45 @@
+package souther.compiler.diag.msg;
+
+import souther.compiler.diag.DiagnosticCode;
+
+/** What a construction is told about the invariant of the type it builds. */
+public sealed interface InvariantMessage extends Message {
+
+    /**
+     * The guards do not establish a clause, so the construction may abort.
+     *
+     * <p>{@code unsettled} is the clauses it could not establish and {@code settled} the ones it
+     * did. Which clause it is, is what an author acts on: the invariant is the conjunction of its
+     * clauses, and being told that "its invariant" may be violated where four of five are settled
+     * leaves them to find the fifth by writing one guard at a time.
+     */
+    @Code(DiagnosticCode.E2011)
+    record TheGuardsDoNotEstablish(String data, String unsettled, String settled)
+            implements InvariantMessage {}
+
+    /** The same, where every clause the check could not establish was written without a name. */
+    @Code(DiagnosticCode.E2011)
+    record TheGuardsDoNotEstablishTheInvariant(String data) implements InvariantMessage {}
+
+    /** What to write where a relation between inputs is what guarantees the clause. */
+    @Code(DiagnosticCode.E2011)
+    record ReifyTheRelationOntoAnInput(String data) implements InvariantMessage {}
+
+    /** The value being built is one the invariant rejects, whatever the path. */
+    @Code(DiagnosticCode.E2010)
+    record TheValueIsOneTheInvariantRejects(String data, String unsettled)
+            implements InvariantMessage {}
+
+    /** The same, where no clause the check refuted was written with a name. */
+    @Code(DiagnosticCode.E2010)
+    record TheValueIsOneTheInvariantRejectsUnnamed(String data) implements InvariantMessage {}
+
+    /** The value is rejected under what is assumed where the construction stands. */
+    @Code(DiagnosticCode.E2010)
+    record TheValueIsRejectedOnAReachablePath(String data, String unsettled)
+            implements InvariantMessage {}
+
+    /** The same, where no clause the check refuted was written with a name. */
+    @Code(DiagnosticCode.E2010)
+    record TheValueIsRejectedOnAReachablePathUnnamed(String data) implements InvariantMessage {}
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/Message.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/Message.java
@@ -17,7 +17,7 @@ package souther.compiler.diag.msg;
  * shown only in a hint belongs to the hint's own message, and a wording that turns on a value is two
  * messages rather than one entry that selects between two sentences.
  */
-public sealed interface Message permits DataMessage, ImportMessage {
+public sealed interface Message permits DataMessage, ImportMessage, InvariantMessage {
 
     /** The catalog entry this renders through, read off where the message is declared. */
     default String key() {


### PR DESCRIPTION
`E2011` said a construction may violate "its invariant"; `E2010` said the value is one "the invariant" rejects. A type may declare five clauses, and which one the guards left standing is the only part an author can act on. Round-5 dogfooding measured what that cost: twelve probe files, each a one-clause copy of a type with a behavior around it, compiled to see which produced the warning.

## The check knew all along

`InvariantChecker` reads the clauses one at a time and decides each — discharged, refuted, or neither. It folded that into a single `Verdict` before reporting.

The name had been dropped even earlier. `TypeOps.effectiveInvariants` flattens a type's own clauses and the ones its spreads bring into one list of `Ast.InvariantClause`, then `Clauses.statedAt` elaborates each to `Core` and returns a list of expressions. From there down there is no name to report, which is why this was never a wording fix.

## What changed

- `TypeOps.declaredInvariants` answers each clause with the declaration it was written on; `effectiveInvariants` is taken from it rather than walking again, so the seventeen callers of the flat list are untouched.
- `Clauses.Stated` carries the clause's name and its declaring type to the discharge walk.
- The walk answers a `Judgment`: the verdict, the clauses it could not establish, and the ones it did. Two readings of one construction merge by taking a clause as unsettled where either reading left it so, and settled only where both did.

```
Constructing `Installment` here may violate `interestNotNegative,
principalPortionNotNegative`: the guards do not establish it. Guard it with
`guard`, or reify the relation into `Installment`'s (or an input's) invariant so
it is assumed here. Established here: portionsMakeThePayment.
```

That is the loan model from round 5, and the sentence is what its twelve probe files were for.

## A clause may have no name

`invariant lo <= hi` is written without one, and a reader cannot be sent to it by name. Those keep the wording that says "its invariant" — seven messages in all, three pairs plus the hint.

Reading the verdict off the named clauses alone made an unnamed clause discharge. Twenty-five existing tests caught it, which is worth recording: the discharge suite is dense enough to catch a fold that changes what is proven.

## Verified

`mvn clean install` green: 4,465 + 198 + 109 + 7 + 1, including two new tests — one that the named clauses are named, one that an unnamed one leaves the old wording.

Rendering, held against the corpus of 2,197 compilations in both locales and both formats: the lines that move are E2011's message and its hint, and nothing else. E2010 has no case in the corpus and is covered by `CompileInvariantViolationReasonTest`, whose eight assertions on the message key move to the derived ones.

Closes #509

🤖 Generated with [Claude Code](https://claude.com/claude-code)
