### PR TITLE
A guard gives way at its departure, and an example row stays a chain

### DIFF
--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -129,6 +129,33 @@ behavior judge : (
     | EscalatedToTheManager
 ```
 
+A `guard` reads the same way and gives way in the same order. Where it fits, it is one line. Where
+it does not, the `else` opens a line under it — the departure is what the guard is for, and left to
+the condition's own breaking it ends up at the end of whichever continuation line the last conjunct
+took. The condition breaks after that, and only where it does not fit the line the `guard` left it.
+
+```
+    guard List.length(rows) >= 1 else NoRows
+
+    guard List.allDistinctBy(x -> x, rows) && List.length(rows) >= 1 && Foo.baaaaaaaar(rows)
+        else NoRows
+
+    guard List.allDistinctBy(x -> x, rows)
+        && List.length(rows) >= 1
+        && List.length(rows) < 100
+        && Foo.bar(rows)
+        else NoRows
+```
+
+A `guard` whose departures are named clauses is written the other way round, because there is no one
+departure to break off: the `else` ends the guard's own line and the clauses go under it.
+
+```
+    guard Lines(rows) as items else
+        | nonEmpty -> NoRows
+        | unique -> DuplicateProduct
+```
+
 A comment keeps what it was written about. On the line of the code it follows it stays there; on a
 line of its own it goes above what follows it, unless a blank line separates it from that and none
 separates it from the code above, in which case it stays under that code. A comment with nothing

--- a/souther-compiler/src/test/java/souther/compiler/fmt/TheDepartureGivesWayBeforeTheConditionInAGuardTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/TheDepartureGivesWayBeforeTheConditionInAGuardTest.java
@@ -1,0 +1,204 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code guard} that does not fit gives way at its {@code else} before it gives way in its
+ * condition.
+ *
+ * <p>The departure is what the guard is for. Written wherever the condition happened to finish, it
+ * ends up at the end of whichever continuation line the last conjunct took and reads as part of that
+ * conjunct — which is what came out while the {@code else} was written with a boundary the layout
+ * could not break at all, so nothing had decided the order and nothing could have said what it was.
+ *
+ * <p>Written as the rule and not as an output, the same way
+ * {@link TheInputsGiveWayBeforeTheOutputInASignatureTest} is: over a swept family, a guard whose
+ * condition is broken has its departure broken too, and the sweep is required to reach all three
+ * outcomes so the implication is not answered by a family that never breaks anything.
+ *
+ * <p>A guard whose departures are named clauses is not this question. Its {@code else} already ends
+ * the guard's own line with the clauses under it, so there is no order between two things to state.
+ */
+class TheDepartureGivesWayBeforeTheConditionInAGuardTest {
+
+    private static final int WIDTH = 100;
+
+    private record Laid(String source, String text, boolean departureBroken,
+            boolean conditionBroken) {}
+
+    @Test
+    void aConditionIsNeverBrokenWhileTheDepartureIsStillOnTheGuardsLine() {
+        List<String> wrong = new ArrayList<>();
+        for (Laid laid : sweep()) {
+            if (laid.conditionBroken() && !laid.departureBroken()) {
+                wrong.add(laid.text());
+            }
+        }
+        assertEquals(List.of(), wrong,
+                wrong.size() + " guards broke the condition with the departure left on the guard's"
+                        + " line, which is the order reversed:\n" + String.join("\n", wrong));
+    }
+
+    /** The premise is reached: the sweep holds a guard of each of the three outcomes. */
+    @Test
+    void theSweepReachesAllThreeOutcomes() {
+        int flat = 0;
+        int departureOnly = 0;
+        int both = 0;
+        for (Laid laid : sweep()) {
+            if (!laid.departureBroken() && !laid.conditionBroken()) {
+                flat++;
+            } else if (laid.departureBroken() && !laid.conditionBroken()) {
+                departureOnly++;
+            } else if (laid.departureBroken() && laid.conditionBroken()) {
+                both++;
+            }
+        }
+        assertTrue(flat > 0 && departureOnly > 0 && both > 0,
+                "the sweep reached " + flat + " guards on one line, " + departureOnly
+                        + " with the departure broken alone and " + both + " with both broken");
+    }
+
+    /** Nothing is broken that fits, and nothing that does not fit is left whole. */
+    @Test
+    void aGuardBreaksWhenItDoesNotFitAndNotBefore() {
+        List<String> wrong = new ArrayList<>();
+        for (Laid laid : sweep()) {
+            boolean fits = guardLine(laid.source()).length() <= WIDTH;
+            if (fits && (laid.departureBroken() || laid.conditionBroken())) {
+                wrong.add("broke a guard of " + guardLine(laid.source()).length() + " columns:\n"
+                        + laid.text());
+            }
+            if (!fits && !laid.departureBroken()) {
+                wrong.add("left a guard of " + guardLine(laid.source()).length()
+                        + " columns on one line:\n" + laid.text());
+            }
+        }
+        assertEquals(List.of(), wrong, String.join("\n", wrong));
+    }
+
+    /**
+     * The condition goes down the page only where it does not fit the line the {@code guard} left
+     * it, which is the second half of the order.
+     */
+    @Test
+    void aConditionIsBrokenOnlyWhereItDoesNotFitTheLineTheGuardLeftIt() {
+        List<String> wrong = new ArrayList<>();
+        for (Laid laid : sweep()) {
+            if (!laid.departureBroken()) {
+                continue;
+            }
+            int columns = "    guard ".length() + conditionOf(laid.source()).length();
+            if (laid.conditionBroken() != (columns > WIDTH)) {
+                wrong.add("a condition of " + columns + " columns came back "
+                        + (laid.conditionBroken() ? "broken" : "whole") + ":\n" + laid.text());
+            }
+        }
+        assertEquals(List.of(), wrong, String.join("\n", wrong));
+    }
+
+    /** A guard whose departures are named clauses keeps the shape it already had. */
+    @Test
+    void namedDeparturesAreWrittenUnderTheGuardsOwnLine() {
+        assertEquals("""
+                module m
+
+                data Lines = List<Int>
+                    invariant nonEmpty = List.length(value) >= 1
+                    invariant unique = List.allDistinctBy(x -> x, value)
+                data Small = Int
+
+                let build (rows) = {
+                    guard Lines(rows) as items else
+                        | nonEmpty -> Small(1)
+                        | unique -> Small(2)
+                    items
+                }
+                """, Formatter.format("""
+                module m
+                data Lines = List<Int>
+                    invariant nonEmpty = List.length(value) >= 1
+                    invariant unique = List.allDistinctBy(x -> x, value)
+                data Small = Int
+
+                let build (rows) = {
+                    guard Lines(rows) as items else
+                        | nonEmpty -> Small(1)
+                        | unique -> Small(2)
+                    items
+                }
+                """));
+    }
+
+    /** Both widths are varied against each other rather than one at a time. */
+    private static List<Laid> sweep() {
+        List<Laid> out = new ArrayList<>();
+        for (int conjuncts = 1; conjuncts <= 3; conjuncts++) {
+            for (int conjunctLength : new int[] {8, 24, 44}) {
+                for (int departureLength : new int[] {5, 20, 40}) {
+                    String source = guard(conjuncts, conjunctLength, departureLength);
+                    String text = Formatter.format(source);
+                    out.add(new Laid(source, text, departureBroken(text), conditionBroken(text)));
+                }
+            }
+        }
+        return out;
+    }
+
+    private static String guard(int conjuncts, int conjunctLength, int departureLength) {
+        StringBuilder sb = new StringBuilder("module m\n\nlet f (n) = {\n    guard ");
+        for (int i = 0; i < conjuncts; i++) {
+            sb.append(i == 0 ? "" : " && ").append(name('c', conjunctLength, i)).append("(n)");
+        }
+        sb.append(" else ").append(name('D', departureLength, 0)).append("(n)");
+        return sb.append("\n    n\n}\n").toString();
+    }
+
+    /** A name of exactly {@code length} characters, distinct per index. */
+    private static String name(char first, int length, int index) {
+        String tail = Integer.toString(index);
+        return first + "x".repeat(length - 1 - tail.length()) + tail;
+    }
+
+    /** The guard as one line, which is the width the layout was asked about. */
+    private static String guardLine(String source) {
+        for (String line : source.split("\n", -1)) {
+            if (line.strip().startsWith("guard ")) {
+                return line;
+            }
+        }
+        throw new IllegalStateException("no guard in " + source);
+    }
+
+    /** What the source writes between `guard` and `else`. */
+    private static String conditionOf(String source) {
+        String line = guardLine(source).strip();
+        return line.substring("guard ".length(), line.lastIndexOf(" else "));
+    }
+
+    /** The departure is broken off when the `else` opens a line. */
+    private static boolean departureBroken(String text) {
+        for (String line : text.split("\n", -1)) {
+            if (line.matches("^\\s+else \\S.*$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** The condition is broken when a conjunct opens a line with its operator. */
+    private static boolean conditionBroken(String text) {
+        for (String line : text.split("\n", -1)) {
+            if (line.matches("^\\s+&& \\S.*$")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -1986,12 +1986,21 @@ public final class Formatter {
                     TokenDoc.at(ofTheTest, expr(exprs.get(0), ofTheTest)),
                     attemptBinder(n), GAP, TokenDoc.token(SyntaxKind.ELSE_KW, "else"), departures));
         }
-        Place ofTheDeparture = places.under(at, exprs.get(1).kind(), Opening.NONE,
+        // The `else` opens the departure's line, so it is the place's opener: a guard that does not
+        // fit gives way there before its condition gives way anywhere. The two are one group and
+        // this is the order it takes — the departure is what the guard is for, and left to the
+        // condition's own breaking it ends up at the end of whichever continuation line the
+        // condition happened to finish on. The condition's group is measured afterwards, on the
+        // line the `guard` left it, so it stays flat where it fits there.
+        Place ofTheDeparture = places.under(at, exprs.get(1).kind(),
+                new Opening.Breaks(TokenDoc.Break.MAY,
+                        concat(TokenDoc.token(SyntaxKind.ELSE_KW, "else"), GAP)),
                 Written.of(exprs.get(1)));
-        return TokenDoc.node(n.kind(), concat(TokenDoc.token(SyntaxKind.GUARD_KW, "guard"), GAP,
+        return TokenDoc.node(n.kind(), group(concat(
+                TokenDoc.token(SyntaxKind.GUARD_KW, "guard"), GAP,
                 TokenDoc.at(ofTheTest, expr(exprs.get(0), ofTheTest)),
-                attemptBinder(n), GAP, TokenDoc.token(SyntaxKind.ELSE_KW, "else"), GAP,
-                TokenDoc.at(ofTheDeparture, expr(exprs.get(1), ofTheDeparture))));
+                attemptBinder(n),
+                nest(INDENT, TokenDoc.at(ofTheDeparture, expr(exprs.get(1), ofTheDeparture))))));
     }
 
     // --- comments ---
@@ -2216,6 +2225,12 @@ public final class Formatter {
                 case EXAMPLE_ROW, FAKE_ROW, MATCH_CASE -> true;
                 default -> false;
             };
+            // A guard's `else` opens the departure's line the way a comma opens a member's, so a
+            // comment written above it is about the departure after it. Read as part of the guard
+            // instead, the comment came back above the `else` — a position the next formatting reads
+            // as a comment about the whole guard, so the first one had already moved it.
+            case ELSE_KW -> t.parent().kind() == SyntaxKind.GUARD_STMT
+                    && t.parent().child(SyntaxKind.ELSE_ARMS).isEmpty();
             default -> isBinaryOperator(t.kind());
         };
     }

--- a/specification.adoc
+++ b/specification.adoc
@@ -1243,16 +1243,19 @@ The check is intraprocedural. Within a behavior's `+let+` body it seeds what the
 
 Guards that cannot all hold describe a path the behavior does not take, and a construction standing on one is neither of the middle two: nothing is built there, so nothing is reported. That the guards contradict is itself derived over the same fragment — `+a <= b+` with `+b <= 0+` bounds `+a+` above without a word about `+a+` — so a path is dead whenever the relations say so, whatever order they were written in.
 
-[,text]
+[,souther]
 ----
-data Money = Decimal invariant value >= 0m
-data WithdrawRequest = { balance: Money, amount: Money }
+data Money = Decimal
+    invariant value >= 0m
+data WithdrawRequest =
+    { balance: Money
+    , amount: Money
+    }
 
 behavior withdraw : (req: WithdrawRequest) -> Money | InsufficientBalance
 let withdraw (req) = {
-    guard req.amount <= req.balance
-        else InsufficientBalance
-    req.balance - req.amount          // discharged: the guard proves balance - amount >= 0
+    guard req.amount <= req.balance else InsufficientBalance
+    req.balance - req.amount // discharged: the guard proves balance - amount >= 0
 }
 ----
 
@@ -1265,15 +1268,15 @@ An *attempted* construction (<<attempted-construction>>) is never possibly viola
 
 A term it compares is the numeric content of a location — a parameter, a field chain, a newtype's wrapped value — or the size of a container or a string: `+List.length+`, `+String.length+`, `+Set.size+`, `+Map.size+` applied to such a location. A value the body reaches nowhere else is a location too, and carries what its type guarantees exactly as a parameter does: what a `+match+` arm binds, and what a standard-library operation hands its closure — an element, and a fold's accumulator. A size is named by the location it is taken of, so a guard and an invariant clause mean the same term exactly when they take the size of the same one. The size of a container is never negative, and the procedure knows that much without being told.
 
-[,text]
+[,souther]
 ----
-data Lines = List<Line> invariant List.length(value) >= 1
+data Lines = List<Line>
+    invariant List.length(value) >= 1
 
 behavior build : (rows: List<Line>) -> Lines | NoRows
 let build (rows) = {
-    guard List.length(rows) >= 1
-        else NoRows
-    Lines(rows)                       // discharged: the guard sizes the same list
+    guard List.length(rows) >= 1 else NoRows
+    Lines(rows) // discharged: the guard sizes the same list
 }
 ----
 
@@ -1358,15 +1361,15 @@ What each keeps:
 
 So `+List.length(List.map(f, xs))+` *is* `+List.length(xs)+` — how the elements are made has no bearing on how many there are — and a guard on the length of `+xs+` discharges a construction from the mapped list. `+List.length(List.filter(p, xs))+` is its own term, no greater than `+List.length(xs)+`: an upper bound on the input bounds the result, and a lower bound on the input says nothing.
 
-[,text]
+[,souther]
 ----
-data Lines = List<Line> invariant List.length(value) >= 1
+data Lines = List<Line>
+    invariant List.length(value) >= 1
 
 behavior build : (rows: List<Row>) -> Lines | NoRows
 let build (rows) = {
-    guard List.length(rows) >= 1
-        else NoRows
-    Lines(List.map(toLine, rows))     // discharged: a mapping keeps the length
+    guard List.length(rows) >= 1 else NoRows
+    Lines(List.map(toLine, rows)) // discharged: a mapping keeps the length
 }
 ----
 
@@ -1462,15 +1465,15 @@ A relation the clause in turn states of a container is read at that container's 
 
 Not every invariant is a comparison. `+List.allDistinctBy(.product, value)+`, `+List.contains(value, codes)+` and `+String.matches("[A-Z]{2}-[0-9]{4}", value)+` state something about a value that no arithmetic relates to anything else. Such a clause is *settled* by a guard rather than derived: a `+guard+` states its condition where it does not depart and denies it where it does, and a construction under a guard stating the clause is discharged, one under a guard denying it a violation.
 
-[,text]
+[,souther]
 ----
-data Lines = List<Line> invariant List.allDistinctBy(.product, value)
+data Lines = List<Line>
+    invariant List.allDistinctBy(.product, value)
 
 behavior build : (rows: List<Line>) -> Lines | DuplicateProduct
 let build (rows) = {
-    guard List.allDistinctBy(.product, rows)
-        else DuplicateProduct
-    Lines(rows)                       // discharged: the guard states the clause
+    guard List.allDistinctBy(.product, rows) else DuplicateProduct
+    Lines(rows) // discharged: the guard states the clause
 }
 ----
 
@@ -2054,11 +2057,10 @@ The DSL holds only these two because it places side effects at the ends of a wor
 
 What is written in `+depends on+` appears as a `+let+` argument, after the business inputs, in declaration order.
 
-[,text]
+[,souther]
 ----
 let preApprove (request, approverId, now) = {
-    guard approverId == request.applicant.managerId
-        else NotAuthorized
+    guard approverId == request.applicant.managerId else NotAuthorized
 
     PreApproved { ...request, preApprovedAt = now(), preApprover = approverId }
 }
@@ -2189,15 +2191,17 @@ let isOver (amount: Amount) = amount > ceiling // a function
 
 A value is named where the value it stands for would be written, and it may be spread (`+Drafting { ...standardRequest, estimatedCost = Amount(50000) }+`). A behavior taking nothing is implemented by a value, since the parameter counts agree.
 
-[,text]
+[,souther]
 ----
-behavior preApprove : (request: AwaitingPreApproval, approverId: EmployeeId) -> PreApproved | NotAuthorized
+behavior preApprove : (
+    request: AwaitingPreApproval,
+    approverId: EmployeeId
+) -> PreApproved | NotAuthorized
     depends on now
     constructs PreApproved, NotAuthorized
 
 let preApprove (request, approverId, now) = {
-    guard approverId == request.applicant.managerId
-        else NotAuthorized
+    guard approverId == request.applicant.managerId else NotAuthorized
 
     PreApproved { ...request, preApprovedAt = now(), preApprover = approverId }
 }
@@ -2567,15 +2571,15 @@ Accumulation (applicative) is inside the decode boundary; case propagation is be
 
 An `+example+` attaches compile-time-checked test rows to a behavior. It is evaluated as part of compilation: a row that does not hold is a compile error (<<e1905>>), so a stale example cannot survive a build. An `+example+` is not exposed and produces no run-time class.
 
-[,text]
+[,souther]
 ----
 example submitTravelRequest
-    | "within the ceiling it submits" :
-        (Drafting { applicant = EmployeeId("e-001"), estimatedCost = Amount(50000) })
-            -> Submitted
-    | "over the ceiling waits for pre-approval" :
-        (Drafting { applicant = EmployeeId("e-001"), estimatedCost = Amount(100001) })
-            -> AwaitingPreApproval
+    | "within the ceiling it submits"
+        : (Drafting { applicant = EmployeeId("e-001"), estimatedCost = Amount(50000) })
+        -> Submitted
+    | "over the ceiling waits for pre-approval"
+        : (Drafting { applicant = EmployeeId("e-001"), estimatedCost = Amount(100001) })
+        -> AwaitingPreApproval
 ----
 
 What a row is held to, and what holding a build to it requires:
@@ -2615,14 +2619,16 @@ A behavior with a `+let+` implementation is evaluated (<<fn>>), and so is a `+>-
 
 A composition's row is written like any other. Its arguments are the first stage's (<<sequential-composition>>), and its expected result is any case of the composition's output — including one that departed the main line at an earlier stage (<<type-routing>>), which is the part no stage's own example can state, because the routing is not any stage's rule.
 
-[,text]
+[,souther]
 ----
-behavior winOrder = settleQuote >-> makeOrder
-    -> Order | BelowFloor
+behavior winOrder = settleQuote >-> makeOrder -> Order | BelowFloor
 
 example winOrder
-    | "meeting the floor wins the order" : (Negotiating { floor = Amount(100) }, Amount(200)) -> Order
-    | "below the floor it stops here"    : (Negotiating { floor = Amount(100) }, Amount(50))
+    | "meeting the floor wins the order"
+        : (Negotiating { floor = Amount(100) }, Amount(200))
+        -> Order
+    | "below the floor it stops here"
+        : (Negotiating { floor = Amount(100) }, Amount(50))
         -> BelowFloor { floor = Amount(100), offered = Amount(50) }
 ----
 
@@ -3201,11 +3207,10 @@ takes; write the construction out (`+T(a.value - b.value)+`).
 
 `+{ ... }+` is an expression. Place `+let+`s and `+guard+`s, then put the result expression last.
 
-[,text]
+[,souther]
 ----
 let preApprove (request, approverId) = {
-    guard approverId == request.applicant.managerId
-        else NotAuthorized
+    guard approverId == request.applicant.managerId else NotAuthorized
 
     PreApproved { ...request, preApprovedAt = now(), preApprover = approverId }
 }


### PR DESCRIPTION
The two layout decisions #518 left open, and the nine specification samples that were waiting on
them. With these, every sample the specification writes as a whole Souther file is one the formatter
is held against — eighty-three, and none left that would pass unmarked.

## #573 — a guard gives way at its departure first

The departure is what a guard is for, and it was written wherever the condition happened to finish.
`guardStmt` put a `Break.NEVER` boundary in front of the `else`, so the layout could not open a line
there whatever the width:

```
    guard List.allDistinctBy(x -> x, rows)
        && List.length(rows) >= 1
        && List.length(rows) < 100 else Small(1)
```

The `else` is the departure's opener now and the guard is one group over both, the same arrangement
#565 used for a signature. A guard that fits is one line; one that does not puts `else` under it and
leaves the condition flat where it fits there; one whose condition does not fit either breaks both.
The named-clause form is untouched — its `else` already ends the guard's own line.

Opening that line made the `else` a separator as far as a comment is concerned, the way a comma and
a `|` are. Without it a comment between the condition and the `else` came back above the `else`,
which the next formatting reads as a comment about the whole guard. The token-boundary sweep caught
it, one probe of 404.

## #574 — an `example` row stays a chain

A row is a chain and a chain is written by one rule: the connector leads the line where it breaks,
the same as `>->`, `|>`, a union's `|` and a match arm's `->`. The formatter was not making an
exception for rows; the specification was, and inconsistently, indenting the `->` one level past the
`:` where nothing else in the document does. The rule wins and the two rows are rewritten.

## The rules

`cli/commands` states the guard rule in both its shapes, with each example run through
`fmt --check`. The test holds the order rather than an output: over a swept family of guards none
has its condition broken with its departure still on the guard's line, and the sweep is required to
reach all three outcomes so the implication is not answered by a family that never breaks anything.

Refs #573 #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)
