### PR TITLE
The canonical form is a contract, and three layout questions it exposed

### DIFF
--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -49,6 +49,60 @@ canonical form is what the verdict is taken against, so a failing build says wha
 than only which file did, and nothing has to be formatted a second time locally to read it. A file
 already in canonical form is not mentioned.
 
+### What the canonical form is
+
+There is one form per program and the formatter derives it from the tree, so nothing about the
+layout you write is kept. These are the rules it derives it by, so that what the tool will write can
+be read here rather than reconstructed from having run it.
+
+Lines are at most 100 columns and a nesting level is 4 spaces. A line longer than 100 columns is one
+whose content holds nowhere to break — a long string, a single long name, a nesting deep enough that
+the indent takes the width. That is not an exemption for some constructs: everything that has a
+boundary to break at breaks at it, and a 130-column `unreachable` message survives only because a
+string literal has none.
+
+Where a blank line goes is yours; how big it is is not. Between two top-level items, and between two
+steps of a block, one blank line comes back as one and three come back as one, and none stays none —
+so a run of related one-line declarations stays a run and a body written as paragraphs keeps them.
+Two places are the file's rather than yours and get a blank line whatever you wrote: under a module
+header, and under the last import. Nothing else is kept: a blank line inside a construct, between
+the fields of a `data` or the arms of a `match`, is not a paragraph break and does not survive.
+
+A `data` product body writes each field on a line of its own, opening the line with the `{` for the
+first and with a `,` for the rest, and closing with a `}` at the body's own indent. It is written
+that way whenever it has a field, whether or not it would fit on one line; a body with no fields is
+`{}`.
+
+```
+data Employee =
+    { id: EmployeeId
+    , rank: Rank
+    }
+```
+
+Everything else written between brackets — a record literal, an argument list, a parameter list, a
+type argument list, a tuple, a list literal, the names in `exposing` and `import` — is written on one
+line if it fits and one member to a line if it does not, each line but the last ending with its `,`.
+No trailing `,` is written before the closing bracket in either case.
+
+```
+let e = Employee { id = EmployeeId("e-1"), rank = Staff }
+
+let wide =
+    Employee {
+        id = EmployeeId("an-identifier-long-enough-that-the-literal-does-not-fit-on-one-line"),
+        rank = Staff
+    }
+```
+
+So the two conventions are the constructs' and not the file's: a `data` body opens its lines with
+the comma and everything else closes them with it.
+
+A comment keeps what it was written about. On the line of the code it follows it stays there; on a
+line of its own it goes above what follows it, unless a blank line separates it from that and none
+separates it from the code above, in which case it stays under that code. A comment with nothing
+after it closes whatever holds it.
+
 <!-- souther-section: examples -->
 ## examples
 

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -51,9 +51,14 @@ already in canonical form is not mentioned.
 
 ### What the canonical form is
 
-There is one form per program and the formatter derives it from the tree, so nothing about the
-layout you write is kept. These are the rules it derives it by, so that what the tool will write can
-be read here rather than reconstructed from having run it.
+The formatter derives the layout rather than keeping yours. Two of the things you wrote are
+structure and not layout, and it keeps those: where a paragraph break is, and what a comment was
+written about. Everything else is derived. So there is one form per program taken with those two —
+write the same program with the same paragraphs and the same comments and the same text comes back,
+however differently the rest of it was laid out.
+
+These are the rules it derives it by, so that what the tool will write can be read here rather than
+reconstructed from having run it.
 
 Lines are at most 100 columns and a nesting level is 4 spaces. A line longer than 100 columns is one
 whose content holds nowhere to break — a long string, a single long name, a nesting deep enough that
@@ -64,9 +69,10 @@ string literal has none.
 Where a blank line goes is yours; how big it is is not. Between two top-level items, and between two
 steps of a block, one blank line comes back as one and three come back as one, and none stays none —
 so a run of related one-line declarations stays a run and a body written as paragraphs keeps them.
-Two places are the file's rather than yours and get a blank line whatever you wrote: under a module
-header, and under the last import. Nothing else is kept: a blank line inside a construct, between
-the fields of a `data` or the arms of a `match`, is not a paragraph break and does not survive.
+Two places are the file's rather than yours and get a blank line whatever you wrote: under the header
+a file opens with — a `module` or an `examples for` — and under the last import. Nothing else is
+kept: a blank line inside a construct, between the fields of a `data` or the arms of a `match`, is
+not a paragraph break and does not survive.
 
 A `data` product body writes each field on a line of its own, opening the line with the `{` for the
 first and with a `,` for the rest, and closing with a `}` at the body's own indent. It is written
@@ -80,10 +86,11 @@ data Employee =
     }
 ```
 
-Everything else written between brackets — a record literal, an argument list, a parameter list, a
-type argument list, a tuple, a list literal, the names in `exposing` and `import` — is written on one
-line if it fits and one member to a line if it does not, each line but the last ending with its `,`.
-No trailing `,` is written before the closing bracket in either case.
+Everything else written between brackets — a record literal, an argument list, a type argument list,
+a tuple, a list literal, the names in `exposing` and `import` — fits or breaks as one thing: written
+on one line where it fits and one member to a line where it does not, each line but the last ending
+with its `,`. No trailing `,` is written before the closing bracket in either case. A behavior's
+parameter list is the exception and is laid out with the signature holding it, below.
 
 ```
 let e = Employee { id = EmployeeId("e-1"), rank = Staff }
@@ -97,6 +104,30 @@ let wide =
 
 So the two conventions are the constructs' and not the file's: a `data` body opens its lines with
 the comma and everything else closes them with it.
+
+A behavior signature lays its inputs and its output out together, so neither is decided on its own.
+Where the whole signature fits, it is one line. Where it does not, the parameter list breaks first —
+one parameter to a line, with the `)` opening the line the output is written on — and the output
+union breaks only where it still does not fit that line. A parameter list short enough for a line of
+its own is therefore written down the page anyway when what follows the arrow leaves it no room:
+inputs give way before the output, so that a signature keeps its three parts whole for as long as it
+can rather than leaving the first member of a union on the signature line beside the arrow.
+
+```
+behavior fits : (a: A, b: B) -> X | Y
+
+behavior preApprove : (
+    request: AwaitingPreApproval,
+    approverId: EmployeeId
+) -> PreApproved | NotAuthorized
+
+behavior judge : (
+    code: Code
+) -> AcceptedByTheUnderwriter
+    | RefusedByTheUnderwriter
+    | DeferredForManualReview
+    | EscalatedToTheManager
+```
 
 A comment keeps what it was written about. On the line of the code it follows it stays there; on a
 line of its own it goes above what follows it, unless a blank line separates it from that and none

--- a/souther-compiler/src/main/resources/souther/date.sou
+++ b/souther-compiler/src/main/resources/souther/date.sou
@@ -8,10 +8,10 @@ module souther.date
 // Argument order follows F#/Elm ([#pipe]): the date operated on comes last, so
 // `d |> Date.addDays(3)` reads left to right. `daysBetween(from, to)` counts whole days from `from`
 // to `to`, negative when `to` precedes `from`.
-let addDays (days: Int, d: Date) : Date = intrinsic "date.addDays"
-let addMonths (months: Int, d: Date) : Date = intrinsic "date.addMonths"
-let addYears (years: Int, d: Date) : Date = intrinsic "date.addYears"
-let daysBetween (from: Date, to: Date) : Int = intrinsic "date.daysBetween"
+let addDays (days: Int, d: Date): Date = intrinsic "date.addDays"
+let addMonths (months: Int, d: Date): Date = intrinsic "date.addMonths"
+let addYears (years: Int, d: Date): Date = intrinsic "date.addYears"
+let daysBetween (from: Date, to: Date): Int = intrinsic "date.daysBetween"
 
 // The parts of a date. `year` and `day` are Ints in both Elm (`Time.toYear` / `toDay`) and .NET
 // (`DateTime.Year` / `Day`). `month` follows .NET rather than Elm, whose `Month` is a twelve-case
@@ -24,6 +24,6 @@ let daysBetween (from: Date, to: Date) : Int = intrinsic "date.daysBetween"
 // nor .NET ships a month-end function either:
 //     let monthStart (d: Date): Date = Date.addDays(1 - Date.day(d), d)
 //     let endOfMonth (d: Date): Date = Date.addDays(0 - 1, Date.addMonths(1, monthStart(d)))
-let year (d: Date) : Int = intrinsic "date.year"
-let month (d: Date) : Int = intrinsic "date.month"
-let day (d: Date) : Int = intrinsic "date.day"
+let year (d: Date): Int = intrinsic "date.year"
+let month (d: Date): Int = intrinsic "date.month"
+let day (d: Date): Int = intrinsic "date.day"

--- a/souther-compiler/src/main/resources/souther/datetime.sou
+++ b/souther-compiler/src/main/resources/souther/datetime.sou
@@ -6,8 +6,8 @@ module souther.datetime
 //
 // Argument order is F#/Elm ([#pipe]): the date-time operated on comes last. `minutesBetween(from,
 // to)` counts whole minutes; `toDate` drops the time of day, yielding a `Date`.
-let addMinutes (minutes: Int, dt: DateTime) : DateTime = intrinsic "datetime.addMinutes"
-let addHours (hours: Int, dt: DateTime) : DateTime = intrinsic "datetime.addHours"
-let addDays (days: Int, dt: DateTime) : DateTime = intrinsic "datetime.addDays"
-let minutesBetween (from: DateTime, to: DateTime) : Int = intrinsic "datetime.minutesBetween"
-let toDate (dt: DateTime) : Date = intrinsic "datetime.toDate"
+let addMinutes (minutes: Int, dt: DateTime): DateTime = intrinsic "datetime.addMinutes"
+let addHours (hours: Int, dt: DateTime): DateTime = intrinsic "datetime.addHours"
+let addDays (days: Int, dt: DateTime): DateTime = intrinsic "datetime.addDays"
+let minutesBetween (from: DateTime, to: DateTime): Int = intrinsic "datetime.minutesBetween"
+let toDate (dt: DateTime): Date = intrinsic "datetime.toDate"

--- a/souther-compiler/src/main/resources/souther/decimal.sou
+++ b/souther-compiler/src/main/resources/souther/decimal.sou
@@ -18,17 +18,17 @@ data RoundingMode = HALF_UP | HALF_EVEN | HALF_DOWN | UP | DOWN | CEILING | FLOO
 // the order the mathematics writes them in and the policy follows them. The `(scale, mode)` pair
 // therefore sits in front of the subject in one and behind the operands in the other, which is the
 // two rules meeting rather than an accident.
-let divide (dividend: Decimal, divisor: Decimal, scale: Int, mode: RoundingMode)
-    : Decimal | DivisionByZero = intrinsic "decimal.divide"
-let toInt (mode: RoundingMode, d: Decimal) : Int = intrinsic "decimal.toInt"
-let round (scale: Int, mode: RoundingMode, d: Decimal) : Decimal = intrinsic "decimal.round"
+let divide (dividend: Decimal, divisor: Decimal, scale: Int, mode: RoundingMode): Decimal
+    | DivisionByZero = intrinsic "decimal.divide"
+let toInt (mode: RoundingMode, d: Decimal): Int = intrinsic "decimal.toInt"
+let round (scale: Int, mode: RoundingMode, d: Decimal): Decimal = intrinsic "decimal.round"
 
-let add (a: Decimal, b: Decimal) : Decimal = intrinsic "decimal.add"
-let subtract (a: Decimal, b: Decimal) : Decimal = intrinsic "decimal.subtract"
-let multiply (a: Decimal, b: Decimal) : Decimal = intrinsic "decimal.multiply"
+let add (a: Decimal, b: Decimal): Decimal = intrinsic "decimal.add"
+let subtract (a: Decimal, b: Decimal): Decimal = intrinsic "decimal.subtract"
+let multiply (a: Decimal, b: Decimal): Decimal = intrinsic "decimal.multiply"
 
 // compare returns -1, 0, or 1 by numeric value, ignoring scale.
-let compare (a: Decimal, b: Decimal) : Int = intrinsic "decimal.compare"
+let compare (a: Decimal, b: Decimal): Int = intrinsic "decimal.compare"
 
 // `fromInt` widens an Int to a Decimal. It is exact — every Int is a Decimal — so nothing has to be
 // stated and it is an ordinary function. The narrowing back, `Decimal.toInt(mode, d)`, drops a
@@ -38,7 +38,7 @@ let compare (a: Decimal, b: Decimal) : Int = intrinsic "decimal.compare"
 // applied to an amount is written `Decimal.fromInt(税抜) * 税率` — the conversion is visible where the
 // value stops being an amount in yen. This is F#'s position for operators (`n * 0.1m` does not
 // compile; `decimal n * 0.1m` does).
-let fromInt (n: Int) : Decimal = intrinsic "decimal.fromInt"
+let fromInt (n: Int): Decimal = intrinsic "decimal.fromInt"
 
 // The same `Basics` arithmetic `Int` carries, on the same reasoning: `<` and `-` are defined for
 // Decimal, so these are ordinary helpers. `abs` compares against `0.0m`, so a value whose scale
@@ -48,4 +48,5 @@ let fromInt (n: Int) : Decimal = intrinsic "decimal.fromInt"
 let abs (d: Decimal): Decimal = if d < 0.0m then 0.0m - d else d
 let min (a: Decimal, b: Decimal): Decimal = if a < b then a else b
 let max (a: Decimal, b: Decimal): Decimal = if a > b then a else b
-let clamp (lo: Decimal, hi: Decimal, d: Decimal): Decimal = if d < lo then lo else if d > hi then hi else d
+let clamp (lo: Decimal, hi: Decimal, d: Decimal): Decimal =
+    if d < lo then lo else if d > hi then hi else d

--- a/souther-compiler/src/main/resources/souther/int.sou
+++ b/souther-compiler/src/main/resources/souther/int.sou
@@ -9,20 +9,20 @@
 // core declaration cannot yet express. See the stdlib implementation-location policy.
 module souther.int
 
-let divide (dividend: Int, divisor: Int) : Int | DivisionByZero = intrinsic "int.divide"
+let divide (dividend: Int, divisor: Int): Int | DivisionByZero = intrinsic "int.divide"
 
 // `truncatingRemainder` is the remainder of a division whose quotient is truncated toward zero, so
 // its result takes the sign of the dividend: `truncatingRemainder(-7, 3)` is `-1`. The name carries
 // that, because a bare `remainder` (or `mod`) means the truncated one in some languages and the
 // floored one in others, and the two disagree on exactly the values a domain is least likely to test.
-let truncatingRemainder (dividend: Int, divisor: Int) : Int | DivisionByZero
-    = intrinsic "int.truncatingRemainder"
-let add (a: Int, b: Int) : Int = intrinsic "int.add"
-let subtract (a: Int, b: Int) : Int = intrinsic "int.subtract"
-let multiply (a: Int, b: Int) : Int = intrinsic "int.multiply"
+let truncatingRemainder (dividend: Int, divisor: Int): Int | DivisionByZero =
+    intrinsic "int.truncatingRemainder"
+let add (a: Int, b: Int): Int = intrinsic "int.add"
+let subtract (a: Int, b: Int): Int = intrinsic "int.subtract"
+let multiply (a: Int, b: Int): Int = intrinsic "int.multiply"
 
 // compare returns -1, 0, or 1 (the function form of the comparison operators).
-let compare (a: Int, b: Int) : Int = intrinsic "int.compare"
+let compare (a: Int, b: Int): Int = intrinsic "int.compare"
 
 // `floorMod` is the remainder of a division whose quotient is floored, so its result takes the sign
 // of the divisor: `floorMod(-7, 3)` is `2`, where `truncatingRemainder(-7, 3)` is `-1`. Both take the
@@ -34,7 +34,7 @@ let compare (a: Int, b: Int) : Int = intrinsic "int.compare"
 // (`invariant Int.floorMod(value, 12) == 0`). That makes it the one standard-library function whose
 // failure is not in its type; `truncatingRemainder` beside it shows the rule it is the exception to.
 // Use that one where a zero divisor must be a business case.
-let floorMod (dividend: Int, divisor: Int) : Int = intrinsic "int.floorMod"
+let floorMod (dividend: Int, divisor: Int): Int = intrinsic "int.floorMod"
 
 // Elm's `Basics` arithmetic, written as ordinary helpers because `<` and `-` already say it all.
 // `abs` negates with the `-` operator, so the one value with no positive counterpart (the smallest

--- a/souther-compiler/src/main/resources/souther/list.sou
+++ b/souther-compiler/src/main/resources/souther/list.sou
@@ -19,20 +19,21 @@ module souther.list
 // value (a closure), applied per element; the self-call is in tail position, so the backend turns the
 // recursion into a loop (no per-element stack frame). `List.get` gives the base case: `None` past the
 // end of the list yields the seed. Every combinator below is derived from it.
-let length (xs: List<'a>) : Int = intrinsic "list.length"
-let find (p: ('a) -> Bool, xs: List<'a>) : Option<'a> = intrinsic "list.find"
-let sortBy (key: ('a) -> 'k, xs: List<'a>) : List<'a> = intrinsic "list.sortBy"
-let max (xs: List<'a>) : Option<'a> = intrinsic "list.max"
-let min (xs: List<'a>) : Option<'a> = intrinsic "list.min"
-let get (index: Int, xs: List<'a>) : Option<'a> = intrinsic "list.get"
+let length (xs: List<'a>): Int = intrinsic "list.length"
+let find (p: ('a) -> Bool, xs: List<'a>): Option<'a> = intrinsic "list.find"
+let sortBy (key: ('a) -> 'k, xs: List<'a>): List<'a> = intrinsic "list.sortBy"
+let max (xs: List<'a>): Option<'a> = intrinsic "list.max"
+let min (xs: List<'a>): Option<'a> = intrinsic "list.min"
+let get (index: Int, xs: List<'a>): Option<'a> = intrinsic "list.get"
 
-private let foldFrom (step: ('acc, 'a) -> 'acc, seed: 'acc, xs: List<'a>, i: Int) : 'acc =
+private let foldFrom (step: ('acc, 'a) -> 'acc, seed: 'acc, xs: List<'a>, i: Int): 'acc =
     match List.get(i, xs) with
         | Some x -> List.foldFrom(step, step(seed, x), xs, i + 1)
         | None -> seed
 
 let map (f: ('a) -> 'b, xs: List<'a>): List<'b> = List.fold((acc, x) -> acc ++ [f(x)], [], xs)
-let filter (keep: ('a) -> Bool, xs: List<'a>): List<'a> = List.fold((acc, x) -> if keep(x) then acc ++ [x] else acc, [], xs)
+let filter (keep: ('a) -> Bool, xs: List<'a>): List<'a> =
+    List.fold((acc, x) -> if keep(x) then acc ++ [x] else acc, [], xs)
 let all (p: ('a) -> Bool, xs: List<'a>): Bool = List.fold((acc, x) -> acc && p(x), true, xs)
 let any (p: ('a) -> Bool, xs: List<'a>): Bool = List.fold((acc, x) -> acc || p(x), false, xs)
 
@@ -42,11 +43,15 @@ let any (p: ('a) -> Bool, xs: List<'a>): Bool = List.fold((acc, x) -> acc || p(x
 // hand-rolling that `(i, acc)` fold for a weighted sum or a positional transform (a check-digit
 // weighting reads `mapIndexed((i, c) -> w(i) * d(c)) |> sum`).
 let mapIndexed (f: (Int, 'a) -> 'b, xs: List<'a>): List<'b> = {
-    let (_, out) = List.fold((acc, x) -> {
-        let (i, ys) = acc
-        let mapped = ys ++ [f(i, x)]
-        (i + 1, mapped)
-    }, (0, []), xs)
+    let (_, out) = List.fold(
+        (acc, x) -> {
+            let (i, ys) = acc
+            let mapped = ys ++ [f(i, x)]
+            (i + 1, mapped)
+        },
+        (0, []),
+        xs
+    )
     out
 }
 
@@ -59,23 +64,31 @@ let mapIndexed (f: (Int, 'a) -> 'b, xs: List<'a>): List<'b> = {
 // the caller to find out. It walks `xs` with the same `(i, ys)` pair accumulator `mapIndexed` uses
 // and reads the partner with `List.get`, so a missing partner simply ends the pairing.
 let zipShortest (xs: List<'a>, ys: List<'b>): List<('a, 'b)> = {
-    let (_, out) = List.fold((acc, x) -> {
-        let (i, pairs) = acc
-        let next = i + 1
-        match List.get(i, ys) with
-            | Some y -> (next, pairs ++ [(x, y)])
-            | None -> (next, pairs)
-    }, (0, []), xs)
+    let (_, out) = List.fold(
+        (acc, x) -> {
+            let (i, pairs) = acc
+            let next = i + 1
+            match List.get(i, ys) with
+                | Some y -> (next, pairs ++ [(x, y)])
+                | None -> (next, pairs)
+        },
+        (0, []),
+        xs
+    )
     out
 }
 
 let unzip (ps: List<('a, 'b)>): (List<'a>, List<'b>) =
-    List.fold((acc, p) -> {
-        let (xs, ys) = acc
-        let (x, y) = p
-        let lefts = xs ++ [x]
-        (lefts, ys ++ [y])
-    }, ([], []), ps)
+    List.fold(
+        (acc, p) -> {
+            let (xs, ys) = acc
+            let (x, y) = p
+            let lefts = xs ++ [x]
+            (lefts, ys ++ [y])
+        },
+        ([], []),
+        ps
+    )
 
 // More of Elm's List module. `sum`/`product` fold a number; `append` and `concat` join with `++`;
 // `contains` folds a Bool using `==` (so it works over any comparable element); `isEmpty` reads the
@@ -88,7 +101,7 @@ let unzip (ps: List<('a, 'b)>): (List<'a>, List<'b>) =
 // `reverse` is a native primitive, not a fold: a left fold can only build a reversed list by
 // prepending (`[x] ++ acc`), and a prepend copies the whole accumulator on an array-backed list, so
 // the fold form is O(n²). The intrinsic walks the input from the end in O(n) (like `sort`).
-let reverse (xs: List<'a>) : List<'a> = intrinsic "list.reverse"
+let reverse (xs: List<'a>): List<'a> = intrinsic "list.reverse"
 
 // `sum`/`product` are primitives rather than folds because a fold written here would have to write
 // its seed, and a written seed is `0` or `0.0m` — one of the two numeric types, never both. The
@@ -97,8 +110,8 @@ let reverse (xs: List<'a>) : List<'a> = intrinsic "list.reverse"
 // classes, so the constraint is a check in the compiler. It admits `Int` and `Decimal` and nothing
 // else — a newtype over one of them declares neither an addition nor a zero of its own, so a list
 // of them is summed by mapping to the wrapped value first.
-let sum (xs: List<'a>) : 'a = intrinsic "list.sum"
-let product (xs: List<'a>) : 'a = intrinsic "list.product"
+let sum (xs: List<'a>): 'a = intrinsic "list.sum"
+let product (xs: List<'a>): 'a = intrinsic "list.product"
 let append (a: List<'a>, b: List<'a>): List<'a> = a ++ b
 let concat (xss: List<List<'a>>): List<'a> = List.fold((acc, xs) -> acc ++ xs, [], xss)
 let contains (value: 'a, xs: List<'a>): Bool = List.fold((acc, x) -> acc || x == value, false, xs)
@@ -109,20 +122,28 @@ let isEmpty (xs: List<'a>): Bool = List.length(xs) == 0
 // end takes the whole list / leaves it empty. They thread the same `(i, ys)` pair accumulator
 // `mapIndexed` uses, keeping the elements whose index falls on the wanted side of `n`.
 let take (n: Int, xs: List<'a>): List<'a> = {
-    let (_, out) = List.fold((acc, x) -> {
-        let (i, ys) = acc
-        let next = i + 1
-        if i < n then (next, ys ++ [x]) else (next, ys)
-    }, (0, []), xs)
+    let (_, out) = List.fold(
+        (acc, x) -> {
+            let (i, ys) = acc
+            let next = i + 1
+            if i < n then (next, ys ++ [x]) else (next, ys)
+        },
+        (0, []),
+        xs
+    )
     out
 }
 
 let drop (n: Int, xs: List<'a>): List<'a> = {
-    let (_, out) = List.fold((acc, x) -> {
-        let (i, ys) = acc
-        let next = i + 1
-        if i >= n then (next, ys ++ [x]) else (next, ys)
-    }, (0, []), xs)
+    let (_, out) = List.fold(
+        (acc, x) -> {
+            let (i, ys) = acc
+            let next = i + 1
+            if i >= n then (next, ys ++ [x]) else (next, ys)
+        },
+        (0, []),
+        xs
+    )
     out
 }
 
@@ -140,18 +161,26 @@ let drop (n: Int, xs: List<'a>): List<'a> = {
 // who knows one can predict the others. Deriving from the total `fold`, they may stand in an
 // invariant.
 let distinct (xs: List<'a>): List<'a> = {
-    let (_, out) = List.fold((acc, x) -> {
-        let (seen, ys) = acc
-        if Set.contains(x, seen) then acc else (Set.insert(x, seen), ys ++ [x])
-    }, (Set.empty, []), xs)
+    let (_, out) = List.fold(
+        (acc, x) -> {
+            let (seen, ys) = acc
+            if Set.contains(x, seen) then acc else (Set.insert(x, seen), ys ++ [x])
+        },
+        (Set.empty, []),
+        xs
+    )
     out
 }
 
 let distinctBy (key: ('a) -> 'k, xs: List<'a>): List<'a> = {
-    let (_, out) = List.fold((acc, x) -> {
-        let (seen, ys) = acc
-        if Set.contains(key(x), seen) then acc else (Set.insert(key(x), seen), ys ++ [x])
-    }, (Set.empty, []), xs)
+    let (_, out) = List.fold(
+        (acc, x) -> {
+            let (seen, ys) = acc
+            if Set.contains(key(x), seen) then acc else (Set.insert(key(x), seen), ys ++ [x])
+        },
+        (Set.empty, []),
+        xs
+    )
     out
 }
 
@@ -161,23 +190,31 @@ let allDistinctBy (key: ('a) -> 'k, xs: List<'a>): Bool =
 // `partition` splits the list by a predicate into (kept, rest), preserving order in each (Elm's
 // List.partition). It folds a pair of empty lists `([], [])`, appending each element to one side.
 let partition (keep: ('a) -> Bool, xs: List<'a>): (List<'a>, List<'a>) =
-    List.fold((acc, x) -> {
-        let (yes, no) = acc
-        if keep(x) then (yes ++ [x], no) else (yes, no ++ [x])
-    }, ([], []), xs)
+    List.fold(
+        (acc, x) -> {
+            let (yes, no) = acc
+            if keep(x) then (yes ++ [x], no) else (yes, no ++ [x])
+        },
+        ([], []),
+        xs
+    )
 
 // `groupBy` buckets the elements by a key into a `Map<'k, List<'a>>`, each bucket in first-seen
 // order (Elm's Dict-based grouping). It folds `Map.empty`, reading the current bucket with `Map.get`
 // (a `None` starts a new one) and writing back the extended bucket — a Map accumulator grown the same
 // way `distinct` grows a list, its key and value types recovered from the block.
 let groupBy (key: ('a) -> 'k, xs: List<'a>): Map<'k, List<'a>> =
-    List.fold((acc, x) ->
-        Map.insert(key(x),
+    List.fold(
+        (acc, x) -> Map.insert(
+            key(x),
             match Map.get(key(x), acc) with
                 | None -> [x]
                 | Some bucket -> bucket ++ [x],
-            acc),
-        Map.empty, xs)
+            acc
+        ),
+        Map.empty,
+        xs
+    )
 
 // `filterMap` maps and drops in one pass (Elm's `List.filterMap`, F#'s `List.choose`): `f` answers
 // with an optional, and only what is there joins the result. This is how an optional field becomes a
@@ -191,16 +228,20 @@ let groupBy (key: ('a) -> 'k, xs: List<'a>): Map<'k, List<'a>> =
 // to give — cannot reach it, because nothing but the core builds an optional; that projection answers
 // a list of nought or one and `flatMap` joins them.
 let filterMap (f: ('a) -> 'b?, xs: List<'a>): List<'b> =
-    List.fold((acc, x) ->
-        match f(x) with
+    List.fold(
+        (acc, x) -> match f(x) with
             | None -> acc
-            | Some v -> acc ++ [v], [], xs)
+            | Some v -> acc ++ [v],
+        [],
+        xs
+    )
 
 // `flatMap` maps each element to a list and joins the results in one pass. Writing it as `map` then
 // `concat` builds an intermediate `List<List<'b>>`, which is why the shape is usually hand-rolled as
 // a fold with `++` in the step — this is that fold, named. The name is the one settled across
 // ecosystems for this operation; Elm's `concatMap` and F#'s `collect` are the same function.
-let flatMap (f: ('a) -> List<'b>, xs: List<'a>): List<'b> = List.fold((acc, x) -> acc ++ f(x), [], xs)
+let flatMap (f: ('a) -> List<'b>, xs: List<'a>): List<'b> =
+    List.fold((acc, x) -> acc ++ f(x), [], xs)
 
 // `foldRight` walks from the end, the counterpart of the left `fold`. Its step takes the element
 // first and the accumulator second — the shape a right fold has, and the opposite of `fold`'s.
@@ -209,7 +250,7 @@ let flatMap (f: ('a) -> List<'b>, xs: List<'a>): List<'b> = List.fold((acc, x) -
 // fold and not an approximation of one: Souther is strict and a list is finite, so the two orders of
 // combination give the same value. Keeping it this way leaves `fold` as the only recursion in the
 // library. Time is O(n); it holds one reversed copy of the list, so extra space is O(n) too.
-let foldRight (step: ('a, 'acc) -> 'acc, seed: 'acc, xs: List<'a>) : 'acc =
+let foldRight (step: ('a, 'acc) -> 'acc, seed: 'acc, xs: List<'a>): 'acc =
     List.fold((acc, x) -> step(x, acc), seed, List.reverse(xs))
 
 // `indexBy` keys the elements by `key`, one entry each, into a `Map<'k, 'a>` (the sibling of the
@@ -223,7 +264,7 @@ let indexBy (key: ('a) -> 'k, xs: List<'a>): Map<'k, 'a> =
 // `sort` orders by the elements' natural order (Elm `List.sort`). Like Elm it is a native
 // primitive, not a fold: an in-language sort needs comparison plus a place to remember the
 // half-built result, which `fold` alone does not give.
-let sort (xs: List<'a>) : List<'a> = intrinsic "list.sort"
+let sort (xs: List<'a>): List<'a> = intrinsic "list.sort"
 
 // `rangeInclusive(from, to)` is the consecutive integers from `from` to `to`, both ends included;
 // `from` above `to` gives the empty list, and a span longer than a list can hold aborts before the
@@ -235,4 +276,4 @@ let sort (xs: List<'a>) : List<'a> = intrinsic "list.sort"
 // positions — the levels of a bay, the digits of a code — has something to walk. Like `reverse` and
 // `sort` it is a primitive: building it from `fold` would need a list to fold over in the first
 // place.
-let rangeInclusive (from: Int, to: Int) : List<Int> = intrinsic "list.rangeInclusive"
+let rangeInclusive (from: Int, to: Int): List<Int> = intrinsic "list.rangeInclusive"

--- a/souther-compiler/src/main/resources/souther/map.sou
+++ b/souther-compiler/src/main/resources/souther/map.sou
@@ -9,23 +9,23 @@ module souther.map
 // Argument order follows F#/Elm ([#pipe]): the map comes last, so `m |> Map.insert(k, v)` reads
 // left to right. `empty` takes no parameter list, so it is a value ([#fn-declaration]) — like `[]`,
 // its key and value are fixed by context, since it has no argument to learn them from.
-let empty : Map<'k, 'a> = intrinsic "map.empty"
-let get (key: 'k, m: Map<'k, 'a>) : Option<'a> = intrinsic "map.get"
+let empty: Map<'k, 'a> = intrinsic "map.empty"
+let get (key: 'k, m: Map<'k, 'a>): Option<'a> = intrinsic "map.get"
 
-let containsKey (key: 'k, m: Map<'k, 'a>) : Bool = intrinsic "map.containsKey"
-let keys (m: Map<'k, 'a>) : List<'k> = intrinsic "map.keys"
-let values (m: Map<'k, 'a>) : List<'a> = intrinsic "map.values"
+let containsKey (key: 'k, m: Map<'k, 'a>): Bool = intrinsic "map.containsKey"
+let keys (m: Map<'k, 'a>): List<'k> = intrinsic "map.keys"
+let values (m: Map<'k, 'a>): List<'a> = intrinsic "map.values"
 
-let singleton (key: 'k, value: 'a) : Map<'k, 'a> = intrinsic "map.singleton"
-let insert (key: 'k, value: 'a, m: Map<'k, 'a>) : Map<'k, 'a> = intrinsic "map.insert"
-let remove (key: 'k, m: Map<'k, 'a>) : Map<'k, 'a> = intrinsic "map.remove"
-let isEmpty (m: Map<'k, 'a>) : Bool = intrinsic "map.isEmpty"
-let size (m: Map<'k, 'a>) : Int = intrinsic "map.size"
+let singleton (key: 'k, value: 'a): Map<'k, 'a> = intrinsic "map.singleton"
+let insert (key: 'k, value: 'a, m: Map<'k, 'a>): Map<'k, 'a> = intrinsic "map.insert"
+let remove (key: 'k, m: Map<'k, 'a>): Map<'k, 'a> = intrinsic "map.remove"
+let isEmpty (m: Map<'k, 'a>): Bool = intrinsic "map.isEmpty"
+let size (m: Map<'k, 'a>): Int = intrinsic "map.size"
 
 // Conversion to / from a list of (key, value) tuples. A tuple type is allowed in a stdlib
 // signature (ADR-0037) — it never crosses a codec boundary. `fromList` lets a later entry win.
-let toList (m: Map<'k, 'a>) : List<('k, 'a)> = intrinsic "map.toList"
-let fromList (entries: List<('k, 'a)>) : Map<'k, 'a> = intrinsic "map.fromList"
+let toList (m: Map<'k, 'a>): List<('k, 'a)> = intrinsic "map.toList"
+let fromList (entries: List<('k, 'a)>): Map<'k, 'a> = intrinsic "map.fromList"
 
 // The higher-order operations, the only ones taking a step function. `Map` adds no privileged loop:
 // `fold` runs `List.fold` over the entries (`toList`, [#stdlib-map]), so the one list-fold loop
@@ -46,16 +46,20 @@ let fromList (entries: List<('k, 'a)>) : Map<'k, 'a> = intrinsic "map.fromList"
 // what the name says and what `update` alone would not. Its step is `('a) -> 'a`, not Elm's
 // `Maybe v -> Maybe v`: `Option` is not surface-writable ([#algebraic-types]), so a step cannot
 // return one — insert a new key with `insert` and drop one with `remove`.
-let fold (step: ('acc, 'k, 'a) -> 'acc, seed: 'acc, m: Map<'k, 'a>) : 'acc =
-    List.fold((acc, e) -> {
-        let (k, v) = e
-        step(acc, k, v)
-    }, seed, Map.toList(m))
+let fold (step: ('acc, 'k, 'a) -> 'acc, seed: 'acc, m: Map<'k, 'a>): 'acc =
+    List.fold(
+        (acc, e) -> {
+            let (k, v) = e
+            step(acc, k, v)
+        },
+        seed,
+        Map.toList(m)
+    )
 
-let mapValues (f: ('k, 'a) -> 'b, m: Map<'k, 'a>) : Map<'k, 'b> =
+let mapValues (f: ('k, 'a) -> 'b, m: Map<'k, 'a>): Map<'k, 'b> =
     Map.fold((acc, k, v) -> Map.insert(k, f(k, v), acc), Map.empty, m)
 
-let updateIfPresent (key: 'k, f: ('a) -> 'a, m: Map<'k, 'a>) : Map<'k, 'a> =
+let updateIfPresent (key: 'k, f: ('a) -> 'a, m: Map<'k, 'a>): Map<'k, 'a> =
     match Map.get(key, m) with
         | None -> m
         | Some v -> Map.insert(key, f(v), m)
@@ -65,7 +69,7 @@ let updateIfPresent (key: 'k, f: ('a) -> 'a, m: Map<'k, 'a>) : Map<'k, 'a> =
 // `fromList` back, which leaves the map type behind for two steps and re-hashes every surviving
 // entry. Named for what the predicate reads, beside `mapValues`, so the pair says which half of an
 // entry each one is about.
-let filterEntries (keep: ('k, 'a) -> Bool, m: Map<'k, 'a>) : Map<'k, 'a> =
+let filterEntries (keep: ('k, 'a) -> Bool, m: Map<'k, 'a>): Map<'k, 'a> =
     Map.fold((acc, k, v) -> if keep(k, v) then Map.insert(k, v, acc) else acc, Map.empty, m)
 
 // The key algebra, matching `Set`'s. All three are named as the set operations they are, so the two
@@ -78,13 +82,13 @@ let filterEntries (keep: ('k, 'a) -> Bool, m: Map<'k, 'a>) : Map<'k, 'a> =
 // These are binary operations, so they take their two operands in the order they are written and the
 // pipe's subject-last rule does not apply: `Set.difference(a, b)` is `a` minus `b`, and threading one
 // through `|>` would put the operands the other way round.
-let union (a: Map<'k, 'v>, b: Map<'k, 'v>) : Map<'k, 'v> =
+let union (a: Map<'k, 'v>, b: Map<'k, 'v>): Map<'k, 'v> =
     Map.fold((acc, k, v) -> if Map.containsKey(k, acc) then acc else Map.insert(k, v, acc), a, b)
 
-let intersection (a: Map<'k, 'v>, b: Map<'k, 'v>) : Map<'k, 'v> =
+let intersection (a: Map<'k, 'v>, b: Map<'k, 'v>): Map<'k, 'v> =
     Map.filterEntries((k, _) -> Map.containsKey(k, b), a)
 
-let difference (a: Map<'k, 'v>, b: Map<'k, 'v>) : Map<'k, 'v> =
+let difference (a: Map<'k, 'v>, b: Map<'k, 'v>): Map<'k, 'v> =
     Map.filterEntries((k, _) -> Bool.not(Map.containsKey(k, b)), a)
 
 // `updateOrInsert` collapses insert-if-absent / modify-if-present into one call: apply `f` to the
@@ -93,7 +97,7 @@ let difference (a: Map<'k, 'v>, b: Map<'k, 'v>) : Map<'k, 'v> =
 // ([#algebraic-types]) — the absent branch takes a plain value (`default`), not the `Maybe -> Maybe`
 // step Elm's `Dict.update` needs. Typical use is accumulation, e.g. counting:
 // `updateOrInsert(k, 1, n -> n + 1, m)`.
-let updateOrInsert (key: 'k, default: 'a, f: ('a) -> 'a, m: Map<'k, 'a>) : Map<'k, 'a> =
+let updateOrInsert (key: 'k, default: 'a, f: ('a) -> 'a, m: Map<'k, 'a>): Map<'k, 'a> =
     match Map.get(key, m) with
         | None -> Map.insert(key, default, m)
         | Some v -> Map.insert(key, f(v), m)

--- a/souther-compiler/src/main/resources/souther/option.sou
+++ b/souther-compiler/src/main/resources/souther/option.sou
@@ -16,9 +16,9 @@ module souther.option
 // `List.find`), not a helper here; its signature is `map(f: ('a) -> 'b, opt: Option<'a>) : Option<'b>`.
 // `andThen` is intentionally absent: its step would have to return an `Option`, which no user lambda can
 // build under the non-surface rule (spec §algebraic-types).
-let map (f: ('a) -> 'b, opt: Option<'a>) : Option<'b> = intrinsic "option.map"
+let map (f: ('a) -> 'b, opt: Option<'a>): Option<'b> = intrinsic "option.map"
 
-let withDefault (default: 'a, opt: Option<'a>) : 'a =
+let withDefault (default: 'a, opt: Option<'a>): 'a =
     match opt with
         | Some v -> v
         | None -> default

--- a/souther-compiler/src/main/resources/souther/set.sou
+++ b/souther-compiler/src/main/resources/souther/set.sou
@@ -10,19 +10,19 @@ module souther.set
 // `String.contains` use, since it is the same question. `union` / `intersection` / `difference(a, b)`
 // are the set algebra (`difference` is `a` minus `b`); being binary operations they keep their
 // operands in the written order rather than taking a subject last.
-let empty : Set<'a> = intrinsic "set.empty"
+let empty: Set<'a> = intrinsic "set.empty"
 
-let singleton (value: 'a) : Set<'a> = intrinsic "set.singleton"
-let insert (value: 'a, s: Set<'a>) : Set<'a> = intrinsic "set.insert"
-let remove (value: 'a, s: Set<'a>) : Set<'a> = intrinsic "set.remove"
-let contains (value: 'a, s: Set<'a>) : Bool = intrinsic "set.contains"
-let union (a: Set<'a>, b: Set<'a>) : Set<'a> = intrinsic "set.union"
-let intersection (a: Set<'a>, b: Set<'a>) : Set<'a> = intrinsic "set.intersection"
-let difference (a: Set<'a>, b: Set<'a>) : Set<'a> = intrinsic "set.difference"
-let isEmpty (s: Set<'a>) : Bool = intrinsic "set.isEmpty"
-let size (s: Set<'a>) : Int = intrinsic "set.size"
-let toList (s: Set<'a>) : List<'a> = intrinsic "set.toList"
-let fromList (xs: List<'a>) : Set<'a> = intrinsic "set.fromList"
+let singleton (value: 'a): Set<'a> = intrinsic "set.singleton"
+let insert (value: 'a, s: Set<'a>): Set<'a> = intrinsic "set.insert"
+let remove (value: 'a, s: Set<'a>): Set<'a> = intrinsic "set.remove"
+let contains (value: 'a, s: Set<'a>): Bool = intrinsic "set.contains"
+let union (a: Set<'a>, b: Set<'a>): Set<'a> = intrinsic "set.union"
+let intersection (a: Set<'a>, b: Set<'a>): Set<'a> = intrinsic "set.intersection"
+let difference (a: Set<'a>, b: Set<'a>): Set<'a> = intrinsic "set.difference"
+let isEmpty (s: Set<'a>): Bool = intrinsic "set.isEmpty"
+let size (s: Set<'a>): Int = intrinsic "set.size"
+let toList (s: Set<'a>): List<'a> = intrinsic "set.toList"
+let fromList (xs: List<'a>): Set<'a> = intrinsic "set.fromList"
 
 // The higher-order operations (Elm `Set.map` / `filter` / `foldl` / `partition`). Like `Map`, `Set`
 // adds no loop of its own: each one goes out through `toList`, uses the List combinator, and comes
@@ -35,18 +35,21 @@ let fromList (xs: List<'a>) : Set<'a> = intrinsic "set.fromList"
 // duplicates (Elm behaves the same way). `fold` runs over `toList`'s order, which is deterministic
 // but unspecified, so a step whose result depends on the order is a mistake the compiler cannot
 // catch — combine with something associative and commutative, as one would in Elm.
-let fold (step: ('acc, 'a) -> 'acc, seed: 'acc, s: Set<'a>) : 'acc =
+let fold (step: ('acc, 'a) -> 'acc, seed: 'acc, s: Set<'a>): 'acc =
     List.fold(step, seed, Set.toList(s))
 
-let map (f: ('a) -> 'b, s: Set<'a>) : Set<'b> =
-    Set.fromList(List.map(f, Set.toList(s)))
+let map (f: ('a) -> 'b, s: Set<'a>): Set<'b> = Set.fromList(List.map(f, Set.toList(s)))
 
-let filter (keep: ('a) -> Bool, s: Set<'a>) : Set<'a> =
+let filter (keep: ('a) -> Bool, s: Set<'a>): Set<'a> =
     Set.fromList(List.filter(keep, Set.toList(s)))
 
 // `partition` answers the pair (kept, rest), the same shape `List.partition` gives.
 let partition (keep: ('a) -> Bool, s: Set<'a>): (Set<'a>, Set<'a>) =
-    Set.fold((acc, x) -> {
-        let (yes, no) = acc
-        if keep(x) then (Set.insert(x, yes), no) else (yes, Set.insert(x, no))
-    }, (Set.empty, Set.empty), s)
+    Set.fold(
+        (acc, x) -> {
+            let (yes, no) = acc
+            if keep(x) then (Set.insert(x, yes), no) else (yes, Set.insert(x, no))
+        },
+        (Set.empty, Set.empty),
+        s
+    )

--- a/souther-compiler/src/main/resources/souther/string.sou
+++ b/souther-compiler/src/main/resources/souther/string.sou
@@ -21,16 +21,16 @@ module souther.string
 //
 // and that no operation here can answer with half a surrogate pair. An invariant written
 // `String.length(value) <= 20` therefore says twenty code points, not twenty columns on a form.
-let length (s: String) : Int = intrinsic "string.length"
-let toInt (s: String) : Int | NotANumber = intrinsic "string.toInt"
-let toDecimal (s: String) : Decimal | NotANumber = intrinsic "string.toDecimal"
+let length (s: String): Int = intrinsic "string.length"
+let toInt (s: String): Int | NotANumber = intrinsic "string.toInt"
+let toDecimal (s: String): Decimal | NotANumber = intrinsic "string.toDecimal"
 
-let trim (s: String) : String = intrinsic "string.trim"
-let lowercase (s: String) : String = intrinsic "string.lowercase"
-let uppercase (s: String) : String = intrinsic "string.uppercase"
-let contains (sub: String, s: String) : Bool = intrinsic "string.contains"
-let startsWith (prefix: String, s: String) : Bool = intrinsic "string.startsWith"
-let endsWith (suffix: String, s: String) : Bool = intrinsic "string.endsWith"
+let trim (s: String): String = intrinsic "string.trim"
+let lowercase (s: String): String = intrinsic "string.lowercase"
+let uppercase (s: String): String = intrinsic "string.uppercase"
+let contains (sub: String, s: String): Bool = intrinsic "string.contains"
+let startsWith (prefix: String, s: String): Bool = intrinsic "string.startsWith"
+let endsWith (suffix: String, s: String): Bool = intrinsic "string.endsWith"
 
 // `isEmpty` says "this text is blank" (Elm `String.isEmpty`), the sibling of `List.isEmpty` /
 // `Map.isEmpty` / `Set.isEmpty`. It reads `length`, so it is an ordinary helper rather than a
@@ -43,26 +43,26 @@ let isEmpty (s: String): Bool = String.length(s) == 0
 // Whole-string regex match (Java Pattern flavour, anchored), for format-constrained values in an
 // invariant — `invariant String.matches("[0-9]{3}-[0-9]{4}", value)`. The pattern must be a string
 // literal, so a malformed regex is a compile error and the whole thing reads as a plain Bool.
-let matches (pattern: String, s: String) : Bool = intrinsic "string.matches"
+let matches (pattern: String, s: String): Bool = intrinsic "string.matches"
 
 // `slice` takes the code points from `fromInclusive` up to but not including `toExclusive`. Half-open
 // is the rule for extracting a range, as `rangeInclusive`'s name is the rule for generating one, so
 // `slice(0, String.length(s), s)` is the whole string and two slices that meet at an index join back
 // into one. An index outside the string, or a `toExclusive` before `fromInclusive`, aborts.
-let slice (fromInclusive: Int, toExclusive: Int, s: String) : String = intrinsic "string.slice"
-let append (a: String, b: String) : String = intrinsic "string.append"
+let slice (fromInclusive: Int, toExclusive: Int, s: String): String = intrinsic "string.slice"
+let append (a: String, b: String): String = intrinsic "string.append"
 
 // Split / join / replace and rendering an Int, ported from Elm's String module (the subset that
 // fits Souther's types — the Char/Maybe/Float-shaped functions do not). `split` keeps empty pieces;
 // `words` splits on whitespace runs and drops them.
-let split (sep: String, s: String) : List<String> = intrinsic "string.split"
-let join (sep: String, xs: List<String>) : String = intrinsic "string.join"
-let replace (target: String, replacement: String, s: String) : String = intrinsic "string.replace"
-let words (s: String) : List<String> = intrinsic "string.words"
-let fromInt (n: Int) : String = intrinsic "string.fromInt"
+let split (sep: String, s: String): List<String> = intrinsic "string.split"
+let join (sep: String, xs: List<String>): String = intrinsic "string.join"
+let replace (target: String, replacement: String, s: String): String = intrinsic "string.replace"
+let words (s: String): List<String> = intrinsic "string.words"
+let fromInt (n: Int): String = intrinsic "string.fromInt"
 
 // `concat` joins a `List<String>` with no separator (Elm `String.concat`); it is `join("", xs)`.
-let concat (xs: List<String>) : String = intrinsic "string.concat"
+let concat (xs: List<String>): String = intrinsic "string.concat"
 
 // `reverse` / `repeat` / `lines`, the rest of Elm's String module that Souther's types allow.
 // `reverse` turns the code points around, so a character outside the basic plane survives it.
@@ -70,9 +70,9 @@ let concat (xs: List<String>) : String = intrinsic "string.concat"
 // rather than quietly giving fewer, as an Int overflow does). `lines` breaks on newlines and
 // accepts both `\n` and `\r\n` (Elm `String.lines`); empty pieces are kept, so a trailing newline
 // leaves an empty last line.
-let reverse (s: String) : String = intrinsic "string.reverse"
-let repeat (n: Int, s: String) : String = intrinsic "string.repeat"
-let lines (s: String) : List<String> = intrinsic "string.lines"
+let reverse (s: String): String = intrinsic "string.reverse"
+let repeat (n: Int, s: String): String = intrinsic "string.repeat"
+let lines (s: String): List<String> = intrinsic "string.lines"
 
 // `padLeft(width, pad, s)` / `padRight` widen `s` to `width` code points with copies of `pad`, and
 // leave a string already that wide alone. `pad` is repeated and cut to the code points still needed,
@@ -86,8 +86,8 @@ let lines (s: String) : List<String> = intrinsic "string.lines"
 // This is what builds a fixed-width identifier: a bay number becomes `"03"` with
 // `padLeft(2, "0", fromInt(bay))`, so a code whose shape a newtype invariant states can be produced
 // in the domain and not only checked there.
-let padLeft (width: Int, pad: String, s: String) : String = intrinsic "string.padLeft"
-let padRight (width: Int, pad: String, s: String) : String = intrinsic "string.padRight"
+let padLeft (width: Int, pad: String, s: String): String = intrinsic "string.padLeft"
+let padRight (width: Int, pad: String, s: String): String = intrinsic "string.padRight"
 
 // `fromDecimal` renders a `Decimal` in plain notation, never in exponent form, keeping the scale the
 // value carries — `1000.00m` is `"1000.00"`, not `"1000"` or `"1.0E+3"`. Scale is incidental to the
@@ -96,7 +96,7 @@ let padRight (width: Int, pad: String, s: String) : String = intrinsic "string.p
 // separators and a currency symbol are presentation and stay outside the domain. The parse in the
 // other direction, `toDecimal`, returns `Decimal | NotANumber` and is a compiler built-in for the
 // same reason `toInt` is.
-let fromDecimal (d: Decimal) : String = intrinsic "string.fromDecimal"
+let fromDecimal (d: Decimal): String = intrinsic "string.fromDecimal"
 
 // Taking a string apart into the units it is made of, without a `Char` type: `characters` gives one
 // code point per element, each a one-code-point `String`, and `codePoints` gives the same split as
@@ -113,5 +113,5 @@ let fromDecimal (d: Decimal) : String = intrinsic "string.fromDecimal"
 //
 // (`toInt`, a case-returning parse `String -> Int | NotANumber`, is a compiler built-in — a core
 // declaration cannot yet name a primitive-headed union.)
-let characters (s: String) : List<String> = intrinsic "string.characters"
-let codePoints (s: String) : List<Int> = intrinsic "string.codePoints"
+let characters (s: String): List<String> = intrinsic "string.characters"
+let codePoints (s: String): List<Int> = intrinsic "string.codePoints"

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentAtTheEndOfALineStaysOnItTest.java
@@ -29,11 +29,8 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 module m
 
                 data WebForm
-
                 data PhoneInquiry
-
                 data Inbound = WebForm | PhoneInquiry // three units; nothing to attribute
-
                 data LeadSource = Inbound
                 """, formatted);
     }
@@ -101,11 +98,8 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 module m
 
                 data A
-
                 data B
-
                 data C
-
                 data S = A // about A
                     | B
                     | C
@@ -145,14 +139,11 @@ class ACommentAtTheEndOfALineStaysOnItTest {
 
                 data Amount = Int
                     invariant value > 0
-
                 data O =
                     { n: Int
                     }
-
                 behavior f : (n: Int) -> O | Amount
                     constructs O, Amount
-
                 let f (n) = {
                     guard Amount(n) as a else
                         // why this arm
@@ -166,14 +157,11 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 data A =
                     { n: Int
                     }
-
                 data B =
                     { n: Int
                     }
-
                 behavior one : (a: A) -> B
                     constructs B
-
                 behavior p =
                     one
                     // why this stage
@@ -199,11 +187,8 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 module m
 
                 data AccountId = String
-
                 data DomainName = String
-
                 data Industry
-
                 data Account =
                     { id: AccountId
                     , domain: DomainName? // an honest optional
@@ -233,10 +218,8 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                     { a: Int
                     , b: Int
                     }
-
                 behavior f : (n: Int) -> O
                     constructs O
-
                 let f (n) =
                     O {
                         a = n, // the first
@@ -263,18 +246,13 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 module m
 
                 data A
-
                 data B
-
                 data S = A | B
-
                 data O =
                     { n: Int
                     }
-
                 behavior f : (s: S) -> O
                     constructs O
-
                 let f (s) =
                     O {
                         n = match s with
@@ -299,9 +277,7 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 module m
 
                 data WebForm
-
                 data PhoneInquiry
-
                 data Inbound = WebForm | PhoneInquiry // a comment long enough that the line it is written on runs well past the hundred columns the canonical form is measured against
                 """, formatted);
     }
@@ -323,15 +299,10 @@ class ACommentAtTheEndOfALineStaysOnItTest {
                 module m
 
                 data AlphaMeasurement
-
                 data BetaMeasurement
-
                 data GammaMeasurement
-
                 data DeltaMeasurement
-
                 data EpsilonMeasurement
-
                 data Measurement = AlphaMeasurement
                     | BetaMeasurement
                     | GammaMeasurement

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentKeepsItsMemberHoweverItIsWrittenTest.java
@@ -46,6 +46,7 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
     void aMemberWrittenAsAnIdentifier() {
         assertEquals("""
                 module m
+
                 import other.mod (
                     A,
                     // about B
@@ -75,16 +76,13 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 data A =
                     { n: Int
                     }
-
                 data B =
                     { n: Int
                     }
-
                 behavior f : (n: Int) -> A | B
                     constructs A,
                         // about B
                         B
-
                 let f (n) = A { n = n }
                 """, Formatter.format("""
                 module m
@@ -109,11 +107,9 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 data A =
                     { n: Int
                     }
-
                 behavior f : (n: Int) -> A
                     // why this one
                     constructs other.A
-
                 let f (n) = A { n = n }
                 """, Formatter.format("""
                 module m
@@ -137,10 +133,8 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 data A =
                     { n: Int
                     }
-
                 behavior f : (n: Int) -> A // result
                     constructs A
-
                 let f (n) = A { n = n }
                 """, Formatter.format("""
                 module m
@@ -175,14 +169,10 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 data O =
                     { n: Int
                     }
-
                 let g (x: Int) = x
-
                 let h (x: Int) = x
-
                 behavior f : (n: Int) -> O
                     constructs O
-
                 let f (n) =
                     O {
                         n = n
@@ -203,6 +193,12 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 """));
     }
 
+    /**
+     * The parameter list goes down the page with it. A comment cannot share the line after it, so
+     * every group holding one is written broken, and a behavior's inputs and output are one group —
+     * the signature decides the two together so that the inputs are what give way to the width
+     * first. What the comment is about is unchanged by that, which is what this asks.
+     */
     @Test
     void aMemberWrittenAsASegmentOfAWrittenUnion() {
         assertEquals("""
@@ -211,15 +207,14 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 data A =
                     { n: Int
                     }
-
                 data B =
                     { n: Int
                     }
-
-                behavior f : (n: Int) -> A
+                behavior f : (
+                    n: Int
+                ) -> A
                     // exceptional result
                     | B
-
                 let f (n) = A { n = n }
                 """, Formatter.format("""
                 module m
@@ -243,9 +238,7 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 module m
 
                 let b (x: Int) = x
-
                 let c (x: Int) = x
-
                 let value =
                     1
                         |> b // about the b stage
@@ -425,18 +418,13 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 module m
 
                 data A
-
                 data B
-
                 data S = A | B
-
                 data O =
                     { n: Int
                     }
-
                 behavior f : (s: S) -> O
                     constructs O
-
                 let f (s) =
                     O {
                         n = match s with
@@ -494,10 +482,8 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 data O =
                     { xs: List<Int>
                     }
-
                 behavior f : () -> O
                     constructs O
-
                 let f =
                     O {
                         // empty for now
@@ -522,9 +508,7 @@ class ACommentKeepsItsMemberHoweverItIsWrittenTest {
                 module m
 
                 data One
-
                 data Two
-
                 let value (n: Int) = if n > 0 then One else Two // about the test
                 """, Formatter.format("""
                 module m

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentSitsAboveTheWholeMemberLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentSitsAboveTheWholeMemberLineTest.java
@@ -73,9 +73,7 @@ class ACommentSitsAboveTheWholeMemberLineTest {
                 module m
 
                 data A
-
                 data B
-
                 data S = A
                     // the comment
                     | B
@@ -99,9 +97,7 @@ class ACommentSitsAboveTheWholeMemberLineTest {
                 module m
 
                 data A
-
                 data B
-
                 data S =
                     // the comment
                     A | B

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentUnderTheLastMemberStaysInsideTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentUnderTheLastMemberStaysInsideTest.java
@@ -52,10 +52,8 @@ class ACommentUnderTheLastMemberStaysInsideTest {
                 module m
 
                 data O
-
                 behavior f : () -> O
                     constructs O
-
                 let f =
                     O {
                         // keep me
@@ -83,10 +81,8 @@ class ACommentUnderTheLastMemberStaysInsideTest {
                     { a: Int
                     , b: Int
                     }
-
                 behavior f : (n: Int) -> O
                     constructs O
-
                 let f (n) =
                     O {
                         a = n,

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AConstructIsFlatUpToTheCanonicalWidthTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AConstructIsFlatUpToTheCanonicalWidthTest.java
@@ -55,6 +55,7 @@ class AConstructIsFlatUpToTheCanonicalWidthTest {
                 new Site("import name list",
                         """
                         module fmtprobe exposing ( f )
+
                         import some.place ( alphaName%s, betaName )
                         """,
                         "import"),

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AForcedBreakIsWrittenWhateverTheWidthTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AForcedBreakIsWrittenWhateverTheWidthTest.java
@@ -255,6 +255,7 @@ class AForcedBreakIsWrittenWhateverTheWidthTest {
             data Alpha
 
             data Beta
+            data Gamma
             """;
 
     /** The blank lines between the line holding {@code above} and the line holding {@code below}. */
@@ -280,13 +281,20 @@ class AForcedBreakIsWrittenWhateverTheWidthTest {
         return between.size();
     }
 
-    /** One blank line between top-level items, and none between a module header and its imports. */
+    /**
+     * A blank line under a module header whatever was written there, and between two items whatever
+     * the author wrote there and nothing else. All three are breaks the width has no say in.
+     */
     @Test
-    void oneBlankLineSeparatesTopLevelItemsAndAnImportFollowsItsHeader() {
+    void aBlankLineUnderTheHeaderAndWhereTheAuthorPutOne() {
         String formatted = Formatter.format(TWO_ITEMS);
-        assertEquals(1, blankLinesBetween(formatted, "data Alpha", "data Beta"));
-        assertEquals(0, blankLinesBetween(formatted,
-                "module fmtprobe exposing ( f )", "import some.place ( alpha )"));
+        assertEquals(1, blankLinesBetween(formatted,
+                "module fmtprobe exposing ( f )", "import some.place ( alpha )"),
+                "a header is written with a blank line under it, and the source has none");
+        assertEquals(1, blankLinesBetween(formatted, "data Alpha", "data Beta"),
+                "the author wrote one here");
+        assertEquals(0, blankLinesBetween(formatted, "data Beta", "data Gamma"),
+                "and none here");
     }
 
     /** A file ends with a newline, and with one. */

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AProbeSurvivesAtEveryTokenBoundaryTest.java
@@ -51,6 +51,7 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
      * from it only by the probe. */
     private static final String WHOLE_MODULE = """
             module m exposing ( A, B, S, run, value )
+
             import other.mod ( Thing )
 
             data A =
@@ -100,6 +101,7 @@ class AProbeSurvivesAtEveryTokenBoundaryTest {
      * example's bindings, a comprehension, and the empty forms of the bracketed constructs. */
     private static final String THE_OTHER_FORMS = """
             module m exposing ()
+
             import other.mod
 
             data Amount = Int

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EverySourceThisShipsIsInCanonicalFormTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EverySourceThisShipsIsInCanonicalFormTest.java
@@ -1,0 +1,71 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.Reserved;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The standard library is written in the form {@code souther fmt} writes.
+ *
+ * <p>It is the only Souther source this project ships, and {@code souther api --source} prints it
+ * to a reader. Source the product hands out and its own formatter rejects is the product
+ * contradicting itself, and it is also the whole of the evidence for the canonical form: a form
+ * nothing is required to be in is one that can drift from every document describing it with nothing
+ * to say which of the two moved. This is what requires it of something.
+ *
+ * <p>The modules are read through {@link Reserved#MODULES} and the same resource path the prelude
+ * loads them by, so a module added there is covered by this without being added here. A list
+ * written out again is a second answer to which modules there are, and the one that goes stale is
+ * the copy.
+ *
+ * <p>What is checked is the text, not that the formatter is happy: formatting is compared against
+ * the file as it is on disk. Asking the formatter whether it would change anything is asking the
+ * thing under test.
+ */
+class EverySourceThisShipsIsInCanonicalFormTest {
+
+    @Test
+    void everyStandardLibraryModuleIsWrittenAsTheFormatterWritesIt() {
+        List<String> differ = new ArrayList<>();
+        for (Reserved.StdlibModule module : Reserved.MODULES) {
+            String resource = "/" + module.moduleName().replace('.', '/') + ".sou";
+            String source = read(resource);
+            if (!source.equals(Formatter.format(source))) {
+                differ.add(resource);
+            }
+        }
+        assertEquals(List.of(), differ,
+                differ.size() + " of " + Reserved.MODULES.size() + " shipped modules are not in"
+                        + " canonical form; run `souther fmt -w` over"
+                        + " souther-compiler/src/main/resources/souther/");
+    }
+
+    /** The sweep covers every module the prelude loads, so a run that found nothing to check would
+     *  pass the assertion above without having asked anything. */
+    @Test
+    void thereAreModulesToCheck() {
+        assertTrue(Reserved.MODULES.size() >= 10,
+                "only " + Reserved.MODULES.size() + " modules were swept");
+    }
+
+    private static String read(String resource) {
+        try (InputStream in = EverySourceThisShipsIsInCanonicalFormTest.class
+                .getResourceAsStream(resource)) {
+            if (in == null) {
+                throw new IllegalStateException("the prelude resource " + resource + " is missing");
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EverySoutherSampleTheSpecificationMarksIsInCanonicalFormTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EverySoutherSampleTheSpecificationMarksIsInCanonicalFormTest.java
@@ -1,0 +1,119 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.cst.CstParser;
+import souther.compiler.doc.SpecDocument;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A sample the specification marks as Souther is a complete fragment, and it is written in the form
+ * {@code souther fmt} writes.
+ *
+ * <p>The specification is what a first-time author copies, so a sample that the formatter then
+ * rewrites teaches a form the tool rejects. Holding the two against each other makes the document
+ * the formatter's corpus: the published statement of the canonical form and the executable one stop
+ * being two things that can drift apart with nothing to say which of them moved.
+ *
+ * <p>Membership is what the document declares, not what happens to parse. A block is checked
+ * because it is written {@code [,souther]} — an author saying this is Souther and not pseudo-code —
+ * and a block written {@code [,text]} is a fragment, a spec-DSL line, or a form being quoted rather
+ * than offered. Taking every block that parses instead would make the parser decide what is
+ * checked, and a parser that grew would pull samples in without anyone marking them.
+ *
+ * <p>So the way to bring a sample under this is to mark it, and marking it is a claim about the
+ * sample that this refutes if it is false. Samples still written {@code [,text]} are not covered
+ * and are not asserted to be anything.
+ */
+class EverySoutherSampleTheSpecificationMarksIsInCanonicalFormTest {
+
+    /** The attribute line a listing carries. A language of {@code souther} is the mark. */
+    private static final Pattern SOUTHER_BLOCK =
+            Pattern.compile("^\\[(?:[a-z]*),\\s*souther\\s*(?:,.*)?]$");
+
+    private static final Pattern DELIMITER = Pattern.compile("^----$");
+
+    @Test
+    void everyMarkedSampleParses() {
+        List<String> broken = new ArrayList<>();
+        for (Sample sample : samples()) {
+            List<?> errors = CstParser.parse(sample.text()).errors();
+            if (!errors.isEmpty()) {
+                broken.add("specification.adoc:" + sample.line() + " " + errors);
+            }
+        }
+        assertEquals(List.of(), broken,
+                broken.size() + " samples are marked `[,souther]` and are not complete Souther;"
+                        + " a fragment is written `[,text]`");
+    }
+
+    @Test
+    void everyMarkedSampleIsWrittenAsTheFormatterWritesIt() {
+        List<String> differ = new ArrayList<>();
+        for (Sample sample : samples()) {
+            if (!CstParser.parse(sample.text()).errors().isEmpty()) {
+                continue;                 // said by the test above; nothing to format
+            }
+            if (!sample.text().equals(Formatter.format(sample.text()))) {
+                differ.add("specification.adoc:" + sample.line());
+            }
+        }
+        assertEquals(List.of(), differ,
+                differ.size() + " marked samples are not in canonical form. A sample teaches the"
+                        + " form a reader copies, so either write it as `souther fmt` does or take"
+                        + " the `[,souther]` mark off it.");
+    }
+
+    /** A run that found no marked sample would pass both assertions above having asked nothing. */
+    @Test
+    void thereAreMarkedSamples() {
+        assertTrue(samples().size() >= 20,
+                "only " + samples().size() + " samples are marked; the sweep found nothing");
+    }
+
+    /** A marked sample: its text, and the line its first line is on. */
+    private record Sample(String text, int line) {}
+
+    private static List<Sample> samples() {
+        List<String> lines = List.of(read().split("\n", -1));
+        List<Sample> out = new ArrayList<>();
+        for (int i = 0; i < lines.size() - 1; i++) {
+            if (!SOUTHER_BLOCK.matcher(lines.get(i)).matches()
+                    || !DELIMITER.matcher(lines.get(i + 1)).matches()) {
+                continue;
+            }
+            int from = i + 2;
+            int to = from;
+            while (to < lines.size() && !DELIMITER.matcher(lines.get(to)).matches()) {
+                to++;
+            }
+            out.add(new Sample(String.join("\n", lines.subList(from, to)) + "\n", from + 1));
+            i = to;
+        }
+        return out;
+    }
+
+    private static String read() {
+        // The specification the build bundled, which is the one `souther doc` answers from. Read
+        // from the tree instead, this would be checking a document the shipped compiler may not
+        // have.
+        String resource = "/META-INF/souther/specification.adoc";
+        try (InputStream in = SpecDocument.class.getResourceAsStream(resource)) {
+            if (in == null) {
+                throw new IllegalStateException(resource + " is not on the class path");
+            }
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/FormatterTest.java
@@ -223,20 +223,15 @@ class FormatterTest {
                 module demo
 
                 data NoItems
-
                 data Duplicate
-
                 data Accepted =
                     { items: Items
                     }
-
                 data Items = List<Int>
                     invariant nonEmpty = List.length(value) >= 1
                     invariant unique = List.allDistinctBy(x -> x, value)
-
                 behavior build : (xs: List<Int>) -> Accepted | NoItems | Duplicate
                     constructs Accepted, Items, NoItems, Duplicate
-
                 let build (xs) = {
                     guard Items(xs) as items else
                         | nonEmpty -> NoItems
@@ -277,15 +272,12 @@ class FormatterTest {
 
                 data Id = String
                     invariant length(value) > 0
-
                 data M =
                     { id: Id
                     , name: String
                     }
-
                 behavior f : (x: M) -> M
                     constructs M
-
                 let f (x) = M { id = x.id, name = x.name }
                 """;
         assertEquals(expected, Formatter.format(messy));
@@ -314,21 +306,15 @@ class FormatterTest {
 
                 data Amount = Int
                     invariant value >= 0
-
                 data Paid = Int
-
                 data Refused
-
                 behavior clock : () -> Amount
                     constructs Amount
-
                 behavior audit : (a: Amount) -> Amount
                     constructs Amount
-
                 behavior pay : (a: Amount) -> Paid | Refused
                     depends on clock, audit
                     constructs Paid, Refused
-
                 let pay (a, clock, audit) = {
                     guard a.value <= 100 else Refused
                     guard Amount(a.value - 1) as charged else Refused
@@ -353,14 +339,10 @@ class FormatterTest {
                 module demo
 
                 data Amount = Int
-
                 let cap = Amount(100)
-
                 let raise (a) = a.value + 1
-
                 behavior pay : (a: Amount) -> Amount
                     constructs Amount
-
                 let pay (a) = Amount(raise(a) + cap.value)
                 """;
         assertEquals(expected, Formatter.format(messy));
@@ -513,12 +495,9 @@ class FormatterTest {
                 data M =
                     { n: Int
                     }
-
                 behavior f : (x: M) -> M
                     constructs M
-
                 let f (x) = x
-
                 example f
                     | "holds" : (M { n = 1 }) -> M { n = 1 }
                 """;
@@ -540,19 +519,14 @@ class FormatterTest {
                 data R =
                     { x: Int
                     }
-
                 behavior clock : () -> String
-
                 behavior f : (r: R) -> R
                     depends on clock
                     constructs R
-
                 let f (r, clock) = r
-
                 fake lookup
                     | (R { x = 1 }) -> R { x = 2 }
                     | _ -> R { x = 0 }
-
                 example f
                     | (R { x = 1 }) with clock = "t" -> R { x = 1 }
                 """;

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheCanonicalFormBreaksAtTheEnclosingStructureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheCanonicalFormBreaksAtTheEnclosingStructureTest.java
@@ -74,6 +74,7 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         """,
                         """
                         module fmtprobe exposing ( f )
+
                         import some.other.place (
                             alphaName,
                             betaName,
@@ -130,7 +131,10 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         ): Receipt = accountIdentifier
                         """),
 
-                new Shape("return type union",
+                // A signature that does not fit gives way at the parameter list first: the union
+                // after the arrow breaks only where the line the `)` leaves it on is still too
+                // narrow for it. The two are one decision and this is the order it takes.
+                new Shape("behavior signature",
                         """
                         module fmtprobe exposing ( judge )
 
@@ -145,10 +149,35 @@ class TheCanonicalFormBreaksAtTheEnclosingStructureTest {
                         """
                         module fmtprobe exposing ( judge )
 
-                        behavior judge : (code: Code) -> AcceptedOutcome
-                            | RefusedOutcome
-                            | DeferredOutcome
-                            | EscalatedOutcome
+                        behavior judge : (
+                            code: Code
+                        ) -> AcceptedOutcome | RefusedOutcome | DeferredOutcome | EscalatedOutcome
+                        """),
+
+                // The same signature with a union too wide for that line, which is where the second
+                // half of the order shows: the parameters have already given way and the union has
+                // to break as well, at its own `|`.
+                new Shape("return type union",
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        behavior judge : (code: Code) -> AcceptedByTheUnderwriter | RefusedByTheUnderwriter | DeferredForManualReview | EscalatedToTheManager
+                        """,
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        behavior judge : (code: Code) -> AcceptedByTheUnderwriter | RefusedByTheUnderwriter |
+                            DeferredForManualReview | EscalatedToTheManager
+                        """,
+                        """
+                        module fmtprobe exposing ( judge )
+
+                        behavior judge : (
+                            code: Code
+                        ) -> AcceptedByTheUnderwriter
+                            | RefusedByTheUnderwriter
+                            | DeferredForManualReview
+                            | EscalatedToTheManager
                         """),
 
                 new Shape("sum cases",

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheInputsGiveWayBeforeTheOutputInASignatureTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheInputsGiveWayBeforeTheOutputInASignatureTest.java
@@ -1,0 +1,178 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A behavior signature that does not fit breaks its parameter list before its output union.
+ *
+ * <p>Written as the rule rather than as an output. The order used to be whichever of the two the
+ * layout reached with too little room left, which is the parameter list last because it is written
+ * first — an answer that came from how the document was built and would come out the other way
+ * after a rearrangement no test would call a change. So what is asserted is the implication over a
+ * swept family: a signature whose union is broken has its parameters broken too. One expected
+ * string would hold just as well if the order had been arrived at by accident.
+ *
+ * <p>The width decides which of the three outcomes a signature gets, and the sweep is required to
+ * produce all three. An implication holds vacuously over a family that never reaches its premise,
+ * so a sweep of only-flat signatures would pass this having asked nothing.
+ */
+class TheInputsGiveWayBeforeTheOutputInASignatureTest {
+
+    private static final int WIDTH = 100;
+
+    /** One signature of the sweep, and what the canonical form did to it. */
+    private record Laid(String source, String text, boolean inputsBroken, boolean outputBroken) {}
+
+    @Test
+    void anOutputIsNeverBrokenWhileTheInputsAreIntact() {
+        List<String> wrong = new ArrayList<>();
+        for (Laid laid : sweep()) {
+            if (laid.outputBroken() && !laid.inputsBroken()) {
+                wrong.add(laid.text());
+            }
+        }
+        assertEquals(List.of(), wrong,
+                wrong.size() + " signatures broke the output union with the parameter list left on"
+                        + " one line, which is the order reversed:\n" + String.join("\n", wrong));
+    }
+
+    /** The premise is reached: the sweep holds a signature of each of the three outcomes, so the
+     *  implication above is not answered by a family that never breaks anything. */
+    @Test
+    void theSweepReachesAllThreeOutcomes() {
+        int flat = 0;
+        int inputsOnly = 0;
+        int both = 0;
+        for (Laid laid : sweep()) {
+            if (!laid.inputsBroken() && !laid.outputBroken()) {
+                flat++;
+            } else if (laid.inputsBroken() && !laid.outputBroken()) {
+                inputsOnly++;
+            } else if (laid.inputsBroken() && laid.outputBroken()) {
+                both++;
+            }
+        }
+        assertTrue(flat > 0 && inputsOnly > 0 && both > 0,
+                "the sweep reached " + flat + " signatures written on one line, " + inputsOnly
+                        + " with the inputs broken alone and " + both + " with both broken");
+    }
+
+    /** Nothing is broken that fits, and nothing that does not fit is left whole. The order says
+     *  which of the two gives way; this says that one of them had to. */
+    @Test
+    void aSignatureBreaksWhenItDoesNotFitAndNotBefore() {
+        List<String> wrong = new ArrayList<>();
+        for (Laid laid : sweep()) {
+            boolean fitsOnOneLine = oneLine(laid.source()).length() <= WIDTH;
+            if (fitsOnOneLine && (laid.inputsBroken() || laid.outputBroken())) {
+                wrong.add("broke a signature of " + oneLine(laid.source()).length()
+                        + " columns:\n" + laid.text());
+            }
+            if (!fitsOnOneLine && !laid.inputsBroken()) {
+                wrong.add("left a signature of " + oneLine(laid.source()).length()
+                        + " columns on one line:\n" + laid.text());
+            }
+        }
+        assertEquals(List.of(), wrong, String.join("\n", wrong));
+    }
+
+    /**
+     * The union goes down the page only where the line the {@code )} leaves it on is too narrow for
+     * it. That is the second half of the order: having given way at the inputs, the layout takes the
+     * output only if it still has to.
+     */
+    @Test
+    void anOutputIsBrokenOnlyWhereItDoesNotFitTheLineTheInputsLeftIt() {
+        List<String> wrong = new ArrayList<>();
+        for (Laid laid : sweep()) {
+            if (!laid.inputsBroken()) {
+                continue;
+            }
+            // `) -> ` and the union, which is the line the inputs left for the output.
+            int columns = ") -> ".length() + unionOf(laid.source()).length();
+            if (laid.outputBroken() != (columns > WIDTH)) {
+                wrong.add("an output of " + columns + " columns came back "
+                        + (laid.outputBroken() ? "broken" : "whole") + ":\n" + laid.text());
+            }
+        }
+        assertEquals(List.of(), wrong, String.join("\n", wrong));
+    }
+
+    /** Every width from a signature that fits to one whose union alone does not, in both
+     *  directions, so that the two are varied against each other rather than one at a time. */
+    private static List<Laid> sweep() {
+        List<Laid> out = new ArrayList<>();
+        for (int params = 1; params <= 3; params++) {
+            for (int nameLength : new int[] {3, 12, 30}) {
+                for (int members = 1; members <= 3; members++) {
+                    for (int memberLength : new int[] {6, 22, 40}) {
+                        String source = signature(params, nameLength, members, memberLength);
+                        String text = Formatter.format(source);
+                        out.add(new Laid(source, text, inputsBroken(text), outputBroken(text)));
+                    }
+                }
+            }
+        }
+        return out;
+    }
+
+    private static String signature(int params, int nameLength, int members, int memberLength) {
+        StringBuilder sb = new StringBuilder("module m\n\nbehavior act : (");
+        for (int i = 0; i < params; i++) {
+            sb.append(i == 0 ? "" : ", ").append(name('a', nameLength, i)).append(": Int");
+        }
+        sb.append(") -> ");
+        for (int i = 0; i < members; i++) {
+            sb.append(i == 0 ? "" : " | ").append(name('A', memberLength, i));
+        }
+        return sb.append("\n").toString();
+    }
+
+    /** A name of exactly {@code length} characters, distinct per index. */
+    private static String name(char first, int length, int index) {
+        String tail = Integer.toString(index);
+        return first + "x".repeat(length - 1 - tail.length()) + tail;
+    }
+
+    /** The signature as one line, which is the width the layout was asked about. */
+    private static String oneLine(String source) {
+        for (String line : source.split("\n", -1)) {
+            if (line.startsWith("behavior ")) {
+                return line;
+            }
+        }
+        throw new IllegalStateException("no signature in " + source);
+    }
+
+    /** What the source writes after the arrow. */
+    private static String unionOf(String source) {
+        String line = oneLine(source);
+        return line.substring(line.indexOf(") -> ") + ") -> ".length());
+    }
+
+    /** The parameter list is broken when the signature's own line ends at the {@code (}. */
+    private static boolean inputsBroken(String text) {
+        for (String line : text.split("\n", -1)) {
+            if (line.matches("^behavior \\S+ : \\($")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** The union is broken when a member opens a line with its {@code |}. */
+    private static boolean outputBroken(String text) {
+        for (String line : text.split("\n", -1)) {
+            if (line.matches("^\\s+\\| \\S.*$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/WhatACommentIsAboutIsReadFromTheBreaksAroundItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/WhatACommentIsAboutIsReadFromTheBreaksAroundItTest.java
@@ -1,0 +1,162 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A comment stands in one of three positions relative to what it is about, and which one is read
+ * from the line breaks around it — the blank line included, not only whether a line ended.
+ *
+ * <p>The three are held together here rather than one to a test, because the answer for each is
+ * what rules the other two out. Reading only whether a line ended leaves two of the three sharing
+ * an answer, and a note written under a declaration comes back describing the next one — a change
+ * of what the comment is about rather than of where it is written, so a test comparing the text of
+ * one of these cases alone would let it through.
+ */
+class WhatACommentIsAboutIsReadFromTheBreaksAroundItTest {
+
+    @Test
+    void onTheCodesOwnLineItIsAboutThatCode() {
+        assertEquals("""
+                module m
+
+                data OwnCost = Reimbursement | Advance // the cases are units
+
+                behavior quote : (c: Cart) -> PricedCart
+                """, Formatter.format("""
+                module m
+                data OwnCost = Reimbursement | Advance // the cases are units
+
+                behavior quote : (c: Cart) -> PricedCart
+                """));
+    }
+
+    @Test
+    void runningIntoWhatFollowsItIsAboutWhatFollows() {
+        assertEquals("""
+                module m
+
+                data OwnCost = Reimbursement | Advance
+                // what quote does
+                behavior quote : (c: Cart) -> PricedCart
+                """, Formatter.format("""
+                module m
+                data OwnCost = Reimbursement | Advance
+                // what quote does
+                behavior quote : (c: Cart) -> PricedCart
+                """));
+    }
+
+    @Test
+    void cutOffFromWhatFollowsItIsAboutWhatIsAboveIt() {
+        assertEquals("""
+                module m
+
+                data OwnCost = Reimbursement | Advance
+                // the cases are units; nothing else declares them
+
+                behavior quote : (c: Cart) -> PricedCart
+                """, Formatter.format("""
+                module m
+                data OwnCost = Reimbursement | Advance
+                // the cases are units; nothing else declares them
+
+                behavior quote : (c: Cart) -> PricedCart
+                """));
+    }
+
+    /**
+     * A blank line above the comment as well as below it puts nothing between it and what follows
+     * that is not also between it and what came before, so it stays what it was: about what follows.
+     */
+    @Test
+    void cutOffFromBothItIsAboutWhatFollows() {
+        assertEquals("""
+                module m
+
+                data OwnCost = Reimbursement | Advance
+
+                // what quote does
+                behavior quote : (c: Cart) -> PricedCart
+                """, Formatter.format("""
+                module m
+                data OwnCost = Reimbursement | Advance
+
+                // what quote does
+
+                behavior quote : (c: Cart) -> PricedCart
+                """));
+    }
+
+    /**
+     * A run of comment lines is one comment for this question. Answered line by line, the last line
+     * of a run with a blank under it would go to one owner and every line above it to the other.
+     */
+    @Test
+    void aRunOfLinesIsAboutOneThing() {
+        assertEquals("""
+                module m
+
+                data OwnCost = Reimbursement | Advance
+                // the cases are units
+                // nothing else declares them
+
+                behavior quote : (c: Cart) -> PricedCart
+                """, Formatter.format("""
+                module m
+                data OwnCost = Reimbursement | Advance
+                // the cases are units
+                // nothing else declares them
+
+                behavior quote : (c: Cart) -> PricedCart
+                """));
+    }
+
+    /**
+     * With nothing after it there is no member for a blank line to separate the comment from, which
+     * is what the fourth carrier answers and not this question. It closes the file.
+     */
+    @Test
+    void withNothingAfterItItClosesTheFile() {
+        assertEquals("""
+                module m
+
+                data OwnCost = Reimbursement | Advance
+                // the cases are units
+                """, Formatter.format("""
+                module m
+                data OwnCost = Reimbursement | Advance
+                // the cases are units
+                """));
+    }
+
+    /** Reading it back gives the same answer, so the position the canonical form writes a comment
+     *  in is one the canonical form reads as that position. */
+    @Test
+    void eachAnswerIsWrittenInTheFormThatIsReadBackAsIt() {
+        for (String source : new String[] {
+                """
+                module m
+                data OwnCost = Reimbursement | Advance // the cases are units
+
+                behavior quote : (c: Cart) -> PricedCart
+                """,
+                """
+                module m
+                data OwnCost = Reimbursement | Advance
+                // what quote does
+                behavior quote : (c: Cart) -> PricedCart
+                """,
+                """
+                module m
+                data OwnCost = Reimbursement | Advance
+                // the cases are units
+
+                behavior quote : (c: Cart) -> PricedCart
+                """}) {
+            String once = Formatter.format(source);
+            assertEquals(once, Formatter.format(once), once);
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/WhatSeparatesTwoItemsComesFromBothOfThemTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/WhatSeparatesTwoItemsComesFromBothOfThemTest.java
@@ -17,15 +17,22 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * What goes between two top-level items, as a function of both of them. The formatter writes one
- * blank line between items unless a module header or an import is followed by an import, which is a
- * decision about a pair and not about the file: a table with one row for {@code SOURCE_FILE} cannot
- * hold it, and a fixture with a header and an import in it does not reach the pair where the first
- * of the two is itself an import.
+ * What goes between two top-level items, as a function of both of them and of what the author
+ * wrote there. Some pairs are the file's: a header is a header and the file begins under it, so a
+ * blank line goes there whatever the source had. The rest are the author's, and what the canonical
+ * form keeps of those is that a paragraph break is there and not how big it was.
  *
- * <p>Every ordered pair the grammar admits is a row. The pairs it does not admit are their own
- * claim below, because what makes this table forty-three cells rather than sixty-four is the grammar
- * and not a choice the formatter made.
+ * <p>It is a decision about a pair and not about the file: a table with one row for
+ * {@code SOURCE_FILE} cannot hold it, and a fixture with a header and an import in it does not
+ * reach the pair where the first of the two is itself an import.
+ *
+ * <p>Every ordered pair the grammar admits is a row, and each row is written three ways — with no
+ * blank line, with one, and with three. A row asked only one way says nothing about whether the
+ * answer came from the pair or from the source: a forced pair and an author's pair agree wherever
+ * the author wrote one blank line, which is how every fixture in this suite used to be written.
+ *
+ * <p>The pairs the grammar does not admit are their own claim below, because what makes this table
+ * forty-three cells rather than sixty-four is the grammar and not a choice the formatter made.
  */
 class WhatSeparatesTwoItemsComesFromBothOfThemTest {
 
@@ -72,19 +79,31 @@ class WhatSeparatesTwoItemsComesFromBothOfThemTest {
             return first.name() + " then " + second.name();
         }
 
-        /** The two written one after the other, under a module header where neither is one. */
-        String source() {
-            String head = first.opensAFile() ? "" : "module m exposing ( f )\n";
-            return head + first.text() + "\n" + second.text() + "\n";
+        /** The two written one after the other with {@code blanks} blank lines between them, under
+         *  a module header where neither is one. */
+        String source(int blanks) {
+            String head = first.opensAFile() ? "" : "module m exposing ( f )\n\n";
+            return head + first.text() + "\n" + "\n".repeat(blanks) + second.text() + "\n";
         }
     }
 
-    static Stream<Pair> pairs() {
-        List<Pair> out = new ArrayList<>();
+    /** One pair, written with a given number of blank lines between its two items. */
+    record Row(Pair pair, int written) {
+        @Override
+        public String toString() {
+            return pair + ", " + written + " blank";
+        }
+    }
+
+    static Stream<Row> rows() {
+        List<Row> out = new ArrayList<>();
         for (Item first : ITEMS) {
             for (Item second : ITEMS) {
-                if (canFollow(first, second)) {
-                    out.add(new Pair(first, second));
+                if (!canFollow(first, second)) {
+                    continue;
+                }
+                for (int written : new int[] {0, 1, 3}) {
+                    out.add(new Row(new Pair(first, second), written));
                 }
             }
         }
@@ -92,12 +111,28 @@ class WhatSeparatesTwoItemsComesFromBothOfThemTest {
     }
 
     /**
-     * The pairs written with no blank line between them. Written out rather than computed, so that
-     * the formatter deciding differently fails this rather than agreeing with itself.
+     * The pairs a blank line goes between whatever the source had, because the separation there is
+     * the file's: a header, and the end of the import block. Written out rather than computed, so
+     * that the formatter deciding differently fails this rather than agreeing with itself.
      */
-    private static final Set<String> TIGHT = Set.of(
+    private static final Set<String> FORCED = Set.of(
             "module header then import",
-            "import then import");
+            "module header then data",
+            "module header then behavior",
+            "module header then definition",
+            "module header then example",
+            "module header then fake",
+            "examples file header then import",
+            "examples file header then data",
+            "examples file header then behavior",
+            "examples file header then definition",
+            "examples file header then example",
+            "examples file header then fake",
+            "import then data",
+            "import then behavior",
+            "import then definition",
+            "import then example",
+            "import then fake");
 
     /** The lines between the last line of {@code first} and the first line of {@code second}. */
     private static int blanksBetween(String formatted, Pair pair) {
@@ -132,26 +167,51 @@ class WhatSeparatesTwoItemsComesFromBothOfThemTest {
      * and answer about something else.
      */
     @ParameterizedTest(name = "{0}")
-    @MethodSource("pairs")
-    void theGrammarAdmitsThisPair(Pair pair) {
-        assertEquals(List.of(), CstParser.parse(pair.source()).errors(),
-                pair + ": the grammar refuses this, so it is not a row of the table");
+    @MethodSource("rows")
+    void theGrammarAdmitsThisPair(Row row) {
+        assertEquals(List.of(), CstParser.parse(row.pair().source(row.written())).errors(),
+                row + ": the grammar refuses this, so it is not a row of the table");
     }
 
     @ParameterizedTest(name = "{0}")
-    @MethodSource("pairs")
-    void whatGoesBetweenThem(Pair pair) {
-        String formatted = Formatter.format(pair.source());
-        assertEquals(TIGHT.contains(pair.toString()) ? 0 : 1, blanksBetween(formatted, pair),
-                pair + ": blank lines between them, in:\n" + formatted);
+    @MethodSource("rows")
+    void whatGoesBetweenThem(Row row) {
+        String formatted = Formatter.format(row.pair().source(row.written()));
+        int expected = FORCED.contains(row.pair().toString()) ? 1 : Math.min(row.written(), 1);
+        assertEquals(expected, blanksBetween(formatted, row.pair()),
+                row + ": blank lines between them, in:\n" + formatted);
     }
 
     /** And it is where the canonical form stays. */
     @ParameterizedTest(name = "{0}")
-    @MethodSource("pairs")
-    void andThatIsAFixedPoint(Pair pair) {
-        String formatted = Formatter.format(pair.source());
+    @MethodSource("rows")
+    void andThatIsAFixedPoint(Row row) {
+        String formatted = Formatter.format(row.pair().source(row.written()));
         assertEquals(formatted, Formatter.format(formatted));
+    }
+
+    /**
+     * Every pair the author decides comes out both ways. A rule read from the source is answered by
+     * a sweep where the source never varies, and the two halves of this table would pass with the
+     * blank line forced everywhere or written nowhere if only one of them were reached.
+     */
+    @Test
+    void thePairsTheAuthorDecidesAreReachedBothWays() {
+        List<String> missing = new ArrayList<>();
+        for (Row row : rows().toList()) {
+            if (FORCED.contains(row.pair().toString())) {
+                continue;
+            }
+            String formatted = Formatter.format(row.pair().source(row.written()));
+            int blanks = blanksBetween(formatted, row.pair());
+            if (row.written() == 0 && blanks != 0) {
+                missing.add(row + ": came back with " + blanks);
+            }
+            if (row.written() > 0 && blanks != 1) {
+                missing.add(row + ": came back with " + blanks);
+            }
+        }
+        assertEquals(List.of(), missing, String.join("\n", missing));
     }
 
     /**
@@ -173,13 +233,19 @@ class WhatSeparatesTwoItemsComesFromBothOfThemTest {
         assertEquals(written, covered);
     }
 
-    /** Both answers the table gives are reached, and by more than one pair each. */
+    /** Both answers the table gives are reached, and by more than one pair each. A table where one
+     *  of the two is empty is a rule with one branch written as though it had two. */
     @Test
     void theTableIsNotOneAnswer() {
-        long tight = pairs().filter(p -> TIGHT.contains(p.toString())).count();
-        long apart = pairs().count() - tight;
-        assertEquals(2, tight, "pairs written with no blank line between them");
-        assertEquals(41, apart, "pairs written with one");
+        List<Pair> pairs = new ArrayList<>();
+        for (Row row : rows().toList()) {
+            if (row.written() == 0) {
+                pairs.add(row.pair());
+            }
+        }
+        long forced = pairs.stream().filter(p -> FORCED.contains(p.toString())).count();
+        assertEquals(17, forced, "pairs the file separates whatever the source had");
+        assertEquals(26, pairs.size() - forced, "pairs the author separates");
     }
 
     /**
@@ -191,7 +257,7 @@ class WhatSeparatesTwoItemsComesFromBothOfThemTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("refusedPairs")
     void anImportComesBeforeEverythingElse(Pair pair) {
-        assertTrue(!CstParser.parse(pair.source()).errors().isEmpty(),
+        assertTrue(!CstParser.parse(pair.source(0)).errors().isEmpty(),
                 pair + ": the grammar admits this, so the table above is missing a row for it");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/fmt/WhereABlankLineGoesIsTheAuthorsAndHowManyIsNotTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/WhereABlankLineGoesIsTheAuthorsAndHowManyIsNotTest.java
@@ -1,0 +1,207 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Between two members written one to a line, a blank line survives and its size does not.
+ *
+ * <p>The two halves are one rule. That a paragraph break is there is something the author wrote and
+ * the canonical form has no other way to know: a block of nine statements and a block of three
+ * groups of three are the same tree, so grouping is the only structure a body has that is not in it.
+ * How big the break is carries nothing, so any number of blank lines comes back as one and the
+ * canonical form still has one answer per input.
+ *
+ * <p>Between members a construct writes with a connector — a {@code data}'s fields, a union's cases,
+ * an argument list — there is no paragraph break to keep. Those members are a run and what is
+ * between two of them is the run's, so a blank line written there is layout and goes.
+ *
+ * <p>{@link WhatSeparatesTwoItemsComesFromBothOfThemTest} holds the same rule over every pair of
+ * top-level items, including the two pairs the file separates whatever the author wrote. This is the
+ * block body's half, and the part no pair of top-level items reaches: a blank line inside a nesting.
+ */
+class WhereABlankLineGoesIsTheAuthorsAndHowManyIsNotTest {
+
+    @Test
+    void aBlockKeepsThePlacesItsAuthorLeftABlankLine() {
+        assertEquals("""
+                module m
+
+                let f (n: Int) = {
+                    let x = 1
+                    let y = 2
+
+                    let z = 3
+
+                    x + y + z
+                }
+                """, Formatter.format("""
+                module m
+                let f (n: Int) = {
+                    let x = 1
+                    let y = 2
+
+                    let z = 3
+
+                    x + y + z
+                }
+                """));
+    }
+
+    @Test
+    void andAnyNumberOfThemIsOne() {
+        assertEquals("""
+                module m
+
+                let f (n: Int) = {
+                    let x = 1
+
+                    x + 1
+                }
+                """, Formatter.format("""
+                module m
+                let f (n: Int) = {
+                    let x = 1
+
+
+
+
+                    x + 1
+                }
+                """));
+    }
+
+    @Test
+    void andWhereTheAuthorLeftNoneThereIsNone() {
+        assertEquals("""
+                module m
+
+                let f (n: Int) = {
+                    let x = 1
+                    let y = 2
+                    x + y
+                }
+                """, Formatter.format("""
+                module m
+                let f (n: Int) = {
+                    let x = 1
+                    let y = 2
+                    x + y
+                }
+                """));
+    }
+
+    /** A comment is a step's, and the paragraph break goes above what it opens rather than between
+     *  the comment and the step it is written over. */
+    @Test
+    void andAParagraphOpensWithItsComment() {
+        assertEquals("""
+                module m
+
+                let f (n: Int) = {
+                    let x = 1
+
+                    // what the rest of it does
+                    let y = 2
+                    x + y
+                }
+                """, Formatter.format("""
+                module m
+                let f (n: Int) = {
+                    let x = 1
+
+                    // what the rest of it does
+                    let y = 2
+                    x + y
+                }
+                """));
+    }
+
+    /** Between the members of a run there is no paragraph to keep. */
+    @Test
+    void aBlankLineInsideAConstructIsLayoutAndGoes() {
+        assertEquals("""
+                module m
+
+                data D =
+                    { a: Int
+                    , b: Int
+                    }
+                """, Formatter.format("""
+                module m
+                data D =
+                    { a: Int
+
+                    , b: Int
+                    }
+                """));
+    }
+
+    /**
+     * A blank line has nothing on it, so it is written with nothing on it. The break that leaves one
+     * is inside whatever nesting the member is in, and written with that nesting's indent it would
+     * leave spaces on a line a reader sees as empty and an editor strips — which would then be a file
+     * {@code fmt --check} and the editor disagree about.
+     */
+    @Test
+    void aBlankLineHasNothingOnIt() {
+        String formatted = Formatter.format("""
+                module m
+                let f (n: Int) = {
+                    let x = 1
+
+                    let y = {
+                        let z = 2
+
+                        z + 1
+                    }
+                    x + y
+                }
+                """);
+        List<String> padded = new ArrayList<>();
+        for (String line : formatted.split("\n", -1)) {
+            if (!line.isEmpty() && line.isBlank()) {
+                padded.add("`" + line + "`");
+            }
+        }
+        assertEquals(List.of(), padded, "blank lines with something on them, in:\n" + formatted);
+        assertTrue(formatted.contains("\n\n        z + 1"),
+                "the blank line inside the nested block is not there, in:\n" + formatted);
+    }
+
+    /** And the form each of these comes back in is read back as itself. */
+    @Test
+    void everyAnswerIsAFixedPoint() {
+        for (String source : new String[] {
+                """
+                module m
+                let f (n: Int) = {
+                    let x = 1
+
+                    x + 1
+                }
+                """,
+                """
+                module m
+                let f (n: Int) = {
+                    let x = 1
+                    x + 1
+                }
+                """,
+                """
+                module m
+                data A = Int
+                data B = Int
+
+                data C = Int
+                """}) {
+            String once = Formatter.format(source);
+            assertEquals(once, Formatter.format(once), once);
+        }
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Carrier.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Carrier.java
@@ -3,9 +3,16 @@ package souther.compiler.fmt;
 /**
  * What a {@link Place} can be handed.
  *
- * <p>Three, because a comment is written in three positions relative to what it is about and the
- * three are not the same question: above the line a place opens, at the end of the line it ends, and
- * inside it under its last member.
+ * <p>Three of these are where a comment stands relative to what it is about, and they divide that
+ * question completely: on lines of its own in front of the place, on the place's own line, and on
+ * lines of its own after it. A set holding only the first two says that a comment below what it
+ * describes is one of the other two, and there is no reading of it that makes it either — written
+ * above the next construct it is about that construct, and written at the end of the previous line
+ * it is a different kind of comment than the author wrote.
+ *
+ * <p>{@link #AT_END} answers a different question, which is why it does not upset that division:
+ * not where a comment stands beside a member, but that no member follows it at all. It is the
+ * comment a container holds after its last member, and what is below it is the container closing.
  */
 enum Carrier {
 
@@ -15,6 +22,17 @@ enum Carrier {
     /** At the end of the line the place ends — after whatever the construct holding it writes
      *  between this place and the next, since that punctuation is on the same line. */
     TRAILING,
+
+    /**
+     * On lines of its own, after the place, with a member still to come.
+     *
+     * <p>Only reached where a blank line separates the comment from that member: without one the
+     * comment runs straight into what follows and is that member's, which is {@link #ABOVE}. The
+     * blank line itself is written by whatever separates the two members and not from here — the
+     * comment is below one member and above the separator, and a carrier that wrote the separator
+     * too would be saying where the next member begins.
+     */
+    BELOW,
 
     /** Inside the place, under its last member and before what closes it. */
     AT_END

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Carriers.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Carriers.java
@@ -119,7 +119,7 @@ final class Carriers {
             switch (slot.which()) {
                 case ABOVE -> parts.add(TokenDoc.concat(c, TokenDoc.HARD_GAP));
                 case TRAILING -> parts.add(c);
-                case AT_END -> parts.add(TokenDoc.concat(TokenDoc.HARD_GAP, c));
+                case BELOW, AT_END -> parts.add(TokenDoc.concat(TokenDoc.HARD_GAP, c));
             }
         }
         return TokenDoc.concat(parts);

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Doc.java
@@ -35,7 +35,10 @@ sealed interface Doc {
      * boundary. */
     final class LineRef {
     }
-    record Hard(Ref ref) implements Doc {}
+
+    /** A break, and whether it writes the indent of the line it opens. The one that does not is the
+     *  one that leaves a blank line: nothing is on that line, so it has no indent. */
+    record Hard(Ref ref, boolean indents) implements Doc {}
     record Concat(List<Doc> parts) implements Doc {}
     record Nest(NestRef ref, int indent, Doc doc) implements Doc {}
 
@@ -85,7 +88,12 @@ sealed interface Doc {
 
     /** Always a newline, and the group holding it is never laid out flat. */
     static Doc hardline() {
-        return new Hard(new Ref());
+        return new Hard(new Ref(), true);
+    }
+
+    /** The same, leaving the line it opens empty: a blank line, written with no indent on it. */
+    static Doc blankLine() {
+        return new Hard(new Ref(), false);
     }
 
     /** Writes nothing, and the group holding it is never laid out flat. */
@@ -213,13 +221,14 @@ sealed interface Doc {
                         sb.append(l.flat());
                         col += l.flat().length();
                     } else {
-                        breaks.add(newline(sb, it));
+                        breaks.add(newline(sb, it, it.indent));
                         col = it.indent;
                     }
                 }
-                case Hard _ -> {
-                    breaks.add(newline(sb, it));
-                    col = it.indent;
+                case Hard h -> {
+                    int indent = h.indents() ? it.indent : 0;
+                    breaks.add(newline(sb, it, indent));
+                    col = indent;
                 }
                 case Trailing t -> {
                     sb.append(' ').append(t.s());
@@ -232,11 +241,12 @@ sealed interface Doc {
         return new Layout(sb.toString(), decisions, extents, breaks, opportunities);
     }
 
-    /** Writes a break and says what it wrote. */
-    private static Newline newline(StringBuilder sb, Item it) {
+    /** Writes a break and says what it wrote. {@code indent} is the item's, except on the break
+     *  that leaves a blank line, whose line has nothing on it to indent. */
+    private static Newline newline(StringBuilder sb, Item it, int indent) {
         int offset = sb.length();
-        sb.append('\n').append(" ".repeat(it.indent()));
-        return new Newline(offset, it.indent(),
+        sb.append('\n').append(" ".repeat(indent));
+        return new Newline(offset, indent,
                 it.under() == null ? List.of() : it.under().outermostFirst());
     }
 

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -229,6 +229,9 @@ public final class Formatter {
             file(out, declared, endsTheLine(e.getKey(), e.getKey().end(), declared),
                     Carrier.TRAILING, e.getValue());
         }
+        for (var e : comments.below().entrySet()) {
+            file(out, declared, entryPlaces(e.getKey(), Carrier.BELOW), Carrier.BELOW, e.getValue());
+        }
         for (var e : comments.atEnd().entrySet()) {
             file(out, declared, entryPlaces(e.getKey(), Carrier.AT_END), Carrier.AT_END, e.getValue());
         }
@@ -524,9 +527,23 @@ public final class Formatter {
             // hands the brackets over and the pass that answers the carriers says.
             return new TokenDoc.Vacant(run, construct, open, close, INDENT);
         }
-        return TokenDoc.node(construct, group(concat(open,
+        return group(bracketed(construct, open, members, close));
+    }
+
+    /**
+     * The same brackets and members, with no group of its own.
+     *
+     * <p>For the one caller that has to decide this bracket's layout together with what is written
+     * after it. A group is one decision, so a construct holding two of them holds two, and which of
+     * the two gives way first is then whichever the layout reaches with too little room left —
+     * an order that comes from how the document was built rather than from anything anyone decided.
+     * Handing the brackets over ungrouped is how a caller makes the two one decision.
+     */
+    private static TokenDoc bracketed(SyntaxKind construct, TokenDoc open, List<Member> members,
+            TokenDoc close) {
+        return TokenDoc.node(construct, concat(open,
                 nest(INDENT, separated(members)),
-                SOFT_GAP, close)));
+                SOFT_GAP, close));
     }
 
     /**
@@ -619,11 +636,15 @@ public final class Formatter {
         comments = attach(file);
         Place ofTheFile = places.fileOf(file);
         List<TokenDoc> parts = new ArrayList<>();
-        SyntaxKind prev = null;
+        List<SyntaxNode> items = new ArrayList<>();
         for (SyntaxNode item : file.childNodes()) {
-            if (!isTopLevel(item.kind())) {
-                continue;
+            if (isTopLevel(item.kind())) {
+                items.add(item);
             }
+        }
+        java.util.Set<SyntaxNode> paragraph = openedByABlankLine(file, items);
+        SyntaxKind prev = null;
+        for (SyntaxNode item : items) {
             // A top-level item's comments are read the same way a member's are, and marked written
             // the same way: an `example`'s comment is the item's leading trivia here and the first
             // row's from inside, and it belongs to whichever asks first.
@@ -634,8 +655,8 @@ public final class Formatter {
             Place at = places.under(ofTheFile, item.kind(),
                     prev == null ? Opening.FILE_BEGINS : Opening.breaks(TokenDoc.Break.ALWAYS),
                     Written.of(item));
-            if (prev != null && blankBetween(prev, item.kind())) {
-                parts.add(HARD_GAP);
+            if (prev != null && blankBetween(prev, item.kind(), paragraph.contains(item))) {
+                parts.add(TokenDoc.BLANK_LINE);
             }
             parts.add(TokenDoc.at(at, concat(item(item, at), TokenDoc.endsTheLineOf(at))));
             prev = item.kind();
@@ -645,12 +666,66 @@ public final class Formatter {
         return concat(parts);
     }
 
-    /** One blank line separates every top-level item, except the module header and its imports,
-     * which stay tight together (as gofmt keeps a package clause and its import block). */
-    private static boolean blankBetween(SyntaxKind prev, SyntaxKind current) {
-        boolean header = (prev == SyntaxKind.MODULE_HEADER || prev == SyntaxKind.IMPORT_DECL)
-                && current == SyntaxKind.IMPORT_DECL;
-        return !header;
+    /**
+     * What separates two top-level items: one blank line, or none.
+     *
+     * <p>Two of them are the file's rather than the author's. A module header is a header and the
+     * file begins under it; the imports are a block and what follows them is the module's own text.
+     * Both are written with a blank line under them whatever was there, which is what gofmt writes
+     * under a package clause and under an import block.
+     *
+     * <p>Everywhere else {@code written} says, which is whether the author put a blank line there.
+     * That a paragraph break is there is something a reader wrote and the canonical form keeps;
+     * how big it is is not, so any number of blank lines comes back as one. The canonical form still
+     * has one answer per input, and a run of related one-line declarations stays a run — which
+     * writing a blank line between every pair took away.
+     */
+    private static boolean blankBetween(SyntaxKind prev, SyntaxKind current, boolean written) {
+        if (prev == SyntaxKind.MODULE_HEADER || prev == SyntaxKind.EXAMPLES_FILE_HEADER) {
+            return true;
+        }
+        if (prev == SyntaxKind.IMPORT_DECL && current != SyntaxKind.IMPORT_DECL) {
+            return true;
+        }
+        return written;
+    }
+
+    /**
+     * Which of {@code members} the author wrote a blank line in front of.
+     *
+     * <p>Read from the trivia between the last code token of one member and the first of the next.
+     * A comment written in that gap belongs to one of the two members, and the blank line beside it
+     * is what separates the two groups either way, so what is asked is the gap and not the comment.
+     *
+     * <p>The tree is lossless and holds the blank lines; nothing read them. Counting the line breaks
+     * rather than asking whether one is there is the whole of the difference between a paragraph
+     * break and the end of a line.
+     */
+    private static java.util.Set<SyntaxNode> openedByABlankLine(SyntaxNode parent,
+            List<SyntaxNode> members) {
+        java.util.Set<SyntaxNode> out =
+                java.util.Collections.newSetFromMap(new IdentityHashMap<>());
+        if (members.size() < 2) {
+            return out;
+        }
+        List<SyntaxToken> blanks = new ArrayList<>();
+        for (SyntaxToken t : tokens(parent)) {
+            if (t.kind() == SyntaxKind.WHITESPACE && newlines(t) >= 2) {
+                blanks.add(t);
+            }
+        }
+        for (int i = 1; i < members.size(); i++) {
+            SyntaxToken last = lastCodeTokenOf(members.get(i - 1));
+            int from = last == null ? members.get(i - 1).end() : last.end();
+            int to = firstCodeOffset(members.get(i));
+            for (SyntaxToken t : blanks) {
+                if (t.start() >= from && t.start() < to) {
+                    out.add(members.get(i));
+                    break;
+                }
+            }
+        }
+        return out;
     }
 
     /** The kinds {@link #file} writes as items of the file, and so the kinds the separation between
@@ -1016,7 +1091,7 @@ public final class Formatter {
             // for it. It still ends that line, which is what lets it own the comment there.
             Place ofTheResult = places.under(ofTheSig, retNode.kind(), Opening.NONE,
                     Written.of(retNode));
-            TokenDoc ret = TokenDoc.at(ofTheResult, concat(retType(retNode, ofTheResult), TokenDoc.endsTheLineOf(ofTheResult)));
+            TokenDoc ret = TokenDoc.at(ofTheResult, retType(retNode, ofTheResult));
             List<TokenDoc> clauses = new ArrayList<>();
             for (SyntaxNode c : s.childNodes()) {
                 if (c.kind() != SyntaxKind.CONSTRUCTS_CLAUSE
@@ -1037,8 +1112,10 @@ public final class Formatter {
             return TokenDoc.node(n.kind(),
                     concat(TokenDoc.token(SyntaxKind.BEHAVIOR_KW, "behavior"), GAP, ident(name),
                             GAP, COLON, GAP, TokenDoc.at(ofTheSig,
-                                    TokenDoc.node(s.kind(), concat(params, GAP, ARROW, GAP,
-                                            ret, nest(INDENT, concat(clauses)))))));
+                                    TokenDoc.node(s.kind(), concat(
+                                            signature(params, ret),
+                                            TokenDoc.carries(ofTheResult, Carrier.TRAILING),
+                                            nest(INDENT, concat(clauses)))))));
         }
         SyntaxNode pipe = n.child(SyntaxKind.PIPE_BEHAVIOR).orElseThrow();
         Place ofThePipe = places.under(at, pipe.kind(), Opening.NONE, Written.of(pipe));
@@ -1067,6 +1144,30 @@ public final class Formatter {
                         TokenDoc.node(pipe.kind(), group(nest(INDENT, concat(parts)))))));
     }
 
+    /**
+     * A behavior's inputs and output as one decision, so that the parameter list is what gives way
+     * when the signature does not fit and the output union is what gives way after it.
+     *
+     * <p>The order is a rule about reading a signature and not about the shape of the tree. A
+     * reader takes a signature as three regions — the name, the inputs, the output — and breaking
+     * the union first leaves one member of it on the signature line, attached to the arrow, with
+     * the rest below: a union whose members are alike, written as though the first were the answer.
+     * Breaking the inputs keeps all three regions whole.
+     *
+     * <p>What states the order is that the parameters have no group of their own and the union
+     * does. This one group covers both, so it is measured with the union flat and breaks at the
+     * parameters; the union is then measured on the line the {@code )} left it, and breaks only
+     * where it does not fit there by itself. Two groups would be two decisions and the layout would
+     * take whichever it reached with too little room — which is the parameters last, since they are
+     * written first.
+     *
+     * <p>The gaps around the arrow never break, so this group adds no place to break that the
+     * parameters and the union did not already have.
+     */
+    private static TokenDoc signature(TokenDoc params, TokenDoc ret) {
+        return group(concat(params, GAP, ARROW, GAP, ret));
+    }
+
     private TokenDoc paramList(SyntaxNode n, Place at) {
         Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
         List<Member> params = new ArrayList<>();
@@ -1076,8 +1177,12 @@ public final class Formatter {
                     concat(ident(firstIdent(p)), GAP, COLON, GAP,
                             retType(p.child(SyntaxKind.RET_TYPE).orElseThrow(), param)))));
         }
-        return TokenDoc.at(run,
-                delimited(run, SyntaxKind.PARAM_LIST, LPAREN, withEndComments(run, params), RPAREN));
+        List<Member> members = withEndComments(run, params);
+        // Ungrouped: a behavior signature lays this list out together with the union after the
+        // arrow, and which of the two gives way first is that construct's rule to state.
+        return TokenDoc.at(run, members.isEmpty()
+                ? new TokenDoc.Vacant(run, SyntaxKind.PARAM_LIST, LPAREN, RPAREN, INDENT)
+                : bracketed(SyntaxKind.PARAM_LIST, LPAREN, members, RPAREN));
     }
 
     /** One stage of a pipeline, which is a name and is written as one. */
@@ -1767,7 +1872,16 @@ public final class Formatter {
     private TokenDoc block(SyntaxNode n, Place at) {
         Place run = places.under(at, n.kind(), Opening.NONE, Written.of(n));
         List<TokenDoc> lines = new ArrayList<>();
-        for (SyntaxNode c : n.childNodes()) {
+        List<SyntaxNode> steps = n.childNodes();
+        // The paragraph breaks between the steps are the author's, the same as between two
+        // top-level items, and for the same reason: what a block has for structure is where its
+        // steps are grouped, and a body written as three paragraphs says something a body written
+        // as nine lines does not.
+        java.util.Set<SyntaxNode> paragraph = openedByABlankLine(n, steps);
+        for (SyntaxNode c : steps) {
+            if (!lines.isEmpty() && paragraph.contains(c)) {
+                lines.add(TokenDoc.BLANK_LINE);
+            }
             // A statement inside a block carries its leading comments the same way a top-level item
             // does. Walking only the child nodes dropped them, so a comment explaining a step was
             // lost on the first format.
@@ -1901,6 +2015,8 @@ public final class Formatter {
             Map<SyntaxNode, List<SyntaxToken>> above,
             /** At the end of the line the node ends. */
             Map<SyntaxNode, List<SyntaxToken>> after,
+            /** On lines of its own below the line the node ends, with a member still to come. */
+            Map<SyntaxNode, List<SyntaxToken>> below,
             /** Inside the node, under its last member and before it closes. */
             Map<SyntaxNode, List<SyntaxToken>> atEnd,
             /** Against a name rather than a node — the identifiers a sum's case or a clause's
@@ -1920,7 +2036,8 @@ public final class Formatter {
 
         static Attachments empty() {
             return new Attachments(new IdentityHashMap<>(), new IdentityHashMap<>(),
-                    new IdentityHashMap<>(), new java.util.HashMap<>(), new java.util.HashMap<>());
+                    new IdentityHashMap<>(), new IdentityHashMap<>(),
+                    new java.util.HashMap<>(), new java.util.HashMap<>());
         }
     }
 
@@ -1934,32 +2051,152 @@ public final class Formatter {
 
     /**
      * Every comment of {@code file}, against where it will be written. One pass over the tokens: a
-     * comment is read as written above the code that follows it or at the end of the code before it,
-     * and then given to whichever construct has the line that code is on.
+     * comment is read as written at the end of the code before it, above the code that follows it,
+     * or below the code before it, and then given to whichever construct has the line that code is
+     * on.
+     *
+     * <p>Which of the three is read from the line breaks around the comment, the blank line
+     * included. A comment on the code's own line was written after that code. A comment on a line
+     * of its own belongs to what follows it — unless a blank line stands under it and none stands
+     * over it, because then the blank line is what separates the comment from what follows and
+     * there is nothing between the comment and the code above. Counting only whether a line ended
+     * left that last case unreadable, and a note written under a declaration came back describing
+     * the next one.
      */
     private static Attachments attach(SyntaxNode file) {
         Attachments out = Attachments.empty();
         List<SyntaxToken> all = tokens(file);
         List<SyntaxToken> code = new ArrayList<>();   // the tokens that were not trivia
-        boolean lineEnded = true;                     // nothing precedes the first token of a file
+        int breaks = 1;                               // nothing precedes the first token of a file
         for (int i = 0; i < all.size(); i++) {
             SyntaxToken t = all.get(i);
             if (t.kind() == SyntaxKind.WHITESPACE) {
-                lineEnded |= t.text().indexOf('\n') >= 0;
+                breaks += newlines(t);
             } else if (t.kind() == SyntaxKind.LINE_COMMENT) {
-                if (lineEnded) {
-                    Follows follows = nextCode(all, i);
-                    above(out, follows.code(), t, file, follows.pastAConnector());
-                } else {
+                if (breaks == 0) {
                     after(out, lastCode(code), t);
+                    breaks = 1;                       // a line comment runs to the end of its line
+                    continue;
                 }
-                lineEnded = true;                     // a line comment runs to the end of its line
+                // A run of comment lines with no blank line in it is one comment as far as this
+                // question goes. Asked line by line, a run with a blank line under it would have
+                // its last line answered one way and every line above it the other.
+                int last = runEnds(all, i);
+                SyntaxNode under = breaks >= 2 || !blankUnder(all, last)
+                        ? null
+                        : belowAnchor(lastCode(code));
+                Follows follows = nextCode(all, last);
+                for (int j = i; j <= last; j++) {
+                    SyntaxToken c = all.get(j);
+                    if (c.kind() != SyntaxKind.LINE_COMMENT) {
+                        continue;
+                    }
+                    if (under != null) {
+                        add(out.below(), under, c);
+                    } else {
+                        above(out, follows.code(), c, file, follows.pastAConnector());
+                    }
+                }
+                i = last;
+                breaks = 1;
             } else {
                 code.add(t);
-                lineEnded = false;
+                breaks = 0;
             }
         }
         return out;
+    }
+
+    /** The line breaks {@code whitespace} holds. Two of them are a blank line. */
+    private static int newlines(SyntaxToken whitespace) {
+        int n = 0;
+        String text = whitespace.text();
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) == '\n') {
+                n++;
+            }
+        }
+        return n;
+    }
+
+    /** The last comment of the run beginning at {@code i}: the comment lines following one another
+     *  with no blank line and no code between them. */
+    private static int runEnds(List<SyntaxToken> all, int i) {
+        int last = i;
+        int breaks = 0;
+        for (int j = i + 1; j < all.size(); j++) {
+            SyntaxToken t = all.get(j);
+            if (t.kind() == SyntaxKind.WHITESPACE) {
+                breaks += newlines(t);
+            } else if (t.kind() == SyntaxKind.LINE_COMMENT && breaks < 2) {
+                last = j;
+                breaks = 0;
+            } else {
+                break;
+            }
+        }
+        return last;
+    }
+
+    /** Whether a blank line stands between the comment at {@code last} and whatever follows it. The
+     *  end of the file is not one: nothing follows there for a blank line to separate it from, and
+     *  a comment with nothing after it is the file's rather than the last declaration's. */
+    private static boolean blankUnder(List<SyntaxToken> all, int last) {
+        int breaks = 0;
+        for (int j = last + 1; j < all.size(); j++) {
+            SyntaxToken t = all.get(j);
+            if (t.kind() != SyntaxKind.WHITESPACE) {
+                return breaks >= 2 && t.kind() != SyntaxKind.EOF;
+            }
+            breaks += newlines(t);
+        }
+        return false;
+    }
+
+    /**
+     * What a comment written under {@code written}, and cut off from what follows by a blank line,
+     * was written about: the outermost construct that ends there.
+     *
+     * <p>Null where the construct ending there is not a member of something that writes its members
+     * on lines of their own. A comment written below one that is not — below the type of a
+     * {@code data} whose {@code invariant} is still to come — is in the middle of a construct, so the
+     * blank line under it separates it from nothing that construct has finished saying, and it is
+     * read as written above what follows, which is what it was before any blank line was read.
+     *
+     * <p>Asked of the member rather than of the place it will be written at, because the place is
+     * found by widening to the nearest one that can carry a comment below it, and widening from the
+     * middle of a construct reaches the whole construct: a comment under a declaration's first line
+     * would come back under its last.
+     */
+    private static SyntaxNode belowAnchor(SyntaxToken written) {
+        if (written == null) {
+            return null;                              // no code above it: it is above what follows
+        }
+        SyntaxToken code = lastOfName(written);
+        // A member with something still to come after it owns its own line, and what is written
+        // below it is below that member rather than below the construct. The last member of a run
+        // ends where the run does, so what is below it is below the whole thing — the same reading
+        // {@link #after} takes of a comment at the end of that line.
+        if (isBareMember(code) && nameEnd(code) != code.parent().end()) {
+            return null;
+        }
+        if (isChainHead(code)) {
+            return null;
+        }
+        SyntaxNode ends = endingAt(code);
+        if (ends.end() != code.end()) {
+            return null;
+        }
+        SyntaxNode holder = ends.parent();
+        return holder != null && writesEachMemberOnItsOwnLine(holder.kind()) ? ends : null;
+    }
+
+    /** Whether a construct of this kind writes each of its members beginning a line of its own, so
+     *  that a member has a line under it that is the member's and not the construct's. These are
+     *  the two that separate members by a break alone; everywhere else a member is written into a
+     *  run its holder wrote the connectors of, and what is under it is under the run. */
+    private static boolean writesEachMemberOnItsOwnLine(SyntaxKind k) {
+        return k == SyntaxKind.SOURCE_FILE || k == SyntaxKind.BLOCK_EXPR;
     }
 
     /**

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Gaps.java
@@ -277,7 +277,7 @@ final class Gaps {
             case TokenDoc.Gap g -> {
                 String flat = answers.get(next[0]++);
                 yield switch (g.policy()) {
-                    case ALWAYS -> Doc.hardline();
+                    case ALWAYS -> g.indents() ? Doc.hardline() : Doc.blankLine();
                     case MAY -> flat.isEmpty() ? Doc.softline() : Doc.line();
                     case NEVER -> flat.isEmpty() ? Doc.NIL : Doc.text(flat);
                 };

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Opening.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Opening.java
@@ -41,7 +41,7 @@ sealed interface Opening {
     /** The boundary that opens the line, or nothing where the line is already open. */
     default TokenDoc boundary() {
         return switch (this) {
-            case Breaks b -> new TokenDoc.Gap(b.policy());
+            case Breaks b -> new TokenDoc.Gap(b.policy(), true);
             case FileBegins _, None _ -> TokenDoc.NIL;
         };
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/TokenDoc.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/TokenDoc.java
@@ -32,13 +32,17 @@ sealed interface TokenDoc {
     TokenDoc NIL = new Nil();
 
     /** Two tokens on one line, with whatever the rule says between them. */
-    TokenDoc GAP = new Gap(Break.NEVER);
+    TokenDoc GAP = new Gap(Break.NEVER, true);
 
     /** A boundary the layout may break, and which holds the rule's answer where it does not. */
-    TokenDoc SOFT_GAP = new Gap(Break.MAY);
+    TokenDoc SOFT_GAP = new Gap(Break.MAY, true);
 
     /** A boundary the layout always breaks. It has no unbroken form, so the rule is not asked. */
-    TokenDoc HARD_GAP = new Gap(Break.ALWAYS);
+    TokenDoc HARD_GAP = new Gap(Break.ALWAYS, true);
+
+    /** A break that leaves a line with nothing on it, which is what a blank line is. Written before
+     *  the boundary that opens the next line, so the two together are one blank line. */
+    TokenDoc BLANK_LINE = new Gap(Break.ALWAYS, false);
 
     /** Writes nothing, and the group holding it is never laid out flat — {@link Doc#MUST_BREAK}. */
     TokenDoc MUST_BREAK = new MustBreak();
@@ -102,7 +106,14 @@ sealed interface TokenDoc {
     record Vacant(Place place, SyntaxKind construct, TokenDoc open, TokenDoc close, int indent)
             implements TokenDoc {}
 
-    record Gap(Break policy) implements TokenDoc {}
+    /**
+     * A boundary between two tokens, and whether the break it may write indents the line it opens.
+     *
+     * <p>Every boundary but one does. The exception is the break that leaves a blank line: the line
+     * it opens has nothing on it, so it has no indent to write, and writing one would leave spaces
+     * on a line a reader sees as empty and an editor strips.
+     */
+    record Gap(Break policy, boolean indents) implements TokenDoc {}
 
     record Concat(List<TokenDoc> parts) implements TokenDoc {}
 
@@ -131,8 +142,15 @@ sealed interface TokenDoc {
      */
     static TokenDoc at(Place place, TokenDoc doc) {
         Opening opening = place.opening();
-        return concat(opening.boundary(), new Carries(place, Carrier.ABOVE), opening.opener(),
-                new At(place, doc));
+        TokenDoc written = concat(opening.boundary(), new Carries(place, Carrier.ABOVE),
+                opening.opener(), new At(place, doc));
+        // A place with a line of its own can be written below as well as above, and the slot is
+        // outside the place because what is written below it is not part of it. A place the
+        // construct runs into has no such line: a comment there would have the rest of the line
+        // written inside it, which is the same reason it cannot be written above one.
+        return opening.opensALine()
+                ? concat(written, new Carries(place, Carrier.BELOW))
+                : written;
     }
 
     /** What the place carries at the end of the line it ends. Written where the construct holding

--- a/specification.adoc
+++ b/specification.adoc
@@ -125,9 +125,9 @@ Only behaviors that appear in the spec DSL are behaviors; implementation helpers
 
 Outside-world dependencies — DB, HTTP, files, clock, ID generation — MUST NOT be implemented in the language. These correspond to the `+// depends:+` and `+// side effect:+` notes in the spec DSL. Only the type is declared in the language.
 
-[,text]
+[,souther]
 ----
-behavior findMember : (id: MemberId) -> Member | NoSuchMember    // no let
+behavior findMember : (id: MemberId) -> Member | NoSuchMember // no let
 ----
 
 The implementation is injected from Java. Writing no implementation (`+let+`) is what "provided from outside" means (<<injected-behavior>>). A caller writes that name in its `+depends on+` (<<depends-on>>). The distinction between dependency (only reads the outside) and side effect (changes the outside) is documentation of intent; it does not affect the rules of value composition.
@@ -209,7 +209,7 @@ Three things hold of a module before anything in it is read:
 * [[a-core-name-is-not-taken]]a module MUST NOT take a name the core has — the reserved `+souther+` namespace, or a standard-library qualifier such as `+List+` (<<reserved-namespace>>). A data MUST NOT take a qualifier's name either: the qualifier is the only spelling that reaches the library, so a declaration of that name hides it;
 * [[every-module-reached-is-on-the-path]]every module a compile reaches — imported, named in a qualified reference, or needed by one that is — MUST be among the modules being compiled or on the path, and what it says it declares MUST be there to read.
 
-[,text]
+[,souther]
 ----
 module example.businesstrip
 ----
@@ -222,20 +222,16 @@ omitting it there is a compile error.
 
 Keywords and the standard library are in English, but user-defined identifiers (types, fields, behaviors) MAY use Unicode. Because the spec DSL is written in Japanese, business vocabulary can be used as identifiers directly. Identifiers SHALL be *NFC-normalized* before binding and comparison; in Japanese a precomposed character and a combining sequence can look identical, so without normalization names that look the same would diverge in binding. Source is UTF-8.
 
-[,text]
+[,souther]
 ----
 data TravelRequest = Drafting | Submitted | AwaitingPreApproval | PreApproved
 ----
 
 Public elements are listed with `+exposing+`.
 
-[,text]
+[,souther]
 ----
-module example.businesstrip exposing (
-    TravelRequest,
-    submitTravelRequest,
-    preApprove
-)
+module example.businesstrip exposing ( TravelRequest, submitTravelRequest, preApprove )
 ----
 
 `+exposing+` exposes at type granularity. A public data's `+decoder()+` / `+encoder()+` is always public API (<<jvm-codec>>), so member-level narrowing such as `+TravelRequest.decoder+` is not written — there is nothing to narrow.
@@ -243,11 +239,9 @@ module example.businesstrip exposing (
 
 When an exposed behavior is a `+>->+` composition, its output SHALL be written in `+exposing+` in the form `+name : cases+` (<<declared-composition-output>>). A composition's output is inferred from its stages (<<composition-with-requirements>>), but at the public boundary a signature is required rather than inference, so that the contract used by another module or by Java does not change silently when an upstream stage changes. Omitting it is a compile error (E1605).
 
-[,text]
+[,souther]
 ----
-module example.order exposing (
-    placeOrder : PlacedOrder | OutOfStock
-)
+module example.order exposing ( placeOrder : PlacedOrder | OutOfStock )
 ----
 
 `+exposing+` is the module's interface description: implementations are inferred, only the boundary is stated explicitly.
@@ -301,17 +295,14 @@ Imports SHALL be listed explicitly. Wildcard imports are forbidden.
 
 [[imports-are-used]]An entry on an import list MUST be written bare somewhere below it. What another module declares is reachable qualified whether or not it is imported, so an entry earns its place only by being used under the name it brings in.
 
-[,text]
+[,souther]
 ----
-import example.employee (
-    Employee,
-    EmployeeId
-)
+import example.employee ( Employee, EmployeeId )
 ----
 
 The standard library is imported in the same form: the qualifier — `+List+`, `+Map+`, `+Set+`, `+String+`, `+Bool+`, `+Int+`, `+Decimal+`, `+Date+`, `+DateTime+`, `+Option+` (<<reserved-namespace>>) — as the name, and the functions used listed. Once imported, they MAY be written unqualified (<<stdlib>>).
 
-[,text]
+[,souther]
 ----
 import List ( map, filter, fold )
 import String ( trim, split )
@@ -367,7 +358,7 @@ A type is also reachable through the module that declares it, written as the mod
 
 [[an-imported-name-denotes-one-thing]]A name an `+import+` brings in MUST denote one thing here. Two modules exposing it, an alias already in use, or this module's own declaration of that spelling each leave the reader with a name and no single answer; reaching one of them qualified is what says which. Like the standard library's `+List.map+`, this needs no `+import+`: the `+import+` line only lets the name be written bare.
 
-[,text]
+[,souther]
 ----
 data Line =
     { quantity: example.counting.Amount
@@ -381,7 +372,7 @@ Which spelling names a type is not something a check has an opinion about. A bar
 
 `+import ... as+` names a module locally, and the alias may then carry the reference. The alias holds only in the module that writes it, and it MUST be a name nothing else answers to there — not another alias, not a module of this compilation, not a standard-library qualifier.
 
-[,text]
+[,souther]
 ----
 import example.counting as Counting
 import example.pricing as Pricing ( taxRate )
@@ -396,10 +387,11 @@ Both parts of an `+import+` are optional: `+import example.pricing as Pricing+` 
 
 A behavior of another module is named the same way, as a `+>->+` stage and as a `+depends on+`. What the qualifier says is which module the behavior comes from, which is what an `+import+` says, so a qualified stage or requirement needs no import line either.
 
-[,text]
+[,souther]
 ----
 behavior ship = inventory.allocate >-> makeInvoice
-behavior notify : (order: PlacedOrder) -> Notified constructs Notified
+behavior notify : (order: PlacedOrder) -> Notified
+    constructs Notified
     depends on messaging.sendMail
 ----
 
@@ -407,7 +399,7 @@ Unlike a type, a behavior's name is also a member name in what is generated: an 
 
 Two same-named types meet in one module because both values exist there; two same-named behaviors meet because the module chose to call both, which is the module not having named what it is doing. A module that genuinely depends on two of them — the same operation offered by two providers, say — declares two behaviors of its own, under names that tell them apart. Each is an injection target (<<injected-behavior>>), and which upstream behavior goes into each is the Java side's to decide.
 
-[,text]
+[,souther]
 ----
 behavior allocateFromPrimary : (line: Line) -> Allocated | OutOfStock
 behavior allocateFromSecondary : (line: Line) -> Allocated | OutOfStock
@@ -465,7 +457,7 @@ What a text MUST be for the compiler to read it is stated with each construct, a
 
 * Both `+data+` declaration fields and record-literal `+TypeName { ... }+` fields are `+,+`-separated (<<product-data>>, <<record-literal>>). A declaration gives a type, so `+name: type+`; a literal binds a value, so `+name = value+` (`+:+` = has this type, `+=+` = is defined as this). A `+...+` spread is an element that composes types but appears in the same comma sequence as fields (<<field-spread>>). An `+invariant+` is a clause placed after the type body (`+{ ... }+` or `+= Y+`) and is not part of the field list (<<invariant>>). A clause's name follows the same rule as everything else named with `+=+` — it is defined as that rule, so `+invariant nonEmpty = List.length(value) >= 1+` (<<invariant-clause-name>>).
 * Argument lists and the enumerations in `+constructs+` / `+depends on+` are `+,+`-separated (<<behavior-io>>, <<constructs>>, <<depends-on>>).
-* Every `+,+`-separated list — declaration and record-literal fields, parameter and argument lists, tuple elements, list literals, and the `+constructs+` / `+depends on+` name lists — MAY carry a single trailing `+,+` before its closing delimiter. It is optional and has no meaning. The sample code in this spec keeps a leading-comma layout instead and writes no trailing comma.
+* Every `+,+`-separated list — declaration and record-literal fields, parameter and argument lists, tuple elements, list literals, and the `+constructs+` / `+depends on+` name lists — MAY carry a single trailing `+,+` before its closing delimiter. It is optional and has no meaning. Where this spec breaks such a list across lines, a `+data+` product body opens each line after the first with its `+,+` (<<product-data>>) and every other list closes each line but the last with its own; neither writes the trailing `+,+`. The convention is the construct's, not the document's.
 * `+|+` is the case separator of a sum and binds more loosely than `+->+`. `+(x: T) -> A | B+` reads as `+(x: T) -> (A | B)+` (the whole output is a sum). Where an anonymous `+|+` is read as a type is the type position's answer (<<a-type-is-written-in-a-type-position>>), and a behavior's parameter refuses one it reads (<<a-parameter-names-one-type>>).
 * `+>->+` is the stage separator of a pipeline: not a binary operator but a flat n-ary sequence. It is associative (<<type-routing>>). Only a behavior name MAY appear in a stage position; parentheses such as `+(f >-> g)+` MUST NOT be written.
 * `+|>+` is the value pipe, binding most loosely and left-associatively. `+a |> f |> g+` reads as `+g(f(a))+`. The left side enters the last argument of the right-hand call and is expanded to a call at parse time (<<pipe>>). This is distinct from the `+>->+` that composes behaviors; it threads the value of an expression.
@@ -588,7 +580,7 @@ The wrapped type must itself be ordered for `+<+` / `+<=+` / `+>+` / `+>=+`; equ
 
 `+Decimal+` ignores scale. `+1.0+` and `+1.00+` are equal.
 
-[,text]
+[,souther]
 ----
 data Amount = Decimal
 // read as 1.00 from a DB column, 1.0 from JSON. Treated as the same amount.
@@ -667,7 +659,7 @@ The only polymorphic types are the stdlib ones (`+Option+`, `+List+`, `+Map+`, `
 
 When the construction of a data with an invariant violates it inside the domain (<<invariant-mvp>>), the computation *aborts*. It returns no value and no case.
 
-[,text]
+[,souther]
 ----
 behavior discount : (d: Quote) -> Discounted
     constructs Discounted
@@ -689,21 +681,24 @@ The mark `+?+` outside a field is written only in the shipped core, as a type va
 
 An optional is *made* in one place: a `+?+` field being given its value (<<optional>>). Writing the type does not make one — `+let p: Option<Int> = None+` is <<e1303>> — and neither does declaring it as a helper's return: a helper answers the optional it read. Where a helper's absence is its own to name, that is a case of the model's own sum.
 
-[,text]
+[,souther]
 ----
-data OrgMember = { manager: OrgMember?, level: Int }
+data OrgMember =
+    { manager: OrgMember?
+    , level: Int
+    }
 
-let firstOver (n: Int, m: OrgMember) : Option<OrgMember> =
+let firstOver (n: Int, m: OrgMember): Option<OrgMember> =
     match m.manager with
         | Some b -> if b.level > n then m.manager else firstOver(n, b)
-        | None -> m.manager             // the absence it read, passed on
+        | None -> m.manager // the absence it read, passed on
 ----
 
 Where the boundary refuses it, what replaces it is a name the model owns. To state "might not be found" as a business result, that is a domain sum (<<unmarked-sum>>); an optional output is reported as itself rather than as a composition that does not fit (<<e1701>>).
 
-[,text]
+[,souther]
 ----
-behavior findMember : (id: MemberId) -> Member | NoSuchMember     // write this
+behavior findMember : (id: MemberId) -> Member | NoSuchMember // write this
 ----
 
 `+Some(T)+` is an exception to the rules of <<sum-data>> (a case is a reference to a named data and cannot carry a payload). Because `+Option+` is built in, users cannot imitate this form. Its contents are taken out with `+match+`; the `+v+` in `+| Some v+` is positionally bound to the wrapped value, not to `+Some+` (<<match>>).
@@ -713,7 +708,7 @@ behavior findMember : (id: MemberId) -> Member | NoSuchMember     // write this
 
 Optionality is expressed with `+?+`.
 
-[,text]
+[,souther]
 ----
 data TravelCompleted =
     { preApprover: EmployeeId?
@@ -761,7 +756,7 @@ A declaration takes the form `+data <Name> = <right-hand side>+`. If the right-h
 
 The spec DSL's `+AND+` maps to a product. A field name is the business role; the type may be specified separately.
 
-[,text]
+[,souther]
 ----
 // spec DSL: data Employee = EmployeeId AND Rank AND ManagerId
 data Employee =
@@ -778,10 +773,16 @@ Role and type may be written separately. In the spec DSL the same concept has a 
 
 Data MAY reference itself (directly or via another data). Structures such as an org chart or a category tree appear routinely in business.
 
-[,text]
+[,souther]
 ----
-data OrgMember = { manager: OrgMember?, name: String }      // the manager is again an OrgMember (the chain ends at None)
-data Department = { children: List<Department>, name: String }   // a tree (a leaf has an empty children list)
+data OrgMember =
+    { manager: OrgMember?
+    , name: String
+    } // the manager is again an OrgMember (the chain ends at None)
+data Department =
+    { children: List<Department>
+    , name: String
+    } // a tree (a leaf has an empty children list)
 ----
 
 The derived codecs follow this self-reference. A nested `+{"name":"a","manager":{"name":"b"}}+` decodes to an `+OrgMember+` whose `+manager+` is again an `+OrgMember+`. Traversing a self-reference *by computation* (climbing the manager chain to the root, counting tree depth) is written with a recursive helper `+let+` (<<fn-declaration>>). `+fold+` folds only a fixed-structure `+List+`, so a self-reference of unbounded depth can be traversed only with helper recursion.
@@ -797,7 +798,7 @@ A self-reference requires a *base case*. A cycle that returns to itself through 
 
 In the spec DSL, a state sharing common items is written as `+data Submitted = TravelRequestCommon AND submittedAt+`, meaning "has all fields of `+TravelRequestCommon+`, plus `+submittedAt+`". Souther expresses this with the `+...+` spread.
 
-[,text]
+[,souther]
 ----
 data TravelRequestCommon =
     { applicant: Employee
@@ -832,19 +833,15 @@ The spec DSL's `+OR+` maps to a sum. *A case MAY reference an already-defined na
 
 [[a-sum-case-is-a-declared-data]]A case MUST be a data that is declared. [[a-sum-does-not-contain-itself]]A sum MUST NOT contain itself, through a case or through a chain of them: a sum's cases are the values it can be, and one of them being the sum is not a value. As in the business-trip model, where each state has its own fields, invariants, and transition behaviors and is bound together by `+OR+`, this structure is represented directly.
 
-[,text]
+[,souther]
 ----
 // spec DSL: data TravelRequest = Drafting OR Submitted OR AwaitingPreApproval OR PreApproved
-data TravelRequest =
-    Drafting
-  | Submitted
-  | AwaitingPreApproval
-  | PreApproved
+data TravelRequest = Drafting | Submitted | AwaitingPreApproval | PreApproved
 ----
 
 Nested sums MAY be written directly.
 
-[,text]
+[,souther]
 ----
 data CostBearer = OwnCost | ClientCost
 data OwnCost = Reimbursement | Advance | CorporateCard
@@ -858,13 +855,23 @@ A case names a data; an inline record MUST NOT be written in a case position. A 
 
 *What holds of every case is a property of the sum.* A sum has no fields of its own, so reading one is an error and the value must be opened with `+match+` — except for a field that *every* case spreads (<<field-spread>>): the sum exposes the fields of a data all of its cases include, and `+d.id+` reads it without opening the value. The same part is spread from the sum into a construction, so `+Filed { ...d, filedOn = on }+` writes at once what a `+match+` arm per case would write alike.
 
-[,text]
+[,souther]
 ----
-data DocumentCommon = { id: String }
-data Draft = { ...DocumentCommon }
-data Sent  = { ...DocumentCommon, at: DateTime }
+data DocumentCommon =
+    { id: String
+    }
+data Draft =
+    { ...DocumentCommon
+    }
+data Sent =
+    { ...DocumentCommon
+    , at: DateTime
+    }
 data Document = Draft | Sent
-data Filed = { ...DocumentCommon, filedOn: Date }
+data Filed =
+    { ...DocumentCommon
+    , filedOn: Date
+    }
 
 let idOf (d: Document): String = d.id
 let file (d: Document, on: Date): Filed = Filed { ...d, filedOn = on }
@@ -881,7 +888,7 @@ A data with no fields is declared with no body. It corresponds to the spec DSL's
 
 [[unit-data-is-written-without-a-body]]A unit data is written without a body. An empty body names a type with one value, which is what a unit data is, so the two spellings would be one declaration written two ways.
 
-[,text]
+[,souther]
 ----
 // spec DSL: data Reimbursement = Unit
 data Reimbursement
@@ -895,13 +902,13 @@ Unit data appear frequently as sum cases (such as `+Staff+` in `+data Rank = Man
 
 A unit written where a module *introduces* a type needs no declaration of its own: the name alone declares it. Three positions introduce a type — a sum's case list (<<sum-data>>), a behavior's output (<<behavior-io>>), and the output declared for a `+>->+` composition, written either on the composition or in `+exposing+` (<<declared-composition-output>>).
 
-[,text]
+[,souther]
 ----
 data CostBearer = OwnCost | ClientCost
 data OwnCost = Reimbursement | Advance | CorporateCard
 // Reimbursement, Advance, CorporateCard and ClientCost are units; nothing else declares them
 
-behavior quote : (c: Cart) -> PricedCart | EmptyCart     // EmptyCart is a unit
+behavior quote : (c: Cart) -> PricedCart | EmptyCart // EmptyCart is a unit
 ----
 
 Everywhere else a type is *referred to*, and a name nothing declares is unknown there and reported: a parameter type, a field's type, `+constructs+`, `+depends on+`, a `+match+` arm, a codec variant, a `+let+`'s declared return type.
@@ -972,7 +979,7 @@ When the right-hand side is a single type rather than a `+{ ... }+` product or a
 
  `+Y+` is written the way a type is written anywhere else: a primitive (`+String+` / `+Int+` / `+Date+`, etc.), a named data, a sum, or a collection (`+List<T>+` / `+Set<T>+` / `+Map<K, V>+`, <<collections>>), including a collection of any of these. `+X+` is a distinct type from `+Y+` (nominally distinguished) with the same (bare) external representation as `+Y+`. The spec DSL's `+data X = Y+` (right-hand side a single name) is written directly.
 
-[,text]
+[,souther]
 ----
 // spec DSL: data EmployeeId = String // not empty
 data EmployeeId = String
@@ -1015,7 +1022,7 @@ A value constraint written as a comment in the spec DSL is made executable as an
 
 [[an-invariant-answers-on-every-path]]An invariant MUST answer on every path through it. It is checked on every construction and at every boundary (<<invariant-mvp>>), so it may not reach an `+unreachable+` and may not reach a `+partial+` helper, which publishes no termination guarantee (<<fn-rules>>).
 
-[,text]
+[,souther]
 ----
 // spec DSL: data Amount = Integer // at least 0, in yen
 data Amount = Int
@@ -1037,7 +1044,7 @@ A clause MAY be given a name, which is what tells it apart from the type's other
 
 [[invariant-clause-name-is-not-underscore]]A clause may not be named `+_+`. `+| _ -> …+` answers the clauses that carry no name (<<attempt-departures>>), so a clause named `+_+` could never be the one it answered. An attempted construction departs by the named clause that did not hold (<<attempted-construction>>), and a decode failure reports the name (<<decoder-error>>).
 
-[,text]
+[,souther]
 ----
 data QuoteLines = List<QuoteLine>
     invariant nonEmpty = List.length(value) >= 1
@@ -1060,26 +1067,30 @@ The clauses are checked in the order they are declared — a `+...+` spread's fi
 
 Allowed: comparison, logical operations, arithmetic, field reference, built-in functions, blocks, and a `+let+` satisfying the three conditions below.
 
-[,text]
+[,souther]
 ----
 let isNonNegative (v: Int) = v >= 0
 
-data Amount = Int  invariant isNonNegative(value)
-data Cart = { items: List<Line> } invariant List.all(x -> isNonNegative(x.quantity), items)
+data Amount = Int
+    invariant isNonNegative(value)
+data Cart =
+    { items: List<Line>
+    }
+    invariant List.all(x -> isNonNegative(x.quantity), items)
 ----
 
 What may be called is a `+let+`, not a behavior (<<fn>>). An invariant is part of what a type is: it travels to an importing module as the source it was written as, together with the helper `+let+`s it names (<<published-modules>>). It names only what travels with it, so a behavior MUST NOT be called from an invariant whatever its requirement set — including one that depends on nothing and is callable from a `+let+` body (<<calling-a-behavior>>). To name a business rule, use a `+let+`.
 
 A value or a helper another module publishes travels with it, so an invariant MAY name one, as a `+let+` body may (<<exposed-values>>). A limit or a format several modules' types are written against is therefore written once, in the module that owns it.
 
-[,text]
+[,souther]
 ----
 module limits exposing ( maxLength )
 
 let maxLength = 20
 ----
 
-[,text]
+[,souther]
 ----
 module Member exposing ( MemberName )
 
@@ -1111,11 +1122,14 @@ The same invariant is handled differently depending on where it breaks.
 * *Decoder (boundary)*: the violation enters a failure (`+Issue+`) of Raoh's `+Result+` (<<decoder-error>>). A value that came from outside was invalid — an *expected result*. Which field broke it can be stated via `+path+` and `+code+`.
 * *behavior (inside the domain)*: it *aborts* (<<algebraic-types>>). A computation among validated values broke a rule — a *model bug*.
 
-[,text]
+[,souther]
 ----
-data Discounted = { amount: Int } invariant amount >= 0
+data Discounted =
+    { amount: Int
+    }
+    invariant amount >= 0
 
-behavior discount : (d: Quote) -> Discounted          // no violation case needed
+behavior discount : (d: Quote) -> Discounted // no violation case needed
     constructs Discounted
 ----
 
@@ -1173,31 +1187,42 @@ let build (rows) = {
 
 A size taken of a container built by an operation is read through that operation, by the rules in <<invariant-discharge-preservation>>. A size taken of anything else — of what a behavior answered — is not a term, and a clause needing it is left to the run-time check.
 
-[,text]
+[,souther]
 ----
-data Q = Int invariant value >= 0
-data Held = { q: Q }
+data Q = Int
+    invariant value >= 0
+data Held =
+    { q: Q
+    }
 data M = A | B
-data A = { q: Q }
+data A =
+    { q: Q
+    }
 
 behavior viaMatch : (x: Held, m: M) -> Q
-let viaMatch (x, m) = match m with
-    | A as a -> x.q + a.q             // discharged: `a` carries A's invariant, as `x` does
-    | B -> x.q
+let viaMatch (x, m) =
+    match m with
+        | A as a -> x.q + a.q // discharged: `a` carries A's invariant, as `x` does
+        | B -> x.q
 
 behavior total : (xs: List<Held>) -> Q
-let total (xs) = List.fold((acc, i) -> acc + i.q, Q(0), xs)   // discharged: both are Q
+let total (xs) = List.fold((acc, i) -> acc + i.q, Q(0), xs) // discharged: both are Q
 ----
 
 A binding given a location *is* that location, so `+let c = cart+` makes `+c.quantity+` the term `+cart.quantity+`. A helper is expanded by binding each argument and reading the parameter through that binding (<<invariant-discharge-representation>>), which is why a construction moved into a helper still reads the terms the caller's guards and input types settled. A binding given anything else is a term of its own; where what it was given is arithmetic over terms the procedure names the two are related, and otherwise nothing about it follows.
 
-[,text]
+[,souther]
 ----
-data Qty = Int invariant value >= 1
-data Cart = { quantity: Int } invariant quantity >= 1
+data Qty = Int
+    invariant value >= 1
+data Cart =
+    { quantity: Int
+    }
+    invariant quantity >= 1
 
-let one (c: Cart): Qty = Qty(c.quantity)         // `c` is `cart`, so this is discharged
-behavior toQty : (cart: Cart) -> Qty constructs Qty
+let one (c: Cart): Qty = Qty(c.quantity) // `c` is `cart`, so this is discharged
+behavior toQty : (cart: Cart) -> Qty
+    constructs Qty
 let toQty (cart) = one(cart)
 ----
 
@@ -1273,12 +1298,13 @@ An operation given two containers, or given a container and something to put in 
 
 So a lower bound on any source named above is a lower bound on the result, and a non-empty list appended to any list is non-empty.
 
-[,text]
+[,souther]
 ----
-data Lines = List<Line> invariant List.length(value) >= 1
+data Lines = List<Line>
+    invariant List.length(value) >= 1
 
 behavior joined : (a: Lines, b: List<Line>) -> Lines
-let joined (a, b) = Lines(a.value ++ b)   // discharged: no shorter than `a`
+let joined (a, b) = Lines(a.value ++ b) // discharged: no shorter than `a`
 ----
 
 Nothing is said the other way. A union answers one of what both sides hold, and an insert of something already there adds none, so the result is not the sum of what was read; an upper bound on the sources does not bound it.
@@ -1314,14 +1340,21 @@ This is bounded to a field *copied*. A field the closure computes from others �
 
 `+List.all(p, xs)+` states `+p+` of each element of `+xs+`. Where a standard-library combinator hands its closure an element of `+xs+`, the check reads the relation again there, with the quantifier's own parameter standing for the element the closure was handed.
 
-[,text]
+[,souther]
 ----
-data Qty = Int invariant value >= 1
-data Line = { quantity: Int }
-data Cart = { items: List<Line> } invariant List.all(i -> i.quantity >= 1, items)
+data Qty = Int
+    invariant value >= 1
+data Line =
+    { quantity: Int
+    }
+data Cart =
+    { items: List<Line>
+    }
+    invariant List.all(i -> i.quantity >= 1, items)
 
-behavior toQty : (cart: Cart) -> List<Qty> constructs Qty
-let toQty (cart) = List.map(i -> Qty(i.quantity), cart.items)   // discharged
+behavior toQty : (cart: Cart) -> List<Qty>
+    constructs Qty
+let toQty (cart) = List.map(i -> Qty(i.quantity), cart.items) // discharged
 ----
 
 Both sources of a relation read alike: an input type's invariant clause, and a `+guard+` or `+if+` on the path stating the relation of the same container.
@@ -1378,13 +1411,16 @@ The answer carries the clause's name where it has one (<<invariant-clause-name>>
 
 The check does not cross behaviors: a relation established in one behavior is not assumed in another (<<sequential-composition>>). Inferring such a precondition would be an implicit cross-unit contract, which the language declines — `+depends on+` and an exposed composition's output are always declared, not inferred (<<depends-on>>). The consistent way to carry a relation is to *reify it as a type invariant*, which the seeding then assumes downstream for free.
 
-[,text]
+[,souther]
 ----
-data WithdrawRequest = { balance: Money, amount: Money }
-    invariant amount <= balance                 // the relation lives in the type
+data WithdrawRequest =
+    { balance: Money
+    , amount: Money
+    }
+    invariant amount <= balance // the relation lives in the type
 
 behavior withdraw : (req: WithdrawRequest) -> Money
-let withdraw (req) = req.balance - req.amount   // discharged with no guard here
+let withdraw (req) = req.balance - req.amount // discharged with no guard here
 ----
 
 So a possible-violation warning over the fields of one input data is a prompt to declare their relation as that data's invariant. When a value's validity is guaranteed *outside* the language — a Java-side or injected contract stronger than any type — there is no type to reify onto, and that construction keeps its run-time check.
@@ -1419,7 +1455,7 @@ The default Decoder is derived from a data's shape by the following conventions.
 * Invariants are checked on construction; a violation becomes a failure (`+Issue+`) of Raoh's `+Result+`. Because decode always succeeds or fails, the destination of a violation always exists (<<violation-destination>>).
 * Errors of independent fields are accumulated (Applicative; <<case-propagation>>). Accumulation is handled by Raoh combinators.
 
-[,text]
+[,souther]
 ----
 // a newtype reads from a bare integer (the data X = Y form)
 data Amount = Int
@@ -1442,16 +1478,15 @@ The invariant check on construction and spread (`+...+`) follow the same semanti
 
 The derived Decoder of a sum data reads the discriminator field `+"type"+` and dispatches to the case's derived Decoder. The tag is the case name.
 
-[,text]
+[,souther]
 ----
-data TravelRequest =
-    Drafting | Submitted | AwaitingPreApproval | PreApproved
+data TravelRequest = Drafting | Submitted | AwaitingPreApproval | PreApproved
 // derived Decoder: reads "type" and dispatches "Drafting" -> Drafting, "Submitted" -> Submitted, ...
 ----
 
 A sum every one of whose cases is a unit data (folded to the leaves) is an *enumeration*: it carries nothing but which case it is, so it travels as that case's name — a bare string — and not as an object holding a discriminator alone. This is the form a fieldless enumeration has everywhere else, and it is what lets such a sum key a `+Map+` at the boundary (<<collections>>): a JSON object's key cannot be an object. A name no case answers to fails the decode at that value's path. One field-bearing case is enough to make the sum an object with `+"type"+` again.
 
-[,text]
+[,souther]
 ----
 data Stage = Prospecting | Won | Lost
 // derived Decoder: reads "Prospecting" / "Won" / "Lost"
@@ -1460,9 +1495,9 @@ data Stage = Prospecting | Won | Lost
 
 A nested sum is folded to the leaf case and dispatched.
 
-[,text]
+[,souther]
 ----
-data OwnCost     = Reimbursement | Advance | CorporateCard
+data OwnCost = Reimbursement | Advance | CorporateCard
 data CostBearer = OwnCost | ClientCost
 // derived Decoder: the name is one of "Reimbursement" / "Advance" / "CorporateCard" / "ClientCost"
 // (every case is a unit data, so this one is an enumeration).
@@ -1476,11 +1511,11 @@ A case's contents are decided by the case's shape. A product case lays fields fl
 [#discriminator-field]
 [[a-case-does-not-declare-the-discriminator-field]]Because a product case lays its fields there, a case MUST NOT declare a field named `+"type"+` — the field and the tag would want one key, and whichever was written second would be all that was left. This is a compile error where the case is declared, not a value quietly written over where it is encoded. It holds of a member of a behavior's output union for the same reason (<<union-encoder>>), and of a field a case takes in by spread as much as one it writes. A data that is neither a case nor a union member may have the field: nothing writes a discriminator beside it.
 
-[,text]
+[,souther]
 ----
 data Rank = Manager | Staff
-data Manager = Level   // newtype
-data Staff             // unit
+data Manager = Level // newtype
+data Staff // unit
 // derived: Manager -> {"type":"Manager","value":3}, Staff -> {"type":"Staff"}
 ----
 
@@ -1559,9 +1594,10 @@ The default Encoder is derived by rules symmetric to the Decoder.
 * `+T?+` (Option; <<optional>>): if `+Some(v)+`, write `+v+` at the key; if `+None+`, omit the key. `+None+` is not written and is read back as `+missing key → None+`, so the round-trip law (<<round-trip>>) holds.
 * A sum data tags the discriminator field `+"type"+` with the case name and converts with the case's derived Encoder. A product case lays fields flatly, a unit case writes only the tag, a newtype case puts contents in `+"value"+` (<<sum-discrimination>>). A nested sum writes the leaf case's tag.
 
-[,text]
+[,souther]
 ----
-data Amount = Int  invariant value >= 0
+data Amount = Int
+    invariant value >= 0
 // derived Encoder: Amount -> Int(self.value) (bare integer)
 
 data Submitted =
@@ -1623,16 +1659,19 @@ behavior placeOrder = validateOrder >-> priceOrder >-> allocateStock            
 
 That a type or a term may come to the right of `+=+` is because the DSL writes it that way; it is not a distinction Souther introduced. The same two lines map to Souther as:
 
-[,text]
+[,souther]
 ----
-behavior preApprove : (request: AwaitingPreApproval, approverId: EmployeeId) -> PreApproved | NotAuthorized
-    constructs PreApproved, NotAuthorized          // a type. Implementation is a let or Java injection
+behavior preApprove : (
+    request: AwaitingPreApproval,
+    approverId: EmployeeId
+) -> PreApproved | NotAuthorized
+    constructs PreApproved, NotAuthorized // a type. Implementation is a let or Java injection
 
 behavior placeOrder = validateOrder >-> priceOrder >-> allocateStock
-                                                 // a composition. It is itself the implementation
+// a composition. It is itself the implementation
 
 // spec DSL: // depends: clock
-behavior now : () -> DateTime                // write the type, no let → injected from Java
+behavior now : () -> DateTime // write the type, no let → injected from Java
 ----
 
 Specification and implementation are separated not because `+data+` already does so, but *so that one line of the spec DSL remains as is* (<<non-functional>>). Just as `+invariant+` rides on `+data+`, `+constructs+` rides on `+behavior+`. Both are the part Souther makes executable of what the spec DSL left in comments (<<mapping-principle>>).
@@ -1642,13 +1681,13 @@ Specification and implementation are separated not because `+data+` already does
 
 The spec DSL's input `+AND+` maps to an argument list. A parameter is always written `+name: type+`.
 
-[,text]
+[,souther]
 ----
 // spec DSL: behavior decidePreApproval = EstimatedCost AND Applicant AND CostBearer -> PreApprovalReasons
 behavior decidePreApproval : (
     estimatedCost: Amount,
-    applicant:     Employee,
-    costBearer:    CostBearer
+    applicant: Employee,
+    costBearer: CostBearer
 ) -> List<PreApprovalReason>
 ----
 
@@ -1661,7 +1700,7 @@ Zero arguments is written `+()+` (as in `+now+`). "No argument" and "takes one `
 
 The spec DSL's output `+OR+` maps directly to a bare sum. No success/failure distinction and no marker such as `+error+` is attached. A behavior is a function from input to one of the possible business results.
 
-[,text]
+[,souther]
 ----
 // spec DSL: behavior submitTravelRequest = Drafting -> Submitted OR AwaitingPreApproval
 behavior submitTravelRequest : (request: Drafting) -> Submitted | AwaitingPreApproval
@@ -1670,7 +1709,7 @@ behavior submitTravelRequest : (request: Drafting) -> Submitted | AwaitingPreApp
 // spec DSL: behavior preApprove = AwaitingPreApproval AND ApproverId -> PreApproved OR NotAuthorized
 // NotAuthorized is just data. Not an error, not a Result.
 behavior preApprove : (
-    request:    AwaitingPreApproval,
+    request: AwaitingPreApproval,
     approverId: EmployeeId
 ) -> PreApproved | NotAuthorized
     constructs PreApproved, NotAuthorized
@@ -1678,17 +1717,17 @@ behavior preApprove : (
 
 The commonest shape a model asks for is "the amount, or the reason there is none", and the value it answers with is usually a primitive or a type another module owns. Both are members (<<union-member>>), so the behavior answers with the value itself and no type is declared to hold it.
 
-[,text]
+[,souther]
 ----
 // spec DSL: behavior computeTaxableAmount = Remuneration AND UpliftPay AND SocialInsurance -> Yen OR DeductionsExceedGross
 behavior computeTaxableAmount : (
-    remuneration:    Remuneration,
-    upliftPay:       Yen,
+    remuneration: Remuneration,
+    upliftPay: Yen,
     socialInsurance: Yen
-) -> Yen | DeductionsExceedGross          // Yen is imported; it is the answer, not a wrapper around it
+) -> Yen | DeductionsExceedGross // Yen is imported; it is the answer, not a wrapper around it
     constructs Yen, DeductionsExceedGross
 
-behavior half : (n: Int) -> Int | NoAnswer   // a primitive is a member the same way
+behavior half : (n: Int) -> Int | NoAnswer // a primitive is a member the same way
     constructs NoAnswer
 ----
 
@@ -1698,15 +1737,15 @@ Which case "departs as a failure" is not decided by this behavior alone. When co
 
 An input may be a sum (spec DSL `+(Submitted OR PreApproved) AND ...+`). A behavior's parameter takes a declared name rather than an anonymous one (<<a-parameter-names-one-type>>), so declare the sum as a named data and write that name. The implementation opens the cases with `+match+`.
 
-[,text]
+[,souther]
 ----
 // name (Submitted OR PreApproved)
 data CompletableRequest = Submitted | PreApproved
 
 // spec DSL: behavior completeTravel : (Submitted OR PreApproved) AND ActualCost AND TravelReport -> TravelCompleted OR InvalidActualCost OR NoTravelReport
 behavior completeTravel : (
-    request:      CompletableRequest,
-    actualCost:   Amount,
+    request: CompletableRequest,
+    actualCost: Amount,
     travelReport: String
 ) -> TravelCompleted | InvalidActualCost | NoTravelReport
     constructs TravelCompleted, InvalidActualCost, NoTravelReport
@@ -1724,7 +1763,7 @@ Exact agreement is two obligations, and a declaration can fail either one on its
 * [[constructs-authority-complete]]every data the implementation constructs MUST appear in the clause (<<e1002>>);
 * [[constructs-no-overdeclaration]]every data the clause names MUST actually be constructed (<<e1006>>).
 
-[,text]
+[,souther]
 ----
 behavior applyChange : (input: ChangeEmailRequest) -> Member
     constructs Member
@@ -1744,13 +1783,16 @@ The built-in `+Some+` / `+None+` (<<algebraic-types>>) do not count as data cons
 
 `+constructs+` is not for guarding invariants — that is handled by `+__construct+` and the Decoder, both of which always check on construction (<<invariant-mvp>>). What `+constructs+` handles is *reading the model*: from the declaration, whether a behavior *creates* a new value or merely *passes through* an existing one. This is not visible from the output type.
 
-[,text]
+[,souther]
 ----
-behavior preApprove : (request: AwaitingPreApproval, approverId: EmployeeId) -> PreApproved | NotAuthorized
-    constructs PreApproved, NotAuthorized   // creates new states
+behavior preApprove : (
+    request: AwaitingPreApproval,
+    approverId: EmployeeId
+) -> PreApproved | NotAuthorized
+    constructs PreApproved, NotAuthorized // creates new states
 
 behavior checkCeiling : (a: Amount) -> Amount | OverCeiling
-    constructs OverCeiling                  // Amount returns the input as is; not created
+    constructs OverCeiling // Amount returns the input as is; not created
 ----
 
 Both have `+Amount+` / `+PreApproved+` in the output, but one creates and the other passes through. This distinction does not appear in the output type. Writing it leaves it in the declaration and makes a check against reading and mis-taking. Omit it and it is inferred — write it (opt-in) if you want the reading and the check.
@@ -1809,7 +1851,7 @@ A record literal and a spread both require construction authority (`+constructs+
 
 To apply processing to each element of a list, pass a block as an argument. A block is written `+<args> -> <expr>+`.
 
-[,text]
+[,souther]
 ----
 // spec DSL: data UnvalidatedOrder  = ... AND List<UnvalidatedOrderLine>
 //           data ValidatedOrder = ... AND List<ValidatedOrderLine>
@@ -1831,7 +1873,7 @@ List.all(isValid, reasons)           // pass by name directly. Same thing
 
 A name that names a function *is* that function where a value goes, whoever declared it: a `+let+` of this module, a `+let+` another module published, and a standard-library function alike. `+String.trim+` written where a value goes is a `+(String) -> String+`, and `+String.trim(s)+` is that function applied to `+s+`. So the two lines above are one rule rather than two, and a function reaches every position a block reaches — an argument, a binding, a branch of an `+if+`, an element of a list a `+fold+` walks.
 
-[,text]
+[,souther]
 ----
 let step: (String) -> String = if flag then String.trim else String.uppercase
 let steps: List<(String) -> String> = [String.trim, String.uppercase]
@@ -1884,9 +1926,12 @@ A lambda's `+(a, b) -> ...+` is its parameter list, not a tuple pattern; a singl
 
 A behavior that touches the outside world writes what it depends on in `+depends on+`.
 
-[,text]
+[,souther]
 ----
-behavior preApprove : (request: AwaitingPreApproval, approverId: EmployeeId) -> PreApproved | NotAuthorized
+behavior preApprove : (
+    request: AwaitingPreApproval,
+    approverId: EmployeeId
+) -> PreApproved | NotAuthorized
     depends on now
     constructs PreApproved, NotAuthorized
 ----
@@ -1970,16 +2015,17 @@ A behavior's `+let+` may call a behavior. Which ones it may call is decided by o
 * An *empty* requirement set: call it by name. Nothing is injected and nothing is written in `+depends on+`.
 * A *non-empty* requirement set: write it in `+depends on+` and call it through that name (<<depends-on>>). It arrives already bound, as any requirement does.
 
-[,text]
+[,souther]
 ----
 behavior preApprove : (request: AwaitingPreApproval) -> PreApproved | NotAuthorized
     depends on now
 
 behavior rejectAndNotify : (request: AwaitingPreApproval) -> Notified | NotAuthorized
     depends on preApprove
-let rejectAndNotify (request, preApprove) = match preApprove(request) with
-    | PreApproved as p -> Notified { to = p.applicant }
-    | NotAuthorized as r -> r
+let rejectAndNotify (request, preApprove) =
+    match preApprove(request) with
+        | PreApproved as p -> Notified { to = p.applicant }
+        | NotAuthorized as r -> r
 ----
 
 A call yields the behavior's declared output. Where that output is a sum, the caller opens it with `+match+`, and a case it does not handle is its own to declare in its output. Nothing departs on its own: departure is what `+>->+` does (<<type-routing>>), and a call is not a stage.
@@ -2043,10 +2089,10 @@ A `+let+` is written `+let <name> (<args>) = <body>+`. If a behavior of the same
 
 Parameters go on the left of `+=+`, and a `+let+` written without them defines a *value*. The parameter list, not the shape of the body, is what tells a function from a value. An empty `+()+` is refused, since it would be a second spelling of the value form.
 
-[,text]
+[,souther]
 ----
-let ceiling = Amount(100000)                    // a value
-let isOver (amount: Amount) = amount > ceiling  // a function
+let ceiling = Amount(100000) // a value
+let isOver (amount: Amount) = amount > ceiling // a function
 ----
 
 A value is named where the value it stands for would be written, and it may be spread (`+Drafting { ...standardRequest, estimatedCost = Amount(50000) }+`). A behavior taking nothing is implemented by a value, since the parameter counts agree.
@@ -2071,7 +2117,7 @@ Arguments are the behavior's argument list followed by `+depends on+` in declara
 
 A `+let+` with no corresponding behavior is a *helper*. Not being a domain behavior, it does not pollute the behavior list, cannot be placed in a `+>->+` stage, and does not appear in `+exposing+`. It states its own type, though a parameter whose type its body determines may leave it unwritten (below).
 
-[,text]
+[,souther]
 ----
 let isNonNegative (v: Int) = v >= 0
 let applyAll (xs: List<Int>, p: (Int) -> Bool) = List.all(p, xs)
@@ -2143,7 +2189,7 @@ A `+let+` may implement a behavior only when both are in the *same module*. A be
 
 An implementation is either a same-named `+let+` (<<fn-declaration>>) or a right-hand `+>->+` composition (<<composition>>). A `+>->+` composition behavior has no `+let+` but does have an implementation, so it is not subject to injection. What is injected is only one that wrote a type and no `+let+`.
 
-[,text]
+[,souther]
 ----
 // spec DSL: // depends: clock
 behavior now : () -> DateTime
@@ -2170,7 +2216,7 @@ Which behaviors get a `+let+` and which are injected is not decided mechanically
 
 A behavior subject to injection (wrote a type, no `+let+`; <<injected-behavior>>) is generated as an *abstract base class*, and for each unit data listed in `+constructs+` has a `+protected+` factory that constructs it. Whether it takes one input or several is orthogonal to injection, exactly as for a `+let+`-implemented behavior (<<jvm-behavior>>): a *single* input extends the unary `+Behavior<In, Out>+` (so it still composes with `+>->+`) and inherits its `+apply+`; *any other count* makes it a standalone abstract class with a typed `+apply(A, B, …)+` and no `+Behavior+` supertype. Two or more inputs are more than `+>->+` passes along, and a behavior taking none has nothing to receive, so neither can follow an arrow; both can still be a pipeline's first stage, which receives the pipeline's own arguments (<<sequential-composition>>). A zero-input behavior therefore declares `+apply()+` and is handed nothing — it produces rather than transforms. A Java implementation overrides that typed `+apply+` directly, so several inputs are passed as arguments rather than bundled into a record. A collection parameter keeps its `+java.util.List+` / `+Map+` / `+Set+` (or the runtime `+Option+`) type with its element type, not `+Object+`.
 
-[,text]
+[,souther]
 ----
 behavior findMember : (id: MemberId) -> Member | NoSuchMember | CorruptStoredData
     constructs NoSuchMember, CorruptStoredData
@@ -2220,16 +2266,16 @@ The exception *type* is agreed between the boundary and the implementation. With
 
 An invariant that a single object cannot decide (schedule overlap, uniqueness) MUST be stated by passing the set needed for the decision as input data, not as a hidden dependency. The side effect of reading existing applications is placed at the workflow boundary (a behavior with no implementation).
 
-[,text]
+[,souther]
 ----
 // spec DSL: behavior checkScheduleOverlap = SameApplicantRequests AND Drafting -> Drafting OR ScheduleOverlap
 data ScheduleOverlap
 
 behavior checkScheduleOverlap : (
     sameApplicantRequests: List<TravelRequest>,
-    request:               Drafting
+    request: Drafting
 ) -> Drafting | ScheduleOverlap
-    constructs ScheduleOverlap        // Drafting returns the input as is; not created
+    constructs ScheduleOverlap // Drafting returns the input as is; not created
 
 // a behavior with no implementation (reads the outside)
 behavior readRequestsOfApplicant : (applicant: EmployeeId) -> List<TravelRequest>
@@ -2247,9 +2293,9 @@ At the destination, whether to write or infer diverges (<<depends-on>>).
 * a simple behavior with a `+let+`: *write* in `+depends on+`; receive it as a `+let+` argument
 * a `+>->+` composition: *infer*; decided by the union of the stages' requirement sets
 
-[,text]
+[,souther]
 ----
-behavior loadAndConvert = findMember >-> toView      // depends on not written
+behavior loadAndConvert = findMember >-> toView // depends on not written
 ----
 
 This requires the implementation of `+findMember+`. Composing several gives a union. A composition is not made to write it, because it is readable from the stage declarations; the spec DSL also attaches no `+// depends:+` to a composition.
@@ -2260,7 +2306,7 @@ The call graph is static at every stage, so the requirement set is decided as a 
 
 This is unchanged by making a `+let+` higher-order.
 
-[,text]
+[,souther]
 ----
 let applyAll (xs: List<MemberId>, p: (MemberId) -> MemberLabel) = List.map(p, xs)
 ----
@@ -2279,7 +2325,7 @@ The requirement set of `+applyAll+` is empty. Whatever `+p+` requires is irrelev
 
 `+>->+` connects behaviors. Of the previous stage's output cases, those the next stage's input type can receive flow to the next stage; the cases it does not receive are carried to the output (departing the mainline).
 
-[,text]
+[,souther]
 ----
 behavior handle = findMember >-> toResponse
 ----
@@ -2288,7 +2334,7 @@ The stage following `+>->+` is single-input (a 1-argument behavior). `+>->+` pas
 
 *The first stage is not restricted.* The first receives the pipeline's own arguments, so any number is fine; the pipeline receives them as is. A behavior subject to injection is a first stage on the same terms as an implemented one (<<java-base-class>>): the pipeline inherits it as a requirement and calls it with those arguments.
 
-[,text]
+[,souther]
 ----
 // spec DSL: behavior reject = AwaitingPreApproval AND RejecterId -> PreApprovalRejected OR NotAuthorized
 //           behavior returnToDraft = PreApprovalRejected -> Drafting
@@ -2336,10 +2382,10 @@ The output sum is treated as an open error row: `+(C | R) | S+` is flattened and
 
 That a case departed the mainline is remembered by the composition, and not forgotten by naming a midpoint.
 
-[,text]
+[,souther]
 ----
-behavior fg = f >-> g          // mainline D, departed C
-behavior x  = fg >-> h         // only mainline D passes to h; C stays departed. x : A -> E | C
+behavior fg = f >-> g // mainline D, departed C
+behavior x = fg >-> h // only mainline D passes to h; C stays departed. x : A -> E | C
 ----
 
 `+fg+` remembers mainline `+D+` and departed `+C+`. In `+fg >-> h+`, only mainline `+D+` passes to `+h+`, and `+C+` stays departed and is carried to the output. So a named-midpoint `+fg >-> h+` is the same `+A -> E | C+` as the one-line `+f >-> g >-> h+`.
@@ -2395,10 +2441,9 @@ An inferred output *changes silently on a distant change* when a stage is a beha
 [#composition-output-agrees-with-inference]
 So a composition *MAY optionally declare its output*. If written, it MUST *exactly match* the inferred output or it is a compile error (E1604). Neither too few (a case appears that is not declared) nor too many (a declared case does not appear) is admitted.
 
-[,text]
+[,souther]
 ----
-behavior placeOrder = validateOrder >-> priceOrder >-> allocateStock
-    -> PlacedOrder | OutOfStock
+behavior placeOrder = validateOrder >-> priceOrder >-> allocateStock -> PlacedOrder | OutOfStock
 ----
 
 `+-> PlacedOrder | OutOfStock+` is the composition's declaration, not the output of the last stage `+allocateStock+`. Because a stage is a behavior reference (name only), the trailing `+->+` reads unambiguously as the composition's. Writing this line makes an error appear here when an upstream stage adds a case, so it does not grow silently downstream.
@@ -2506,7 +2551,7 @@ What a row may name is a property of the value graph, not of one definition's te
 
 A row may also *apply a helper* — the rule the row is about — wherever a fixture value is written: an input, an expected result, a `+with+` value, a `+fake+` table's inputs and outputs, a record field, a list element, a map key or value, and an argument of another helper application. The helper is *run*, as the module that compiled it runs it, and the value it returns is read back into the form a fixture is written in, so what encloses the application is built the one way. Where nothing encloses it — the application is the whole of an expected result, or the whole of a value the row names — the row asserts the value the helper answered with, and which case that is comes from the value rather than from the text. Its arguments are fixtures like any others, so a fixture that breaks the argument type's invariant is <<e1903>>.
 
-[,text]
+[,souther]
 ----
 let taxIncluded (amount: Amount) = Amount(amount.value * 110 / 100)
 
@@ -2549,11 +2594,11 @@ example preApprove
 
 A *function dependency* — one whose result varies with its input — is given by a `+fake+` declaration: an input→output table matched by value equality, defaulting to a `+_+` row or, absent one, a miss error (<<e1909>>). A multi-input injected dependency (<<java-base-class>>) is faked the same way, with the row's inputs matched as a tuple.
 
-[,text]
+[,souther]
 ----
 fake findManager
     | (EmployeeId("e-1")) -> EmployeeId("boss-1")
-    | _               -> EmployeeId("unknown")
+    | _ -> EmployeeId("unknown")
 ----
 
 Each dependency of the target must have a fake — a `+with+` on the row or a `+fake+` table — or it is a compile error (<<e1908>>). A fake, like an example, is written inline or in an attached `+examples for+` file, and is local to its module. `+fake+` is a contextual keyword.
@@ -2587,13 +2632,13 @@ A `+with dep = value+` is read this way only where `+dep+` takes no input. A fak
 
 Neither side is ranked. A model being migrated onto may run against a stand-in while the real answer is still being harvested, which is written the way a mistake is; what is known is that the two disagree, and where each is written. So it is a warning, and it is said at both statements rather than at one of them.
 
-[,text]
+[,souther]
 ----
 behavior findMember : (id: MemberId) -> Found | Missing
 
 example findMember
     | "a member that is registered" : (MemberId("m-1")) -> Found { id = MemberId("m-1") }
-    | "a member that is not"        : (MemberId("m-9")) -> Missing { reason = "no such member" }
+    | "a member that is not" : (MemberId("m-9")) -> Missing { reason = "no such member" }
 ----
 
 How many rows are waiting is what `+souther examples+` reports; it is not a compile warning, because waiting is the normal state of a model being written and a warning on every one of them says nothing.
@@ -2760,10 +2805,11 @@ A reader that took an empty stdout for a refused command reads the exit status i
 [#let]
 === let
 
-[,text]
+[,souther]
 ----
 let normalized = String.trim(input)
-let counted: Map<String, Int> = List.fold((acc, k) -> Map.updateOrInsert(k, 1, n -> n + 1, acc), Map.empty, keys)
+let counted: Map<String, Int> =
+    List.fold((acc, k) -> Map.updateOrInsert(k, 1, n -> n + 1, acc), Map.empty, keys)
 ----
 
 Reassignment is forbidden. A `+let+` is placed inside a block expression (<<block-expression>>). What follows `+let x = v+` is the scope of that binding, nested at desugaring time.
@@ -2869,14 +2915,16 @@ The `+Some+` of `+Option+` (<<algebraic-types>>) extracts the wrapped value by *
 
 When the contents are a newtype, the constructor-destructuring form nests inside the positional binding: `+| Some(EmployeeId(v)) -> v+` opens the wrapped `+EmployeeId+` and binds `+v+` to its base value, so the `+.value+` on the positional binding is not written. The first written name MUST be the element type — `+Some+` wraps `+EmployeeId+`, so `+Some(EmailAddress(v))+` is a compile error — and each further name opens one more layer, the same rule as `+X(Y(s))+` on a user case. This nesting is allowed only in a pattern; `+Some(...)+` is still not a construction form (<<algebraic-types>>). The short `+| Some v+` (bind the whole contents) stays.
 
-[,text]
+[,souther]
 ----
-data TravelCompleted = { preApprover: EmployeeId? }
+data TravelCompleted =
+    { preApprover: EmployeeId?
+    }
 
 let approverLabel (c: TravelCompleted) =
     match c.preApprover with
-        | Some(EmployeeId(v)) -> v         // v is the base value, no .value
-        | None              -> "None"
+        | Some(EmployeeId(v)) -> v // v is the base value, no .value
+        | None -> "None"
 ----
 
 [#match-covers-every-case]
@@ -3123,9 +3171,9 @@ A single application of a function instantiates each variable its declared signa
 
 A primitive is declared as a core function with a body of `+= intrinsic "key"+`. `+key+` names the JVM operation the backend emits and is *prefixed per type* to make it unique (`+"string.trim"+`, separating `+list.length+` and `+string.length+`).
 
-[,text]
+[,souther]
 ----
-let trim (s: String) : String = intrinsic "string.trim"
+let trim (s: String): String = intrinsic "string.trim"
 ----
 
 An intrinsic MUST declare its return type (it cannot be inferred from `+intrinsic+`). A call is type-checked against the declared signature — that is, `+trim+` is "a built-in function whose signature is placed in core", and this declaration, not a hardcoded compiler table, decides its arguments and return value — and the backend emits the bytecode for `+key+`. It is neither inlined nor lowered. Only the reserved namespace may write it. A user cannot call the JVM directly and only calls blessed functions (<<asymmetric-interop>>).
@@ -3194,7 +3242,7 @@ What is canonical is the *value*; nothing about comparison changes. NFC and not 
 
 `+matches(pattern, s)+` is a whole-string regular-expression match (Java `+Pattern+` flavour, anchored: the *entire* string must match), returning a plain `+Bool+`. It is what states a format-constrained value as an invariant — `+data PostalCode = String invariant String.matches("[0-9]{3}-[0-9]{4}", value)+`. The `+pattern+` MUST evaluate to a string at compile time: it is validated there (compiled once to confirm it is well-formed), so a malformed regex is a compile error rather than a runtime exception. A string literal evaluates to one, and so does a `{plus}{plus}` of literals and of values — a `+let+` with no parameter list (<<fn-declaration>>) — which is how types whose formats share a part hold that part once instead of spelling it out in each of them:
 
-[,text]
+[,souther]
 ----
 let sitePrefix = "001"
 
@@ -3250,7 +3298,7 @@ abs  min  max  clamp
 
 Division makes the rounding scale and mode explicit as arguments. `+Decimal.divide(dividend, divisor, 2, HALF_UP)+` rounds HALF_UP at 2 decimal places. The mode is an ordinary value of the data core declares:
 
-[,text]
+[,souther]
 ----
 data RoundingMode = HALF_UP | HALF_EVEN | HALF_DOWN | UP | DOWN | CEILING | FLOOR
 ----
@@ -3437,7 +3485,7 @@ A date is written `+Date("2026-07-25")+` and a date-time `+DateTime("2026-07-25T
 
 A month boundary follows from `+day+` and belongs in the domain:
 
-[,text]
+[,souther]
 ----
 let monthStart (d: Date): Date = Date.addDays(1 - Date.day(d), d)
 let endOfMonth (d: Date): Date = Date.addDays(0 - 1, Date.addMonths(1, monthStart(d)))
@@ -4642,7 +4690,7 @@ An anonymous output union takes an imported member (<<union-member>>), and the d
 
 The move for a sum is to translate: match the imported result and return a case of this module. A module boundary is where another context's vocabulary is restated in this one's.
 
-[,text]
+[,souther]
 ----
 // allocate is imported and OutOfStock is its departure; CannotAllocate is this module's answer to it
 behavior allocateAndShip : (number: PartNumber) -> ShipmentOrder | CannotShip | CannotAllocate


### PR DESCRIPTION
`souther fmt` writes a canonical form and nothing in this repository was required to be in it — not
the standard library, not the specification's samples, and `fmt --check` ran in no CI job and no
build step. Fifteen of the sixteen `.sou` files here were not in it, and 57 of the 83 specification
samples that parse as whole files were not either.

That is what #518 turned out to be about, one level under the round-5 report's "the formatter
contradicts the documentation". Separating what that report had as one finding gave four things, and
this is three of them; the fourth is layout policy and is four decisions of its own, two settled
here and two still open.

## Three layout questions answered by rule

Each was decided by how the document happened to be built rather than by anything written down.

**What a comment is about** was read from whether it started a line and nothing else, so a note
written under a declaration and cut off from the next one by a blank line came back describing that
next declaration — a change of what the comment is about, which the text does not show. `attach`
counts the newlines now, and `Carrier` gains `BELOW`: a comment below what it describes is neither of
the other two, and the set that was short one was the asymmetric one.

**Which part of a behavior signature gives way** (#565) was the output union, because it was the
outer group. It left one member of a symmetric union on the signature line attached to the arrow with
the rest below. The parameters give way first now, and the union breaks only where the line the `)`
left it on is still too narrow.

**A blank line between two members** (#566) was written between every pair of top-level items and
deleted inside every block, both unconditionally. Where a paragraph break is is the author's and how
big it is is not: none stays none, any number comes back as one. A module header and the last import
keep a blank line under them whatever the source had, which is what gofmt does.

## The contract

The ten standard-library modules are canonical and `EverySourceThisShipsIsInCanonicalFormTest` reads
them through `Reserved.MODULES`, so a module added there is covered without being added here.
`souther api --source` prints these to a reader, and shipped source the product's own formatter
rejects is the product contradicting itself.

A specification sample says for itself whether it is Souther: `[,souther]` is a claim that the block
is a whole fragment in canonical form, and a test refutes it if it is not. Membership is what the
document declares and not what happens to parse, so a parser that grows does not pull samples into
the check that nobody marked. Seventy-four are marked; nine are not, each waiting on #573 or #574.

The rules themselves are published in `cli/commands`, which had said a canonical form exists and
nothing about what it is.

The `delimiters` section claimed a leading-comma layout for every sample in the document. The split
is by construct and is the one the formatter already writes; the document's own multi-line record
literal is a counterexample to its own sentence, and that sentence is what six models read before
writing code `fmt --check` then rejected. It is scoped to the construct now.

The bench corpus is left out: it is input to the parser and the compiler rather than model code.

## Not here

`guard … else` (#573) and an `example` row's connectors (#574) are the two layout decisions still
open. The nine unmarked samples are waiting on them.

Refs #518 #565 #566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
