### PR TITLE
A break opportunity belongs to the group whose decision settles it

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/fmt/ABreakOpportunityBelongsToAGroupTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ABreakOpportunityBelongsToAGroupTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -92,5 +93,21 @@ class ABreakOpportunityBelongsToAGroupTest {
             case Doc.Concat c -> c.parts().stream().mapToLong(ABreakOpportunityBelongsToAGroupTest::linesIn).sum();
             default -> 0;
         };
+    }
+
+    /**
+     * Two places written the same way are two opportunities. Read by their shape they would be one,
+     * and a witness naming one of them would be naming both.
+     */
+    @Test
+    void andTwoWrittenTheSameWayAreTwo() {
+        Doc doc = Doc.group(Doc.concat(
+                Doc.text("ab"), Doc.line(), Doc.text("cd"), Doc.line(), Doc.text("ef")));
+
+        List<Opportunity> found = doc.layout(100).opportunities();
+
+        assertEquals(2, found.size());
+        assertNotSame(found.get(0).line(), found.get(1).line(),
+                "each is its own, and neither stands for the other");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ABreakOpportunityBelongsToAGroupTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ABreakOpportunityBelongsToAGroupTest.java
@@ -1,0 +1,96 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A place the layout may break belongs to the group whose decision settles it.
+ *
+ * <p>The conditional-layout rule answers about a group, and a deviation from it is a source that
+ * broke where the canonical form does not or kept whole what it breaks. Saying which of the two
+ * needs the group that decided, and where the canonical form is flat there is no break to have been
+ * decided — nothing the layout wrote points at the group. So what a source gap is matched against
+ * is the opportunity, which is there either way.
+ */
+class ABreakOpportunityBelongsToAGroupTest {
+
+    /** A group that fits: its opportunities are there, and none of them was written as a break. */
+    @Test
+    void aFlatGroupStillHasItsOpportunities() {
+        Doc doc = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd")));
+
+        Layout layout = doc.layout(100);
+
+        assertEquals("ab cd", layout.text());
+        assertEquals(1, layout.opportunities().size());
+        assertEquals(false, layout.opportunities().get(0).broke());
+    }
+
+    /** And the same group over the width breaks at the same opportunity. */
+    @Test
+    void andTheSameGroupTooWideBreaksAtIt() {
+        Doc doc = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd")));
+
+        Layout layout = doc.layout(4);
+
+        assertEquals("ab\ncd", layout.text());
+        assertEquals(1, layout.opportunities().size());
+        assertEquals(true, layout.opportunities().get(0).broke());
+    }
+
+    /** An opportunity names the group that settled it, and that is the decision explaining it. */
+    @Test
+    void andItNamesTheGroupThatSettledIt() {
+        Doc inner = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd")));
+        Doc outer = Doc.group(Doc.concat(Doc.text("x"), Doc.line(), inner));
+
+        Layout layout = outer.layout(100);
+
+        assertEquals("x ab cd", layout.text());
+        assertEquals(2, layout.opportunities().size());
+        List<Doc.GroupRef> settling = layout.opportunities().stream()
+                .map(Opportunity::settledBy).toList();
+        assertEquals(List.of(((Doc.Group) outer).ref(), ((Doc.Group) inner).ref()), settling,
+                "the outer group's own, then the one inside it — the innermost group holding it");
+    }
+
+    /** And the decision it names is in the layout, so a reader goes from the opportunity to why. */
+    @Test
+    void andThatGroupsDecisionIsThere() {
+        Doc doc = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd")));
+
+        Layout layout = doc.layout(4);
+        Opportunity broke = layout.opportunities().get(0);
+
+        assertTrue(layout.decisions().stream().anyMatch(d -> d.group() == broke.settledBy()),
+                "the group that settled it decided, and the decision says why");
+    }
+
+    /** Every boundary the layout may break is one opportunity, over a real source. */
+    @Test
+    void andOverASourceEveryOneIsThere() {
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            Doc doc = Formatter.canonicalize(
+                    souther.compiler.cst.CstParser.parse(source).root()).construction().doc()
+                    .resolve();
+            long lines = linesIn(doc);
+            assertEquals(lines, doc.layout(100).opportunities().size(),
+                    "one opportunity per boundary the layout may break, in:\n" + source);
+        }
+    }
+
+    private static long linesIn(Doc doc) {
+        return switch (doc) {
+            case Doc.Line _ -> 1;
+            case Doc.Group g -> linesIn(g.doc());
+            case Doc.Nest n -> linesIn(n.doc());
+            case Doc.At a -> linesIn(a.doc());
+            case Doc.Concat c -> c.parts().stream().mapToLong(ABreakOpportunityBelongsToAGroupTest::linesIn).sum();
+            default -> 0;
+        };
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ABreakOpportunityBelongsToAGroupTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ABreakOpportunityBelongsToAGroupTest.java
@@ -110,4 +110,32 @@ class ABreakOpportunityBelongsToAGroupTest {
         assertNotSame(found.get(0).line(), found.get(1).line(),
                 "each is its own, and neither stands for the other");
     }
+
+    /**
+     * A boundary the layout may break outside every group is not an opportunity. The outermost
+     * context breaks, so it always breaks and no decision settles it — which is what a forced break
+     * is rather than a conditional one, and an opportunity naming nobody would be one a witness
+     * could not explain.
+     */
+    @Test
+    void andOneOutsideEveryGroupIsNotAnOpportunity() {
+        Doc outsideEveryGroup = Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd"));
+
+        Layout layout = outsideEveryGroup.layout(100);
+
+        assertEquals("ab\ncd", layout.text(), "it breaks, since the outermost context does");
+        assertEquals(List.of(), layout.opportunities());
+    }
+
+    /** And the formatter writes none of those, so nothing real is left out by that. */
+    @Test
+    void andTheFormatterWritesNoneOfThem() {
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            Doc doc = Formatter.canonicalize(
+                    souther.compiler.cst.CstParser.parse(source).root()).construction().doc()
+                    .resolve();
+            assertEquals(linesIn(doc), doc.layout(100).opportunities().size(),
+                    "a boundary the layout may break that no group settles, in:\n" + source);
+        }
+    }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheLayoutKeepsWhatItsTextCannotSayTest.java
@@ -27,7 +27,7 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
     /** Two documents laid out to one text, for two reasons. */
     @Test
     void aWidthBreakAndAForcedBreakWriteTheSameCharacters() {
-        Doc tooWide = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
+        Doc tooWide = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd")));
         Doc forced = Doc.group(Doc.concat(Doc.text("ab"), Doc.hardline(), Doc.text("cd")));
 
         Layout byWidth = tooWide.layout(4);
@@ -48,7 +48,7 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
     /** And a group that fits says so, rather than saying nothing. */
     @Test
     void andAGroupThatFitsIsADecisionToo() {
-        Doc fits = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
+        Doc fits = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd")));
 
         Layout layout = fits.layout(100);
 
@@ -61,8 +61,8 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
      * kind of group. */
     @Test
     void andTwoGroupsWrittenTheSameWayAreTwoDecisions() {
-        Doc one = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
-        Doc other = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, Doc.text("cd")));
+        Doc one = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd")));
+        Doc other = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), Doc.text("cd")));
 
         Layout layout = Doc.concat(one, Doc.hardline(), other).layout(100);
 
@@ -76,7 +76,7 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
      * layout's to say and not something a reader counts off the line. */
     @Test
     void andTheColumnAGroupWasMeasuredAtIsItsOwn() {
-        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.LINE, Doc.text("ef")));
+        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.line(), Doc.text("ef")));
         Layout layout = Doc.concat(Doc.text("ab "), inner).layout(100);
 
         assertEquals("ab cd ef", layout.text());
@@ -90,8 +90,8 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
      */
     @Test
     void everyGroupIsOneDecisionAndMeasuringTakesNone() {
-        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.LINE, Doc.text("ef")));
-        Doc outer = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, inner));
+        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.line(), Doc.text("ef")));
+        Doc outer = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), inner));
 
         Layout layout = outer.layout(100);
 
@@ -104,8 +104,8 @@ class TheLayoutKeepsWhatItsTextCannotSayTest {
      * answered about a group it made up, which is why this reads the identities. */
     @Test
     void andADecisionNamesTheGroupThatWasLaidOut() {
-        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.LINE, Doc.text("ef")));
-        Doc outer = Doc.group(Doc.concat(Doc.text("ab"), Doc.LINE, inner));
+        Doc inner = Doc.group(Doc.concat(Doc.text("cd"), Doc.line(), Doc.text("ef")));
+        Doc outer = Doc.group(Doc.concat(Doc.text("ab"), Doc.line(), inner));
 
         List<Doc.GroupRef> laidOut = outer.layout(100).decisions().stream()
                 .map(GroupDecision::group).toList();

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -15,8 +15,6 @@ import java.util.List;
 sealed interface Doc {
 
     Doc NIL = new Nil();
-    Doc LINE = new Line(" ");        // a space when flat, a newline when broken
-    Doc SOFTLINE = new Line("");     // nothing when flat, a newline when broken
 
     /** Writes nothing, and the group holding it is never laid out flat. A comment cannot share the
      * line after it, so a construct holding one breaks even where its own content would have fitted
@@ -30,7 +28,13 @@ sealed interface Doc {
      * in particular, and told apart only by their kind two hardlines are one answer. */
     final class Ref {
     }
-    record Line(String flat) implements Doc {}
+    record Line(LineRef ref, String flat) implements Doc {}
+
+    /** Which place the layout may break this is. Two written the same way are two of them, and the
+     * conditional-layout rule answers about the group that settles one rather than about a kind of
+     * boundary. */
+    final class LineRef {
+    }
     record Hard(Ref ref) implements Doc {}
     record Concat(List<Doc> parts) implements Doc {}
     record Nest(NestRef ref, int indent, Doc doc) implements Doc {}
@@ -67,6 +71,16 @@ sealed interface Doc {
 
     static Doc text(String s) {
         return new Text(s);
+    }
+
+    /** A space when the line it is on is whole, and a newline where it is not. */
+    static Doc line() {
+        return new Line(new LineRef(), " ");
+    }
+
+    /** Nothing when the line it is on is whole, and a newline where it is not. */
+    static Doc softline() {
+        return new Line(new LineRef(), "");
     }
 
     /** Always a newline, and the group holding it is never laid out flat. */
@@ -137,6 +151,7 @@ sealed interface Doc {
     default Layout layout(int width) {
         List<GroupDecision> decisions = new ArrayList<>();
         List<Newline> breaks = new ArrayList<>();
+        List<Opportunity> opportunities = new ArrayList<>();
         java.util.Map<Place, Extent> extents = new java.util.LinkedHashMap<>();
         // A place that writes a region and also carries a comment has both an `At` and a
         // point; the region is where it is, so the points are kept apart and read only
@@ -162,19 +177,20 @@ sealed interface Doc {
                 case Concat c -> {
                     List<Doc> parts = c.parts();
                     for (int i = parts.size() - 1; i >= 0; i--) {
-                        todo.push(new Item(it.indent, it.mode, parts.get(i), null, it.under));
+                        todo.push(it.within(parts.get(i)));
                     }
                 }
                 case Nest n -> todo.push(new Item(it.indent + n.indent(), it.mode, n.doc(), null,
-                        new Nesting(n.ref(), it.under)));
+                        new Nesting(n.ref(), it.under), it.within()));
                 case PointOf p -> points.putIfAbsent(p.place(),
                         new Extent(sb.length(), sb.length()));
                 case At a -> {
                     // The close is pushed first so that it is popped after everything written at
                     // the place, which is what makes the span the interval the place occupies.
                     opened.put(a.place(), sb.length());
-                    todo.push(new Item(it.indent, it.mode, Doc.NIL, a.place(), it.under));
-                    todo.push(new Item(it.indent, it.mode, a.doc(), null, it.under));
+                    todo.push(new Item(it.indent, it.mode, Doc.NIL, a.place(), it.under,
+                            it.within()));
+                    todo.push(it.within(a.doc()));
                 }
                 case Group g -> {
                     Outcome outcome = flatnessOf(width - col,
@@ -182,9 +198,12 @@ sealed interface Doc {
                     decisions.add(new GroupDecision(g.ref(), col, outcome));
                     todo.push(new Item(it.indent,
                             outcome instanceof Outcome.Flat ? Mode.FLAT : Mode.BREAK, g.doc(),
-                            null, it.under));
+                            null, it.under, g.ref()));
                 }
                 case Line l -> {
+                    // The group that settles it is the innermost one holding it, which is the one
+                    // the walk was inside when it reached here.
+                    opportunities.add(new Opportunity(l.ref(), it.within(), it.mode != Mode.FLAT));
                     if (it.mode == Mode.FLAT) {
                         sb.append(l.flat());
                         col += l.flat().length();
@@ -205,7 +224,7 @@ sealed interface Doc {
             }
         }
         points.forEach(extents::putIfAbsent);
-        return new Layout(sb.toString(), decisions, extents, breaks);
+        return new Layout(sb.toString(), decisions, extents, breaks, opportunities);
     }
 
     /** Writes a break and says what it wrote. */
@@ -294,14 +313,22 @@ sealed interface Doc {
     /** {@code closes} is the place this item ends, and is set only on the marker pushed to run
      * after everything written at that place. {@code under} is the nestings it is written inside,
      * innermost first. */
-    record Item(int indent, Mode mode, Doc doc, Place closes, Nesting under) {
+    record Item(int indent, Mode mode, Doc doc, Place closes, Nesting under, GroupRef within) {
 
         Item(int indent, Mode mode, Doc doc) {
-            this(indent, mode, doc, null, null);
+            this(indent, mode, doc, null, null, null);
         }
 
         Item(int indent, Mode mode, Doc doc, Place closes) {
-            this(indent, mode, doc, closes, null);
+            this(indent, mode, doc, closes, null, null);
+        }
+
+        Item(int indent, Mode mode, Doc doc, Place closes, Nesting under) {
+            this(indent, mode, doc, closes, under, null);
+        }
+
+        Item within(Doc doc) {
+            return new Item(indent, mode, doc, null, under, within);
         }
     }
 

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -202,8 +202,13 @@ sealed interface Doc {
                 }
                 case Line l -> {
                     // The group that settles it is the innermost one holding it, which is the one
-                    // the walk was inside when it reached here.
-                    opportunities.add(new Opportunity(l.ref(), it.within(), it.mode != Mode.FLAT));
+                    // the walk was inside when it reached here. One outside every group is not an
+                    // opportunity: the outermost context breaks, so it always breaks and no
+                    // decision settles it. The formatter writes none, which is its own check.
+                    if (it.within() != null) {
+                        opportunities.add(new Opportunity(l.ref(), it.within(),
+                                it.mode != Mode.FLAT));
+                    }
                     if (it.mode == Mode.FLAT) {
                         sb.append(l.flat());
                         col += l.flat().length();

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
@@ -278,7 +278,7 @@ final class Gaps {
                 String flat = answers.get(next[0]++);
                 yield switch (g.policy()) {
                     case ALWAYS -> Doc.hardline();
-                    case MAY -> flat.isEmpty() ? Doc.SOFTLINE : Doc.LINE;
+                    case MAY -> flat.isEmpty() ? Doc.softline() : Doc.line();
                     case NEVER -> flat.isEmpty() ? Doc.NIL : Doc.text(flat);
                 };
             }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Layout.java
@@ -16,18 +16,20 @@ import java.util.List;
  * What is kept is what the layout realized, which is what the canonicalization rules are about.
  */
 record Layout(String text, List<GroupDecision> decisions,
-        java.util.Map<Place, Extent> extents, List<Newline> breaks) {
+        java.util.Map<Place, Extent> extents, List<Newline> breaks,
+        List<Opportunity> opportunities) {
 
     Layout {
         decisions = List.copyOf(decisions);
         extents = java.util.Map.copyOf(extents);
         breaks = List.copyOf(breaks);
+        opportunities = List.copyOf(opportunities);
     }
 
     /** This layout with one more place located. */
     Layout and(Place place, Extent extent) {
         java.util.Map<Place, Extent> out = new java.util.LinkedHashMap<>(extents);
         out.put(place, extent);
-        return new Layout(text, decisions, out, breaks);
+        return new Layout(text, decisions, out, breaks, opportunities);
     }
 }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Opportunity.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Opportunity.java
@@ -1,0 +1,13 @@
+package souther.compiler.fmt;
+
+/**
+ * A place the layout may break, the group whose decision settles it, and what the layout wrote
+ * there.
+ *
+ * <p>It is here whether or not a break was written. Where the canonical form keeps a line whole
+ * there is no break to point at, and a source that broke there has still departed from the group's
+ * decision — so what a source gap is matched against is the opportunity rather than what the layout
+ * realized.
+ */
+record Opportunity(Doc.LineRef line, Doc.GroupRef settledBy, boolean broke) {
+}


### PR DESCRIPTION
The conditional-layout rule answers about a group: it is written on one line, or down the page. A deviation from it is a source that did the other thing, and saying which needs the group that decided. Nothing related the two.

A place the layout may break lowered to one of two shared objects, so there was nothing to name; and a `GroupDecision` said what a group came to and nothing about what was inside it.

## Why a realized break is the wrong thing to match against

Both readings have to be answerable:

```
source broke        canonical flat     -> the group is flat, and the source broke inside it
source on one line  canonical broke    -> the group broke, and the source kept it whole
```

Only the second has a break the layout wrote. Where the canonical form keeps a line whole there is nothing to point at, and the source has still departed from that group's decision.

So what a source gap is matched against is the **opportunity** — the place the layout may break — which is there either way and names the group whose decision settles it.

```
Opportunity(line, settledBy, broke)
```

The group is the innermost one holding it, which is the one the walk was inside when it reached there.

## Why it is the unit

Over this repository 1629 differences are a line breaking or not breaking, spread over 565 distinct enclosing constructs — and even that overstates the decisions, since one group written down the page changes every member boundary under it. A witness per differing adjacency is the 438-differences-are-not-438-decisions finding of #444 in the place it does most damage.

## What holds it

A group that fits still has its opportunities and none of them broke; the same group over the width breaks at the same one; an opportunity names the group that settled it and that group's decision is in the layout; two written the same way are two; and over every corpus source there is one opportunity per boundary the layout may break.

Three mutations fail: recording the enclosing group rather than the innermost one, recording only the opportunities that broke, and giving every place the layout may break one shared identity. The last is the weakness a group's decisions had until #545 read their identities and a nesting's until #548 — the same one, one type further down.

4543 tests pass.

Closes #552

🤖 Generated with [Claude Code](https://claude.com/claude-code)
