### PR TITLE
A did-you-mean is decided by the name, not by the order candidates arrive in

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Suggest.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Suggest.java
@@ -29,7 +29,10 @@ public final class Suggest {
      * {@code limit} of them.
      *
      * <p>A candidate must also be further than its own length is short — a two-letter name would
-     * otherwise be within two edits of everything and suggest whatever came first.
+     * otherwise be within two edits of everything and suggest something it has nothing to do with.
+     *
+     * <p>Ties are broken by the name. A candidate list carries no order the author chose, so an
+     * answer that depended on the one it happens to arrive in would be no answer at all.
      */
     public static List<String> nearest(String name, Collection<String> candidates, int bound, int limit) {
         record Near(String candidate, int distance) {}
@@ -56,25 +59,20 @@ public final class Suggest {
         return best == null ? "" : " (did you mean `" + best + "`?)";
     }
 
-    /** The closest in-scope candidate to {@code name} within the closeness bound, or {@code null}.
-     * The structured form of {@link #hint}, for a diagnostic's {@code suggestion} field. */
+    /**
+     * The closest in-scope candidate to {@code name} within the closeness bound, or {@code null}.
+     * The structured form of {@link #hint}, for a diagnostic's {@code suggestion} field.
+     *
+     * <p>Answered through {@link #nearest} so that two candidates at the same distance are decided
+     * by the same total order both ways of asking use. The collections a caller offers are sets and
+     * key views built by {@code Map.copyOf}, whose iteration order the JVM salts per run: a
+     * selection that kept whichever of two equally close names it met first named a different one
+     * on a different run of the same compile. Which of them the author meant is not something an
+     * encounter order knows, so the tie is settled by the name.
+     */
     public static String candidate(String name, Collection<String> candidates) {
-        String best = null;
-        int bestDistance = Integer.MAX_VALUE;
-        for (String candidate : candidates) {
-            if (candidate.equals(name)) {
-                continue;
-            }
-            int d = distance(name, candidate);
-            if (d < bestDistance) {
-                bestDistance = d;
-                best = candidate;
-            }
-        }
-        if (best != null && bestDistance <= NEAR_ENOUGH && bestDistance < name.length()) {
-            return best;
-        }
-        return null;
+        List<String> near = nearest(name, candidates, NEAR_ENOUGH, 1);
+        return near.isEmpty() ? null : near.getFirst();
     }
 
     /** Levenshtein edit distance (insert/delete/substitute), on Unicode code points. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ASuggestionDoesNotDependOnTheOrderCandidatesAreOfferedInTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASuggestionDoesNotDependOnTheOrderCandidatesAreOfferedInTest.java
@@ -1,0 +1,52 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A "did you mean" names the same candidate however the candidates were handed over.
+ *
+ * <p>The collections a caller offers carry no order anyone chose: the names bound at a point come
+ * from an immutable copy, whose iteration order the JVM salts per run, and an import alias reaches
+ * the qualifier list through another. Two candidates the same distance from the misspelling are
+ * equally good answers, so whichever the loop met first was the answer — and the same source got a
+ * different hint on a different run.
+ *
+ * <p>Asserted as invariance under permutation rather than by compiling the same source many times.
+ * A test that compiles and looks at the hint is asking which way the salt fell, and passes about
+ * half the time whether the selection is canonical or not.
+ */
+class ASuggestionDoesNotDependOnTheOrderCandidatesAreOfferedInTest {
+
+    /** Both are one edit from `aac`, and neither is the name itself. */
+    private static final List<String> TIED = List.of("aaa", "aab");
+    private static final List<String> TIED_REVERSED = List.of("aab", "aaa");
+
+    @Test
+    void namesTheSameCandidateWhicheverOrderTheTiedOnesArrivedIn() {
+        assertEquals(Suggest.candidate("aac", TIED), Suggest.candidate("aac", TIED_REVERSED));
+    }
+
+    @Test
+    void breaksATieByName() {
+        assertEquals("aaa", Suggest.candidate("aac", TIED_REVERSED));
+    }
+
+    @Test
+    void answersWhatTheNearestOfOneAnswers() {
+        // The two ways of asking for the closest candidate are one question. The bound is written
+        // here rather than read from the class, and 2 is what an identifier is matched under, so
+        // the two are asked under the same closeness.
+        assertEquals(Suggest.nearest("aac", TIED_REVERSED, 2, 1).getFirst(),
+                Suggest.candidate("aac", TIED_REVERSED));
+    }
+
+    /** A tie is what the order reaches; the answer where there is no tie is unchanged. */
+    @Test
+    void stillNamesTheOneNearestCandidate() {
+        assertEquals("amount", Suggest.candidate("amont", List.of("quantity", "amount", "price")));
+    }
+}


### PR DESCRIPTION
Closes the audit #535 asked for, and fixes the one defect it turned up.

## What was measured

The `examples` report, over the whole `souther-examples` corpus (17 modules), three runs in `en` and
two in `ja`, 10,856 lines each: byte-identical. The generated classes, which #535 also named as
unmeasured, over the same corpus, three runs, 5,003 `.class` files: byte-identical, and written in
the same order.

The instrument was checked before the result was believed. `Set.copyOf` and `Map.copyOf` do salt
their iteration order on the JDK these runs used, and a twelve-run probe put a two-element set both
ways round. The measurement could have failed.

None of the sets #535 listed has an order that reaches a reader: `Partitions.uncertain`,
`GuardReachability`, `Axis.excluded`, `PartitionEvidence.covered`, `Adequacy.covered` and
`contradicted`, `Probe` and `RowOutcome.hits` are read by `contains`, `size`, `retainAll` or
`sorted`, and every reader of `RowClasses.of` is a keyed `get`. Two of them are not covered by the
measurement and the static reading is all there is: the corpus prints no "declared unreachable"
line anywhere, and nothing prints `contradicted` at all. The full audit is written up on the issue.

## What the audit found

`Suggest.candidate` kept whichever of two equally close candidates it met first, and every
collection handed to it is unordered — `Resolve.Bindings.byName` and `Symbols.aliases` are both
`Map.copyOf`, whose iteration order the JVM salts per run. So the same source named a different
name on a different run. Sixteen JVMs each, before and after:

| | before | after |
|---|---|---|
| E1023 `= aac` with `aaa`, `aab` in scope | aaa 7 / aab 9 | 16/16 aaa |
| E1401 `= aac(1)` with the same two | aaa 10 / aab 6 | 16/16 aaa |
| E1504 `Qac.Alpha` under aliases `Qaa`, `Qab` | Qaa 3 / Qab 13 | 16/16 Qaa |

`Suggest.nearest`, in the same class, already sorted by distance and then by name. The two ways of
asking for the closest candidate meant different things, and only one of them was independent of
the order the candidates arrived in.

Two paths do not move and are unchanged: an unknown type name is matched against a plain `HashMap`
keyed by `String`, and an unknown behavior name against a map built by `Ordered.map`.

## The fix

`candidate` answers through `nearest(name, candidates, NEAR_ENOUGH, 1)`, so the tie is settled by
the name and both entry points are one question.

The producers are left as they are. A set nobody iterates is right to be an immutable copy, and a
reader that handles unordered input is a stronger answer than an ordered container at each of the
places one is built.

## The test

`ASuggestionDoesNotDependOnTheOrderCandidatesAreOfferedInTest` asserts invariance under
permutation: the same candidates in two orders give one answer. Written the other way — compile a
source repeatedly and read the hint — it would be asking which way the salt fell, and would pass
about half the time whether the selection is canonical or not. Three of its four assertions fail
deterministically on the parent commit; the fourth, where there is no tie, passes there and here.

`mvn clean install` is green: 4478 tests in `souther-compiler`, 198 in `souther-lsp`, 7 in
`souther-cli`.

## Not in this change

`ObservedValue.fields()` hands out a `LinkedHashMap` for "a stable iteration order" and
`Constructed` immediately drops it through `Map.copyOf`. Nothing iterates those fields today, so it
is not observable and it is not what #535 is about. Whether that comment is still the intended
contract — fix the representation — or is stale — delete the comment — is a separate question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
