### PR TITLE
A lookup that came back with nothing means one thing

### DIFF
--- a/docs/adr/0008-asymmetric-java-interop.md
+++ b/docs/adr/0008-asymmetric-java-interop.md
@@ -23,14 +23,17 @@ Souther -> arbitrary Java API              forbidden (only via a non-implemented
 ```
 
 Because Souther cannot reach into Java freely, it also ships no DB/HTTP/file APIs of its
-own — those live behind injected behaviors. Arbitrary JVM calls are a compile error
-(E1401), which points the modeler at declaring a behavior without a `let` and providing
-the implementation from Java.
+own — those live behind injected behaviors. The language offers no path to one: there is
+no syntax and no name-resolution route by which a body reaches a JVM API, so a spelling
+such as `java.time.LocalDate.now` is not a call the compiler recognises and refuses. It
+names no qualifier the language knows, and its root is reported as a name that is not in
+scope like any other. Reaching the outside world is declaring a behavior without a `let`
+and providing the implementation from Java.
 
 Keeping the arrow one-way is what preserves the closed construction paths (ADR-0002) and
 keeps every business branch in the output sum rather than hidden in a foreign call.
 
 ## References
 
-- Specification: `[#asymmetric-interop]`, `[#out-of-scope]`, `[#e1401]`
+- Specification: `[#asymmetric-interop]`, `[#out-of-scope]`
 - ADR-0002 (closed construction paths), ADR-0006 (outside-world via missing implementation), ADR-0007 (unmarked sum output)

--- a/docs/adr/0066-a-helper-is-typed-by-its-body.md
+++ b/docs/adr/0066-a-helper-is-typed-by-its-body.md
@@ -54,7 +54,7 @@ Making the rule uniform surfaced a defect it had been hiding. The shadowing guar
 
 Two more of the rule's own sentences were not what the code did. An arm determines its sibling only where it answers a value, and `unreachable` answers none — its `Never` fits every expectation because it states nothing, so taking it for an answer settled `let choose (b: Bool, v) = if b then v else unreachable "..."` as `Never` and let every call through. Which types say nothing about a value is one question now, asked in one place beside the empty collection's bottom. And a closure was read with no expectation and against no bindings, so `List.find((v) -> v, xs)` left the element open although the step's declared result says `v` answers a `Bool`. A call is solved in the stages `CallElaborator.applySignature` uses — result, then the arguments that are not closures, then the closures — which is also what lets a fold's seed say what its step accumulates.
 
-The report order is settled with it. A helper does not reach a behavior at all (E1401), and asking for the parameter's type first sent the author to write an annotation that changed nothing; the call is reported instead.
+The report order is settled with it. A helper does not reach a behavior at all (E1818), and asking for the parameter's type first sent the author to write an annotation that changed nothing; the call is reported instead.
 
 Measured again after the change: 2194 compiler tests and every module of souther-lang/examples pass, and no existing annotation had to move. What an author gains is that the same shapes their code already takes — a closure over a collection, an argument whose type a sibling argument fixes, an arm beside an arm — no longer ask for a type the body already knows (#302).
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -958,9 +958,19 @@ public final class Resolve {
             return bareLibraryName;
         }
         List<String> candidates = reachable(bound);
-        return CompileException.of(Diagnostic
-                        .at(written.region())
-                        .suggestion(Suggest.candidate(name, candidates)).say(new NameMessage.NoValueOfThatNameInScope(written.quoted())).build());
+        Diagnostic.Builder report = Diagnostic
+                .at(written.region())
+                .suggestion(Suggest.candidate(name, candidates));
+        // A name another module of this compilation exposes is the one kind of unresolved name that
+        // has somewhere to go, and it is what a name left off an import list looks like from here.
+        // Said as what is known — that module has it — rather than as an instruction, since reaching
+        // it qualified needs no import at all.
+        String elsewhere = written.canonical().indexOf('.') < 0
+                ? symbols.moduleExposing(name) : null;
+        if (elsewhere != null) {
+            report = report.hint(new NameMessage.ItIsExposedByAnotherModule(elsewhere, name));
+        }
+        return CompileException.of(report.say(new NameMessage.NoValueOfThatNameInScope(written.quoted())).build());
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Resolve.java
@@ -837,8 +837,7 @@ public final class Resolve {
         if (qualifier == null || !isNamespace(qualifier.canonical())) {
             return null;
         }
-        CompileException why = applied ? notCallable(written, bound)
-                : unknownIdentifier(written, bound);
+        CompileException why = unknownIdentifier(written, bound);
         ValueName resolved = answered(written, nothing(written.canonical(), why));
         return new Ast.Var(written, resolved,
                 ReachName.of(resolved, written.canonical(), values.module()));
@@ -879,11 +878,17 @@ public final class Resolve {
                 : nothing(written.canonical(), unknownIdentifier(written, bound));
     }
 
-    /** The same, for the name an application applies: what is not there is reported differently. */
+    /**
+     * The same, for the name an application applies.
+     *
+     * <p>How the lookup is made differs — an application may reach what a bare name may not — and
+     * what a miss means does not. A name that resolved to nothing resolved to nothing, and the
+     * position it was written in is a fact about the source rather than about the name.
+     */
     private ValueName calledName(Ast.Apply call, Bindings bound) {
         ValueName denotes = lookup(call.written(), true, bound);
         return denotes != null ? denotes
-                : nothing(call.written(), notCallable(call.name(), bound));
+                : nothing(call.written(), unknownIdentifier(call.name(), bound));
     }
 
     /**
@@ -958,28 +963,6 @@ public final class Resolve {
                         .suggestion(Suggest.candidate(name, candidates)).say(new NameMessage.NoValueOfThatNameInScope(written.quoted())).build());
     }
 
-    /**
-     * A name applied to arguments that names nothing that can be applied. A standard-library
-     * function written bare is told apart: it exists, and is reached either qualified or by
-     * importing the name (spec §stdlib).
-     */
-    private CompileException notCallable(WrittenName written, Bindings bound) {
-        CompileException notALibraryMember = notALibraryMember(written);
-        if (notALibraryMember != null) {
-            return notALibraryMember;
-        }
-        String name = written.canonical();
-        CompileException bareLibraryName = StdlibNames.writtenBare(written.quoted(), name,
-                written.region());
-        if (bareLibraryName != null) {
-            return bareLibraryName;
-        }
-        List<String> candidates = reachable(bound);
-        return CompileException.of(Diagnostic.at(written.region())
-                        
-                        .suggestion(Suggest.candidate(name, candidates))
-                        .hint(new DeclarationMessage.ImplementItFromJavaInstead()).say(new DeclarationMessage.NotABehaviorOrABuiltin(written.quoted())).build());
-    }
 
     /**
      * The names bound at a point in a body, each with the binding it is. Persistent: extending it

--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -122,7 +122,7 @@ public final class SpecChecker {
      * because the fix differs: a behavior that depends on nothing is called instead, a {@code >->}
      * composition cannot be rested on because its requirements are not written, and a name that is no
      * behavior has to be declared or imported. The body check would see only a call it cannot type
-     * and report all three as an arbitrary JVM call (E1401, issue #96).
+     * and report all three as a name that resolves to nothing (E1023).
      */
     static void checkRequiresAreInjectionTargets(Ast.Module module, Map<String, ReqSig> reqSigs,
                                                  Map<String, ReqSig> calleeSigs) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -157,9 +157,6 @@ public final class Symbols {
         return contains(candidate) && exposes(target, candidate.name()) ? candidate : null;
     }
 
-    /** The module a qualifier names — a module of this compilation, or an import alias — or null
-     * when it names none. Used to tell "unknown module" apart from "unknown type in a known
-     * module". */
     /**
      * The module of this compilation that exposes {@code name}, or null where that is not exactly
      * one module.
@@ -186,6 +183,9 @@ public final class Symbols {
         return found;
     }
 
+    /** The module a qualifier names — a module of this compilation, or an import alias — or null
+     * when it names none. Used to tell "unknown module" apart from "unknown type in a known
+     * module". */
     public String moduleOfQualifier(String qualifier) {
         String alias = aliases.get(qualifier);
         if (alias != null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Symbols.java
@@ -160,6 +160,32 @@ public final class Symbols {
     /** The module a qualifier names — a module of this compilation, or an import alias — or null
      * when it names none. Used to tell "unknown module" apart from "unknown type in a known
      * module". */
+    /**
+     * The module of this compilation that exposes {@code name}, or null where that is not exactly
+     * one module.
+     *
+     * <p>Asked where a bare name resolved to nothing, so that a name left off an import list is told
+     * apart from a name nothing declares. This module is not among them: what it declares is already
+     * in scope, so reaching here means it does not.
+     *
+     * <p>Exactly one, because the answer is written into a report as the module to reach for. Two
+     * modules exposing the spelling makes naming either one a guess, and a guess in a hint is worse
+     * than the silence it replaces — the reader is already being told the name is not in scope.
+     */
+    public String moduleExposing(String name) {
+        String found = null;
+        for (String other : new java.util.TreeSet<>(registry.moduleNames())) {
+            if (other.equals(module) || !registry.exposedBy(other).contains(name)) {
+                continue;
+            }
+            if (found != null) {
+                return null;
+            }
+            found = other;
+        }
+        return found;
+    }
+
     public String moduleOfQualifier(String qualifier) {
         String alias = aliases.get(qualifier);
         if (alias != null) {

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeChecker.java
@@ -207,7 +207,7 @@ public final class TypeChecker {
         // `injectedRecursiveHelpers`, to be emitted here rather than declared here.
         // A helper is checked standing on its own as well as expanded into what calls it, and both
         // readings answer the same about a behavior's name: it becomes the function value it names,
-        // which a helper may then not apply (E1401). Told nothing, the standalone reading would
+        // which a helper may then not apply (E1818). Told nothing, the standalone reading would
         // refuse the name for being a name rather than for being a behavior a helper cannot reach.
         HelperInliner inliner = HelperInliner.forModule(module, publishedToHere)
                 .namingBehaviors(InjectionSigs.arities(calleeSigs));
@@ -361,7 +361,7 @@ public final class TypeChecker {
             throw new Unanswerable(module.pos());
         }
         // Fail-fast with the reqSigs it reads: a `depends on` that named something else leaves the call
-        // untypeable, and the body check would report it as a call to an unknown name (E1401).
+        // untypeable, and the body check would report it as a call to an unknown name (E1023).
         SpecChecker.checkRequiresAreInjectionTargets(module, reqSigs, calleeSigs);
         // Fail-fast too: a behavior reaching itself has no first element to build, and the code that
         // works out requirement sets and emits classes would walk the loop.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -161,7 +161,7 @@ data.the-field-is-in-the-shared-part-of-none-of-these=A spread of a sum provides
 # invariant type (E1101)
 declaration.an-invariant-expression-is-bool=An invariant expression must have type Bool, but this is {given}.
 
-# arbitrary Java call (E1401) and stdlib qualifier
+# a behavior reached from where one is not called (E1818) and stdlib qualifier
 behavior.a-behavior-cannot-be-called-from-here=`{behavior}` is a behavior, and it cannot be called from here.
 behavior.what-reaches-a-behavior=A helper `let` does not reach a behavior, and a `>->` composition is composed with rather than called. Call `{behavior}` from a behavior's own `let` and pass the result in.
 check.construct.position.title=CONSTRUCTION NOT ALLOWED HERE

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -72,6 +72,7 @@ check.notcallable.title=BEHAVIOR NOT CALLABLE HERE
 check.unknown.title=NAMING ERROR
 declaration.it-cannot-be-held-as-a-value-here=`{name}` is {what}, and cannot be held as a value here.
 name.no-value-of-that-name-in-scope=I cannot find a value named `{name}` in scope.
+name.it-is-exposed-by-another-module=`{module}` exposes `{name}`. Reach it as `{module}.{name}`, or name it in an import of `{module}`.
 name.no-type-of-that-name=I cannot find a type named `{name}`.
 name.no-behavior-of-that-name-in-this-pipeline=I cannot find a behavior named `{name}` in this pipeline.
 

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -40,7 +40,6 @@ e1201.title=NON-EXHAUSTIVE MATCH
 e1301.title=USE OF NULL
 e1303.title=WRITING AN OPTION CASE
 e1305.title=UNCREATABLE INJECTED DATA
-e1401.title=ARBITRARY JAVA CALL
 e1501.title=CYCLIC IMPORT
 e1602.title=MISSING DEPENDS ON
 e1603.title=OVER-DECLARED DEPENDS ON
@@ -162,8 +161,6 @@ data.the-field-is-in-the-shared-part-of-none-of-these=A spread of a sum provides
 declaration.an-invariant-expression-is-bool=An invariant expression must have type Bool, but this is {given}.
 
 # arbitrary Java call (E1401) and stdlib qualifier
-declaration.not-a-behavior-or-a-builtin=`{name}` is not a behavior or a builtin.
-declaration.implement-it-from-java-instead=Declare a behavior without a `let` and implement it from Java; arbitrary JVM calls are not allowed.
 behavior.a-behavior-cannot-be-called-from-here=`{behavior}` is a behavior, and it cannot be called from here.
 behavior.what-reaches-a-behavior=A helper `let` does not reach a behavior, and a `>->` composition is composed with rather than called. Call `{behavior}` from a behavior's own `let` and pass the result in.
 check.construct.position.title=CONSTRUCTION NOT ALLOWED HERE

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -158,7 +158,7 @@ data.the-field-is-in-the-shared-part-of-none-of-these=直和のスプレッド�
 # 不変条件の型（E1101）
 declaration.an-invariant-expression-is-bool=不変条件の式は Bool 型でなければなりませんが、これは {given} です。
 
-# 任意の Java 呼び出し（E1401）・stdlib 修飾
+# behavior を呼べない場所から呼んだ場合（E1818）・stdlib 修飾
 behavior.a-behavior-cannot-be-called-from-here=`{behavior}` は behavior ですが、ここからは呼べません。
 behavior.what-reaches-a-behavior=ヘルパ `let` は behavior に届かず、`>->` 合成は呼ぶものではなく合成するものです。`{behavior}` は behavior 自身の `let` から呼んで、結果を渡してください。
 check.construct.position.title=ここに構築は書けません

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -39,7 +39,6 @@ e1201.title=網羅されていない match
 e1301.title=null の使用
 e1303.title=Option のケース名の使用
 e1305.title=生成できない注入データ
-e1401.title=任意の Java 呼び出し
 e1501.title=循環 import
 e1602.title=depends on 宣言の不足
 e1603.title=depends on の過剰宣言
@@ -159,8 +158,6 @@ data.the-field-is-in-the-shared-part-of-none-of-these=直和のスプレッド�
 declaration.an-invariant-expression-is-bool=不変条件の式は Bool 型でなければなりませんが、これは {given} です。
 
 # 任意の Java 呼び出し（E1401）・stdlib 修飾
-declaration.not-a-behavior-or-a-builtin=`{name}` は behavior でも組み込みでもありません。
-declaration.implement-it-from-java-instead=`let` を持たない behavior を宣言し Java 側で実装してください。任意の JVM 呼び出しは許可されていません。
 behavior.a-behavior-cannot-be-called-from-here=`{behavior}` は behavior ですが、ここからは呼べません。
 behavior.what-reaches-a-behavior=ヘルパ `let` は behavior に届かず、`>->` 合成は呼ぶものではなく合成するものです。`{behavior}` は behavior 自身の `let` から呼んで、結果を渡してください。
 check.construct.position.title=ここに構築は書けません

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -71,6 +71,7 @@ check.notcallable.title=ここからは呼べない behavior
 check.unknown.title=名前が見つかりません
 declaration.it-cannot-be-held-as-a-value-here=`{name}` は{what}なので、ここで値として保持できません。
 name.no-value-of-that-name-in-scope=`{name}` という名前の値がスコープに見つかりません。
+name.it-is-exposed-by-another-module=`{module}` が `{name}` を公開しています。`{module}.{name}` と書くか、`{module}` の import に名前を挙げてください。
 name.no-type-of-that-name=`{name}` という名前の型が見つかりません。
 name.no-behavior-of-that-name-in-this-pipeline=このパイプラインに `{name}` という名前の behavior が見つかりません。
 

--- a/souther-compiler/src/test/java/souther/compiler/AnUnresolvedNameIsTheSameDiagnosisWhereverItStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnUnresolvedNameIsTheSameDiagnosisWhereverItStandsTest.java
@@ -1,0 +1,133 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.CompileException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a name that resolves to nothing is reported as, wherever it was written.
+ *
+ * <p>One fact is established — the lookup came back with nothing — and one thing follows from it:
+ * this name is not in scope. Where the name stood when it failed to resolve is a fact about the
+ * source and not about the name, so it decides what else may be offered and not what the failure is.
+ *
+ * <p>Held against every embedding rather than against the one that was reported, because the defect
+ * was a second answer for the same fact: a name applied to arguments was reported as a call to
+ * something on the JVM, which is a cause nothing here establishes and which sent an author who had
+ * left a name off an import list to go and write a Java class.
+ */
+class AnUnresolvedNameIsTheSameDiagnosisWhereverItStandsTest {
+
+    private static final String TYPES = """
+            module t exposing (Out, f)
+
+            data Out = { v: Int }
+
+            let twice (n: Int) : Int = n + n
+            """;
+
+    private static final String BEHAVIOR = """
+            behavior f : (n: Int) -> Out
+                constructs Out
+            """;
+
+    private static String verdict(String body) {
+        try {
+            Compiler.compile(TYPES + "\n" + BEHAVIOR + "\nlet f (n) = " + body + "\n");
+            return "ok";
+        } catch (CompileException e) {
+            return e.diagnostic().code();
+        }
+    }
+
+    /**
+     * Every embedding of an unresolved name is the same diagnosis.
+     *
+     * <p>Asked as one map, because what is held is that the answer does not vary — a single case
+     * fixing one embedding is satisfied by a second answer written for the others.
+     */
+    @Test
+    void everyEmbeddingOfAnUnresolvedNameIsANamingError() {
+        Map<String, String> embeddings = new LinkedHashMap<>();
+        embeddings.put("as a value", "Out { v = Missing }");
+        embeddings.put("applied", "Out { v = Missing(n) }");
+        embeddings.put("handed to a helper", "Out { v = twice(Missing) }");
+        embeddings.put("applied inside an application", "Out { v = twice(Missing(n)) }");
+        embeddings.put("applied to nothing", "Out { v = Missing() }");
+
+        Map<String, String> expected = new LinkedHashMap<>(embeddings);
+        expected.replaceAll((_, _) -> "E1023");
+        assertEquals(expected, verdicts(embeddings));
+    }
+
+    /**
+     * A member a module of this compilation has not got is the same again.
+     *
+     * <p>The qualifier resolves and the member does not, which is one lookup coming back with
+     * nothing however the name was spelled. Applying it says no more about the JVM than writing it
+     * bare does.
+     */
+    @Test
+    void aMemberARealModuleHasNotGotIsANamingErrorAppliedOrNot() {
+        String up = """
+                module up exposing (Amount)
+
+                data Amount = Int
+                """;
+        String down = """
+                module down exposing (Out, f)
+
+                import up (Amount)
+
+                data Out = { v: Int }
+
+                behavior f : (n: Int) -> Out
+                    constructs Out
+
+                let f (n) = Out { v = %s }
+                """;
+
+        assertEquals("E1023", codeOf(up, down.formatted("up.noSuch")), "written bare");
+        assertEquals("E1023", codeOf(up, down.formatted("up.noSuch(n)")), "and applied");
+    }
+
+    /**
+     * What the failure is and what to do about it are two things, and only the first is fixed here.
+     *
+     * <p>A near spelling is worth offering and is offered; it is carried beside the diagnosis rather
+     * than deciding it. The defect this replaces had the remediation choosing the cause — the advice
+     * to implement the name from Java was what made the report say the name was a JVM call.
+     */
+    @Test
+    void aNearSpellingIsOfferedBesideTheDiagnosisAndDoesNotDecideIt() {
+        String source = TYPES + "\n" + BEHAVIOR + "\nlet f (n) = Out { v = twise(n) }\n";
+        CompileException e = org.junit.jupiter.api.Assertions.assertThrows(
+                CompileException.class, () -> Compiler.compile(source));
+
+        assertEquals("E1023", e.diagnostic().code());
+        assertTrue(e.getMessage().contains("twice"),
+                "the near spelling is offered: " + e.getMessage());
+    }
+
+    private static Map<String, String> verdicts(Map<String, String> bodies) {
+        Map<String, String> out = new LinkedHashMap<>();
+        bodies.forEach((where, body) -> out.put(where, verdict(body)));
+        return out;
+    }
+
+    /** The code a multi-module compilation is refused with. */
+    private static String codeOf(String... sources) {
+        try {
+            Compiler.compileModules(java.util.List.of(sources));
+            return "ok";
+        } catch (CompileException e) {
+            return e.diagnostic().code();
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnUnresolvedNameIsTheSameDiagnosisWhereverItStandsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnUnresolvedNameIsTheSameDiagnosisWhereverItStandsTest.java
@@ -8,6 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -115,10 +116,83 @@ class AnUnresolvedNameIsTheSameDiagnosisWhereverItStandsTest {
                 "the near spelling is offered: " + e.getMessage());
     }
 
+    /**
+     * A name another module of this compilation exposes is still not in scope, and the report says
+     * where it is.
+     *
+     * <p>The commonest way to reach an unresolved name is to leave one off an import list, and the
+     * spelling suggestion cannot help there: it offers names within reach, and this one is not. What
+     * the compiler knows is that a module of this compilation has it, which is a fact and not an
+     * instruction — reaching it qualified needs no import at all.
+     */
+    @Test
+    void aNameAnotherModuleExposesIsSaidToBeThere() {
+        String up = """
+                module up exposing (Amount)
+
+                data Amount = Int
+                """;
+        String down = """
+                module down exposing (Out, f)
+
+                data Out = { v: Int }
+
+                behavior f : (n: Int) -> Out
+                    constructs Out
+
+                let f (n) = Out { v = Amount(n).value }
+                """;
+        String reported = messageOf(up, down);
+
+        assertTrue(reported.contains("E1023"), reported);
+        assertTrue(reported.contains("`up` exposes `Amount`"), reported);
+    }
+
+    /**
+     * Two modules exposing the spelling is no answer, so none is given.
+     *
+     * <p>A hint naming one of them is a guess, and the reader is already being told the name is not
+     * in scope. The diagnosis does not change.
+     */
+    @Test
+    void aSpellingTwoModulesExposeIsLeftWithoutAModuleToName() {
+        String up = """
+                module up exposing (Amount)
+
+                data Amount = Int
+                """;
+        String other = """
+                module other exposing (Amount)
+
+                data Amount = Int
+                """;
+        String down = """
+                module down exposing (Out, f)
+
+                data Out = { v: Int }
+
+                behavior f : (n: Int) -> Out
+                    constructs Out
+
+                let f (n) = Out { v = Amount(n).value }
+                """;
+        String reported = messageOf(up, other, down);
+
+        assertTrue(reported.contains("E1023"), reported);
+        assertFalse(reported.contains("exposes `Amount`"), reported);
+    }
+
     private static Map<String, String> verdicts(Map<String, String> bodies) {
         Map<String, String> out = new LinkedHashMap<>();
         bodies.forEach((where, body) -> out.put(where, verdict(body)));
         return out;
+    }
+
+    /** What a multi-module compilation was refused with, rendered the way an author reads it. */
+    private static String messageOf(String... sources) {
+        CompileException e = org.junit.jupiter.api.Assertions.assertThrows(CompileException.class,
+                () -> Compiler.compileModules(java.util.List.of(sources)));
+        return e.diagnostic().code() + " " + e.getMessage();
     }
 
     /** The code a multi-module compilation is refused with. */

--- a/souther-compiler/src/test/java/souther/compiler/CompileDependsOnClauseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileDependsOnClauseTest.java
@@ -113,8 +113,10 @@ class CompileDependsOnClauseTest {
         assertEquals("E1607", e.code(), e.getMessage());
     }
 
+    /** A callee nothing declares is a name that resolves to nothing, whatever the clause says: the
+     *  absence of a `depends on` neither excuses it nor makes it a different kind of error. */
     @Test
-    void anArbitraryCallWithNoDependsOnClauseIsStillE1401() {
+    void aCalleeNoDependsOnClauseNamesIsStillAnUnresolvedName() {
         String src = """
                 module demo
                 data A = { x: Int }
@@ -124,7 +126,7 @@ class CompileDependsOnClauseTest {
                 let use (a) = someJavaMethod(a)
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("E1401", e.code(), e.getMessage());
+        assertEquals("E1023", e.code(), e.getMessage());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileErrorCodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileErrorCodeTest.java
@@ -24,7 +24,7 @@ class CompileErrorCodeTest {
     }
 
     @Test
-    void callingSomethingThatIsNotABehaviorIsE1401() {
+    void callingANameNothingDeclaresIsE1023() {
         String src = """
                 module demo
                 data N = Int
@@ -32,6 +32,6 @@ class CompileErrorCodeTest {
                 let f (n) = someJavaMethod(n)
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertEquals("E1401", e.code());
+        assertEquals("E1023", e.code());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/CompileErrorCodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileErrorCodeTest.java
@@ -7,8 +7,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/** Diagnostic codes for two rejected constructs: {@code null} (E1301) and a call to something
- *  that is not a behavior or builtin (E1401). See spec 22.8, 22.10. */
+/** Diagnostic codes for two rejected constructs: {@code null} (E1301) and a call to a name nothing
+ *  declares (E1023). */
 class CompileErrorCodeTest {
 
     @Test

--- a/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticCode.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/DiagnosticCode.java
@@ -87,7 +87,6 @@ public enum DiagnosticCode {
     E1323("a-matches-pattern-is-a-literal-regular-expression", "check.type.mismatch.title"),
     E1324("newtype-arithmetic-follows-the-units", "check.type.mismatch.title"),
     E1325("a-boundary-carries-the-models-own-vocabulary", "check.boundary.title"),
-    E1401("no-arbitrary-jvm-calls", "e1401.title"),
     E1402("core-privileges-stay-in-the-core", "parse.title"),
 
     // --- modules, requirements, composition ---

--- a/souther-syntax/src/main/java/souther/compiler/diag/RetiredDiagnosticCode.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/RetiredDiagnosticCode.java
@@ -17,6 +17,7 @@ public enum RetiredDiagnosticCode {
     E1001,
     E1003,
     E1302,
+    E1401,
     E1601,
     E1801;
 

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/DeclarationMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/DeclarationMessage.java
@@ -64,11 +64,6 @@ public sealed interface DeclarationMessage extends Message {
 
     record ExposeItOrMakeItAUnitData(String data) implements DeclarationMessage, Supporting {}
 
-    @Code(DiagnosticCode.E1401)
-    record NotABehaviorOrABuiltin(String name) implements DeclarationMessage, Reported {}
-
-    record ImplementItFromJavaInstead() implements DeclarationMessage, Supporting {}
-
     @Code(DiagnosticCode.E1501)
     record CyclicModuleDependency() implements DeclarationMessage, Reported {}
 

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/NameMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/NameMessage.java
@@ -48,6 +48,8 @@ public sealed interface NameMessage extends Message {
     @Code(DiagnosticCode.E1023)
     record NoValueOfThatNameInScope(String name) implements NameMessage, Reported {}
 
+    record ItIsExposedByAnotherModule(String module, String name) implements NameMessage, Supporting {}
+
     @Code(DiagnosticCode.E1023)
     record NoTypeOfThatName(String name) implements NameMessage, Reported {}
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -4120,7 +4120,7 @@ Reported at the `+match+` (<<branches-agree-on-a-type>>). It answers with one va
 [#e1302-removed]
 === (retired)
 
-E1302 is retired. `+.sou+` has no `+throw+` and no `+catch+` to reject: the rule that a failure is answered as a case of the output rather than raised is carried by the grammar, and a Java method named in an expression is E1401 (<<out-of-scope>>).
+E1302 is retired. `+.sou+` has no `+throw+` and no `+catch+` to reject: the rule that a failure is answered as a case of the output rather than raised is carried by the grammar, and a Java method named in an expression names nothing the language knows, so it is reported as a name that is not in scope (<<out-of-scope>>, <<e1023>>).
 
 [#e1303]
 === Writing an option case
@@ -4343,7 +4343,7 @@ Reported at the parameter, or at the behavior for its output (<<a-boundary-carri
 [#e1401-removed]
 === (retired)
 
-E1401 is retired. It was raised where a name applied to arguments resolved to nothing, which is what E1023 says (<<e1023>>) — nothing established that such a name was on the JVM, and the sample above was itself reported as an unknown name. That arbitrary Java calls are out of scope is a design decision and stays one (<<no-arbitrary-jvm-calls>>); it was never a thing a compile could find.
+E1401 is retired. It was raised where a name applied to arguments resolved to nothing, which is what E1023 says (<<e1023>>), and nothing established that such a name was on the JVM. `+java.time.LocalDate.now+`, which this section used as its example, is read from a root `+java+` that names no qualifier and resolves to nothing, so it was reported as an unknown name and not as this. That arbitrary Java calls are out of scope is a design decision and stays one (<<no-arbitrary-jvm-calls>>); it was never a thing a compile could find.
 
 [#e1402]
 === A core form is written outside the core

--- a/specification.adoc
+++ b/specification.adoc
@@ -4340,15 +4340,10 @@ Reported at the operator (<<newtype-arithmetic-follows-the-units>>). Which rule 
 
 Reported at the parameter, or at the behavior for its output (<<a-boundary-carries-the-models-own-vocabulary>>). `+DivisionByZero+` and `+NotANumber+` say what `+Int.divide+` and `+String.toInt+` can answer, `+RoundingMode+` says what `+Decimal.round+` takes, and `+Raw+` is reserved; each is the language's account of one of its own operations. A behavior that has the same thing to report declares the case — `+data Undivided+`, answered as `+-> Int | Undivided+` — so that what the behavior publishes stays its own even when the language's account of itself changes. Reported wherever the name stands in what crosses, at any depth and as a member of an output union.
 
-[#e1401]
-=== Arbitrary Java calls
+[#e1401-removed]
+=== (retired)
 
-[,text]
-----
-`java.time.LocalDate.now` is not a behavior or a builtin.
-Hint: Declare a behavior without a `let` and implement it from Java; arbitrary JVM calls
-are not allowed.
-----
+E1401 is retired. It was raised where a name applied to arguments resolved to nothing, which is what E1023 says (<<e1023>>) — nothing established that such a name was on the JVM, and the sample above was itself reported as an unknown name. That arbitrary Java calls are out of scope is a design decision and stays one (<<no-arbitrary-jvm-calls>>); it was never a thing a compile could find.
 
 [#e1402]
 === A core form is written outside the core
@@ -4850,7 +4845,7 @@ Reported at the call (<<what-is-summed-is-a-number>>). The same shape as <<e1816
 Hint: Call it from the behavior's own `let` and pass the result in, or name it in `depends on`.
 ----
 
-Reported at the call (<<a-helper-does-not-call-a-behavior>>). A helper is expanded into whatever calls it and travels to an importing module as source, so what it may name is what travels with it; a `+>->+` composition is composed with a behavior rather than calling one. Not <<e1401>>, which is about a name that is no behavior at all.
+Reported at the call (<<a-helper-does-not-call-a-behavior>>). A helper is expanded into whatever calls it and travels to an importing module as source, so what it may name is what travels with it; a `+>->+` composition is composed with a behavior rather than calling one. Not <<e1023>>, which is a name that resolves to nothing; this one resolves, to a behavior.
 
 [#e1901]
 === Example target is not a behavior


### PR DESCRIPTION
Closes #513.

## What was wrong

`Resolve` had two fallbacks answering the same question, differing in their last line:

```java
private ValueName valueName(...)  { ... : nothing(..., unknownIdentifier(written, bound)); }
private ValueName calledName(...) { ... : nothing(..., notCallable(call.name(), bound)); }
```

`unknownIdentifier` and `notCallable` both asked whether the spelling was a library member, both asked whether a library name had been written bare, both offered a near spelling. Then one said the name is not in scope (E1023) and the other said the name is a call to something on the JVM (E1401), chosen by whether the source had written arguments after it.

The observation is `lookup(name) == nothing`. What follows from it is that the name is not in scope. That the name is a JVM call does not follow from it, and nothing else established it — so a typo and a name left off an import list were reported under a title about Java interop, with a hint to declare a behavior and implement it from Java.

## E1401 had no producer that had looked

Measured rather than assumed. Its one emission site was that fallback, reached two ways, both of them "not found":

| written | before |
|---|---|
| `Missing(n)` — a bare name nothing declares | E1401 |
| `up.noSuch(n)` — a member a real module has not got | E1401 |
| `java.time.LocalDate.now(n)` — **the specification's own E1401 sample** | E1023 |

The documented example of the code does not produce it: `java` is not a namespace, so the chain reads as a field access and its root is a value nothing declares. Nothing in the compiler establishes that a name is on the JVM, so no site could have raised E1401 for the reason it names.

So it is retired rather than kept for a producer that cannot exist. The number was published, so it goes to `RetiredDiagnosticCode` with a `[#e1401-removed]` note; that list has no constructor a site can name, which holds "E1401 means the compiler checked" by construction rather than by a test. That arbitrary Java calls are out of scope stays a design decision (`no-arbitrary-jvm-calls`) — it was never a thing a compile could find.

The build had recorded this once already. `aKeyNamedForACodeIsEmittedUnderIt` notes two codes found reporting a rule other than the one they were filed under; one of the two was this.

## What replaces the second answer

A miss means one thing. How the lookup is made still differs — an application may reach what a bare name may not — and only the meaning of a miss is written once.

Cause and remediation are separate. The near spelling is carried beside the diagnosis; it was the remediation that had chosen the cause, since the advice to implement the name from Java is what made the report say the name was a JVM call.

The second commit adds what the suggestion cannot reach. A spelling suggestion offers names within reach, and a name left off an import list is not within reach — which is the whole problem, and was the real case #513 was found in:

```
I cannot find a value named `Amount` in scope.
Hint: `up` exposes `Amount`. Reach it as `up.Amount`, or name it in an import of `up`.
```

Only where exactly one module exposes the spelling, read off a sorted set. Two makes naming either one a guess, and a guess in a hint is worse than the silence it replaces.

## Held by a check

`AnUnresolvedNameIsTheSameDiagnosisWhereverItStandsTest` holds the property rather than the case: the primary diagnosis of an unresolved name is stable under syntactic embedding. `Missing`, `Missing(n)`, `Missing()`, `twice(Missing)`, `twice(Missing(n))`, `up.noSuch`, `up.noSuch(n)` — one map, one answer. Fixing the reported case alone is satisfied by a second answer written for the others, which is how this arrived.

Two existing tests held the old answer. Both wrote `someJavaMethod(a)`, a name that resolves to nothing; neither established anything about the JVM. What each was for survives — a callee no `depends on` clause names is still an unresolved name.

## Not in this change

Three open issues were checked for the same cause while investigating. #516 is the same defect one level up — `Unknown module` is reported where the producer established only that the module is not on this compilation's path, and the rule that actually refuses it (`run` takes a single self-contained file) is known to a different part of the code. #522 is the sibling but not the same: the parser genuinely observed `expected }, found |`, so it is under-observation rather than overclaim, and the two need different fixes. #521 and #517 are a pair of their own — a measure that found nothing reported as success, and a measure that does not apply omitted in silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
