### PR TITLE
A documentation name is resolved rather than ranked

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -16,6 +16,11 @@ import java.util.Map;
  * topics as {@code set/topic<TAB>title}; a name prints that section or topic; {@code --search
  * <term>} spans both. The tab-separated listing is one line per entry so a tool — a coding agent
  * above all — can pick a name without scraping prose.
+ *
+ * <p>A search asks three things in turn and stops at the first that answers. Whether the term is a
+ * name, which is settled rather than scored, and answers with that one document. Whether the
+ * documents say it as it stands, which is a phrase search. Whether they say its words, which is
+ * ranked by how many of them each document holds.
  */
 public final class DocCommand {
 
@@ -67,17 +72,37 @@ public final class DocCommand {
                 }
             }
             String term = args[1];
-            List<String> lines = new ArrayList<>(hits(spec, shipped, term));
-            if (lines.isEmpty() && term.contains(" ")) {
-                // A phrase is matched whole, so a reader who typed a question rather than a term
-                // gets nothing. Rather than answer with silence, the words are tried separately.
-                err.println("no section says `" + term + "` — searching for its words instead");
-                for (String word : term.split("\\s+")) {
-                    for (String line : hits(spec, shipped, word)) {
-                        if (!lines.contains(line)) {
-                            lines.add(line);
-                        }
-                    }
+            // What a reader arriving from a diagnostic holds is a name, and a name resolves. Asked
+            // first and answered on its own, because the section a name names is not a matter of
+            // how much prose says its words: a heading's anchor is written where no section's body
+            // reaches, so ranking it would answer with the sections that cite it and never with it.
+            SpecDocument.Section named = spec.named(term);
+            if (named != null) {
+                resolved(term, named.anchor(), err);
+                print(named, out);
+                return 0;
+            }
+            LibraryDocs.Topic topic = shipped.named(term);
+            String shippedText = topic == null ? null : shipped.read(topic.name());
+            if (shippedText != null) {
+                resolved(term, topic.name(), err);
+                out.print(shippedText);
+                return 0;
+            }
+            List<String> lines = hits(spec, shipped, List.of(term), Match.ANYWHERE);
+            List<String> asked = DocName.words(term);
+            if (lines.isEmpty() && asked.size() > 1) {
+                // Nobody's name and nobody's phrase, so what is left to answer from is the words.
+                // Every section is scored against the whole query at once: taking the words one at
+                // a time and laying the answers end to end would fill the page from the first of
+                // them, and a reader who wrote eight words would be answered for one.
+                List<String> byWord = hits(spec, shipped, asked, Match.WORD);
+                if (!byWord.isEmpty()) {
+                    // Said only where it happened. A term whose words are nowhere either is answered
+                    // that nothing says it, and being told twice, in two ways, is being told less.
+                    err.println("no section says `" + term
+                            + "` — ranking the sections by how many of its words they say");
+                    lines = byWord;
                 }
             }
             if (lines.isEmpty()) {
@@ -122,10 +147,38 @@ public final class DocCommand {
             // not told so cannot tell an answer to what they asked from the nearest thing to it.
             err.println("`" + anchor + "` is written in `" + section.anchor() + "`, which is what follows");
         }
+        print(section, out);
+        return 0;
+    }
+
+    /**
+     * A section, headed as the document heads it.
+     *
+     * <p>The one place a section is written out, so that a name resolved by a search and the same
+     * name read outright are answered with the same text rather than with two renderings of it.
+     */
+    private static void print(SpecDocument.Section section, PrintStream out) {
         out.println("=".repeat(section.level()) + " " + section.title() + " [#" + section.anchor() + "]");
         out.println();
         out.println(section.body());
-        return 0;
+    }
+
+    /**
+     * Says that {@code asked} was taken as a name, and which document it named.
+     *
+     * <p>A search that answers with one document rather than a list has done something the reader
+     * did not ask for in so many words, and a reader who is not told cannot tell it from a search
+     * that found one hit. Where the name is written inside a document rather than being that
+     * document's own, that is said too: {@code an-optional-does-not-stand-in-a-boundary} is a rule
+     * inside a section, and the section is what there is to answer with.
+     */
+    private static void resolved(String asked, String name, PrintStream err) {
+        if (DocName.asWords(asked).equals(DocName.asWords(name))) {
+            err.println("`" + asked + "` is a name, so it is resolved rather than searched for");
+            return;
+        }
+        err.println("`" + asked + "` is a name written in `" + name
+                + "` — resolved rather than searched for, and that is what follows");
     }
 
     /** What separates one part of a documentation name from the next. */
@@ -184,25 +237,28 @@ public final class DocCommand {
      * after the other would put the best answer out of reach whenever the other side has enough
      * weak matches to fill the page, and the shipped topics — being few — are what would vanish.
      */
-    private record Found(String name, String title, String snippet, boolean titled, int occurrences) {
+    private record Found(String name, String title, String snippet, boolean titled, int matched,
+            int occurrences) {
 
         String rendered() {
             return name + "\t" + title + (snippet.isBlank() ? "" : "\n    " + snippet);
         }
     }
 
-    private static List<String> hits(SpecDocument spec, LibraryDocs shipped, String term) {
+    private static List<String> hits(SpecDocument spec, LibraryDocs shipped, List<String> terms,
+            Match how) {
         List<Found> found = new ArrayList<>();
-        for (SpecDocument.Hit hit : spec.rank(term)) {
+        for (SpecDocument.Hit hit : spec.rank(terms, how)) {
             found.add(new Found(hit.section().anchor(), hit.section().title(), hit.snippet(),
-                    hit.titled(), hit.occurrences()));
+                    hit.titled(), hit.matched(), hit.occurrences()));
         }
-        for (LibraryDocs.Hit hit : shipped.rank(term)) {
+        for (LibraryDocs.Hit hit : shipped.rank(terms, how)) {
             found.add(new Found(hit.topic().name(), hit.topic().title(), hit.snippet(),
-                    hit.titled(), hit.occurrences()));
+                    hit.titled(), hit.matched(), hit.occurrences()));
         }
         return found.stream()
-                .sorted(java.util.Comparator.comparing(Found::titled).reversed()
+                .sorted(java.util.Comparator.comparingInt(Found::matched).reversed()
+                        .thenComparing(java.util.Comparator.comparing(Found::titled).reversed())
                         .thenComparing(java.util.Comparator.comparingInt(Found::occurrences).reversed()))
                 .map(Found::rendered)
                 .toList();

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -42,8 +42,12 @@ public final class DocCommand {
     }
 
     static int run(String[] args, PrintStream out, PrintStream err, Caller caller, ClassLoader loader) {
-        SpecDocument spec = SpecDocument.bundled(caller);
-        LibraryDocs shipped = LibraryDocs.on(loader, caller);
+        // Taken together, because the names they publish are one name space and a name resolving
+        // against it is what a search asks first. Which document a name reaches is settled by the
+        // two of them being held at once, not by the order this reads them.
+        Documents documents = Documents.on(caller, loader);
+        SpecDocument spec = documents.spec();
+        LibraryDocs shipped = documents.shipped();
         if (args.length == 0) {
             for (SpecDocument.Section s : spec.sections()) {
                 out.println(s.anchor() + "\t" + "  ".repeat(s.level() - 2) + s.title());

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocName.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocName.java
@@ -1,24 +1,70 @@
 package souther.compiler.doc;
 
+import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
- * The one form a documentation name is looked up by.
+ * The forms a documentation name takes on its way to a lookup.
  *
  * <p>A name is written in more than one case before it reaches a lookup: the specification anchors
  * a diagnostic as {@code e2010} and the compiler prints the same diagnostic as {@code E2010}, which
  * is the form a reader copies. Both name the same thing, so both have to arrive at the same key.
  *
- * <p>Only the key is folded. What a name is spelled as belongs to whoever wrote it — a section
+ * <p>A name is also written in more than one place. An anchor spells the words it is made of with
+ * hyphens because that is what an AsciiDoc identifier may hold, and prose spells the same rule with
+ * spaces. A reader who has read the rule and goes looking for it types the words. So a search asks
+ * for a name by its words, and {@code an-optional-does-not-stand-in-a-boundary} and {@code an
+ * optional does not stand in a boundary} are one question.
+ *
+ * <p>Only the keys are folded. What a name is spelled as belongs to whoever wrote it — a section
  * keeps its anchor as the specification writes it, and a shipped topic keeps a name that is also
  * the path its text is read from, which the class path resolves by the spelling on the file.
  */
 final class DocName {
+
+    /** What separates one word of a name from the next, whatever the name is written in. */
+    private static final Pattern NOT_A_WORD = Pattern.compile("[^\\p{L}\\p{N}]+");
 
     private DocName() {}
 
     /** The key {@code name} is registered and asked for under. */
     static String canonical(String name) {
         return name.toLowerCase(Locale.ROOT);
+    }
+
+    /**
+     * The key a search resolves {@code name} by: its words, one space between them.
+     *
+     * <p>This is the wider of the two folds, so a name that reaches {@link #canonical} reaches this
+     * one, and a search that resolves names answers for everything the read path answers for.
+     */
+    static String asWords(String name) {
+        return NOT_A_WORD.matcher(canonical(name)).replaceAll(" ").strip();
+    }
+
+    /**
+     * Whether {@code query} is a name at all, before asking which one it is.
+     *
+     * <p>A query of nothing but punctuation has no words, and folds to what a name of nothing but
+     * punctuation would fold to. Neither is a name, and answering one with the other would resolve
+     * {@code ---} to whatever the document happened to write as {@code ___}.
+     */
+    static boolean isName(String query) {
+        return !asWords(query).isEmpty();
+    }
+
+    /**
+     * The words {@code text} is made of, each said once, in the order it says them.
+     *
+     * <p>A word said twice is the same word asked for twice, and a query that asks for it twice is
+     * asking for what it already asked for. Counting it again would rank a section that says that
+     * one word over a section that says the rest of them.
+     */
+    static List<String> words(String text) {
+        return NOT_A_WORD.splitAsStream(canonical(text))
+                .filter(word -> !word.isEmpty())
+                .distinct()
+                .toList();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/doc/Documents.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/Documents.java
@@ -1,0 +1,50 @@
+package souther.compiler.doc;
+
+/**
+ * The specification and the doc sets on the class path, as the one set of documents a reader asks.
+ *
+ * <p>A reader has one question and these have one answer between them: a listing gives the names
+ * from both, a search ranks both and sorts once, and a name resolves against both. So the names are
+ * one name space, and it is here that it is one — each document keeps its own names, and nothing
+ * below this holds both to look at them together.
+ *
+ * <p>Which is why the uniqueness of a name is checked here. Each document refuses two of its own
+ * names that come together under either fold, and neither can say anything about the other's. A
+ * specification anchor {@code cli-commands} and a shipped topic {@code cli/commands} are two names
+ * to read by and one name to resolve, and whichever the search asked for first would win, quietly,
+ * by the order this code happens to ask in. That is not an order to settle it by, and there is no
+ * order that would be: one of the two documents would be unreachable by the name it publishes.
+ */
+final class Documents {
+
+    private final SpecDocument spec;
+    private final LibraryDocs shipped;
+
+    /** The two of them, refusing a name they would both answer for. */
+    Documents(SpecDocument spec, LibraryDocs shipped) {
+        // One way round is every collision: a key both hold is a spec name, so asking the shipped
+        // topics for each of the specification's names is asking about all of them.
+        for (String name : spec.names()) {
+            LibraryDocs.Topic topic = shipped.named(name);
+            if (topic != null) {
+                throw new IllegalStateException("a specification name and a shipped topic are the"
+                        + " same words: `" + name + "` and `" + topic.name() + "`");
+            }
+        }
+        this.spec = spec;
+        this.shipped = shipped;
+    }
+
+    /** The bundled specification and everything {@code loader} carries, answered as {@code caller}. */
+    static Documents on(Caller caller, ClassLoader loader) {
+        return new Documents(SpecDocument.bundled(caller), LibraryDocs.on(loader, caller));
+    }
+
+    SpecDocument spec() {
+        return spec;
+    }
+
+    LibraryDocs shipped() {
+        return shipped;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/doc/LibraryDocs.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/LibraryDocs.java
@@ -75,6 +75,8 @@ public final class LibraryDocs {
     /** Keyed by {@link DocName#canonical}, so a topic is found in whatever case it is asked for.
      *  The topic keeps its own spelling: the name is also the path its text is read from. */
     private final Map<String, Topic> byName;
+    /** The same topics keyed by {@link DocName#asWords}, which is how a search resolves a name. */
+    private final Map<String, Topic> byWords;
     /**
      * What a search ranks: every file and every part of one, each over its own text.
      *
@@ -92,6 +94,12 @@ public final class LibraryDocs {
         this.byName = byName;
         this.ranked = ranked;
         this.caller = caller;
+        Map<String, Topic> byWords = new LinkedHashMap<>();
+        // A jar's own doing, unlike a name that is this compiler's to keep apart: two topics whose
+        // names are the same words are still two names to read by, so the one a search resolves to
+        // is settled here — the first the registry gave — rather than by which was read last.
+        byName.values().forEach(topic -> byWords.putIfAbsent(DocName.asWords(topic.name()), topic));
+        this.byWords = byWords;
     }
 
     /** The doc sets reachable through {@code loader} — for the CLI, everything bundled with it. */
@@ -270,55 +278,67 @@ public final class LibraryDocs {
         return text(topic);
     }
 
+    /**
+     * The topic {@code query} is the name of, written as its words or as its doc set spells it, or
+     * null when it names nothing. The same question {@link #read} answers, asked the way a reader
+     * who has the name says it aloud.
+     */
+    public Topic named(String query) {
+        return DocName.isName(query) ? byWords.get(DocName.asWords(query)) : null;
+    }
+
     /** Every topic whose title or text contains {@code term}, case-insensitively. */
     public List<Topic> search(String term) {
         return rank(term).stream().map(Hit::topic).toList();
     }
 
-    /** A topic the term was found in, scored the same way a specification section is. */
-    public record Hit(Topic topic, boolean titled, int occurrences, String snippet) {}
+    /** A topic the query was found in, scored the same way a specification section is. */
+    public record Hit(Topic topic, boolean titled, int matched, int occurrences, String snippet) {}
 
     /**
-     * The topics that say {@code term}, each with what a caller needs to rank it against a
-     * specification section: whether the title names it, how often it is said, and the line it was
-     * found on.
+     * The topics that say {@code term} as it stands, each with what a caller needs to rank it
+     * against a specification section.
      */
     public List<Hit> rank(String term) {
         if (term == null || term.isBlank()) {
             return List.of();
         }
-        String needle = term.toLowerCase();
+        return rank(List.of(term), Match.ANYWHERE);
+    }
+
+    /**
+     * The topics that say any of {@code terms}: how much of the query each holds, whether its title
+     * or its name is what was asked for, how often it is said, and the line one was found on.
+     *
+     * <p>Scored the way a specification section is, by the same {@link Match}, because the two are
+     * merged into one answer and sorted once. A shipped topic ranked under its own meaning of the
+     * numbers beside it would be placed against sections it was never compared with.
+     */
+    List<Hit> rank(List<String> asked, Match how) {
+        List<String> terms = asked.stream().map(DocName::canonical).toList();
         List<Hit> hits = new ArrayList<>();
         for (Topic topic : ranked) {
-            String body = own(topic);
-            boolean titled = topic.title().toLowerCase().contains(needle)
-                    || topic.name().toLowerCase().contains(needle);
-            int occurrences = count(body.toLowerCase(), needle);
-            if (titled || occurrences > 0) {
-                hits.add(new Hit(topic, titled, occurrences, snippet(topic, term)));
+            Match.Held held = how.held((topic.title() + " " + topic.name()).toLowerCase(),
+                    own(topic).toLowerCase(), terms);
+            if (held.matched() > 0) {
+                hits.add(new Hit(topic, held.named(), held.matched(), held.occurrences(),
+                        snippet(topic, terms, how)));
             }
         }
         return hits;
     }
 
-    private static int count(String haystack, String needle) {
-        if (needle.isEmpty()) {
-            return 0;
-        }
-        int n = 0;
-        for (int at = haystack.indexOf(needle); at >= 0; at = haystack.indexOf(needle, at + needle.length())) {
-            n++;
-        }
-        return n;
-    }
-
     /** The line of {@code topic} that says {@code term}, cut to a readable width. */
     public String snippet(Topic topic, String term) {
-        String needle = term.toLowerCase();
+        return snippet(topic, List.of(DocName.canonical(term)), Match.ANYWHERE);
+    }
+
+    /** The line of {@code topic} that says one of {@code terms}, cut to a readable width. */
+    private String snippet(Topic topic, List<String> terms, Match how) {
         String line = own(topic).lines()
                 .map(String::strip)
                 .filter(l -> !l.isEmpty() && !l.startsWith("#") && !l.startsWith("|"))
-                .filter(l -> l.toLowerCase().contains(needle))
+                .filter(l -> terms.stream().anyMatch(term -> how.says(l.toLowerCase(), term)))
                 .findFirst()
                 .orElse("");
         return line.length() <= 120 ? line : line.substring(0, 119) + "…";

--- a/souther-compiler/src/main/java/souther/compiler/doc/LibraryDocs.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/LibraryDocs.java
@@ -75,7 +75,8 @@ public final class LibraryDocs {
     /** Keyed by {@link DocName#canonical}, so a topic is found in whatever case it is asked for.
      *  The topic keeps its own spelling: the name is also the path its text is read from. */
     private final Map<String, Topic> byName;
-    /** The same topics keyed by {@link DocName#asWords}, which is how a search resolves a name. */
+    /** The same topics keyed by {@link DocName#asWords}, which is how a search resolves a name.
+     *  The same topics: a name that reaches one of these reaches the other. */
     private final Map<String, Topic> byWords;
     /**
      * What a search ranks: every file and every part of one, each over its own text.
@@ -88,18 +89,13 @@ public final class LibraryDocs {
     /** Who the text is spelled for, wherever it sends its reader somewhere. */
     private final Caller caller;
 
-    private LibraryDocs(ClassLoader loader, Map<String, Topic> byName, List<Topic> ranked,
-            Caller caller) {
+    private LibraryDocs(ClassLoader loader, Map<String, Topic> byName, Map<String, Topic> byWords,
+            List<Topic> ranked, Caller caller) {
         this.loader = loader;
         this.byName = byName;
+        this.byWords = byWords;
         this.ranked = ranked;
         this.caller = caller;
-        Map<String, Topic> byWords = new LinkedHashMap<>();
-        // A jar's own doing, unlike a name that is this compiler's to keep apart: two topics whose
-        // names are the same words are still two names to read by, so the one a search resolves to
-        // is settled here — the first the registry gave — rather than by which was read last.
-        byName.values().forEach(topic -> byWords.putIfAbsent(DocName.asWords(topic.name()), topic));
-        this.byWords = byWords;
     }
 
     /** The doc sets reachable through {@code loader} — for the CLI, everything bundled with it. */
@@ -109,7 +105,7 @@ public final class LibraryDocs {
 
     /** The same sets, read as {@code caller} is to be answered. */
     static LibraryDocs on(ClassLoader loader, Caller caller) {
-        Map<String, Topic> byName = new LinkedHashMap<>();
+        Names named = new Names();
         List<Topic> ranked = new ArrayList<>();
         try {
             Enumeration<URL> registries = loader.getResources(ROOT + "sets");
@@ -131,13 +127,13 @@ public final class LibraryDocs {
                         // divide it between them: nothing is counted twice and nothing is left out.
                         Topic whole = new Topic(topic, titleOf(text, file), 0, resource, 0,
                                 text.length(), without(0, text.length(), parts));
-                        register(byName, whole);
+                        named.register(whole);
                         ranked.add(whole);
                         for (Named part : parts) {
                             Topic held = new Topic(part.name(), part.title(), part.level(), resource,
                                     part.from(), part.to(),
                                     without(part.from(), part.to(), inside(part, parts)));
-                            register(byName, held);
+                            named.register(held);
                             ranked.add(held);
                         }
                     }
@@ -146,14 +142,37 @@ public final class LibraryDocs {
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-        return new LibraryDocs(loader, byName, List.copyOf(ranked), caller);
+        return new LibraryDocs(loader, named.byName, named.byWords, List.copyOf(ranked), caller);
     }
 
-    private static void register(Map<String, Topic> byName, Topic topic) {
-        Topic taken = byName.put(DocName.canonical(topic.name()), topic);
-        if (taken != null) {
-            throw new IllegalStateException("two shipped topics are asked for by the same name: `"
-                    + taken.name() + "` and `" + topic.name() + "`");
+    /**
+     * The topics read so far, under each fold a lookup uses.
+     *
+     * <p>A topic is registered under both or under neither. A doc set naming two topics that come
+     * together under either fold has published one name for two documents, and which of them a
+     * reader is answered with would be settled by the order its registry happened to list them —
+     * the read path taking the last and a search taking the first. That the names are a jar's to
+     * choose is why it is refused where the jar is read rather than settled quietly here.
+     */
+    private static final class Names {
+
+        private final Map<String, Topic> byName = new LinkedHashMap<>();
+        private final Map<String, Topic> byWords = new LinkedHashMap<>();
+        private final Map<String, String> askedAs = new LinkedHashMap<>();
+
+        void register(Topic topic) {
+            Topic taken = byName.put(DocName.canonical(topic.name()), topic);
+            if (taken != null) {
+                throw new IllegalStateException("two shipped topics are asked for by the same name: `"
+                        + taken.name() + "` and `" + topic.name() + "`");
+            }
+            String words = DocName.asWords(topic.name());
+            String said = askedAs.put(words, topic.name());
+            if (said != null) {
+                throw new IllegalStateException("two shipped topics are the same words: `"
+                        + said + "` and `" + topic.name() + "`");
+            }
+            byWords.put(words, topic);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/doc/Match.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/Match.java
@@ -1,0 +1,99 @@
+package souther.compiler.doc;
+
+import java.util.List;
+
+/**
+ * What counts as a document saying a term.
+ *
+ * <p>A phrase is a run of characters: a reader who types one is quoting the document, and where the
+ * quoted run sits relative to the words around it is not something they said anything about. A word
+ * is a word: {@code an} is not what {@code command} says, and a fallback that read it as one would
+ * have its shortest words matching nearly every section and deciding the order of the answer.
+ *
+ * <p>Both corpora ask this rather than each spelling out its own comparison, because a search runs
+ * over the two of them and sorts the result once. Two definitions of what a match is would put the
+ * specification and a shipped topic on one list under two meanings of the number beside them.
+ *
+ * <p>Every text and every term reaching these is already folded to lower case by whoever holds it,
+ * which for a document is once for the whole search rather than once for each term looked for in it.
+ */
+enum Match {
+
+    /** Anywhere in the text, wherever the run of characters begins and ends. */
+    ANYWHERE {
+        @Override
+        boolean at(String text, int found, int length) {
+            return true;
+        }
+    },
+
+    /** Only where the text has nothing but the term: no letter or digit either side of it. */
+    WORD {
+        @Override
+        boolean at(String text, int found, int length) {
+            return (found == 0 || !Character.isLetterOrDigit(text.charAt(found - 1)))
+                    && (found + length == text.length()
+                            || !Character.isLetterOrDigit(text.charAt(found + length)));
+        }
+    };
+
+    /** Whether the run of {@code length} characters at {@code found} is the text saying the term. */
+    abstract boolean at(String text, int found, int length);
+
+    /**
+     * How often {@code text} says {@code term}.
+     *
+     * <p>A term of no characters sits at every position and is said nowhere: a walk over its
+     * occurrences would never advance past the first.
+     */
+    final int count(String text, String term) {
+        if (term.isEmpty()) {
+            return 0;
+        }
+        int said = 0;
+        for (int at = text.indexOf(term); at >= 0; at = text.indexOf(term, at + term.length())) {
+            if (at(text, at, term.length())) {
+                said++;
+            }
+        }
+        return said;
+    }
+
+    /** Whether {@code text} says {@code term} at all. */
+    final boolean says(String text, String term) {
+        return count(text, term) > 0;
+    }
+
+    /**
+     * What a document holds of a query: whether what it is called is one of the terms, how many of
+     * them it holds at all, and how often it says them.
+     *
+     * <p>{@code matched} before {@code occurrences} is the whole of why a query is one question. A
+     * document holding four of the terms is a better answer than one saying the first of them forty
+     * times, whichever of them the reader happened to type first.
+     */
+    record Held(boolean named, int matched, int occurrences) {}
+
+    /**
+     * What the document called {@code called} and saying {@code body} holds of {@code terms}.
+     *
+     * <p>One rule for every corpus a search spans, because the answers are merged and sorted once.
+     * A specification section and a shipped topic scored by two rules would be placed against each
+     * other by numbers that do not mean the same thing.
+     */
+    final Held held(String called, String body, List<String> terms) {
+        boolean named = false;
+        int matched = 0;
+        int occurrences = 0;
+        for (String term : terms) {
+            boolean here = says(called, term);
+            int said = count(body, term);
+            named |= here;
+            occurrences += said;
+            if (here || said > 0) {
+                matched++;
+            }
+        }
+        return new Held(named, matched, occurrences);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
@@ -86,7 +86,13 @@ public final class McpServer {
     private static final List<Tool> TOOLS = List.of(
             new Tool("doc_search",
                     "Search the Souther language specification and every bundled library doc for a term."
-                            + " Answers the 20 best hits unless `limit` says otherwise.",
+                            + " A term that is a name answers with that one document: the anchor a"
+                            + " diagnostic cites resolves whether it is written with its hyphens"
+                            + " (`an-optional-does-not-stand-in-a-boundary`) or as its words (`an optional"
+                            + " does not stand in a boundary`), and so does a diagnostic code. Otherwise"
+                            + " the documents saying the term are listed, and failing that the ones saying"
+                            + " its words, most of them first. Answers the 20 best hits unless `limit`"
+                            + " says otherwise.",
                     List.of(new Param("term", Kind.STRING, true, "the word or phrase to look for"),
                             new Param("limit", Kind.COUNT, false,
                                     "how many hits to answer with; 0 for all of them (default 20)"))),

--- a/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/SpecDocument.java
@@ -58,29 +58,59 @@ public final class SpecDocument {
     /** Keyed by {@link DocName#canonical}: every name the document writes, and the section it
      *  resolves to. Several names may resolve to one section. */
     private final Map<String, Section> byAnchor;
+    /** The same names keyed by {@link DocName#asWords}, which is how a search resolves one. */
+    private final Map<String, Section> byWords;
     private final List<Section> inOrder;
     private final List<String> ownTexts;
     private final List<String> names;
 
     private SpecDocument(List<Section> sections, List<String> ownTexts,
-            Map<String, Section> byAnchor, List<String> names) {
+            Map<String, Section> byAnchor, Map<String, Section> byWords, List<String> names) {
         this.inOrder = List.copyOf(sections);
         this.ownTexts = List.copyOf(ownTexts);
         this.byAnchor = Map.copyOf(byAnchor);
+        this.byWords = Map.copyOf(byWords);
         this.names = List.copyOf(names);
     }
 
-    /** Registers {@code anchor} as a name for {@code section}, refusing a name already taken. Two
-     *  names that fold to one key would otherwise answer by whichever was read second. */
-    private static void register(Map<String, Section> byAnchor, Map<String, String> writtenAs,
-            String anchor, Section section) {
-        String key = DocName.canonical(anchor);
-        String taken = writtenAs.put(key, anchor);
-        if (taken != null) {
-            throw new IllegalStateException("two names to ask for fold together: `"
-                    + taken + "` and `" + anchor + "`");
+    /**
+     * The names read so far, under each fold a lookup uses, with the spelling each was read as.
+     *
+     * <p>Both folds are held together because a name is registered under both or under neither: one
+     * of them holding a name the other does not is a name one tool answers for and the other cannot.
+     */
+    private static final class Names {
+
+        private final Map<String, Section> byAnchor = new LinkedHashMap<>();
+        private final Map<String, Section> byWords = new LinkedHashMap<>();
+        private final Map<String, String> writtenAs = new LinkedHashMap<>();
+        private final Map<String, String> askedAs = new LinkedHashMap<>();
+
+        /**
+         * Registers {@code anchor} as a name for {@code section}, refusing a name already taken.
+         *
+         * <p>Two names that fold to one key would otherwise answer by whichever was read second,
+         * and both folds are checked because both are lookups. A pair that only the wider fold
+         * brings together — {@code also-named} and {@code also_named} — reads as two names in the
+         * document and would be one question to a reader who typed either, answered from whichever
+         * the document happened to write last.
+         */
+        void register(String anchor, Section section) {
+            String key = DocName.canonical(anchor);
+            String taken = writtenAs.put(key, anchor);
+            if (taken != null) {
+                throw new IllegalStateException("two names to ask for fold together: `"
+                        + taken + "` and `" + anchor + "`");
+            }
+            String words = DocName.asWords(anchor);
+            String said = askedAs.put(words, anchor);
+            if (said != null) {
+                throw new IllegalStateException("two names are the same words: `"
+                        + said + "` and `" + anchor + "`");
+            }
+            byAnchor.put(key, section);
+            byWords.put(words, section);
         }
-        byAnchor.put(key, section);
     }
 
     /** The specification this compiler was built from, bundled in its jar. */
@@ -176,11 +206,10 @@ public final class SpecDocument {
             sections.add(new Section(here.anchors().getFirst(), here.title(), here.level(), body));
             ownTexts.add(String.join("\n", List.of(lines).subList(here.bodyFrom(), ownEnd)).strip());
         }
-        Map<String, Section> byAnchor = new LinkedHashMap<>();
-        Map<String, String> writtenAs = new LinkedHashMap<>();
+        Names named = new Names();
         for (int h = 0; h < headings.size(); h++) {
             for (String anchor : headings.get(h).anchors()) {
-                register(byAnchor, writtenAs, anchor, sections.get(h));
+                named.register(anchor, sections.get(h));
             }
         }
         // An anchor written anywhere else names a place inside a section rather than a section, and
@@ -200,15 +229,16 @@ public final class SpecDocument {
             }
             Matcher anchor = ANCHOR.matcher(lines[i]);
             if (anchor.matches()) {
-                register(byAnchor, writtenAs, anchor.group(1), standingIn);
+                named.register(anchor.group(1), standingIn);
                 continue;
             }
             Matcher inline = INLINE_ANCHOR.matcher(lines[i]);
             while (inline.find()) {
-                register(byAnchor, writtenAs, inline.group(1), standingIn);
+                named.register(inline.group(1), standingIn);
             }
         }
-        return new SpecDocument(sections, ownTexts, byAnchor, List.copyOf(writtenAs.values()));
+        return new SpecDocument(sections, ownTexts, named.byAnchor, named.byWords,
+                List.copyOf(named.writtenAs.values()));
     }
 
     /**
@@ -241,6 +271,20 @@ public final class SpecDocument {
     }
 
     /**
+     * The section {@code query} is the name of, written as its words or as the document spells it,
+     * or null when it names nothing.
+     *
+     * <p>This is the same question {@link #section} answers and not a well-scored guess at it. A
+     * name resolves or it does not, and what a name resolves to is not for prose to decide: a
+     * heading's anchor is written on a line of its own that belongs to no section's body, so a
+     * search that went looking for it in the text would find it only where another section cites it
+     * and would answer with every section but the one it names.
+     */
+    public Section named(String query) {
+        return DocName.isName(query) ? byWords.get(DocName.asWords(query)) : null;
+    }
+
+    /**
      * Every name that resolves, as the document spells it, in the order the document writes them.
      *
      * <p>The same names {@link #section} answers for, so a caller suggesting what a reader might
@@ -260,20 +304,21 @@ public final class SpecDocument {
     }
 
     /**
-     * A section the term was found in: whether its title names it, how often it says it, and the
-     * line it was found on. The line is what makes a list of hits an answer rather than a filtered
-     * table of contents — without it a reader has to open each section to tell a hit from a
-     * coincidence.
+     * A section the query was found in: how many of the terms asked for it holds, whether its title
+     * or its anchor is one of them, how often it says them, and the line one was found on. The line
+     * is what makes a list of hits an answer rather than a filtered table of contents — without it a
+     * reader has to open each section to tell a hit from a coincidence.
      */
-    public record Hit(Section section, boolean titled, int occurrences, String snippet) {}
+    public record Hit(Section section, boolean titled, int matched, int occurrences, String snippet) {}
 
     /** How wide a snippet may run before it stops being readable in a list. */
     private static final int SNIPPET_WIDTH = 120;
 
     /**
-     * The sections that say {@code term}, best answer first: a section titled with the term, then
-     * the sections that dwell on it most. A word common enough to appear across the specification
-     * is otherwise no answer at all — over half the document comes back and nothing is chosen.
+     * The sections that say {@code term} as it stands, best answer first: a section titled with the
+     * term, then the sections that dwell on it most. A word common enough to appear across the
+     * specification is otherwise no answer at all — over half the document comes back and nothing
+     * is chosen.
      */
     public List<Hit> rank(String term) {
         // A term of no characters sits at every position and matches everything, which is not an
@@ -281,33 +326,54 @@ public final class SpecDocument {
         if (term == null || term.isBlank()) {
             return List.of();
         }
-        String needle = term.toLowerCase();
+        return rank(List.of(term), Match.ANYWHERE);
+    }
+
+    /**
+     * The sections that say any of {@code terms}, the ones that say most of them first.
+     *
+     * <p>How much of the query a section holds is what is asked before how often it says any of it,
+     * because a query of several words is one question. Ranking each word on its own and laying the
+     * answers end to end spends the whole answer on whichever word was typed first, and a section
+     * saying four of them sits behind every section saying the opening one.
+     *
+     * <p>Where a section holds as much of the query as another, the one whose title or anchor is
+     * what was asked for comes first, and then the one that dwells on it. A query of one term is
+     * every section holding all of it, so those two settle it, which is what a phrase search is.
+     */
+    List<Hit> rank(List<String> asked, Match how) {
+        // Folded once for the whole search rather than once per section, and here rather than at
+        // each caller, so that a term arriving in the case a reader copied it in is one term.
+        List<String> terms = asked.stream().map(DocName::canonical).toList();
         List<Hit> hits = new ArrayList<>();
         for (int i = 0; i < inOrder.size(); i++) {
             Section s = inOrder.get(i);
-            boolean titled = s.title().toLowerCase().contains(needle);
-            String own = ownTexts.get(i);
-            int occurrences = count(own.toLowerCase(), needle);
-            if (titled || occurrences > 0) {
-                hits.add(new Hit(s, titled, occurrences, snippet(own, needle)));
+            // The anchor is asked of the same text the title is: an anchor is what a reader has in
+            // hand, and a section whose prose never writes its own anchor is most of them.
+            Match.Held held = how.held((s.title() + " " + s.anchor()).toLowerCase(),
+                    ownTexts.get(i).toLowerCase(), terms);
+            if (held.matched() > 0) {
+                hits.add(new Hit(s, held.named(), held.matched(), held.occurrences(),
+                        snippet(ownTexts.get(i), terms, how)));
             }
         }
         return hits.stream()
-                .sorted(java.util.Comparator.comparing(Hit::titled).reversed()
+                .sorted(java.util.Comparator.comparingInt(Hit::matched).reversed()
+                        .thenComparing(java.util.Comparator.comparing(Hit::titled).reversed())
                         .thenComparing(java.util.Comparator.comparingInt(Hit::occurrences).reversed()))
                 .toList();
     }
 
     /**
-     * The line {@code needle} was found on, trimmed of the AsciiDoc that carries no meaning aloud
-     * and cut to a readable width around the term. A section matched only by its title falls back
-     * to its opening line, which is what it is about.
+     * The line one of {@code terms} was found on, trimmed of the AsciiDoc that carries no meaning
+     * aloud and cut to a readable width around it. A section matched only by its title or its anchor
+     * falls back to its opening line, which is what it is about.
      */
-    private static String snippet(String body, String needle) {
+    private static String snippet(String body, List<String> terms, Match how) {
         String line = body.lines()
                 .map(String::strip)
                 .filter(l -> !l.isEmpty() && !l.startsWith("|") && !l.startsWith("["))
-                .filter(l -> l.toLowerCase().contains(needle))
+                .filter(l -> terms.stream().anyMatch(term -> how.says(l.toLowerCase(), term)))
                 .findFirst()
                 .orElseGet(() -> body.lines().map(String::strip)
                         .filter(l -> !l.isEmpty() && !l.startsWith("[") && !l.startsWith("|"))
@@ -316,20 +382,10 @@ public final class SpecDocument {
         if (plain.length() <= SNIPPET_WIDTH) {
             return plain;
         }
-        int at = plain.toLowerCase().indexOf(needle);
+        int at = terms.stream().mapToInt(term -> plain.toLowerCase().indexOf(term))
+                .filter(found -> found >= 0).min().orElse(-1);
         int from = at < 0 ? 0 : Math.max(0, at - SNIPPET_WIDTH / 3);
         int to = Math.min(plain.length(), from + SNIPPET_WIDTH);
         return (from > 0 ? "…" : "") + plain.substring(from, to).strip() + (to < plain.length() ? "…" : "");
-    }
-
-    private static int count(String haystack, String needle) {
-        if (needle.isEmpty()) {
-            return 0;
-        }
-        int n = 0;
-        for (int at = haystack.indexOf(needle); at >= 0; at = haystack.indexOf(needle, at + needle.length())) {
-            n++;
-        }
-        return n;
     }
 }

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -93,6 +93,12 @@ Every diagnostic code the compiler prints is the name of the section explaining 
 the `E2011` in a banner is {{doc:E2011}}. Nothing else has to be read off the banner for the
 lookup to work.
 
+A search asks three things in turn and stops at the first that answers. Whether the term is a name,
+in which case that one document is the answer — the hyphens of a name are its spelling, so
+`an-optional-does-not-stand-in-a-boundary` and `an optional does not stand in a boundary` are the
+same question, and so is a diagnostic code. Whether the documents say the term as it stands, which
+lists them. Whether they say its words, which lists them by how many of the words each one says.
+
 <!-- souther-section: api -->
 ## api
 

--- a/souther-compiler/src/test/java/souther/compiler/doc/ANameIsResolvedRatherThanRankedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ANameIsResolvedRatherThanRankedTest.java
@@ -149,7 +149,7 @@ class ANameIsResolvedRatherThanRankedTest {
         // `somelib/guide-notes` and `somelib/guide/notes` are two names to read by and one name to
         // resolve, so one of the two documents is unreachable by name however this settled it.
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> shipping("guide.md", """
+                () -> shipping("somelib", "guide.md", """
                         # A guide
 
                         <!-- souther-section: notes -->
@@ -169,19 +169,42 @@ class ANameIsResolvedRatherThanRankedTest {
                 refused.getMessage());
     }
 
-    /** A jar shipping one doc set of the given {@code file, text} pairs. */
-    private LibraryDocs shipping(String... files) {
+    @Test
+    void andSoIsASpecificationNameAShippedTopicWouldAnswerForToo() {
+        // `cli-commands` and `cli/commands` are one name to resolve and two documents to read, and
+        // neither document can see the other's names: whichever corpus the search asked first would
+        // win, and the other would publish a name nothing reaches.
+        SpecDocument spec = SpecDocument.of("""
+                = A Specification
+
+                [#cli-commands]
+                == The commands
+
+                What the command line takes.
+                """);
+        LibraryDocs shipped = shipping("cli", "commands.md", "# Commands\n\nWhat this library takes.\n");
+
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> new Documents(spec, shipped));
+
+        assertTrue(refused.getMessage().contains("cli-commands")
+                        && refused.getMessage().contains("cli/commands"),
+                "and says which two names came together: " + refused.getMessage());
+    }
+
+    /** A jar shipping the doc set {@code set} with the given {@code file, text} pairs. */
+    private LibraryDocs shipping(String set, String... files) {
         try {
             Path jar = Files.createTempDirectory("docset").resolve("somelib-1.0.jar");
             try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
                 out.putNextEntry(new JarEntry("META-INF/souther-docs/sets"));
-                out.write("somelib\n".getBytes(StandardCharsets.UTF_8));
-                out.putNextEntry(new JarEntry("META-INF/souther-docs/somelib/index"));
+                out.write((set + "\n").getBytes(StandardCharsets.UTF_8));
+                out.putNextEntry(new JarEntry("META-INF/souther-docs/" + set + "/index"));
                 for (int i = 0; i < files.length; i += 2) {
                     out.write((files[i] + "\n").getBytes(StandardCharsets.UTF_8));
                 }
                 for (int i = 0; i < files.length; i += 2) {
-                    out.putNextEntry(new JarEntry("META-INF/souther-docs/somelib/" + files[i]));
+                    out.putNextEntry(new JarEntry("META-INF/souther-docs/" + set + "/" + files[i]));
                     out.write(files[i + 1].getBytes(StandardCharsets.UTF_8));
                 }
             }

--- a/souther-compiler/src/test/java/souther/compiler/doc/ANameIsResolvedRatherThanRankedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ANameIsResolvedRatherThanRankedTest.java
@@ -4,11 +4,18 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -135,6 +142,53 @@ class ANameIsResolvedRatherThanRankedTest {
 
         assertTrue(searched.out().contains("[#behavior]"),
                 "`jvm-behavior` is titled `behavior`, and a title is not an identity: " + searched.out());
+    }
+
+    @Test
+    void aDocSetNamingTwoTopicsTheSameWordsIsRefusedWhereItIsRead() {
+        // `somelib/guide-notes` and `somelib/guide/notes` are two names to read by and one name to
+        // resolve, so one of the two documents is unreachable by name however this settled it.
+        IllegalStateException refused = assertThrows(IllegalStateException.class,
+                () -> shipping("guide.md", """
+                        # A guide
+
+                        <!-- souther-section: notes -->
+                        ## Notes
+
+                        What is worth noting.
+                        """, "guide-notes.md", """
+                        # Notes on the guide
+
+                        Something else entirely.
+                        """));
+
+        assertTrue(refused.getMessage().contains("the same words"),
+                "and says which two names came together: " + refused.getMessage());
+        assertTrue(refused.getMessage().contains("guide-notes")
+                        && refused.getMessage().contains("guide/notes"),
+                refused.getMessage());
+    }
+
+    /** A jar shipping one doc set of the given {@code file, text} pairs. */
+    private LibraryDocs shipping(String... files) {
+        try {
+            Path jar = Files.createTempDirectory("docset").resolve("somelib-1.0.jar");
+            try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+                out.putNextEntry(new JarEntry("META-INF/souther-docs/sets"));
+                out.write("somelib\n".getBytes(StandardCharsets.UTF_8));
+                out.putNextEntry(new JarEntry("META-INF/souther-docs/somelib/index"));
+                for (int i = 0; i < files.length; i += 2) {
+                    out.write((files[i] + "\n").getBytes(StandardCharsets.UTF_8));
+                }
+                for (int i = 0; i < files.length; i += 2) {
+                    out.putNextEntry(new JarEntry("META-INF/souther-docs/somelib/" + files[i]));
+                    out.write(files[i + 1].getBytes(StandardCharsets.UTF_8));
+                }
+            }
+            return LibraryDocs.on(new URLClassLoader(new URL[]{jar.toUri().toURL()}, null), Caller.CLI);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/doc/ANameIsResolvedRatherThanRankedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ANameIsResolvedRatherThanRankedTest.java
@@ -1,0 +1,149 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name is answered by resolving it, and a name is what a reader arriving from a diagnostic has:
+ * {@code E1313} cites {@code an-optional-does-not-stand-in-a-boundary}, and a reader who reaches for
+ * a search with it in hand is holding an identifier rather than a description.
+ *
+ * <p>So the name space the read path answers over is the search's first question, and it either
+ * answers or it does not. Scoring a name against prose instead would leave which section an
+ * identifier resolves to decided by how often the specification happens to say its words, and a name
+ * whose section never writes it out — which every heading anchor is, the anchor line belonging to no
+ * section's body — would resolve to the sections that cite it and never to the one it names.
+ */
+class ANameIsResolvedRatherThanRankedTest {
+
+    private final SpecDocument spec = SpecDocument.bundled();
+    private final LibraryDocs shipped = LibraryDocs.on(getClass().getClassLoader(), Caller.CLI);
+
+    /** The same name with its segments written as the words they are, which is how a reader says it. */
+    private static String asWords(String name) {
+        return name.replaceAll("[^A-Za-z0-9]+", " ").strip();
+    }
+
+    private record Answer(int code, String out, String err) {}
+
+    private Answer run(String... args) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int code = DocCommand.run(args,
+                new PrintStream(out, true, StandardCharsets.UTF_8),
+                new PrintStream(err, true, StandardCharsets.UTF_8));
+        return new Answer(code, out.toString(StandardCharsets.UTF_8), err.toString(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void everyNameTheReadPathResolvesTheSearchResolvesToo() {
+        List<String> unresolved = new ArrayList<>();
+        for (String name : spec.names()) {
+            SpecDocument.Section resolved = spec.named(name);
+            if (resolved == null || !resolved.anchor().equals(spec.section(name).anchor())) {
+                unresolved.add(name + " -> " + (resolved == null ? "nothing" : resolved.anchor()));
+            }
+        }
+        for (LibraryDocs.Topic topic : shipped.topics()) {
+            LibraryDocs.Topic resolved = shipped.named(topic.name());
+            if (resolved == null || !resolved.name().equals(topic.name())) {
+                unresolved.add(topic.name() + " -> " + (resolved == null ? "nothing" : resolved.name()));
+            }
+        }
+
+        assertEquals(List.of(), unresolved,
+                "what one tool answers for by name is what the other one looks for first");
+    }
+
+    @Test
+    void andResolvesItWrittenAsTheWordsItIsMadeOf() {
+        List<String> unresolved = new ArrayList<>();
+        for (String name : spec.names()) {
+            SpecDocument.Section resolved = spec.named(asWords(name));
+            if (resolved == null || !resolved.anchor().equals(spec.section(name).anchor())) {
+                unresolved.add(asWords(name) + " -> " + (resolved == null ? "nothing" : resolved.anchor()));
+            }
+        }
+        for (LibraryDocs.Topic topic : shipped.topics()) {
+            LibraryDocs.Topic resolved = shipped.named(asWords(topic.name()));
+            if (resolved == null || !resolved.name().equals(topic.name())) {
+                unresolved.add(asWords(topic.name()) + " -> "
+                        + (resolved == null ? "nothing" : resolved.name()));
+            }
+        }
+
+        assertEquals(List.of(), unresolved,
+                "a reader types the name a document cites, and a document cites it in prose as its"
+                        + " words: the hyphens are the anchor's spelling and not part of what it names");
+    }
+
+    @Test
+    void aSearchForANameAnswersWithThatSectionAndNothingBeside() {
+        Answer searched = run("--search", "an optional does not stand in a boundary");
+        Answer read = run("an-optional-does-not-stand-in-a-boundary");
+
+        assertEquals(read.out(), searched.out(),
+                "the search answers with the section, not with a page of sections that share a word");
+        assertTrue(searched.err().contains("is a name written in `external-representation`"),
+                "and says the term was taken as a name, and which section holds the rule it names: "
+                        + searched.err());
+    }
+
+    @Test
+    void aDiagnosticCodeIsANameAndNotATermToBeScored() {
+        Answer searched = run("--search", "E1004");
+        Answer read = run("E1004");
+
+        assertEquals(read.out(), searched.out(),
+                "the code the compiler printed is what a reader searches with first");
+        assertTrue(searched.out().contains("[#e1004]"), "and it resolves: " + searched.out());
+        assertTrue(searched.err().contains("is a name"),
+                "and the reader is told why one section came back rather than a list: " + searched.err());
+    }
+
+    @Test
+    void aQueryWhoseWordsAreNowhereIsToldThatAndNotToldItTwice() {
+        Answer searched = run("--search", "borrowck zzyzx");
+
+        assertTrue(searched.err().contains("nothing says `borrowck zzyzx`"),
+                "the term drew a blank and that is the whole of it: " + searched.err());
+        assertTrue(!searched.err().contains("ranking"),
+                "a ranking that ranked nothing is not something that happened: " + searched.err());
+        assertEquals("", searched.out());
+    }
+
+    @Test
+    void aNameAnswersWithTheSectionItNamesAndNotTheSectionsThatCiteIt() {
+        Answer searched = run("--search", "mapping-principle");
+
+        assertTrue(searched.out().contains("[#mapping-principle]"),
+                "`mapping-principle` is written in prose only where another section cites it, and"
+                        + " the section it names is the answer: " + searched.out());
+    }
+
+    @Test
+    void aNameOutranksASectionWhoseTitleReadsTheSameWay() {
+        Answer searched = run("--search", "behavior");
+
+        assertTrue(searched.out().contains("[#behavior]"),
+                "`jvm-behavior` is titled `behavior`, and a title is not an identity: " + searched.out());
+    }
+
+    @Test
+    void aTermThatNamesNothingIsSearchedForAsBefore() {
+        Answer searched = run("--search", "type");
+
+        assertEquals(0, searched.code());
+        assertTrue(searched.out().lines().anyMatch(l -> l.matches("\\S+\t.*")),
+                "a term that is nobody's name is still ranked across the sections that say it:\n"
+                        + searched.out());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/AQueryIsScoredWholeAndNotOneWordAtATimeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/AQueryIsScoredWholeAndNotOneWordAtATimeTest.java
@@ -1,0 +1,125 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Comparator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A query nobody's name and nobody's prose says whole is answered by its words, and the answer is
+ * the query's, not its first word's. Ranking each word on its own and laying the results end to end
+ * spends the whole answer on whichever word came first: a section that says four of the words is
+ * held behind every section that says the opening one, and the reader is answered for a query they
+ * did not write.
+ *
+ * <p>The word a section says is a word, too. A run of characters that happens to sit inside another
+ * word is not the document saying it — {@code an} is not what {@code command} says — and a fallback
+ * that counts those has its commonest words matching everywhere and deciding everything.
+ */
+class AQueryIsScoredWholeAndNotOneWordAtATimeTest {
+
+    private final SpecDocument fixture = SpecDocument.of("""
+            = A Specification
+
+            [#all]
+            == Everything
+
+            nested if else belongs, all of them written here.
+
+            [#some]
+            == Two of them
+
+            else and belongs, written down.
+
+            [#one]
+            == Only the opening one
+
+            nested, and nothing more.
+            """);
+
+    private final SpecDocument words = SpecDocument.of("""
+            = A Specification
+
+            [#whole]
+            == A whole word
+
+            an else.
+
+            [#run]
+            == A run of characters
+
+            command and demand.
+            """);
+
+    private String search(String term) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream print = new PrintStream(out, true, StandardCharsets.UTF_8);
+        DocCommand.run(new String[]{"--search", term, "--limit", "0"}, print,
+                new PrintStream(ByteArrayOutputStream.nullOutputStream(), true, StandardCharsets.UTF_8));
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    @Test
+    void theSectionThatSaysMoreOfTheQueryComesFirst() {
+        List<SpecDocument.Hit> hits = fixture.rank(DocName.words("nested if else belongs"), Match.WORD);
+
+        assertEquals(List.of("all", "some", "one"),
+                hits.stream().map(h -> h.section().anchor()).toList(),
+                "four of the words outranks two, and two outranks the one the query opens with");
+    }
+
+    @Test
+    void aHitSaysHowManyOfTheQuerysWordsItHolds() {
+        List<SpecDocument.Hit> hits = fixture.rank(DocName.words("nested if else belongs"), Match.WORD);
+
+        assertEquals(List.of(4, 2, 1), hits.stream().map(SpecDocument.Hit::matched).toList());
+    }
+
+    @Test
+    void aWordIsAWholeWordAndNotARunOfCharactersInsideAnother() {
+        List<SpecDocument.Hit> hits = words.rank(DocName.words("an else"), Match.WORD);
+
+        assertEquals(List.of("whole"), hits.stream().map(h -> h.section().anchor()).toList(),
+                "`command` and `demand` are not the document saying `an`");
+    }
+
+    @Test
+    void aRepeatedWordIsNotWorthTwiceAsMuch() {
+        List<SpecDocument.Hit> once = fixture.rank(DocName.words("nested if else belongs"), Match.WORD);
+        List<SpecDocument.Hit> twice = fixture.rank(
+                DocName.words("nested if else belongs if else"), Match.WORD);
+
+        assertEquals(once.stream().map(h -> h.section().anchor()).toList(),
+                twice.stream().map(h -> h.section().anchor()).toList(),
+                "a query that says a word twice asks for the same thing");
+    }
+
+    @Test
+    void theOrderTheWordsWereTypedInDoesNotDecideTheAnswer() {
+        assertEquals(search("string literal escape backslash"),
+                search("backslash escape literal string"),
+                "the same words asked for in another order are the same question");
+    }
+
+    @Test
+    void andThatHoldsOfTheSpecificationItselfAndNotOnlyOfAFixture() {
+        SpecDocument spec = SpecDocument.bundled();
+        List<String> asked = DocName.words("nested if else which if an else belongs to");
+
+        List<SpecDocument.Hit> hits = spec.rank(asked, Match.WORD);
+
+        assertEquals(hits, hits.stream()
+                        .sorted(Comparator.comparingInt(SpecDocument.Hit::matched).reversed())
+                        .toList(),
+                "no section that says more of the query sits below one that says less of it");
+        assertTrue(hits.getFirst().matched() > 1,
+                "and the answer is not the opening word's: " + hits.getFirst().section().anchor()
+                        + " says " + hits.getFirst().matched() + " of them");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/ASearchHitShowsWhyItMatchedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ASearchHitShowsWhyItMatchedTest.java
@@ -54,7 +54,9 @@ class ASearchHitShowsWhyItMatchedTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PrintStream print = new PrintStream(out, true, StandardCharsets.UTF_8);
 
-        assertEquals(0, DocCommand.run(new String[]{"--search", "newtype"}, print, print));
+        // A term that is nobody's name, which is what a list of hits is the answer to: a name is
+        // resolved to the one section it names.
+        assertEquals(0, DocCommand.run(new String[]{"--search", "single-value newtype"}, print, print));
 
         List<String> lines = out.toString(StandardCharsets.UTF_8).lines().toList();
         assertTrue(lines.getFirst().matches("\\S+\t.*"), "a hit is still one tab-separated line: " + lines.getFirst());
@@ -67,7 +69,7 @@ class ASearchHitShowsWhyItMatchedTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         PrintStream print = new PrintStream(out, true, StandardCharsets.UTF_8);
 
-        DocCommand.run(new String[]{"--search", "invariant"}, print, print);
+        DocCommand.run(new String[]{"--search", "type"}, print, print);
 
         assertTrue(out.toString(StandardCharsets.UTF_8).lines()
                         .filter(l -> l.startsWith("    "))

--- a/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest.java
@@ -151,7 +151,7 @@ class EveryAnswerIsReachableWithoutLeavingTheMcpToolsTest {
 
     @Test
     void aSearchAnswersTheCountItWasAskedFor() {
-        String three = text(call("doc_search", "{\"term\":\"newtype\",\"limit\":3}"));
+        String three = text(call("doc_search", "{\"term\":\"type\",\"limit\":3}"));
 
         assertEquals(3, three.lines().filter(line -> line.contains("\t")).count(),
                 "three hits, whatever the default would have been");

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheDocCommandAnswersFromTheBundledSpecTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheDocCommandAnswersFromTheBundledSpecTest.java
@@ -47,11 +47,12 @@ class TheDocCommandAnswersFromTheBundledSpecTest {
 
     @Test
     void searchListsTheSectionsThatSayTheTerm() {
-        Answer answer = run("--search", "newtype");
+        Answer answer = run("--search", "single-value newtype");
 
         assertEquals(0, answer.code());
-        assertTrue(answer.out().lines().anyMatch(l -> l.startsWith("newtype\t")),
-                "the newtype section is among the hits:\n" + answer.out());
+        assertTrue(answer.out().lines().anyMatch(l -> l.startsWith("newtype-comparison\t")),
+                "a term nobody is named after is answered with the sections that say it:\n"
+                        + answer.out());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/doc/TheSchemaAClientReadsIsTheOneTheServerEnforcesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/TheSchemaAClientReadsIsTheOneTheServerEnforcesTest.java
@@ -84,7 +84,7 @@ class TheSchemaAClientReadsIsTheOneTheServerEnforcesTest {
     @Test
     void aCountWrittenWithAPointIsReadAsTheCountAndNotMerelyAllowed() {
         String one = serve("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":"
-                + "\"doc_search\",\"arguments\":{\"term\":\"newtype\",\"limit\":1.0}}}")
+                + "\"doc_search\",\"arguments\":{\"term\":\"type\",\"limit\":1.0}}}")
                 .getFirst().get("result").get("content").get(0).get("text").asString();
 
         assertEquals(1, one.lines().filter(line -> line.contains("\t")).count(), one);


### PR DESCRIPTION
Closes #519.

`doc_read` and `doc_search` read one document and asked it two different
questions. The read path answers over the names the specification writes; the
search ranked titles and prose and never consulted them, so whether a name
could be found by searching for it depended on whether some paragraph happened
to spell it out.

Of the 473 names the read path resolves, the search ranked the named section
first for 184. For 136 it answered with the sections that cite the name and
never the one it names — a name is written in prose only where another section
cites it. For 123 it answered with nothing, 102 of those being diagnostic
codes: `doc_search {term: "E1004"}` said nothing says it while
`doc_read {name: "E1004"}` printed the section. A heading's anchor is written
on the line above the heading, and that line belongs to no section's body, so
the name a reader most often arrives holding is the one the text never says.

## What a search does now

It asks three things in turn and stops at the first that answers.

1. **Name.** Resolved over the same names the read path answers for, folded to
   the words they are made of, and answered with that one document.
   `an-optional-does-not-stand-in-a-boundary` and `an optional does not stand
   in a boundary` are one question, and so is a diagnostic code in either case.
2. **Phrase.** The documents saying the term as it stands, as before.
3. **Words.** The documents saying its words, ranked by how many of them each
   one holds.

All 491 names — 473 in the specification and 18 shipped topics — resolve, both
as written and as their words. The listing is a regression test rather than a
measurement: `ANameIsResolvedRatherThanRankedTest` walks every one of them.

## The word fallback was a second defect

It ranked each word on its own and appended the results, so the page came from
whichever word was typed first. `{term: "nested if else which if an else
belongs to"}` was answered with the hits for `nested`. A query is scored whole
now, by how many of its words a document holds before how often it says any of
them, which also makes the answer independent of the order the words were
typed in. A word is a whole word there — `an` was matching inside `command`.

The two corpora were also scored by two rules: a shipped topic was found by its
name and a specification section was not, while the two are merged into one
list and sorted once. Both go through one `Match` now.

## Tests

Four existing tests searched for `newtype` or `invariant` to exercise a hit
list or a `limit`. Both are names, so those searches answer with one section
now; the tests ask the same things of a term that is nobody's name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
