### PR TITLE
Every departure from the canonical form is some rule's

### DIFF
--- a/souther-compiler/src/test/java/souther/compiler/AFormatCheckSaysWhichRuleEachDifferenceAnswersToTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AFormatCheckSaysWhichRuleEachDifferenceAnswersToTest.java
@@ -20,9 +20,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * form's and cannot say why any of them is there, so a reader who wanted to write the canonical form
  * rather than have it written for them had to work the rule out from the characters.
  *
- * <p>What is not named is said. Some of what a canonical form has against a source is not a rule
- * that has been written down yet, and a list that named what it can and stopped would read as a file
- * with these differences and no others.
+ * <p>What is not named is said. A list that named what it can and stopped would read as a file with
+ * these differences and no others, so the command shows a diff for whatever is left over — which
+ * over every source measured is nothing.
  */
 class AFormatCheckSaysWhichRuleEachDifferenceAnswersToTest {
 
@@ -99,15 +99,16 @@ class AFormatCheckSaysWhichRuleEachDifferenceAnswersToTest {
     }
 
     /**
-     * And a difference no rule accounts for is said and shown.
+     * A difference in the code tokens is a rule like any other.
      *
      * <p>A definition whose right-hand side is a lambda is written with its parameters on the left,
      * which writes tokens the source has not — so the rules that hold the two token streams side by
-     * side cannot answer about it, and what the others say is not all of it. A reader told only what
-     * is named would take the file for fixed.
+     * side have nothing to pair, and this used to be answered with a diff and the note that what was
+     * named was not all of it. Which tokens are written is itself a decision, and it is the one the
+     * others read.
      */
     @Test
-    void aDifferenceNoRuleAccountsForIsSaidAndShown() throws Exception {
+    void aDifferenceInTheCodeTokensIsNamedTheSameWay() throws Exception {
         Path file = source("m.sou", """
                 module billing exposing ( f )
 
@@ -117,8 +118,10 @@ class AFormatCheckSaysWhichRuleEachDifferenceAnswersToTest {
         Said said = run("fmt", file.toString(), "--check");
 
         assertEquals(1, said.code());
-        assertTrue(said.out().contains("no rule accounts for yet"), said.out());
-        assertTrue(said.out().contains("@@"),
-                "and what is left is shown rather than left to be guessed at: " + said.out());
+        assertTrue(said.out().contains("a definition writes its parameters to the left of the `=`"),
+                "the rule is named: " + said.out());
+        assertTrue(!said.out().contains("no rule accounts for yet"),
+                "and there is nothing left over to show a diff for: " + said.out());
+        assertTrue(!said.out().contains("@@"), said.out());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentOnALineOfItsOwnBeginsAtItsLevelsColumnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentOnALineOfItsOwnBeginsAtItsLevelsColumnTest.java
@@ -1,0 +1,137 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A comment written on a line of its own begins where that line's level does.
+ *
+ * <p>Not a rule of its own. The layout writes the comment at the indent of the break in front of it,
+ * which is the level it stands under — so the column is the indentation rule's answer and what was
+ * missing is the source's side of it: a line the canonical form opens for a comment was one the
+ * source could not be asked about, so a comment written anywhere at all left the report with nothing
+ * to say.
+ *
+ * <p>The rules about comments answer the questions around it — how many lines stand between it and
+ * what it is above, and what stands in front of one at the end of a line of code. Neither of them is
+ * a column.
+ */
+class ACommentOnALineOfItsOwnBeginsAtItsLevelsColumnTest {
+
+    @Test
+    void aCommentInsideAConstructIsSomeRules() {
+        String source = """
+                module m
+
+                data R =
+                    { a: Int
+                         // about b
+                    , b: Int
+                    }
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(!report.deviations().isEmpty(), "no rule named it");
+        assertTrue(report.whole(), "and what is named is not all of it");
+    }
+
+    /** One above a top-level item stands at the file's own column. */
+    @Test
+    void andOneAboveATopLevelItemIsToo() {
+        String source = """
+                module m
+
+                    // about f
+                let f (a: Int): Int = a
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(!report.deviations().isEmpty(), "no rule named it");
+        assertTrue(report.whole(), "and what is named is not all of it");
+    }
+
+    /**
+     * A run of comments is written at one column, and a source that lined the second one up under
+     * the first's text has moved it off that column.
+     *
+     * <p>This is the shape the corpus has: a comment too long for its line, continued on the next
+     * and hand-aligned under the first.
+     */
+    @Test
+    void andTheContinuationOfARunIsAtTheSameColumn() {
+        String source = """
+                module m
+
+                data R =
+                    { a: Int // membership, not order, and two rows for one
+                                 // are not two
+                    , b: Int
+                    }
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(report.whole(), "what is named is not all of it");
+        assertEquals(List.of("one level deeper is one indent further in"),
+                report.deviations().stream().map(Deviations.Deviation::rule).toList(),
+                "the column is the indentation rule's answer, and the only one here");
+    }
+
+    /**
+     * A comment the canonical form carries somewhere else has no column here.
+     *
+     * <p>The line the source wrote it on is one the repair is about to take away, so an indent
+     * written onto it would be an expectation about a line that will not be there. This rule reads
+     * the carrier decision rather than competing with it — and where it did not, the two answered
+     * about the same characters and the composition refused, which is how it was found.
+     */
+    @Test
+    void andACommentCarriedSomewhereElseIsNotThisRulesLine() {
+        String source = """
+                module m
+
+                data R =
+                    { a: Int
+                    , b: Int
+                    }
+
+                let r: R =
+                    R { a = 1
+                          // about b
+                        , b = 2
+                        }
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(report.whole(), "what is named is not all of it");
+        assertTrue(report.deviations().stream()
+                        .anyMatch(d -> d.rule().equals(
+                                "a comment is carried by the construct it was written against")),
+                "the comment moves, and that is what is said about it: " + report.deviations());
+    }
+
+    /** And a source that has its comments where the canonical form does has nothing against it. */
+    @Test
+    void andACanonicalSourceHasNothingAgainstIt() {
+        String source = """
+                module m
+
+                // about R
+                data R =
+                    { a: Int
+                    // about b
+                    , b: Int
+                    }
+                """;
+
+        assertEquals(source, Formatter.format(source));
+        assertEquals(List.of(), Deviations.of(source).deviations());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ACommentThatOpensTheFileIsOnALineOfItsOwnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ACommentThatOpensTheFileIsOnALineOfItsOwnTest.java
@@ -1,0 +1,73 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A comment written before anything else in the file is on a line of its own.
+ *
+ * <p>Which of the two rules about comments answers was read from what stands between a comment and
+ * the code in front of it: a stretch holding a line break meant the comment opens its own line. At
+ * the top of a file there is no code in front of it, so that stretch is empty and the first comment
+ * of every source was taken for one at the end of a line — the rule about what stands above a
+ * comment was never asked, and a blank line written into the run under the header had nothing to
+ * name it.
+ *
+ * <p>What is in front of a comment on its line is what says it, and at the top of a file that is
+ * nothing.
+ */
+class ACommentThatOpensTheFileIsOnALineOfItsOwnTest {
+
+    @Test
+    void aBlankLineInsideTheRunThatOpensAFileIsSomeRules() {
+        String source = """
+                // one
+
+                // two
+                module m
+
+                let f (a: Int): Int = a
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(!report.deviations().isEmpty(), "no rule named it");
+        assertTrue(report.whole(), "and what is named is not all of it");
+        assertEquals("a comment on a line of its own is written above the line it owns",
+                report.deviations().get(0).rule());
+    }
+
+    /** The same run written the way the canonical form writes it has nothing against it. */
+    @Test
+    void andTheRunWithNoBlankLineInItHasNothingAgainstIt() {
+        String source = """
+                // one
+                // two
+                module m
+
+                let f (a: Int): Int = a
+                """;
+
+        assertEquals(source, Formatter.format(source));
+        assertEquals(List.of(), Deviations.of(source).deviations());
+    }
+
+    /** And a comment at the end of a line of code is still that one's. */
+    @Test
+    void andACommentAfterCodeIsStillTheOtherRules() {
+        String source = """
+                module m
+
+                let f (a: Int): Int = a     // about f
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertEquals(List.of("a comment at the end of a line is written one space after the code"),
+                report.deviations().stream().map(Deviations.Deviation::rule).toList());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/AGroupsBreakEndsOneLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/AGroupsBreakEndsOneLineTest.java
@@ -1,0 +1,80 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A group written down the page ends one line at each place it breaks, and not two.
+ *
+ * <p>The conditional-layout rule answers whether the group is written on one line or down the page,
+ * which is a decision about the group and is why its witness is a pair of booleans. How many lines
+ * end at one of the places it breaks is a different question, and the answer is one: a blank line
+ * inside a construct is written where the author wrote a paragraph break between its members, which
+ * is a forced break and is a rule that says so.
+ *
+ * <p>Left unanswered, a source that put a blank line at a boundary a group settles departed from a
+ * canonical form no rule could name: the group did break there, so the conditional witness says
+ * nothing, and no obligation stands at that boundary for the forced rules to count lines at.
+ */
+class AGroupsBreakEndsOneLineTest {
+
+    private static final String BROKEN = """
+            module m exposing ( f )
+
+            data Result =
+                { alpha: Int
+                , beta: Int
+                }
+
+            let f (n: Int): Result =
+                Result { alpha = n + 100000, beta = n + 200000, alpha = n + 300000, beta = n + 400000, alpha = n + 500000 }
+            """;
+
+    /** The construct this is about is one the width decided, and it is written down the page. */
+    @Test
+    void theConstructIsOneTheWidthWroteDownThePage() {
+        String canonical = Formatter.format(BROKEN);
+
+        assertTrue(canonical.contains("Result {\n"),
+                "the width was expected to break it:\n" + canonical);
+    }
+
+    @Test
+    void aBlankLineAtOneOfItsBreaksIsSomeRules() {
+        String canonical = Formatter.format(BROKEN);
+        String source = canonical.replaceFirst("alpha = n \\+ 100000,\n", "alpha = n + 100000,\n\n");
+
+        assertTrue(!source.equals(canonical), "the source was expected to differ");
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(!report.deviations().isEmpty(), "no rule named it");
+        assertTrue(report.whole(), "and what is named is not all of it");
+    }
+
+    /** And what it says is a count of lines, which is what a blank line is one too many of. */
+    @Test
+    void andWhatItSaysIsHowManyLinesEndThere() {
+        String canonical = Formatter.format(BROKEN);
+        String source = canonical.replaceFirst("alpha = n \\+ 100000,\n", "alpha = n + 100000,\n\n");
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertEquals(List.of("a group written down the page ends one line where it breaks"),
+                report.deviations().stream().map(Deviations.Deviation::rule).toList());
+        assertEquals("one line ends here", report.deviations().get(0).canonical());
+        assertEquals("two do", report.deviations().get(0).source());
+    }
+
+    /** A source that wrote the construct as the canonical form does has nothing against it. */
+    @Test
+    void andACanonicalSourceHasNothingAgainstIt() {
+        String canonical = Formatter.format(BROKEN);
+
+        assertEquals(canonical, Formatter.format(canonical));
+        assertEquals(List.of(), Deviations.of(canonical).deviations());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ALineTheFileHoldsIsWrittenAtColumnZeroTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ALineTheFileHoldsIsWrittenAtColumnZeroTest.java
@@ -1,0 +1,87 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The file is a level of its own, and the lines it holds begin at column zero.
+ *
+ * <p>The indentation rule answers about a pair of levels, and the outermost pair is the file and the
+ * first level written inside it. Without the file among them the pair has one member: a line written
+ * under no nesting is at a column nothing decided, and a source that indented every one of its
+ * definitions departed from a canonical form no rule could name.
+ *
+ * <p>That is what this holds — not that the formatter writes column zero, which the golden corpus
+ * has always said, but that a source writing something else is told which rule it is about.
+ */
+class ALineTheFileHoldsIsWrittenAtColumnZeroTest {
+
+    @Test
+    void aDefinitionWrittenFurtherInIsSomeRules() {
+        String source = """
+                module m
+
+                    let f (a: Int): Int = a
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(!report.deviations().isEmpty(), "no rule named it");
+        assertTrue(report.whole(), "and what is named is not all of it");
+    }
+
+    /** The header opens the file and is written at that level too. */
+    @Test
+    void andSoIsTheHeaderTheFileOpensWith() {
+        String source = """
+                  module m
+
+                let f (a: Int): Int = a
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(!report.deviations().isEmpty(), "no rule named it");
+        assertTrue(report.whole(), "and what is named is not all of it");
+    }
+
+    /**
+     * And the deviation is the indentation rule's, at the file's level.
+     *
+     * <p>Written out because a source indented at the top level also has every line under it
+     * indented, and a report naming the levels inside would tell an author to move lines whose step
+     * is right.
+     */
+    @Test
+    void andTheRuleItNamesIsTheOneAboutColumns() {
+        String source = """
+                module m
+
+                    let f (a: Int): Int = a
+                """;
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertEquals(1, report.deviations().size(), "one decision, and: " + report.deviations());
+        assertEquals("a line the file holds begins at column zero",
+                report.deviations().get(0).rule());
+    }
+
+    /** A source already in canonical form has nothing against it, so the rule is not answering
+     *  about every line there is. */
+    @Test
+    void andACanonicalSourceHasNothingAgainstIt() {
+        String source = """
+                module m
+
+                let f (a: Int): Int = a
+                """;
+
+        assertEquals(source, Formatter.format(source));
+        assertEquals(List.of(), Deviations.of(source).deviations());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/ATokenTheCanonicalFormWritesOrDoesNotIsSomeRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/ATokenTheCanonicalFormWritesOrDoesNotIsSomeRulesTest.java
@@ -1,0 +1,91 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The canonical form's code tokens are a decision too, and a source that wrote others is told which.
+ *
+ * <p>Three of them, and {@link ACanonicalFormCanRewriteCodeTokensTest} is where they are written
+ * out: a trailing comma is dropped, the bar in front of a match's first arm is written, and a
+ * definition whose body is a lambda is written with its parameters on the left. Until they were
+ * decisions, a source that wrote any of them had a report with nothing in it at all — the rules that
+ * hold the two token streams side by side cannot pair them, so they refuse, and the deviations that
+ * had nothing to do with the tokens went unsaid with them.
+ *
+ * <p>They come first in the order the rules depend on each other. What a layout rule answers about is
+ * a boundary between two tokens, and which tokens those are is what these settle.
+ */
+class ATokenTheCanonicalFormWritesOrDoesNotIsSomeRulesTest {
+
+    /**
+     * The sites are the ones already written out, which is where the domain comes from.
+     *
+     * <p>{@link ACanonicalFormCanRewriteCodeTokensTest} has one row per construct the grammar
+     * admits a trailing comma in — every loop in the parser that reads a comma — with the bar and
+     * the two lambda forms beside them. Building the candidates here again would be a second list
+     * of the same thing, and the one that went stale would be this one.
+     */
+    static Stream<ACanonicalFormCanRewriteCodeTokensTest.Rewrite> rewrites() {
+        return ACanonicalFormCanRewriteCodeTokensTest.rewrites();
+    }
+
+    /** What each of the three kinds of change is called where a report names it. */
+    private static String ruleFor(String change) {
+        return switch (change) {
+            case "a token is removed" ->
+                    "a comma-separated run is written without a comma after its last member";
+            case "a token is added" -> "a match writes every arm with its bar";
+            case "the tokens are rewritten" ->
+                    "a definition writes its parameters to the left of the `=`";
+            default -> throw new AssertionError("no such change: " + change);
+        };
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("rewrites")
+    void theTokenTheCanonicalFormWritesIsNamed(
+            ACanonicalFormCanRewriteCodeTokensTest.Rewrite rewrite) {
+        Deviations.Report report = Deviations.of(rewrite.source());
+
+        assertTrue(report.deviations().stream()
+                        .anyMatch(d -> d.rule().equals(ruleFor(rewrite.change()))),
+                "the rule was not named: " + report.deviations());
+        assertTrue(report.whole(), "and what is named is not all of it: " + report.deviations());
+    }
+
+    /**
+     * And what else the source got wrong is named with it.
+     *
+     * <p>This is what the refusal cost. A source that writes a lambda on the right of a definition
+     * is an ordinary source, and every other rule stopped answering about it — so the report for a
+     * file with one rewrite in it and a hundred spacing deviations was empty.
+     */
+    @Test
+    void andWhatElseTheSourceGotWrongIsNamedWithIt() {
+        String source = "module m\n\nlet f = (x)  ->  x\n";
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(report.whole(), "what is named is not all of it: " + report.deviations());
+        assertEquals("module m\n\nlet f (x) = x\n", Formatter.format(source));
+    }
+
+    /** A source that writes the tokens the canonical form writes has nothing against it. */
+    @Test
+    void andASourceWithTheSameTokensHasNothingAgainstIt() {
+        for (ACanonicalFormCanRewriteCodeTokensTest.Rewrite rewrite : rewrites().toList()) {
+            String canonical = Formatter.format(rewrite.source());
+
+            assertEquals(List.of(), Deviations.of(canonical).deviations(),
+                    "the canonical form of " + rewrite.name() + " has something against it");
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
@@ -1,0 +1,162 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import souther.compiler.cst.CstParser;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A source that departs from the canonical form departs at some rule's unit.
+ *
+ * <p>This is the check the whole issue rests on, and it is the one that cannot be written from the
+ * rules: asked of the rules, a departure none of them holds is not a departure. So the candidates
+ * are made from the text and put to the parser — one line of a canonical form written differently,
+ * kept where the grammar still admits it and where the canonical form of what is written is the one
+ * it came from. Each of those is a source differing from its canonical form in one way and in no
+ * other, and what is held is that the report names it and repairing what the rules say writes the
+ * canonical form back.
+ *
+ * <p>Not from the formatter's own output. A departure it never writes is still one an author can
+ * write, and three of the rules here were missing because the corpus never showed them: a top-level
+ * line indented, a comment at a column of its own, a blank line at a place a group settles.
+ *
+ * <p>One candidate per kind of line rather than one per line. What decides a rule's answer is what
+ * opens the line and how deep it stands, not which of a file's forty definitions it is — so a
+ * source contributes each shape it has once, and a file's length adds nothing but time.
+ */
+class EveryDepartureFromTheCanonicalFormIsSomeRulesTest {
+
+    /** A canonical form with one line of it written differently. */
+    record Departure(String kind, String shape, String text, String canonical) {
+
+        @Override
+        public String toString() {
+            return kind + " — " + shape;
+        }
+    }
+
+    static Stream<Departure> departures() {
+        List<Departure> out = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        // Shortest first, and one candidate per shape across the whole corpus. A shape is a shape
+        // wherever it stands, and asking about it in the smallest source that has it is the same
+        // question asked of less text.
+        List<String> corpus = new ArrayList<>(WhatGoesBetweenTwoTokensOnALineTest.corpus());
+        corpus.sort(java.util.Comparator.comparingInt(String::length));
+        for (String source : corpus) {
+            String canonical = Formatter.format(source);
+            List<String> lines = List.of(canonical.split("\n", -1));
+            for (int i = 0; i < lines.size(); i++) {
+                for (Map.Entry<String, String> m : written(lines, i).entrySet()) {
+                    String text = m.getValue();
+                    String shape = shapeOf(lines.get(i));
+                    if (text == null || text.equals(canonical)
+                            || seen.contains(m.getKey() + " of " + shape)) {
+                        continue;   // this shape is already among them, written this way
+                    }
+                    if (!CstParser.parse(text).errors().isEmpty()
+                            || !Formatter.format(text).equals(canonical)) {
+                        continue;   // not a departure: another source, with a canonical form of
+                                    // its own. The shape is left to be met again, so a line the
+                                    // grammar refuses one way of writing does not take the shape
+                                    // out of the sweep.
+                    }
+                    seen.add(m.getKey() + " of " + shape);
+                    out.add(new Departure(m.getKey(), shape, text, canonical));
+                }
+            }
+        }
+        return out.stream();
+    }
+
+    /** What opens a line and how far in it stands, which is what a rule's answer turns on. */
+    private static String shapeOf(String line) {
+        String content = line.strip();
+        String opens = content.isEmpty() ? "nothing"
+                : content.startsWith("//") ? "a comment"
+                : content.split(" ", 2)[0];
+        return "`" + opens + "` at " + (line.length() - line.stripLeading().length());
+    }
+
+    /** One line of a canonical form, written the ways an author could have written it. */
+    private static Map<String, String> written(List<String> lines, int i) {
+        Map<String, String> out = new LinkedHashMap<>();
+        String line = lines.get(i);
+        out.put("one column further in", replacing(lines, i, " " + line));
+        out.put("one column back",
+                line.startsWith(" ") ? replacing(lines, i, line.substring(1)) : null);
+        out.put("at no column at all",
+                line.startsWith(" ") ? replacing(lines, i, line.strip()) : null);
+        out.put("run on into the next line", i + 1 < lines.size() ? joining(lines, i) : null);
+        out.put("with a blank line under it", inserting(lines, i + 1));
+        out.put("with a space at the end of it", replacing(lines, i, line + " "));
+        int space = line.indexOf(' ', line.length() - line.stripLeading().length());
+        out.put("with a space doubled in it", space > 0 && space < line.length() - 1
+                ? replacing(lines, i, line.substring(0, space) + " " + line.substring(space))
+                : null);
+        out.put("with a space taken out of it",
+                space > 0 && space + 1 < line.length() && line.charAt(space + 1) != ' '
+                        ? replacing(lines, i, line.substring(0, space) + line.substring(space + 1))
+                        : null);
+        return out;
+    }
+
+    private static String replacing(List<String> lines, int i, String with) {
+        List<String> copy = new ArrayList<>(lines);
+        copy.set(i, with);
+        return String.join("\n", copy);
+    }
+
+    private static String inserting(List<String> lines, int i) {
+        List<String> copy = new ArrayList<>(lines);
+        copy.add(i, "");
+        return String.join("\n", copy);
+    }
+
+    private static String joining(List<String> lines, int i) {
+        List<String> copy = new ArrayList<>(lines);
+        copy.set(i, copy.get(i) + " " + copy.get(i + 1).stripLeading());
+        copy.remove(i + 1);
+        return String.join("\n", copy);
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("departures")
+    void aDepartureIsNamedByARule(Departure departure) {
+        Deviations.Report report = Deviations.of(departure.text());
+
+        assertTrue(!report.deviations().isEmpty(),
+                "no rule names it:\n" + departure.text());
+        assertTrue(report.whole(),
+                "what is named is not all of it: " + report.deviations() + "\n"
+                        + departure.text());
+    }
+
+    /**
+     * Every way of writing a line differently reached the parser, and each of them was admitted
+     * somewhere.
+     *
+     * <p>A row that produced no candidate at all is a check that ran on nothing and said it passed,
+     * which is what a sweep over generated candidates fails at silently.
+     */
+    @Test
+    void andEveryWayOfWritingALineDifferentlyIsAmongThem() {
+        Set<String> kinds = new LinkedHashSet<>();
+        departures().forEach(d -> kinds.add(d.kind()));
+
+        assertEquals(written(List.of("    let f (a: Int): Int = a", "    let g = a"), 0).keySet(),
+                kinds, "a way of writing a line that no candidate was built for");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
@@ -32,9 +32,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * write, and three of the rules here were missing because the corpus never showed them: a top-level
  * line indented, a comment at a column of its own, a blank line at a place a group settles.
  *
- * <p>One candidate per kind of line rather than one per line. What decides a rule's answer is what
- * opens the line and how deep it stands, not which of a file's forty definitions it is — so a
- * source contributes each shape it has once, and a file's length adds nothing but time.
+ * <p>One candidate per kind of line rather than one per line, and the kind is read from the layout:
+ * what broke in front of the line, what breaks after it, what is written at the start of it and how
+ * deep it stands. Written from the characters instead — the word the line opens with and its column
+ * — it would put a boundary an obligation broke, one a group settled and one a comment stands at
+ * under one name, which is this check's own mistake made one level up.
+ *
+ * <p>Over this corpus that comes to a few hundred candidates of a few thousand lines. Every line of
+ * every source, written every way, was run against these rules and named: 3823 of 3823. It is not
+ * run that way here because it takes three minutes, and what the reduction rests on is the sentence
+ * above rather than that measurement.
  */
 class EveryDepartureFromTheCanonicalFormIsSomeRulesTest {
 
@@ -56,12 +63,14 @@ class EveryDepartureFromTheCanonicalFormIsSomeRulesTest {
         List<String> corpus = new ArrayList<>(WhatGoesBetweenTwoTokensOnALineTest.corpus());
         corpus.sort(java.util.Comparator.comparingInt(String::length));
         for (String source : corpus) {
-            String canonical = Formatter.format(source);
+            Formatter.CanonicalForm form = Formatter.canonicalize(CstParser.parse(source).root());
+            String canonical = form.layout().text();
             List<String> lines = List.of(canonical.split("\n", -1));
+            List<String> shapes = shapesOf(form, lines);
             for (int i = 0; i < lines.size(); i++) {
                 for (Map.Entry<String, String> m : written(lines, i).entrySet()) {
                     String text = m.getValue();
-                    String shape = shapeOf(lines.get(i));
+                    String shape = shapes.get(i);
                     if (text == null || text.equals(canonical)
                             || seen.contains(m.getKey() + " of " + shape)) {
                         continue;   // this shape is already among them, written this way
@@ -81,13 +90,63 @@ class EveryDepartureFromTheCanonicalFormIsSomeRulesTest {
         return out.stream();
     }
 
-    /** What opens a line and how far in it stands, which is what a rule's answer turns on. */
-    private static String shapeOf(String line) {
-        String content = line.strip();
-        String opens = content.isEmpty() ? "nothing"
-                : content.startsWith("//") ? "a comment"
-                : content.split(" ", 2)[0];
-        return "`" + opens + "` at " + (line.length() - line.stripLeading().length());
+    /**
+     * What each line of a canonical form is, in the terms the rules answer in.
+     *
+     * <p>Read from the layout and not from the characters. Two lines that open with the same word
+     * at the same column can stand at boundaries three different rules answer for — one an
+     * obligation broke, one a group settled, one a comment stands at — and a sweep that took them
+     * for the same thing would ask about the first and drop the other two. That is the mistake this
+     * whole check is written to avoid, made one level up.
+     *
+     * <p>So a line is named by what breaks in front of it, what breaks after it, what is written at
+     * the start of it and how deep it stands. What is left over — which identifier is on it, how
+     * long it is — is what a rule's answer does not turn on.
+     */
+    private static List<String> shapesOf(Formatter.CanonicalForm form, List<String> lines) {
+        String text = form.layout().text();
+        Map<Integer, Newline> ends = new LinkedHashMap<>();
+        Map<Integer, Integer> depth = new LinkedHashMap<>();
+        for (Newline n : form.layout().breaks()) {
+            int line = (int) text.substring(0, n.offset()).chars().filter(c -> c == '\n').count();
+            ends.putIfAbsent(line, n);
+            depth.putIfAbsent(line + 1, n.under().size());
+        }
+        Map<Integer, Place> opened = new LinkedHashMap<>();
+        form.layout().extents().forEach((place, extent) -> {
+            Place standing = opened.get(extent.start());
+            if (standing == null
+                    || form.layout().extents().get(standing).end() < extent.end()) {
+                opened.put(extent.start(), place);
+            }
+        });
+        List<String> out = new ArrayList<>();
+        int at = 0;
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
+            String content = line.strip();
+            Place place = opened.get(at + line.length() - line.stripLeading().length());
+            String opens = content.isEmpty() ? "nothing"
+                    : content.startsWith("//") ? "a comment"
+                    : place != null ? place.construct().name()
+                    : "no place";
+            out.add(cause(ends.get(i - 1)) + " / " + opens + " / " + cause(ends.get(i))
+                    + " at depth " + depth.getOrDefault(i, 0)
+                    + " and column " + (line.length() - line.stripLeading().length()));
+            at += line.length() + 1;
+        }
+        return out;
+    }
+
+    /** What wrote a break: the obligation it discharges, or the group that settled it. */
+    private static String cause(Newline n) {
+        if (n == null) {
+            return "the start of the file";
+        }
+        return switch (n.cause()) {
+            case Newline.Cause.Forced f -> f.obligation().name();
+            case Newline.Cause.Settled _ -> "a group's own break";
+        };
     }
 
     /** One line of a canonical form, written the ways an author could have written it. */

--- a/souther-compiler/src/test/java/souther/compiler/fmt/NothingIsWrittenAtTheEndOfALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/NothingIsWrittenAtTheEndOfALineTest.java
@@ -1,0 +1,77 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A line ends where what is written on it does.
+ *
+ * <p>The layout writes whitespace after a newline, as the indent of the line it opens, and never
+ * before one. So a source with a space at the end of a line has departed from the canonical form —
+ * and the rules that answer about the same characters do not say it: the break rules count how many
+ * lines end at a boundary, the spacing rule answers about boundaries written on a line, and a
+ * blank line carrying spaces is at no level's column.
+ *
+ * <p>Every line of the source, and not only the ones the canonical form has. What the rule expects
+ * is nothing, which is true of a line wherever it stands, so this needs no correspondence to ask.
+ */
+class NothingIsWrittenAtTheEndOfALineTest {
+
+    @Test
+    void aSpaceAfterTheLastTokenOfALineIsSomeRules() {
+        String source = "module m\n\nlet f (a: Int): Int = a   \n";
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(!report.deviations().isEmpty(), "no rule named it");
+        assertTrue(report.whole(), "and what is named is not all of it");
+        assertEquals("a line ends where what is written on it does",
+                report.deviations().get(0).rule());
+    }
+
+    /** A blank line carrying spaces is a line with nothing on it and something at the end of it. */
+    @Test
+    void andSoAreTheSpacesOnABlankLine() {
+        String source = "module m\n    \nlet f (a: Int): Int = a\n";
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(!report.deviations().isEmpty(), "no rule named it");
+        assertTrue(report.whole(), "and what is named is not all of it");
+    }
+
+    /**
+     * The expectation is the canonical form's own: over the corpus it writes no line that ends in
+     * whitespace.
+     *
+     * <p>Written as a measurement of the output rather than of the document, because what a reader
+     * has in hand is the text.
+     */
+    @Test
+    void andTheCanonicalFormWritesNoneOfIt() {
+        List<String> found = new ArrayList<>();
+        for (String source : WhatGoesBetweenTwoTokensOnALineTest.corpus()) {
+            for (String line : Formatter.format(source).split("\n", -1)) {
+                if (!line.equals(line.stripTrailing())) {
+                    found.add(line);
+                }
+            }
+        }
+
+        assertEquals(List.of(), found, "the canonical form ends a line with whitespace");
+    }
+
+    /** And a source with none of it has nothing against it. */
+    @Test
+    void andASourceWithNoneOfItHasNothingAgainstIt() {
+        String source = "module m\n\nlet f (a: Int): Int = a\n";
+
+        assertEquals(source, Formatter.format(source));
+        assertEquals(List.of(), Deviations.of(source).deviations());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/fmt/RepairingWhatTheRulesSayWritesTheCanonicalFormTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/fmt/RepairingWhatTheRulesSayWritesTheCanonicalFormTest.java
@@ -1,0 +1,93 @@
+package souther.compiler.fmt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import souther.compiler.cst.CstParser;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Repairing what the rules say writes the canonical form, over every source this repository has.
+ *
+ * <p>The oracle is the formatter. What the rules answer is composed into a text and that text is the
+ * one the formatter writes — so a set of rules that implements a different canonical form fails
+ * here, however well each of them reads.
+ *
+ * <p>Applied until it stops changing the text, and not in one pass. The rules read each other's
+ * results: which tokens are written settles what the layout rules' boundaries are, and where the
+ * lines break settles what the indentation rule's lines are. Asked of a source whose breaks are
+ * still wrong, the indentation rule answers about lines that will not exist.
+ *
+ * <p>{@link Deviations.Report#whole} is that statement, so this holds the report rather than
+ * repeating the repair — a source it is true of is one where every difference from the canonical
+ * form was named by a rule.
+ */
+class RepairingWhatTheRulesSayWritesTheCanonicalFormTest {
+
+    static Stream<Path> sources() throws IOException {
+        List<Path> out = new ArrayList<>();
+        try (Stream<Path> walk = Files.walk(Path.of(".."))) {
+            walk.filter(p -> p.toString().endsWith(".sou"))
+                    .filter(p -> !p.toString().contains("target"))   // a build's copy of one
+                    .sorted().forEach(out::add);
+        }
+        return out.stream();
+    }
+
+    private static String read(Path p) {
+        try {
+            return Files.readString(p, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sources")
+    void everySourceIsWhollyNamed(Path path) {
+        String source = read(path);
+        assertEquals(List.of(), CstParser.parse(source).errors(), "this source does not parse");
+
+        Deviations.Report report = Deviations.of(source);
+
+        assertTrue(report.whole(),
+                "repairing what the rules say does not write the canonical form of " + path
+                        + "; what they said was " + report.deviations());
+    }
+
+    /**
+     * And some of them are not in canonical form, so the sweep above is answering a question.
+     *
+     * <p>A corpus every file of which is already canonical would pass with no rule written at all:
+     * the report would be empty and repairing nothing would write the text back.
+     */
+    @Test
+    void andSomeOfThemHaveSomethingAgainstThem() throws IOException {
+        List<Path> differ = new ArrayList<>();
+        int deviations = 0;
+        for (Path path : sources().toList()) {
+            String source = read(path);
+            if (!Formatter.format(source).equals(source)) {
+                differ.add(path);
+                deviations += Deviations.of(source).deviations().size();
+            }
+        }
+
+        assertTrue(differ.size() >= 5,
+                "too few sources depart from the canonical form for this to hold anything: "
+                        + differ);
+        assertTrue(deviations >= 500, "and too few deviations among them: " + deviations);
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Deviations.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Deviations.java
@@ -5,7 +5,9 @@ import souther.compiler.cst.SyntaxNode;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * What the canonical form has against a source, one decision at a time.
@@ -40,44 +42,98 @@ public final class Deviations {
         }
     }
 
-    /** What the canonical form has against {@code source}. Assumes it parses. */
+    /**
+     * What the canonical form has against {@code source}. Assumes it parses.
+     *
+     * <p>Asked round by round, in the order the rules depend on each other. A rule that reads
+     * another's result answers about a text the first has not written yet — which tokens are
+     * written settles what the layout rules' boundaries are, and where the lines break settles what
+     * the indentation rule's lines are — so the rules are asked, what they say is repaired, and
+     * they are asked again until nothing changes.
+     *
+     * <p>Every round's deviations are the report's, at the place in the source they came from.
+     * Keeping only the first round's would say a file has one thing wrong with it when repairing
+     * that one leaves nine more.
+     */
     public static Report of(String source) {
         SyntaxNode root = CstParser.parse(source).root();
-        Formatter.CanonicalForm canonical = Formatter.canonicalize(root);
-        List<Witness> witnesses = all(source, canonical);
+        String canonical = Formatter.canonicalize(root).text();
         List<Deviation> out = new ArrayList<>();
-        for (Witness w : witnesses) {
-            int at = Repair.where(source, canonical, w);
-            if (at < 0) {
-                continue;
+        Set<String> seen = new LinkedHashSet<>();
+        List<List<Repair.Edit>> repaired = new ArrayList<>();
+        String text = source;
+        for (int round = 0; round < 8; round++) {
+            Formatter.CanonicalForm form = Formatter.canonicalize(CstParser.parse(text).root());
+            Witnesses.Pairing pairing = new Witnesses.Pairing(text, form);
+            List<Witness> witnesses = all(text, form, pairing);
+            for (Witness w : witnesses) {
+                int at = Repair.where(text, form, pairing, w);
+                if (at < 0) {
+                    continue;
+                }
+                int was = at;
+                for (int i = repaired.size() - 1; i >= 0; i--) {
+                    was = Repair.before(repaired.get(i), was);
+                }
+                Deviation d = new Deviation(lineOf(source, was), columnOf(source, was), rule(w),
+                        canonicalSide(w), sourceSide(w));
+                if (seen.add(d.line() + ":" + d.column() + ": " + d.rule())) {
+                    out.add(d);
+                }
             }
-            out.add(new Deviation(lineOf(source, at), columnOf(source, at), rule(w),
-                    canonicalSide(w), sourceSide(w)));
+            if (witnesses.isEmpty()) {
+                break;
+            }
+            List<Repair.Edit> edits;
+            try {
+                edits = Repair.edits(text, form, pairing, witnesses);
+            } catch (Witnesses.NoCorrespondence _) {
+                return new Report(sorted(out), false);   // a family that could not answer
+            }
+            String next = Repair.apply(text, edits);
+            if (next.equals(text)) {
+                break;
+            }
+            repaired.add(edits);
+            text = next;
         }
+        return new Report(sorted(out), text.equals(canonical));
+    }
+
+    private static List<Deviation> sorted(List<Deviation> deviations) {
+        List<Deviation> out = new ArrayList<>(deviations);
         out.sort(Comparator.comparingInt(Deviation::line).thenComparingInt(Deviation::column));
-        return new Report(out, settles(source, canonical.text()));
+        return out;
     }
 
     /**
      * Every family's answer about one source.
      *
      * <p>A family that cannot answer is left out rather than allowed to end the report. Four of
-     * them hold the two token streams side by side, which the canonicalization that rewrites a
-     * definition's lambda makes impossible — and a source that writes one is an ordinary source,
-     * not a broken one. What the rest of them can say is still worth saying, and
-     * {@link Report#whole} is what tells a reader that it is not all of it.
+     * them hold the two token streams side by side, and where the canonical form writes other
+     * tokens than the source they have nothing to pair — so they say nothing this round, the rules
+     * about which tokens are written say what they say, and the next round asks them again of a
+     * source whose tokens are settled. {@link Report#whole} is what tells a reader whether that
+     * ever came to the canonical form.
      *
      * <p>Only that. A family throwing anything else is a defect in the formatter or in the rule,
      * and swallowing it here would report it as this source being unusual.
      */
     private static List<Witness> all(String source, Formatter.CanonicalForm canonical) {
+        return all(source, canonical, new Witnesses.Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    private static List<Witness> all(String source, Formatter.CanonicalForm canonical,
+            Witnesses.Pairing pairing) {
         List<Witness> out = new ArrayList<>();
-        List<Family> families = List.of(Witnesses::spacing, Witnesses::separation,
-                Witnesses::indentation, Witnesses::forced, Witnesses::conditional,
-                Witnesses::comments);
+        List<Family> families = List.of(Witnesses::tokens, Witnesses::spacing,
+                Witnesses::separation,
+                Witnesses::indentation, Witnesses::forced, Witnesses::settled,
+                Witnesses::conditional, Witnesses::comments, Witnesses::lineEnds);
         for (Family family : families) {
             try {
-                out.addAll(family.of(source, canonical));
+                out.addAll(family.of(source, canonical, pairing));
             } catch (Witnesses.NoCorrespondence _) {
                 // this family has no question to ask about this source. Anything else it throws is
                 // a defect and is left to be seen as one.
@@ -88,43 +144,25 @@ public final class Deviations {
 
     /** What one family has against a source. */
     private interface Family {
-        List<Witness> of(String source, Formatter.CanonicalForm canonical);
-    }
-
-    /**
-     * Whether repairing what the rules say writes the canonical form.
-     *
-     * <p>Applied until it stops changing the text. A rule that reads another's result answers about
-     * lines the first has not written yet, so one pass says less than the rules do together.
-     */
-    private static boolean settles(String source, String canonical) {
-        String text = source;
-        for (int round = 0; round < 8; round++) {
-            Formatter.CanonicalForm form = Formatter.canonicalize(CstParser.parse(text).root());
-            List<Witness> witnesses = all(text, form);
-            if (witnesses.isEmpty()) {
-                break;
-            }
-            String next;
-            try {
-                next = Repair.repair(text, form, witnesses);
-            } catch (Witnesses.NoCorrespondence _) {
-                return false;   // a family that could not answer, so this is not all of it
-            }
-            if (next.equals(text)) {
-                break;
-            }
-            text = next;
-        }
-        return text.equals(canonical);
+        List<Witness> of(String source, Formatter.CanonicalForm canonical,
+                Witnesses.Pairing pairing);
     }
 
     private static String rule(Witness w) {
         return switch (w) {
             case Witness.BetweenTwoTokens _ -> "what goes between two tokens on a line";
             case Witness.Separation _ -> Obligation.A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS.said();
-            case Witness.Indentation _ -> "one level deeper is one indent further in";
+            // Two statements and one rule. The step between two levels is what it says everywhere
+            // inside the file; at the file itself there is no level outside to measure from, and a
+            // report that told an author their definitions are one indent further in than nothing
+            // would be naming a level that is not there.
+            case Witness.Indentation i -> i.unit().outer() == null
+                    ? "a line the file holds begins at column zero"
+                    : "one level deeper is one indent further in";
             case Witness.Forced f -> f.unit().obligation().said();
+            case Witness.Settled _ -> "a group written down the page ends one line where it breaks";
+            case Witness.AtTheEndOfALine _ -> "a line ends where what is written on it does";
+            case Witness.ACodeToken t -> t.unit().kind().said();
             case Witness.Conditional _ -> "a construct whose line would exceed the width breaks";
             case Witness.TrailingComment _ ->
                     "a comment at the end of a line is written one space after the code";
@@ -141,6 +179,9 @@ public final class Deviations {
             case Witness.Separation s -> lines(s.canonical());
             case Witness.Indentation i -> i.canonical() + " columns";
             case Witness.Forced f -> ends(f.canonical());
+            case Witness.Settled s -> ends(s.canonical());
+            case Witness.AtTheEndOfALine e -> quoted(e.canonical());
+            case Witness.ACodeToken t -> quoted(t.canonical());
             case Witness.Conditional c -> c.canonicalIsWhole() ? "on one line" : "down the page";
             case Witness.TrailingComment t -> quoted(t.canonical());
             case Witness.CommentAbove a -> lineBreaks(a.canonical());
@@ -155,6 +196,9 @@ public final class Deviations {
             case Witness.Indentation i -> i.source().size() == 1
                     ? i.source().get(0) + " columns" : i.source() + " columns";
             case Witness.Forced f -> ends(f.source());
+            case Witness.Settled s -> ends(s.source());
+            case Witness.AtTheEndOfALine e -> quoted(e.source());
+            case Witness.ACodeToken t -> quoted(t.source());
             case Witness.Conditional c -> c.sourceIsWhole() ? "on one line" : "down the page";
             case Witness.TrailingComment t -> quoted(t.source());
             case Witness.CommentAbove a -> lineBreaks(a.source());

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Formatter.java
@@ -667,7 +667,13 @@ public final class Formatter {
         // the next belongs to a construct like any other. Left unnamed, the one adjacency a reader
         // can close up by hand — writing two top-level items on a line — is the one no rule is
         // recorded against.
-        return TokenDoc.node(file.kind(), concat(parts));
+        //
+        // And it is a level, written at column zero. The indentation rule answers about a pair of
+        // levels, so without the file among them the outermost pair has one member and the column
+        // its lines begin at is decided by nothing: a source that indented every definition it has
+        // departed from a canonical form no rule could name. Nesting by nothing writes what it
+        // wrote before.
+        return TokenDoc.nest(0, TokenDoc.node(file.kind(), concat(parts)));
     }
 
     /**
@@ -1308,7 +1314,7 @@ public final class Formatter {
 
     /** The lambda a parameter-less definition was written as, or null when its body is an ordinary
      * expression and the definition is a value. */
-    private static SyntaxNode liftedLambda(SyntaxNode n) {
+    static SyntaxNode liftedLambda(SyntaxNode n) {
         if (n.child(SyntaxKind.BLOCK_EXPR).isPresent() || n.child(SyntaxKind.INTRINSIC_BODY).isPresent()) {
             return null;
         }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Repair.java
@@ -1,14 +1,11 @@
 package souther.compiler.fmt;
 
-import souther.compiler.cst.CstParser;
-import souther.compiler.cst.SyntaxNode;
 import souther.compiler.cst.SyntaxToken;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 /**
@@ -42,14 +39,28 @@ final class Repair {
      */
     static String repair(String source, Formatter.CanonicalForm canonical,
             List<Witness> witnesses) {
+        return apply(source,
+                edits(source, canonical, new Witnesses.Pairing(source, canonical), witnesses));
+    }
+
+    /**
+     * The stretches the expectations of {@code witnesses} come to, composed and in the order they
+     * are written.
+     *
+     * <p>Separate from writing them so that a caller can say where the text it is now looking at
+     * came from. The report asks the rules again after a repair — a rule that reads another's
+     * result has nothing to say until that one is answered — and a deviation found in the second
+     * text is about a place in the first.
+     */
+    static List<Edit> edits(String source, Formatter.CanonicalForm canonical,
+            Witnesses.Pairing pairing, List<Witness> witnesses) {
         List<Edit> edits = new ArrayList<>();
         for (Witness w : witnesses) {
-            edits.addAll(of(source, canonical, w));
+            edits.addAll(of(source, canonical, pairing, w));
         }
         edits.sort(Comparator.comparingInt(Edit::from)
                 .thenComparing(Comparator.comparingInt(Edit::to).reversed()));
-        StringBuilder out = new StringBuilder();
-        int at = 0;
+        List<Edit> out = new ArrayList<>();
         Edit last = null;
         for (Edit e : edits) {
             if (e.equals(last)) {
@@ -69,17 +80,49 @@ final class Repair {
                                 + ", and they do not agree: [" + last.text() + "] against ["
                                 + e.text() + "]");
             }
-            last = e;
-            if (e.from() < at) {
+            if (last != null && e.from() < last.to()) {
                 throw new IllegalStateException(
                         "two expectations over one stretch of the source, at " + e.from()
                                 + "; the rules answer about their own units, and this is two of them"
                                 + " answering about the same characters");
             }
+            last = e;
+            out.add(e);
+        }
+        return out;
+    }
+
+    /** {@code source} with {@code edits} written into it. */
+    static String apply(String source, List<Edit> edits) {
+        StringBuilder out = new StringBuilder();
+        int at = 0;
+        for (Edit e : edits) {
             out.append(source, at, e.from()).append(e.text());
             at = e.to();
         }
         return out.append(source.substring(at)).toString();
+    }
+
+    /**
+     * Where an offset of a repaired text stood in the text it was repaired from.
+     *
+     * <p>An offset inside a stretch a rule wrote over comes back as the start of that stretch: what
+     * is there now was written by the repair, and where it came from is the whole of what it
+     * replaced.
+     */
+    static int before(List<Edit> edits, int at) {
+        int delta = 0;
+        for (Edit e : edits) {
+            int from = e.from() + delta;
+            if (at < from) {
+                break;
+            }
+            if (at < from + e.text().length()) {
+                return e.from();
+            }
+            delta += e.text().length() - (e.to() - e.from());
+        }
+        return at - delta;
     }
 
     /**
@@ -89,26 +132,46 @@ final class Repair {
      * have to say before anything can be written there.
      */
     static List<Edit> of(String source, Formatter.CanonicalForm canonical, Witness w) {
+        return of(source, canonical, new Witnesses.Pairing(source, canonical), w);
+    }
+
+    /**
+     * The same, for a caller that has already read the two texts' tokens.
+     *
+     * <p>Read once for a whole repair rather than once per witness. What a witness is about is
+     * found by pairing the two token streams, and a source with three hundred of them was parsed a
+     * thousand times to write one text.
+     */
+    static List<Edit> of(String source, Formatter.CanonicalForm canonical,
+            Witnesses.Pairing pairing, Witness w) {
         return switch (w) {
-            case Witness.BetweenTwoTokens b -> List.of(spacing(source, b));
+            case Witness.BetweenTwoTokens b -> List.of(spacing(pairing, b));
             case Witness.Separation s -> List.of(separation(source, canonical, s));
-            case Witness.Indentation i -> indentation(source, canonical, i);
+            case Witness.Indentation i -> indentation(source, canonical, pairing, i);
             case Witness.Forced f -> switch (f.unit().adjacency()) {
-                case -1 -> List.of(ending(source, canonical));
-                case -2 -> List.of(aboveTheLastComment(source, canonical));
-                default -> gaps(source, canonical, List.of(f.unit().adjacency()));
+                case -1 -> List.of(ending(source, canonical, pairing));
+                case -2 -> List.of(aboveTheLastComment(source, canonical, pairing));
+                default -> gaps(source, canonical, pairing, List.of(f.unit().adjacency()));
             };
-            case Witness.Conditional c -> gaps(source, canonical, opportunitiesOf(canonical, c));
+            case Witness.Conditional c ->
+                    gaps(source, canonical, pairing, opportunitiesOf(canonical, pairing, c));
+            case Witness.Settled s ->
+                    gaps(source, canonical, pairing, List.of(s.unit().adjacency()));
+            case Witness.AtTheEndOfALine e -> List.of(new Edit(e.unit().at(),
+                    e.unit().at() + e.source().length(), e.canonical()));
+            case Witness.ACodeToken t -> List.of(new Edit(t.unit().at(),
+                    t.unit().at() + t.source().length(), t.canonical()));
             case Witness.TrailingComment t -> List.of(new Edit(
                     t.unit().at() - t.source().length(), t.unit().at(), t.canonical()));
             case Witness.CommentAbove a -> List.of(under(source, a));
-            case Witness.CommentCarrier c -> moved(source, canonical, c);
+            case Witness.CommentCarrier c -> moved(source, canonical, pairing, c);
         };
     }
 
     /** Where in the source a witness lands, or -1 where nothing of it is written there. */
-    static int where(String source, Formatter.CanonicalForm canonical, Witness w) {
-        List<Edit> edits = of(source, canonical, w);
+    static int where(String source, Formatter.CanonicalForm canonical, Witnesses.Pairing pairing,
+            Witness w) {
+        List<Edit> edits = of(source, canonical, pairing, w);
         return edits.isEmpty() ? -1 : edits.get(0).from();
     }
 
@@ -125,21 +188,20 @@ final class Repair {
      * their step is right and it is the column underneath that changed.
      */
     private static List<Edit> indentation(String source, Formatter.CanonicalForm canonical,
-            Witness.Indentation witness) {
-        Map<Newline, Integer> lines = Witnesses.sourceLines(source, canonical);
+            Witnesses.Pairing pairing, Witness.Indentation witness) {
         List<Edit> out = new ArrayList<>();
         Set<Integer> at = new LinkedHashSet<>();
-        for (Map.Entry<Newline, Integer> e : lines.entrySet()) {
-            List<Doc.NestRef> under = e.getKey().under();
-            if (!under.contains(witness.unit().inner()) || !at.add(e.getValue())) {
+        for (Witnesses.CanonicalLine line : Witnesses.lines(source, canonical, pairing)) {
+            if (line.sourceStart() == null || !line.under().contains(witness.unit().inner())
+                    || !at.add(line.sourceStart())) {
                 continue;
             }
-            int lineStart = e.getValue();
+            int lineStart = line.sourceStart();
             int indent = lineStart;
             while (indent < source.length() && source.charAt(indent) == ' ') {
                 indent++;
             }
-            out.add(new Edit(lineStart, indent, " ".repeat(e.getKey().indent())));
+            out.add(new Edit(lineStart, indent, " ".repeat(line.indent())));
         }
         return out;
     }
@@ -155,10 +217,10 @@ final class Repair {
      * write the comment twice or lose it.
      */
     private static List<Edit> gaps(String source, Formatter.CanonicalForm canonical,
-            List<Integer> adjacencies) {
+            Witnesses.Pairing pairing, List<Integer> adjacencies) {
         String text = canonical.layout().text();
-        List<SyntaxToken> had = Witnesses.code(CstParser.parse(source).root());
-        List<SyntaxToken> writes = Witnesses.code(CstParser.parse(text).root());
+        List<SyntaxToken> had = pairing.hadCode();
+        List<SyntaxToken> writes = pairing.writesCode();
         List<Edit> out = new ArrayList<>();
         for (int i : adjacencies) {
             if (i < 0 || i + 1 >= writes.size()) {
@@ -176,9 +238,8 @@ final class Repair {
 
     /** Which adjacencies of the canonical form the opportunities a group settles stand at. */
     private static List<Integer> opportunitiesOf(Formatter.CanonicalForm canonical,
-            Witness.Conditional witness) {
-        List<SyntaxToken> writes =
-                Witnesses.code(CstParser.parse(canonical.layout().text()).root());
+            Witnesses.Pairing pairing, Witness.Conditional witness) {
+        List<SyntaxToken> writes = pairing.writesCode();
         List<Integer> out = new ArrayList<>();
         for (Opportunity o : canonical.layout().opportunities()) {
             if (o.settledBy() != witness.unit().group()) {
@@ -220,10 +281,11 @@ final class Repair {
      * with the two tokens it stands between, this one has no pair and was written nowhere — so the
      * rule was a value, the witness was made, and neither the report nor the repair had it.
      */
-    private static Edit ending(String source, Formatter.CanonicalForm canonical) {
+    private static Edit ending(String source, Formatter.CanonicalForm canonical,
+            Witnesses.Pairing pairing) {
         String text = canonical.layout().text();
-        int from = lastWritten(source);
-        int wrote = lastWritten(text);
+        int from = lastWritten(pairing.hadCode(), pairing.hadComments());
+        int wrote = lastWritten(pairing.writesCode(), pairing.writesComments());
         if (from < 0 || wrote < 0) {
             return new Edit(source.length(), source.length(), "");
         }
@@ -231,11 +293,12 @@ final class Repair {
     }
 
     /** What the canonical form writes between its last code token and the comment after it. */
-    private static Edit aboveTheLastComment(String source, Formatter.CanonicalForm canonical) {
+    private static Edit aboveTheLastComment(String source, Formatter.CanonicalForm canonical,
+            Witnesses.Pairing pairing) {
         String text = canonical.layout().text();
         String has = Witnesses.aboveTheLastComment(source);
         String wrote = Witnesses.aboveTheLastComment(text);
-        List<SyntaxToken> code = Witnesses.code(CstParser.parse(source).root());
+        List<SyntaxToken> code = pairing.hadCode();
         int from = code.isEmpty() ? 0 : code.get(code.size() - 1).end();
         return new Edit(from, from + has.length(), wrote);
     }
@@ -248,10 +311,7 @@ final class Repair {
      * either write over it or be left alone for holding one — and the file's own break would again
      * be a rule with a witness and nothing written for it.
      */
-    private static int lastWritten(String text) {
-        SyntaxNode root = CstParser.parse(text).root();
-        List<SyntaxToken> code = Witnesses.code(root);
-        List<SyntaxToken> comments = Witnesses.comments(root);
+    private static int lastWritten(List<SyntaxToken> code, List<SyntaxToken> comments) {
         int at = -1;
         if (!code.isEmpty()) {
             at = code.get(code.size() - 1).end();
@@ -272,10 +332,10 @@ final class Repair {
      * they hold, and the comment is part of what they hold.
      */
     private static List<Edit> moved(String source, Formatter.CanonicalForm canonical,
-            Witness.CommentCarrier witness) {
+            Witnesses.Pairing pairing, Witness.CommentCarrier witness) {
         String text = canonical.layout().text();
-        List<SyntaxToken> had = Witnesses.code(CstParser.parse(source).root());
-        List<SyntaxToken> writes = Witnesses.code(CstParser.parse(text).root());
+        List<SyntaxToken> had = pairing.hadCode();
+        List<SyntaxToken> writes = pairing.writesCode();
         List<Edit> out = new ArrayList<>();
         for (int i : new int[] {witness.canonical(), witness.source()}) {
             if (i < 0 || i + 1 >= writes.size()) {
@@ -289,8 +349,8 @@ final class Repair {
     }
 
     /** What the canonical form writes between the two tokens of a boundary. */
-    private static Edit spacing(String source, Witness.BetweenTwoTokens witness) {
-        List<SyntaxToken> had = Witnesses.code(CstParser.parse(source).root());
+    private static Edit spacing(Witnesses.Pairing pairing, Witness.BetweenTwoTokens witness) {
+        List<SyntaxToken> had = pairing.hadCode();
         int i = witness.unit().adjacency();
         return new Edit(had.get(i).end(), had.get(i + 1).start(), witness.canonical());
     }

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Rewrites.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Rewrites.java
@@ -1,0 +1,190 @@
+package souther.compiler.fmt;
+
+import souther.compiler.cst.SyntaxElement;
+import souther.compiler.cst.SyntaxKind;
+import souther.compiler.cst.SyntaxNode;
+import souther.compiler.cst.SyntaxToken;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Where a source's code tokens and its canonical form's differ, and what the canonical form writes
+ * there.
+ *
+ * <p>These are decisions like any other, and they were the ones with no unit. The layout rules
+ * answer about a boundary between two tokens; which tokens those are is settled before any of them
+ * is asked, and a source that wrote others left every one of them with nothing to pair.
+ *
+ * <p>Three of them, and the sites are read from the source rather than from what the formatter did
+ * on the way through. Two are optional tokens the grammar admits and the canonical form has one
+ * answer for — a comma after a run's last member, which it never writes, and the bar in front of a
+ * match's first arm, which it always does. The third is a definition written as a lambda, whose
+ * parameters the canonical form writes to the left of the {@code =}.
+ */
+final class Rewrites {
+
+    private Rewrites() {
+    }
+
+    /** Which of the three a site is. */
+    enum Kind {
+
+        /** A comma after the last member of a comma-separated run, which is not written. */
+        A_TRAILING_COMMA,
+
+        /** The bar in front of a match's first arm, which is written. */
+        THE_FIRST_ARMS_BAR,
+
+        /** A definition whose body is a lambda, whose parameters are written to the left. */
+        A_DEFINITIONS_PARAMETERS;
+
+        /** What the rule says, for a reader who is being told their source does not. */
+        String said() {
+            return switch (this) {
+                case A_TRAILING_COMMA ->
+                        "a comma-separated run is written without a comma after its last member";
+                case THE_FIRST_ARMS_BAR -> "a match writes every arm with its bar";
+                case A_DEFINITIONS_PARAMETERS ->
+                        "a definition writes its parameters to the left of the `=`";
+            };
+        }
+    }
+
+    /**
+     * One site, the stretch of the source it is about, and the two answers.
+     *
+     * <p>{@code from} and {@code to} are what a repair writes over, which for an optional token the
+     * source did not write is the empty stretch where it would stand.
+     */
+    record Site(Kind kind, int from, int to, String canonical, String source) {}
+
+    /** Every site of {@code root} where the canonical form's tokens are not the source's. */
+    static List<Site> sitesOf(SyntaxNode root) {
+        List<Site> out = new ArrayList<>();
+        walk(root, out);
+        return out;
+    }
+
+    private static void walk(SyntaxNode node, List<Site> out) {
+        trailingComma(node).ifPresent(comma -> out.add(new Site(Kind.A_TRAILING_COMMA,
+                comma.start(), comma.end(), "", comma.text())));
+        if (node.kind() == SyntaxKind.MATCH_EXPR) {
+            // In front of what the arm writes and not in front of the arm: a node begins where its
+            // leading trivia does, and a bar written there would stand at the end of the line above.
+            firstArmWithoutItsBar(node).ifPresent(arm -> out.add(new Site(Kind.THE_FIRST_ARMS_BAR,
+                    firstToken(arm).start(), firstToken(arm).start(), "| ", "")));
+        }
+        if (node.kind() == SyntaxKind.FN_DEF) {
+            SyntaxNode lambda = Formatter.liftedLambda(node);
+            if (lambda != null) {
+                out.add(lifted(node, lambda));
+            }
+        }
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxNode child) {
+                walk(child, out);
+            }
+        }
+    }
+
+    /**
+     * The comma a node writes after its last member, if it has one.
+     *
+     * <p>A comma is that one where nothing follows it but what closes the run: a bracket, the arrow
+     * of an example row's bindings, or the end of the node. Everywhere else what follows is another
+     * member — which in some runs is a node and in others a bare name, so what is asked is what
+     * comes after rather than what a member looks like.
+     */
+    private static java.util.Optional<SyntaxToken> trailingComma(SyntaxNode node) {
+        List<SyntaxElement> written = new ArrayList<>();
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxNode || (e instanceof SyntaxToken t && !t.isTrivia()
+                    && t.kind() != SyntaxKind.LINE_COMMENT && t.kind() != SyntaxKind.EOF)) {
+                written.add(e);
+            }
+        }
+        for (int i = 0; i < written.size(); i++) {
+            if (!(written.get(i) instanceof SyntaxToken comma)
+                    || comma.kind() != SyntaxKind.COMMA) {
+                continue;
+            }
+            if (i + 1 == written.size()
+                    || (written.get(i + 1) instanceof SyntaxToken next && closes(next.kind()))) {
+                return java.util.Optional.of(comma);
+            }
+        }
+        return java.util.Optional.empty();
+    }
+
+    /** The tokens that end a comma-separated run rather than standing inside one. */
+    private static boolean closes(SyntaxKind kind) {
+        return switch (kind) {
+            case RPAREN, RBRACKET, RBRACE, GT, ARROW -> true;
+            default -> false;
+        };
+    }
+
+    /** A match's first arm, where the source wrote no bar in front of it. */
+    private static java.util.Optional<SyntaxNode> firstArmWithoutItsBar(SyntaxNode match) {
+        for (SyntaxElement e : match.children()) {
+            if (e instanceof SyntaxToken t && t.kind() == SyntaxKind.PIPE) {
+                return java.util.Optional.empty();   // the first thing of the arms is a bar
+            }
+            if (e instanceof SyntaxNode arm && arm.kind() == SyntaxKind.MATCH_CASE) {
+                return java.util.Optional.of(arm);
+            }
+        }
+        return java.util.Optional.empty();
+    }
+
+    /**
+     * A definition written as a lambda, and the header the canonical form writes for it.
+     *
+     * <p>The stretch runs from the {@code =} to the lambda's {@code ->}, and what goes there is the
+     * parameters and then the {@code =}. The parameters are copied as the source wrote them —
+     * anything inside them is another rule's, and one of those rules is the comma this same pass
+     * answers about.
+     */
+    private static Site lifted(SyntaxNode definition, SyntaxNode lambda) {
+        SyntaxToken assign = definition.token(SyntaxKind.ASSIGN).orElseThrow();
+        SyntaxToken arrow = lambda.token(SyntaxKind.ARROW).orElseThrow();
+        int from = lambda.token(SyntaxKind.LPAREN).map(SyntaxToken::start).orElseGet(
+                () -> firstParameter(lambda).start());
+        String params = text(lambda, from, arrow.start()).strip();
+        return new Site(Kind.A_DEFINITIONS_PARAMETERS, assign.start(), arrow.end(),
+                (params.startsWith("(") ? params : "(" + params + ")") + " =",
+                text(definition, assign.start(), arrow.end()));
+    }
+
+    /** A lambda's one bare parameter, for the {@code x -> e} form the canonical form parenthesises. */
+    private static SyntaxToken firstParameter(SyntaxNode lambda) {
+        for (SyntaxElement e : lambda.children()) {
+            if (e instanceof SyntaxNode param) {
+                return firstToken(param);
+            }
+        }
+        throw new IllegalStateException("a lambda with no parameter");
+    }
+
+    private static SyntaxToken firstToken(SyntaxNode node) {
+        for (SyntaxElement e : node.children()) {
+            if (e instanceof SyntaxToken t && !t.isTrivia()) {
+                return t;
+            }
+            if (e instanceof SyntaxNode child) {
+                return firstToken(child);
+            }
+        }
+        throw new IllegalStateException("a node with no token");
+    }
+
+    /** The source between two offsets, read from the tree the two came from. */
+    private static String text(SyntaxNode node, int from, int to) {
+        SyntaxNode root = node;
+        while (root.parent() != null) {
+            root = root.parent();
+        }
+        return root.text().substring(from - root.start(), to - root.start());
+    }
+}

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witness.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witness.java
@@ -20,6 +20,26 @@ import souther.compiler.cst.SyntaxKind;
 sealed interface Witness {
 
     /**
+     * The unit of the rules about which code tokens are written: one site of the source the grammar
+     * lets the two differ at.
+     *
+     * <p>A site and not a token. Two of these are about a token the source wrote and the canonical
+     * form does not, and one is about the other way round — so the unit is the place in the source
+     * where the question is asked, which is there whichever way it is answered.
+     */
+    record TokenSite(Rewrites.Kind kind, int at) {}
+
+    /**
+     * What the canonical form writes at a site where its code tokens are not the source's.
+     *
+     * <p>First in the order the rules depend on each other. Every other rule here answers about a
+     * boundary between two of the canonical form's tokens and asks what the source has between the
+     * same two of its own; which tokens those are is what this settles, and until it did a source
+     * that wrote a trailing comma had a report with nothing at all in it.
+     */
+    record ACodeToken(TokenSite unit, String canonical, String source) implements Witness {}
+
+    /**
      * The indentation rule's unit: a level of nesting and the one it is written inside.
      *
      * <p>A pair, because what the rule says is that the inner is one indent further in than the
@@ -110,6 +130,27 @@ sealed interface Witness {
             implements Witness {}
 
     /**
+     * The unit of the rule about what a line ends with: one line of the source, named by where what
+     * stands at the end of it begins.
+     *
+     * <p>The source's line and not the canonical form's. What this rule expects is nothing, which
+     * is true of a line wherever it stands, so it is asked of every line the source has rather than
+     * of the ones the two texts share.
+     */
+    record LineEnd(int at) {}
+
+    /**
+     * What a line ends with: nothing, against what the source wrote there.
+     *
+     * <p>The layout writes whitespace after a newline, as the indent of the line it opens, and
+     * never before one. The rules that answer about the same characters answer other questions —
+     * how many lines end at a boundary, what stands between two tokens on a line, how far in a
+     * level begins — so until this was a value a space at the end of a line was a departure with no
+     * rule to name it.
+     */
+    record AtTheEndOfALine(LineEnd unit, String canonical, String source) implements Witness {}
+
+    /**
      * The comment rules' unit: one comment, named by where the source wrote it.
      *
      * <p>The comment and not the line it is on. Where a run of them stands above a definition, each
@@ -147,6 +188,27 @@ sealed interface Witness {
      * numbers are adjacencies of the code both texts share.
      */
     record CommentCarrier(Comment unit, int canonical, int source) implements Witness {}
+
+    /**
+     * The unit of the rule about what a group's break writes: one place a group settled by breaking,
+     * named by which adjacency of the canonical form's tokens it stands at.
+     *
+     * <p>The boundary and not the group. Whether the group is written down the page is one decision
+     * about all of them, and {@link Conditional} is that; how many lines end at one of them is asked
+     * and answered there, the same as at a boundary an obligation breaks.
+     */
+    record BrokenBoundary(int adjacency) {}
+
+    /**
+     * A group's break at one boundary: how many lines the canonical form ends there, and how many
+     * the source ends.
+     *
+     * <p>One. A blank line inside a construct is a paragraph break the author wrote between two of
+     * its members, which is a forced break and says so; at a place a group settles, nothing writes
+     * a second line. Only where the source ended a line there too — one that ran the boundary
+     * together departed from the group's decision, and {@link Conditional} is what says that.
+     */
+    record Settled(BrokenBoundary unit, int canonical, int source) implements Witness {}
 
     /**
      * A forced-layout rule's unit: one boundary the canonical form breaks whatever the width, and

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
@@ -21,8 +21,13 @@ import java.util.Set;
  * own unit — so this attributes the differences to the units they came from and hands back one
  * witness per unit, which is what an author can act on.
  *
- * <p>One family at a time. The indentation rule is here; the others are added as each one's unit and
- * expectation become values.
+ * <p>One family per rule, and each of them answers about its own unit: a boundary for spacing, a pair
+ * of items for separation, a pair of levels for indentation, a group for conditional layout, a
+ * comment for the rules about comments, a site of the source for the rules about which code tokens
+ * are written.
+ *
+ * <p>A family reads the results of the rules it depends on rather than competing with them, and
+ * where what it depends on is not settled yet it says nothing: the rules are asked again once it is.
  */
 final class Witnesses {
 
@@ -49,6 +54,28 @@ final class Witnesses {
     }
 
     /**
+     * What the rules about which code tokens are written have against {@code source}.
+     *
+     * <p>Read from the source alone. Where the two texts' tokens differ, no rule that pairs them
+     * can be asked at all, so this one is asked first and of the source's own tree: the sites are
+     * the ones the grammar admits, and what the canonical form writes at each of them is the rule.
+     */
+    static List<Witness> tokens(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
+        return tokens(source, canonical);
+    }
+
+    /** What the rules about which code tokens are written have against {@code source}. */
+    static List<Witness> tokens(String source, Formatter.CanonicalForm canonical) {
+        List<Witness> out = new ArrayList<>();
+        for (Rewrites.Site site : Rewrites.sitesOf(CstParser.parse(source).root())) {
+            out.add(new Witness.ACodeToken(new Witness.TokenSite(site.kind(), site.from()),
+                    site.canonical(), site.source()));
+        }
+        return out;
+    }
+
+    /**
      * What the indentation rule has against {@code source}.
      *
      * <p>A level's column on each side. The canonical form's is what the layout wrote; the source's
@@ -61,35 +88,37 @@ final class Witnesses {
      * line nobody wrote.
      */
     static List<Witness> indentation(String source, Formatter.CanonicalForm canonical) {
-        Layout layout = canonical.layout();
+        return indentation(source, canonical, new Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    static List<Witness> indentation(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
         Map<Doc.NestRef, Integer> written = new IdentityHashMap<>();
         Map<Doc.NestRef, Set<Integer>> had = new IdentityHashMap<>();
-        Map<Integer, Place> opened = placesByStart(layout);
 
-        for (Newline n : layout.breaks()) {
-            if (n.under().isEmpty() || !n.indents()) {
-                continue;   // a line the file holds under no nesting, or one with nothing on it:
-                            // neither is a line written at a level's column
-            }
-            Doc.NestRef innermost = n.under().get(n.under().size() - 1);
-            Integer already = written.put(innermost, n.indent());
-            if (already != null && already != n.indent()) {
+        List<CanonicalLine> lines = lines(source, canonical, pairing);
+        for (CanonicalLine line : lines) {
+            Doc.NestRef innermost = line.under().get(line.under().size() - 1);
+            Integer already = written.put(innermost, line.indent());
+            if (already != null && already != line.indent()) {
                 throw new IllegalStateException(
                         "one level of nesting, written at column " + already + " and at column "
-                                + n.indent() + "; a level has one column and the layout wrote two");
+                                + line.indent() + "; a level has one column and the layout wrote"
+                                + " two");
             }
-            Integer column = columnFor(source, canonical, opened, n);
-            if (column != null) {
-                had.computeIfAbsent(innermost, _ -> new LinkedHashSet<>()).add(column);
+            if (line.sourceStart() != null) {
+                had.computeIfAbsent(innermost, _ -> new LinkedHashSet<>())
+                        .add(indentAt(source, line.sourceStart()));
             }
         }
 
         List<Witness> out = new ArrayList<>();
         Set<Witness.Levels> seen = new LinkedHashSet<>();
-        for (Newline n : layout.breaks()) {
-            for (int i = 0; i < n.under().size(); i++) {
-                Doc.NestRef inner = n.under().get(i);
-                Doc.NestRef outer = i == 0 ? null : n.under().get(i - 1);
+        for (CanonicalLine line : lines) {
+            for (int i = 0; i < line.under().size(); i++) {
+                Doc.NestRef inner = line.under().get(i);
+                Doc.NestRef outer = i == 0 ? null : line.under().get(i - 1);
                 Witness.Levels unit = new Witness.Levels(outer, inner);
                 if (!seen.add(unit)) {
                     continue;
@@ -105,57 +134,115 @@ final class Witnesses {
     }
 
     /**
-     * Where the source begins the line each break of the canonical form opens, for the breaks whose
-     * line the source opened too.
+     * A line the canonical form writes: how far in it begins, the levels it is written under, and
+     * where the source begins the same line.
      *
-     * <p>The offset that line starts at, so that what stands in front of the first thing on it is
-     * the indent a repair writes over. A break the source has no line for is not here: the source
-     * broke somewhere else, and moving an indent would be answering a question about a line nobody
-     * wrote.
+     * <p>{@code sourceStart} is the offset that line starts at in the source, so that what stands in
+     * front of the first thing on it is the indent a repair writes over, and null where the source
+     * opened no line there — it broke somewhere else, and moving an indent would be answering a
+     * question about a line nobody wrote.
      */
-    static Map<Newline, Integer> sourceLines(String source, Formatter.CanonicalForm canonical) {
+    record CanonicalLine(int indent, List<Doc.NestRef> under, Integer sourceStart) {
+
+        CanonicalLine {
+            under = List.copyOf(under);
+        }
+    }
+
+    /**
+     * The lines the canonical form writes, in the order it writes them.
+     *
+     * <p>One per break, and the one the file opens with: nothing breaks in front of the first line,
+     * and left out of this the column it begins at is a column no rule was ever asked about.
+     *
+     * <p>A break leaving a blank line is not one of these. Its line has nothing on it, so it is at
+     * no level's column and a reader taking its zero for one would have the level it stands under
+     * written at two columns.
+     */
+    static List<CanonicalLine> lines(String source, Formatter.CanonicalForm canonical) {
+        return lines(source, canonical, new Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    static List<CanonicalLine> lines(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
         Layout layout = canonical.layout();
         Map<Integer, Place> opened = placesByStart(layout);
-        Map<Newline, Integer> out = new LinkedHashMap<>();
+        List<CanonicalLine> out = new ArrayList<>();
+        List<Doc.NestRef> file = fileLevel(layout);
+        if (!file.isEmpty()) {
+            out.add(new CanonicalLine(indentAt(layout.text(), 0), file, 0));
+        }
         for (Newline n : layout.breaks()) {
-            if (!n.indents()) {
-                continue;   // its line has nothing on it, so there is no indent to repair
+            if (n.under().isEmpty() || !n.indents()) {
+                continue;
             }
-            Integer start = lineStartFor(source, canonical, opened, n);
-            if (start != null) {
-                out.put(n, start);
-            }
+            out.add(new CanonicalLine(n.indent(), n.under(),
+                    lineStartFor(source, canonical, opened, pairing, n)));
         }
         return out;
     }
 
     /**
-     * How far in the source wrote the line the canonical form opens with {@code n}, or null where
-     * it opened no line there.
+     * The two texts' tokens, read once for a whole run of questions about their lines.
      *
-     * <p>Two ways of finding that line, because not every line the canonical form opens is a
-     * place's. A closing bracket takes a line of its own and is written by the construct rather
-     * than at a place, so a break in front of one is found through the token the two texts have in
-     * common instead.
+     * <p>The comments are here as well as the code. A line the canonical form opens for a comment is
+     * one no place is written at, and asked through the code alone it comes back as the line of the
+     * next token — a line the comment is not on. That is what left a comment written anywhere at all
+     * with no rule to answer for its column.
      */
-    private static Integer columnFor(String source, Formatter.CanonicalForm canonical,
-            Map<Integer, Place> opened, Newline n) {
-        Integer start = lineStartFor(source, canonical, opened, n);
-        if (start == null) {
-            return null;
+    record Pairing(List<SyntaxToken> hadCode, List<SyntaxToken> writesCode,
+            List<SyntaxToken> hadComments, List<SyntaxToken> writesComments) {
+
+        Pairing(String source, Formatter.CanonicalForm canonical) {
+            this(source, canonical.layout().text());
         }
+
+        Pairing(String source, String text) {
+            this(code(CstParser.parse(source).root()), code(CstParser.parse(text).root()),
+                    comments(CstParser.parse(source).root()),
+                    comments(CstParser.parse(text).root()));
+        }
+    }
+
+    /**
+     * The levels the file's own first line is written under: the outermost one alone.
+     *
+     * <p>Read from a break rather than named, because which nesting the file is is the document's
+     * to say. Every break is written inside it, so the first of any break's levels is it.
+     */
+    private static List<Doc.NestRef> fileLevel(Layout layout) {
+        for (Newline n : layout.breaks()) {
+            if (!n.under().isEmpty()) {
+                return List.of(n.under().get(0));
+            }
+        }
+        return List.of();
+    }
+
+    /** How far in the line beginning at {@code start} is written. */
+    private static int indentAt(String text, int start) {
         int indent = 0;
-        while (start + indent < source.length() && source.charAt(start + indent) == ' ') {
+        while (start + indent < text.length() && text.charAt(start + indent) == ' ') {
             indent++;
         }
         return indent;
     }
 
-    /** Where the source begins the line, by the same two ways. */
+    /**
+     * Where the source begins the line the canonical form opens with {@code n}, or null where it
+     * opened no line there.
+     *
+     * <p>Three ways of finding that line, because not every line the canonical form opens is a
+     * place's. A comment is written by the carrier that holds it, and a closing bracket is written
+     * by the construct; both are asked through what the two texts have in common — the comments in
+     * the order they are written, and the code tokens.
+     */
     private static Integer lineStartFor(String source, Formatter.CanonicalForm canonical,
-            Map<Integer, Place> opened, Newline n) {
+            Map<Integer, Place> opened, Pairing pairing, Newline n) {
         Layout layout = canonical.layout();
-        Place place = opened.get(n.offset() + 1 + n.indent());
+        int begins = n.offset() + 1 + n.indent();
+        Place place = opened.get(begins);
         if (sourceColumn(source, canonical, place, lineAfter(layout.text(), n)) != null) {
             int start = canonical.construction().places().sourcesOf(place).get(0).start();
             return source.lastIndexOf('\n', Math.max(0, start - 1)) + 1;
@@ -163,8 +250,12 @@ final class Witnesses {
         if (place != null) {
             return null;   // a place is written there and the source did not open a line for it
         }
-        List<SyntaxToken> had = code(CstParser.parse(source).root());
-        List<SyntaxToken> writes = code(CstParser.parse(layout.text()).root());
+        Integer comment = commentLineFor(source, pairing, begins);
+        if (comment != null) {
+            return comment;
+        }
+        List<SyntaxToken> had = pairing.hadCode();
+        List<SyntaxToken> writes = pairing.writesCode();
         if (had.size() != writes.size()) {
             return null;
         }
@@ -173,6 +264,44 @@ final class Witnesses {
                 continue;
             }
             int at = had.get(i + 1).start();
+            int lineStart = source.lastIndexOf('\n', Math.max(0, at - 1)) + 1;
+            return source.substring(lineStart, at).isBlank() ? lineStart : null;
+        }
+        return null;
+    }
+
+    /**
+     * Where the source begins the line it wrote the comment the canonical form opens a line with at
+     * {@code begins}, or null where the canonical form opens no comment line there or the source
+     * did not write that comment on a line of its own.
+     *
+     * <p>The comments pair up in the order they are written, which is what {@link #comments} rests
+     * on too: the formatter writes every comment of a source exactly once.
+     *
+     * <p>A source that wrote the comment at the end of a line of code has not put it at a column —
+     * where it stands is what the rules about comments answer, and this rule would be moving a
+     * comment rather than a line.
+     *
+     * <p>Nor is a comment the canonical form carries somewhere else. That decision is another
+     * rule's and this one reads its result: the line the source has for such a comment is one the
+     * repair is about to take away, and an indent written onto it would be an expectation about a
+     * line that will not be there. The composition finds this rather than the two rules quietly
+     * writing over each other, which is how it was found.
+     */
+    private static Integer commentLineFor(String source, Pairing pairing, int begins) {
+        if (pairing.hadComments().size() != pairing.writesComments().size()
+                || pairing.hadCode().size() != pairing.writesCode().size()) {
+            return null;
+        }
+        for (int i = 0; i < pairing.writesComments().size(); i++) {
+            if (pairing.writesComments().get(i).start() != begins) {
+                continue;
+            }
+            int at = pairing.hadComments().get(i).start();
+            if (follows(pairing.writesCode(), pairing.writesComments().get(i).start())
+                    != follows(pairing.hadCode(), at)) {
+                return null;   // carried somewhere else, so this is not the line it is written on
+            }
             int lineStart = source.lastIndexOf('\n', Math.max(0, at - 1)) + 1;
             return source.substring(lineStart, at).isBlank() ? lineStart : null;
         }
@@ -198,9 +327,15 @@ final class Witnesses {
      * not one it should guess.
      */
     static List<Witness> spacing(String source, Formatter.CanonicalForm canonical) {
+        return spacing(source, canonical, new Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    static List<Witness> spacing(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
         String text = canonical.layout().text();
-        List<SyntaxToken> had = code(CstParser.parse(source).root());
-        List<SyntaxToken> writes = code(CstParser.parse(text).root());
+        List<SyntaxToken> had = pairing.hadCode();
+        List<SyntaxToken> writes = pairing.writesCode();
         if (had.size() != writes.size()) {
             throw new NoCorrespondence(
                     "the source has " + had.size() + " tokens and its canonical form "
@@ -244,16 +379,22 @@ final class Witnesses {
      * is not one this can answer about.
      */
     static List<Witness> comments(String source, Formatter.CanonicalForm canonical) {
+        return comments(source, canonical, new Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    static List<Witness> comments(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
         String text = canonical.layout().text();
-        List<SyntaxToken> had = comments(CstParser.parse(source).root());
-        List<SyntaxToken> writes = comments(CstParser.parse(text).root());
+        List<SyntaxToken> had = pairing.hadComments();
+        List<SyntaxToken> writes = pairing.writesComments();
         if (had.size() != writes.size()) {
             throw new NoCorrespondence(
                     "the source holds " + had.size() + " comments and its canonical form "
                             + writes.size() + "; the two cannot be held side by side");
         }
-        List<SyntaxToken> hadCode = code(CstParser.parse(source).root());
-        List<SyntaxToken> writesCode = code(CstParser.parse(text).root());
+        List<SyntaxToken> hadCode = pairing.hadCode();
+        List<SyntaxToken> writesCode = pairing.writesCode();
         boolean aligned = hadCode.size() == writesCode.size();
         List<Witness> out = new ArrayList<>();
         for (int i = 0; i < had.size(); i++) {
@@ -269,11 +410,11 @@ final class Witnesses {
             }
             String hadBefore = before(source, had.get(i));
             String writesBefore = before(text, writes.get(i));
-            if (writesBefore.indexOf('\n') < 0 && hadBefore.indexOf('\n') < 0
+            if (!opensItsLine(text, writes.get(i)) && !opensItsLine(source, had.get(i))
                     && !hadBefore.equals(writesBefore)) {
                 out.add(new Witness.TrailingComment(unit, writesBefore, hadBefore));
             }
-            if (writesBefore.indexOf('\n') >= 0 && !endsTheFile(text, writes.get(i))) {
+            if (opensItsLine(text, writes.get(i)) && !endsTheFile(text, writes.get(i))) {
                 int wrote = newlines(after(text, writes.get(i)));
                 int has = newlines(after(source, had.get(i)));
                 if (wrote != has) {
@@ -304,6 +445,19 @@ final class Witnesses {
      */
     private static boolean endsTheFile(String text, SyntaxToken comment) {
         return text.substring(comment.end()).isBlank();
+    }
+
+    /**
+     * Whether nothing but whitespace stands in front of a comment on its line.
+     *
+     * <p>Read from the line rather than from the stretch back to the code before it. At the top of
+     * a file there is no code in front of a comment, so that stretch is empty and every source's
+     * first comment came back as one at the end of a line — which is a rule that answers about the
+     * space in front of it and not about the lines around it.
+     */
+    private static boolean opensItsLine(String text, SyntaxToken comment) {
+        int lineStart = text.lastIndexOf('\n', Math.max(0, comment.start() - 1)) + 1;
+        return text.substring(lineStart, comment.start()).isBlank();
     }
 
     /** What stands between a comment and the code before it, back to the line it starts on. */
@@ -355,6 +509,12 @@ final class Witnesses {
      * by the second, so what stands between the first and that comment is the separation, and blank
      * lines anywhere in the gap are lines the canonical form does not write.
      */
+    static List<Witness> separation(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
+        return separation(source, canonical);   // it reads the places, not the tokens
+    }
+
+    /** What the separation rule has against {@code source}. */
     static List<Witness> separation(String source, Formatter.CanonicalForm canonical) {
         List<Place> items = topLevel(canonical);
         List<Witness> out = new ArrayList<>();
@@ -392,9 +552,15 @@ final class Witnesses {
      * is the answer that would tell an author to close up a line a comment holds open.
      */
     static List<Witness> conditional(String source, Formatter.CanonicalForm canonical) {
+        return conditional(source, canonical, new Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    static List<Witness> conditional(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
         Layout layout = canonical.layout();
-        List<SyntaxToken> had = code(CstParser.parse(source).root());
-        List<SyntaxToken> writes = code(CstParser.parse(layout.text()).root());
+        List<SyntaxToken> had = pairing.hadCode();
+        List<SyntaxToken> writes = pairing.writesCode();
         if (had.size() != writes.size()) {
             throw new NoCorrespondence(
                     "the source has " + had.size() + " tokens and its canonical form "
@@ -434,6 +600,110 @@ final class Witnesses {
     }
 
     /**
+     * What the rule about the end of a line has against {@code source}: the lines it wrote
+     * something at the end of.
+     *
+     * <p>Asked of the source's lines directly. The expectation is nothing, and that is what the
+     * canonical form writes at the end of every line it has, so there is no unit of the canonical
+     * form to find the source's answer at — which also makes this the one rule that can answer
+     * about a source whose tokens the canonical form rewrites.
+     *
+     * <p>The last line of a source is one of these only where nothing but whitespace is written on
+     * it. Anywhere else what stands after the last newline is what the file's own rule is about —
+     * how a file ends — and its repair writes the whole of that stretch, so answering here as well
+     * would be two rules over the same characters.
+     */
+    static List<Witness> lineEnds(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
+        return lineEnds(source, canonical);   // it reads the source's lines, not the tokens
+    }
+
+    /** What the rule about the end of a line has against {@code source}. */
+    static List<Witness> lineEnds(String source, Formatter.CanonicalForm canonical) {
+        List<Witness> out = new ArrayList<>();
+        int from = 0;
+        while (true) {
+            int newline = source.indexOf('\n', from);
+            int ends = newline < 0 ? source.length() : newline;
+            int at = ends;
+            while (at > from && (source.charAt(at - 1) == ' ' || source.charAt(at - 1) == '\t')) {
+                at--;
+            }
+            if (at < ends && (newline >= 0 || (from > 0 && at == from))) {
+                out.add(new Witness.AtTheEndOfALine(new Witness.LineEnd(at), "",
+                        source.substring(at, ends)));
+            }
+            if (newline < 0) {
+                return out;
+            }
+            from = newline + 1;
+        }
+    }
+
+    /**
+     * What the rule about a group's breaks has against {@code source}: the places it settled by
+     * breaking, where the source ended a different number of lines.
+     *
+     * <p>One line ends at each of them. A blank line inside a construct is written where the author
+     * wrote a paragraph break between two members, and that is a forced break with an obligation of
+     * its own — so a source that left a blank line at a place a group settles has departed from
+     * something, and until this rule was a value it was the one departure nothing could name: the
+     * group did break there, so the conditional rule agrees, and no obligation stands there for the
+     * forced rules to count lines at.
+     *
+     * <p>Only where the source ended a line there. One that ran the boundary together departed from
+     * the group's decision, which {@link #conditional} answers for, and saying it here as well
+     * would say one thing twice.
+     *
+     * <p>And not where an obligation breaks the same boundary. Two rules would count the same
+     * newlines from their own units and one of them would be wrong about how many belong there.
+     */
+    static List<Witness> settled(String source, Formatter.CanonicalForm canonical) {
+        return settled(source, canonical, new Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    static List<Witness> settled(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
+        Layout layout = canonical.layout();
+        String text = layout.text();
+        List<SyntaxToken> had = pairing.hadCode();
+        List<SyntaxToken> writes = pairing.writesCode();
+        if (had.size() != writes.size()) {
+            throw new NoCorrespondence(
+                    "the source has " + had.size() + " tokens and its canonical form "
+                            + writes.size() + "; the two cannot be held side by side");
+        }
+        Set<Integer> obliged = new LinkedHashSet<>();
+        for (Newline n : layout.breaks()) {
+            if (n.cause() instanceof Newline.Cause.Forced) {
+                obliged.add(adjacencyAt(writes, n.offset()));
+            }
+        }
+        List<Witness> out = new ArrayList<>();
+        Set<Integer> seen = new LinkedHashSet<>();
+        for (Opportunity o : layout.opportunities()) {
+            if (!o.broke()) {
+                continue;
+            }
+            int i = adjacencyAt(writes, o.at());
+            if (i < 0 || obliged.contains(i) || !seen.add(i)) {
+                continue;
+            }
+            String has = source.substring(had.get(i).end(), had.get(i + 1).start());
+            String wrote = text.substring(writes.get(i).end(), writes.get(i + 1).start());
+            if (has.contains("//") || wrote.contains("//")) {
+                continue;   // what is written around a comment is the comment rules'
+            }
+            if (newlines(has) > 0 && newlines(has) != newlines(wrote)) {
+                out.add(new Witness.Settled(new Witness.BrokenBoundary(i), newlines(wrote),
+                        newlines(has)));
+            }
+        }
+        return out;
+    }
+
+    /**
      * What the forced-layout rules have against {@code source}: the boundaries the canonical form
      * breaks whatever the width and the source wrote on a line.
      *
@@ -454,10 +724,16 @@ final class Witnesses {
      * its own unit, and a gap holding a comment to the rules about comments.
      */
     static List<Witness> forced(String source, Formatter.CanonicalForm canonical) {
+        return forced(source, canonical, new Pairing(source, canonical));
+    }
+
+    /** The same, for a caller that has already read the two texts' tokens. */
+    static List<Witness> forced(String source, Formatter.CanonicalForm canonical,
+            Pairing pairing) {
         Layout layout = canonical.layout();
         String text = layout.text();
-        List<SyntaxToken> had = code(CstParser.parse(source).root());
-        List<SyntaxToken> writes = code(CstParser.parse(layout.text()).root());
+        List<SyntaxToken> had = pairing.hadCode();
+        List<SyntaxToken> writes = pairing.writesCode();
         if (had.size() != writes.size()) {
             throw new NoCorrespondence(
                     "the source has " + had.size() + " tokens and its canonical form "

--- a/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
+++ b/souther-fmt/src/main/java/souther/compiler/fmt/Witnesses.java
@@ -199,9 +199,11 @@ final class Witnesses {
         }
 
         Pairing(String source, String text) {
-            this(code(CstParser.parse(source).root()), code(CstParser.parse(text).root()),
-                    comments(CstParser.parse(source).root()),
-                    comments(CstParser.parse(text).root()));
+            this(CstParser.parse(source).root(), CstParser.parse(text).root());
+        }
+
+        private Pairing(SyntaxNode source, SyntaxNode text) {
+            this(code(source), code(text), comments(source), comments(text));
         }
     }
 


### PR DESCRIPTION
`souther fmt --check` answers with the decisions a source did not take. What was left of #444 was the departures no decision covered: three kinds of change to the code tokens that were not decisions at all, and three layout rules the sixteen `.sou` files of this repository never ask for.

## How the missing rules were found

Asked of the rules, a departure none of them holds is not a departure. So the candidates are made from the text and put to the parser: one line of a canonical form written differently — a level moved, a line run on into the next, a blank line, a space added or taken out — kept where the grammar still admits it and where the canonical form of what is written is the one it came from. Each of those is a source that differs from its canonical form in one way and in no other.

Three of them had no rule.

**The file is a level.** A break written under no nesting was skipped, so the column a top-level line begins at was decided by nothing: a source that indented every definition it has departed from a canonical form no rule could name. The document is nested by nothing at the top, which writes what it wrote before and gives the outermost pair of levels its outer member.

**A comment on a line of its own begins at its level's column.** That was already the indentation rule's answer, and the source's side of it was missing — a line the canonical form opens for a comment is one no place is written at, and asked through the code alone it came back as the line of the next token. A comment the canonical form carries somewhere else is left out, because the line the source has for it is one the repair is about to take away. The composition found that by refusing rather than by writing over it.

**A group written down the page ends one line at each place it breaks.** The conditional rule answers whether a group is written on one line or down the page, so a source that left a blank line at one of its boundaries had broken where the canonical form breaks and departed from something nothing said.

Two more came out of the same sweep: **a line ends where what is written on it does** — the break rules count how many lines end at a boundary and the spacing rule answers about boundaries written on a line, so a space at the end of a line was in neither — and **a comment that opens a file is on a line of its own**, which the rule that told the two comment cases apart could not see, because at the top of a file nothing stands in front of it.

## The code tokens

A trailing comma, which the canonical form never writes; the bar in front of a match's first arm, which it always writes; a definition whose body is a lambda, whose parameters it writes to the left of the `=`. `Rewrites` reads the sites from the source's tree, and each is a rule with a unit, an expectation and a repair.

Until they were decisions, a source that wrote any of them came back with an **empty report**. The rules that hold the two token streams side by side have nothing to pair, so they say nothing, and the deviations that had nothing to do with the tokens went unsaid with them:

```
$ souther fmt m.sou --check
m.sou:3:29: a comma-separated run is written without a comma after its last member
    the canonical form: nothing; this source: `,`
m.sou:4:7: a definition writes its parameters to the left of the `=`
    the canonical form: `(x) =`; this source: `= (x) ->`
```

The report is asked round by round, in the order the rules depend on each other, and every round's deviations are the report's at the place in the source they came from. Which tokens are written settles what the layout rules' boundaries are; where the lines break settles what the indentation rule's lines are. `Repair` is split into the edits, writing them, and reading an offset of a repaired text back to where it stood.

## What it comes to

| | before | after |
| --- | --- | --- |
| of the sixteen `.sou` files, wholly named | 15 | **16** |
| single-line departures made from them, named by a rule | — | **404 of 404** |
| the seventeen constructs whose code tokens are rewritten | 0 named | **17 named, and each settles** |

Wholly named is `repair*(E, S) = F(S)`: the rules are asked, what they say is repaired, and they are asked again until the text stops changing.

## What holds it

`EveryDepartureFromTheCanonicalFormIsSomeRulesTest` is the sweep, one candidate per way of writing a line differently and shape of line. `RepairingWhatTheRulesSayWritesTheCanonicalFormTest` is A over every source in the repository, with a control that some of them do differ — a corpus already in canonical form would pass with no rule written at all. There is a fixture per rule, and the rules about code tokens are held against the seventeen rows `ACanonicalFormCanRewriteCodeTokensTest` already writes out, which is every construct the grammar admits a trailing comma in.

One existing test is turned around: `fmt --check` on a definition written as a lambda used to be held to say that what it named was not all of it, and now names the rule.

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)
