### PR TITLE
An option the run does not read is not passed over in silence

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/CliOption.java
+++ b/souther-compiler/src/main/java/souther/compiler/CliOption.java
@@ -1,0 +1,223 @@
+package souther.compiler;
+
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The options this command line takes, and what has to hold of a line that writes them.
+ *
+ * <p>Each command used to answer this for itself, out of the tokens it had a {@code case} for and a
+ * default branch that read everything else as a path. That answers one question — is this token
+ * mine — and only in the commands that thought to ask it: {@code doc} and {@code api} never did, so
+ * {@code api Option --nope} ran as though nothing had been written. It also cannot answer the other
+ * question at all. An option arrives as a local variable, and a local carries its value and not the
+ * fact that somebody wrote it, so an option whose reader sits behind a condition that did not hold
+ * is indistinguishable from one nobody asked for. {@code --boundaries} without {@code --generate}
+ * was accepted, never read, and answered with the report it would have printed anyway.
+ *
+ * <p>So what a line wrote is kept as what it wrote — the set of options present, before any of them
+ * is turned into a value — and the constraints are read off this table once, above the dispatch,
+ * for every command. Three of them are structural and are written here: which command an option
+ * belongs to, which other option it needs beside it, and which two may not be written together. The
+ * fourth kind is not: whether an option's value makes the next one pointless (a colour under a JSON
+ * renderer) is a question about what the values mean, which belongs to the command that means them.
+ */
+enum CliOption {
+
+    FORMAT("compile/run/examples", Value.TAKEN, "--format"),
+    LANG("compile/run/examples", Value.TAKEN, "--lang"),
+    COLOR("compile/run/examples", Value.TAKEN, "--color"),
+    CLASS_PATH("compile/run/examples/japi", Value.TAKEN, "-cp", "--class-path"),
+    OUT_DIR("compile", Value.TAKEN, "-d"),
+    ADEQUACY("compile", Value.TAKEN, "--adequacy"),
+    WARNINGS("compile", Value.TAKEN, "--warnings"),
+    BEHAVIOR("run/examples", Value.TAKEN, "--behavior"),
+    INPUT("run", Value.TAKEN, "--input"),
+    WRITE("fmt", Value.NONE, "-w", "--write"),
+    CHECK("fmt", Value.NONE, "--check"),
+    MODULE("examples", Value.TAKEN, "--module"),
+    GENERATE("examples", Value.NONE, "--generate"),
+    BOUNDARIES("examples", Value.NONE, "--boundaries"),
+    STRICT("examples", Value.NONE, "--strict"),
+    SEARCH("doc/api", Value.TAKEN, "--search"),
+    LIMIT("doc", Value.TAKEN, "--limit"),
+    SOURCE("api", Value.TAKEN, "--source");
+
+    /** Whether the token after this one is its value or the next argument. */
+    enum Value { NONE, TAKEN }
+
+    /** Why a command line is refused: a catalog key and what fills it. */
+    record Refusal(String key, Object... args) {}
+
+    /**
+     * What one reading of a command line found: why it is refused, if it is, and the language it is
+     * to be answered in.
+     *
+     * <p>The two come from the same walk because they are answers about the same tokens. Reading the
+     * line twice — once to find {@code --lang}, once to check it — is two rules for what a token is,
+     * and they part company on the lines that need them most: a value that is spelt like an option
+     * is a value to one walk and an option to the other.
+     */
+    record Reading(Refusal refusal, String lang) {}
+
+    /**
+     * The commands that take the option, in the form a refusal names them.
+     *
+     * <p>Not the commands it is documented under. The usage text groups an option under one heading
+     * — {@code --behavior} under {@code examples} — and {@code run} takes it too; a refusal built
+     * from the heading would send an author to the wrong command line.
+     */
+    private final String owners;
+
+    private final Value value;
+
+    /** Every spelling of the option, the first of which is the one a refusal names it by. */
+    private final List<String> spellings;
+
+    CliOption(String owners, Value value, String... spellings) {
+        this.owners = owners;
+        this.value = value;
+        this.spellings = List.of(spellings);
+    }
+
+    /**
+     * What each option needs written beside it.
+     *
+     * <p>The usage text has said this all along — {@code [--generate [--boundaries]]}, {@code doc
+     * --search <term> [--limit <n>]} — as a nesting of brackets, which is a statement no program
+     * reads. Here it is the same statement in the form the check is made from.
+     */
+    private static final Map<CliOption, CliOption> NEEDS = new EnumMap<>(Map.of(
+            BOUNDARIES, GENERATE,
+            LIMIT, SEARCH));
+
+    /**
+     * The pairs no line may write together, each declared once and read both ways round. Written as
+     * a pair rather than as a field on either option, because a conflict is a fact about the two of
+     * them and stating it twice is two things to keep in step.
+     */
+    private static final List<Set<CliOption>> EXCLUSIVE = List.of(EnumSet.of(WRITE, CHECK));
+
+    private static final Map<String, CliOption> BY_SPELLING = spellingIndex();
+
+    private static Map<String, CliOption> spellingIndex() {
+        Map<String, CliOption> index = new LinkedHashMap<>();
+        for (CliOption option : values()) {
+            for (String spelling : option.spellings) {
+                index.put(spelling, option);
+            }
+        }
+        return Map.copyOf(index);
+    }
+
+    /** Every spelling this compiler knows, in the order the table writes them. */
+    static Set<String> spellings() {
+        return new LinkedHashSet<>(BY_SPELLING.keySet());
+    }
+
+    /** The commands that take the option written this way, or null where this compiler has none. */
+    static String owners(String spelling) {
+        CliOption option = BY_SPELLING.get(spelling);
+        return option == null ? null : option.owners;
+    }
+
+    private boolean ownedBy(String command) {
+        for (String owner : owners.split("/")) {
+            if (owner.equals(command)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Why this command may not be run as written, or null where nothing on the line refuses it.
+     *
+     * <p>Asked before the command is dispatched, so the answer is the same one whichever command was
+     * named, and a command written after this one is under it without having to remember to be.
+     *
+     * <p>A token reading as an option is a token beginning {@code --}: a bare {@code --} is one, and
+     * is refused as an option nobody has. A single dash is not, which is the rule {@code run} has
+     * always had — a file may be named {@code -d} and a command that has no {@code -d} still reads it
+     * as one. That makes the short options command-scoped: {@code fmt} knows {@code -w} and
+     * {@code compile} reads the same token as a path.
+     */
+    static Reading read(String command, String[] args) {
+        EnumSet<CliOption> written = EnumSet.noneOf(CliOption.class);
+        Map<CliOption, String> asWritten = new EnumMap<>(CliOption.class);
+        Refusal token = null;
+        String lang = null;
+        for (int i = 0; i < args.length; i++) {
+            String word = args[i];
+            CliOption option = BY_SPELLING.get(word);
+            if (option == null) {
+                if (word.startsWith("--") && token == null) {
+                    token = new Refusal("cli.option.unknown", word, command);
+                }
+                continue;   // a source file, a name, or a short option this compiler has no such
+            }
+            if (!option.ownedBy(command)) {
+                if (word.startsWith("--") && token == null) {
+                    token = new Refusal("cli.option.foreign", word, command, option.owners);
+                }
+                continue;   // a short option this command does not know still reads as a path
+            }
+            written.add(option);
+            asWritten.put(option, word);
+            if (option.value == Value.TAKEN) {
+                // Whatever follows is this option's value, option-shaped or not: `--module
+                // --generate` names a module, which is what the command's own parser reads it as.
+                // A value that is not there at all is the command's to report, since what it says
+                // when one is missing is written per option.
+                if (++i < args.length && option == LANG) {
+                    lang = args[i];   // the last one written, which is the one the parsers read
+                }
+            }
+        }
+        return new Reading(token != null ? token : unmet(written, asWritten), lang);
+    }
+
+    /** The first constraint between options this line does not meet, or null where it meets them. */
+    private static Refusal unmet(Set<CliOption> written, Map<CliOption, String> asWritten) {
+        for (CliOption option : written) {
+            CliOption needed = NEEDS.get(option);
+            if (needed != null && !written.contains(needed)) {
+                return new Refusal("cli.option.needs",
+                        asWritten.get(option), needed.spellings.get(0));
+            }
+        }
+        for (Set<CliOption> pair : EXCLUSIVE) {
+            if (written.containsAll(pair)) {
+                List<CliOption> both = List.copyOf(pair);
+                return new Refusal("cli.option.exclusive",
+                        asWritten.get(both.get(0)), asWritten.get(both.get(1)));
+            }
+        }
+        return null;
+    }
+
+    /** What the option needs written beside it, or null where it stands on its own. */
+    static String needed(String spelling) {
+        CliOption option = BY_SPELLING.get(spelling);
+        CliOption needs = option == null ? null : NEEDS.get(option);
+        return needs == null ? null : needs.spellings.get(0);
+    }
+
+    /** The pairs no command line may write together, as the spellings a refusal names them by. */
+    static List<List<String>> exclusive() {
+        List<List<String>> pairs = new java.util.ArrayList<>();
+        for (Set<CliOption> pair : EXCLUSIVE) {
+            List<String> spelt = new java.util.ArrayList<>();
+            for (CliOption option : pair) {
+                spelt.add(option.spellings.get(0));
+            }
+            pairs.add(List.copyOf(spelt));
+        }
+        return List.copyOf(pairs);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/CliOption.java
+++ b/souther-compiler/src/main/java/souther/compiler/CliOption.java
@@ -172,9 +172,17 @@ enum CliOption {
             if (option.value == Value.TAKEN) {
                 // Whatever follows is this option's value, option-shaped or not: `--module
                 // --generate` names a module, which is what the command's own parser reads it as.
-                // A value that is not there at all is the command's to report, since what it says
-                // when one is missing is written per option.
-                if (++i < args.length && option == LANG) {
+                if (++i >= args.length) {
+                    // And an option written last has no value at all. Answered here rather than
+                    // where each one is read: `--limit` is read inside a loop that skipped it when
+                    // nothing followed, so `doc --search newtype --limit` searched under the
+                    // default and said nothing — the same silence as an option nobody reads.
+                    if (token == null) {
+                        token = new Refusal("cli.option.value", word);
+                    }
+                    break;
+                }
+                if (option == LANG) {
                     lang = args[i];   // the last one written, which is the one the parsers read
                 }
             }
@@ -199,6 +207,12 @@ enum CliOption {
             }
         }
         return null;
+    }
+
+    /** Whether the token after this one is read as its value. */
+    static boolean takesValue(String spelling) {
+        CliOption option = BY_SPELLING.get(spelling);
+        return option != null && option.value == Value.TAKEN;
     }
 
     /** What the option needs written beside it, or null where it stands on its own. */

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -174,7 +174,7 @@ public final class Main {
             case "doc" -> () -> DocCommand.run(rest, System.out, System.err);
             case "api" -> () -> ApiCommand.run(rest, System.out, System.err);
             case "japi" -> () -> JapiCommand.run(rest, System.out, System.err);
-            case "mcp" -> () -> McpServer.serve(System.in, System.out);
+            case "mcp" -> () -> mcpSubcommand(rest);
             default -> null;
         };
     }
@@ -384,6 +384,28 @@ public final class Main {
             System.err.println("io error: " + e.getMessage());
             return 1;
         }
+    }
+
+    /**
+     * {@code souther mcp}: serves doc, api and japi over MCP stdio, and is written on its own.
+     *
+     * <p>Said here rather than left to the check above the dispatch, because what the check lets
+     * through is a permission this command cannot honour. A token that reads as a short option
+     * another command owns is passed on as an operand — a file may be named {@code -d}, and the
+     * command that has no {@code -d} reads it as one — and that is sound wherever there is an
+     * operand for it to be. There is none here. This command was handed its arguments and read none
+     * of them, so {@code souther mcp -w} served as though nothing had been written, and so did
+     * {@code souther mcp model.sou}. What a command takes no arguments at all is a fact about its
+     * own grammar, which is where it is now stated.
+     */
+    private static int mcpSubcommand(String[] args) {
+        if (args.length > 0) {
+            System.err.println(Messages.get("cli.mcp.arguments",
+                    RenderOptions.asking(null).locale(), String.join(", ", args)));
+            System.err.println(USAGE);
+            return 2;
+        }
+        return McpServer.serve(System.in, System.out);
     }
 
     /** The level {@code --adequacy} names, or null where it names none. */

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -56,7 +56,7 @@ public final class Main {
               japi <class-or-package>[#<member>] [-cp <path>]      a dependency jar's public API, with javadoc
             options (doc):
               --search <term>           sections and topics that say the term, best answer first
-              --limit <n>               how many hits to show (default 20; 0 for all of them)
+              --limit <n>               with --search, how many hits to show (default 20; 0 for all)
             options (api):
               --source <Module>         a stdlib module's own source, design comments included
               mcp                                                  serve doc/api/japi over MCP stdio
@@ -78,42 +78,9 @@ public final class Main {
                                        (overrides SOUTHER_LANG; with neither, en)
               --color auto|always|never  color the human output (default: auto)""";
 
-    /**
-     * Which commands take each option: what a command reads when it has to say that an option is
-     * not its own but is somebody's.
-     *
-     * <p>Written here rather than read back out of {@link #USAGE}. The usage text is what an author
-     * is shown, and reading it for what an option means is the dependency the wrong way round — it
-     * says an option under the heading of the commands it is documented with, which is not the same
-     * set as the commands that accept it — {@code --behavior} is documented under {@code examples}
-     * and taken by {@code run} as well. This table is the one the commands answer from, and a test
-     * holds it against both the usage text and what each parser has a case for.
-     */
-    private static final Map<String, String> OPTION_OWNERS = Map.ofEntries(
-            Map.entry("--format", "compile/run/examples"),
-            Map.entry("--lang", "compile/run/examples"),
-            Map.entry("--color", "compile/run/examples"),
-            Map.entry("-cp", "compile/run/examples/japi"),
-            Map.entry("--class-path", "compile/run/examples/japi"),
-            Map.entry("-d", "compile"),
-            Map.entry("--adequacy", "compile"),
-            Map.entry("--warnings", "compile"),
-            Map.entry("--behavior", "run/examples"),
-            Map.entry("--input", "run"),
-            Map.entry("-w", "fmt"),
-            Map.entry("--write", "fmt"),
-            Map.entry("--check", "fmt"),
-            Map.entry("--module", "examples"),
-            Map.entry("--generate", "examples"),
-            Map.entry("--boundaries", "examples"),
-            Map.entry("--strict", "examples"),
-            Map.entry("--search", "doc/api"),
-            Map.entry("--limit", "doc"),
-            Map.entry("--source", "api"));
-
-    /** Every option this table names, for the test that holds it against the usage text. */
+    /** Every option this compiler knows, for the test that holds the table against the usage text. */
     static java.util.Set<String> knownOptions() {
-        return OPTION_OWNERS.keySet();
+        return CliOption.spellings();
     }
 
     /** The usage text, for the test that holds it against the table. */
@@ -123,28 +90,7 @@ public final class Main {
 
     /** The commands that take {@code option}, or null where this compiler has no such option. */
     static String optionOwners(String option) {
-        return OPTION_OWNERS.get(option);
-    }
-
-    /**
-     * Whether the token reads as an option rather than as a path.
-     *
-     * <p>What {@code run} has always asked, now asked by the commands that were not asking it. A
-     * short option a command does not know still reads as a path, which is where {@code run} draws
-     * the line too. A bare {@code --} reads as an option and is refused as an unknown one; no command
-     * takes it as the end of its options yet.
-     */
-    private static boolean looksLikeOption(String arg) {
-        return arg.startsWith("--");
-    }
-
-    /** The usage error a command answers with when a token reads as an option it has no case for. */
-    private static int unknownOption(String command, String option) {
-        String owners = OPTION_OWNERS.get(option);
-        System.err.println("unknown option `" + option + "` for `" + command + "`"
-                + (owners == null ? "" : " — it is an option of " + owners));
-        System.err.println(USAGE);
-        return 2;
+        return CliOption.owners(option);
     }
 
     public static void main(String[] args) {
@@ -187,24 +133,49 @@ public final class Main {
     static int dispatch(String[] args) {
         String command = args.length == 0 ? "" : args[0];
         String[] rest = args.length == 0 ? args : java.util.Arrays.copyOfRange(args, 1, args.length);
+        java.util.function.IntSupplier asked = commandNamed(command, rest);
+        if (asked == null) {
+            String hint = command.endsWith(".sou")
+                    ? "no command given — did you mean `souther compile " + command
+                            + " …` or `souther run " + command + " …`?"
+                    : command.isEmpty() ? "no command given" : "unknown command `" + command + "`";
+            System.err.println(hint);
+            System.err.println(USAGE);
+            return 2;
+        }
+        // Before the command, and the same check whichever one was named. What each parser used to
+        // ask for itself — is this token mine — three of them asked and two did not, and none of
+        // them could ask the question the tokens cannot answer one at a time: whether an option
+        // written here is one this line ever reads.
+        CliOption.Reading read = CliOption.read(command, rest);
+        if (read.refusal() != null) {
+            System.err.println(Messages.get(read.refusal().key(),
+                    RenderOptions.asking(read.lang()).locale(), read.refusal().args()));
+            System.err.println(USAGE);
+            return 2;
+        }
+        return asked.getAsInt();
+    }
+
+    /**
+     * The command this line names, or null where it names none.
+     *
+     * <p>Resolved before its arguments are checked and kept unrun, so which commands there are is
+     * said once. A list of the names beside this one is a second statement of it, and the check
+     * above reads a command name — a name missing from that list is a command whose options nothing
+     * looks at, which is the shape of the defect the check exists for.
+     */
+    private static java.util.function.IntSupplier commandNamed(String command, String[] rest) {
         return switch (command) {
-            case "run" -> runSubcommand(rest);
-            case "compile" -> compileSubcommand(rest);
-            case "fmt" -> fmtSubcommand(rest);
-            case "examples" -> examplesSubcommand(rest);
-            case "doc" -> DocCommand.run(rest, System.out, System.err);
-            case "api" -> ApiCommand.run(rest, System.out, System.err);
-            case "japi" -> JapiCommand.run(rest, System.out, System.err);
-            case "mcp" -> McpServer.serve(System.in, System.out);
-            default -> {
-                String hint = command.endsWith(".sou")
-                        ? "no command given — did you mean `souther compile " + command
-                                + " …` or `souther run " + command + " …`?"
-                        : command.isEmpty() ? "no command given" : "unknown command `" + command + "`";
-                System.err.println(hint);
-                System.err.println(USAGE);
-                yield 2;
-            }
+            case "run" -> () -> runSubcommand(rest);
+            case "compile" -> () -> compileSubcommand(rest);
+            case "fmt" -> () -> fmtSubcommand(rest);
+            case "examples" -> () -> examplesSubcommand(rest);
+            case "doc" -> () -> DocCommand.run(rest, System.out, System.err);
+            case "api" -> () -> ApiCommand.run(rest, System.out, System.err);
+            case "japi" -> () -> JapiCommand.run(rest, System.out, System.err);
+            case "mcp" -> () -> McpServer.serve(System.in, System.out);
+            default -> null;
         };
     }
 
@@ -275,12 +246,7 @@ public final class Main {
                         }
                     }
                 }
-                default -> {
-                    if (looksLikeOption(args[i])) {
-                        return unknownOption("compile", args[i]);
-                    }
-                    sources.add(Path.of(args[i]));
-                }
+                default -> sources.add(Path.of(args[i]));
             }
         }
         if (sources.isEmpty()) {
@@ -376,12 +342,7 @@ public final class Main {
                 case "--generate" -> generate = true;
                 case "--boundaries" -> boundaries = true;
                 case "--strict" -> strict = true;
-                default -> {
-                    if (looksLikeOption(args[i])) {
-                        return unknownOption("examples", args[i]);
-                    }
-                    sources.add(Path.of(args[i]));
-                }
+                default -> sources.add(Path.of(args[i]));
             }
         }
         if (sources.isEmpty()) {
@@ -496,21 +457,12 @@ public final class Main {
             switch (a) {
                 case "-w", "--write" -> write = true;
                 case "--check" -> check = true;
-                default -> {
-                    if (looksLikeOption(a)) {
-                        return unknownOption("fmt", a);
-                    }
-                    files.add(Path.of(a));
-                }
+                default -> files.add(Path.of(a));
             }
         }
         if (files.isEmpty()) {
             System.err.println("fmt takes at least one .sou file");
             System.err.println(USAGE);
-            return 2;
-        }
-        if (write && check) {
-            System.err.println("`-w` and `--check` are mutually exclusive");
             return 2;
         }
         if (!write && !check && files.size() > 1) {
@@ -774,6 +726,20 @@ public final class Main {
 
         boolean json() {
             return "json".equals(format);
+        }
+
+        /**
+         * These flags as a line that wrote {@code --lang} and nothing else, for the refusal raised
+         * before any subcommand has parsed its arguments.
+         *
+         * <p>Through here rather than resolving beside it. A usage error is one of the answers this
+         * command line gives, and which language it is written in is this class's question — asking
+         * it twice is two policies that happen to agree.
+         */
+        static RenderOptions asking(String lang) {
+            RenderOptions options = new RenderOptions();
+            options.lang = lang;
+            return options;
         }
 
         /**

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -201,9 +201,6 @@ public final class Main {
     private static int compileSubcommand(String[] rawArgs) {
         RenderOptions render = new RenderOptions();
         String[] args = render.extract(rawArgs);
-        if (args == null) {
-            return 2;
-        }
         List<Path> sources = new ArrayList<>();
         List<Path> classPath = new ArrayList<>();
         Path outDir = Path.of(".");
@@ -212,35 +209,22 @@ public final class Main {
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
                 case "--adequacy" -> {
-                    if (++i >= args.length || adequacyLevel(args[i]) == null) {
+                    if (adequacyLevel(args[++i]) == null) {
                         System.err.println("`--adequacy` takes off, witness or all");
                         return 2;
                     }
                     measure = Adequacy.Asked.warningsAt(adequacyLevel(args[i]));
                 }
                 case "--warnings" -> {
-                    if (++i >= args.length
-                            || !(args[i].equals("report") || args[i].equals("error"))) {
+                    if (!(args[++i].equals("report") || args[i].equals("error"))) {
                         System.err.println("`--warnings` takes report or error");
                         return 2;
                     }
                     refuseWarnings = args[i].equals("error");
                 }
-                case "-d" -> {
-                    if (++i >= args.length) {
-                        System.err.println("`-d` needs an output directory");
-                        System.err.println(USAGE);
-                        return 2;
-                    }
-                    outDir = Path.of(args[i]);
-                }
+                case "-d" -> outDir = Path.of(args[++i]);
                 case "-cp", "--class-path" -> {
-                    if (++i >= args.length) {
-                        System.err.println("`" + args[i - 1] + "` needs a class path");
-                        System.err.println(USAGE);
-                        return 2;
-                    }
-                    for (String entry : args[i].split(java.io.File.pathSeparator)) {
+                    for (String entry : args[++i].split(java.io.File.pathSeparator)) {
                         if (!entry.isBlank()) {
                             classPath.add(Path.of(entry));
                         }
@@ -298,9 +282,6 @@ public final class Main {
     private static int examplesSubcommand(String[] rawArgs) {
         RenderOptions render = new RenderOptions();
         String[] args = render.extract(rawArgs);
-        if (args == null) {
-            return 2;
-        }
         List<Path> sources = new ArrayList<>();
         List<Path> classPath = new ArrayList<>();
         String module = null;
@@ -314,31 +295,14 @@ public final class Main {
         for (int i = 0; i < args.length; i++) {
             switch (args[i]) {
                 case "-cp", "--class-path" -> {
-                    if (++i >= args.length) {
-                        System.err.println("`" + args[i - 1] + "` needs a class path");
-                        System.err.println(USAGE);
-                        return 2;
-                    }
-                    for (String entry : args[i].split(java.io.File.pathSeparator)) {
+                    for (String entry : args[++i].split(java.io.File.pathSeparator)) {
                         if (!entry.isBlank()) {
                             classPath.add(Path.of(entry));
                         }
                     }
                 }
-                case "--module" -> {
-                    if (++i >= args.length) {
-                        System.err.println("`--module` needs a module name");
-                        return 2;
-                    }
-                    module = Reserved.name(args[i]);   // a name from outside
-                }
-                case "--behavior" -> {
-                    if (++i >= args.length) {
-                        System.err.println("`--behavior` needs a behavior name");
-                        return 2;
-                    }
-                    behavior = Reserved.name(args[i]);   // a name from outside
-                }
+                case "--module" -> module = Reserved.name(args[++i]);   // a name from outside
+                case "--behavior" -> behavior = Reserved.name(args[++i]);   // a name from outside
                 case "--generate" -> generate = true;
                 case "--boundaries" -> boundaries = true;
                 case "--strict" -> strict = true;
@@ -535,9 +499,6 @@ public final class Main {
     private static int runSubcommand(String[] rawArgs) {
         RenderOptions render = new RenderOptions();
         String[] args = render.extract(rawArgs);
-        if (args == null) {
-            return 2;
-        }
         Path source = firstSource(args);
         List<Path> sources = source == null ? List.of() : List.of(source);
         List<Located> warnings = new ArrayList<>();
@@ -762,25 +723,20 @@ public final class Main {
             };
         }
 
-        /** The arguments with these flags taken out, or {@code null} where one of them was written
-         *  without its value — which the caller answers as a usage error. */
+        /**
+         * The arguments with these flags taken out.
+         *
+         * <p>Each of them has its value where this reads one: an option written without one is
+         * refused before any command is run, against the same table this walk agrees with.
+         */
         String[] extract(String[] args) {
             List<String> kept = new ArrayList<>();
             for (int i = 0; i < args.length; i++) {
                 String option = args[i];
                 switch (option) {
-                    case "--format", "--lang", "--color" -> {
-                        if (++i >= args.length) {
-                            System.err.println("`" + option + "` needs a value");
-                            System.err.println(USAGE);
-                            return null;
-                        }
-                        switch (option) {
-                            case "--format" -> format = args[i];
-                            case "--lang" -> lang = args[i];
-                            default -> color = args[i];
-                        }
-                    }
+                    case "--format" -> format = args[++i];
+                    case "--lang" -> lang = args[++i];
+                    case "--color" -> color = args[++i];
                     default -> kept.add(option);
                 }
             }

--- a/souther-compiler/src/main/java/souther/compiler/Runner.java
+++ b/souther-compiler/src/main/java/souther/compiler/Runner.java
@@ -157,9 +157,6 @@ public final class Runner {
                     classPath.addAll(entriesOf(value(args, ++i, option)));
                 }
                 default -> {
-                    if (args[i].startsWith("--")) {
-                        throw usage("run.usage.unknownoption", "unknown option `" + args[i] + "`", args[i]);
-                    }
                     if (file != null) {
                         throw usage("run.usage.singlefile", "run takes a single .sou file");
                     }

--- a/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/ApiCommand.java
@@ -33,6 +33,16 @@ public final class ApiCommand {
             listPublished(out, null);
             return 0;
         }
+        // Which of the things this line asked for is the one being answered. The forms below read
+        // the front of the line and nothing after it, so `api Option --source String` answered about
+        // `Option` and dropped an option of its own without a word — a listing a reader has no way
+        // to tell from the one they asked for. What `souther doc` already says, said here too.
+        int reads = args[0].equals("--source") || args[0].equals("--search") ? 2 : 1;
+        if (args.length > reads) {
+            err.println("`souther api` reads one at a time; asked for "
+                    + String.join(", ", List.of(args)) + " — reading `"
+                    + String.join(" ", List.of(args).subList(0, reads)) + "`");
+        }
         if (args[0].equals("--source")) {
             if (args.length < 2) {
                 err.println("usage: souther api --source <Module>");

--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -57,13 +57,22 @@ public final class DocCommand {
             }
             int limit = DEFAULT_LIMIT;
             for (int i = 2; i < args.length; i++) {
-                if (args[i].equals("--limit") && i + 1 < args.length) {
-                    try {
-                        limit = Integer.parseInt(args[++i]);
-                    } catch (NumberFormatException e) {
-                        err.println("--limit takes a number, or 0 for everything");
-                        return 2;
-                    }
+                if (!args[i].equals("--limit")) {
+                    continue;
+                }
+                // Written last, this used to fall out of the condition and leave the default in
+                // force — the search ran, answered under a limit nobody asked for, and said nothing
+                // about the option it dropped. A caller reaching this command through `souther doc`
+                // is refused before it; one reaching it directly is refused here.
+                if (i + 1 >= args.length) {
+                    err.println("--limit takes a number, or 0 for everything");
+                    return 2;
+                }
+                try {
+                    limit = Integer.parseInt(args[++i]);
+                } catch (NumberFormatException e) {
+                    err.println("--limit takes a number, or 0 for everything");
+                    return 2;
                 }
             }
             String term = args[1];

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -26,6 +26,7 @@ cli.option.unknown=unknown option `{0}` for `{1}`
 cli.option.foreign=unknown option `{0}` for `{1}` — it is an option of {2}
 cli.option.needs=`{0}` is only read with `{1}`, which this command line does not write
 cli.option.value=`{0}` needs a value
+cli.mcp.arguments=`souther mcp` is written on its own; it was given {0}
 cli.option.exclusive=`{0}` and `{1}` are mutually exclusive
 cli.warnings.refused=No classes were written: warnings are treated as errors.
 cli.run.classpath=use `-cp` / `--class-path` to make compiled modules available to `run`.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -25,6 +25,7 @@ diag.suggestion=did you mean `{0}`?
 cli.option.unknown=unknown option `{0}` for `{1}`
 cli.option.foreign=unknown option `{0}` for `{1}` — it is an option of {2}
 cli.option.needs=`{0}` is only read with `{1}`, which this command line does not write
+cli.option.value=`{0}` needs a value
 cli.option.exclusive=`{0}` and `{1}` are mutually exclusive
 cli.warnings.refused=No classes were written: warnings are treated as errors.
 cli.run.classpath=use `-cp` / `--class-path` to make compiled modules available to `run`.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -22,6 +22,10 @@ diag.diff.expected=But it needs to be:
 diag.suggestion=did you mean `{0}`?
 
 # --- what the command line says about the build, rather than about the source ---
+cli.option.unknown=unknown option `{0}` for `{1}`
+cli.option.foreign=unknown option `{0}` for `{1}` — it is an option of {2}
+cli.option.needs=`{0}` is only read with `{1}`, which this command line does not write
+cli.option.exclusive=`{0}` and `{1}` are mutually exclusive
 cli.warnings.refused=No classes were written: warnings are treated as errors.
 cli.run.classpath=use `-cp` / `--class-path` to make compiled modules available to `run`.
 cli.examples.strict.refused={0} gap(s) named above: the rows do not cover the model.
@@ -572,7 +576,6 @@ example.the-with-is-here=the `with {behavior}`
 
 # --- souther run (the command line drives one behavior; not compile errors) ---
 run.usage.line=usage: souther run <file.sou> [-cp <path>] [--behavior <name>] [--input <json>]
-run.usage.unknownoption=unknown option `{0}`
 run.usage.singlefile=run takes a single .sou file
 run.usage.nofile=no source file given
 run.usage.optionvalue=`{0}` needs a value

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -24,6 +24,7 @@ diag.suggestion=`{0}` の間違いではありませんか？
 cli.option.unknown=`{1}` に `{0}` というオプションはありません。
 cli.option.foreign=`{1}` に `{0}` というオプションはありません。{2} のオプションです。
 cli.option.needs=`{0}` が読まれるのは `{1}` があるときだけですが、このコマンドラインには書かれていません。
+cli.option.value=`{0}` には値が必要です。
 cli.option.exclusive=`{0}` と `{1}` は同時に指定できません。
 cli.warnings.refused=警告をエラーとして扱う設定のため、クラスを出力しませんでした。
 cli.run.classpath=コンパイル済みモジュールを `run` から参照するには `-cp` / `--class-path` を使います。

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -21,6 +21,10 @@ diag.diff.expected=期待:
 diag.suggestion=`{0}` の間違いではありませんか？
 
 # --- ソースではなくビルドについてコマンドラインが言うこと ---
+cli.option.unknown=`{1}` に `{0}` というオプションはありません。
+cli.option.foreign=`{1}` に `{0}` というオプションはありません。{2} のオプションです。
+cli.option.needs=`{0}` が読まれるのは `{1}` があるときだけですが、このコマンドラインには書かれていません。
+cli.option.exclusive=`{0}` と `{1}` は同時に指定できません。
 cli.warnings.refused=警告をエラーとして扱う設定のため、クラスを出力しませんでした。
 cli.run.classpath=コンパイル済みモジュールを `run` から参照するには `-cp` / `--class-path` を使います。
 cli.examples.strict.refused=上に挙げた {0} 件を行が覆っていません。
@@ -567,7 +571,6 @@ example.the-with-is-here=`with {behavior}`
 
 # --- souther run（コマンドラインが behavior を1つ駆動する。コンパイルエラーではない） ---
 run.usage.line=使い方: souther run <file.sou> [-cp <パス>] [--behavior <名前>] [--input <json>]
-run.usage.unknownoption=不明なオプション `{0}` です。
 run.usage.singlefile=run が取る .sou ファイルは1つです。
 run.usage.nofile=ソースファイルが指定されていません。
 run.usage.optionvalue=`{0}` には値が必要です。

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -25,6 +25,7 @@ cli.option.unknown=`{1}` に `{0}` というオプションはありません。
 cli.option.foreign=`{1}` に `{0}` というオプションはありません。{2} のオプションです。
 cli.option.needs=`{0}` が読まれるのは `{1}` があるときだけですが、このコマンドラインには書かれていません。
 cli.option.value=`{0}` には値が必要です。
+cli.mcp.arguments=`souther mcp` は引数を取りませんが、{0} が指定されています。
 cli.option.exclusive=`{0}` と `{1}` は同時に指定できません。
 cli.warnings.refused=警告をエラーとして扱う設定のため、クラスを出力しませんでした。
 cli.run.classpath=コンパイル済みモジュールを `run` から参照するには `-cp` / `--class-path` を使います。

--- a/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmNothingReachesIsNotOwedARowTest.java
@@ -74,7 +74,7 @@ class AnArmNothingReachesIsNotOwedARowTest {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
         try {
-            Main.main(new String[] {"examples", "--boundaries", file.toString()});
+            Main.main(new String[] {"examples", file.toString()});
         } finally {
             System.setOut(was);
         }

--- a/souther-compiler/src/test/java/souther/compiler/AnOptionThatIsWrittenIsOneTheRunReadsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnOptionThatIsWrittenIsOneTheRunReadsTest.java
@@ -1,0 +1,312 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An option a command line writes is one the run reads, or the line is refused.
+ *
+ * <p>{@code --boundaries} on its own was accepted and answered with the report it would have printed
+ * anyway. The flag is read at one place, inside the branch {@code --generate} opens, so a line that
+ * wrote it without {@code --generate} set a variable nothing looked at — and a reader who had just
+ * been told {@code boundary 0/2} read the unchanged report as an answer about their model rather
+ * than as an option that never applied. Silence is the one thing the command line cannot say here,
+ * and the same command already holds the opposite standard for {@code --module} and
+ * {@code --behavior}: a name that resolves to no subject is a usage error, not a report of nothing.
+ *
+ * <p>Every command, and not only the ones whose parser thought to ask. {@code doc} and {@code api}
+ * read their options by position and had no case for a token they did not expect, so
+ * {@code api Option --nope} ran as though it were not there and {@code api --search fold --limit 1}
+ * printed every hit.
+ */
+class AnOptionThatIsWrittenIsOneTheRunReadsTest {
+
+    @TempDir
+    Path dir;
+
+    private record Said(int code, String err, String out) {}
+
+    /** Runs the command line and answers with its exit code and what it wrote. */
+    private Said run(String... args) {
+        PrintStream originalErr = System.err;
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            int code = Main.dispatch(args);
+            return new Said(code, err.toString(StandardCharsets.UTF_8),
+                    out.toString(StandardCharsets.UTF_8));
+        } finally {
+            System.setErr(originalErr);
+            System.setOut(originalOut);
+        }
+    }
+
+    private static final String MODEL = """
+            module example.timesheet
+
+            data MinuteOfDay = Int
+                invariant withinDay = value >= 0 && value <= 1440
+
+            data Shift =
+                { startsAt: MinuteOfDay
+                , endsAt: MinuteOfDay
+                }
+                invariant endsAfterStart = startsAt < endsAt
+
+            data Short
+            data Long
+
+            behavior classify : (shift: Shift) -> Short | Long
+                constructs Short, Long
+
+            let classify (shift) =
+                if shift.endsAt.value - shift.startsAt.value >= 480 then Long else Short
+
+            example classify
+                | "short" : (Shift { startsAt = MinuteOfDay(540), endsAt = MinuteOfDay(600) })
+                    -> Short
+            """;
+
+    private Path model() throws Exception {
+        Path file = dir.resolve("timesheet.sou");
+        Files.writeString(file, MODEL);
+        return file;
+    }
+
+    // --- the option that is read behind another one -----------------------------------------------
+
+    @Test
+    void boundariesWithoutGenerateIsRefused() throws Exception {
+        Said said = run("examples", model().toString(), "--boundaries");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("`--boundaries`"), said.err());
+        assertTrue(said.err().contains("`--generate`"), said.err());
+    }
+
+    /** The refusal comes before the report, so the reader is not shown a measurement to misread. */
+    @Test
+    void boundariesWithoutGenerateReportsNothing() throws Exception {
+        Said said = run("examples", model().toString(), "--boundaries");
+
+        assertEquals("", said.out(), said.out());
+    }
+
+    @Test
+    void boundariesWithGenerateIsTheLineThatWasMeant() throws Exception {
+        Said said = run("examples", model().toString(), "--generate", "--boundaries");
+
+        assertEquals(0, said.code(), said.err());
+        assertTrue(said.out().contains("MinuteOfDay(1440)"), said.out());
+    }
+
+    /** The order they are written in is not one of the conditions. */
+    @Test
+    void boundariesBeforeGenerateIsTheSameLine() throws Exception {
+        Said said = run("examples", model().toString(), "--boundaries", "--generate");
+
+        assertEquals(0, said.code(), said.err());
+        assertTrue(said.out().contains("MinuteOfDay(1440)"), said.out());
+    }
+
+    /** {@code doc}'s own conditional option: the limit is read out of the search and nowhere else. */
+    @Test
+    void limitWithoutSearchIsRefused() {
+        Said said = run("doc", "--limit", "5");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("`--limit`"), said.err());
+        assertTrue(said.err().contains("`--search`"), said.err());
+    }
+
+    @Test
+    void limitWithSearchIsTheLineThatWasMeant() {
+        Said said = run("doc", "--search", "newtype", "--limit", "2");
+        Said all = run("doc", "--search", "newtype", "--limit", "0");
+
+        assertEquals(0, said.code(), said.err());
+        assertTrue(said.out().lines().count() < all.out().lines().count(),
+                said.out() + " against " + all.out());
+    }
+
+    /**
+     * Every option the table says needs another, asked of a command that takes it — so a pair added
+     * tomorrow is under this without anything here being written again.
+     *
+     * <p>Beside the two written out above rather than instead of them. This reads the same table the
+     * check reads, so a pair the table is missing is a pair it does not ask about: dropping
+     * {@code --boundaries} from the relation leaves this passing over one fewer option and saying
+     * nothing. The named cases are what holds each of those two rows down.
+     */
+    @Test
+    void everyOptionThatNeedsAnotherIsRefusedWithoutIt() {
+        for (String option : Main.knownOptions()) {
+            String needed = CliOption.needed(option);
+            if (needed == null) {
+                continue;
+            }
+            String owner = Main.optionOwners(option).split("/")[0];
+            Said said = run(owner, option);
+
+            assertEquals(2, said.code(), option + ": " + said.err());
+            assertTrue(said.err().contains("`" + needed + "`"),
+                    option + " needs " + needed + ": " + said.err());
+        }
+    }
+
+    // --- the two that may not be written together -------------------------------------------------
+
+    @Test
+    void everyExclusivePairIsRefusedTogether() throws Exception {
+        for (List<String> pair : CliOption.exclusive()) {
+            String owner = Main.optionOwners(pair.get(0)).split("/")[0];
+            Said said = run(owner, model().toString(), pair.get(0), pair.get(1));
+
+            assertEquals(2, said.code(), pair + ": " + said.err());
+            assertTrue(said.err().contains("`" + pair.get(0) + "`"), pair + ": " + said.err());
+            assertTrue(said.err().contains("`" + pair.get(1) + "`"), pair + ": " + said.err());
+        }
+    }
+
+    /** The refusal names the option the way the line wrote it, not the way the table lists it. */
+    @Test
+    void anOptionIsNamedAsItWasWritten() throws Exception {
+        Said said = run("fmt", model().toString(), "--write", "--check");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("`--write`"), said.err());
+        assertFalse(said.err().contains("`-w`"), said.err());
+    }
+
+    // --- the commands that were not asking ---------------------------------------------------------
+
+    /**
+     * {@code api} reads its options by position, so a token it did not expect fell through to the
+     * name it was asked about and the run went on.
+     */
+    @Test
+    void aCommandThatReadsByPositionRefusesAnUnknownOption() {
+        Said said = run("api", "Option", "--nope");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("unknown option `--nope`"), said.err());
+        assertEquals("", said.out(), said.out());
+    }
+
+    /** An option that exists and is another command's, asked of a command that reads by position. */
+    @Test
+    void aCommandThatReadsByPositionRefusesAnotherCommandsOption() {
+        Said said = run("api", "--search", "fold", "--limit", "1");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("unknown option `--limit`"), said.err());
+        assertTrue(said.err().contains("it is an option of doc"), said.err());
+        assertEquals("", said.out(), said.out());
+    }
+
+    @Test
+    void docRefusesAnUnknownOption() {
+        Said said = run("doc", "--nope");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("unknown option `--nope`"), said.err());
+    }
+
+    @Test
+    void japiRefusesAnUnknownOption() {
+        Said said = run("japi", "java.lang.String", "--nope");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("unknown option `--nope`"), said.err());
+    }
+
+    /** What each of those commands does with a line of its own is untouched. */
+    @Test
+    void aCommandThatReadsByPositionStillAnswers() {
+        Said said = run("api", "--search", "fold");
+
+        assertEquals(0, said.code(), said.err());
+        assertTrue(said.out().contains("List.fold"), said.out());
+    }
+
+    /**
+     * An option of the command's own, written where the command does not read it. The check above
+     * the dispatch passes it — it is {@code api}'s option, written with the value {@code api} takes
+     * — and the command answers the front of the line. Which one it read is what {@code doc} says of
+     * the same line, and is what tells the reader the rest of what they wrote did not apply.
+     */
+    @Test
+    void aCommandThatReadsByPositionSaysWhichQuestionItAnswered() {
+        Said said = run("api", "Option", "--source", "String");
+
+        assertEquals(0, said.code(), said.err());
+        assertTrue(said.err().contains("reading `Option`"), said.err());
+        assertTrue(said.err().contains("--source"), said.err());
+        assertTrue(said.out().contains("Option.map"), said.out());
+    }
+
+    /** And says nothing where the line asked for one thing. */
+    @Test
+    void aLineThatAsksForOneThingIsAnsweredWithoutANote() {
+        Said said = run("api", "--source", "String");
+
+        assertEquals(0, said.code(), said.err());
+        assertFalse(said.err().contains("reads one at a time"), said.err());
+    }
+
+    // --- what a value is ---------------------------------------------------------------------------
+
+    /**
+     * A value spelt like an option is a value. The check walks the line the way the parsers do, so
+     * a module named {@code --generate} is the module the command was asked about — a wrong name,
+     * answered as one — and not an option that arrived twice.
+     */
+    @Test
+    void aValueSpeltLikeAnOptionIsAValue() throws Exception {
+        Said said = run("examples", model().toString(), "--module", "--generate", "--boundaries");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("`--boundaries`"), said.err());
+        assertTrue(said.err().contains("`--generate`"), said.err());
+    }
+
+    /** A short option a command does not know still reads as a path, which is the older rule. */
+    @Test
+    void aShortOptionAnotherCommandOwnsIsStillAPath() throws Exception {
+        Said said = run("compile", model().toString(), "-d", dir.resolve("out").toString(), "-w");
+
+        assertNotEquals(2, said.code(), said.err());
+        assertFalse(said.err().contains("unknown option"), said.err());
+    }
+
+    // --- the language the refusal is written in ----------------------------------------------------
+
+    /**
+     * Read off the same line it refuses. The command line resolves the language in one place and
+     * every answer it gives is in that language; a refusal raised before the subcommand parses is
+     * still one of its answers.
+     */
+    @Test
+    void aRefusalIsWrittenInTheLanguageTheLineAsksFor() throws Exception {
+        Said said = run("examples", model().toString(), "--boundaries", "--lang", "ja");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("`--boundaries`"), said.err());
+        assertFalse(said.err().contains("is only read with"), said.err());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnOptionThatIsWrittenIsOneTheRunReadsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnOptionThatIsWrittenIsOneTheRunReadsTest.java
@@ -134,14 +134,27 @@ class AnOptionThatIsWrittenIsOneTheRunReadsTest {
         assertTrue(said.err().contains("`--search`"), said.err());
     }
 
+    /**
+     * Counted in hits, and asked of a term the specification says a great many times. A hit is
+     * several lines — the section and the context under it — so counting lines measures how much
+     * each hit had to say rather than how many were shown, and a term with two hits answers the
+     * same text under either limit. That is how this passed here and failed on CI.
+     */
     @Test
     void limitWithSearchIsTheLineThatWasMeant() {
-        Said said = run("doc", "--search", "newtype", "--limit", "2");
-        Said all = run("doc", "--search", "newtype", "--limit", "0");
+        Said said = run("doc", "--search", "type", "--limit", "2");
+        Said all = run("doc", "--search", "type", "--limit", "0");
 
         assertEquals(0, said.code(), said.err());
-        assertTrue(said.out().lines().count() < all.out().lines().count(),
-                said.out() + " against " + all.out());
+        assertTrue(hits(all) > 2, "a term with no more hits than the limit measures nothing: " + all.out());
+        assertTrue(hits(said) < hits(all), said.out() + " against " + all.out());
+    }
+
+    /** What the search answered, without the lines quoted under each one or the count of the rest. */
+    private static long hits(Said said) {
+        return said.out().lines()
+                .filter(line -> !line.startsWith("    ") && !line.startsWith("… "))
+                .count();
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/AnOptionTheRunDoesNotReadIsNotPassedOverInSilenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnOptionTheRunDoesNotReadIsNotPassedOverInSilenceTest.java
@@ -8,6 +8,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -16,7 +17,12 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * An option a command line writes is one the run reads, or the line is refused.
+ * An option the run does not read is not passed over in silence.
+ *
+ * <p>Not that every option written is read — {@code api Option --source String} answers about
+ * {@code Option} and drops the option, and says which of the two it read rather than refusing the
+ * line. What holds of all of them is the weaker sentence: the line is refused, or the run says what
+ * it did not use. What no line gets is the answer it would have got with the option left out.
  *
  * <p>{@code --boundaries} on its own was accepted and answered with the report it would have printed
  * anyway. The flag is read at one place, inside the branch {@code --generate} opens, so a line that
@@ -31,7 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * {@code api Option --nope} ran as though it were not there and {@code api --search fold --limit 1}
  * printed every hit.
  */
-class AnOptionThatIsWrittenIsOneTheRunReadsTest {
+class AnOptionTheRunDoesNotReadIsNotPassedOverInSilenceTest {
 
     @TempDir
     Path dir;
@@ -135,19 +141,113 @@ class AnOptionThatIsWrittenIsOneTheRunReadsTest {
     }
 
     /**
-     * Counted in hits, and asked of a term the specification says a great many times. A hit is
-     * several lines — the section and the context under it — so counting lines measures how much
-     * each hit had to say rather than how many were shown, and a term with two hits answers the
-     * same text under either limit. That is how this passed here and failed on CI.
+     * What the option promises, which is that two is how many are shown — not that the answer got
+     * shorter, and not how many the specification happens to say the term.
+     *
+     * <p>Counted in hits. A hit is several lines, the section and the context quoted under it, so
+     * counting lines measures how much each one had to say; two hits under either limit print the
+     * same text and the comparison holds with the option never read. That is how this passed here
+     * and failed on CI. The control says when the question is empty.
      */
     @Test
-    void limitWithSearchIsTheLineThatWasMeant() {
+    void limitWithSearchShowsThatManyHits() {
         Said said = run("doc", "--search", "type", "--limit", "2");
         Said all = run("doc", "--search", "type", "--limit", "0");
 
         assertEquals(0, said.code(), said.err());
         assertTrue(hits(all) > 2, "a term with no more hits than the limit measures nothing: " + all.out());
-        assertTrue(hits(said) < hits(all), said.out() + " against " + all.out());
+        assertEquals(2, hits(said), said.out());
+    }
+
+    /**
+     * The value that is not there. `--limit` is read inside a loop that skipped it when nothing
+     * followed, so this searched under the default and answered as though the option had not been
+     * written — the defect this class is about, one option over.
+     */
+    @Test
+    void anOptionWrittenWithoutItsValueIsRefused() {
+        Said said = run("doc", "--search", "newtype", "--limit");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("`--limit`"), said.err());
+        assertEquals("", said.out(), said.out());
+    }
+
+    /**
+     * Which options take a value is written twice: in the table, where the walk above the dispatch
+     * decides whether the token after an option is its value or the next argument, and in the parser
+     * that reads it. Nothing makes the two agree, and a disagreement is not a compile error — a
+     * parser reading a value the table calls a flag takes the argument after it, and one the table
+     * calls valued has its value read as an argument.
+     *
+     * <p>Asked by writing each option the way the table says it is written, with a source file after
+     * it, and looking at what became of the file. The observation does not go through the table: a
+     * parser that swallowed the file says it was given none, and one that read the value as a second
+     * file says it could not open it. Both are what a disagreement produces, in either direction.
+     *
+     * <p>Over the commands whose subject is a file. {@code doc}, {@code api} and {@code japi} read
+     * their arguments by position rather than in a loop, so {@code --search}, {@code --limit} and
+     * {@code --source} are outside this and are held by the cases written out above.
+     */
+    @Test
+    void theTableAndTheParsersAgreeOnWhichOptionsTakeAValue() throws Exception {
+        Path out = dir.resolve("out");
+        Path empty = Files.createDirectories(dir.resolve("empty"));
+        Path formatted = canonical();
+        for (String option : Main.knownOptions()) {
+            String owner = Main.optionOwners(option).split("/")[0];
+            if (!List.of("compile", "examples", "fmt").contains(owner)) {
+                continue;
+            }
+            String value = valueFor(option, empty, out);
+            assertEquals(CliOption.takesValue(option), value != null,
+                    option + ": this test has no value to write for an option that takes one");
+
+            List<String> line = new ArrayList<>(List.of(owner));
+            if (owner.equals("compile")) {
+                line.addAll(List.of("-d", out.toString()));
+            }
+            if (option.equals("--boundaries")) {
+                line.add("--generate");   // which it is only read with
+            }
+            line.add(option);
+            if (value != null) {
+                line.add(value);
+            }
+            line.add(formatted.toString());
+
+            Said said = run(line.toArray(String[]::new));
+
+            assertFalse(said.err().contains("at least one .sou file"),
+                    line + ": the file was read as this option's value: " + said.err());
+            assertFalse(said.err().contains("io error"),
+                    line + ": this option's value was read as a file: " + said.err());
+            assertFalse(said.err().contains("unknown option"), line + ": " + said.err());
+        }
+    }
+
+    /** What to write after the option, or null where the table says it takes nothing. */
+    private String valueFor(String option, Path empty, Path out) {
+        return switch (option) {
+            case "--format" -> "human";
+            case "--lang" -> "en";
+            case "--color" -> "never";
+            case "--adequacy" -> "off";
+            case "--warnings" -> "report";
+            case "--module" -> "example.timesheet";
+            case "--behavior" -> "classify";
+            case "-cp", "--class-path" -> empty.toString();
+            case "-d" -> out.toString();
+            default -> null;
+        };
+    }
+
+    /** The model in the form `fmt --check` accepts, so that probing `--check` says nothing about
+     *  how the file happened to be written here. */
+    private Path canonical() throws Exception {
+        Path file = model();
+        assertEquals(0, run("fmt", "-w", file.toString()).code());
+        return file;
     }
 
     /** What the search answered, without the lines quoted under each one or the count of the rest. */
@@ -174,7 +274,10 @@ class AnOptionThatIsWrittenIsOneTheRunReadsTest {
                 continue;
             }
             String owner = Main.optionOwners(option).split("/")[0];
-            Said said = run(owner, option);
+            // With its value, so that what this reads is the option it is missing and not the value
+            // it is missing — an option written last is refused for that first.
+            Said said = CliOption.takesValue(option)
+                    ? run(owner, option, "1") : run(owner, option);
 
             assertEquals(2, said.code(), option + ": " + said.err());
             assertTrue(said.err().contains("`" + needed + "`"),

--- a/souther-compiler/src/test/java/souther/compiler/AnOptionTheRunDoesNotReadIsNotPassedOverInSilenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnOptionTheRunDoesNotReadIsNotPassedOverInSilenceTest.java
@@ -410,6 +410,38 @@ class AnOptionTheRunDoesNotReadIsNotPassedOverInSilenceTest {
         assertFalse(said.err().contains("unknown option"), said.err());
     }
 
+    /**
+     * And is not passed on to a command with nowhere to put it. Reading an unknown short token as an
+     * operand is what every other command does with it; {@code mcp} has no operand, read none of
+     * what it was handed, and served as though the line had been written on its own.
+     */
+    @Test
+    void aCommandWithNoOperandRefusesWhatItWouldNotRead() {
+        Said said = run("mcp", "-w");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("`souther mcp`"), said.err());
+        assertTrue(said.err().contains("-w"), said.err());
+    }
+
+    /** A path is not an operand of it either. */
+    @Test
+    void aCommandWithNoOperandRefusesAPathToo() {
+        Said said = run("mcp", "model.sou");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("model.sou"), said.err());
+    }
+
+    /** And an option nobody has is still refused above it, as it was. */
+    @Test
+    void aCommandWithNoOperandStillRefusesAnUnknownOption() {
+        Said said = run("mcp", "--nope");
+
+        assertEquals(2, said.code(), said.err());
+        assertTrue(said.err().contains("unknown option `--nope`"), said.err());
+    }
+
     // --- the language the refusal is written in ----------------------------------------------------
 
     /**


### PR DESCRIPTION
`souther examples model.sou --boundaries` was accepted, exited 0, and wrote output byte-identical to the run with no flag.

## The cause

`boundaries` is a local `boolean` read at one place, inside `if (generate)`. Without `--generate` nothing looks at it.

Underneath that: an option arrives as a local variable, and a local carries its value and not the fact that somebody wrote it. There is no state in which an option is *present but unread*, so silence is the default answer for any option whose reader sits behind a condition. The one table the CLI had, `OPTION_OWNERS`, answers a different question — which command takes an option — and each parser asked even that for itself, so `doc`, `api` and `japi`, which read their arguments by position, never asked it at all.

The dependency was written in prose only: the usage line `[--generate [--boundaries]]` and `commands.md`. The test that reads the usage text splits on `[\s,\[\]|]+`, discarding the brackets that state the nesting — so the three-way agreement between usage, table and parsers was over the set of option names, never over the grammar.

## The change

`CliOption` holds every option with its owner, whether it takes a value, what it needs beside it, and what it may not be written with. `Main.dispatch` reads the line once, before the subcommand runs, and refuses what the table refuses. Each parser has dropped its own unknown-option branch; `fmt`'s `-w`/`--check` is one row of the table; `Runner`'s unknown-option throw and its catalog key are gone.

| line | before | after |
| --- | --- | --- |
| `examples m.sou --boundaries` | exit 0, identical output | exit 2, `` `--boundaries` is only read with `--generate`, … `` |
| `api Option --nope` | exit 0, answered about `Option` | exit 2, ``unknown option `--nope` for `api` `` |
| `api --search fold --limit 1` | exit 0, every hit | exit 2, ``… — it is an option of doc`` |
| `doc --limit 5` | exit 2, ``no section `--limit` `` | exit 2, `` `--limit` is only read with `--search`, … `` |
| `api Option --source String` | exit 0, `--source` dropped in silence | says which of the two it read, as `doc` does |

Refusals go through the message catalog (`cli.option.unknown` / `.foreign` / `.needs` / `.exclusive`, en and ja) and resolve their locale through `RenderOptions`, which is where this command line decides what language it answers in.

Two things deliberately not done. The check is not built by parsing the usage text's brackets back into the relation — that keeps usage as a second grammar to hold in step, and the right direction is the other one. And `--color` under `--format json` is left alone: it is an option accepted and unread because of another option's *value*, which needs a decision about what the command line means before it needs a row in a table. Filed as #576.

`--limit` needing `--search` is not in the reported defect. It falls out of the same relation, and leaving it out would have left `doc --limit 5` answering `no section \`--limit\``.

## What this branch found

`AnArmNothingReachesIsNotOwedARowTest` was passing `--boundaries` to a report it only reads measures out of. The flag had never applied — the defect's own witness, sitting in the suite.

Making the line strict turned that into a crashed surefire fork rather than a failing assertion, because the test calls `Main.main`, which calls `System.exit`. The run still summarised as `Tests run: 4599, Failures: 0`.

## Verification

`mvn -o clean test`, whole reactor: 4611 / 198 / 109 / 1, `BUILD SUCCESS`. 21 new tests. Every line in the table above was run through a rebuilt `souther.jar`, not only through the harness.

Refs #515
Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)
