### PR TITLE
A string literal ends on its line and refuses an escape it does not read

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -1048,8 +1048,16 @@ public final class Backend {
      * jar built before this carries a {@code $Enc} that writes {@code {"value": …}} and a
      * {@code $Dec} that demands it, which this compiler's sum encoder would wrap a second time and
      * its sum decoder would hand the inner value to.
+     *
+     * <p>Version 11 narrows what a string literal may be: it ends on the line it began on, and a
+     * backslash is read only before {@code n}, {@code t}, {@code r}, a quote and another backslash
+     * (spec §string-literal). A published helper's body travels in the jar as source and is read
+     * back by the importing compiler (spec §exposed-values), so what a literal may be is part of
+     * what a compiled module promises. A jar built before this may carry a body this compiler
+     * cannot read — a literal that ran past its line — or one whose backslash the older compiler
+     * dropped in silence and this one refuses.
      */
-    public static final int BOUNDARY_VERSION = 10;
+    public static final int BOUNDARY_VERSION = 11;
 
     /** The class a module's own declarations are published on. It carries nothing but them. */
     public static String moduleClassName(String moduleName) {

--- a/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
+++ b/souther-compiler/src/main/java/souther/compiler/frontend/AstBuilder.java
@@ -1503,7 +1503,12 @@ public final class AstBuilder {
                     case 'r' -> '\r';
                     case '"' -> '"';
                     case '\\' -> '\\';
-                    default -> e;
+                    // The lexer refuses a backslash written before anything else, and a source
+                    // that did not read never reaches here (CstFrontend raises on the first
+                    // error). Reading it as the character alone would take a character the author
+                    // wrote out of the value and say nothing about it.
+                    default -> throw new IllegalStateException(
+                            "an escape the lexer refuses reached the builder: \\" + e);
                 });
             } else {
                 sb.append(c);

--- a/souther-compiler/src/main/java/souther/compiler/highlight/TmLanguageGenerator.java
+++ b/souther-compiler/src/main/java/souther/compiler/highlight/TmLanguageGenerator.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 /**
  * Generates a TextMate grammar ({@code souther.tmLanguage.json}) from the language's lexical
@@ -130,16 +131,34 @@ public final class TmLanguageGenerator {
         return m;
     }
 
+    /**
+     * A string literal, ended by its quote or by the line, whichever comes first — the literal does
+     * not span lines, so a missing quote colours one line rather than the rest of the file.
+     *
+     * <p>The escapes come from {@link CstLexer#escapes()}, and a backslash before anything else is
+     * marked as what it is: the compiler refuses it, and an editor that coloured it as an escape
+     * would be promising a compile that does not happen.
+     */
     private static Map<String, Object> strings() {
         Map<String, Object> escape = new LinkedHashMap<>();
         escape.put("name", "constant.character.escape.souther");
-        escape.put("match", "\\\\.");
+        escape.put("match", "\\\\[" + escapeClass() + "]");
+        Map<String, Object> refused = new LinkedHashMap<>();
+        refused.put("name", "invalid.illegal.escape.souther");
+        refused.put("match", "\\\\.");
         Map<String, Object> m = new LinkedHashMap<>();
         m.put("name", "string.quoted.double.souther");
         m.put("begin", "\"");
-        m.put("end", "\"");
-        m.put("patterns", List.of(escape));
+        m.put("end", "\"|$");
+        m.put("patterns", List.of(escape, refused));
         return m;
+    }
+
+    /** The escapes as a character class, sorted for a stable, reproducible file. */
+    private static String escapeClass() {
+        return new TreeSet<>(CstLexer.escapes()).stream()
+                .map(TmLanguageGenerator::regexEscape)
+                .collect(Collectors.joining());
     }
 
     /** A word-boundary alternation over a sorted keyword set (sorted for a stable, reproducible file). */

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -511,6 +511,7 @@ parse.a-fake-needs-at-least-one-row=A `fake` needs at least one `|` row.
 parse.a-type-variable-needs-a-name-after-the-apostrophe=A type variable needs a name after `'`, e.g. `'a`.
 parse.a-fractional-literal-needs-the-m-suffix=A fractional literal is a Decimal and needs the `m` suffix (write `{literal}m`); Souther has no floating-point type.
 parse.a-string-literal-is-not-closed=This string literal is not closed before the end of the line.
+parse.an-escape-is-not-one-the-language-reads=`\\{escaped}` is not an escape this language reads. The escapes are `\\n`, `\\t`, `\\r`, `\\"` and `\\\\`; a backslash of its own is written `\\\\`.
 parse.an-unexpected-character=Unexpected character `{character}`.
 tok.name=a name
 tok.integer=an integer

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -506,6 +506,7 @@ parse.a-fake-needs-at-least-one-row=fake には `|` で始まる行が少なく�
 parse.a-type-variable-needs-a-name-after-the-apostrophe=型変数には `'` の後ろに名前が必要です（例: `'a`）。
 parse.a-fractional-literal-needs-the-m-suffix=小数リテラルは Decimal です。`m` を付けてください（例: `{literal}m`）。Souther に浮動小数点型はありません。
 parse.a-string-literal-is-not-closed=この文字列リテラルが行末までに閉じられていません。
+parse.an-escape-is-not-one-the-language-reads=`\\{escaped}` は読めるエスケープではありません。読めるのは `\\n` `\\t` `\\r` `\\"` `\\\\` です。バックスラッシュ自体は `\\\\` と書きます。
 parse.an-unexpected-character=予期しない文字 `{character}` です。
 tok.name=名前
 tok.integer=整数

--- a/souther-compiler/src/main/resources/souther/compiler/highlight/souther.tmLanguage.json
+++ b/souther-compiler/src/main/resources/souther/compiler/highlight/souther.tmLanguage.json
@@ -34,9 +34,12 @@
     "strings" : {
       "name" : "string.quoted.double.souther",
       "begin" : "\"",
-      "end" : "\"",
+      "end" : "\"|$",
       "patterns" : [ {
         "name" : "constant.character.escape.souther",
+        "match" : "\\\\[\"\\\\nrt]"
+      }, {
+        "name" : "invalid.illegal.escape.souther",
         "match" : "\\\\."
       } ]
     },

--- a/souther-compiler/src/test/java/souther/compiler/cst/AStringLiteralEndsOnItsOwnLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/cst/AStringLiteralEndsOnItsOwnLineTest.java
@@ -1,0 +1,73 @@
+package souther.compiler.cst;
+
+import souther.compiler.diag.msg.ParseMessage;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * What a string literal may be, held against the lexer that decides it.
+ *
+ * <p>Two rules, and each is about what the reader is told rather than only about what is refused.
+ * A literal that ran past its line took the rest of the file into itself and reported the loss
+ * wherever it finally stopped, so the one missing quote was answered somewhere it was not. A
+ * backslash before something that is not an escape used to be read as the character alone, which
+ * took a character the author wrote out of the value and said nothing.
+ *
+ * <p>The last test is the positive control: the five escapes still read, so a refusal here is a
+ * refusal of what the rule names and not of every backslash.
+ */
+class AStringLiteralEndsOnItsOwnLineTest {
+
+    private static List<String> saidBy(String src) {
+        return CstLexer.lex(src).errors().stream()
+                .map(error -> error.said().getClass().getSimpleName())
+                .toList();
+    }
+
+    private static List<String> literalsOf(String src) {
+        return CstLexer.lex(src).tokens().stream()
+                .filter(token -> token.kind() == SyntaxKind.STRING_LIT)
+                .map(GreenToken::text)
+                .toList();
+    }
+
+    @Test
+    void aQuoteMissingBeforeTheNewlineIsSaidAtThatLine() {
+        String src = """
+                let a = "one
+                let b = 1
+                """;
+        assertEquals("AStringLiteralIsNotClosed", saidBy(src).getFirst());
+        assertEquals("\"one", literalsOf(src).getFirst());
+    }
+
+    @Test
+    void aBackslashDoesNotCarryTheLiteralOverTheNewline() {
+        String src = "let a = \"one\\\nlet b = 1\n";
+        assertEquals("AStringLiteralIsNotClosed", saidBy(src).getFirst());
+        assertEquals("\"one\\", literalsOf(src).getFirst());
+    }
+
+    @Test
+    void aBackslashBeforeSomethingThatIsNotAnEscapeIsRefusedAndNamed() {
+        List<ParseMessage.AnEscapeIsNotOneTheLanguageReads> said =
+                CstLexer.lex("let a = \"a\\qb\"\n").errors().stream()
+                        .map(error -> error.said())
+                        .filter(ParseMessage.AnEscapeIsNotOneTheLanguageReads.class::isInstance)
+                        .map(ParseMessage.AnEscapeIsNotOneTheLanguageReads.class::cast)
+                        .toList();
+        assertEquals(1, said.size());
+        assertEquals("q", said.getFirst().escaped());
+    }
+
+    @Test
+    void theFiveEscapesAreRead() {
+        String src = "let a = \"n\\nt\\tr\\rq\\\"b\\\\\"\n";
+        assertEquals(List.of(), saidBy(src));
+        assertEquals(1, literalsOf(src).size());
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/cst/CstLexer.java
+++ b/souther-syntax/src/main/java/souther/compiler/cst/CstLexer.java
@@ -3,9 +3,11 @@ package souther.compiler.cst;
 import souther.compiler.diag.msg.ParseMessage;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * A trivia-preserving, non-throwing lexer. It turns source into a flat stream of {@link GreenToken}s
@@ -47,6 +49,21 @@ public final class CstLexer {
     /** The reserved keywords, the single source of truth a syntax-highlighter grammar derives from. */
     public static Set<String> keywords() {
         return KEYWORDS.keySet();
+    }
+
+    /** The characters a backslash may be written before. */
+    private static final String ESCAPES = "ntr\"\\";
+
+    /**
+     * The characters a backslash may be written before, each as it is written.
+     *
+     * <p>The same list the scan refuses by, so a highlighter marking what the compiler refuses reads
+     * this rather than restating it. Two lists would disagree the first time one of them moved, and
+     * the editor would colour as an escape what a compile then rejects.
+     */
+    public static Set<String> escapes() {
+        return ESCAPES.chars().mapToObj(c -> String.valueOf((char) c))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     /** The lexer's result: the token stream (trivia and a trailing {@code EOF} included) and any
@@ -151,22 +168,40 @@ public final class CstLexer {
         emit(SyntaxKind.INT_LIT, start);
     }
 
+    /**
+     * A string literal, which ends on the line it began on.
+     *
+     * <p>A newline closes nothing: a literal whose quote is missing is one line's mistake, and a
+     * scan that ran past the line would take the rest of the file into it and report the loss
+     * wherever it finally stopped. Written this way the reader is told where the quote is missing.
+     * A newline in a value is written {@code \n}.
+     */
     private void string(int start) {
         pos++;   // opening quote
-        while (pos < src.length() && src.charAt(pos) != '"') {
-            if (src.charAt(pos) == '\\' && pos + 1 < src.length()) {
-                pos += 2;   // skip the escaped character
+        while (pos < src.length() && src.charAt(pos) != '"' && !endsTheLine(src.charAt(pos))) {
+            if (src.charAt(pos) == '\\' && pos + 1 < src.length() && !endsTheLine(src.charAt(pos + 1))) {
+                char escaped = src.charAt(pos + 1);
+                if (ESCAPES.indexOf(escaped) < 0) {
+                    errors.add(CstError.of(pos, 2,
+                            new ParseMessage.AnEscapeIsNotOneTheLanguageReads(String.valueOf(escaped))));
+                }
+                pos += 2;   // the backslash and what it was written before
             } else {
                 pos++;
             }
         }
-        if (pos >= src.length()) {
+        if (pos >= src.length() || endsTheLine(src.charAt(pos))) {
             errors.add(CstError.of(start, pos - start, new ParseMessage.AStringLiteralIsNotClosed()));
-            emit(SyntaxKind.STRING_LIT, start);   // covers to EOF, keeping the tree lossless
+            emit(SyntaxKind.STRING_LIT, start);   // stops at the line, keeping the tree lossless
             return;
         }
         pos++;   // closing quote
         emit(SyntaxKind.STRING_LIT, start);
+    }
+
+    /** Whether {@code c} ends the line, either spelling of it. */
+    private static boolean endsTheLine(char c) {
+        return c == '\n' || c == '\r';
     }
 
     /** A type variable {@code 'a}. Only the core writes these; the parser gates their use. */

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/ParseMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/ParseMessage.java
@@ -126,6 +126,16 @@ public sealed interface ParseMessage extends Message {
     @Code(DiagnosticCode.E2305)
     record AStringLiteralIsNotClosed() implements ParseMessage, Reported {}
 
+    /**
+     * A backslash written before something the language does not read as an escape.
+     *
+     * <p>Refused rather than read as the character alone: dropping the backslash would take a
+     * character the author wrote out of the value and say nothing, so a mistyped `\d` would become
+     * `d` and a pattern would be run against text nobody wrote.
+     */
+    @Code(DiagnosticCode.E2305)
+    record AnEscapeIsNotOneTheLanguageReads(String escaped) implements ParseMessage, Reported {}
+
     @Code(DiagnosticCode.E2306)
     record AnUnexpectedCharacter(String character) implements ParseMessage, Reported {}
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -547,7 +547,7 @@ A backslash is read before these characters, and before nothing else:
 \\   a backslash
 ----
 
-A backslash written before anything else is refused (<<e2305>>). It is not read as the character alone: doing that would take a character the author wrote out of the value and say nothing about it, so `+"\d"+` would be the text `+d+`. A regular expression's class is therefore written with the backslash doubled — `+"\\d{3}"+` is the four characters `+\d{3}+` (<<stdlib-string>>).
+A backslash written before anything else is refused (<<e2305>>). It is not read as the character alone: doing that would take a character the author wrote out of the value and say nothing about it, so `+"\d"+` would be the text `+d+`. A regular expression's class is therefore written with the backslash doubled — `+"\\d{3}"+` is the text `+\d{3}+` (<<stdlib-string>>).
 
 A literal's value is normalized to Unicode NFC. A source file is text from an editor, which is the other place text arrives from outside — the first being a decoder, which canonicalizes for the same reason (<<decoder>>). Two canonically equivalent forms are the same text by Unicode's definition and different values to a comparison by code units, so a literal left as written would compare unequal to the same text that came in through a boundary. Which form an editor writes is not something the author chose. The folding is NFC and not NFKC: compatibility folding turns ① into 1 and a half-width kana into a full-width one, which is a different claim about the text than "these are the same characters".
 

--- a/specification.adoc
+++ b/specification.adoc
@@ -531,6 +531,26 @@ DateTime     // date-time. ISO 8601. java.time.LocalDateTime
 
 An integer literal is written as `+500+` and is `+Int+`. A `+Decimal+` literal takes an `+m+` suffix — `+500m+`, `+1.5m+`, `+0.5m+`. A fractional literal without `+m+`, such as `+1.5+`, is an error. Souther has no binary floating-point type and defaults fractions to `+Decimal+` (exact decimal), so `+Int+` and `+Decimal+` MUST be made explicit at the literal.
 
+[#string-literal]
+==== String literals
+
+A `+String+` literal is written between `+"+` and `+"+`, and it ends on the line it began on. A literal not closed before the end of the line is refused there (<<e2305>>). A newline in a value is written `+\n+`; the language has no multi-line literal form.
+
+A backslash is read before these characters, and before nothing else:
+
+[,text]
+----
+\n   a newline
+\t   a tab
+\r   a carriage return
+\"   a quote, which does not close the literal
+\\   a backslash
+----
+
+A backslash written before anything else is refused (<<e2305>>). It is not read as the character alone: doing that would take a character the author wrote out of the value and say nothing about it, so `+"\d"+` would be the text `+d+`. A regular expression's class is therefore written with the backslash doubled — `+"\\d{3}"+` is the four characters `+\d{3}+` (<<stdlib-string>>).
+
+A literal's value is normalized to Unicode NFC. A source file is text from an editor, which is the other place text arrives from outside — the first being a decoder, which canonicalizes for the same reason (<<decoder>>). Two canonically equivalent forms are the same text by Unicode's definition and different values to a comparison by code units, so a literal left as written would compare unequal to the same text that came in through a boundary. Which form an editor writes is not something the author chose. The folding is NFC and not NFKC: compatibility folding turns ① into 1 and a half-width kana into a full-width one, which is a different claim about the text than "these are the same characters".
+
 [#equality]
 ==== Equality
 
@@ -3182,7 +3202,7 @@ data SiteId = String
     invariant String.matches(sitePrefix ++ "[0-9A-Za-z]{12}", value)
 ----
 
-What is validated is the string the whole expression evaluates to, not the pieces it is written in. At run time the pattern is compiled on first use and cached, not recompiled on each call. A regex backslash class is written with a doubled backslash (`+"\\d{3}"+`), since a string literal drops the backslash of an unknown escape (<<primitives>>). A pattern a run-time value takes part in is therefore not accepted (a future `+Regex+`/`+fromString+` would carry that, returning a case for an invalid pattern); a pattern the compiler can read is what the invariant needs. Regex lives in core rather than a package, since Souther has no package layer. A pathological pattern can backtrack; keep invariant patterns simple.
+What is validated is the string the whole expression evaluates to, not the pieces it is written in. At run time the pattern is compiled on first use and cached, not recompiled on each call. A regex backslash class is written with a doubled backslash (`+"\\d{3}"+`), since `+\d+` is not an escape a string literal reads and a lone backslash before `+d+` is refused (<<string-literal>>). A pattern a run-time value takes part in is therefore not accepted (a future `+Regex+`/`+fromString+` would carry that, returning a case for an invalid pattern); a pattern the compiler can read is what the invariant needs. Regex lives in core rather than a package, since Souther has no package layer. A pathological pattern can backtrack; keep invariant patterns simple.
 
 The middle row is the rest of what Souther's types allow, which have no `+Char+`, `+Maybe+` or `+Float+`. `+split(sep, s)+` splits by a separator into `+List<String>+`, keeping empty pieces (`+split(",", "a,,b")+` is `+["a", "", "b"]+`). `+words(s)+` splits by runs of whitespace, dropping empty pieces. `+join(sep, xs)+` joins with a separator. `+replace(target, replacement, s)+` replaces every occurrence of `+target+`. `+fromInt(n)+` makes an `+Int+` a decimal string. `+concat(xs)+` joins a `+List<String>+` with no separator (equal to `+join("", xs)+`). The primary subject string is last (<<pipe>>). There is no `+Char+` type and no character-mapping operation.
 
@@ -5468,7 +5488,7 @@ A fractional literal is a Decimal and needs the `m` suffix (write `1.5m`); South
 floating-point type.
 ----
 
-Reported while reading the text into tokens, before anything is parsed (<<literal-syntax>>): a string not closed before the end of the line, a fractional literal with no `+m+`, a type variable with no name after `+'+`, a character that begins nothing.
+Reported where a literal is not written in the form its type takes (<<literal-syntax>>). Most of it is answered while the text is read into tokens, before anything is parsed: a string not closed before the end of the line, a backslash written before something that is not an escape (<<string-literal>>), a fractional literal with no `+m+`. One is answered after, where a literal was expected and what stands there cannot be one.
 
 [#e2306]
 === The text is not made of tokens


### PR DESCRIPTION
Closes #570.

What a string literal is had never been decided. The lexer scanned to the closing quote or to the end of the file, so a literal spanned lines and a missing quote swallowed the rest of the file before reporting the loss wherever it stopped. A backslash before anything unrecognised was read as the character alone, so `"\d"` was the text `d`.

Neither rule was written anywhere, and the two places that spoke of them described a third thing: E2305 and the message the compiler prints both say "a string not closed before the end of the line", which is not what the lexer did.

## Why Elm's rule

Souther grounds its syntax in F# and Elm, and on both of these points they disagree, so the grounding does not settle it. Measured rather than recalled — Elm 0.19.2 and `dotnet fsi`:

| | newline inside `"..."` | `"a\qb"` |
| --- | --- | --- |
| Elm | refused — `ENDLESS STRING`, points at `"""` | refused — `UNKNOWN ESCAPE`, lists what it reads |
| F# | accepted, newline in the value | accepted, `\` and `q` both kept |
| Souther, before | accepted, newline in the value | accepted, backslash dropped |

Of the three, only Souther discarded a character the author wrote and said nothing. On the newline, Elm's rule keeps one missing quote to one line, and it is the rule E2305's own sentence already described. Souther has no `"""` to lose by it — and adding one, or `\'`, or `\u{...}`, is a separate decision that nothing has asked for.

## What changed

- `CstLexer` stops at the line and refuses a backslash before anything but `n`, `t`, `r`, a quote and another backslash, naming the ones it reads (`AnEscapeIsNotOneTheLanguageReads`, E2305).
- `AstBuilder.unescaped` has no default to fall to: the lexer has refused it, and a source that did not read never reaches there.
- `specification.adoc` gains `[#string-literal]` — the escapes, the refusal, and the NFC normalization a literal's value already got. `stdlib-string` explained the doubled backslash of a regex class by the dropped-backslash rule; it is the refusal now. E2305's own section was listing two of E2306's producers, and now lists its own.
- `BOUNDARY_VERSION` moves to 11. A published helper's body travels in the jar as source and is read back by the importing compiler, so what a literal may be is part of what a compiled module promises.
- The TextMate grammar was writing the old rule too. It now ends at the line, and takes its escapes from `CstLexer.escapes()` — the same list the scan refuses by — marking anything else as invalid.

## Checks

`mvn clean test` across every module: 572 test classes, no failures.

The 16 `.sou` files in the repository were run through the new lexer before the change was believed: none of them held a literal that spanned a line or a backslash the language does not read.

`AStringLiteralEndsOnItsOwnLineTest` holds the two rules against the lexer, with the five escapes as its positive control so a refusal is a refusal of what the rule names.

Found while investigating #520, and filed apart from it because this changes what the compiler accepts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
