### PR TITLE
The layout is a value, and its text is that value's projection

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhatEachBreakWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhatEachBreakWroteTest.java
@@ -1,0 +1,72 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.cst.CstParser;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A break is a decision and the layout keeps it: where it was written, how far in, and which
+ * nesting it was written under.
+ *
+ * <p>Two of the fourteen rules ask about this and neither can be answered from the document. The
+ * indentation rule asks about a pair of consecutive nesting levels, so a written indent of eight on
+ * its own leaves the pair to be worked out from the text. And a blank line is two breaks at one
+ * adjacency — {@link Gaps#boundaries} shows one boundary there, so what the top-level separation
+ * rule decided is a canonical fact the document's view cannot show.
+ */
+class ALayoutSaysWhatEachBreakWroteTest {
+
+    /** A blank line is two breaks and comes back as two. */
+    @Test
+    void aBlankLineIsTwoBreaks() {
+        Layout layout = Formatter.document(CstParser.parse("""
+                module m
+
+                data A
+
+                data B
+                """).root()).resolve().layout(100);
+
+        List<Integer> offsets = layout.breaks().stream().map(Newline::offset).toList();
+        String text = layout.text();
+        assertEquals("module m\n\ndata A\n\ndata B\n", text);
+        assertEquals(List.of(8, 9, 16, 17, 24), offsets,
+                "each newline the layout wrote, and the two of a blank line are both there");
+    }
+
+    /** A break says how far in it was written and which nesting wrote it. */
+    @Test
+    void andABreakSaysWhichNestingItWasWrittenUnder() {
+        Doc inner = Doc.nest(4, Doc.concat(Doc.text("a"), Doc.HARDLINE, Doc.text("b")));
+        Layout layout = Doc.group(inner).layout(100);
+
+        assertEquals("a\n    b", layout.text());
+        assertEquals(1, layout.breaks().size());
+        Newline wrote = layout.breaks().get(0);
+        assertEquals(4, wrote.indent());
+        assertEquals(List.of(((Doc.Nest) inner).ref()), wrote.under(),
+                "the nesting it was written under, by that nesting's own identity");
+    }
+
+    /** Two nestings written the same way are two, so the pair of levels a break sits between is
+     * readable rather than guessed from the amounts. */
+    @Test
+    void andConsecutiveLevelsAreTellableApart() {
+        Doc innermost = Doc.nest(4, Doc.concat(Doc.text("b"), Doc.HARDLINE, Doc.text("c")));
+        Doc outer = Doc.nest(4, Doc.concat(Doc.text("a"), Doc.HARDLINE, innermost));
+        Layout layout = Doc.group(outer).layout(100);
+
+        assertEquals("a\n    b\n        c", layout.text());
+        assertEquals(List.of(4, 8), layout.breaks().stream().map(Newline::indent).toList());
+        assertEquals(
+                List.of(List.of(((Doc.Nest) outer).ref()),
+                        List.of(((Doc.Nest) outer).ref(), ((Doc.Nest) innermost).ref())),
+                layout.breaks().stream().map(Newline::under).toList(),
+                "the second break is one level further in than the first, and says so by naming"
+                        + " the nesting rather than by the difference of two numbers");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhatEachBreakWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhatEachBreakWroteTest.java
@@ -7,6 +7,7 @@ import souther.compiler.cst.CstParser;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 
 /**
  * A break is a decision and the layout keeps it: where it was written, how far in, and which
@@ -62,11 +63,15 @@ class ALayoutSaysWhatEachBreakWroteTest {
 
         assertEquals("a\n    b\n        c", layout.text());
         assertEquals(List.of(4, 8), layout.breaks().stream().map(Newline::indent).toList());
-        assertEquals(
-                List.of(List.of(((Doc.Nest) outer).ref()),
-                        List.of(((Doc.Nest) outer).ref(), ((Doc.Nest) innermost).ref())),
-                layout.breaks().stream().map(Newline::under).toList(),
-                "the second break is one level further in than the first, and says so by naming"
-                        + " the nesting rather than by the difference of two numbers");
+
+        List<Doc.NestRef> shallower = layout.breaks().get(0).under();
+        List<Doc.NestRef> deeper = layout.breaks().get(1).under();
+        assertEquals(1, shallower.size());
+        assertEquals(2, deeper.size());
+        assertEquals(shallower, deeper.subList(0, 1),
+                "the deeper break is written under the shallower one's nesting and one more");
+        assertNotSame(deeper.get(0), deeper.get(1),
+                "and that one more is a nesting of its own — two nestings written the same way are"
+                        + " two, so the levels are named rather than told apart by their amounts");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhatEachBreakWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhatEachBreakWroteTest.java
@@ -42,7 +42,7 @@ class ALayoutSaysWhatEachBreakWroteTest {
     /** A break says how far in it was written and which nesting wrote it. */
     @Test
     void andABreakSaysWhichNestingItWasWrittenUnder() {
-        Doc inner = Doc.nest(4, Doc.concat(Doc.text("a"), Doc.HARDLINE, Doc.text("b")));
+        Doc inner = Doc.nest(4, Doc.concat(Doc.text("a"), Doc.hardline(), Doc.text("b")));
         Layout layout = Doc.group(inner).layout(100);
 
         assertEquals("a\n    b", layout.text());
@@ -57,8 +57,8 @@ class ALayoutSaysWhatEachBreakWroteTest {
      * readable rather than guessed from the amounts. */
     @Test
     void andConsecutiveLevelsAreTellableApart() {
-        Doc innermost = Doc.nest(4, Doc.concat(Doc.text("b"), Doc.HARDLINE, Doc.text("c")));
-        Doc outer = Doc.nest(4, Doc.concat(Doc.text("a"), Doc.HARDLINE, innermost));
+        Doc innermost = Doc.nest(4, Doc.concat(Doc.text("b"), Doc.hardline(), Doc.text("c")));
+        Doc outer = Doc.nest(4, Doc.concat(Doc.text("a"), Doc.hardline(), innermost));
         Layout layout = Doc.group(outer).layout(100);
 
         assertEquals("a\n    b\n        c", layout.text());

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * A place is somewhere the canonical form writes something, and the layout is where it wrote it. The
@@ -32,6 +33,28 @@ class ALayoutSaysWhereEachPlaceWasWrittenTest {
             placesOf(Formatter.document(CstParser.parse(source).root()), written);
             assertEquals(written.size(), layout.spans().size(),
                     "one span per place, in:\n" + source);
+        }
+    }
+
+    /**
+     * A place is written inside the place that holds it. {@code Place.parent} says "the place this
+     * one is written inside", and a function type used to name the bracketed run alone while its
+     * result was written after it — a parent that did not hold its child.
+     */
+    @Test
+    void andAPlaceIsWrittenInsideTheOneThatHoldsIt() {
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            Layout layout = layoutOf(source);
+            for (Place place : layout.spans().keySet()) {
+                Span span = layout.spans().get(place);
+                Span above = place.parent() == null ? null : layout.spans().get(place.parent());
+                if (above == null) {
+                    continue;
+                }
+                assertTrue(above.start() <= span.start() && span.end() <= above.end(),
+                        place.construct() + " at " + span + " is not inside its parent "
+                                + place.parent().construct() + " at " + above + ", in:\n" + source);
+            }
         }
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
@@ -1,0 +1,65 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.cst.CstParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A place is somewhere the canonical form writes something, and the layout is where it wrote it. The
+ * document knows the places (#506) and the run knows the columns; between them the span a place
+ * occupies in the text is a fact neither has been asked for.
+ *
+ * <p>Without it a reader of a difference has to find a place in the output by matching text, which
+ * is the search the places were made to replace.
+ */
+class ALayoutSaysWhereEachPlaceWasWrittenTest {
+
+    private static Layout layoutOf(String source) {
+        return Formatter.document(CstParser.parse(source).root()).resolve().layout(100);
+    }
+
+    /** Every place the document holds is a place the layout wrote somewhere. */
+    @Test
+    void everyPlaceOfTheDocumentHasASpan() {
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            Layout layout = layoutOf(source);
+            List<Place> written = new ArrayList<>();
+            placesOf(Formatter.document(CstParser.parse(source).root()), written);
+            assertEquals(written.size(), layout.spans().size(),
+                    "one span per place, in:\n" + source);
+        }
+    }
+
+    /** And what a span covers is what was written there. */
+    @Test
+    void andASpanCoversWhatWasWrittenThere() {
+        Layout layout = layoutOf("""
+                module m
+                let g (x: Int): Int = x
+                """);
+        List<String> covered = layout.spans().entrySet().stream()
+                .filter(e -> e.getKey().construct() == souther.compiler.cst.SyntaxKind.FN_PARAM_LIST)
+                .map(e -> layout.text().substring(e.getValue().start(), e.getValue().end()))
+                .toList();
+        assertEquals(List.of("(x: Int)"), covered);
+    }
+
+    private static void placesOf(TokenDoc doc, List<Place> out) {
+        switch (doc) {
+            case TokenDoc.At a -> {
+                out.add(a.place());
+                placesOf(a.doc(), out);
+            }
+            case TokenDoc.Node n -> placesOf(n.doc(), out);
+            case TokenDoc.Nest n -> placesOf(n.doc(), out);
+            case TokenDoc.Group g -> placesOf(g.doc(), out);
+            case TokenDoc.Concat c -> c.parts().forEach(part -> placesOf(part, out));
+            default -> { }
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
@@ -1,0 +1,125 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.cst.CstParser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+/**
+ * Laying a document out decides things its text does not record. A group written down the page
+ * because it did not fit and one written down the page because it holds a forced break come out as
+ * the same characters, and only one of them is a decision the width made.
+ *
+ * <p>This is what a reader of a difference needs and cannot get from the output: told that a line
+ * broke, they still have to be told whether the canonical form would have kept it whole at another
+ * width. Recovering that from the text means measuring the group again, which is running the layout
+ * a second time and calling the answer evidence.
+ */
+class TheLayoutKeepsWhatItsTextCannotSayTest {
+
+    /** Two documents laid out to one text, for two reasons. */
+    @Test
+    void aWidthBreakAndAForcedBreakWriteTheSameCharacters() {
+        Doc tooWide = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
+        Doc forced = Doc.group(Doc.concat(Doc.text("ab"), Doc.HARDLINE, Doc.text("cd")));
+
+        Layout byWidth = tooWide.layout(4);
+        Layout byForce = forced.layout(100);
+
+        assertEquals("ab\ncd", byWidth.text());
+        assertEquals(byWidth.text(), byForce.text(), "the two are one text");
+
+        assertEquals(1, byWidth.decisions().size());
+        assertEquals(1, byForce.decisions().size());
+        assertNotEquals(
+                byWidth.decisions().get(0).outcome(),
+                byForce.decisions().get(0).outcome(),
+                "the same text, and the layout says the two groups were laid out for"
+                        + " different reasons");
+    }
+
+    /** And a group that fits says so, rather than saying nothing. */
+    @Test
+    void andAGroupThatFitsIsADecisionToo() {
+        Doc fits = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
+
+        Layout layout = fits.layout(100);
+
+        assertEquals("ab cd", layout.text());
+        assertEquals(1, layout.decisions().size());
+    }
+
+    /** Two groups written the same way are two decisions. A layout that kept them by their shape
+     * would keep one, and the conditional-layout rule answers about a group rather than about a
+     * kind of group. */
+    @Test
+    void andTwoGroupsWrittenTheSameWayAreTwoDecisions() {
+        Doc one = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
+        Doc other = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
+
+        Layout layout = Doc.concat(one, Doc.HARDLINE, other).layout(100);
+
+        assertEquals("ab cd\nab cd", layout.text());
+        assertEquals(2, layout.decisions().size());
+        assertEquals(2, layout.decisions().stream().map(GroupDecision::group).distinct().count(),
+                "two groups, and the layout tells them apart");
+    }
+
+    /** The column a group was measured at is what the width was compared against, so it is the
+     * layout's to say and not something a reader counts off the line. */
+    @Test
+    void andTheColumnAGroupWasMeasuredAtIsItsOwn() {
+        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.LINE, Doc.text("ef")));
+        Layout layout = Doc.concat(Doc.text("ab "), inner).layout(100);
+
+        assertEquals("ab cd ef", layout.text());
+        assertEquals(List.of(3), layout.decisions().stream().map(GroupDecision::startColumn).toList());
+    }
+
+    /**
+     * Every group of a document is one decision of its layout. Measuring a group walks ahead over
+     * the groups inside it, and a layout that took a decision there would report the inner one twice
+     * — once for having been considered and once for having been laid out.
+     */
+    @Test
+    void everyGroupIsOneDecisionAndMeasuringTakesNone() {
+        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.LINE, Doc.text("ef")));
+        Doc outer = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, inner));
+
+        Layout layout = outer.layout(100);
+
+        assertEquals("ab cd ef", layout.text());
+        assertEquals(2, layout.decisions().size(),
+                "the outer group and the one inside it, and the inner one once");
+    }
+
+    /** And over a real source: the document's groups and the layout's decisions are the same
+     * number, so none is dropped and none is taken twice. */
+    @Test
+    void andOverASourceTheCountsAgree() {
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            Doc doc = Formatter.document(CstParser.parse(source).root()).resolve();
+            List<Doc> groups = new ArrayList<>();
+            groupsOf(doc, groups);
+            assertEquals(groups.size(), doc.layout(100).decisions().size(),
+                    "one decision per group, in:\n" + source);
+        }
+    }
+
+    private static void groupsOf(Doc doc, List<Doc> out) {
+        switch (doc) {
+            case Doc.Group g -> {
+                out.add(g);
+                groupsOf(g.doc(), out);
+            }
+            case Doc.Nest n -> groupsOf(n.doc(), out);
+            case Doc.Concat c -> c.parts().forEach(part -> groupsOf(part, out));
+            default -> { }
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
@@ -6,6 +6,7 @@ import souther.compiler.cst.CstParser;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -98,23 +99,41 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
                 "the outer group and the one inside it, and the inner one once");
     }
 
-    /** And over a real source: the document's groups and the layout's decisions are the same
-     * number, so none is dropped and none is taken twice. */
+    /** A decision names the group that was laid out. Counting them agrees with a layout that
+     * answered about a group it made up, which is why this reads the identities. */
     @Test
-    void andOverASourceTheCountsAgree() {
+    void andADecisionNamesTheGroupThatWasLaidOut() {
+        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.LINE, Doc.text("ef")));
+        Doc outer = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, inner));
+
+        List<Doc.GroupRef> laidOut = outer.layout(100).decisions().stream()
+                .map(GroupDecision::group).toList();
+
+        assertEquals(List.of(((Doc.Group) outer).ref(), ((Doc.Group) inner).ref()), laidOut,
+                "the outer group and then the one inside it, each by its own identity");
+    }
+
+    /** And over a real source: the groups the document holds are the groups the layout decided
+     * about, one for one. */
+    @Test
+    void andOverASourceTheyAreTheSameGroups() {
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
             Doc doc = Formatter.document(CstParser.parse(source).root()).resolve();
-            List<Doc> groups = new ArrayList<>();
-            groupsOf(doc, groups);
-            assertEquals(groups.size(), doc.layout(100).decisions().size(),
+            List<Doc.GroupRef> written = new ArrayList<>();
+            groupsOf(doc, written);
+            List<Doc.GroupRef> decided = doc.layout(100).decisions().stream()
+                    .map(GroupDecision::group).toList();
+            assertEquals(written.size(), decided.size(),
                     "one decision per group, in:\n" + source);
+            assertEquals(Set.copyOf(written), Set.copyOf(decided),
+                    "and about those groups rather than about others, in:\n" + source);
         }
     }
 
-    private static void groupsOf(Doc doc, List<Doc> out) {
+    private static void groupsOf(Doc doc, List<Doc.GroupRef> out) {
         switch (doc) {
             case Doc.Group g -> {
-                out.add(g);
+                out.add(g.ref());
                 groupsOf(g.doc(), out);
             }
             case Doc.Nest n -> groupsOf(n.doc(), out);

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
@@ -27,7 +28,7 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
     @Test
     void aWidthBreakAndAForcedBreakWriteTheSameCharacters() {
         Doc tooWide = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
-        Doc forced = Doc.group(Doc.concat(Doc.text("ab"), Doc.HARDLINE, Doc.text("cd")));
+        Doc forced = Doc.group(Doc.concat(Doc.text("ab"), Doc.hardline(), Doc.text("cd")));
 
         Layout byWidth = tooWide.layout(4);
         Layout byForce = forced.layout(100);
@@ -63,7 +64,7 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
         Doc one = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
         Doc other = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
 
-        Layout layout = Doc.concat(one, Doc.HARDLINE, other).layout(100);
+        Layout layout = Doc.concat(one, Doc.hardline(), other).layout(100);
 
         assertEquals("ab cd\nab cd", layout.text());
         assertEquals(2, layout.decisions().size());
@@ -141,5 +142,38 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
             case Doc.Concat c -> c.parts().forEach(part -> groupsOf(part, out));
             default -> { }
         }
+    }
+
+    /**
+     * A group holding a forced break is written down the page at every width, so what decided its
+     * layout is that break and not the column it was measured at. Read off where the measurement
+     * happened to stop, a group too wide to fit and holding a hardline answers with the width — and
+     * answers with the break at a width where the same group is just as broken.
+     */
+    @Test
+    void aGroupThatCanNeverBeFlatSaysSoAtEveryWidth() {
+        Doc wideAndForced = Doc.group(Doc.concat(
+                Doc.text("way-too-wide"), Doc.hardline(), Doc.text("tail")));
+
+        assertEquals(wideAndForced.layout(1000).decisions().get(0).outcome(),
+                wideAndForced.layout(4).decisions().get(0).outcome(),
+                "the width it was measured at does not change what refused the flat layout");
+        assertInstanceOf(Outcome.BrokenByForcedLayout.class,
+                wideAndForced.layout(4).decisions().get(0).outcome());
+    }
+
+    /** And the break that refused is the one named, so the rule behind it can be given later
+     * without the group being measured again to find out which it was. */
+    @Test
+    void andTheDecisionNamesWhatRefusedTheFlatLayout() {
+        Doc refusing = Doc.hardline();
+        Doc other = Doc.hardline();
+        Doc doc = Doc.group(Doc.concat(Doc.text("a"), refusing, Doc.text("b")));
+
+        Outcome outcome = Doc.concat(doc, other, Doc.text("c")).layout(100)
+                .decisions().get(0).outcome();
+
+        assertEquals(new Outcome.BrokenByForcedLayout(refusing), outcome,
+                "the break inside the group and not the one after it");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
@@ -137,6 +137,7 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
                 groupsOf(g.doc(), out);
             }
             case Doc.Nest n -> groupsOf(n.doc(), out);
+            case Doc.At a -> groupsOf(a.doc(), out);
             case Doc.Concat c -> c.parts().forEach(part -> groupsOf(part, out));
             default -> { }
         }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -30,7 +30,12 @@ sealed interface Doc {
     record Line(String flat) implements Doc {}
     record Hard() implements Doc {}
     record Concat(List<Doc> parts) implements Doc {}
-    record Nest(int indent, Doc doc) implements Doc {}
+    record Nest(NestRef ref, int indent, Doc doc) implements Doc {}
+
+    /** Which nesting a nesting is. Two written the same way are two of them, and what the
+     * indentation rule answers about is a pair of consecutive ones rather than a pair of amounts. */
+    final class NestRef {
+    }
     record Group(GroupRef ref, Doc doc) implements Doc {}
 
     /** What is written at one place of the canonical form. The document says which place; the
@@ -72,7 +77,7 @@ sealed interface Doc {
     }
 
     static Doc nest(int indent, Doc doc) {
-        return new Nest(indent, doc);
+        return new Nest(new NestRef(), indent, doc);
     }
 
     static Doc at(Place place, Doc doc) {
@@ -111,6 +116,7 @@ sealed interface Doc {
      */
     default Layout layout(int width) {
         List<GroupDecision> decisions = new ArrayList<>();
+        List<Newline> breaks = new ArrayList<>();
         java.util.Map<Place, Span> spans = new java.util.LinkedHashMap<>();
         java.util.Map<Place, Integer> opened = new java.util.IdentityHashMap<>();
         StringBuilder sb = new StringBuilder();
@@ -132,16 +138,17 @@ sealed interface Doc {
                 case Concat c -> {
                     List<Doc> parts = c.parts();
                     for (int i = parts.size() - 1; i >= 0; i--) {
-                        todo.push(new Item(it.indent, it.mode, parts.get(i)));
+                        todo.push(new Item(it.indent, it.mode, parts.get(i), null, it.under));
                     }
                 }
-                case Nest n -> todo.push(new Item(it.indent + n.indent(), it.mode, n.doc()));
+                case Nest n -> todo.push(new Item(it.indent + n.indent(), it.mode, n.doc(), null,
+                        new Nesting(n.ref(), it.under)));
                 case At a -> {
                     // The close is pushed first so that it is popped after everything written at
                     // the place, which is what makes the span the interval the place occupies.
                     opened.put(a.place(), sb.length());
-                    todo.push(new Item(it.indent, it.mode, Doc.NIL, a.place()));
-                    todo.push(new Item(it.indent, it.mode, a.doc()));
+                    todo.push(new Item(it.indent, it.mode, Doc.NIL, a.place(), it.under));
+                    todo.push(new Item(it.indent, it.mode, a.doc(), null, it.under));
                 }
                 case Group g -> {
                     Fit fit = fits(width - col, new Item(it.indent, Mode.FLAT, g.doc()), todo);
@@ -151,19 +158,19 @@ sealed interface Doc {
                         case REFUSED -> new Outcome.BrokenByForcedLayout();
                     }));
                     todo.push(new Item(it.indent,
-                            fit == Fit.FITS ? Mode.FLAT : Mode.BREAK, g.doc()));
+                            fit == Fit.FITS ? Mode.FLAT : Mode.BREAK, g.doc(), null, it.under));
                 }
                 case Line l -> {
                     if (it.mode == Mode.FLAT) {
                         sb.append(l.flat());
                         col += l.flat().length();
                     } else {
-                        sb.append('\n').append(" ".repeat(it.indent));
+                        breaks.add(newline(sb, it));
                         col = it.indent;
                     }
                 }
                 case Hard _ -> {
-                    sb.append('\n').append(" ".repeat(it.indent));
+                    breaks.add(newline(sb, it));
                     col = it.indent;
                 }
                 case Trailing t -> {
@@ -173,7 +180,15 @@ sealed interface Doc {
                 case MustBreak _ -> { }
             }
         }
-        return new Layout(sb.toString(), decisions, spans);
+        return new Layout(sb.toString(), decisions, spans, breaks);
+    }
+
+    /** Writes a break and says what it wrote. */
+    private static Newline newline(StringBuilder sb, Item it) {
+        int offset = sb.length();
+        sb.append('\n').append(" ".repeat(it.indent()));
+        return new Newline(offset, it.indent(),
+                it.under() == null ? List.of() : it.under().outermostFirst());
     }
 
     /** What a flat layout of a group came to. Refused and too wide are not one answer: the first is
@@ -246,11 +261,29 @@ sealed interface Doc {
     enum Mode { FLAT, BREAK }
 
     /** {@code closes} is the place this item ends, and is set only on the marker pushed to run
-     * after everything written at that place. */
-    record Item(int indent, Mode mode, Doc doc, Place closes) {
+     * after everything written at that place. {@code under} is the nestings it is written inside,
+     * innermost first. */
+    record Item(int indent, Mode mode, Doc doc, Place closes, Nesting under) {
 
         Item(int indent, Mode mode, Doc doc) {
-            this(indent, mode, doc, null);
+            this(indent, mode, doc, null, null);
+        }
+
+        Item(int indent, Mode mode, Doc doc, Place closes) {
+            this(indent, mode, doc, closes, null);
+        }
+    }
+
+    /** The nestings something is written inside, innermost first. */
+    record Nesting(NestRef ref, Nesting outer) {
+
+        /** Outermost first, which is the order the levels are read in. */
+        List<NestRef> outermostFirst() {
+            List<NestRef> out = new ArrayList<>();
+            for (Nesting n = this; n != null; n = n.outer()) {
+                out.add(0, n.ref());
+            }
+            return out;
         }
     }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -12,7 +12,7 @@ import java.util.List;
  * indent) otherwise. This is what lets the formatter keep a short record or pipeline on one line and
  * break a long one, from a single description of its shape.
  */
-public sealed interface Doc {
+sealed interface Doc {
 
     Doc NIL = new Nil();
     Doc LINE = new Line(" ");        // a space when flat, a newline when broken
@@ -32,6 +32,10 @@ public sealed interface Doc {
     record Concat(List<Doc> parts) implements Doc {}
     record Nest(int indent, Doc doc) implements Doc {}
     record Group(GroupRef ref, Doc doc) implements Doc {}
+
+    /** What is written at one place of the canonical form. The document says which place; the
+     * layout says where it ended up. */
+    record At(Place place, Doc doc) implements Doc {}
 
     /**
      * Which group a group is. Two groups written the same way are still two of them, and a layout
@@ -71,6 +75,10 @@ public sealed interface Doc {
         return new Nest(indent, doc);
     }
 
+    static Doc at(Place place, Doc doc) {
+        return new At(place, doc);
+    }
+
     static Doc group(Doc doc) {
         return new Group(new GroupRef(), doc);
     }
@@ -103,12 +111,18 @@ public sealed interface Doc {
      */
     default Layout layout(int width) {
         List<GroupDecision> decisions = new ArrayList<>();
+        java.util.Map<Place, Span> spans = new java.util.LinkedHashMap<>();
+        java.util.Map<Place, Integer> opened = new java.util.IdentityHashMap<>();
         StringBuilder sb = new StringBuilder();
         Deque<Item> todo = new ArrayDeque<>();
         todo.push(new Item(0, Mode.BREAK, this));   // the outermost context breaks
         int col = 0;
         while (!todo.isEmpty()) {
             Item it = todo.pop();
+            if (it.closes != null) {
+                spans.put(it.closes, new Span(opened.get(it.closes), sb.length()));
+                continue;
+            }
             switch (it.doc) {
                 case Nil _ -> { }
                 case Text t -> {
@@ -122,6 +136,13 @@ public sealed interface Doc {
                     }
                 }
                 case Nest n -> todo.push(new Item(it.indent + n.indent(), it.mode, n.doc()));
+                case At a -> {
+                    // The close is pushed first so that it is popped after everything written at
+                    // the place, which is what makes the span the interval the place occupies.
+                    opened.put(a.place(), sb.length());
+                    todo.push(new Item(it.indent, it.mode, Doc.NIL, a.place()));
+                    todo.push(new Item(it.indent, it.mode, a.doc()));
+                }
                 case Group g -> {
                     Fit fit = fits(width - col, new Item(it.indent, Mode.FLAT, g.doc()), todo);
                     decisions.add(new GroupDecision(g.ref(), col, switch (fit) {
@@ -152,7 +173,7 @@ public sealed interface Doc {
                 case MustBreak _ -> { }
             }
         }
-        return new Layout(sb.toString(), decisions);
+        return new Layout(sb.toString(), decisions, spans);
     }
 
     /** What a flat layout of a group came to. Refused and too wide are not one answer: the first is
@@ -193,6 +214,7 @@ public sealed interface Doc {
                 }
                 case Nest n -> todo.push(new Item(it.indent + n.indent(), it.mode, n.doc()));
                 case Group g -> todo.push(new Item(it.indent, it.mode, g.doc()));
+                case At a -> todo.push(new Item(it.indent, it.mode, a.doc()));
                 case Line l -> {
                     if (it.mode == Mode.FLAT) {
                         remaining -= l.flat().length();
@@ -223,5 +245,12 @@ public sealed interface Doc {
 
     enum Mode { FLAT, BREAK }
 
-    record Item(int indent, Mode mode, Doc doc) {}
+    /** {@code closes} is the place this item ends, and is set only on the marker pushed to run
+     * after everything written at that place. */
+    record Item(int indent, Mode mode, Doc doc, Place closes) {
+
+        Item(int indent, Mode mode, Doc doc) {
+            this(indent, mode, doc, null);
+        }
+    }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -31,7 +31,15 @@ public sealed interface Doc {
     record Hard() implements Doc {}
     record Concat(List<Doc> parts) implements Doc {}
     record Nest(int indent, Doc doc) implements Doc {}
-    record Group(Doc doc) implements Doc {}
+    record Group(GroupRef ref, Doc doc) implements Doc {}
+
+    /**
+     * Which group a group is. Two groups written the same way are still two of them, and a layout
+     * that kept its decisions by their shape would keep one — so this is an identity and carries
+     * nothing else.
+     */
+    final class GroupRef {
+    }
 
     /**
      * A comment written at the end of a line of code. It is not content the width has to make room
@@ -64,7 +72,7 @@ public sealed interface Doc {
     }
 
     static Doc group(Doc doc) {
-        return new Group(doc);
+        return new Group(new GroupRef(), doc);
     }
 
     /** Joins {@code parts} with {@code sep} between each. */
@@ -79,9 +87,22 @@ public sealed interface Doc {
         return new Concat(out);
     }
 
-    /** Renders this document to a string at the given target {@code width} (columns), using
-     * {@code indentUnit} spaces per nesting level increment already folded into nest amounts. */
+    /** The text this document lays out to at the given target {@code width} (columns), which is
+     * {@link #layout}'s projection. */
     default String render(int width) {
+        return layout(width).text();
+    }
+
+    /**
+     * This document laid out at the given target {@code width} (columns): the text, and what the
+     * layout decided on the way to it.
+     *
+     * <p>A decision is taken once, where the outer walk reaches the group. {@link #fits} walks ahead
+     * over groups it is only measuring and takes none, so what comes back is what was laid out
+     * rather than what was considered.
+     */
+    default Layout layout(int width) {
+        List<GroupDecision> decisions = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
         Deque<Item> todo = new ArrayDeque<>();
         todo.push(new Item(0, Mode.BREAK, this));   // the outermost context breaks
@@ -102,9 +123,14 @@ public sealed interface Doc {
                 }
                 case Nest n -> todo.push(new Item(it.indent + n.indent(), it.mode, n.doc()));
                 case Group g -> {
-                    Mode mode = fits(width - col, new Item(it.indent, Mode.FLAT, g.doc()), todo)
-                            ? Mode.FLAT : Mode.BREAK;
-                    todo.push(new Item(it.indent, mode, g.doc()));
+                    Fit fit = fits(width - col, new Item(it.indent, Mode.FLAT, g.doc()), todo);
+                    decisions.add(new GroupDecision(g.ref(), col, switch (fit) {
+                        case FITS -> new Outcome.Flat();
+                        case TOO_WIDE -> new Outcome.BrokenByWidth();
+                        case REFUSED -> new Outcome.BrokenByForcedLayout();
+                    }));
+                    todo.push(new Item(it.indent,
+                            fit == Fit.FITS ? Mode.FLAT : Mode.BREAK, g.doc()));
                 }
                 case Line l -> {
                     if (it.mode == Mode.FLAT) {
@@ -126,14 +152,18 @@ public sealed interface Doc {
                 case MustBreak _ -> { }
             }
         }
-        return sb.toString();
+        return new Layout(sb.toString(), decisions);
     }
+
+    /** What a flat layout of a group came to. Refused and too wide are not one answer: the first is
+     * a fact about the group's content and the second about the width it was measured against. */
+    enum Fit { FITS, TOO_WIDE, REFUSED }
 
     /** Whether the documents starting with {@code first} then the queued rest fit in {@code remaining}
      * columns before the next forced break — the standard flat-fits check. */
-    private static boolean fits(int remaining, Item first, Deque<Item> rest) {
+    private static Fit fits(int remaining, Item first, Deque<Item> rest) {
         if (remaining < 0) {
-            return false;
+            return Fit.TOO_WIDE;
         }
         Deque<Item> todo = new ArrayDeque<>();
         todo.push(first);
@@ -145,14 +175,14 @@ public sealed interface Doc {
             } else if (restIt.hasNext()) {
                 it = restIt.next();
             } else {
-                return true;
+                return Fit.FITS;
             }
             switch (it.doc) {
                 case Nil _ -> { }
                 case Text t -> {
                     remaining -= t.s().length();
                     if (remaining < 0) {
-                        return false;
+                        return Fit.TOO_WIDE;
                     }
                 }
                 case Concat c -> {
@@ -167,25 +197,25 @@ public sealed interface Doc {
                     if (it.mode == Mode.FLAT) {
                         remaining -= l.flat().length();
                         if (remaining < 0) {
-                            return false;
+                            return Fit.TOO_WIDE;
                         }
                     } else {
-                        return true;   // a break within reach means it fits
+                        return Fit.FITS;   // a break within reach means it fits
                     }
                 }
                 case Hard _ -> {
                     // a hardline cannot be laid out flat: inside the group under test (FLAT) it forces
                     // a break; in an already-broken outer context it just ends the measured line.
-                    return it.mode != Mode.FLAT;
+                    return it.mode == Mode.FLAT ? Fit.REFUSED : Fit.FITS;
                 }
                 case Trailing _ -> {
                     // the same, and for the same reason: whatever follows starts a new line, so it
                     // is measured against that line rather than this one, and the comment's own
                     // width is measured against nothing.
-                    return it.mode != Mode.FLAT;
+                    return it.mode == Mode.FLAT ? Fit.REFUSED : Fit.FITS;
                 }
                 case MustBreak _ -> {
-                    return it.mode != Mode.FLAT;
+                    return it.mode == Mode.FLAT ? Fit.REFUSED : Fit.FITS;
                 }
             }
         }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -17,18 +17,21 @@ sealed interface Doc {
     Doc NIL = new Nil();
     Doc LINE = new Line(" ");        // a space when flat, a newline when broken
     Doc SOFTLINE = new Line("");     // nothing when flat, a newline when broken
-    Doc HARDLINE = new Hard();       // always a newline; forces the enclosing group to break
 
     /** Writes nothing, and the group holding it is never laid out flat. A comment cannot share the
      * line after it, so a construct holding one breaks even where its own content would have fitted
      * — and where the break itself is the enclosing construct's to write, as the brackets of a list
      * whose only content is a comment. */
-    Doc MUST_BREAK = new MustBreak();
 
     record Nil() implements Doc {}
     record Text(String s) implements Doc {}
+
+    /** Which of the things that refuse a flat layout this one is. A group is broken by one of them
+     * in particular, and told apart only by their kind two hardlines are one answer. */
+    final class Ref {
+    }
     record Line(String flat) implements Doc {}
-    record Hard() implements Doc {}
+    record Hard(Ref ref) implements Doc {}
     record Concat(List<Doc> parts) implements Doc {}
     record Nest(NestRef ref, int indent, Doc doc) implements Doc {}
 
@@ -55,12 +58,22 @@ sealed interface Doc {
      * for — it sits past the end of the line whatever its length — but nothing else can share the
      * line after it, so a group holding one cannot be laid out flat.
      */
-    record Trailing(String s) implements Doc {}
+    record Trailing(Ref ref, String s) implements Doc {}
 
-    record MustBreak() implements Doc {}
+    record MustBreak(Ref ref) implements Doc {}
 
     static Doc text(String s) {
         return new Text(s);
+    }
+
+    /** Always a newline, and the group holding it is never laid out flat. */
+    static Doc hardline() {
+        return new Hard(new Ref());
+    }
+
+    /** Writes nothing, and the group holding it is never laid out flat. */
+    static Doc mustBreak() {
+        return new MustBreak(new Ref());
     }
 
     static Doc concat(Doc... parts) {
@@ -73,7 +86,7 @@ sealed interface Doc {
 
     /** A comment at the end of the line the preceding document ends on. */
     static Doc trailing(String s) {
-        return new Trailing(s);
+        return new Trailing(new Ref(), s);
     }
 
     static Doc nest(int indent, Doc doc) {
@@ -151,14 +164,12 @@ sealed interface Doc {
                     todo.push(new Item(it.indent, it.mode, a.doc(), null, it.under));
                 }
                 case Group g -> {
-                    Fit fit = fits(width - col, new Item(it.indent, Mode.FLAT, g.doc()), todo);
-                    decisions.add(new GroupDecision(g.ref(), col, switch (fit) {
-                        case FITS -> new Outcome.Flat();
-                        case TOO_WIDE -> new Outcome.BrokenByWidth();
-                        case REFUSED -> new Outcome.BrokenByForcedLayout();
-                    }));
+                    Outcome outcome = flatnessOf(width - col,
+                            new Item(it.indent, Mode.FLAT, g.doc()), todo);
+                    decisions.add(new GroupDecision(g.ref(), col, outcome));
                     todo.push(new Item(it.indent,
-                            fit == Fit.FITS ? Mode.FLAT : Mode.BREAK, g.doc(), null, it.under));
+                            outcome instanceof Outcome.Flat ? Mode.FLAT : Mode.BREAK, g.doc(),
+                            null, it.under));
                 }
                 case Line l -> {
                     if (it.mode == Mode.FLAT) {
@@ -191,16 +202,18 @@ sealed interface Doc {
                 it.under() == null ? List.of() : it.under().outermostFirst());
     }
 
-    /** What a flat layout of a group came to. Refused and too wide are not one answer: the first is
-     * a fact about the group's content and the second about the width it was measured against. */
-    enum Fit { FITS, TOO_WIDE, REFUSED }
-
-    /** Whether the documents starting with {@code first} then the queued rest fit in {@code remaining}
-     * columns before the next forced break — the standard flat-fits check. */
-    private static Fit fits(int remaining, Item first, Deque<Item> rest) {
-        if (remaining < 0) {
-            return Fit.TOO_WIDE;
-        }
+    /**
+     * What a flat layout of a group comes to: written on one line, or written down the page because
+     * it is over the width, or because something in it refuses to share a line at all.
+     *
+     * <p>Refusing wins over the width. A group holding a forced break is written down the page
+     * whatever it is measured against, so the width did not decide it — and answering with whichever
+     * of the two the walk met first would make the reason a fact about where the measuring stopped.
+     * The walk therefore goes on past the overflow, over the group's own flat content, to see
+     * whether one is there.
+     */
+    private static Outcome flatnessOf(int remaining, Item first, Deque<Item> rest) {
+        boolean over = remaining < 0;
         Deque<Item> todo = new ArrayDeque<>();
         todo.push(first);
         Iterator<Item> restIt = rest.iterator();
@@ -211,15 +224,13 @@ sealed interface Doc {
             } else if (restIt.hasNext()) {
                 it = restIt.next();
             } else {
-                return Fit.FITS;
+                return over ? new Outcome.BrokenByWidth() : new Outcome.Flat();
             }
             switch (it.doc) {
                 case Nil _ -> { }
                 case Text t -> {
                     remaining -= t.s().length();
-                    if (remaining < 0) {
-                        return Fit.TOO_WIDE;
-                    }
+                    over |= remaining < 0;
                 }
                 case Concat c -> {
                     List<Doc> parts = c.parts();
@@ -233,26 +244,31 @@ sealed interface Doc {
                 case Line l -> {
                     if (it.mode == Mode.FLAT) {
                         remaining -= l.flat().length();
-                        if (remaining < 0) {
-                            return Fit.TOO_WIDE;
-                        }
+                        over |= remaining < 0;
                     } else {
-                        return Fit.FITS;   // a break within reach means it fits
+                        // the measured stretch ends here, and what follows is another line's
+                        return over ? new Outcome.BrokenByWidth() : new Outcome.Flat();
                     }
                 }
-                case Hard _ -> {
-                    // a hardline cannot be laid out flat: inside the group under test (FLAT) it forces
-                    // a break; in an already-broken outer context it just ends the measured line.
-                    return it.mode == Mode.FLAT ? Fit.REFUSED : Fit.FITS;
+                // Refuses a flat layout where it is inside the group being measured. In an
+                // already-broken outer context it just ends the stretch being measured.
+                case Hard h -> {
+                    if (it.mode == Mode.FLAT) {
+                        return new Outcome.BrokenByForcedLayout(h);
+                    }
+                    return over ? new Outcome.BrokenByWidth() : new Outcome.Flat();
                 }
-                case Trailing _ -> {
-                    // the same, and for the same reason: whatever follows starts a new line, so it
-                    // is measured against that line rather than this one, and the comment's own
-                    // width is measured against nothing.
-                    return it.mode == Mode.FLAT ? Fit.REFUSED : Fit.FITS;
+                case Trailing t -> {
+                    if (it.mode == Mode.FLAT) {
+                        return new Outcome.BrokenByForcedLayout(t);
+                    }
+                    return over ? new Outcome.BrokenByWidth() : new Outcome.Flat();
                 }
-                case MustBreak _ -> {
-                    return it.mode == Mode.FLAT ? Fit.REFUSED : Fit.FITS;
+                case MustBreak m -> {
+                    if (it.mode == Mode.FLAT) {
+                        return new Outcome.BrokenByForcedLayout(m);
+                    }
+                    return over ? new Outcome.BrokenByWidth() : new Outcome.Flat();
                 }
             }
         }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -1268,9 +1268,11 @@ public final class Formatter {
                 }
             }
         }
-        return TokenDoc.node(n.kind(), concat(TokenDoc.at(run,
-                delimited(run, SyntaxKind.FN_TYPE, LPAREN, withEndComments(run, params), RPAREN)),
-                        GAP, ARROW, GAP, result));
+        // The place is the whole function type and not the bracketed run alone: the result is
+        // written at a place under it, and a place holds what is written at the places beneath it.
+        return TokenDoc.node(n.kind(), TokenDoc.at(run, concat(
+                delimited(run, SyntaxKind.FN_TYPE, LPAREN, withEndComments(run, params), RPAREN),
+                GAP, ARROW, GAP, result)));
     }
 
     private TokenDoc retType(SyntaxNode n, Place at) {

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
@@ -255,7 +255,7 @@ final class Gaps {
     private static Doc lower(TokenDoc doc, List<String> answers, int[] next) {
         return switch (doc) {
             case TokenDoc.Nil _ -> Doc.NIL;
-            case TokenDoc.MustBreak _ -> Doc.MUST_BREAK;
+            case TokenDoc.MustBreak _ -> Doc.mustBreak();
             case TokenDoc.Token t -> Doc.text(t.lexeme());
             case TokenDoc.Comment c -> Doc.text(c.text());
             case TokenDoc.Trailing t -> Doc.trailing(t.text());
@@ -275,7 +275,7 @@ final class Gaps {
             case TokenDoc.Gap g -> {
                 String flat = answers.get(next[0]++);
                 yield switch (g.policy()) {
-                    case ALWAYS -> Doc.HARDLINE;
+                    case ALWAYS -> Doc.hardline();
                     case MAY -> flat.isEmpty() ? Doc.SOFTLINE : Doc.LINE;
                     case NEVER -> flat.isEmpty() ? Doc.NIL : Doc.text(flat);
                 };

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
@@ -260,7 +260,7 @@ final class Gaps {
             case TokenDoc.Comment c -> Doc.text(c.text());
             case TokenDoc.Trailing t -> Doc.trailing(t.text());
             case TokenDoc.Node n -> lower(n.doc(), answers, next);
-            case TokenDoc.At a -> lower(a.doc(), answers, next);
+            case TokenDoc.At a -> Doc.at(a.place(), lower(a.doc(), answers, next));
             case TokenDoc.Carries _, TokenDoc.Vacant _ -> throw new IllegalStateException(
                     "a carrier reached the layout unresolved");
             case TokenDoc.Nest n -> Doc.nest(n.indent(), lower(n.doc(), answers, next));

--- a/souther-fmt/src/main/java/souther/compiler/fmt/GroupDecision.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/GroupDecision.java
@@ -1,0 +1,11 @@
+package souther.compiler.fmt;
+
+/**
+ * What the layout did with one group, and the column it was measured from.
+ *
+ * <p>The group is named by its own identity rather than by its shape. Two groups written the same
+ * way are two decisions, and the conditional-layout rule answers about a group rather than about a
+ * kind of group.
+ */
+public record GroupDecision(Doc.GroupRef group, int startColumn, Outcome outcome) {
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/GroupDecision.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/GroupDecision.java
@@ -7,5 +7,5 @@ package souther.compiler.fmt;
  * way are two decisions, and the conditional-layout rule answers about a group rather than about a
  * kind of group.
  */
-public record GroupDecision(Doc.GroupRef group, int startColumn, Outcome outcome) {
+record GroupDecision(Doc.GroupRef group, int startColumn, Outcome outcome) {
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
@@ -15,9 +15,10 @@ import java.util.List;
  * that a nesting was entered; those are the mechanism and they change when the code is rearranged.
  * What is kept is what the layout realized, which is what the canonicalization rules are about.
  */
-public record Layout(String text, List<GroupDecision> decisions) {
+record Layout(String text, List<GroupDecision> decisions, java.util.Map<Place, Span> spans) {
 
-    public Layout {
+    Layout {
         decisions = List.copyOf(decisions);
+        spans = java.util.Map.copyOf(spans);
     }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
@@ -15,10 +15,12 @@ import java.util.List;
  * that a nesting was entered; those are the mechanism and they change when the code is rearranged.
  * What is kept is what the layout realized, which is what the canonicalization rules are about.
  */
-record Layout(String text, List<GroupDecision> decisions, java.util.Map<Place, Span> spans) {
+record Layout(String text, List<GroupDecision> decisions,
+        java.util.Map<Place, Span> spans, List<Newline> breaks) {
 
     Layout {
         decisions = List.copyOf(decisions);
         spans = java.util.Map.copyOf(spans);
+        breaks = List.copyOf(breaks);
     }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
@@ -1,0 +1,23 @@
+package souther.compiler.fmt;
+
+import java.util.List;
+
+/**
+ * A canonical form as it was laid out: the text, and the decisions the layout took to arrive at it.
+ *
+ * <p>{@link Doc} is the program — what may break where, and how far in. This is what running it
+ * produced. The two are kept apart because the text is a projection: a group written down the page
+ * because it did not fit and one written down the page because it holds a forced break are the same
+ * characters, and a reader given only the characters has to lay the document out again to tell them
+ * apart.
+ *
+ * <p>Not a record of how the layout was computed. Nothing here says that {@code fits} was called or
+ * that a nesting was entered; those are the mechanism and they change when the code is rearranged.
+ * What is kept is what the layout realized, which is what the canonicalization rules are about.
+ */
+public record Layout(String text, List<GroupDecision> decisions) {
+
+    public Layout {
+        decisions = List.copyOf(decisions);
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Newline.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Newline.java
@@ -1,0 +1,18 @@
+package souther.compiler.fmt;
+
+import java.util.List;
+
+/**
+ * A break the layout wrote: where it is, how far in the line after it starts, and the nestings it
+ * was written under, outermost first.
+ *
+ * <p>The nestings are named rather than measured. The indentation rule answers about a pair of
+ * consecutive levels, and a written indent of eight says only what the second of the two came to —
+ * a formatter indenting the first level by four and the second by six writes the same eight.
+ */
+record Newline(int offset, int indent, List<Doc.NestRef> under) {
+
+    Newline {
+        under = List.copyOf(under);
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Outcome.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Outcome.java
@@ -21,6 +21,10 @@ sealed interface Outcome {
     /** Written down the page because the line it would take is over the width. */
     record BrokenByWidth() implements Outcome {}
 
-    /** Written down the page because something in it cannot share a line with what follows. */
-    record BrokenByForcedLayout() implements Outcome {}
+    /**
+     * Written down the page because something in it cannot share a line with what follows, and
+     * that thing. Naming it is what lets the obligation behind it be given later without the group
+     * being measured again to find out which of them it was.
+     */
+    record BrokenByForcedLayout(Doc refusing) implements Outcome {}
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Outcome.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Outcome.java
@@ -13,7 +13,7 @@ package souther.compiler.fmt;
  * refused rather than not fitted; naming the obligation behind a forced break is the forced-layout
  * rule's, and it can be given without changing this.
  */
-public sealed interface Outcome {
+sealed interface Outcome {
 
     /** Written on one line: the line it takes is within the width and nothing in it refuses to. */
     record Flat() implements Outcome {}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Outcome.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Outcome.java
@@ -1,0 +1,26 @@
+package souther.compiler.fmt;
+
+/**
+ * Why a group was laid out the way it was.
+ *
+ * <p>Broken and broken are not one answer. A group is written down the page because the line it
+ * would take is over the width, or because it holds something that cannot be laid out flat at all —
+ * a forced break, a trailing comment, a construct that refuses to. Told only that it broke, a reader
+ * cannot say whether another width would have kept it whole, and working that out means measuring
+ * the group again.
+ *
+ * <p>Which rule the thing that refused answers to is not here. This says that the flat layout was
+ * refused rather than not fitted; naming the obligation behind a forced break is the forced-layout
+ * rule's, and it can be given without changing this.
+ */
+public sealed interface Outcome {
+
+    /** Written on one line: the line it takes is within the width and nothing in it refuses to. */
+    record Flat() implements Outcome {}
+
+    /** Written down the page because the line it would take is over the width. */
+    record BrokenByWidth() implements Outcome {}
+
+    /** Written down the page because something in it cannot share a line with what follows. */
+    record BrokenByForcedLayout() implements Outcome {}
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Span.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Span.java
@@ -1,0 +1,10 @@
+package souther.compiler.fmt;
+
+/** Where something was written in a laid-out canonical form: from {@code start} up to {@code end}. */
+record Span(int start, int end) {
+
+    @Override
+    public String toString() {
+        return start + ".." + end;
+    }
+}


### PR DESCRIPTION
`Doc.render` decided how the canonical form was laid out and returned only its text. Which groups were written flat, at what column each was measured, what indent each break was written at, and where each place ended up were all computed there and dropped.

That was the last canonical decision in the formatter that was not a value. `Doc -> String` is now `Doc -> Layout -> String`, and `render` is the projection.

## What the layout holds

**Group decisions.** A group is named by an identity of its own, because two groups written the same way are two decisions. The outcome says why, not only whether: `fits` returned false both for a line over the width and for a group holding something that cannot be laid out flat at all, and told apart only by the text those two are the same characters. Which obligation a forced break answers to is deliberately **not** here — that is the forced-layout rule's and can be given without changing this.

**Place spans.** `Gaps.lower` dropped the places #506 made on the way to the layout program, so a canonical form knew which places it had and not where any of them ended up. Finding one in the output meant matching text, which is the search places were made to replace.

**Breaks.** Every newline the layout wrote, with the indent the line after it starts at and the nestings it was written under. A blank line is two forced breaks at one adjacency and `Gaps.boundaries` shows one boundary there, so the separation rule's answer had nowhere to be read from; both breaks are here because both were written. The nestings are named rather than measured — the indentation rule answers about a pair of consecutive levels, and an indent of eight says only what the second came to.

## A defect it found

`Place.parent` says "the place this one is written inside", and a function type did not. Its place named the bracketed run — `('k, 'a)` of `('k, 'a) -> Bool` — while the result was written at a place under it and after it. Seven of the standard library's types are like that.

Nothing could have said so before: the two are the same characters whichever place they belong to, and the parent relation was only ever read as a chain to walk up. Measuring where each place was written is what shows it. The fix moves one `at(...)` and changes no text.

## What holds it

The existing fixtures hold the projection: 4487 tests pass and the golden corpus is unchanged, which is what says the layout writes what it always wrote.

Four mutations, each required to fail:

- a decision naming a fresh group rather than the one laid out — caught by the identities, and **not** by counting them, which is what an earlier version of the sweep did;
- a shared identity for every nesting — caught by reading the layout's two chains against each other. The first version read its expectation off the document it was checking and held;
- dropping the second break of a blank line — caught by name;
- taking a decision while measuring rather than while laying out — this cannot arise: `fits` has no way to record, and a fixture holds that a group visited only by a look-ahead produces one decision and not two.

## Not a renderer trace

Nothing here says that `fits` was called or that a nesting was entered. Those are the mechanism and change when the code is rearranged. What is kept is what the layout realized, which is what the canonicalization rules are about — the same line #506 drew for places.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)
