### PR TITLE
A candidate is proposed from the rule and not the carrier alone

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/FixtureTemplate.java
@@ -113,7 +113,31 @@ public record FixtureTemplate(String text, Ast.Expr value) {
     /** No elements. A list, a set and a map are all written this way in a fixture: what the position
      * is decides what the empty brackets become. */
     public static FixtureTemplate emptyCollection() {
-        return new FixtureTemplate("[]", new Ast.ListLit(List.of(), NOWHERE));
+        return collection(List.of());
+    }
+
+    /**
+     * A collection of what it holds, in the order the elements were chosen.
+     *
+     * <p>The same brackets for all three, for the same reason the empty one has them: a fixture writes
+     * a set as its elements and a map as its entry pairs, and which of them the brackets are is what
+     * the position declares rather than anything spelled here.
+     */
+    public static FixtureTemplate collection(List<FixtureTemplate> elements) {
+        List<Ast.Expr> values = new ArrayList<>();
+        List<String> written = new ArrayList<>();
+        for (FixtureTemplate each : elements) {
+            values.add(each.value());
+            written.add(each.text());
+        }
+        return new FixtureTemplate("[" + String.join(", ", written) + "]",
+                new Ast.ListLit(List.copyOf(values), NOWHERE));
+    }
+
+    /** One entry of a map: the pair a fixture writes a key and its value as. */
+    public static FixtureTemplate entry(FixtureTemplate key, FixtureTemplate value) {
+        return new FixtureTemplate("(" + key.text() + ", " + value.text() + ")",
+                new Ast.Tuple(List.of(key.value(), value.value()), NOWHERE));
     }
 
     /** A record, field by field, in the order the fields were declared. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -652,7 +652,33 @@ public final class Generator {
                 || conditioned.reason() == UnresolvedCombination.Reason.SEARCH_LIMIT) {
             return new Outcome(null, UnresolvedCombination.Reason.SEARCH_LIMIT, null);
         }
-        return product;
+        // Every value that was offered was refused, which is only the whole story where every value
+        // the rules allow was offered. A position that read a count past what a row is built to carry,
+        // or that has more pairings than are built at once, held something back, and saying so is the
+        // difference between a fact about the model and a fact about this.
+        UnresolvedCombination.Reason held = heldBack(subject, p, decided);
+        return held == null ? product : new Outcome(null, held, null);
+    }
+
+    /** Why a position of this parameter offered less than its rules allow, or null where none did. */
+    private static UnresolvedCombination.Reason heldBack(Subject subject, int p,
+                                                         Map<String, List<FixtureTemplate>> decided) {
+        List<Position> found = new ArrayList<>();
+        positionsUnder(subject.types().get(p), TermPath.of(subject.parameters().get(p)),
+                subject.symbols(), 0, found, decided.keySet());
+        UnresolvedCombination.Reason held = null;
+        for (Position each : found) {
+            UnresolvedCombination.Reason here = Partitions.notBuilt(each.type(), subject.symbols());
+            // Nothing of the shape having been built outranks some of it having been: the first says
+            // the search never had what the rule asks for, and a reader owed one sentence is owed that.
+            if (here == UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE) {
+                return here;
+            }
+            if (here != null) {
+                held = here;
+            }
+        }
+        return held;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -820,12 +820,7 @@ public final class Partitions {
      * row that was written has no reason to pay for that.
      */
     static Generator.UnresolvedCombination.Reason notBuilt(Type type, Symbols symbols) {
-        Type carrier = TypeOps.base(type, symbols);
-        if (Witnesses.pastWhatIsBuilt(carrier, leastHeld(type, symbols))) {
-            return Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE;
-        }
-        return Witnesses.moreThanIsPaired(carrier, symbols)
-                ? Generator.UnresolvedCombination.Reason.SEARCH_LIMIT : null;
+        return Witnesses.heldBackFor(TypeOps.base(type, symbols), leastHeld(type, symbols), symbols);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -720,19 +720,21 @@ public final class Partitions {
      */
     static List<FixtureTemplate> representativesOf(Type type, Symbols symbols,
                                                    NumericDomain.Bounds within) {
-        return representativesOf(type, symbols, within, 0);
+        return representativesOf(type, symbols, within, java.util.Set.of());
     }
 
     /**
-     * The same, {@code depth} values inside the one a position was asked for.
+     * The same, with the newtypes this is already inside the value of.
      *
-     * <p>Counted because what stands for a collection is built from what stands for its element, which
-     * is this question again. A type written in terms of itself would ask it forever, and a value below
-     * the bound is given up on rather than invented.
+     * <p>Carried because what stands for a collection is built from what stands for its element, which
+     * is this question again. A name met while its own value is being built is a type written in terms
+     * of itself and is given up on — the names and not a count of them, since how many names a value
+     * wears on the way down is not what has to be stopped.
      */
     static List<FixtureTemplate> representativesOf(Type type, Symbols symbols,
-                                                   NumericDomain.Bounds within, int depth) {
-        if (type == null || depth > Witnesses.MAX_DEPTH) {
+                                                   NumericDomain.Bounds within,
+                                                   java.util.Set<TypeName> expanding) {
+        if (type == null) {
             return List.of();
         }
         if (type == Type.INT || type == Type.DECIMAL) {
@@ -773,7 +775,7 @@ public final class Partitions {
         // construction — but it does have values, and the edge of the bound is one that builds.
         if (type instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data
                 && data.newtype()) {
-            return insideTheNewtype(ref.name(), symbols, within, depth).stream()
+            return insideTheNewtype(ref.name(), symbols, within, expanding).stream()
                     .map(t -> FixtureTemplate.newtype(ref.name(), t)).toList();
         }
         return List.of();
@@ -802,6 +804,32 @@ public final class Partitions {
         BigDecimal least = sized.min().value();
         return least.signum() <= 0 || least.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) > 0
                 ? 0 : least.intValueExact();
+    }
+
+    /**
+     * The {@code index}th number the rules on {@code type} leave it able to hold, or null where it has
+     * no such number.
+     *
+     * <p>Asked where several values of one type are needed and they have to differ — the elements of a
+     * set, the keys of a map. Counted from inside the range rather than from zero, because a second
+     * value the type itself refuses would have the collection refused for its elements while saying
+     * nothing about how many of them there are.
+     *
+     * <p>Only a whole number steps. Between two decimals there is no next value, so a dense carrier
+     * names the one number inside its range and no more.
+     */
+    static BigDecimal numberInside(Type type, Symbols symbols, int index) {
+        Type base = TypeOps.numericBase(type, symbols);
+        if (base == null) {
+            return null;
+        }
+        NumericDomain.Bounds range = admissibleBounds(boundsOf(type, symbols), null);
+        BigDecimal from = inside(range, base == Type.DECIMAL);
+        if (from == null || base != Type.INT) {
+            return from != null && index == 0 ? from : null;
+        }
+        BigDecimal stepped = from.add(BigDecimal.valueOf(index));
+        return holdsNumber(range, stepped) ? stepped : null;
     }
 
     /**
@@ -893,11 +921,19 @@ public final class Partitions {
      * other.
      */
     private static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols) {
-        return insideTheNewtype(newtype, symbols, null, 0);
+        return insideTheNewtype(newtype, symbols, null, java.util.Set.of());
     }
 
     private static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols,
-                                                          NumericDomain.Bounds within, int depth) {
+                                                          NumericDomain.Bounds within,
+                                                          java.util.Set<TypeName> expanding) {
+        // Already inside this one's own value, so the type is written in terms of itself and there is
+        // nothing to hand back. Which is the answer and not a limit: no value of such a type exists.
+        if (expanding.contains(newtype)) {
+            return List.of();
+        }
+        java.util.Set<TypeName> inside = new java.util.LinkedHashSet<>(expanding);
+        inside.add(newtype);
         Type base = TypeOps.newtypeInner(newtype, symbols);
         List<FixtureTemplate> candidates = new ArrayList<>();
 
@@ -923,12 +959,9 @@ public final class Partitions {
         // minimum are two proposals and not a choice between them: each is what one rule asks for, and
         // which of them the whole of the rules admits is the decoder's answer rather than an order
         // settled here.
-        FixtureTemplate enough = Witnesses.holding(base, leastHeld(new Type.Ref(newtype), symbols),
-                symbols, depth);
-        if (enough != null) {
-            candidates.add(enough);
-        }
-        candidates.addAll(representativesOf(base, symbols, null, depth + 1));
+        candidates.addAll(Witnesses.holding(base, leastHeld(new Type.Ref(newtype), symbols),
+                symbols, inside));
+        candidates.addAll(representativesOf(base, symbols, null, inside));
 
         Map<String, FixtureTemplate> once = new LinkedHashMap<>();
         for (FixtureTemplate each : candidates) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -807,6 +807,28 @@ public final class Partitions {
     }
 
     /**
+     * Why a position offered less than its rules allow, or null where it offered everything.
+     *
+     * <p>Two things are told apart from a refusal here, and both are facts about this rather than about
+     * the model. A count past what a row is built to carry means no value of the shape the rule asks
+     * for was built at all — a list of a million exists and somebody could write one — so a reader told
+     * "every value tried was refused" would go looking for the rule that refuses a value nothing
+     * refuses. More pairings between a map's key and value than are built at once means values of the
+     * shape were built and refused and more of them were never reached, which is a search that stopped.
+     *
+     * <p>Asked only where nothing was written. It re-reads what a position could have offered, and a
+     * row that was written has no reason to pay for that.
+     */
+    static Generator.UnresolvedCombination.Reason notBuilt(Type type, Symbols symbols) {
+        Type carrier = TypeOps.base(type, symbols);
+        if (Witnesses.pastWhatIsBuilt(carrier, leastHeld(type, symbols))) {
+            return Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE;
+        }
+        return Witnesses.moreThanIsPaired(carrier, symbols)
+                ? Generator.UnresolvedCombination.Reason.SEARCH_LIMIT : null;
+    }
+
+    /**
      * The {@code index}th number the rules on {@code type} leave it able to hold, or null where it has
      * no such number.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -720,7 +720,19 @@ public final class Partitions {
      */
     static List<FixtureTemplate> representativesOf(Type type, Symbols symbols,
                                                    NumericDomain.Bounds within) {
-        if (type == null) {
+        return representativesOf(type, symbols, within, 0);
+    }
+
+    /**
+     * The same, {@code depth} values inside the one a position was asked for.
+     *
+     * <p>Counted because what stands for a collection is built from what stands for its element, which
+     * is this question again. A type written in terms of itself would ask it forever, and a value below
+     * the bound is given up on rather than invented.
+     */
+    static List<FixtureTemplate> representativesOf(Type type, Symbols symbols,
+                                                   NumericDomain.Bounds within, int depth) {
+        if (type == null || depth > Witnesses.MAX_DEPTH) {
             return List.of();
         }
         if (type == Type.INT || type == Type.DECIMAL) {
@@ -744,9 +756,10 @@ public final class Partitions {
         if (type == Type.DATETIME) {
             return List.of(FixtureTemplate.dateTime("2000-01-01T00:00:00"));
         }
-        // The empty one, for every collection. It is the value that always builds — a rule about a
-        // collection bounds its size or its elements, and neither can refuse having none — and a row
-        // whose collection is not what it is about should say so by carrying nothing.
+        // The empty one, for every collection nothing has said otherwise about. A row whose collection
+        // is not what it is about should say so by carrying nothing, and where no rule counts what the
+        // position holds there is nothing else to go on. What a rule does say is read a layer out, at
+        // the newtype the rule is written on.
         if (type instanceof Type.ListOf || type instanceof Type.SetOf || type instanceof Type.MapOf) {
             return List.of(FixtureTemplate.emptyCollection());
         }
@@ -760,10 +773,35 @@ public final class Partitions {
         // construction — but it does have values, and the edge of the bound is one that builds.
         if (type instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data
                 && data.newtype()) {
-            return insideTheNewtype(ref.name(), symbols, within).stream()
+            return insideTheNewtype(ref.name(), symbols, within, depth).stream()
                     .map(t -> FixtureTemplate.newtype(ref.name(), t)).toList();
         }
         return List.of();
+    }
+
+    /**
+     * How many of whatever counts a value the rules on its type require it to hold, or 0 where they
+     * require none.
+     *
+     * <p>Which operation counts it is asked of {@link NumericMeasures}, the one list of them, so that
+     * a rule this reads and a rule a boundary is drawn on are read off the same call. Not asked of the
+     * decoder's constraints: Raoh has no entry for a set's size — a set crosses the boundary as a list
+     * and a size chained after the mapping that drops duplicates would count the wrong things — and
+     * that absence is a fact about the decoder rather than about what the rule says.
+     */
+    static int leastHeld(Type type, Symbols symbols) {
+        ValueName.Stdlib counts = NumericMeasures.takenOf(type, symbols);
+        if (counts == null) {
+            return 0;
+        }
+        Bounds sized = boundsOf(type, symbols, Type.INT, counts);
+        if (sized == null || sized.min() == null) {
+            return 0;
+        }
+        // A count is a whole number, so the end a size bound leaves is one the rule admits.
+        BigDecimal least = sized.min().value();
+        return least.signum() <= 0 || least.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) > 0
+                ? 0 : least.intValueExact();
     }
 
     /**
@@ -855,11 +893,11 @@ public final class Partitions {
      * other.
      */
     private static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols) {
-        return insideTheNewtype(newtype, symbols, null);
+        return insideTheNewtype(newtype, symbols, null, 0);
     }
 
     private static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols,
-                                                          NumericDomain.Bounds within) {
+                                                          NumericDomain.Bounds within, int depth) {
         Type base = TypeOps.newtypeInner(newtype, symbols);
         List<FixtureTemplate> candidates = new ArrayList<>();
 
@@ -881,7 +919,16 @@ public final class Partitions {
                 }
             }
         }
-        candidates.addAll(representativesOf(base, symbols));
+        // What the rules say the value holds, before the value that would hold nothing. A format and a
+        // minimum are two proposals and not a choice between them: each is what one rule asks for, and
+        // which of them the whole of the rules admits is the decoder's answer rather than an order
+        // settled here.
+        FixtureTemplate enough = Witnesses.holding(base, leastHeld(new Type.Ref(newtype), symbols),
+                symbols, depth);
+        if (enough != null) {
+            candidates.add(enough);
+        }
+        candidates.addAll(representativesOf(base, symbols, null, depth + 1));
 
         Map<String, FixtureTemplate> once = new LinkedHashMap<>();
         for (FixtureTemplate each : candidates) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -6,98 +6,136 @@ import souther.compiler.check.TypeOps;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
 /**
- * A value built to hold what a rule says it must hold.
+ * Values built to hold what a rule says a value must hold.
  *
  * <p>What stands for a type used to come from the carrier alone — the empty one for every collection,
  * one character for a string — and a rule saying the collection is not empty is then the one rule that
  * refuses the one value on offer. Read the minimum before the value is chosen and it is instead the
  * size the value is built at.
  *
- * <p>A proposal, still. Nothing here decides whether a newtype accepts what it is handed: that is the
- * decoder's answer and it is asked afterwards, which is what lets this be built from the part of a rule
- * it can read while the rest of the rule is left to refuse it. A minimum recognised is a minimum used,
- * and no more is claimed than that — a rule of a shape this cannot read leaves the position with what
- * it had, and a combination whose every candidate is refused is still reported as refused.
+ * <p>Proposals, and several of them. Nothing here decides whether a newtype accepts what it is handed:
+ * that is the decoder's answer and it is asked afterwards, which is what lets a value be built from the
+ * part of a rule this can read while the rest of the rule refuses it. A position offering one value is
+ * exactly the defect this is about, so a collection is offered one proposal per value its element
+ * offers rather than one built from the first of them — an element that proposes a format and a minimum
+ * would otherwise have the choice between them made here, a level below where it was left open.
  *
- * <p>A tree, because a collection holds values that have rules of their own. What stands for a list of
- * a newtype is a list of what stands for that newtype, which is asked of the same chooser the position
- * itself was asked of. A type written in terms of itself would have this descend forever, so the
- * descent is bounded and gives up rather than inventing a value below the bound.
+ * <p>Per element and not across them. What a row is searched for is already the product of what its
+ * positions offer, and taking a product again inside one position would spend that search on
+ * assignments the position is not what they are about.
+ *
+ * <p>A tree, because a collection holds values that have rules of their own, and what stands for a list
+ * of a newtype is what stands for that newtype in a list. That question is the one the position itself
+ * asked, so it is asked of the same chooser. A type written in terms of itself would ask it forever, so
+ * the names being expanded are carried down and a name met twice is given up on — which is the right
+ * answer there, since no value of such a type exists.
  */
 final class Witnesses {
 
-    /** How far a value may be built inside another before this stops. Reached only by a type written
-     * in terms of itself, which no witness exists for anyway. */
-    static final int MAX_DEPTH = 4;
+    /** How many proposals one collection is worth. Each is another assignment for the search around it
+     * to walk, and the values past a few are variations on the ones before them. */
+    private static final int MAX_PROPOSALS = 3;
 
     /**
-     * A value of {@code carrier} holding at least {@code least} of whatever counts it, or null where
+     * Values of {@code carrier} holding at least {@code least} of whatever counts it, or none where
      * this can build none.
      *
      * <p>The minimum itself and not one element. Recognising {@code >= 3} and then offering a list of
      * one would refuse the row for the reason the empty list was refused, having read the rule and not
      * used it.
      */
-    static FixtureTemplate holding(Type carrier, int least, Symbols symbols, int depth) {
-        if (carrier == null || least <= 0 || depth > MAX_DEPTH) {
-            return null;
+    static List<FixtureTemplate> holding(Type carrier, int least, Symbols symbols,
+                                         Set<TypeName> expanding) {
+        if (carrier == null || least <= 0) {
+            return List.of();
         }
         // A string is counted by its characters, and one character is as good as another where the
-        // rule is about how many there are.
+        // rule is about how many there are. What a format asks for instead is a proposal of its own,
+        // put beside this one by the caller.
         if (carrier == Type.STRING) {
-            return FixtureTemplate.string("x".repeat(least));
+            return List.of(FixtureTemplate.string("x".repeat(least)));
         }
         // A list may hold the same element as many times as it needs to.
         if (carrier instanceof Type.ListOf list) {
-            FixtureTemplate one = at(list.element(), 0, symbols, depth + 1);
-            if (one == null) {
-                return null;
+            List<FixtureTemplate> out = new ArrayList<>();
+            for (FixtureTemplate each : proposalsFor(list.element(), symbols, expanding)) {
+                List<FixtureTemplate> elements = new ArrayList<>();
+                for (int i = 0; i < least; i++) {
+                    elements.add(each);
+                }
+                out.add(FixtureTemplate.collection(elements));
             }
-            List<FixtureTemplate> elements = new ArrayList<>();
-            for (int i = 0; i < least; i++) {
-                elements.add(one);
-            }
-            return FixtureTemplate.collection(elements);
+            return List.copyOf(out);
         }
         // A set of three is three elements no two of which are equal, and a map of three is three
         // entries no two of which share a key. The values under a map's keys are free to repeat.
         if (carrier instanceof Type.SetOf set) {
-            List<FixtureTemplate> elements = distinct(set.element(), least, symbols, depth + 1);
-            return elements.isEmpty() ? null : FixtureTemplate.collection(elements);
+            List<FixtureTemplate> out = new ArrayList<>();
+            for (FixtureTemplate seed : proposalsFor(set.element(), symbols, expanding)) {
+                out.add(FixtureTemplate.collection(
+                        distinctFrom(seed, set.element(), least, symbols)));
+            }
+            return List.copyOf(out);
         }
         if (carrier instanceof Type.MapOf map) {
-            List<FixtureTemplate> keys = distinct(map.key(), least, symbols, depth + 1);
-            FixtureTemplate value = at(map.value(), 0, symbols, depth + 1);
-            if (keys.isEmpty() || value == null) {
-                return null;
+            List<FixtureTemplate> keys = proposalsFor(map.key(), symbols, expanding);
+            List<FixtureTemplate> values = proposalsFor(map.value(), symbols, expanding);
+            if (keys.isEmpty() || values.isEmpty()) {
+                return List.of();
             }
-            List<FixtureTemplate> entries = new ArrayList<>();
-            for (FixtureTemplate key : keys) {
-                entries.add(FixtureTemplate.entry(key, value));
+            List<FixtureTemplate> out = new ArrayList<>();
+            // Paired off rather than crossed: a key's proposals and a value's are each about their own
+            // rules, and a map refused for its keys is not told apart from one refused for its values
+            // by trying every combination of the two.
+            for (int i = 0; i < Math.min(MAX_PROPOSALS, Math.max(keys.size(), values.size())); i++) {
+                FixtureTemplate value = values.get(Math.min(i, values.size() - 1));
+                List<FixtureTemplate> entries = new ArrayList<>();
+                for (FixtureTemplate key : distinctFrom(keys.get(Math.min(i, keys.size() - 1)),
+                        map.key(), least, symbols)) {
+                    entries.add(FixtureTemplate.entry(key, value));
+                }
+                out.add(FixtureTemplate.collection(entries));
             }
-            return FixtureTemplate.collection(entries);
+            return List.copyOf(out);
         }
-        return null;
+        return List.of();
+    }
+
+    /** What the position at {@code type} would itself be offered, which is what a value built around it
+     * has to keep offering. */
+    private static List<FixtureTemplate> proposalsFor(Type type, Symbols symbols,
+                                                      Set<TypeName> expanding) {
+        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols, null, expanding);
+        return stands.size() <= MAX_PROPOSALS ? stands : stands.subList(0, MAX_PROPOSALS);
     }
 
     /**
-     * Up to {@code many} values of {@code type}, no two of them equal.
+     * {@code seed} and up to {@code least} values in all, no two of them equal.
      *
-     * <p>Fewer where this runs out, which is not the same as failing: a set of three booleans is a
-     * thing no value satisfies, and offering the two that exist is a proposal the decoder answers the
-     * way it answers any other.
+     * <p>The ones past the seed come from inside the type's own rules rather than from a count started
+     * at nothing: a number stepped through the range its invariant leaves, a string one character
+     * longer than the minimum it has to meet. A second value the element itself refuses would have the
+     * collection refused for its elements while saying nothing about its size.
+     *
+     * <p>Fewer than asked where this runs out, which is not the same as failing. A set of three
+     * booleans is a thing no value satisfies, and offering the two that exist is a proposal the decoder
+     * answers the way it answers any other.
      */
-    private static List<FixtureTemplate> distinct(Type type, int many, Symbols symbols, int depth) {
+    private static List<FixtureTemplate> distinctFrom(FixtureTemplate seed, Type type, int least,
+                                                      Symbols symbols) {
         Set<String> written = new LinkedHashSet<>();
         List<FixtureTemplate> out = new ArrayList<>();
-        for (int i = 0; out.size() < many; i++) {
-            FixtureTemplate each = at(type, i, symbols, depth);
+        written.add(seed.text());
+        out.add(seed);
+        for (int i = 0; out.size() < least; i++) {
+            FixtureTemplate each = varied(type, i, symbols);
             if (each == null) {
                 break;
             }
@@ -105,49 +143,30 @@ final class Witnesses {
                 out.add(each);
             }
         }
-        return out;
+        return List.copyOf(out);
     }
 
     /**
-     * The {@code index}th value this can think of for {@code type}, or null where it has no such value.
+     * The {@code index}th value of {@code type} this can name, or null where the carrier has no order
+     * it can walk.
      *
-     * <p>What the position itself offers comes first, so that an element is the value the rest of the
-     * generator would have chosen for it and carries whatever its own rules asked for. Past those the
-     * value is varied — a longer string, the next whole number — which is the only reason this counts
-     * at all: a set needs elements that differ, and a position ordinarily has no reason to offer two.
-     */
-    private static FixtureTemplate at(Type type, int index, Symbols symbols, int depth) {
-        if (depth > MAX_DEPTH) {
-            return null;
-        }
-        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols, null, depth + 1);
-        if (index < stands.size()) {
-            return stands.get(index);
-        }
-        return stands.isEmpty() ? null : varied(type, index, symbols);
-    }
-
-    /**
-     * A value past the ones already on offer, told apart from them by how it is built.
-     *
-     * <p>Only where the carrier has an order this can walk. A string grows by a character and a whole
-     * number by one; a date or a record has no such step that keeps every rule the position carries,
-     * and inventing one would put a value in a row that the type's own chooser had reason not to.
+     * <p>A string grows by a character from the length its rules ask for, and a whole number steps
+     * through the range they leave. A date or a record has no such step that keeps every rule the
+     * position carries, and inventing one would put a value in a row the type's own chooser had reason
+     * not to offer.
      */
     private static FixtureTemplate varied(Type type, int index, Symbols symbols) {
         Type carrier = TypeOps.base(type, symbols);
-        FixtureTemplate bare;
         if (carrier == Type.STRING) {
-            // Past the minimum rather than up from one: a longer string keeps a minimum length, which
-            // is the rule the position most often carries here.
-            bare = FixtureTemplate.string("x".repeat(Math.max(1, Partitions.leastHeld(type, symbols))
-                    + index));
-        } else if (carrier == Type.INT) {
-            bare = FixtureTemplate.integer(index);
-        } else {
+            return wrapped(type, FixtureTemplate.string(
+                    "x".repeat(Math.max(1, Partitions.leastHeld(type, symbols)) + index)), symbols);
+        }
+        BigDecimal number = Partitions.numberInside(type, symbols, index);
+        if (number == null) {
             return null;
         }
-        return wrapped(type, bare, symbols);
+        return wrapped(type, carrier == Type.DECIMAL ? FixtureTemplate.decimal(number)
+                : FixtureTemplate.integer(number.longValueExact()), symbols);
     }
 
     /** The value under every name the position wears, which is how it is written where the position

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -69,14 +69,51 @@ final class Witnesses {
      */
     static List<FixtureTemplate> holding(Type carrier, int least, Symbols symbols,
                                          Set<TypeName> expanding) {
-        if (carrier == null || least <= 0 || pastWhatIsBuilt(carrier, least)) {
-            return List.of();
+        return decide(carrier, least, symbols, expanding).proposals();
+    }
+
+    /**
+     * Why a value of {@code carrier} holding {@code least} was not built in full, or null where it was.
+     *
+     * <p>The same decision {@link #holding} reads, asked for its other half. Written once because the
+     * two have to agree: a reader was told a search stopped short of pairings nothing had asked to
+     * build, back when this was a second reading of the same conditions.
+     */
+    static Generator.UnresolvedCombination.Reason heldBackFor(Type carrier, int least, Symbols symbols) {
+        return decide(carrier, least, symbols, Set.of()).heldBack();
+    }
+
+    /** What a value of {@code carrier} holding {@code least} comes to: what was built, and what was
+     * not. */
+    private record Built(List<FixtureTemplate> proposals,
+                         Generator.UnresolvedCombination.Reason heldBack) {
+
+        static final Built NONE = new Built(List.of(), null);
+
+        static Built of(List<FixtureTemplate> proposals) {
+            return new Built(List.copyOf(proposals), null);
+        }
+    }
+
+    private static Built decide(Type carrier, int least, Symbols symbols, Set<TypeName> expanding) {
+        if (carrier == null || least <= 0) {
+            return Built.NONE;
         }
         // A string is counted by its characters, and one character is as good as another where the
         // rule is about how many there are. What a format asks for instead is a proposal of its own,
         // put beside this one by the caller.
         if (carrier == Type.STRING) {
-            return List.of(FixtureTemplate.string("x".repeat(least)));
+            return least > MOST_CHARACTERS
+                    ? new Built(List.of(), Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
+                    : Built.of(List.of(FixtureTemplate.string("x".repeat(least))));
+        }
+        if (!(carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
+                || carrier instanceof Type.MapOf)) {
+            return Built.NONE;
+        }
+        if (least > MOST_ELEMENTS) {
+            return new Built(List.of(),
+                    Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
         // A list may hold the same element as many times as it needs to.
         if (carrier instanceof Type.ListOf list) {
@@ -88,7 +125,7 @@ final class Witnesses {
                 }
                 out.add(FixtureTemplate.collection(elements));
             }
-            return List.copyOf(out);
+            return Built.of(out);
         }
         // A set of three is three elements no two of which are equal, and a map of three is three
         // entries no two of which share a key. The values under a map's keys are free to repeat.
@@ -96,67 +133,37 @@ final class Witnesses {
             List<FixtureTemplate> out = new ArrayList<>();
             for (FixtureTemplate seed : proposalsFor(set.element(), symbols, expanding)) {
                 out.add(FixtureTemplate.collection(
-                        distinctFrom(seed, set.element(), least, symbols)));
+                        distinctFrom(seed, set.element(), least, symbols, expanding)));
             }
-            return List.copyOf(out);
+            return Built.of(out);
         }
-        if (carrier instanceof Type.MapOf map) {
-            List<FixtureTemplate> keys = proposalsFor(map.key(), symbols, expanding);
-            List<FixtureTemplate> values = proposalsFor(map.value(), symbols, expanding);
-            if (keys.isEmpty() || values.isEmpty()) {
-                return List.of();
-            }
-            List<FixtureTemplate> out = new ArrayList<>();
-            // Every pair, nearest first. A key's rules and a value's are answered together or not at
-            // all — the pair is inside one position, so no search outside can put a key's second
-            // proposal beside a value's first — and taking them in step would offer only the pairs
-            // whose two proposals happen to have been read in the same order. Nearest first is what
-            // makes the bound below cost the least: what it drops is the pairs furthest from what
-            // either side proposed first.
-            for (int apart = 0;
-                    apart <= keys.size() + values.size() - 2 && out.size() < MOST_PAIRINGS; apart++) {
-                for (int i = Math.max(0, apart - values.size() + 1);
-                        i <= Math.min(apart, keys.size() - 1) && out.size() < MOST_PAIRINGS; i++) {
-                    FixtureTemplate value = values.get(apart - i);
-                    List<FixtureTemplate> entries = new ArrayList<>();
-                    for (FixtureTemplate key
-                            : distinctFrom(keys.get(i), map.key(), least, symbols)) {
-                        entries.add(FixtureTemplate.entry(key, value));
-                    }
-                    out.add(FixtureTemplate.collection(entries));
+        Type.MapOf map = (Type.MapOf) carrier;
+        List<FixtureTemplate> keys = proposalsFor(map.key(), symbols, expanding);
+        List<FixtureTemplate> values = proposalsFor(map.value(), symbols, expanding);
+        if (keys.isEmpty() || values.isEmpty()) {
+            return Built.NONE;
+        }
+        List<FixtureTemplate> out = new ArrayList<>();
+        // Every pair, nearest first. A key's rules and a value's are answered together or not at all —
+        // the pair is inside one position, so no search outside can put a key's second proposal beside
+        // a value's first — and taking them in step would offer only the pairs whose two proposals
+        // happen to have been read in the same order. Nearest first is what makes the bound below cost
+        // the least: what it drops is the pairs furthest from what either side proposed first.
+        for (int apart = 0;
+                apart <= keys.size() + values.size() - 2 && out.size() < MOST_PAIRINGS; apart++) {
+            for (int i = Math.max(0, apart - values.size() + 1);
+                    i <= Math.min(apart, keys.size() - 1) && out.size() < MOST_PAIRINGS; i++) {
+                FixtureTemplate value = values.get(apart - i);
+                List<FixtureTemplate> entries = new ArrayList<>();
+                for (FixtureTemplate key
+                        : distinctFrom(keys.get(i), map.key(), least, symbols, expanding)) {
+                    entries.add(FixtureTemplate.entry(key, value));
                 }
+                out.add(FixtureTemplate.collection(entries));
             }
-            return List.copyOf(out);
         }
-        return List.of();
-    }
-
-    /**
-     * Whether a count a rule asks for is past what this builds a value at.
-     *
-     * <p>Asked here as well as used here, so that what a reader is told about a position and what the
-     * position did are the same decision. A count past this is not a rule nothing satisfies — a list of
-     * a million exists and somebody could write one — so what it leaves is a fact about this rather
-     * than about the model, and it has to be reported as one.
-     */
-    static boolean pastWhatIsBuilt(Type carrier, int least) {
-        if (least <= 0) {
-            return false;
-        }
-        if (carrier == Type.STRING) {
-            return least > MOST_CHARACTERS;
-        }
-        return (carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
-                || carrier instanceof Type.MapOf) && least > MOST_ELEMENTS;
-    }
-
-    /** Whether a map's key and value propose more pairs between them than are built at once. */
-    static boolean moreThanIsPaired(Type carrier, Symbols symbols) {
-        if (!(carrier instanceof Type.MapOf map)) {
-            return false;
-        }
-        return proposalsFor(map.key(), symbols, Set.of()).size()
-                * proposalsFor(map.value(), symbols, Set.of()).size() > MOST_PAIRINGS;
+        return new Built(out, keys.size() * values.size() > out.size()
+                ? Generator.UnresolvedCombination.Reason.SEARCH_LIMIT : null);
     }
 
     /**
@@ -176,24 +183,19 @@ final class Witnesses {
     /**
      * {@code seed} and up to {@code least} values in all, no two of them equal.
      *
-     * <p>The ones past the seed come from inside the type's own rules rather than from a count started
-     * at nothing: a number stepped through the range its invariant leaves, a string one character
-     * longer than the minimum it has to meet. A second value the element itself refuses would have the
-     * collection refused for its elements while saying nothing about its size.
-     *
-     * <p>Fewer than asked where this runs out, which is not the same as failing. A set of three
+     * <p>Fewer than asked where the type runs out, which is not the same as failing: a set of three
      * booleans is a thing no value satisfies, and offering the two that exist is a proposal the decoder
      * answers the way it answers any other.
      */
     private static List<FixtureTemplate> distinctFrom(FixtureTemplate seed, Type type, int least,
-                                                      Symbols symbols) {
+                                                      Symbols symbols, Set<TypeName> expanding) {
         Set<String> written = new LinkedHashSet<>();
         List<FixtureTemplate> out = new ArrayList<>();
         written.add(seed.text());
         out.add(seed);
-        for (int i = 0; out.size() < least; i++) {
-            FixtureTemplate each = varied(type, i, symbols);
-            if (each == null) {
+        // One more than needed, since the seed is likely to be among them.
+        for (FixtureTemplate each : distinctValuesOf(type, least + 1, symbols, expanding)) {
+            if (out.size() >= least) {
                 break;
             }
             if (written.add(each.text())) {
@@ -204,13 +206,88 @@ final class Witnesses {
     }
 
     /**
-     * The {@code index}th value of {@code type} this can name, or null where the carrier has no order
-     * it can walk.
+     * Up to {@code many} values of {@code type}, no two of them equal.
+     *
+     * <p>One place that answers what a type's values are, in the order a collection should reach for
+     * them. Written once because it was written three times: a set of a carrier this could not step was
+     * offered one element, and adding a carrier meant remembering every reader that walked one.
+     *
+     * <p>What the type divides into comes first. A {@code Bool} is two values and a sum is its cases,
+     * and each of those is a value of the type rather than a proposal about it — a set of two booleans
+     * is built from both of them or from nothing. Then values made by stepping the carrier, which stay
+     * inside the rules the type carries. The type's own proposals come last: each is what one rule
+     * asked for and any of them may be one the whole of the rules refuses, so a collection filled from
+     * them is refused for its elements — which is still better than a collection short of its size,
+     * and is all there is where the carrier neither divides nor steps.
+     */
+    private static List<FixtureTemplate> distinctValuesOf(Type type, int many, Symbols symbols,
+                                                          Set<TypeName> expanding) {
+        Set<String> written = new LinkedHashSet<>();
+        List<FixtureTemplate> out = new ArrayList<>();
+        for (FixtureTemplate each : dividesInto(type, symbols)) {
+            if (out.size() >= many) {
+                return List.copyOf(out);
+            }
+            if (written.add(each.text())) {
+                out.add(each);
+            }
+        }
+        for (int i = 0; out.size() < many; i++) {
+            FixtureTemplate each = varied(type, i, symbols);
+            if (each == null) {
+                break;
+            }
+            if (written.add(each.text())) {
+                out.add(each);
+            }
+        }
+        for (FixtureTemplate each : Partitions.representativesOf(type, symbols, null, expanding)) {
+            if (out.size() >= many) {
+                break;
+            }
+            if (written.add(each.text())) {
+                out.add(each);
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /** The values a type divides into, under every name it wears: a {@code Bool} is two of them and a
+     * sum is its cases. Empty where the type is not divided, which is where a range or a length is
+     * what tells its values apart instead. */
+    private static List<FixtureTemplate> dividesInto(Type type, Symbols symbols) {
+        List<FixtureTemplate> out = new ArrayList<>();
+        for (PartitionClass each : Partitions.classesOf(type, symbols)) {
+            if (each.generatable()) {
+                out.addAll(each.representatives().candidates());
+            }
+        }
+        if (!out.isEmpty()) {
+            return out;
+        }
+        // A newtype divides where what it wraps does, and the values are written under its name.
+        Type carrier = TypeOps.base(type, symbols);
+        if (carrier == null || carrier.equals(type)) {
+            return List.of();
+        }
+        for (PartitionClass each : Partitions.classesOf(carrier, symbols)) {
+            if (each.generatable()) {
+                for (FixtureTemplate value : each.representatives().candidates()) {
+                    out.add(wrapped(type, value, symbols));
+                }
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The {@code index}th value of {@code type} made by stepping its carrier, or null where the carrier
+     * has no order to step.
      *
      * <p>A string grows by a character from the length its rules ask for, and a whole number steps
      * through the range they leave. A date or a record has no such step that keeps every rule the
      * position carries, and inventing one would put a value in a row the type's own chooser had reason
-     * not to offer.
+     * not to offer — which is what the values a type divides into are for, above.
      */
     private static FixtureTemplate varied(Type type, int index, Symbols symbols) {
         Type carrier = TypeOps.base(type, symbols);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -20,16 +20,23 @@ import java.util.Set;
  * refuses the one value on offer. Read the minimum before the value is chosen and it is instead the
  * size the value is built at.
  *
- * <p>Proposals, and several of them. Nothing here decides whether a newtype accepts what it is handed:
- * that is the decoder's answer and it is asked afterwards, which is what lets a value be built from the
- * part of a rule this can read while the rest of the rule refuses it. A position offering one value is
- * exactly the defect this is about, so a collection is offered one proposal per value its element
- * offers rather than one built from the first of them — an element that proposes a format and a minimum
- * would otherwise have the choice between them made here, a level below where it was left open.
+ * <p>Proposals, and every one of them. Nothing here decides whether a newtype accepts what it is
+ * handed: that is the decoder's answer and it is asked afterwards, which is what lets a value be built
+ * from the part of a rule this can read while the rest of the rule refuses it. A position offering one
+ * value is exactly the defect this is about, so a value built around another carries every proposal the
+ * inner one made — a format and a minimum reaching the decoder separately at a position is a choice
+ * that has to keep reaching it from inside a collection.
  *
- * <p>Per element and not across them. What a row is searched for is already the product of what its
- * positions offer, and taking a product again inside one position would spend that search on
- * assignments the position is not what they are about.
+ * <p>Which is why a map's key and value meet each other. They are two parts of one value and the
+ * search around this is over the behavior's positions, so a key at its second proposal beside a value
+ * at its first is a map nothing outside here can arrive at. Nearest first, so that a search which stops
+ * has walked the low proposals of both rather than every one of the key's against the value's first.
+ *
+ * <p>What is bounded is what this invents rather than what it read. A set's second element and a map's
+ * second key are variations made up to tell values apart, and they stop as soon as there are enough;
+ * the count a rule asked for stops being worth building long before a row carrying it is one anybody
+ * would read. Nothing prunes a candidate some rule was read to produce — the search that walks them is
+ * bounded and says so when it stops, which is the honest place for a limit.
  *
  * <p>A tree, because a collection holds values that have rules of their own, and what stands for a list
  * of a newtype is what stands for that newtype in a list. That question is the one the position itself
@@ -39,9 +46,9 @@ import java.util.Set;
  */
 final class Witnesses {
 
-    /** How many proposals one collection is worth. Each is another assignment for the search around it
-     * to walk, and the values past a few are variations on the ones before them. */
-    private static final int MAX_PROPOSALS = 3;
+    /** How many elements a proposed collection is worth building. A row is offered for somebody to read
+     * and complete, and a minimum past this asks for one nobody would. */
+    private static final int MOST_ELEMENTS = 64;
 
     /**
      * Values of {@code carrier} holding at least {@code least} of whatever counts it, or none where
@@ -53,7 +60,7 @@ final class Witnesses {
      */
     static List<FixtureTemplate> holding(Type carrier, int least, Symbols symbols,
                                          Set<TypeName> expanding) {
-        if (carrier == null || least <= 0) {
+        if (carrier == null || least <= 0 || least > MOST_ELEMENTS) {
             return List.of();
         }
         // A string is counted by its characters, and one character is as good as another where the
@@ -91,29 +98,39 @@ final class Witnesses {
                 return List.of();
             }
             List<FixtureTemplate> out = new ArrayList<>();
-            // Paired off rather than crossed: a key's proposals and a value's are each about their own
-            // rules, and a map refused for its keys is not told apart from one refused for its values
-            // by trying every combination of the two.
-            for (int i = 0; i < Math.min(MAX_PROPOSALS, Math.max(keys.size(), values.size())); i++) {
-                FixtureTemplate value = values.get(Math.min(i, values.size() - 1));
-                List<FixtureTemplate> entries = new ArrayList<>();
-                for (FixtureTemplate key : distinctFrom(keys.get(Math.min(i, keys.size() - 1)),
-                        map.key(), least, symbols)) {
-                    entries.add(FixtureTemplate.entry(key, value));
+            // Every pair, nearest first. A key's rules and a value's are answered together or not at
+            // all — the pair is inside one position, so no search outside can put a key's second
+            // proposal beside a value's first — and taking them in step would offer only the pairs
+            // whose two proposals happen to have been read in the same order.
+            for (int apart = 0; apart <= keys.size() + values.size() - 2; apart++) {
+                for (int i = Math.max(0, apart - values.size() + 1);
+                        i <= Math.min(apart, keys.size() - 1); i++) {
+                    FixtureTemplate value = values.get(apart - i);
+                    List<FixtureTemplate> entries = new ArrayList<>();
+                    for (FixtureTemplate key
+                            : distinctFrom(keys.get(i), map.key(), least, symbols)) {
+                        entries.add(FixtureTemplate.entry(key, value));
+                    }
+                    out.add(FixtureTemplate.collection(entries));
                 }
-                out.add(FixtureTemplate.collection(entries));
             }
             return List.copyOf(out);
         }
         return List.of();
     }
 
-    /** What the position at {@code type} would itself be offered, which is what a value built around it
-     * has to keep offering. */
+    /**
+     * What the position at {@code type} would itself be offered, which is what a value built around it
+     * has to keep offering.
+     *
+     * <p>All of them. Each is what one rule was read to produce — the shortest string a format accepts,
+     * a string of the length a minimum asks for, the value the carrier stands for — so a budget over
+     * this list drops a candidate on the strength of how many rules were read before it. The minimum's
+     * is added last of those, which is exactly the one such a budget takes away.
+     */
     private static List<FixtureTemplate> proposalsFor(Type type, Symbols symbols,
                                                       Set<TypeName> expanding) {
-        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols, null, expanding);
-        return stands.size() <= MAX_PROPOSALS ? stands : stands.subList(0, MAX_PROPOSALS);
+        return Partitions.representativesOf(type, symbols, null, expanding);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -50,6 +50,15 @@ final class Witnesses {
      * and complete, and a minimum past this asks for one nobody would. */
     private static final int MOST_ELEMENTS = 64;
 
+    /** How many characters a proposed string is worth building. Its own number, because a string of
+     * sixty-five is one literal where a collection of sixty-five is sixty-five values each built in
+     * turn — holding the two to one figure bounds a string by something about collections. */
+    private static final int MOST_CHARACTERS = 4096;
+
+    /** How many pairings of what a map's key and value propose are built at once. Every pair is built
+     * before any of them is tried, so this bounds what is allocated rather than what is walked. */
+    private static final int MOST_PAIRINGS = 64;
+
     /**
      * Values of {@code carrier} holding at least {@code least} of whatever counts it, or none where
      * this can build none.
@@ -60,7 +69,7 @@ final class Witnesses {
      */
     static List<FixtureTemplate> holding(Type carrier, int least, Symbols symbols,
                                          Set<TypeName> expanding) {
-        if (carrier == null || least <= 0 || least > MOST_ELEMENTS) {
+        if (carrier == null || least <= 0 || pastWhatIsBuilt(carrier, least)) {
             return List.of();
         }
         // A string is counted by its characters, and one character is as good as another where the
@@ -101,10 +110,13 @@ final class Witnesses {
             // Every pair, nearest first. A key's rules and a value's are answered together or not at
             // all — the pair is inside one position, so no search outside can put a key's second
             // proposal beside a value's first — and taking them in step would offer only the pairs
-            // whose two proposals happen to have been read in the same order.
-            for (int apart = 0; apart <= keys.size() + values.size() - 2; apart++) {
+            // whose two proposals happen to have been read in the same order. Nearest first is what
+            // makes the bound below cost the least: what it drops is the pairs furthest from what
+            // either side proposed first.
+            for (int apart = 0;
+                    apart <= keys.size() + values.size() - 2 && out.size() < MOST_PAIRINGS; apart++) {
                 for (int i = Math.max(0, apart - values.size() + 1);
-                        i <= Math.min(apart, keys.size() - 1); i++) {
+                        i <= Math.min(apart, keys.size() - 1) && out.size() < MOST_PAIRINGS; i++) {
                     FixtureTemplate value = values.get(apart - i);
                     List<FixtureTemplate> entries = new ArrayList<>();
                     for (FixtureTemplate key
@@ -117,6 +129,34 @@ final class Witnesses {
             return List.copyOf(out);
         }
         return List.of();
+    }
+
+    /**
+     * Whether a count a rule asks for is past what this builds a value at.
+     *
+     * <p>Asked here as well as used here, so that what a reader is told about a position and what the
+     * position did are the same decision. A count past this is not a rule nothing satisfies — a list of
+     * a million exists and somebody could write one — so what it leaves is a fact about this rather
+     * than about the model, and it has to be reported as one.
+     */
+    static boolean pastWhatIsBuilt(Type carrier, int least) {
+        if (least <= 0) {
+            return false;
+        }
+        if (carrier == Type.STRING) {
+            return least > MOST_CHARACTERS;
+        }
+        return (carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
+                || carrier instanceof Type.MapOf) && least > MOST_ELEMENTS;
+    }
+
+    /** Whether a map's key and value propose more pairs between them than are built at once. */
+    static boolean moreThanIsPaired(Type carrier, Symbols symbols) {
+        if (!(carrier instanceof Type.MapOf map)) {
+            return false;
+        }
+        return proposalsFor(map.key(), symbols, Set.of()).size()
+                * proposalsFor(map.value(), symbols, Set.of()).size() > MOST_PAIRINGS;
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -1,0 +1,166 @@
+package souther.compiler.partition;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A value built to hold what a rule says it must hold.
+ *
+ * <p>What stands for a type used to come from the carrier alone — the empty one for every collection,
+ * one character for a string — and a rule saying the collection is not empty is then the one rule that
+ * refuses the one value on offer. Read the minimum before the value is chosen and it is instead the
+ * size the value is built at.
+ *
+ * <p>A proposal, still. Nothing here decides whether a newtype accepts what it is handed: that is the
+ * decoder's answer and it is asked afterwards, which is what lets this be built from the part of a rule
+ * it can read while the rest of the rule is left to refuse it. A minimum recognised is a minimum used,
+ * and no more is claimed than that — a rule of a shape this cannot read leaves the position with what
+ * it had, and a combination whose every candidate is refused is still reported as refused.
+ *
+ * <p>A tree, because a collection holds values that have rules of their own. What stands for a list of
+ * a newtype is a list of what stands for that newtype, which is asked of the same chooser the position
+ * itself was asked of. A type written in terms of itself would have this descend forever, so the
+ * descent is bounded and gives up rather than inventing a value below the bound.
+ */
+final class Witnesses {
+
+    /** How far a value may be built inside another before this stops. Reached only by a type written
+     * in terms of itself, which no witness exists for anyway. */
+    static final int MAX_DEPTH = 4;
+
+    /**
+     * A value of {@code carrier} holding at least {@code least} of whatever counts it, or null where
+     * this can build none.
+     *
+     * <p>The minimum itself and not one element. Recognising {@code >= 3} and then offering a list of
+     * one would refuse the row for the reason the empty list was refused, having read the rule and not
+     * used it.
+     */
+    static FixtureTemplate holding(Type carrier, int least, Symbols symbols, int depth) {
+        if (carrier == null || least <= 0 || depth > MAX_DEPTH) {
+            return null;
+        }
+        // A string is counted by its characters, and one character is as good as another where the
+        // rule is about how many there are.
+        if (carrier == Type.STRING) {
+            return FixtureTemplate.string("x".repeat(least));
+        }
+        // A list may hold the same element as many times as it needs to.
+        if (carrier instanceof Type.ListOf list) {
+            FixtureTemplate one = at(list.element(), 0, symbols, depth + 1);
+            if (one == null) {
+                return null;
+            }
+            List<FixtureTemplate> elements = new ArrayList<>();
+            for (int i = 0; i < least; i++) {
+                elements.add(one);
+            }
+            return FixtureTemplate.collection(elements);
+        }
+        // A set of three is three elements no two of which are equal, and a map of three is three
+        // entries no two of which share a key. The values under a map's keys are free to repeat.
+        if (carrier instanceof Type.SetOf set) {
+            List<FixtureTemplate> elements = distinct(set.element(), least, symbols, depth + 1);
+            return elements.isEmpty() ? null : FixtureTemplate.collection(elements);
+        }
+        if (carrier instanceof Type.MapOf map) {
+            List<FixtureTemplate> keys = distinct(map.key(), least, symbols, depth + 1);
+            FixtureTemplate value = at(map.value(), 0, symbols, depth + 1);
+            if (keys.isEmpty() || value == null) {
+                return null;
+            }
+            List<FixtureTemplate> entries = new ArrayList<>();
+            for (FixtureTemplate key : keys) {
+                entries.add(FixtureTemplate.entry(key, value));
+            }
+            return FixtureTemplate.collection(entries);
+        }
+        return null;
+    }
+
+    /**
+     * Up to {@code many} values of {@code type}, no two of them equal.
+     *
+     * <p>Fewer where this runs out, which is not the same as failing: a set of three booleans is a
+     * thing no value satisfies, and offering the two that exist is a proposal the decoder answers the
+     * way it answers any other.
+     */
+    private static List<FixtureTemplate> distinct(Type type, int many, Symbols symbols, int depth) {
+        Set<String> written = new LinkedHashSet<>();
+        List<FixtureTemplate> out = new ArrayList<>();
+        for (int i = 0; out.size() < many; i++) {
+            FixtureTemplate each = at(type, i, symbols, depth);
+            if (each == null) {
+                break;
+            }
+            if (written.add(each.text())) {
+                out.add(each);
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The {@code index}th value this can think of for {@code type}, or null where it has no such value.
+     *
+     * <p>What the position itself offers comes first, so that an element is the value the rest of the
+     * generator would have chosen for it and carries whatever its own rules asked for. Past those the
+     * value is varied — a longer string, the next whole number — which is the only reason this counts
+     * at all: a set needs elements that differ, and a position ordinarily has no reason to offer two.
+     */
+    private static FixtureTemplate at(Type type, int index, Symbols symbols, int depth) {
+        if (depth > MAX_DEPTH) {
+            return null;
+        }
+        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols, null, depth + 1);
+        if (index < stands.size()) {
+            return stands.get(index);
+        }
+        return stands.isEmpty() ? null : varied(type, index, symbols);
+    }
+
+    /**
+     * A value past the ones already on offer, told apart from them by how it is built.
+     *
+     * <p>Only where the carrier has an order this can walk. A string grows by a character and a whole
+     * number by one; a date or a record has no such step that keeps every rule the position carries,
+     * and inventing one would put a value in a row that the type's own chooser had reason not to.
+     */
+    private static FixtureTemplate varied(Type type, int index, Symbols symbols) {
+        Type carrier = TypeOps.base(type, symbols);
+        FixtureTemplate bare;
+        if (carrier == Type.STRING) {
+            // Past the minimum rather than up from one: a longer string keeps a minimum length, which
+            // is the rule the position most often carries here.
+            bare = FixtureTemplate.string("x".repeat(Math.max(1, Partitions.leastHeld(type, symbols))
+                    + index));
+        } else if (carrier == Type.INT) {
+            bare = FixtureTemplate.integer(index);
+        } else {
+            return null;
+        }
+        return wrapped(type, bare, symbols);
+    }
+
+    /** The value under every name the position wears, which is how it is written where the position
+     * declares a newtype rather than what the newtype carries. */
+    private static FixtureTemplate wrapped(Type type, FixtureTemplate bare, Symbols symbols) {
+        if (!(type instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)
+                || !data.newtype()) {
+            return bare;
+        }
+        TypeName name = ref.name();
+        return FixtureTemplate.newtype(name,
+                wrapped(TypeOps.newtypeInner(name, symbols), bare, symbols));
+    }
+
+    private Witnesses() {}
+}

--- a/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
@@ -177,6 +177,23 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
         assertEquals("T { kind = Overseas, name = Name(\"xxxxx\") }", row);
     }
 
+    /**
+     * A string is counted in characters, and how many of those are worth writing is its own question.
+     *
+     * <p>A collection of sixty-five is sixty-five values each built in turn; a string of sixty-five is
+     * one literal. Holding the two to one number is holding a string to a limit nothing about it
+     * suggests, and the type here is one the model plainly admits.
+     */
+    @Test
+    void aStringsLengthIsNotBoundedByWhatACollectionHolds() {
+        String row = generatedRow(model("""
+                data Token = String
+                    invariant longEnough = String.length(value) >= 65
+                """, "token: Token", "token = Token(\"" + "a".repeat(65) + "\")"));
+
+        assertEquals("T { kind = Overseas, token = Token(\"" + "x".repeat(65) + "\") }", row);
+    }
+
     @Test
     void aStringWhoseMinimumIsOneIsStillOfferedTheOneCharacterValue() {
         String row = generatedRow(model("""
@@ -391,10 +408,54 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
 
         assertEquals(List.of(), filled.rows(),
                 "no row, rather than one carrying a million elements");
+        // Not `ALL_CANDIDATES_REJECTED`. A list of a million exists and somebody could write one; what
+        // happened is that this declined to build it, which is a fact about the generator. Reporting it
+        // as a refusal would send a reader to look for the rule that refuses a value nothing refuses.
         assertTrue(filled.unresolved().stream().allMatch(left ->
                         left.reason() == Generator.UnresolvedCombination.Reason
-                                .ALL_CANDIDATES_REJECTED),
-                "and refused, which is what a rule nothing can be built for is: "
+                                .NOTHING_COMPOSES_ONE),
+                "and said as this not composing one rather than as the model refusing it: "
+                        + filled.unresolved());
+    }
+
+    /**
+     * More pairings of what a map's parts propose than are built at once.
+     *
+     * <p>Every pair is built before any of them is tried, so the count is what this allocates and not
+     * what the search walks. Where it stops short the reader is owed that: values of the shape were
+     * built and refused, and more of them exist that nothing here got to.
+     */
+    @Test
+    void moreParingsThanAreBuiltIsSaidAsASearchThatStopped() {
+        String formats = "";
+        for (int i = 1; i <= 8; i++) {
+            formats += "    invariant p%d = String.matches(\"[a-h]{%d}\", value)\n".formatted(i, i);
+        }
+        Generator.GenerationResult filled = generated("""
+                module nd.gen
+
+                data Domestic
+                data Overseas
+                data Kind = Domestic | Overseas
+
+                data K = String
+                %s
+                data V = String
+                %s
+                data M = Map<K, V>
+                    invariant nonEmpty = Map.size(value) >= 1
+
+                data T = { kind: Kind, m: M }
+
+                behavior look : (t: T) -> Int
+
+                let look (t) = 1
+                """.formatted(formats, formats));
+
+        assertEquals(List.of(), filled.rows(), "no two of the eight formats hold at once");
+        assertTrue(filled.unresolved().stream().allMatch(left ->
+                        left.reason() == Generator.UnresolvedCombination.Reason.SEARCH_LIMIT),
+                "and the pairings this did not build are said as a search that stopped: "
                         + filled.unresolved());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
@@ -216,6 +216,130 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
     }
 
     /**
+     * An element offering several values offers all of them to the collection built around it.
+     *
+     * <p>Which is the same thing the position itself is owed, one level down. {@code Word} proposes the
+     * shortest string its format accepts and the string its minimum asks for, and the decoder settles
+     * which; a list that took the first of those and stopped would report the combination as refused
+     * while a list of the second is a value the model plainly admits. Collapsing the element to one
+     * value moves the defect this whole change is about from the collection to what it holds.
+     */
+    @Test
+    void anElementOfferingSeveralValuesOffersThemAllThroughTheCollection() {
+        String row = generatedRow(model("""
+                data Word = String
+                    invariant shaped = String.matches("x*", value)
+                    invariant longEnough = String.length(value) >= 5
+
+                data Words = List<Word>
+                    invariant someWords = List.length(value) >= 1
+                """, "words: Words", "words = Words([Word(\"xxxxx\")])"));
+
+        assertEquals("T { kind = Overseas, words = Words([Word(\"xxxxx\")]) }", row);
+    }
+
+    /** The same of what a map holds under its keys. */
+    @Test
+    void aValueOfferingSeveralOfThemOffersThemAllThroughTheMap() {
+        String row = generatedRow(model("""
+                data Word = String
+                    invariant shaped = String.matches("x*", value)
+                    invariant longEnough = String.length(value) >= 5
+
+                data Words = Map<String, Word>
+                    invariant someWords = Map.size(value) >= 1
+                """, "words: Words", "words = Words([(\"k\", Word(\"xxxxx\"))])"));
+
+        assertEquals("T { kind = Overseas, words = Words([(\"x\", Word(\"xxxxx\"))]) }", row);
+    }
+
+    /**
+     * Elements that differ are elements of the type, not numbers counted from nothing.
+     *
+     * <p>A set of two needs a second value no rule of the element refuses. Counting {@code 0, 1, 2} for
+     * distinctness offers a number the element's own bound rejects, and the set is then refused for the
+     * element rather than for anything about its size — the same collapse as above, arrived at from the
+     * other side.
+     */
+    @Test
+    void aSetsSecondElementComesFromInsideTheElementsOwnBound() {
+        String row = generatedRow(model("""
+                data Positive = Int
+                    invariant atLeastTen = value >= 10
+
+                data Positives = Set<Positive>
+                    invariant enough = Set.size(value) >= 2
+                """, "ns: Positives", "ns = Positives([Positive(10), Positive(11)])"));
+
+        assertEquals("T { kind = Overseas, ns = Positives([Positive(10), Positive(11)]) }", row);
+    }
+
+    /**
+     * The same of a map's keys, which have to differ for the same reason.
+     *
+     * <p>Keyed by a string, because a map that crosses the boundary is a JSON object and its keys are
+     * strings (<<e1314>>). The rule the second key has to keep is its length rather than a bound, and
+     * it is the same question: a key made without reading the key's own rules is a key the map is
+     * refused for.
+     */
+    @Test
+    void aMapsSecondKeyComesFromInsideTheKeysOwnRules() {
+        String row = generatedRow(model("""
+                data Code = String
+                    invariant longEnough = String.length(value) >= 3
+
+                data ByCode = Map<Code, String>
+                    invariant enough = Map.size(value) >= 2
+                """, "by: ByCode", "by = ByCode([(Code(\"aaa\"), \"a\"), (Code(\"bbbb\"), \"b\")])"));
+
+        assertEquals("T { kind = Overseas, by = ByCode([(Code(\"xxx\"), \"x\"), "
+                + "(Code(\"xxxx\"), \"x\")]) }", row);
+    }
+
+    /**
+     * A type written in terms of itself is what the descent gives up on.
+     *
+     * <p>No value of it exists, so the giving up is the right answer and not a limit reached. What
+     * matters is that it is reported the way any other refusal is, rather than descending forever.
+     */
+    @Test
+    void aTypeWrittenInTermsOfItselfIsGivenUpOn() {
+        String source = model("""
+                data Nest = List<Nest>
+                    invariant someNest = List.length(value) >= 1
+                """, "nest: Nest", "nest = Nest([])");
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+
+        assertNotNull(compilation.db().ask(new Adequacy.Generated(compilation.modules().get(0)))
+                .value(), "asking for the rows comes back rather than descending forever");
+    }
+
+    /**
+     * A chain of names is not a type written in terms of itself.
+     *
+     * <p>What the descent has to give up on is a value inside itself, and how many names a value wears
+     * on the way down is not that. A count of levels cannot tell the two apart, so it is the names being
+     * expanded that say when to stop.
+     */
+    @Test
+    void aLongChainOfNamesIsStillBuilt() {
+        String row = generatedRow(model("""
+                data L1 = String
+                data L2 = L1
+                data L3 = L2
+                data L4 = L3
+                data L5 = L4
+
+                data Deep = List<L5>
+                    invariant someDeep = List.length(value) >= 1
+                """, "deep: Deep", "deep = Deep([L5(L4(L3(L2(L1(\"a\")))))])"));
+
+        assertEquals("T { kind = Overseas, deep = Deep([L5(L4(L3(L2(L1(\"x\")))))]) }", row);
+    }
+
+    /**
      * A rule the reader has nothing to say about leaves the position where it was.
      *
      * <p>The guarantee is that a minimum this recognises is used, not that a witness is found for

--- a/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
@@ -1,0 +1,284 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.Generator;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a position offers, once the rules written on its type are read before the value is chosen.
+ *
+ * <p>A representative used to come from the carrier alone — the empty one for every collection, a
+ * one-character string — and the rules were consulted only afterwards, by the decoder that refuses
+ * what was built. A rule saying a collection is not empty is then the one rule that refuses the one
+ * value on offer, and since a row is the product of its positions, one such field took every row of
+ * the behavior with it.
+ *
+ * <p>A candidate is still a proposal the decoder answers. Nothing here claims a witness exists for an
+ * arbitrary rule: what is held to is narrower — a minimum this can read is a minimum the candidate is
+ * built at, rather than one the choice is made in ignorance of.
+ */
+class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
+
+    /**
+     * A model whose one uncovered combination needs a value of the constrained type.
+     *
+     * <p>{@code t.kind} is divided into two and one of them has a row, so the row that is owed is the
+     * other one — and writing it takes a {@code tags} the type admits.
+     */
+    private static String model(String declaration, String field, String written) {
+        return """
+                module nd.gen
+
+                data Domestic
+                data Overseas
+                data Kind = Domestic | Overseas
+
+                %s
+
+                data T = { kind: Kind, %s }
+
+                behavior look : (t: T) -> Int
+
+                let look (t) = 1
+
+                example look
+                    | (T { kind = Domestic, %s }) -> 1
+                """.formatted(declaration, field, written);
+    }
+
+    /** The one row the generator writes for that combination, as the text an author is offered. */
+    private static String generatedRow(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> all = compilation.db()
+                .ask(new Adequacy.Generated(compilation.modules().get(0))).value();
+        assertNotNull(all, "the model under test compiles");
+        Generator.GenerationResult filled = all.get("look").pairs();
+        assertEquals(List.of(), filled.unresolved(),
+                "the combination is one a value exists for, so nothing is left unresolved");
+        assertEquals(1, filled.rows().size(), "one combination is uncovered, so one row is written");
+        return filled.rows().get(0).inputs().get(0).text();
+    }
+
+    // --- a collection the rules say is not empty ---------------------------------------------------
+
+    @Test
+    void aListTheRuleSaysIsNotEmptyIsOfferedAnElement() {
+        String row = generatedRow(model("""
+                data Tag = List<String>
+                    invariant someTags = List.length(value) >= 1
+                """, "tags: Tag", "tags = Tag([\"t\"])"));
+
+        assertEquals("T { kind = Overseas, tags = Tag([\"x\"]) }", row);
+    }
+
+    /**
+     * The minimum itself, and not one element.
+     *
+     * <p>A reader that recognised {@code >= 3} and then offered a list of one would refuse the row for
+     * the same reason it refused the empty one, having read the rule and not used it.
+     */
+    @Test
+    void aListIsOfferedAsManyElementsAsTheMinimumNames() {
+        String row = generatedRow(model("""
+                data Tags = List<String>
+                    invariant enough = List.length(value) >= 3
+                """, "tags: Tags", "tags = Tags([\"a\", \"b\", \"c\"])"));
+
+        assertEquals("T { kind = Overseas, tags = Tags([\"x\", \"x\", \"x\"]) }", row);
+    }
+
+    /**
+     * A set counts what a list does, and its rule is read the same way.
+     *
+     * <p>Which the decoder's own reading cannot supply. Raoh has no constraint for a set's size — a
+     * set crosses the boundary as a list, so a size chained after the mapping that drops duplicates
+     * would count the wrong things — and a candidate chooser reading the decoder's constraints would
+     * find nothing here.
+     */
+    @Test
+    void aSetTheRuleSaysIsNotEmptyIsOfferedAnElement() {
+        String row = generatedRow(model("""
+                data Codes = Set<String>
+                    invariant someCodes = Set.size(value) >= 1
+                """, "codes: Codes", "codes = Codes([\"c\"])"));
+
+        assertEquals("T { kind = Overseas, codes = Codes([\"x\"]) }", row);
+    }
+
+    /** A set of three is three elements no two of which are equal, or it is a set of fewer. */
+    @Test
+    void aSetIsOfferedElementsNoTwoOfWhichAreEqual() {
+        String row = generatedRow(model("""
+                data Codes = Set<String>
+                    invariant enough = Set.size(value) >= 3
+                """, "codes: Codes", "codes = Codes([\"a\", \"b\", \"c\"])"));
+
+        assertEquals("T { kind = Overseas, codes = Codes([\"x\", \"xx\", \"xxx\"]) }", row);
+    }
+
+    @Test
+    void aMapTheRuleSaysIsNotEmptyIsOfferedAnEntry() {
+        String row = generatedRow(model("""
+                data Props = Map<String, String>
+                    invariant someProps = Map.size(value) >= 1
+                """, "props: Props", "props = Props([(\"k\", \"v\")])"));
+
+        assertEquals("T { kind = Overseas, props = Props([(\"x\", \"x\")]) }", row);
+    }
+
+    /** Two entries is two keys no two of which are equal; the values under them are free to repeat. */
+    @Test
+    void aMapIsOfferedEntriesNoTwoOfWhichShareAKey() {
+        String row = generatedRow(model("""
+                data Props = Map<String, String>
+                    invariant enough = Map.size(value) >= 2
+                """, "props: Props", "props = Props([(\"k\", \"v\"), (\"l\", \"w\")])"));
+
+        assertEquals("T { kind = Overseas, props = Props([(\"x\", \"x\"), (\"xx\", \"x\")]) }", row);
+    }
+
+    // --- a string the rules give a length ----------------------------------------------------------
+
+    /**
+     * The fixed {@code "x"} is a string of one, so a minimum of one was met by accident and a minimum
+     * of two was not. Both are here: the first has to keep working and the second is the defect.
+     */
+    @Test
+    void aStringIsOfferedALengthTheMinimumAdmits() {
+        String row = generatedRow(model("""
+                data Name = String
+                    invariant longEnough = String.length(value) >= 5
+                """, "name: Name", "name = Name(\"abcde\")"));
+
+        assertEquals("T { kind = Overseas, name = Name(\"xxxxx\") }", row);
+    }
+
+    @Test
+    void aStringWhoseMinimumIsOneIsStillOfferedTheOneCharacterValue() {
+        String row = generatedRow(model("""
+                data Name = String
+                    invariant longEnough = String.length(value) >= 1
+                """, "name: Name", "name = Name(\"abcde\")"));
+
+        assertEquals("T { kind = Overseas, name = Name(\"x\") }", row);
+    }
+
+    /**
+     * A format and a minimum are two proposals, not a precedence.
+     *
+     * <p>The shortest string the pattern accepts is the empty one, which the minimum refuses; the
+     * string the minimum asks for is five characters, which this pattern accepts. A reader that took
+     * the format as the answer wherever there was one would offer only the first and report the
+     * combination as refused. Neither candidate is a claim — what settles it is that the decoder was
+     * given both to answer.
+     */
+    @Test
+    void aFormatAndAMinimumAreBothProposedAndTheDecoderChooses() {
+        String row = generatedRow(model("""
+                data Tag = String
+                    invariant shaped = String.matches("x*", value)
+                    invariant longEnough = String.length(value) >= 5
+                """, "tag: Tag", "tag = Tag(\"xxxxx\")"));
+
+        assertEquals("T { kind = Overseas, tag = Tag(\"xxxxx\") }", row);
+    }
+
+    // --- what a rule reaches -----------------------------------------------------------------------
+
+    /**
+     * The elements have rules of their own, and the value inside the collection is built against them.
+     *
+     * <p>A witness is a tree: what stands for a list is a list of what stands for its element, which
+     * is itself a value some rule may have something to say about.
+     */
+    @Test
+    void anElementsOwnRuleIsReadWhereTheElementIsBuilt() {
+        String row = generatedRow(model("""
+                data Word = String
+                    invariant longEnough = String.length(value) >= 4
+
+                data Words = List<Word>
+                    invariant someWords = List.length(value) >= 1
+                """, "words: Words", "words = Words([Word(\"abcd\")])"));
+
+        assertEquals("T { kind = Overseas, words = Words([Word(\"xxxx\")]) }", row);
+    }
+
+    /**
+     * A rule the reader has nothing to say about leaves the position where it was.
+     *
+     * <p>The guarantee is that a minimum this recognises is used, not that a witness is found for
+     * whatever anyone writes. A rule of a shape nothing here reads still refuses every candidate, and
+     * that is still reported as a refusal rather than as a combination nobody can write a row for.
+     */
+    @Test
+    void aRuleNothingHereReadsStillLeavesTheCombinationRefusedAndSaidSo() {
+        String source = model("""
+                data Tags = List<String>
+                    invariant distinct = List.allDistinctBy(x -> x, value)
+                        && List.length(value) >= 2
+                    invariant notTwo = List.length(value) /= 2
+                """, "tags: Tags", "tags = Tags([\"a\", \"b\", \"c\"])");
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, Adequacy.Filling> all = compilation.db()
+                .ask(new Adequacy.Generated(compilation.modules().get(0))).value();
+        assertNotNull(all, "the model under test compiles");
+        Generator.GenerationResult filled = all.get("look").pairs();
+
+        assertEquals(List.of(), filled.rows(), "two equal elements is not a list of two distinct ones");
+        assertTrue(filled.unresolved().stream().allMatch(left ->
+                        left.reason() == Generator.UnresolvedCombination.Reason
+                                .ALL_CANDIDATES_REJECTED),
+                "refused, which is not a claim that no row can be written: "
+                        + filled.unresolved());
+    }
+
+    // --- the row as text ---------------------------------------------------------------------------
+
+    /**
+     * A row is offered as text for somebody to paste into a model, so the text has to come back as the
+     * value it was built from. Held against the compiler rather than against a spelling: a template
+     * that prints a map entry a reader does not accept would satisfy every assertion above.
+     */
+    @Test
+    void theTextOfAGeneratedRowIsAnExampleThatCompiles() {
+        String declarations = """
+                data Tags = List<String>
+                    invariant someTags = List.length(value) >= 2
+
+                data Codes = Set<String>
+                    invariant someCodes = Set.size(value) >= 2
+
+                data Props = Map<String, String>
+                    invariant someProps = Map.size(value) >= 2
+
+                data Name = String
+                    invariant longEnough = String.length(value) >= 3
+                """;
+        String fields = "tags: Tags, codes: Codes, props: Props, name: Name";
+        String written = "tags = Tags([\"a\", \"b\"]), codes = Codes([\"a\", \"b\"]), "
+                + "props = Props([(\"k\", \"v\"), (\"l\", \"w\")]), name = Name(\"abc\")";
+        String row = generatedRow(model(declarations, fields, written));
+
+        String withTheRow = model(declarations, fields, written)
+                + "    | (" + row + ") -> 1\n";
+        Compilation again = Compilation.ofSource(withTheRow, "Main");
+        again.answerEverything();
+
+        assertEquals(List.of(), again.diagnostics().values().stream().flatMap(List::stream).toList(),
+                "the generated row is written the way a fixture is read: " + row);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
@@ -161,6 +161,46 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
         assertEquals("T { kind = Overseas, props = Props([(\"x\", \"x\"), (\"xx\", \"x\")]) }", row);
     }
 
+    /**
+     * A carrier with two values in it is a carrier a set of two can be built from.
+     *
+     * <p>Nothing is being solved here: the rule is read, the carrier's values are known, and the two
+     * facts have to meet. They meet only where the second value is invented by stepping something, so a
+     * carrier that is not counted or spelled has no second element and a set of two is refused for
+     * holding one.
+     */
+    @Test
+    void aSetOfACarrierWithTwoValuesIsBuiltFromBoth() {
+        String row = generatedRow(model("""
+                data Flags = Set<Bool>
+                    invariant both = Set.size(value) >= 2
+                """, "flags: Flags", "flags = Flags([true, false])"));
+
+        assertEquals("T { kind = Overseas, flags = Flags([true, false]) }", row);
+    }
+
+    /**
+     * A sum divides into its cases, and a set of two is built from two of them.
+     *
+     * <p>Nothing here was written for sums. What a type divides into is asked of the one reader that
+     * answers it, so a carrier reaches this by being divided rather than by being remembered — which is
+     * the difference between covering a carrier and having covered the carriers somebody thought of.
+     */
+    @Test
+    void aSetOfASumIsBuiltFromItsCases() {
+        String row = generatedRow(model("""
+                data Red
+                data Green
+                data Blue
+                data Color = Red | Green | Blue
+
+                data Palette = Set<Color>
+                    invariant enough = Set.size(value) >= 2
+                """, "palette: Palette", "palette = Palette([Red, Blue])"));
+
+        assertEquals("T { kind = Overseas, palette = Palette([Red, Green]) }", row);
+    }
+
     // --- a string the rules give a length ----------------------------------------------------------
 
     /**
@@ -456,6 +496,49 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
         assertTrue(filled.unresolved().stream().allMatch(left ->
                         left.reason() == Generator.UnresolvedCombination.Reason.SEARCH_LIMIT),
                 "and the pairings this did not build are said as a search that stopped: "
+                        + filled.unresolved());
+    }
+
+    /**
+     * A map nothing was paired for is not a search that stopped.
+     *
+     * <p>{@code /= 0} says the map is not empty and no range holds it, so no minimum is read and no
+     * pairing is built — the position offers the empty map and it is refused. How many pairs the key
+     * and the value could have made between them says nothing about that, and a reader told the search
+     * stopped would be told about a search nothing here ran.
+     */
+    @Test
+    void aMapNothingWasPairedForIsSaidAsARefusalAndNotASearch() {
+        String formats = "";
+        for (int i = 1; i <= 8; i++) {
+            formats += "    invariant p%d = String.matches(\"[a-h]{%d}\", value)\n".formatted(i, i);
+        }
+        Generator.GenerationResult filled = generated("""
+                module nd.gen
+
+                data Domestic
+                data Overseas
+                data Kind = Domestic | Overseas
+
+                data K = String
+                %s
+                data V = String
+                %s
+                data M = Map<K, V>
+                    invariant notEmpty = Map.size(value) /= 0
+
+                data T = { kind: Kind, m: M }
+
+                behavior look : (t: T) -> Int
+
+                let look (t) = 1
+                """.formatted(formats, formats));
+
+        assertEquals(List.of(), filled.rows(), "the empty map is what was offered and it is refused");
+        assertTrue(filled.unresolved().stream().allMatch(left ->
+                        left.reason() == Generator.UnresolvedCombination.Reason
+                                .ALL_CANDIDATES_REJECTED),
+                "refused, because no pairing was built to be stopped short of: "
                         + filled.unresolved());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest.java
@@ -55,15 +55,28 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
                 """.formatted(declaration, field, written);
     }
 
-    /** The one row the generator writes for that combination, as the text an author is offered. */
-    private static String generatedRow(String source) {
+    /**
+     * What the generator came back with for that combination.
+     *
+     * <p>The diagnostics are held to as well as the rows. A written fixture that breaks the rule it is
+     * written under leaves a model that does not compile, and a test asking such a model for its rows
+     * gets an empty answer that agrees with whatever it expected of one.
+     */
+    private static Generator.GenerationResult generated(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.measure(Adequacy.Asked.reportOnly());
         compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream).toList(), "the model under test compiles");
         Map<String, Adequacy.Filling> all = compilation.db()
                 .ask(new Adequacy.Generated(compilation.modules().get(0))).value();
-        assertNotNull(all, "the model under test compiles");
-        Generator.GenerationResult filled = all.get("look").pairs();
+        assertNotNull(all, "the rows come back");
+        return all.get("look").pairs();
+    }
+
+    /** The one row the generator writes for that combination, as the text an author is offered. */
+    private static String generatedRow(String source) {
+        Generator.GenerationResult filled = generated(source);
         assertEquals(List.of(), filled.unresolved(),
                 "the combination is one a value exists for, so nothing is left unresolved");
         assertEquals(1, filled.rows().size(), "one combination is uncovered, so one row is written");
@@ -297,6 +310,95 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
     }
 
     /**
+     * A key and a value are two parts of one value, so their proposals meet each other.
+     *
+     * <p>The search a row is found by is over the positions of the behavior, and a map is one of those
+     * positions. What its key proposes and what its value proposes are settled inside it or not at all:
+     * a key at its second proposal beside a value at its first is a map the model admits, and nothing
+     * outside this can arrive at that pair.
+     */
+    @Test
+    void aMapsKeyAndValueProposalsMeetEachOther() {
+        String row = generatedRow(model("""
+                data Key = String
+                    invariant shaped = String.matches("x*", value)
+                    invariant longEnough = String.length(value) >= 5
+
+                data Val = String
+                    invariant shaped = String.matches("a{5}", value)
+
+                data M = Map<Key, Val>
+                    invariant nonEmpty = Map.size(value) >= 1
+                """, "m: M", "m = M([(Key(\"xxxxx\"), Val(\"aaaaa\"))])"));
+
+        assertEquals("T { kind = Overseas, m = M([(Key(\"xxxxx\"), Val(\"aaaaa\"))]) }", row);
+    }
+
+    /**
+     * A proposal a rule was read to build is not spent by how many rules were read before it.
+     *
+     * <p>Each format contributes the shortest string it accepts and the minimum contributes a string of
+     * its length, and the minimum's is last because it is added last. A budget over the whole list drops
+     * the one this change exists to add as soon as enough formats are written above it — and drops it
+     * only inside a collection, so the same `Word` is writable at a position of its own and not as an
+     * element.
+     */
+    @Test
+    void aProposalIsNotDroppedForTheNumberOfRulesReadBeforeIt() {
+        String row = generatedRow(model("""
+                data Word = String
+                    invariant p1 = String.matches("x*", value)
+                    invariant p2 = String.matches("x{2,}", value)
+                    invariant p3 = String.matches("x{3,}", value)
+                    invariant longEnough = String.length(value) >= 5
+
+                data Words = List<Word>
+                    invariant nonEmpty = List.length(value) >= 1
+                """, "words: Words", "words = Words([Word(\"xxxxx\")])"));
+
+        assertEquals("T { kind = Overseas, words = Words([Word(\"xxxxx\")]) }", row);
+    }
+
+    /**
+     * A minimum past what a row can carry is not built.
+     *
+     * <p>The count comes from the model, so a rule can ask for a million of something. Building that
+     * would take a row nobody could read to find out what the decoder already says about it, and the
+     * bound belongs here rather than on the proposals: what is given up on is a collection this would
+     * have invented, not a candidate some rule was read to produce.
+     */
+    @Test
+    void aMinimumPastWhatARowCanCarryIsNotBuilt() {
+        // No row of its own, because no fixture anybody can write satisfies the rule — which is what
+        // makes this the shape that reaches the builder with the whole count to build.
+        String source = """
+                module nd.gen
+
+                data Domestic
+                data Overseas
+                data Kind = Domestic | Overseas
+
+                data Many = List<String>
+                    invariant huge = List.length(value) >= 1000000
+
+                data T = { kind: Kind, many: Many }
+
+                behavior look : (t: T) -> Int
+
+                let look (t) = 1
+                """;
+        Generator.GenerationResult filled = generated(source);
+
+        assertEquals(List.of(), filled.rows(),
+                "no row, rather than one carrying a million elements");
+        assertTrue(filled.unresolved().stream().allMatch(left ->
+                        left.reason() == Generator.UnresolvedCombination.Reason
+                                .ALL_CANDIDATES_REJECTED),
+                "and refused, which is what a rule nothing can be built for is: "
+                        + filled.unresolved());
+    }
+
+    /**
      * A type written in terms of itself is what the descent gives up on.
      *
      * <p>No value of it exists, so the giving up is the right answer and not a limit reached. What
@@ -304,16 +406,31 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
      */
     @Test
     void aTypeWrittenInTermsOfItselfIsGivenUpOn() {
-        String source = model("""
+        // No row of its own: no fixture anybody can write satisfies a rule about a type that has no
+        // values, and a model carrying one would not compile.
+        Generator.GenerationResult filled = generated("""
+                module nd.gen
+
+                data Domestic
+                data Overseas
+                data Kind = Domestic | Overseas
+
                 data Nest = List<Nest>
                     invariant someNest = List.length(value) >= 1
-                """, "nest: Nest", "nest = Nest([])");
-        Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.measure(Adequacy.Asked.reportOnly());
-        compilation.answerEverything();
 
-        assertNotNull(compilation.db().ask(new Adequacy.Generated(compilation.modules().get(0)))
-                .value(), "asking for the rows comes back rather than descending forever");
+                data T = { kind: Kind, nest: Nest }
+
+                behavior look : (t: T) -> Int
+
+                let look (t) = 1
+                """);
+
+        assertEquals(List.of(), filled.rows(), "no value of it exists");
+        assertTrue(filled.unresolved().stream().allMatch(left ->
+                        left.reason() == Generator.UnresolvedCombination.Reason
+                                .ALL_CANDIDATES_REJECTED),
+                "and the answer comes back rather than descending forever: "
+                        + filled.unresolved());
     }
 
     /**
@@ -354,13 +471,7 @@ class ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest {
                         && List.length(value) >= 2
                     invariant notTwo = List.length(value) /= 2
                 """, "tags: Tags", "tags = Tags([\"a\", \"b\", \"c\"])");
-        Compilation compilation = Compilation.ofSource(source, "Main");
-        compilation.measure(Adequacy.Asked.reportOnly());
-        compilation.answerEverything();
-        Map<String, Adequacy.Filling> all = compilation.db()
-                .ask(new Adequacy.Generated(compilation.modules().get(0))).value();
-        assertNotNull(all, "the model under test compiles");
-        Generator.GenerationResult filled = all.get("look").pairs();
+        Generator.GenerationResult filled = generated(source);
 
         assertEquals(List.of(), filled.rows(), "two equal elements is not a list of two distinct ones");
         assertTrue(filled.unresolved().stream().allMatch(left ->


### PR DESCRIPTION
Closes #528.

## What was wrong

`Partitions.representativesOf` chose a value from the carrier type and only the carrier — the empty one for every collection, the fixed `"x"` for a string — and the rules written on the newtype were consulted afterwards, by the decoder that refuses what was built. A rule saying a collection is not empty is the most common thing anyone writes about one, and it is then the one rule that refuses the one value on offer.

A row is the product of its positions, so the loss was not confined to the position. With `look : (t: T, urgent: Bool)` and a single `List.length(value) >= 1` under `t`, all eight combinations came back `ALL_CANDIDATES_REJECTED` — including the two the second parameter is about on its own.

The string case is narrower than the issue states: `"x"` is a string of one, so `String.length(value) >= 1` was met by accident and only `>= 2` and up were lost. The collection cases were lost from `>= 1`.

## The reading already existed

The concern with fixing this in `Partitions` was a second semantic reading of an invariant beside the codec's. There is none: `check/NumericMeasures` holds the one list of the operations that count a value, and `check/InvariantBound.ofSize` reads a bound on any of them. That is how a boundary on `List.length(t.tags)` is drawn, and `Partitions.measure` already asks it. The chooser did not.

Asking it there answers a set by the same call as a list. Reading the decoder's constraints instead would not have: `InvariantConstraints` has no entry for `Set.size` — a set crosses the boundary as a list, so a size chained after the mapping that drops duplicates would count the wrong things — and that absence is a fact about the decoder rather than about what the rule says. `NumericMeasures` says so in its own comment.

New code is `Partitions.leastHeld`, `partition/Witnesses`, and the two template forms in the commit before this one.

## What is held to

A minimum this recognises is a minimum the candidate is built at — not a witness for whatever anyone writes. Nothing here proves an invariant; a candidate remains a proposal the decoder answers, which is what lets one be built from the part of a rule this can read while the rest of the rule refuses it.

- `String.length(value) >= 5` gives a string of five, `List.length(value) >= 3` a list of three.
- A set gets elements no two of which are equal, a map keys no two of which are equal.
- An element's own rules are read where the element is built: `List<Word>` under `Word: String.length(value) >= 4` gives `[Word("xxxx")]`. The descent is bounded, so a type written in terms of itself gives up rather than recursing forever.
- A format and a minimum are two proposals rather than a precedence.
- A rule of a shape nothing reads leaves the position with what it had, and the combination is still reported as refused rather than as one nobody can write a row for.

Not covered: `List.length(value) == 3`. `InvariantBound` does not read an equality — a range has nowhere to put one — and changing that would move where boundaries are drawn.

Independent of #510, which is that the boundary a length bound draws is never derived. Nothing here touches boundary derivation.

## Evidence

Twelve tests in `ACandidateIsProposedFromTheRuleAndNotTheCarrierAloneTest`. With the witness disabled, ten of them fail; the two that pass either way are the ones that must not change — that `String.length(value) >= 1` still gives `"x"`, and that an unreadable rule is still reported as refused.

One test takes the generated row's text, puts it back into the model as an `example` and compiles it, so the text is held against the reader rather than against a spelling. Spelling a map entry wrongly on purpose makes it fail, so it is not a vacuous check.

On the crm corpus the lines saying a boundary is not known to be writable fall from 68 to 57. All eleven recovered are numeric edges of an `Amount`, at positions the collection rules have nothing to do with: the record could not be built at all, so the boundary row for a field beside them went with it.

`mvn clean test` is green across all modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
