### PR TITLE
The helper diagnostics say the values they are about

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.msg.HelperMessage;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
@@ -470,9 +471,10 @@ public final class Elaborator {
         if (narrowGot == null) {
             throw narrowFailed;   // the narrow type errored and there was no sum to fall back to
         }
-        throw CompileException.of(Diagnostic.of(DiagnosticCode.E1806, "check.fn.argtype")
-                        .at(stepArg.pos()).args(fnName, Type.show(narrowGot),
-                                Type.show(TypeOps.substitute(declaredStep.result(), bind))).build());
+        throw CompileException.of(Diagnostic.at(stepArg.pos())
+                .say(new HelperMessage.TheFunctionTakesAnotherType(fnName, Type.show(narrowGot),
+                        Type.show(TypeOps.substitute(declaredStep.result(), bind))))
+                .build());
     }
 
     /** Elaborates a block argument at {@code paramTypes}; the node it returns carries the
@@ -485,25 +487,31 @@ public final class Elaborator {
             Core value = elaborate(arg, env, ctx);
             if (value.type() instanceof Type.FnOf fn) {
                 if (fn.params().size() != paramTypes.size()) {
-                    throw CompileException.of(Diagnostic.of(DiagnosticCode.E1802, "check.fn.callarity")
-                                    .at(arg.pos()).args(fnName, paramTypes.size(), fn.params().size())
-                                    .build());
+                    throw CompileException.of(Diagnostic.at(arg.pos())
+                            .say(new HelperMessage.TheFunctionTakesAnotherNumberOfArguments(fnName,
+                                    String.valueOf(paramTypes.size()),
+                                    String.valueOf(fn.params().size())))
+                            .build());
                 }
                 for (int i = 0; i < paramTypes.size(); i++) {
                     if (!TypeOps.assignable(paramTypes.get(i), fn.params().get(i), ctx.symbols())) {
-                        throw CompileException.of(Diagnostic.of(DiagnosticCode.E1806, "check.fn.argtype")
-                                        .at(arg.pos()).args(fnName, Type.show(paramTypes.get(i)),
-                                                Type.show(fn.params().get(i))).build());
+                        throw CompileException.of(Diagnostic.at(arg.pos())
+                                .say(new HelperMessage.TheFunctionTakesAnotherType(fnName,
+                                        Type.show(paramTypes.get(i)),
+                                        Type.show(fn.params().get(i))))
+                                .build());
                     }
                 }
                 return value;
             }
-            throw CompileException.of(Diagnostic.of(DiagnosticCode.E1804, "check.fn.expectsblock")
-                            .at(arg.pos()).args(fnName).build());
+            throw CompileException.of(Diagnostic.at(arg.pos()).say(new HelperMessage.ThisExpectsABlock(fnName)).build());
         }
         if (block.params().size() != paramTypes.size()) {
-            throw CompileException.of(Diagnostic.of(DiagnosticCode.E1802, "check.fn.blockarity")
-                            .at(block.pos()).args(paramTypes.size(), block.params().size()).build());
+            throw CompileException.of(Diagnostic.at(block.pos())
+                    .say(new HelperMessage.TheBlockIsWrittenWithAnotherNumberOfParameters(
+                            String.valueOf(paramTypes.size()),
+                            String.valueOf(block.params().size())))
+                    .build());
         }
         Scope inner = env;
         for (int i = 0; i < paramTypes.size(); i++) {
@@ -918,8 +926,10 @@ public final class Elaborator {
      * describes a function. Raised from the surface check below and from the value path, so the two
      * shapes a function binding takes (a bare lambda, one an {@code if} chooses) read the same. */
     static CompileException functionAnnotation(Ast.LetIn li) {
-        return CompileException.of(Diagnostic.of(DiagnosticCode.E1810, "check.fn.annotation")
-                        .at(li.pos()).args(li.name()).hint("check.fn.annotation.hint").build());
+        return CompileException.of(Diagnostic.at(li.pos())
+                .say(new HelperMessage.AFunctionTypeIsWrittenOutsideAHelperParameter(li.name()))
+                .hint(new HelperMessage.RemoveTheAnnotation())
+                .build());
     }
 
     /**
@@ -936,9 +946,11 @@ public final class Elaborator {
                 throw functionAnnotation(li);
             }
             if (declared.params().size() != lambda.params().size()) {
-                throw CompileException.of(Diagnostic.of(DiagnosticCode.E1802, "check.fn.lambdaarity")
-                                .at(lambda.pos())
-                                .args(lambda.params().size(), declared.params().size()).build());
+                throw CompileException.of(Diagnostic.at(lambda.pos())
+                        .say(new HelperMessage.TheLambdaIsAppliedWithAnotherNumberOfArguments(
+                                String.valueOf(lambda.params().size()),
+                                String.valueOf(declared.params().size())))
+                        .build());
             }
         }
         TypeChecker.forEachChild(e, sub -> checkAnnotatedLambdaBindings(sub, symbols));
@@ -960,15 +972,17 @@ public final class Elaborator {
         List<List<Type>> uses = new ArrayList<>();
         collectApplications(binder, body, env, ctx, uses, Set.of());
         if (uses.isEmpty()) {
-            throw CompileException.of(Diagnostic.of(DiagnosticCode.E1808, "check.fn.noinfer")
-                            .at(body.pos()).args(binder.name()).build());
+            throw CompileException.of(Diagnostic.at(body.pos())
+                    .say(new HelperMessage.TheFunctionsTypeCannotBeRead(binder.name()))
+                    .build());
         }
         List<Type> first = uses.get(0);
         for (List<Type> u : uses) {
             if (!u.equals(first)) {
-                throw CompileException.of(Diagnostic.of(DiagnosticCode.E1807, "check.fn.difftypes")
-                                .at(body.pos()).args(binder.name(), first.toString(), u.toString())
-                                .build());
+                throw CompileException.of(Diagnostic.at(body.pos())
+                        .say(new HelperMessage.TheFunctionIsAppliedAtTwoTypes(binder.name(),
+                                first.toString(), u.toString()))
+                        .build());
             }
         }
         return first;
@@ -1151,8 +1165,11 @@ public final class Elaborator {
         return switch (value) {
             case Ast.Block b -> {
                 if (b.params().size() != paramTypes.size()) {
-                    throw CompileException.of(Diagnostic.of(DiagnosticCode.E1802, "check.fn.lambdaarity")
-                                    .at(b.pos()).args(b.params().size(), paramTypes.size()).build());
+                    throw CompileException.of(Diagnostic.at(b.pos())
+                            .say(new HelperMessage.TheLambdaIsAppliedWithAnotherNumberOfArguments(
+                                    String.valueOf(b.params().size()),
+                                    String.valueOf(paramTypes.size())))
+                            .build());
                 }
                 Scope inner = env;
                 for (int i = 0; i < paramTypes.size(); i++) {
@@ -1168,8 +1185,10 @@ public final class Elaborator {
                 Type t = then.type();
                 Type f = els.type();
                 if (!t.equals(f)) {
-                    throw CompileException.of(Diagnostic.of(DiagnosticCode.E1807, "check.fn.branchtypes")
-                                    .at(iff.pos(), 2).args(Type.show(t), Type.show(f)).build());
+                    throw CompileException.of(Diagnostic.at(iff.pos(), 2)
+                            .say(new HelperMessage.TheBranchesAnswerDifferentFunctionTypes(
+                                    Type.show(t), Type.show(f)))
+                            .build());
                 }
                 yield new Core.If(cond, then, els, t, iff.pos());
             }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperInliner.java
@@ -11,6 +11,7 @@ import souther.compiler.types.ReachName;
 import souther.compiler.types.ValueName;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.msg.HelperMessage;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.SourcePos;
 
@@ -742,15 +743,19 @@ public final class HelperInliner {
             }
             String param = params.get(i).name();
             if (fnParam < 0) {
-                throw CompileException.of(Diagnostic.of(DiagnosticCode.E1804, "check.fn.argnotfn")
-                                .at(lambda.pos()).args(call.written(), i + 1, param).build());
+                throw CompileException.of(Diagnostic.at(lambda.pos())
+                        .say(new HelperMessage.ThisArgumentTakesNoFunction(call.written(),
+                                String.valueOf(i + 1), param))
+                        .build());
             }
             String shape = params.stream().map(Ast.FnParam::name)
                     .collect(java.util.stream.Collectors.joining(", "));
-            throw CompileException.of(Diagnostic.of(DiagnosticCode.E1804, "check.fn.argorder")
-                            .at(lambda.pos())
-                            .args(call.written(), i + 1, param, fnParam + 1, params.get(fnParam).name(), shape)
-                            .hint("check.fn.argorder.hint").build());
+            throw CompileException.of(Diagnostic.at(lambda.pos())
+                    .say(new HelperMessage.TheFunctionGoesToAnotherArgument(call.written(),
+                            String.valueOf(i + 1), param, String.valueOf(fnParam + 1),
+                            params.get(fnParam).name()))
+                    .hint(new HelperMessage.WriteTheCallThisWay(call.written(), shape))
+                    .build());
         }
     }
 
@@ -1092,14 +1097,16 @@ public final class HelperInliner {
                 ? writing.scopedLambdas().get(local.id()) : null;
         LambdaOrigin origin = applied == null ? null : applied.origin();
         if (origin != null) {
-            return CompileException.of(Diagnostic.of(DiagnosticCode.E1802, "check.fn.blockparam.arity")
-                            .at(origin.pos())
-                            .args(origin.param(), origin.owner(), given,
-                                    helper.params().size()).build());
+            return CompileException.of(Diagnostic.at(origin.pos())
+                    .say(new HelperMessage.TheBlockTakesAnotherNumberOfArguments(origin.param(),
+                            origin.owner(), String.valueOf(given),
+                            String.valueOf(helper.params().size())))
+                    .build());
         }
-        return CompileException.of(Diagnostic.of(DiagnosticCode.E1802, "check.helper.arity")
-                        .at(call.name().region())
-                        .args(helper.name(), helper.params().size(), given).build());
+        return CompileException.of(Diagnostic.at(call.name().region())
+                .say(new HelperMessage.CalledWithAnotherNumberOfArguments(helper.name(),
+                        String.valueOf(helper.params().size()), String.valueOf(given)))
+                .build());
     }
 
     /**
@@ -1209,10 +1216,11 @@ public final class HelperInliner {
         String shape = written == null ? null : written.stream()
                 .map(Ast.FnParam::name)
                 .collect(java.util.stream.Collectors.joining(", "));
-        Diagnostic.Builder d = Diagnostic.of(DiagnosticCode.E1804, "check.fn.argnotvalue").at(arg.pos())
-                .args(rawCall.written(), index + 1, p.name(), shape);
+        Diagnostic.Builder d = Diagnostic.at(arg.pos())
+                .say(new HelperMessage.ThisArgumentTakesAFunction(rawCall.written(),
+                        String.valueOf(index + 1), p.name()));
         if (shape != null) {
-            d.hint("check.fn.argnotvalue.hint");
+            d.hint(new HelperMessage.WriteTheCallThisWay(rawCall.written(), shape));
         }
         return CompileException.of(d.build());
     }

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -4,6 +4,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.msg.HelperMessage;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.Region;
 import souther.compiler.diag.SourcePos;
@@ -72,8 +73,9 @@ public final class HelperTyping {
                     if (recursive) {
                         // a recursive helper is lowered to a method, not inlined, so no call site
                         // expands it — its parameter types cannot be inferred and must be declared.
-                        throw CompileException.of(Diagnostic.of(DiagnosticCode.E1811, "check.helper.annotate")
-                                        .at(p.written().region()).args(h.name(), p.name()).build());
+                        throw CompileException.of(Diagnostic.at(p.written().region())
+                                .say(new HelperMessage.AParameterNeedsItsType(h.name(), p.name()))
+                                .build());
                     }
                     // a parameter with no type beside it takes one from the body (spec 13.1).
                     inferred.add(i);
@@ -159,8 +161,9 @@ public final class HelperTyping {
             if (declaredReturn != null) {
                 Type declared = declaredReturn;
                 if (!TypeOps.assignable(bodyType, declared, symbols)) {
-                    throw CompileException.of(Diagnostic.of(DiagnosticCode.E1812, "check.helper.return")
-                                    .at(h.pos()).args(h.name(), Type.show(declared), Type.show(bodyType))
+                    throw CompileException.of(Diagnostic.at(h.pos())
+                            .say(new HelperMessage.TheBodyIsNotWhatTheHelperDeclares(h.name(),
+                                    Type.show(declared), Type.show(bodyType)))
                                     .build());
                 }
             }
@@ -267,8 +270,10 @@ public final class HelperTyping {
         for (int idx : open) {
             Ast.FnParam p = h.params().get(idx);
             if (HelperParams.isApplied(body, p.binder())) {
-                throw CompileException.of(Diagnostic.of(DiagnosticCode.E1811, "check.helper.fnparam")
-                                .at(p.written().region()).args(h.name(), p.name()).build());
+                throw CompileException.of(Diagnostic.at(p.written().region())
+                        .say(new HelperMessage.AFunctionTypedParameterNeedsItsType(h.name(),
+                                p.name()))
+                        .build());
             }
         }
         Map<Integer, HelperParams.OpenUse> openUses = new HashMap<>();
@@ -292,12 +297,15 @@ public final class HelperTyping {
             // not ask — where a body that says nothing at all might have said something.
             HelperParams.OpenUse left = openUses.get(idx);
             boolean field = left != null && left.readAField();
-            String key = field ? "check.helper.infer.field" : "check.helper.infer";
-            Diagnostic.Builder d = Diagnostic.of(DiagnosticCode.E1811, key)
-                    .at(p.written().region()).args(h.name(), p.name());
+            Diagnostic.Builder d = Diagnostic.at(p.written().region())
+                    .say(field
+                            ? new HelperMessage.AParameterIsOnlyReadThroughAField(h.name(), p.name())
+                            : new HelperMessage.AParameterIsNotDeterminedByTheBody(h.name(),
+                                    p.name()));
             if (left != null) {
                 d.secondary(Region.ofWidth(left.use().pos(), Elaborator.width(left.use())),
-                        field ? "check.helper.infer.field.use" : "check.helper.infer.use");
+                        field ? "helper.a-field-is-read-off-it-and-that-names-no-type"
+                                : "helper.this-use-names-no-type");
             }
             throw CompileException.of(d.build());
         }
@@ -330,8 +338,9 @@ public final class HelperTyping {
             List<Type> params = new ArrayList<>();
             for (Ast.FnParam p : h.params()) {
                 if (p.type() == null) {
-                    throw CompileException.of(Diagnostic.of(DiagnosticCode.E1811, "check.helper.annotate")
-                                    .at(p.written().region()).args(name, p.name()).build());
+                    throw CompileException.of(Diagnostic.at(p.written().region())
+                            .say(new HelperMessage.AParameterNeedsItsType(name, p.name()))
+                            .build());
                 }
                 // a recursive helper is a static method taking its parameters as values; a function
                 // parameter is passed as a first-class Fn (a closure), applied inside the method.
@@ -534,8 +543,10 @@ public final class HelperTyping {
      * (`'b?` / `String`), not in the checker's own spelling. */
     private static CompileException blockReturnMismatch(Ast.FnDef h, String paramName, Type want,
                                                         Type got, SourcePos pos) {
-        return CompileException.of(Diagnostic.of(DiagnosticCode.E1805, "check.fn.blockparam.return")
-                        .at(pos).args(paramName, h.name(), Type.show(want), Type.show(got)).build());
+        return CompileException.of(Diagnostic.at(pos)
+                .say(new HelperMessage.TheBlockAnswersAnotherType(paramName, h.name(),
+                        Type.show(want), Type.show(got)))
+                .build());
     }
 
     /** Whether a type still holds a type variable, so nothing concrete can be checked against it yet.
@@ -551,9 +562,11 @@ public final class HelperTyping {
                                          Map<String, Type> bind) {
         if (arg instanceof Ast.Block lambda) {
             if (lambda.params().size() != want.params().size()) {
-                throw CompileException.of(Diagnostic.of(DiagnosticCode.E1802, "check.fn.blockparam.arity")
-                                .at(arg.pos()).args(paramName, h.name(), want.params().size(),
-                                        lambda.params().size()).build());
+                throw CompileException.of(Diagnostic.at(arg.pos())
+                        .say(new HelperMessage.TheBlockTakesAnotherNumberOfArguments(paramName,
+                                h.name(), String.valueOf(want.params().size()),
+                                String.valueOf(lambda.params().size())))
+                        .build());
             }
             Scope lenv = env;
             for (int j = 0; j < lambda.params().size(); j++) {
@@ -586,8 +599,10 @@ public final class HelperTyping {
             }
         } else if (arg instanceof Ast.Var v
                 && env.of(v.denotes(), v.name()) instanceof Type vt && !(vt instanceof Type.FnOf)) {
-            throw CompileException.of(Diagnostic.of(DiagnosticCode.E1803, "check.fn.notfunction")
-                            .at(arg.pos()).args(paramName, h.name(), v.name()).build());
+            throw CompileException.of(Diagnostic.at(arg.pos())
+                    .say(new HelperMessage.AValueWhereAFunctionIsTaken(paramName, h.name(),
+                            v.name()))
+                    .build());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -304,8 +304,8 @@ public final class HelperTyping {
                                     p.name()));
             if (left != null) {
                 d.secondary(Region.ofWidth(left.use().pos(), Elaborator.width(left.use())),
-                        field ? "helper.a-field-is-read-off-it-and-that-names-no-type"
-                                : "helper.this-use-names-no-type");
+                        field ? new HelperMessage.AFieldIsReadOffItAndThatNamesNoType()
+                                : new HelperMessage.ThisUseNamesNoType());
             }
             throw CompileException.of(d.build());
         }

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -247,13 +247,13 @@ check.impl.reqorder=`let {0}` parameter `{1}` should be `{2}`: what `depends on`
 
 # helper `let` declaration rules
 check.helper.title=HELPER DECLARATION
-check.helper.annotate=Helper `let {0}` must annotate parameter `{1}` with its type.
-check.helper.infer=Helper `let {0}` parameter `{1}` is not determined by its body; annotate it with its type.
-check.helper.infer.use=this use does not name a type
-check.helper.infer.field=Helper `let {0}` parameter `{1}` is only read through a field, which names no type; annotate it with its type.
-check.helper.infer.field.use=a field is read off it, and that names no type
-check.helper.fnparam=Helper `let {0}` parameter `{1}` is used as a function; a function-typed parameter must be annotated with its type.
-check.helper.return=Helper `let {0}` declares it returns {1}, but its body is {2}.
+helper.a-parameter-needs-its-type=Helper `let {helper}` must annotate parameter `{parameter}` with its type.
+helper.a-parameter-is-not-determined-by-the-body=Helper `let {helper}` parameter `{parameter}` is not determined by its body; annotate it with its type.
+helper.this-use-names-no-type=this use does not name a type
+helper.a-parameter-is-only-read-through-a-field=Helper `let {helper}` parameter `{parameter}` is only read through a field, which names no type; annotate it with its type.
+helper.a-field-is-read-off-it-and-that-names-no-type=a field is read off it, and that names no type
+helper.a-function-typed-parameter-needs-its-type=Helper `let {helper}` parameter `{parameter}` is used as a function; a function-typed parameter must be annotated with its type.
+helper.the-body-is-not-what-the-helper-declares=Helper `let {helper}` declares it returns {declared}, but its body is {body}.
 check.rechelper.return=Recursive helper `let {0}` must declare its return type (`let {0} (...) : <type> = ...`), because its result cannot be inferred through the recursion.
 check.rechelper.pure=Recursive helper `let {0}` is pure and cannot call the injected behavior `{1}` — put the effect in the behavior that calls this helper.
 check.invariant.invalid.title=INVALID INVARIANT
@@ -375,22 +375,21 @@ check.bridge.collision.member.hint=A member goes by its own name with `Case` aft
 
 # first-class functions and function-typed helper parameters
 check.fn.title=FUNCTION
-check.fn.blockparam.arity=The block passed to `{0}` of `let {1}` takes {2} argument(s), but is written with {3}.
-check.fn.blockparam.return=The block passed to `{0}` of `let {1}` must return {2}, but returns {3}.
-check.fn.notfunction=`{0}` of `let {1}` expects a function, but `{2}` is a value, not a function.
-check.fn.argorder=Argument {1} of `{0}` is `{2}`, which does not take a function. The function goes to argument {3} (`{4}`).
-check.fn.argorder.hint=Write `{0}({5})`.
-check.fn.argnotvalue=Argument {1} of `{0}` is `{2}`, which takes a function: pass a named function or a lambda.
-check.fn.argnotvalue.hint=Write `{0}({3})`.
-check.fn.argnotfn=Argument {1} of `{0}` is `{2}`, which does not take a function: a lambda or a field getter cannot be written here.
-check.fn.callarity=`{0}` calls its function with {1} argument(s), but the function takes {2}.
-check.fn.argtype=`{0}`''s element type {1} is not acceptable to the function, which takes {2}.
-check.fn.expectsblock=`{0}` expects a block, e.g. `{0}((acc, x) -> ..., seed, xs)`.
-check.fn.blockarity=This block takes {0} parameter(s), but got {1}.
-check.fn.noinfer=Cannot infer the type of the function `{0}`: write its type (`let {0}: (Int) -> Bool = ...`), or apply it in this scope so its parameter types can be read off the application. An application inside a lambda is in that lambda''s scope, not this one, and says nothing here.
-check.fn.difftypes=The function `{0}` is applied with different argument types: {1} vs {2}.
-check.fn.lambdaarity=This lambda takes {0} parameter(s), but is applied with {1}.
-check.fn.branchtypes=The two branches produce different function types: {0} vs {1}.
+helper.the-block-takes-another-number-of-arguments=The block passed to `{parameter}` of `let {helper}` takes {takes} argument(s), but is written with {written}.
+helper.the-block-answers-another-type=The block passed to `{parameter}` of `let {helper}` must return {must}, but returns {returns}.
+helper.a-value-where-a-function-is-taken=`{parameter}` of `let {helper}` expects a function, but `{written}` is a value, not a function.
+helper.the-function-goes-to-another-argument=Argument {at} of `{call}` is `{parameter}`, which does not take a function. The function goes to argument {functionAt} (`{functionParameter}`).
+helper.write-the-call-this-way=Write `{call}({shape})`.
+helper.this-argument-takes-a-function=Argument {at} of `{call}` is `{parameter}`, which takes a function: pass a named function or a lambda.
+helper.this-argument-takes-no-function=Argument {at} of `{call}` is `{parameter}`, which does not take a function: a lambda or a field getter cannot be written here.
+helper.the-function-takes-another-number-of-arguments=`{call}` calls its function with {called} argument(s), but the function takes {takes}.
+helper.the-function-takes-another-type=`{call}`'s element type {given} is not acceptable to the function, which takes {takes}.
+helper.this-expects-a-block=`{call}` expects a block, e.g. `{call}((acc, x) -> ..., seed, xs)`.
+helper.the-block-is-written-with-another-number-of-parameters=This block takes {takes} parameter(s), but got {written}.
+helper.the-functions-type-cannot-be-read=Cannot infer the type of the function `{name}`: write its type (`let {name}: (Int) -> Bool = ...`), or apply it in this scope so its parameter types can be read off the application. An application inside a lambda is in that lambda's scope, not this one, and says nothing here.
+helper.the-function-is-applied-at-two-types=The function `{name}` is applied with different argument types: {one} vs {other}.
+helper.the-lambda-is-applied-with-another-number-of-arguments=This lambda takes {takes} parameter(s), but is applied with {applied}.
+helper.the-branches-answer-different-function-types=The two branches produce different function types: {one} vs {other}.
 
 # remaining
 check.impl.compose=`let {0}` cannot implement the composition `behavior {0}`, which is already its own implementation.
@@ -455,9 +454,9 @@ check.qualified.notdefined=`{1}` declares no `{0}`.
 check.temporal.literal=`{0}(...)` takes a written string, e.g. `Date("2026-07-01")` / `DateTime("2026-07-01T09:00")`.
 check.temporal.malformed=`{1}` is not a {0}. Write `Date("2026-07-01")` / `DateTime("2026-07-01T09:00")`.
 check.newtype.arity=`{0}` wraps one value, but is applied to {1} argument(s).
-check.helper.arity=Helper `let {0}` takes {1} argument(s), but is called with {2}.
-check.fn.annotation=The binding `{0}` is a function, and a function type may be written only in a helper parameter.
-check.fn.annotation.hint=Remove the annotation.
+helper.called-with-another-number-of-arguments=Helper `let {helper}` takes {takes} argument(s), but is called with {called}.
+helper.a-function-type-is-written-outside-a-helper-parameter=The binding `{binding}` is a function, and a function type may be written only in a helper parameter.
+helper.remove-the-annotation=Remove the annotation.
 check.behavior.collision.data=behavior `{0}`''s first letter is capitalized to form the JVM class `{1}` (spec 19.5), which collides with data `{1}`; rename one so their class names differ.
 check.behavior.collision.behavior=behaviors `{0}` and `{1}` both capitalize to the same JVM class `{2}` (spec 19.5); rename one so their class names differ.
 check.result.collision.data=The output of `{0}` is a union, so it is generated as a sealed interface `{1}` (spec 19.8) — and `data {1}` already takes that class name.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -243,13 +243,13 @@ check.impl.reqorder=`let {0}` の引数 `{1}` は `{2}` であるべきです。
 
 # ヘルパ `let` の宣言規則
 check.helper.title=ヘルパの宣言
-check.helper.annotate=ヘルパ `let {0}` は引数 `{1}` に型注釈を付ける必要があります。
-check.helper.infer=ヘルパ `let {0}` の引数 `{1}` は本体から型が決まりません。型注釈を付けてください。
-check.helper.infer.use=この使い方は型を名指していません
-check.helper.infer.field=ヘルパ `let {0}` の引数 `{1}` はフィールド越しにしか読まれておらず、フィールドは型を名指しません。型注釈を付けてください。
-check.helper.infer.field.use=フィールドを読んでいますが、それは型を名指しません
-check.helper.fnparam=ヘルパ `let {0}` の引数 `{1}` は関数として使われています。関数型引数には型注釈が必要です。
-check.helper.return=ヘルパ `let {0}` は {1} を返すと宣言していますが、本体は {2} です。
+helper.a-parameter-needs-its-type=ヘルパ `let {helper}` は引数 `{parameter}` に型注釈を付ける必要があります。
+helper.a-parameter-is-not-determined-by-the-body=ヘルパ `let {helper}` の引数 `{parameter}` は本体から型が決まりません。型注釈を付けてください。
+helper.this-use-names-no-type=この使い方は型を名指していません
+helper.a-parameter-is-only-read-through-a-field=ヘルパ `let {helper}` の引数 `{parameter}` はフィールド越しにしか読まれておらず、フィールドは型を名指しません。型注釈を付けてください。
+helper.a-field-is-read-off-it-and-that-names-no-type=フィールドを読んでいますが、それは型を名指しません
+helper.a-function-typed-parameter-needs-its-type=ヘルパ `let {helper}` の引数 `{parameter}` は関数として使われています。関数型引数には型注釈が必要です。
+helper.the-body-is-not-what-the-helper-declares=ヘルパ `let {helper}` は {declared} を返すと宣言していますが、本体は {body} です。
 check.rechelper.return=再帰ヘルパ `let {0}` は戻り値の型を宣言する必要があります（`let {0} (...) : <型> = ...`）。再帰を通じて結果を推論できないためです。
 check.rechelper.pure=再帰ヘルパ `let {0}` は純粋であり、注入 behavior `{1}` を呼べません。作用はこのヘルパを呼ぶ behavior に置いてください。
 check.invariant.invalid.title=不正な不変条件
@@ -371,22 +371,21 @@ check.bridge.collision.member.hint=メンバーは自分の名前に `Case` を�
 
 # 第一級関数と関数型のヘルパ引数
 check.fn.title=関数
-check.fn.blockparam.arity=`let {1}` の `{0}` に渡されたブロックは引数を {2} 個取りますが、{3} 個で書かれています。
-check.fn.blockparam.return=`let {1}` の `{0}` に渡されたブロックは {2} を返さなければなりませんが、{3} を返します。
-check.fn.notfunction=`let {1}` の `{0}` は関数を必要としますが、`{2}` は値であって関数ではありません。
-check.fn.argorder=`{0}` の引数 {1} は `{2}` で、関数を受け取りません。関数は引数 {3}（`{4}`）に渡します。
-check.fn.argorder.hint=`{0}({5})` の順で書いてください。
-check.fn.argnotvalue=`{0}` の引数 {1} は `{2}` で、関数を受け取ります。名前付き関数かラムダを渡してください。
-check.fn.argnotvalue.hint=`{0}({3})` の順で書いてください。
-check.fn.argnotfn=`{0}` の引数 {1} は `{2}` で、関数を受け取りません。ラムダやフィールドゲッターはここに書けません。
-check.fn.callarity=`{0}` は関数を {1} 個の引数で呼びますが、関数は {2} 個取ります。
-check.fn.argtype=`{0}` の要素型 {1} は、{2} を取る関数に渡せません。
-check.fn.expectsblock=`{0}` はブロックを必要とします（例: `{0}((acc, x) -> ..., seed, xs)`）。
-check.fn.blockarity=このブロックは引数を {0} 個取りますが、{1} 個です。
-check.fn.noinfer=関数 `{0}` の型を推論できません。型を書く（`let {0}: (Int) -> Bool = ...`）か、このスコープで適用して引数の型を読めるようにしてください。ラムダの中の適用はそのラムダのスコープなので、ここでは何も言いません。
-check.fn.difftypes=関数 `{0}` が異なる引数型で適用されています: {1} と {2}。
-check.fn.lambdaarity=このラムダは引数を {0} 個取りますが、{1} 個で適用されています。
-check.fn.branchtypes=2つの分岐が異なる関数型を生成します: {0} と {1}。
+helper.the-block-takes-another-number-of-arguments=`let {helper}` の `{parameter}` に渡されたブロックは引数を {takes} 個取りますが、{written} 個で書かれています。
+helper.the-block-answers-another-type=`let {helper}` の `{parameter}` に渡されたブロックは {must} を返さなければなりませんが、{returns} を返します。
+helper.a-value-where-a-function-is-taken=`let {helper}` の `{parameter}` は関数を必要としますが、`{written}` は値であって関数ではありません。
+helper.the-function-goes-to-another-argument=`{call}` の引数 {at} は `{parameter}` で、関数を受け取りません。関数は引数 {functionAt}（`{functionParameter}`）に渡します。
+helper.write-the-call-this-way=`{call}({shape})` の順で書いてください。
+helper.this-argument-takes-a-function=`{call}` の引数 {at} は `{parameter}` で、関数を受け取ります。名前付き関数かラムダを渡してください。
+helper.this-argument-takes-no-function=`{call}` の引数 {at} は `{parameter}` で、関数を受け取りません。ラムダやフィールドゲッターはここに書けません。
+helper.the-function-takes-another-number-of-arguments=`{call}` は関数を {called} 個の引数で呼びますが、関数は {takes} 個取ります。
+helper.the-function-takes-another-type=`{call}` の要素型 {given} は、{takes} を取る関数に渡せません。
+helper.this-expects-a-block=`{call}` はブロックを必要とします（例: `{call}((acc, x) -> ..., seed, xs)`）。
+helper.the-block-is-written-with-another-number-of-parameters=このブロックは引数を {takes} 個取りますが、{written} 個です。
+helper.the-functions-type-cannot-be-read=関数 `{name}` の型を推論できません。型を書く（`let {name}: (Int) -> Bool = ...`）か、このスコープで適用して引数の型を読めるようにしてください。ラムダの中の適用はそのラムダのスコープなので、ここでは何も言いません。
+helper.the-function-is-applied-at-two-types=関数 `{name}` が異なる引数型で適用されています: {one} と {other}。
+helper.the-lambda-is-applied-with-another-number-of-arguments=このラムダは引数を {takes} 個取りますが、{applied} 個で適用されています。
+helper.the-branches-answer-different-function-types=2つの分岐が異なる関数型を生成します: {one} と {other}。
 
 # 残り
 check.impl.compose=`let {0}` は合成 `behavior {0}` を実装できません。合成は既に自身の実装です。
@@ -451,9 +450,9 @@ check.qualified.notdefined=`{1}` に `{0}` は定義されていません。
 check.temporal.literal=`{0}(...)` は書かれた文字列を取ります（例: `Date("2026-07-01")` / `DateTime("2026-07-01T09:00")`）。
 check.temporal.malformed=`{1}` は {0} として読めません。`Date("2026-07-01")` / `DateTime("2026-07-01T09:00")` の形で書いてください。
 check.newtype.arity=`{0}` は値を1つ包みますが、{1} 個の引数で適用されています。
-check.helper.arity=ヘルパ `let {0}` は引数を {1} 個取りますが、{2} 個で呼ばれています。
-check.fn.annotation=束縛 `{0}` は関数です。関数型はヘルパの引数位置にしか書けません。
-check.fn.annotation.hint=型注釈を外してください。
+helper.called-with-another-number-of-arguments=ヘルパ `let {helper}` は引数を {takes} 個取りますが、{called} 個で呼ばれています。
+helper.a-function-type-is-written-outside-a-helper-parameter=束縛 `{binding}` は関数です。関数型はヘルパの引数位置にしか書けません。
+helper.remove-the-annotation=型注釈を外してください。
 check.behavior.collision.data=behavior `{0}` は先頭が大文字化され JVM クラス `{1}` になり（spec 19.5）、data `{1}` と衝突します。クラス名が異なるよう、どちらかをリネームしてください。
 check.behavior.collision.behavior=behavior `{0}` と `{1}` はどちらも先頭大文字化で同じ JVM クラス `{2}` になります（spec 19.5）。クラス名が異なるよう、どちらかをリネームしてください。
 check.result.collision.data=`{0}` の出力はユニオンなので、sealed interface `{1}` として生成されます（spec 19.8）が、そのクラス名は `data {1}` が既に使っています。

--- a/souther-compiler/src/test/java/souther/compiler/AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest.java
@@ -66,7 +66,7 @@ class AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest {
     }
 
     private static boolean names(List<Diagnostic> found, String helper) {
-        return found.stream().anyMatch(d -> d.values().containsValue(helper));
+        return found.stream().anyMatch(d -> helper.equals(d.values().get("helper")));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest.java
@@ -66,7 +66,7 @@ class AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest {
     }
 
     private static boolean names(List<Diagnostic> found, String helper) {
-        return found.stream().anyMatch(d -> List.of(d.args()).contains(helper));
+        return found.stream().anyMatch(d -> d.values().containsValue(helper));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingCostsOneDefinitionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ANameThatDenotesNothingCostsOneDefinitionTest.java
@@ -103,11 +103,11 @@ class ANameThatDenotesNothingCostsOneDefinitionTest {
     void aParameterTheBodyGenuinelyLeavesOpenIsStillReported() {
         // The signal is answered where it is raised for a broken name, not suppressed wholesale: a
         // body that names no type for its parameter is a different thing, and still says so.
-        assertEquals(List.of("check.helper.infer"), messageKeys("""
+        assertEquals(List.of("helper.a-parameter-is-not-determined-by-the-body"), messageKeys("""
                 module demo
                 let id (v) = v
                 """), "nothing in the body names a type for `v`, so the annotation is asked for");
-        assertEquals(List.of("check.helper.infer.field"), messageKeys("""
+        assertEquals(List.of("helper.a-parameter-is-only-read-through-a-field"), messageKeys("""
                 module demo
                 let g (r) = r.x
                 """), "a parameter only ever read through a field still says which it was");

--- a/souther-compiler/src/test/java/souther/compiler/CompileFunctionBindingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFunctionBindingTest.java
@@ -281,7 +281,7 @@ class CompileFunctionBindingTest {
 
         for (String src : List.of(lambda, libraryName)) {
             CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-            assertEquals("check.fn.noinfer", e.diagnostic().messageKey(), e.getMessage());
+            assertEquals("helper.the-functions-type-cannot-be-read", e.diagnostic().messageKey(), e.getMessage());
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileFunctionValueFlowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileFunctionValueFlowTest.java
@@ -137,7 +137,7 @@ class CompileFunctionValueFlowTest {
                                     Result { ns = List.map(f, o.xs) }
                                 }
                                 """));
-        assertEquals("check.fn.noinfer", e.diagnostic().messageKey());
+        assertEquals("helper.the-functions-type-cannot-be-read", e.diagnostic().messageKey());
     }
 
     // Reading the applications must not swallow what is wrong inside one. A mistake in an argument is

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperBodyTypingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperBodyTypingTest.java
@@ -225,7 +225,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = X(choose(true, x.value))
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.infer", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-is-not-determined-by-the-body", e.diagnostic().messageKey(), e.getMessage());
         assertTrue(e.getMessage().contains("choose") && e.getMessage().contains("v"), e.getMessage());
     }
 
@@ -241,7 +241,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = X(List.length(ignored(x, [ 1, 2 ])))
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.infer", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-is-not-determined-by-the-body", e.diagnostic().messageKey(), e.getMessage());
         assertTrue(e.getMessage().contains("ignored") && e.getMessage().contains("v"), e.getMessage());
     }
 
@@ -257,7 +257,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = X(id(x.value))
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.infer", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-is-not-determined-by-the-body", e.diagnostic().messageKey(), e.getMessage());
         assertTrue(e.getMessage().contains("id") && e.getMessage().contains("v"), e.getMessage());
     }
 
@@ -276,9 +276,9 @@ class CompileHelperBodyTypingTest {
                 let f (l) = X(total(l))
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.infer.field", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-is-only-read-through-a-field", e.diagnostic().messageKey(), e.getMessage());
         assertFalse(e.diagnostic().secondary().isEmpty(), "the open use is labelled");
-        assertEquals("check.helper.infer.field.use", e.diagnostic().secondary().get(0).labelKey());
+        assertEquals("helper.a-field-is-read-off-it-and-that-names-no-type", e.diagnostic().secondary().get(0).labelKey());
         assertEquals(5, e.diagnostic().secondary().get(0).region().start().line(),
                 "the label sits on `line.qty`, the use that names no type");
     }
@@ -295,7 +295,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = X(apply((n) -> n * 2, x.value))
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.fnparam", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-function-typed-parameter-needs-its-type", e.diagnostic().messageKey(), e.getMessage());
     }
 
     @Test
@@ -310,7 +310,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = x
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.fnparam", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-function-typed-parameter-needs-its-type", e.diagnostic().messageKey(), e.getMessage());
     }
 
     @Test
@@ -358,7 +358,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = x
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.infer", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-is-not-determined-by-the-body", e.diagnostic().messageKey(), e.getMessage());
     }
 
     @Test
@@ -504,7 +504,7 @@ class CompileHelperBodyTypingTest {
                 }
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.infer", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-is-not-determined-by-the-body", e.diagnostic().messageKey(), e.getMessage());
     }
 
     @Test
@@ -582,7 +582,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = x
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.infer", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-is-not-determined-by-the-body", e.diagnostic().messageKey(), e.getMessage());
     }
 
     @Test
@@ -597,7 +597,7 @@ class CompileHelperBodyTypingTest {
                 let f (n) = N(count(n.value))
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.annotate", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-needs-its-type", e.diagnostic().messageKey(), e.getMessage());
     }
 
     @Test
@@ -612,7 +612,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = x
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.return", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.the-body-is-not-what-the-helper-declares", e.diagnostic().messageKey(), e.getMessage());
     }
 
     @Test
@@ -760,7 +760,7 @@ class CompileHelperBodyTypingTest {
                 let f (x) = X(id(x.value))
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("check.helper.infer", e.diagnostic().messageKey(), e.getMessage());
+        assertEquals("helper.a-parameter-is-not-determined-by-the-body", e.diagnostic().messageKey(), e.getMessage());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/CompileLambdaLetTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLambdaLetTest.java
@@ -73,6 +73,6 @@ class CompileLambdaLetTest {
         // It is refused for what is actually missing: nothing here says what the function takes.
         // Applied in this scope its parameter types would be read off the application; carried out
         // of it, only a written type can say.
-        assertEquals("check.fn.noinfer", ex.diagnostic().messageKey(), ex.getMessage());
+        assertEquals("helper.the-functions-type-cannot-be-read", ex.diagnostic().messageKey(), ex.getMessage());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileLetAnnotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLetAnnotationTest.java
@@ -143,7 +143,7 @@ class CompileLetAnnotationTest {
                     Out { v = f(i.v) }
                 }
                 """);
-        assertEquals("check.fn.lambdaarity", d.messageKey());
+        assertEquals("helper.the-lambda-is-applied-with-another-number-of-arguments", d.messageKey());
     }
 
     // The annotated type is the binding's type for everything downstream: the value reaches a helper
@@ -186,8 +186,8 @@ class CompileLetAnnotationTest {
                 }
                 """);
         assertEquals("check.fn.title", d.titleKey());
-        assertEquals("check.fn.annotation", d.messageKey());
-        assertEquals("f", d.args()[0]);
+        assertEquals("helper.a-function-type-is-written-outside-a-helper-parameter", d.messageKey());
+        assertEquals("f", d.values().get("binding"));
     }
 
     // The other shape a function binding takes — one an `if` chooses, which stays a first-class Fn
@@ -205,7 +205,7 @@ class CompileLetAnnotationTest {
                 }
                 """);
         assertEquals("check.fn.title", d.titleKey());
-        assertEquals("check.fn.annotation", d.messageKey());
+        assertEquals("helper.a-function-type-is-written-outside-a-helper-parameter", d.messageKey());
     }
 
     // A sum annotation widens a case value to its sum, so the body's `match` sees both arms.

--- a/souther-compiler/src/test/java/souther/compiler/CompileLibraryFunctionByNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileLibraryFunctionByNameTest.java
@@ -127,7 +127,7 @@ class CompileLibraryFunctionByNameTest {
                 let go (i) = Out { ns = List.map(Decimal.toInt, i.ds) }
                 """));
 
-        assertEquals("check.fn.blockparam.arity", e.diagnostic().messageKey());
+        assertEquals("helper.the-block-takes-another-number-of-arguments", e.diagnostic().messageKey());
     }
 
     /** An empty collection is a declaration with no parameter list, so it is already the value it

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -261,6 +261,12 @@ public final class Diagnostic {
             return this;
         }
 
+        /** A second place to point at, saying what it says as the values it is about. */
+        public Builder secondary(Region region, Message label) {
+            this.secondary.add(new LabeledRegion(region, null, label));
+            return this;
+        }
+
         /** A second place to point at, in the same file as the primary region. */
         public Builder secondary(Region region, String labelKey, Object... labelArgs) {
             this.secondary.add(new LabeledRegion(region, null, labelKey, labelArgs));

--- a/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Diagnostic.java
@@ -70,6 +70,18 @@ public final class Diagnostic {
         return said;
     }
 
+    /**
+     * The values this is about, by the names its catalog entry writes them under, or empty for a
+     * site not yet written as a message.
+     *
+     * <p>What a reader is shown and what a caller reads are the same values under the same names —
+     * a test asking which helper was reported asks for `helper`, rather than looking for it inside a
+     * sentence or at a position in an array.
+     */
+    public java.util.Map<String, Object> values() {
+        return said == null ? java.util.Map.of() : souther.compiler.diag.msg.MessageValues.of(said);
+    }
+
     public Severity severity() {
         return severity;
     }

--- a/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/HumanRenderer.java
@@ -47,7 +47,8 @@ public final class HumanRenderer implements DiagnosticRenderer {
             }
             snippet(out, other.region(), src, CYAN);
             if (other.labelled()) {
-                out.append(color(DIM, Messages.get(other.labelKey(), locale, other.labelArgs())))
+                out.append(color(DIM, other.said() != null ? Messages.render(other.said(), locale)
+                        : Messages.get(other.labelKey(), locale, other.labelArgs())))
                         .append('\n');
             }
         }

--- a/souther-syntax/src/main/java/souther/compiler/diag/JsonRenderer.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/JsonRenderer.java
@@ -54,7 +54,8 @@ public final class JsonRenderer implements DiagnosticRenderer {
                     }
                 }
                 s.put("region", region(other.region()));
-                s.put("label", Messages.get(other.labelKey(), locale, other.labelArgs()));
+                s.put("label", other.said() != null ? Messages.render(other.said(), locale)
+                        : Messages.get(other.labelKey(), locale, other.labelArgs()));
                 secs.add(s);
             }
             obj.put("secondary", secs);

--- a/souther-syntax/src/main/java/souther/compiler/diag/LabeledRegion.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/LabeledRegion.java
@@ -1,5 +1,7 @@
 package souther.compiler.diag;
 
+import souther.compiler.diag.msg.Message;
+
 /**
  * A secondary source region with a note. Used when one error points at more than one place — the
  * left behavior's output and the right behavior's input of a failed composition, or the two
@@ -12,7 +14,18 @@ package souther.compiler.diag;
  * line that happens to sit at that number in the first. Read it through
  * {@link #sourceIdOr(String)}: a resolver is asked about a source that is named, never about null.
  */
-public record LabeledRegion(Region region, String sourceId, String labelKey, Object[] labelArgs) {
+public record LabeledRegion(Region region, String sourceId, String labelKey, Object[] labelArgs,
+                            Message said) {
+
+    /** A label written as a message. */
+    public LabeledRegion(Region region, String sourceId, Message said) {
+        this(region, sourceId, said.key(), new Object[0], said);
+    }
+
+    /** A label written as a key and its arguments. */
+    public LabeledRegion(Region region, String sourceId, String labelKey, Object[] labelArgs) {
+        this(region, sourceId, labelKey, labelArgs, null);
+    }
 
     public LabeledRegion {
         // Two things can say which file this is in — what the label was given, and what the region's
@@ -37,10 +50,10 @@ public record LabeledRegion(Region region, String sourceId, String labelKey, Obj
     /** What makes two labels the same label. A record compares an array component by identity, and
      * {@code labelArgs} is one. */
     public record Of(Region region, String sourceId, String labelKey,
-                     java.util.List<Object> labelArgs) {}
+                     java.util.List<Object> labelArgs, Message said) {}
 
     public Of identity() {
         return new Of(region, sourceId, labelKey,
-                labelArgs == null ? java.util.List.of() : java.util.Arrays.asList(labelArgs));
+                labelArgs == null ? java.util.List.of() : java.util.Arrays.asList(labelArgs), said);
     }
 }

--- a/souther-syntax/src/main/java/souther/compiler/diag/Spot.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/Spot.java
@@ -9,17 +9,18 @@ package souther.compiler.diag;
  * <p>{@code labelKey} is null for the primary region, which has no note of its own: what it points
  * at is what the message is about.
  */
-public record Spot(String sourceId, Region region, String labelKey, Object[] labelArgs) {
+public record Spot(String sourceId, Region region, String labelKey, Object[] labelArgs,
+                   souther.compiler.diag.msg.Message said) {
 
     /** The primary region of {@code d}, in {@code sourceId}. */
     public static Spot primary(Diagnostic d, String sourceId) {
-        return new Spot(sourceId, d.region(), null, null);
+        return new Spot(sourceId, d.region(), null, null, null);
     }
 
     /** A secondary region, in its own source or the diagnostic's when it names none. */
     public static Spot secondary(LabeledRegion label, String diagnosticSourceId) {
         return new Spot(label.sourceIdOr(diagnosticSourceId), label.region(),
-                label.labelKey(), label.labelArgs());
+                label.labelKey(), label.labelArgs(), label.said());
     }
 
     /** Whether this spot carries a note — false for the primary region. */

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/HelperMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/HelperMessage.java
@@ -1,0 +1,129 @@
+package souther.compiler.diag.msg;
+
+import souther.compiler.diag.DiagnosticCode;
+
+/** What a helper, a function passed to one, and a `let` implementing a behavior are told. */
+public sealed interface HelperMessage extends Message {
+
+    // --- a helper's own declaration ---
+
+    /** A helper's parameter is written without the type it takes. */
+    @Code(DiagnosticCode.E1811)
+    record AParameterNeedsItsType(String helper, String parameter) implements HelperMessage {}
+
+    /** The body does not determine the parameter's type. */
+    @Code(DiagnosticCode.E1811)
+    record AParameterIsNotDeterminedByTheBody(String helper, String parameter)
+            implements HelperMessage {}
+
+    /** Where the use that fails to determine it is pointed at. */
+    @Code(DiagnosticCode.E1811)
+    record ThisUseNamesNoType() implements HelperMessage {}
+
+    /** The parameter is only ever read through a field, which names no type. */
+    @Code(DiagnosticCode.E1811)
+    record AParameterIsOnlyReadThroughAField(String helper, String parameter)
+            implements HelperMessage {}
+
+    /** Where the field read that fails to determine it is pointed at. */
+    @Code(DiagnosticCode.E1811)
+    record AFieldIsReadOffItAndThatNamesNoType() implements HelperMessage {}
+
+    /** A parameter used as a function must be written with its type. */
+    @Code(DiagnosticCode.E1811)
+    record AFunctionTypedParameterNeedsItsType(String helper, String parameter)
+            implements HelperMessage {}
+
+    /** The body answers something other than what the helper declares. */
+    @Code(DiagnosticCode.E1812)
+    record TheBodyIsNotWhatTheHelperDeclares(String helper, String declared, String body)
+            implements HelperMessage {}
+
+    /** A helper is called with a number of arguments it does not take. */
+    @Code(DiagnosticCode.E1802)
+    record CalledWithAnotherNumberOfArguments(String helper, String takes, String called)
+            implements HelperMessage {}
+
+    // --- what is passed to one ---
+
+    /** A block passed to a function parameter takes a different number of arguments. */
+    @Code(DiagnosticCode.E1802)
+    record TheBlockTakesAnotherNumberOfArguments(String parameter, String helper, String takes,
+                                                 String written) implements HelperMessage {}
+
+    /** A block passed to a function parameter answers the wrong type. */
+    @Code(DiagnosticCode.E1805)
+    record TheBlockAnswersAnotherType(String parameter, String helper, String must, String returns)
+            implements HelperMessage {}
+
+    /** A value is passed where a function is taken. */
+    @Code(DiagnosticCode.E1803)
+    record AValueWhereAFunctionIsTaken(String parameter, String helper, String written)
+            implements HelperMessage {}
+
+    /** A lambda is written on an argument that takes a value, and another takes the function. */
+    @Code(DiagnosticCode.E1804)
+    record TheFunctionGoesToAnotherArgument(String call, String at, String parameter,
+                                            String functionAt, String functionParameter)
+            implements HelperMessage {}
+
+    /** What that call reads as, written out. */
+    @Code(DiagnosticCode.E1804)
+    record WriteTheCallThisWay(String call, String shape) implements HelperMessage {}
+
+    /** A value is written on the argument that takes the function. */
+    @Code(DiagnosticCode.E1804)
+    record ThisArgumentTakesAFunction(String call, String at, String parameter)
+            implements HelperMessage {}
+
+    /** A lambda or a field getter is written on an argument that takes neither. */
+    @Code(DiagnosticCode.E1804)
+    record ThisArgumentTakesNoFunction(String call, String at, String parameter)
+            implements HelperMessage {}
+
+    /** An operation is written without the block it takes. */
+    @Code(DiagnosticCode.E1804)
+    record ThisExpectsABlock(String call) implements HelperMessage {}
+
+    /** A function is called with a number of arguments it does not take. */
+    @Code(DiagnosticCode.E1802)
+    record TheFunctionTakesAnotherNumberOfArguments(String call, String called, String takes)
+            implements HelperMessage {}
+
+    /** A block is written with a number of parameters the position does not take. */
+    @Code(DiagnosticCode.E1802)
+    record TheBlockIsWrittenWithAnotherNumberOfParameters(String takes, String written)
+            implements HelperMessage {}
+
+    /** A lambda is applied with a number of arguments it does not take. */
+    @Code(DiagnosticCode.E1802)
+    record TheLambdaIsAppliedWithAnotherNumberOfArguments(String takes, String applied)
+            implements HelperMessage {}
+
+    /** What the function is given is not what it takes. */
+    @Code(DiagnosticCode.E1806)
+    record TheFunctionTakesAnotherType(String call, String given, String takes)
+            implements HelperMessage {}
+
+    /** A function value's type cannot be read where it is written. */
+    @Code(DiagnosticCode.E1808)
+    record TheFunctionsTypeCannotBeRead(String name) implements HelperMessage {}
+
+    /** One function value is applied at two argument types. */
+    @Code(DiagnosticCode.E1807)
+    record TheFunctionIsAppliedAtTwoTypes(String name, String one, String other)
+            implements HelperMessage {}
+
+    /** Two branches answer function values of different types. */
+    @Code(DiagnosticCode.E1807)
+    record TheBranchesAnswerDifferentFunctionTypes(String one, String other)
+            implements HelperMessage {}
+
+    /** A function type is written somewhere other than a helper's parameter. */
+    @Code(DiagnosticCode.E1810)
+    record AFunctionTypeIsWrittenOutsideAHelperParameter(String binding) implements HelperMessage {}
+
+    /** What to do about it. */
+    @Code(DiagnosticCode.E1810)
+    record RemoveTheAnnotation() implements HelperMessage {}
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/Message.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/Message.java
@@ -17,7 +17,8 @@ package souther.compiler.diag.msg;
  * shown only in a hint belongs to the hint's own message, and a wording that turns on a value is two
  * messages rather than one entry that selects between two sentences.
  */
-public sealed interface Message permits CodecMessage, DataMessage, ImportMessage, InvariantMessage, MatchMessage {
+public sealed interface Message permits CodecMessage, DataMessage, HelperMessage, ImportMessage, InvariantMessage,
+        MatchMessage {
 
     /** The catalog entry this renders through, read off where the message is declared. */
     default String key() {


### PR DESCRIPTION
The `fn`, `helper` and `impl` keys move to `HelperMessage` — twenty-four messages, spread over `HelperInliner`, `HelperTyping` and `Elaborator`.

## What the migration found

**A hint reaching past its own message.** `check.fn.argorder.hint` is `Write \`{0}({5})\``, filled from the arguments of the line above it — a message whose own text uses `{0}` through `{4}`, so the hint was reading a sixth argument the message passed for the hint's benefit and never showed. It carries the call and the shape itself now.

**Two hints that are one.** `check.fn.argorder.hint` and `check.fn.argnotvalue.hint` are the same sentence with the same values, written twice because each site named its own key. One message, one entry, two sites.

**Tests reading a value by its position.** `AModuleIsToldAboutItsHelpersInTheOrderItWroteThemTest` asked which helper was reported by searching `args()` for the string, and `CompileLetAnnotationTest` read `args()[0]`. `Diagnostic.values()` answers by name, so they ask for `helper` and `binding` — an assertion that survives the message gaining a value.

## Verified

`mvn clean install` green: 4,472 + 198 + 109 + 7 + 1.

Rendering is unchanged: the corpus of 2,197 compilations, both locales, both formats, byte-identical.

## Where #527 stands

Seven areas migrated, **183 untyped sites left** — `example` (12), `attempt` (8), `module` (7), `fake` (5), `pipe`, `sum`, `stdlib`, `numeric`, and the rest, with `parse` last because two of its sites take the code and the key as arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
