### PR TITLE
A term that reads another holds its name and not its shape

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -44,6 +44,22 @@ final class Terms {
      * atom's name is made: the key and the kind of number behind it are decided in one step, and
      * anywhere else would be a second place that has to agree about which is which. */
     private final Map<String, Granularity> atomKinds = new HashMap<>();
+    /**
+     * Every canonical shape this has built, and the name it goes by.
+     *
+     * <p>What a term is made of is a graph and not a tree: a name read twice is one value read twice,
+     * and `+let (a, b) = t+` reads `+t+` twice by itself. A shape written out in full holds a copy of
+     * each of its parts, so a part read twice is written twice, and a chain of them doubles per link —
+     * twenty-four links asked for more characters than an array can hold. Held under a name, a shape
+     * that reads another holds the name and not the shape, and what a link adds is a name.
+     *
+     * <p>The names are the identity the rest of this asks about, and two shapes are one name exactly
+     * when they are the same shape. That is the same equality the strings had — a shape is compared by
+     * its parts' names, which are compared the same way, all the way down to what a location is
+     * called. So naming an expression still answers what the expression answers, which is what makes a
+     * name an alias.
+     */
+    private final Map<String, String> shapes = new HashMap<>();
 
     Terms(Symbols symbols) {
         this.symbols = symbols;
@@ -241,12 +257,26 @@ final class Terms {
     /** {@link #sizeAtom}, with the atom it names recorded as a whole number. A size counts elements,
      * so there is nothing to decide about it. */
     String sizeAtomOf(Core e, java.util.function.Function<Core, String> key) {
-        return named(sizeAtom(e, key), Granularity.DISCRETE);
+        return named(shared(sizeAtom(e, key)), Granularity.DISCRETE);
     }
 
     /** {@link #sizeKey}, with the atom it names recorded. */
     String sizeKeyOf(ValueName size, String container) {
-        return named(sizeKey(size, container), Granularity.DISCRETE);
+        return named(shared(sizeKey(size, container)), Granularity.DISCRETE);
+    }
+
+    /** {@code shape} under the name it goes by here, so that what reads it reads the name. */
+    private String shared(String shape) {
+        if (shape == null) {
+            return null;
+        }
+        String had = shapes.get(shape);
+        if (had != null) {
+            return had;
+        }
+        String name = "@" + shapes.size();
+        shapes.put(shape, name);
+        return name;
     }
 
     /** {@code key}, with how its values are spaced recorded against it. */
@@ -376,26 +406,26 @@ final class Terms {
             case Core.Str s -> quoted(s.value());
             case Core.Bool b -> Boolean.toString(b.value());
             case Core.UnitValue u -> u.data().toString();
-            case Core.Neg n -> wrap("-", termKey(n.operand(), at, bound, depth));
+            case Core.Neg n -> shared(wrap("-", termKey(n.operand(), at, bound, depth)));
             case Core.Binary b -> {
                 String l = termKey(b.left(), at, bound, depth);
                 String r = termKey(b.right(), at, bound, depth);
-                yield l == null || r == null ? null : binaryKey(b.op(), l, r);
+                yield l == null || r == null ? null : shared(binaryKey(b.op(), l, r));
             }
-            case Core.ListLit l -> elementsKey("[", l.elements(), at, bound, depth, "]");
-            case Core.Tuple t -> elementsKey("(", t.elements(), at, bound, depth, ")");
-            case Core.TupleGet g -> wrap("." + g.index(), termKey(g.tuple(), at, bound, depth));
-            case Core.If iff -> elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
-                    at, bound, depth, ")");
+            case Core.ListLit l -> shared(elementsKey("[", l.elements(), at, bound, depth, "]"));
+            case Core.Tuple t -> shared(elementsKey("(", t.elements(), at, bound, depth, ")"));
+            case Core.TupleGet g -> shared(wrap("." + g.index(), termKey(g.tuple(), at, bound, depth)));
+            case Core.If iff -> shared(elementsKey("if(", List.of(iff.cond(), iff.then(), iff.els()),
+                    at, bound, depth, ")"));
             case Core.Block b -> {
                 Map<BindingId, String> inner = binding(bound, b.params(), depth);
-                yield wrap("\\" + b.params().size(), termKey(b.body(), at, inner, depth + 1));
+                yield shared(wrap("\\" + b.params().size(), termKey(b.body(), at, inner, depth + 1)));
             }
             case Core.LetIn li -> {
                 String value = termKey(li.value(), at, bound, depth);
                 Map<BindingId, String> inner = binding(bound, List.of(li.binder()), depth);
                 String body = termKey(li.body(), at, inner, depth + 1);
-                yield value == null || body == null ? null : "let(" + value + ", " + body + ")";
+                yield value == null || body == null ? null : shared("let(" + value + ", " + body + ")");
             }
             // A construction is a pure function of its fields, and a closure that builds one is what a
             // mapping usually is. Fields are keyed in name order, so two sites writing them in
@@ -411,12 +441,14 @@ final class Terms {
                     }
                     sb.append(i == 0 ? "" : ", ").append(inits.get(i).name()).append('=').append(v);
                 }
-                yield sb.append('}').toString();
+                yield shared(sb.append('}').toString());
             }
             // Only the operations the representation kept standing: they are the library's own, so
             // they are pure and one written call is one value.
-            case Core.PreservedCall c ->
-                    elementsKey(c.operation().name() + "(", c.args(), at, bound, depth, ")");
+            // Named like the rest, and the one whose spelling something else reproduces: a size
+            // atom is built from the same shape by `sizeKey`, so both reach the same name.
+            case Core.PreservedCall c -> shared(
+                    elementsKey(c.operation().name() + "(", c.args(), at, bound, depth, ")"));
             default -> null;
         };
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest.java
@@ -1,0 +1,111 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a canonical key costs when the term it names reads a named value twice.
+ *
+ * <p>What terms are made of is a graph and not a tree. A name read twice is one value read twice, and
+ * `+let (a, b) = t+` reads `+t+` twice by itself, so a chain of those is a graph whose nodes grow by
+ * one per link and whose paths double. A key holding each of its parts in full holds one copy per
+ * path — twenty-four links asked for more characters than an array can hold.
+ *
+ * <p>Held on the size of the key rather than on the time a compile takes. Time is what the growth
+ * showed up as last: the chain measured flat right up to the link that asked for two gigabytes at
+ * once, because the walk is one lookup per name and only what it wrote doubled. What was wrong is the
+ * size of the representation, so that is what is measured, and it is measured where it is built.
+ *
+ * <p>Written as bindings, since that is where the sharing is. A value is read twice by being named
+ * and read twice, not by a tree holding one node twice — which is also why the walk stayed linear
+ * while the writing did not.
+ */
+class ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest {
+
+    private static final SourcePos NOWHERE = new SourcePos(0, 0);
+    private static final BindingOwner OWNER = new BindingOwner.OfValue("m", "f");
+
+    /** {@code v0 = 1 + 1}, then {@code v(i) = v(i-1) + v(i-1)}: each link names one value and reads
+     *  it twice. Answers the key of the last link. */
+    private static String chainKey(Terms terms, int links) {
+        Denotations at = Denotations.none();
+        Core value = new Core.Binary(Ast.BinOp.ADD, new Core.Int(1, Type.INT, NOWHERE),
+                new Core.Int(1, Type.INT, NOWHERE), Type.INT, NOWHERE);
+        String key = terms.bodyKey(value, at);
+        for (int i = 0; i < links; i++) {
+            BindingId id = new BindingId(OWNER, i);
+            at = at.binding(id, value, new Denotes.Term(key, true));
+            Core read = new Core.Read("v" + i, id, Type.INT, NOWHERE);
+            value = new Core.Binary(Ast.BinOp.ADD, read, read, Type.INT, NOWHERE);
+            key = terms.bodyKey(value, at);
+        }
+        return key;
+    }
+
+    private static int keyLength(int links) {
+        String key = chainKey(new Terms(Symbols.none()), links);
+        return key == null ? -1 : key.length();
+    }
+
+    /**
+     * A link adds a name to read, and a name is what a link adds.
+     *
+     * <p>Asked at four lengths as one map, because what is held is that the number does not follow the
+     * chain — one length is met by any growth at all, and it was met by one that doubled.
+     */
+    @Test
+    void aLinkCostsTheSameWhateverIsUnderIt() {
+        // Asked shortest first and held as it goes, so that a key which follows the chain is caught
+        // at the length where it is still a number and not at the one where it is an allocation.
+        Map<Integer, Integer> measured = new LinkedHashMap<>();
+        for (int links : List.of(4, 8, 16, 32)) {
+            int length = keyLength(links);
+            measured.put(links, length);
+            assertTrue(length > 0 && length <= 16,
+                    "a key names one shape and is read as a name: " + measured);
+        }
+    }
+
+    /**
+     * The chain a compile met, at a length the growth never allowed.
+     *
+     * <p>Twenty-four links is where it stopped, having asked for two gigabytes. A thousand is past
+     * every length that was reachable, and the key is still a name.
+     */
+    @Test
+    void aChainLongerThanTheOldLimitIsStillOneName() {
+        assertTrue(keyLength(1000) <= 16, "the key at a thousand links: " + keyLength(1000));
+    }
+
+    /**
+     * Naming a shape does not merge two shapes that differ.
+     *
+     * <p>Which is the property the keys are for: two terms are one key exactly when they compute one
+     * value, and that is what makes naming an expression not change what is known of it. A chain of
+     * four and a chain of five read alike at every link but the last.
+     */
+    @Test
+    void twoShapesThatDifferAreTwoNames() {
+        Terms terms = new Terms(Symbols.none());
+        String four = chainKey(terms, 4);
+        String five = chainKey(terms, 5);
+        String fourAgain = chainKey(terms, 4);
+
+        assertEquals(four, fourAgain, "one shape is one name");
+        assertNotEquals(four, five, "and two shapes are two");
+    }
+}


### PR DESCRIPTION
Closes #563.

## What it is

Not tuple destructuring, and not compile time.

`Terms.termKey` builds a term's canonical key by writing the shape out in full, with each part's shape inside it. A bound name is not a term of its own — by design, since naming an expression must not change what is known of it — so `pathKey`'s `Core.Read` case returns the key of the expression the name was bound to:

```java
case Core.Read r -> at.of(r.binding()).key();
```

What terms are made of is therefore a graph: a name read twice is one value read twice. A shape written out in full holds one copy per path, so a value on two paths is written twice, and a chain of those doubles per link.

Measured, longest key in characters:

| links | 2 | 4 | 6 | 8 | 10 | 12 |
|---|---|---|---|---|---|---|
| chars | 132 | 564 | 2,292 | 9,204 | 38,900 | 155,636 |

Four times per two links. At 24 the `StringBuilder` asks for more than an array can hold and the compile dies inside `elementsKey`.

## Three corrections to the issue

**It is not compile time that is exponential, it is the representation.** 22 links takes 0.56s, 23 takes 0.73s, 24 dies immediately. Time is flat right up to the wall, because the walk is one map lookup per name — only what it *wrote* doubled.

**`AstBuilder.bindPattern` is not where the doubling is.** It makes two reads of one name; the doubling is in the key builder. A chain with no destructuring at all doubles identically:

```
let v0 = x + x
let v1 = v0 + v0
let v2 = v1 + v1
```
121, 505, 2041, 8185, 34809 characters at 2, 4, 6, 8, 10 links.

**So the scope is any local read twice**, not local tuples. The title would be more accurate as something like *Canonical term keys expand shared local bindings exponentially*.

## The fix

The doctrine stays. `let a = x + 1; a` and `x + 1` keep one identity — that is what `denotationOf` decides and what the discharge machinery reads keys for. What changes is the representation of the equivalence class.

A shape is recorded under a name, and a shape that reads another holds the name. The equality is the one the strings had, and for the same reason: two shapes are one name exactly when they are the same shape, compared by their parts' names, compared the same way down to what a location is called. This is an intern table doing structural comparison and handing back a name — not a hash, so there is nothing to collide.

A size atom is the one shape something else spells out. `sizeKey` builds it from the same parts so that a guard's term and a clause's atom cannot drift apart, and it is named through the same table, so both sides reach the same name.

After: 24 links 0.47s, 40 links 0.45s, 200 links 0.60s, 1000 links 1.31s.

## The test measures the representation, not the clock

`ATermThatReadsAnotherHoldsItsNameAndNotItsShapeTest` drives `Terms` directly with bindings — which is where the sharing is — and holds that the key is a name at 4, 8, 16 and 32 links, and still a name at 1000. Shortest first, so a key that follows the chain is caught at the length where it is still a number rather than at the one where it is an allocation: with the naming removed it fails at 4 links, on 249 characters.

A third case holds the property the keys exist for, which the fix must not buy its size with: one shape is one name, and two shapes that differ are two.

## One thing this does not fix, and why it is not reached

`termKey` walks both children of a binary even when they are the same node, so a `Core` tree that shares a node *by object identity* is still walked exponentially. The compiler does not build one for this shape — sharing goes through `Denotations`, where a name costs a map lookup — which is exactly why the times were flat. I found this by writing the first version of the test with object sharing and watching it hang. Bounding the walk would need a memo keyed on the node together with `at`, `bound` and `depth`; nothing produces the input that needs it, so it is not in this change.

## The sweep

Searched for the same shape elsewhere: something that builds a parent's representation by embedding a child's complete representation, recursively.

`CoverageSites.shape` is the same form — a recursive text builder over `Core` — and is safe, because it stops at `Core.Read` with the name and does not follow the binding. That is the distinguishing property, and a cheap thing to check: **a recursive representation is bounded by the source unless it dereferences a binding, and exponential as soon as it does.** `Terms` was the only builder in the compiler that dereferences one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
