### PR TITLE
One canonicalization run answers for itself

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/fmt/ADefinitionsBodyOwnsItsCommentTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ADefinitionsBodyOwnsItsCommentTest.java
@@ -166,7 +166,7 @@ class ADefinitionsBodyOwnsItsCommentTest {
                     // about the body
                     x
                 """).root();
-        Formatter.Construction built = Formatter.build(root);
+        Formatter.Construction built = Formatter.canonicalize(root).construction();
 
         SyntaxNode lambda = only(root, SyntaxKind.LAMBDA_EXPR);
         SyntaxNode body = childOf(lambda, SyntaxKind.VAR_EXPR);

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhatEachBreakWroteTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhatEachBreakWroteTest.java
@@ -24,13 +24,13 @@ class ALayoutSaysWhatEachBreakWroteTest {
     /** A blank line is two breaks and comes back as two. */
     @Test
     void aBlankLineIsTwoBreaks() {
-        Layout layout = Formatter.document(CstParser.parse("""
+        Layout layout = Formatter.canonicalize(CstParser.parse("""
                 module m
 
                 data A
 
                 data B
-                """).root()).resolve().layout(100);
+                """).root()).layout();
 
         List<Integer> offsets = layout.breaks().stream().map(Newline::offset).toList();
         String text = layout.text();

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -20,19 +21,34 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ALayoutSaysWhereEachPlaceWasWrittenTest {
 
-    private static Layout layoutOf(String source) {
-        return Formatter.document(CstParser.parse(source).root()).resolve().layout(100);
+    private static Formatter.CanonicalForm canonical(String source) {
+        return Formatter.canonicalize(CstParser.parse(source).root());
     }
 
-    /** Every place the document holds is a place the layout wrote somewhere. */
+    private static Layout layoutOf(String source) {
+        return canonical(source).layout();
+    }
+
+    /**
+     * Every place a canonicalization made is a place its layout wrote somewhere — those places, by
+     * identity, and not as many places as it made.
+     *
+     * <p>This used to build the document a second time to walk it, and a second canonicalization
+     * makes its own places: the two collections came out the same size and shared not one member,
+     * so the count held and said nothing about the layout's places.
+     */
     @Test
-    void everyPlaceOfTheDocumentHasASpan() {
+    void everyPlaceOfTheRunHasASpan() {
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
-            Layout layout = layoutOf(source);
+            Formatter.CanonicalForm canonical = canonical(source);
             List<Place> written = new ArrayList<>();
-            placesOf(Formatter.document(CstParser.parse(source).root()), written);
-            assertEquals(written.size(), layout.spans().size(),
-                    "one span per place, in:\n" + source);
+            placesOf(canonical.construction().doc(), written);
+            assertEquals(List.of(), written.stream()
+                            .filter(p -> !canonical.layout().spans().containsKey(p)).toList(),
+                    "places this run's document writes that its layout wrote nowhere, in:\n"
+                            + source);
+            assertEquals(written.size(), canonical.layout().spans().size(),
+                    "and no others, in:\n" + source);
         }
     }
 
@@ -84,5 +100,26 @@ class ALayoutSaysWhereEachPlaceWasWrittenTest {
             case TokenDoc.Concat c -> c.parts().forEach(part -> placesOf(part, out));
             default -> { }
         }
+    }
+
+    /**
+     * What two canonicalizations of one source share. Nothing: each makes its own places, and a
+     * layout asked about another run's place answers that it wrote it nowhere rather than refusing
+     * the question. Written down so that the reason a canonical form is one object is a stated fact
+     * and not a habit.
+     */
+    @Test
+    void andTwoRunsShareNoneOfIt() {
+        String source = "module m\n\nlet g (x: Int): Int = x\n";
+        Formatter.CanonicalForm one = canonical(source);
+        Formatter.CanonicalForm other = canonical(source);
+
+        assertEquals(one.text(), other.text());
+        List<Place> theirs = new ArrayList<>();
+        placesOf(other.construction().doc(), theirs);
+        assertFalse(theirs.isEmpty());
+        assertEquals(List.of(),
+                theirs.stream().filter(p -> one.layout().spans().containsKey(p)).toList(),
+                "a place of one run is not a place the other laid out");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
@@ -38,7 +38,7 @@ class ALayoutSaysWhereEachPlaceWasWrittenTest {
      * so the count held and said nothing about the layout's places.
      */
     @Test
-    void everyPlaceOfTheRunHasASpan() {
+    void everyPlaceTheDocumentWritesHasASpan() {
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
             Formatter.CanonicalForm canonical = canonical(source);
             List<Place> written = new ArrayList<>();
@@ -122,4 +122,32 @@ class ALayoutSaysWhereEachPlaceWasWrittenTest {
                 theirs.stream().filter(p -> one.layout().spans().containsKey(p)).toList(),
                 "a place of one run is not a place the other laid out");
     }
+
+    /**
+     * And the places a run makes that its document writes nowhere. A place is made for the line a
+     * construct opens with — a {@code data} declaration's {@code =}, a block's brace, a match's
+     * {@code with} — and it carries the comment written at the end of that line while holding none
+     * of the text; a construct that writes through its members, like a product body, makes a place
+     * that is the parent of theirs and wraps nothing itself; and the file's own place wraps nothing
+     * at all.
+     *
+     * <p>So {@code spans()} answers where an {@code At} was written, not where a place is. Stated
+     * here rather than left to be found, because a witness naming one of these as a comment's owner
+     * cannot say where in the output it is.
+     */
+    @Test
+    void butNotEveryPlaceTheRunMakes() {
+        Formatter.CanonicalForm canonical = canonical(SOURCE_WITH_A_HEADER_COMMENT);
+        List<String> unlocated = canonical.places().stream()
+                .filter(p -> !canonical.layout().spans().containsKey(p))
+                .map(p -> p.construct() + (p.parent() == null ? " (the file)" : ""))
+                .toList();
+
+        assertEquals(List.of("SOURCE_FILE (the file)", "ASSIGN", "PRODUCT_BODY"), unlocated,
+                "the file, the anchor that carries the header line's comment, and the parent of the"
+                        + " fields \u2014 none of them locatable in the output");
+    }
+
+    private static final String SOURCE_WITH_A_HEADER_COMMENT =
+            "module m\ndata D =   // about the block\n    { a: Int\n    , b: Int\n    }\n";
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
@@ -30,8 +30,11 @@ class ALayoutSaysWhereEachPlaceWasWrittenTest {
     }
 
     /**
-     * Every place a canonicalization made is a place its layout wrote somewhere — those places, by
-     * identity, and not as many places as it made.
+     * Every place this run's document writes is a place its layout wrote somewhere — those places,
+     * by identity, and not as many of them as the document has.
+     *
+     * <p>The places the document writes, and not every place the run made: some of those are
+     * written nowhere, which {@link #butNotEveryPlaceTheRunMakes} says and #555 settles.
      *
      * <p>This used to build the document a second time to walk it, and a second canonicalization
      * makes its own places: the two collections came out the same size and shared not one member,
@@ -103,13 +106,13 @@ class ALayoutSaysWhereEachPlaceWasWrittenTest {
     }
 
     /**
-     * What two canonicalizations of one source share. Nothing they made: each run makes its own
-     * places and its own groups, and a layout asked about another run's identity answers that it
+     * What two canonicalizations of one source share of the places and the groups they make.
+     * Neither: each run makes its own, and a layout asked about the other run's answers that it
      * wrote it nowhere rather than refusing the question. Written down so that the reason a
      * canonical form is one object is a stated fact and not a habit.
      */
     @Test
-    void andTwoRunsShareNothingTheyMade() {
+    void andTwoRunsShareNoPlacesOrGroups() {
         String source = "module m\n\nlet g (x: Int): Int = x\n";
         Formatter.CanonicalForm one = canonical(source);
         Formatter.CanonicalForm other = canonical(source);
@@ -131,6 +134,32 @@ class ALayoutSaysWhereEachPlaceWasWrittenTest {
         assertEquals(theirGroups.size(), ours.size());
         assertEquals(List.of(), theirGroups.stream().filter(ours::contains).toList(),
                 "and a group of one run is not a group the other decided about");
+    }
+
+    /**
+     * And the places a run makes that its document writes nowhere. A place is made for the line a
+     * construct opens with — a {@code data} declaration's {@code =}, a block's brace, a match's
+     * {@code with} — and it carries the comment written at the end of that line while holding none
+     * of the text; a construct that writes through its members, like a product body, makes a place
+     * that is the parent of theirs and wraps nothing itself; and the file's own place wraps nothing
+     * at all.
+     *
+     * <p>So the spans answer where an annotation was written, not where a place is. Stated here
+     * rather than left to be found, because a witness naming one of these as a comment's owner
+     * cannot say where in the output it is. What a place's location is when it writes no text of
+     * its own is #555.
+     */
+    @Test
+    void butNotEveryPlaceTheRunMakes() {
+        Formatter.CanonicalForm canonical = canonical(SOURCE_WITH_A_HEADER_COMMENT);
+        List<String> unlocated = canonical.places().stream()
+                .filter(p -> !canonical.layout().spans().containsKey(p))
+                .map(p -> p.construct() + (p.parent() == null ? " (the file)" : ""))
+                .toList();
+
+        assertEquals(List.of("SOURCE_FILE (the file)", "ASSIGN", "PRODUCT_BODY"), unlocated,
+                "the file, the anchor that carries the header line's comment, and the parent of the"
+                        + " fields \u2014 none of them locatable in the output");
     }
 
     private static final String SOURCE_WITH_A_HEADER_COMMENT =

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALayoutSaysWhereEachPlaceWasWrittenTest.java
@@ -103,49 +103,34 @@ class ALayoutSaysWhereEachPlaceWasWrittenTest {
     }
 
     /**
-     * What two canonicalizations of one source share. Nothing: each makes its own places, and a
-     * layout asked about another run's place answers that it wrote it nowhere rather than refusing
-     * the question. Written down so that the reason a canonical form is one object is a stated fact
-     * and not a habit.
+     * What two canonicalizations of one source share. Nothing they made: each run makes its own
+     * places and its own groups, and a layout asked about another run's identity answers that it
+     * wrote it nowhere rather than refusing the question. Written down so that the reason a
+     * canonical form is one object is a stated fact and not a habit.
      */
     @Test
-    void andTwoRunsShareNoneOfIt() {
+    void andTwoRunsShareNothingTheyMade() {
         String source = "module m\n\nlet g (x: Int): Int = x\n";
         Formatter.CanonicalForm one = canonical(source);
         Formatter.CanonicalForm other = canonical(source);
 
         assertEquals(one.text(), other.text());
-        List<Place> theirs = new ArrayList<>();
-        placesOf(other.construction().doc(), theirs);
-        assertFalse(theirs.isEmpty());
+
+        List<Place> theirPlaces = new ArrayList<>();
+        placesOf(other.construction().doc(), theirPlaces);
+        assertFalse(theirPlaces.isEmpty());
         assertEquals(List.of(),
-                theirs.stream().filter(p -> one.layout().spans().containsKey(p)).toList(),
+                theirPlaces.stream().filter(p -> one.layout().spans().containsKey(p)).toList(),
                 "a place of one run is not a place the other laid out");
-    }
 
-    /**
-     * And the places a run makes that its document writes nowhere. A place is made for the line a
-     * construct opens with — a {@code data} declaration's {@code =}, a block's brace, a match's
-     * {@code with} — and it carries the comment written at the end of that line while holding none
-     * of the text; a construct that writes through its members, like a product body, makes a place
-     * that is the parent of theirs and wraps nothing itself; and the file's own place wraps nothing
-     * at all.
-     *
-     * <p>So {@code spans()} answers where an {@code At} was written, not where a place is. Stated
-     * here rather than left to be found, because a witness naming one of these as a comment's owner
-     * cannot say where in the output it is.
-     */
-    @Test
-    void butNotEveryPlaceTheRunMakes() {
-        Formatter.CanonicalForm canonical = canonical(SOURCE_WITH_A_HEADER_COMMENT);
-        List<String> unlocated = canonical.places().stream()
-                .filter(p -> !canonical.layout().spans().containsKey(p))
-                .map(p -> p.construct() + (p.parent() == null ? " (the file)" : ""))
-                .toList();
-
-        assertEquals(List.of("SOURCE_FILE (the file)", "ASSIGN", "PRODUCT_BODY"), unlocated,
-                "the file, the anchor that carries the header line's comment, and the parent of the"
-                        + " fields \u2014 none of them locatable in the output");
+        List<Doc.GroupRef> theirGroups = other.layout().decisions().stream()
+                .map(GroupDecision::group).toList();
+        List<Doc.GroupRef> ours = one.layout().decisions().stream()
+                .map(GroupDecision::group).toList();
+        assertFalse(theirGroups.isEmpty());
+        assertEquals(theirGroups.size(), ours.size());
+        assertEquals(List.of(), theirGroups.stream().filter(ours::contains).toList(),
+                "and a group of one run is not a group the other decided about");
     }
 
     private static final String SOURCE_WITH_A_HEADER_COMMENT =

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryAdjacencyHasOneBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryAdjacencyHasOneBoundaryTest.java
@@ -26,7 +26,7 @@ class EveryAdjacencyHasOneBoundaryTest {
         List<String> unbounded = new ArrayList<>();
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
             unbounded.addAll(Gaps.adjacenciesWithNoBoundary(
-                    Formatter.document(CstParser.parse(source).root())));
+                    Formatter.canonicalize(CstParser.parse(source).root()).construction().doc()));
         }
         assertEquals(List.of(), unbounded.stream().distinct().toList(),
                 "pairs written next to each other with nothing between them to decide");

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest.java
@@ -80,7 +80,7 @@ class EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest {
     void theyAreTheTokensOfTheOutput() {
         List<String> wrong = new ArrayList<>();
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
-            List<TokenDoc.Token> laid = laidOut(Formatter.document(CstParser.parse(source).root()));
+            List<TokenDoc.Token> laid = laidOut(Formatter.canonicalize(CstParser.parse(source).root()).construction().doc());
             List<SyntaxToken> output = written(Formatter.format(source));
             if (laid.size() != output.size()) {
                 wrong.add("the document lays out " + laid.size() + " tokens and the output has "
@@ -118,7 +118,7 @@ class EveryTokenTheDocumentLaysOutIsOneTokenOfTheOutputTest {
                 let spread (p: P): R = R { ...p.inner, b = 1 }
                 """;
         Set<String> laid = new LinkedHashSet<>();
-        for (TokenDoc.Token t : laidOut(Formatter.document(CstParser.parse(source).root()))) {
+        for (TokenDoc.Token t : laidOut(Formatter.canonicalize(CstParser.parse(source).root()).construction().doc())) {
             laid.add(t.kind() + " " + t.lexeme());
         }
         for (String token : List.of(

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheConstructABoundaryNamesIsTheOneTheOutputHasTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheConstructABoundaryNamesIsTheOneTheOutputHasTest.java
@@ -75,7 +75,7 @@ class TheConstructABoundaryNamesIsTheOneTheOutputHasTest {
         List<String> wrong = new ArrayList<>();
         int compared = 0;
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
-            List<Gaps.Boundary> said = boundaries(Formatter.document(CstParser.parse(source).root()));
+            List<Gaps.Boundary> said = boundaries(Formatter.canonicalize(CstParser.parse(source).root()).construction().doc());
             List<SyntaxToken> output = written(Formatter.format(source));
             assertEquals(output.size() - 1, said.size(),
                     "one boundary for each adjacency of the canonical form of:\n" + source);

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
@@ -119,7 +119,7 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
     @Test
     void andOverASourceTheyAreTheSameGroups() {
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
-            Doc doc = Formatter.document(CstParser.parse(source).root()).resolve();
+            Doc doc = Formatter.canonicalize(CstParser.parse(source).root()).construction().doc().resolve();
             List<Doc.GroupRef> written = new ArrayList<>();
             groupsOf(doc, written);
             List<Doc.GroupRef> decided = doc.layout(100).decisions().stream()

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ThePlacesTheCanonicalFormWritesAreItsOwnTest.java
@@ -159,7 +159,7 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
      */
     @Test
     void andAPlaceMayStandForNothingTheSourceWrote() {
-        Formatter.Construction built = Formatter.build(CstParser.parse("""
+        Formatter.Construction built = Formatter.canonicalize(CstParser.parse("""
                 module m
                 data R =
                     { x: Int
@@ -170,7 +170,7 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
 
                 fake f
                     | _ -> R { x = 0 }
-                """).root());
+                """).root()).construction();
 
         List<Place> empty = new ArrayList<>();
         for (Place p : placesIn(built.doc())) {
@@ -205,7 +205,7 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
         List<String> unwritten = new ArrayList<>();
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
             SyntaxNode file = CstParser.parse(source).root();
-            Formatter.Construction built = Formatter.build(file);
+            Formatter.Construction built = Formatter.canonicalize(file).construction();
             for (SyntaxNode n : allOf(file)) {
                 if (n.kind() == SyntaxKind.SOURCE_FILE) {
                     continue;
@@ -234,7 +234,7 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
     void andEveryPlaceTheConstructionMakesIsWrittenInTheDocument() {
         List<String> unmarked = new ArrayList<>();
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
-            Formatter.Construction built = Formatter.build(CstParser.parse(source).root());
+            Formatter.Construction built = Formatter.canonicalize(CstParser.parse(source).root()).construction();
             for (Place p : built.places().made()) {
                 if (built.order().get(p) == null) {
                     unmarked.add(p.construct() + " under "
@@ -292,7 +292,7 @@ class ThePlacesTheCanonicalFormWritesAreItsOwnTest {
 
     private Formatter.Construction build(String src) {
         root = CstParser.parse(src).root();
-        return Formatter.build(root);
+        return Formatter.canonicalize(root).construction();
     }
 
     private static SyntaxNode childOf(SyntaxNode n, SyntaxKind kind) {

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheRuleAnswersEveryBoundaryTheGrammarCanBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheRuleAnswersEveryBoundaryTheGrammarCanBuildTest.java
@@ -268,7 +268,7 @@ class TheRuleAnswersEveryBoundaryTheGrammarCanBuildTest {
         Set<String> outside = new TreeSet<>();
         for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
             for (Gaps.Boundary b : Gaps.boundaries(
-                    Formatter.document(CstParser.parse(source).root()))) {
+                    Formatter.canonicalize(CstParser.parse(source).root()).construction().doc())) {
                 if (b.joining() == null || b.policy() == TokenDoc.Break.ALWAYS) {
                     continue;   // not one the rule was asked about
                 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -106,24 +106,10 @@ public final class Formatter {
      * source (e.g. to check for syntax errors) and need not parse it again. Assumes {@code file}
      * came from a clean parse. */
     public static String format(SyntaxNode file) {
-        try {
-            Formatter formatter = new Formatter();
-            // The construction, then the carriers, then the boundaries, then the layout. Each stage
-            // is whole before the next begins: a comment goes to a place of the canonical form and
-            // there are no places until the construction has finished making them.
-            TokenDoc resolved = formatter.resolved(formatter.file(file));
-            List<SyntaxToken> missing = unconsumed(file, formatter.consumedComments);
-            if (!missing.isEmpty()) {
-                throw new IllegalStateException(
-                        missing.size() + " comment(s) in this source reached no construct and would"
-                                + " have been dropped; the first is at offset "
-                                + missing.get(0).start() + ": "
-                                + missing.get(0).text().stripTrailing());
-            }
-            return resolved.resolve().render(WIDTH);
-        } catch (StackOverflowError _) {
-            throw tooDeep();
-        }
+        // The construction, then the carriers, then the boundaries, then the layout. Each stage is
+        // whole before the next begins: a comment goes to a place of the canonical form and there
+        // are no places until the construction has finished making them.
+        return canonicalize(file).text();
     }
 
     /**
@@ -132,7 +118,48 @@ public final class Formatter {
      * them is decided from the document, so a check on that decision reads the document.
      */
     static TokenDoc document(SyntaxNode file) {
-        return build(file).doc();
+        return canonicalize(file).construction().doc();
+    }
+
+    /**
+     * What one canonicalization of {@code file} came to: everything it made, and the text it came
+     * to, from the one run that made them.
+     *
+     * <p>The identities are why this is one object. A {@link Place}, a {@link Doc.GroupRef} and the
+     * rest are made by a run and mean something only to it — {@link Layout} keys its spans and
+     * decisions on them and {@link Correspondence} keys its relation on the same places. Asked for
+     * separately they come from separate runs, and a place of one has no span in the other's layout.
+     * Nothing refuses the mixture: a lookup simply misses, so two collections of the same size can
+     * share no member and a count of them holds.
+     */
+    record CanonicalForm(Construction construction, Layout layout) {
+
+        String text() {
+            return layout.text();
+        }
+
+        /** The places this run made, in the order it made them. */
+        List<Place> places() {
+            return construction.places().made();
+        }
+    }
+
+    /** Canonicalizes {@code file}: one construction, laid out, and everything either of them made. */
+    static CanonicalForm canonicalize(SyntaxNode file) {
+        try {
+            Construction construction = build(file);
+            List<SyntaxToken> missing = unconsumed(file, construction.consumed());
+            if (!missing.isEmpty()) {
+                throw new IllegalStateException(
+                        missing.size() + " comment(s) in this source reached no construct and would"
+                                + " have been dropped; the first is at offset "
+                                + missing.get(0).start() + ": "
+                                + missing.get(0).text().stripTrailing());
+            }
+            return new CanonicalForm(construction, construction.doc().resolve().layout(WIDTH));
+        } catch (StackOverflowError _) {
+            throw tooDeep();
+        }
     }
 
     /**
@@ -145,14 +172,16 @@ public final class Formatter {
      * body, so text is not enough to say which place owns one.
      */
     record Construction(TokenDoc doc, Correspondence places,
-            Map<Place, Map<Carrier, List<SyntaxToken>>> carriers, Map<Place, Integer> order) {}
+            Map<Place, Map<Carrier, List<SyntaxToken>>> carriers, Map<Place, Integer> order,
+            java.util.Set<Integer> consumed) {}
 
     static Construction build(SyntaxNode file) {
         Formatter formatter = new Formatter();
         TokenDoc doc = formatter.file(file);
         Map<Place, Integer> order = Place.orderedIn(doc);
-        return new Construction(formatter.resolved(doc), formatter.places, formatter.assigned,
-                order);
+        TokenDoc resolved = formatter.resolved(doc);
+        return new Construction(resolved, formatter.places, formatter.assigned, order,
+                formatter.consumedComments);
     }
 
     /** {@code doc} with the comments in it. The one place a carrier is answered. */

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -166,7 +166,7 @@ public final class Formatter {
             Map<Place, Map<Carrier, List<SyntaxToken>>> carriers, Map<Place, Integer> order,
             java.util.Set<Integer> consumed) {}
 
-    static Construction build(SyntaxNode file) {
+    private static Construction build(SyntaxNode file) {
         Formatter formatter = new Formatter();
         TokenDoc doc = formatter.file(file);
         Map<Place, Integer> order = Place.orderedIn(doc);

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -113,15 +113,6 @@ public final class Formatter {
     }
 
     /**
-     * The document this formatter builds for {@code file}. For a test that has to see the tokens
-     * the formatter lays out rather than the text they render to — what is written between two of
-     * them is decided from the document, so a check on that decision reads the document.
-     */
-    static TokenDoc document(SyntaxNode file) {
-        return canonicalize(file).construction().doc();
-    }
-
-    /**
      * What one canonicalization of {@code file} came to: everything it made, and the text it came
      * to, from the one run that made them.
      *


### PR DESCRIPTION
A canonicalization makes identities — a place for every place it writes, a group for every group, a nesting, a forced break — and everything it has to say is said over them. `Layout` keys its spans and decisions on them; `Correspondence` keys its relation on the same places.

They belong to that run. Two canonicalizations of one source share none:

```
two runs over one source
   places   10 and 10, shared by identity: 0
   groups   4 and 4, shared by identity: 0

a layout from one run, asked about the other run's places
   0 of 10 have a span
   the same question about its own run's places: 10 of 10
```

And the API handed them out a call at a time. `Formatter.document(root)` looks like a function — same input, same shape of answer — and `format` built its own construction separately, so the two were already two runs.

## The failure is a lookup that misses

Nothing rejects the mixture. No exception, no type error: a place is a place, a layout takes it, and the answer is that it wrote it nowhere. Two collections come out the same size and share not one member, so a count of them holds.

`ALayoutSaysWhereEachPlaceWasWrittenTest.everyPlaceOfTheDocumentHasASpan` built the document a second time to walk it and asserted the two were the same size. Asked by identity instead:

```
expected: <0> but was: <10>
```

None of the places it walked had a span in the layout it was checking. The first test written against this API was misled by it, and the misuse was pinned as a fixture. `TheLayoutKeepsWhatItsTextCannotSayTest` escaped only because #545 changed its group assertions from counts to identities after the same weakness turned up there.

## What is here

`canonicalize(file)` is one run and returns what it made — the construction, and the layout keyed on it. `format` is that run's text. The edges from a `SyntaxNode` to a part of a run are gone: `document(SyntaxNode)` and `build(SyntaxNode)` were both a source in and one run's piece out, and a caller could hold either beside another run's layout. A test that wants a document or a construction asks a canonicalization for one, and the longer call is the point — it says at the call site which run the piece belongs to.

The sweep compares the layout against its own run's document, and a fixture states what two runs share, so the reason a canonical form is one object is written down rather than relied on.

## What narrowing it to one run turned up

Of the 3202 places the corpus makes, 63 have no span: the file's own place, an anchor for the line a construct opens with — a `data` declaration's `=`, a block's brace, a match's `with` — and a construct that writes through its members. They are not idle. Given `data D =   // about the block` the `ASSIGN` place carries that comment and holds none of the text.

So `spans()` answers where an annotation was written and not where a place is, and its domain comes from where the construction happened to put one rather than from what a place means. That is held as a fixture here and settled in #555, which also removes the `continue` that has been taking parents without spans out of #545's containment check.

4499 tests pass.

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)
