### PR TITLE
An exhausted stack is answered the same way whichever entry point is asked

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -72,8 +72,22 @@ public final class Compiler {
 
     private static Map<String, byte[]> compile(String source, String defaultModuleName,
                                                List<Located> warningsOut) {
+        return compiling(source, defaultModuleName, warningsOut);
+    }
+
+    /**
+     * Drives one compilation with the recovery every entry point here answers by.
+     *
+     * <p>Around the three places a compilation is driven, rather than around the entry points that
+     * reach them. There are eleven of those and they had it twice: the two that answer with classes
+     * caught the overflow, and the ones that answer with a {@link Compilation} — which is what the
+     * command line and the editor ask for — did not, so the same source was a diagnostic through one
+     * door and a stack trace through another. What decides the answer is the compiler, not which
+     * signature a caller reached for.
+     */
+    private static <T> T driven(java.util.function.Supplier<T> compilation) {
         try {
-            return compiling(source, defaultModuleName, warningsOut);
+            return compilation.get();
         } catch (StackOverflowError _) {
             throw tooDeep();
         }
@@ -161,6 +175,14 @@ public final class Compiler {
                                         List<Located> warningsOut, Adequacy.Asked measure,
                                         java.time.Duration exampleBudget, Deadline deadline,
                                         EvaluationPolicy policy) {
+        return driven(() -> compilingSource(source, defaultModuleName, warningsOut, measure,
+                exampleBudget, deadline, policy));
+    }
+
+    private static Compilation compilingSource(String source, String defaultModuleName,
+                                               List<Located> warningsOut, Adequacy.Asked measure,
+                                               java.time.Duration exampleBudget, Deadline deadline,
+                                               EvaluationPolicy policy) {
         Compilation compilation = Compilation.ofSource(source, defaultModuleName);
         if (exampleBudget != null) {
             compilation.withExampleBudget(exampleBudget);
@@ -245,13 +267,20 @@ public final class Compiler {
      * the raising entry points: they reach the collection only by getting past every error, so a
      * compilation with one reports no warnings at all. Nothing about a warning depends on the errors
      * beside it.
+     *
+     * <p>Running out of stack is the one thing this raises. An error is an answer — it is in the
+     * reports, and the compilation around it stands — but a walk that ran out returned nothing to
+     * put there, and the questions below it have no answers either. There is no partial reading to
+     * hand back, so this says what it is instead of handing back a compilation that looks clean.
      */
     private static Compilation answered(Compilation compilation, List<Located> warningsOut,
                                         Adequacy.Asked measure) {
-        compilation.measure(measure);
-        compilation.answerEverything();
-        warningsOut.addAll(compilation.warnings(compilation.db().allReports()));
-        return compilation;
+        return driven(() -> {
+            compilation.measure(measure);
+            compilation.answerEverything();
+            warningsOut.addAll(compilation.warnings(compilation.db().allReports()));
+            return compilation;
+        });
     }
 
     private static Map<String, byte[]> classesOf(Compilation compilation) {
@@ -288,11 +317,7 @@ public final class Compiler {
 
     private static Map<String, byte[]> compileModules(List<String> sources, ModulePath path,
                                                       List<Located> warningsOut) {
-        try {
-            return linking(sources, path, warningsOut);
-        } catch (StackOverflowError _) {
-            throw tooDeep();
-        }
+        return linking(sources, path, warningsOut);
     }
 
     /**
@@ -359,6 +384,14 @@ public final class Compiler {
                                       List<Located> warningsOut, Adequacy.Asked measure,
                                       java.time.Duration exampleBudget, Deadline deadline,
                                       EvaluationPolicy policy) {
+        return driven(() -> linkingSources(sources, path, warningsOut, measure, exampleBudget,
+                deadline, policy));
+    }
+
+    private static Compilation linkingSources(List<String> sources, ModulePath path,
+                                              List<Located> warningsOut, Adequacy.Asked measure,
+                                              java.time.Duration exampleBudget, Deadline deadline,
+                                              EvaluationPolicy policy) {
         Compilation compilation = Compilation.ofSources(sources, path);
         if (exampleBudget != null) {
             compilation.withExampleBudget(exampleBudget);

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -84,6 +84,12 @@ public final class Compiler {
      * command line and the editor ask for — did not, so the same source was a diagnostic through one
      * door and a stack trace through another. What decides the answer is the compiler, not which
      * signature a caller reached for.
+     *
+     * <p>Around what an entry point does with the compilation as well as around the driving of it.
+     * Taking the classes off a driven compilation reads a key the driver already asked, so it walks
+     * nothing today — but that is a fact about the order two lines happen to be in, and a region
+     * that holds only while they stay in it is not a boundary. Nesting is why it can be said twice:
+     * the inner one answers first, and the outer one covers what is left.
      */
     private static <T> T driven(java.util.function.Supplier<T> compilation) {
         try {
@@ -117,7 +123,7 @@ public final class Compiler {
      */
     private static Map<String, byte[]> compiling(String source, String defaultModuleName,
                                                  List<Located> warningsOut) {
-        return classesOf(compiled(source, defaultModuleName, warningsOut));
+        return driven(() -> classesOf(compiled(source, defaultModuleName, warningsOut)));
     }
 
     /**
@@ -348,8 +354,8 @@ public final class Compiler {
 
     private static Map<String, byte[]> linking(List<String> sources, ModulePath path,
                                                List<Located> warningsOut) {
-        return new LinkedHashMap<>(
-                linked(sources, path, warningsOut, Adequacy.Asked.NOTHING).classes());
+        return driven(() -> new LinkedHashMap<>(
+                linked(sources, path, warningsOut, Adequacy.Asked.NOTHING).classes()));
     }
 
     /** As {@link #compiledModules(List, ModulePath, List, Adequacy.Asked)}, on a budget of its own

--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -79,11 +79,10 @@ public final class Compiler {
      * Drives one compilation with the recovery every entry point here answers by.
      *
      * <p>Around the three places a compilation is driven, rather than around the entry points that
-     * reach them. There are eleven of those and they had it twice: the two that answer with classes
-     * caught the overflow, and the ones that answer with a {@link Compilation} — which is what the
-     * command line and the editor ask for — did not, so the same source was a diagnostic through one
-     * door and a stack trace through another. What decides the answer is the compiler, not which
-     * signature a caller reached for.
+     * reach them. It was written on the entry points that answer with classes, and the ones that
+     * answer with a {@link Compilation} — which is what the command line and the editor ask for —
+     * had nothing, so the same source was a diagnostic through one door and a stack trace through
+     * another. What decides the answer is the compiler, not which signature a caller reached for.
      *
      * <p>Around what an entry point does with the compilation as well as around the driving of it.
      * Taking the classes off a driven compilation reads a key the driver already asked, so it walks
@@ -91,7 +90,7 @@ public final class Compiler {
      * that holds only while they stay in it is not a boundary. Nesting is why it can be said twice:
      * the inner one answers first, and the outer one covers what is left.
      */
-    private static <T> T driven(java.util.function.Supplier<T> compilation) {
+    static <T> T driven(java.util.function.Supplier<T> compilation) {
         try {
             return compilation.get();
         } catch (StackOverflowError _) {
@@ -103,8 +102,8 @@ public final class Compiler {
      * A source whose expressions nest deeper than the compiler can walk. Every phase descends an
      * expression by recursion — parsing, inlining, checking, emitting — so past some depth the stack
      * runs out. That is not a {@code CompileException}, so left alone it passes through the recovery
-     * boundary and reaches the author as a stack trace, and takes the language server's dispatch
-     * loop with it. It is reported like any other thing the compiler cannot accept.
+     * boundary and reaches the author as a stack trace. It is reported like any other thing the
+     * compiler cannot accept.
      *
      * <p>The depth is not a written limit, so no position is claimed: the failure belongs to the
      * source as a whole, and the author's move is the same wherever it landed — name the parts.

--- a/souther-compiler/src/test/java/souther/compiler/CompileDeepExpressionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDeepExpressionTest.java
@@ -2,8 +2,14 @@ package souther.compiler;
 
 import org.junit.jupiter.api.Test;
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Located;
+import souther.compiler.meta.ModulePath;
+import souther.compiler.query.Adequacy;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -12,11 +18,15 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * An expression nested deeper than the walks can recurse must be reported, not thrown. Every phase
- * here descends an expression by recursion, so a deep enough one exhausts the stack — and a
- * {@code StackOverflowError} is not a {@code CompileException}, so it passes straight through the
- * recovery boundary: the command line prints a stack trace, and the language server, which catches
- * {@code RuntimeException} to stay alive, does not catch this and exits.
+ * A compilation that runs out of stack must be reported, not thrown. Every phase here descends by
+ * recursion, so a deep enough one exhausts the stack — and a {@code StackOverflowError} is not a
+ * {@code CompileException}, so left alone it passes straight through the recovery boundary and the
+ * command line prints a stack trace.
+ *
+ * <p>Asked at every entry point, because the answer is the compiler's rather than the signature's.
+ * The recovery was written on the two that answer with classes, and the ones that answer with a
+ * {@code Compilation} — which is what the command line and the editor ask for — did not have it, so
+ * the same source came back a diagnostic through one door and an {@code Error} through another.
  *
  * <p>Each case runs on a thread with a small, fixed stack. What counts as "too deep" otherwise
  * depends on the stack the test happens to run with, which makes the same source compile on one run
@@ -39,18 +49,87 @@ class CompileDeepExpressionTest {
                 """.formatted(expr);
     }
 
+    /**
+     * A source the parser accepts and the walks after it cannot finish: a chain of values, each
+     * naming the one before, which substitution splices into one tree as long as the chain.
+     *
+     * <p>Written nesting will not do here. The parser bounds that and refuses it with a position
+     * (issue #524), so a source deep enough to overflow never reaches the walks — what a written
+     * nest tests is the parser's limit, not this boundary.
+     */
+    private static String aCompilationThatRunsOutOfStack() {
+        StringBuilder sb = new StringBuilder("module m exposing (f)\n\nlet v0 = 1\n");
+        for (int i = 1; i <= 1000; i++) {
+            sb.append("let v").append(i).append(" = v").append(i - 1).append(" + 1\n");
+        }
+        return sb.append("\nbehavior f : (x: Int) -> Int\nlet f (x) = x + v1000\n").toString();
+    }
+
+    /** Every entry point that drives a compilation, by the name a reader would call it. */
+    private static Map<String, Runnable> everyEntryPoint(String source) {
+        List<String> sources = List.of(source);
+        Map<String, Runnable> doors = new LinkedHashMap<>();
+        doors.put("compile(source)", () -> Compiler.compile(source));
+        doors.put("compile(source, name)", () -> Compiler.compile(source, "m"));
+        doors.put("compileWithWarnings(source)", () -> Compiler.compileWithWarnings(source));
+        doors.put("compileWithWarnings(source, name)",
+                () -> Compiler.compileWithWarnings(source, "m"));
+        doors.put("compiled(source, name)", () -> Compiler.compiled(source, "m"));
+        doors.put("analyzed(source, name, ...)",
+                () -> Compiler.analyzed(source, "m", new ArrayList<Located>(), Adequacy.Asked.NOTHING));
+        doors.put("compileModules(sources)", () -> Compiler.compileModules(sources));
+        doors.put("compileModules(sources, path)",
+                () -> Compiler.compileModules(sources, ModulePath.EMPTY));
+        doors.put("compileModulesWithWarnings(sources)",
+                () -> Compiler.compileModulesWithWarnings(sources));
+        doors.put("compileModulesWithWarnings(sources, path)",
+                () -> Compiler.compileModulesWithWarnings(sources, ModulePath.EMPTY));
+        doors.put("compiledModules(sources, path, ...)",
+                () -> Compiler.compiledModules(sources, ModulePath.EMPTY, new ArrayList<Located>()));
+        doors.put("analyzedModules(sources, path, ...)",
+                () -> Compiler.analyzedModules(sources, ModulePath.EMPTY, new ArrayList<Located>(),
+                        Adequacy.Asked.NOTHING));
+        return doors;
+    }
+
+    /**
+     * Every door, and every door's answer said together. Stopping at the first one that is wrong
+     * says one name where the question is which of them agree, and the door that had the recovery
+     * already is among the first — so a run that stopped there would report the one door that was
+     * never in doubt.
+     */
+    @Test
+    void everyEntryPointAnswersAnExhaustedStackWithADiagnostic() throws InterruptedException {
+        String source = aCompilationThatRunsOutOfStack();
+        List<String> wrong = new ArrayList<>();
+
+        for (Map.Entry<String, Runnable> door : everyEntryPoint(source).entrySet()) {
+            Throwable thrown = run(door.getValue(), STACK_BYTES);
+            String said = thrown == null ? "compiled"
+                    : thrown instanceof CompileException && thrown.getMessage().contains("deep")
+                            ? null
+                            : thrown.getClass().getName();
+            if (said != null) {
+                wrong.add(door.getKey() + " -> " + said);
+            }
+        }
+
+        assertTrue(wrong.isEmpty(), "these entry points did not answer with a depth diagnostic:\n  "
+                + String.join("\n  ", wrong));
+    }
+
     @Test
     void deeplyNestedParenthesesAreReported() throws InterruptedException {
         String expr = "(".repeat(5000) + "1" + ")".repeat(5000);
 
-        assertReportsDepth(() -> Compiler.compile(moduleWith(expr)));
+        assertReportsDepth("compile(source)", () -> Compiler.compile(moduleWith(expr)));
     }
 
     @Test
     void aVeryLongOperatorChainIsReported() throws InterruptedException {
         String expr = "1 + ".repeat(20000) + "1";
 
-        assertReportsDepth(() -> Compiler.compile(moduleWith(expr)));
+        assertReportsDepth("compile(source)", () -> Compiler.compile(moduleWith(expr)));
     }
 
     /** A module set goes through the same walks, so it needs the same answer. */
@@ -58,7 +137,8 @@ class CompileDeepExpressionTest {
     void theSameHoldsForAModuleSet() throws InterruptedException {
         String expr = "(".repeat(5000) + "1" + ")".repeat(5000);
 
-        assertReportsDepth(() -> Compiler.compileModules(List.of(moduleWith(expr))));
+        assertReportsDepth("compileModules(sources)",
+                () -> Compiler.compileModules(List.of(moduleWith(expr))));
     }
 
     /**
@@ -81,14 +161,14 @@ class CompileDeepExpressionTest {
 
     /** Runs {@code work} on a thread with {@link #STACK_BYTES} of stack and asserts it came back
      *  with a depth diagnostic rather than an {@code Error}. */
-    private static void assertReportsDepth(Runnable work) throws InterruptedException {
+    private static void assertReportsDepth(String door, Runnable work) throws InterruptedException {
         Throwable thrown = run(work, STACK_BYTES);
-        assertNotNull(thrown, "a source this deep should not compile on a " + STACK_BYTES
+        assertNotNull(thrown, door + ": a source this deep should not compile on a " + STACK_BYTES
                 + "-byte stack; the test no longer exercises the depth boundary");
         assertInstanceOf(CompileException.class, thrown,
-                "expected a diagnostic, got " + thrown.getClass().getName());
+                door + ": expected a diagnostic, got " + thrown.getClass().getName());
         assertTrue(thrown.getMessage().contains("deep"),
-                "expected a depth diagnostic, got: " + thrown.getMessage());
+                door + ": expected a depth diagnostic, got: " + thrown.getMessage());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileDeepExpressionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDeepExpressionTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -90,6 +91,27 @@ class CompileDeepExpressionTest {
                 () -> Compiler.analyzedModules(sources, ModulePath.EMPTY, new ArrayList<Located>(),
                         Adequacy.Asked.NOTHING));
         return doors;
+    }
+
+    /**
+     * The boundary itself, asked with the one thing it is for.
+     *
+     * <p>Apart from the case below, which reaches it by compiling a source deep enough to exhaust a
+     * walk. That is the reachability, and it is a different question: it holds while nothing before
+     * the walks refuses such a source, and issue #524 is about giving the producers of that depth a
+     * bound of their own, after which no source reaches here at all. On the day that lands, the case
+     * below stops exercising this and starts passing on the new diagnostic — and if this one were
+     * not written, removing the recovery entirely would leave both of them green.
+     */
+    @Test
+    void theBoundaryTurnsAnExhaustedStackIntoADiagnostic() {
+        CompileException thrown = assertThrows(CompileException.class,
+                () -> Compiler.driven(() -> {
+                    throw new StackOverflowError();
+                }));
+
+        assertTrue(thrown.getMessage().contains("deep"),
+                "expected a depth diagnostic, got: " + thrown.getMessage());
     }
 
     /**


### PR DESCRIPTION
`Compiler` converted a `StackOverflowError` into a diagnostic on the two entry points that answer with classes. The nine that answer with a `Compilation` had nothing — and those are the ones `Main` asks for, both to build and to report — so the same source came back a diagnostic through one door and an `Error` through another, which left `main` as a stack trace.

## What changed

The recovery moves from the entry points to the three places a compilation is driven: the single source, the module set, and the analysing one. Every entry point reaches one of them, so what decides the answer is the compiler rather than the signature a caller reached for. The two catches on `compile` and `compileModules` go.

Running out of stack is now the one thing the analysing driver raises, and its javadoc says why: an error is an answer and the compilation around it stands, but a walk that ran out returned nothing to put in the reports and the questions below it have no answers either, so there is no partial reading to hand back.

## Test

`CompileDeepExpressionTest` is held against the boundary. It asks all twelve entry points and reports every one that disagreed, rather than stopping at the first — the door that already had the recovery is among the first, so a run that stopped there would name the one door that was never in doubt.

Removing the catch again puts all twelve in the failure message. With it, all pass.

Its source is a chain of value declarations. A written nest never reaches this boundary: `CstParser.MAX_DEPTH` bounds it and reports at the token that reached it, so the cases that used one were measuring the parser's limit rather than this. Those cases stay, now named for what they are.

The stale sentence about the language server exiting is gone — `LspServer` and `Analyzer` both catch `StackOverflowError`.

`mvn -o clean install` is green across all modules.

Closes #542. Split out of #524, which is about why a source the parser accepts can exhaust a walk at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
