### PR TITLE
Whether a size can be built is answered by what builds it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -1085,14 +1085,13 @@ public final class Generator {
                     : new Edge(List.of(at), null, numberOf(value));
         }
         int size = countOf(value);
+        if (size < 0) {
+            return Edge.none(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
+        }
         Type carrier = TypeOps.base(axis.type(), symbols);
-        List<FixtureTemplate> built = size < 0 ? List.of()
-                : Witnesses.ofSize(carrier, size, symbols, Set.of());
+        List<FixtureTemplate> built = Witnesses.ofSize(carrier, size, symbols, Set.of());
         if (built.isEmpty()) {
-            UnresolvedCombination.Reason why = size < 0 ? null
-                    : Witnesses.reasonForSize(carrier, size, symbols);
-            return Edge.none(why == null
-                    ? UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE : why);
+            return Edge.none(Witnesses.reasonForSize(carrier, size, symbols));
         }
         List<FixtureTemplate> out = new ArrayList<>();
         for (FixtureTemplate each : built) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -97,10 +97,14 @@ public final class Generator {
              * Nothing here knows how to compose a value of the shape asked for.
              *
              * <p>Apart from {@code NO_REPRESENTATIVE}, which says the position has no values. This
-             * says the search has no way to write one — a string of a given length is the case
-             * (#528) — and that is a fact about this compiler rather than about the model. Told
-             * apart because the first licenses "no value can be written there" and this one does
-             * not: the edge may be the easiest row in the file to write by hand.
+             * says the search has no way to write one — a collection of more elements than a row is
+             * worth carrying is the case — and that is a fact about this compiler rather than about
+             * the model. Told apart because the first licenses "no value can be written there" and
+             * this one does not: the edge may be the easiest row in the file to write by hand.
+             *
+             * <p>Which is why nothing decides this from the shape of the question. A reason read off
+             * the kind of term outlives whatever made it true, and says a value cannot be composed
+             * while the same generation composes one in the row above.
              */
             NOTHING_COMPOSES_ONE,
             /** Every value tried was refused at construction. */
@@ -290,32 +294,22 @@ public final class Generator {
                     UnresolvedCombination.Reason.NO_REPRESENTATIVE));
         }
         String label = axis.term() + " = " + written(obligation.value());
-        // A line on something taken of the value is not met by writing that number at the position:
-        // a length of five is a string of five characters, and nothing here composes one (#528).
-        // Said as having no value to offer rather than by handing the decoder an integer where a
-        // string goes — which it refuses, and "every value tried was refused" would then report an
-        // opinion the decoder never had about a boundary a row could easily meet.
-        if (!(axis.term() instanceof NumericTerm.ValueOf)) {
-            return new BoundaryAttempt.Unresolved(new UnresolvedCombination(List.of(label),
-                    UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE));
-        }
-        FixtureTemplate at = valueOf(obligation.value(), axis.type(), subject.symbols());
-        if (at == null) {
-            return new BoundaryAttempt.Unresolved(new UnresolvedCombination(List.of(label),
-                    UnresolvedCombination.Reason.NO_REPRESENTATIVE));
+        Edge edge = edgeOf(axis, obligation.value(), subject.symbols());
+        if (edge.values().isEmpty()) {
+            return new BoundaryAttempt.Unresolved(
+                    new UnresolvedCombination(List.of(label), edge.reason()));
         }
         List<FixtureTemplate> inputs = new ArrayList<>();
         // What the rest of the row has to sit beside. A field of a record is not chosen from its
         // own type once another field of that record is fixed: the rule relating them says what
         // is left, and taking the bottom of the type's range instead is how a boundary that can
         // be written came back as one every value tried was refused at.
-        BigDecimal settledAt = numberOf(obligation.value());
-        Map<String, BigDecimal> settled = settledAt == null ? Map.of()
-                : Map.of(axis.path().toString(), settledAt);
+        Map<String, BigDecimal> settled = edge.settledAt() == null ? Map.of()
+                : Map.of(axis.path().toString(), edge.settledAt());
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
             Map<String, List<FixtureTemplate>> here =
                     TermPath.of(subject.parameters().get(p)).head().equals(axis.path().head())
-                            ? Map.of(axis.path().toString(), List.of(at)) : Map.of();
+                            ? Map.of(axis.path().toString(), edge.values()) : Map.of();
             Outcome tried = valueAt(subject, p, here, settled, check);
             if (tried.value() == null) {
                 return new BoundaryAttempt.Unresolved(
@@ -1053,6 +1047,69 @@ public final class Generator {
             }
         }
         return null;
+    }
+
+    /**
+     * What a row is to carry where a boundary is drawn: the values to try there, why there are none
+     * where there are none, and the number the position itself is thereby settled at.
+     *
+     * <p>The last is a number only sometimes. A line on the content of a location settles that
+     * location at it, and what the rest of the record may hold is read from the rules relating them;
+     * a line on a count taken of a location settles no number inside it, and saying it did would tell
+     * the rest of the row that a string's length is the number the string holds.
+     */
+    private record Edge(List<FixtureTemplate> values, UnresolvedCombination.Reason reason,
+                        BigDecimal settledAt) {
+
+        Edge {
+            values = List.copyOf(values);
+        }
+
+        static Edge none(UnresolvedCombination.Reason why) {
+            return new Edge(List.of(), why, null);
+        }
+    }
+
+    /**
+     * The values that stand on {@code value}'s edge of {@code axis}.
+     *
+     * <p>Which values those are is the term's question. The content of a location is the number
+     * written at it; a count taken of a location is met by whatever carries that count, and what
+     * carries a count is {@link Witnesses}'s to answer — asked rather than decided here, so that a
+     * value it learns to build is a boundary this reaches without being told again.
+     */
+    private static Edge edgeOf(Axis axis, ObservedValue value, Symbols symbols) {
+        if (!(axis.term() instanceof NumericTerm.SizeOf)) {
+            FixtureTemplate at = valueOf(value, axis.type(), symbols);
+            return at == null ? Edge.none(UnresolvedCombination.Reason.NO_REPRESENTATIVE)
+                    : new Edge(List.of(at), null, numberOf(value));
+        }
+        int size = countOf(value);
+        Type carrier = TypeOps.base(axis.type(), symbols);
+        List<FixtureTemplate> built = size < 0 ? List.of()
+                : Witnesses.ofSize(carrier, size, symbols, Set.of());
+        if (built.isEmpty()) {
+            UnresolvedCombination.Reason why = size < 0 ? null
+                    : Witnesses.reasonForSize(carrier, size, symbols);
+            return Edge.none(why == null
+                    ? UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE : why);
+        }
+        List<FixtureTemplate> out = new ArrayList<>();
+        for (FixtureTemplate each : built) {
+            out.add(Witnesses.wrapped(axis.type(), each, symbols));
+        }
+        return new Edge(out, null, null);
+    }
+
+    /** {@code value} as a count of things, or -1 where it is not one. A count is whole and no larger
+     * than the values there are to count, so a number outside that is a size nothing carries. */
+    private static int countOf(ObservedValue value) {
+        BigDecimal number = numberOf(value);
+        if (number == null || number.stripTrailingZeros().scale() > 0
+                || number.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) > 0) {
+            return -1;
+        }
+        return number.intValue();
     }
 
     /** A boundary value written the way the position takes it: bare where the position is a number,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -312,8 +312,14 @@ public final class Generator {
                             ? Map.of(axis.path().toString(), edge.values()) : Map.of();
             Outcome tried = valueAt(subject, p, here, settled, check);
             if (tried.value() == null) {
+                // Where the refusal is of the values this edge offered, what the edge held back
+                // outranks it: values that were never built were not among the ones refused.
+                UnresolvedCombination.Reason why =
+                        !here.isEmpty() && tried.reason()
+                                == UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED
+                                ? edge.refused() : tried.reason();
                 return new BoundaryAttempt.Unresolved(
-                        new UnresolvedCombination(List.of(label), tried.reason(), tried.detail()));
+                        new UnresolvedCombination(List.of(label), why, tried.detail()));
             }
             inputs.add(tried.value());
         }
@@ -1059,14 +1065,25 @@ public final class Generator {
      * the rest of the row that a string's length is the number the string holds.
      */
     private record Edge(List<FixtureTemplate> values, UnresolvedCombination.Reason reason,
-                        BigDecimal settledAt) {
+                        BigDecimal settledAt, UnresolvedCombination.Reason heldBack) {
 
         Edge {
             values = List.copyOf(values);
         }
 
         static Edge none(UnresolvedCombination.Reason why) {
-            return new Edge(List.of(), why, null);
+            return new Edge(List.of(), why, null, null);
+        }
+
+        /**
+         * What to report where every value offered here was refused.
+         *
+         * <p>Not always that they were refused. Where the values are some of the values and the rest
+         * were never built, the search stopping is the more of the two facts, and the one a reader
+         * would act on: another value of this edge may be the one that builds.
+         */
+        UnresolvedCombination.Reason refused() {
+            return heldBack == null ? UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED : heldBack;
         }
     }
 
@@ -1082,22 +1099,22 @@ public final class Generator {
         if (!(axis.term() instanceof NumericTerm.SizeOf)) {
             FixtureTemplate at = valueOf(value, axis.type(), symbols);
             return at == null ? Edge.none(UnresolvedCombination.Reason.NO_REPRESENTATIVE)
-                    : new Edge(List.of(at), null, numberOf(value));
+                    : new Edge(List.of(at), null, numberOf(value), null);
         }
         int size = countOf(value);
         if (size < 0) {
             return Edge.none(UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE);
         }
         Type carrier = TypeOps.base(axis.type(), symbols);
-        List<FixtureTemplate> built = Witnesses.ofSize(carrier, size, symbols, Set.of());
-        if (built.isEmpty()) {
+        Witnesses.Sized built = Witnesses.ofSize(carrier, size, symbols, Set.of());
+        if (built.values().isEmpty()) {
             return Edge.none(Witnesses.reasonForSize(carrier, size, symbols));
         }
         List<FixtureTemplate> out = new ArrayList<>();
-        for (FixtureTemplate each : built) {
+        for (FixtureTemplate each : built.values()) {
             out.add(Witnesses.wrapped(axis.type(), each, symbols));
         }
-        return new Edge(out, null, null);
+        return new Edge(out, null, null, built.heldBack());
     }
 
     /** {@code value} as a count of things, or -1 where it is not one. A count is whole and no larger

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -183,8 +183,8 @@ final class Intervals {
             return List.of();
         }
         List<FixtureTemplate> out = new ArrayList<>();
-        for (FixtureTemplate each
-                : Witnesses.ofSize(TypeOps.base(type, symbols), inside.intValue(), symbols, Set.of())) {
+        for (FixtureTemplate each : Witnesses
+                .ofSize(TypeOps.base(type, symbols), inside.intValue(), symbols, Set.of()).values()) {
             out.add(Witnesses.wrapped(type, each, symbols));
         }
         return List.copyOf(out);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Intervals.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Turning the lines a model draws through one numeric position into the ranges between them.
@@ -116,15 +117,14 @@ final class Intervals {
      *
      * <p>The term says how a row's value is read into a number and how its numbers are spaced; the
      * type says what a value written at one of them looks like. A range of lengths has the first and
-     * not the second — a string five characters long is a value nothing here can write (#528) — so
-     * those classes are named and left without a representative rather than given the number itself.
+     * not the second: five is not what is written at the position, a string of five characters is,
+     * and which values carry a count is asked of what builds them rather than settled here.
      */
     static List<PartitionClass> classesOf(List<Interval> intervals, NumericTerm of, Type type,
                                           Symbols symbols) {
         boolean decimal = of.decimal(type, symbols);
         souther.compiler.types.TypeName wrapper = type instanceof Type.Ref ref
                 && TypeOps.isSingleValueNewtype(type, symbols) ? ref.name() : null;
-        boolean writable = of instanceof NumericTerm.ValueOf;
         List<PartitionClass> classes = new ArrayList<>();
         for (Interval range : intervals) {
             String id = of + "/" + range.label();
@@ -135,16 +135,17 @@ final class Intervals {
                         new Membership.Incomplete(missing.code());
                 case NumericTerm.Reading.NotNumber _ -> Membership.NO_MATCH;
             };
-            if (!writable) {
+            if (inside == null) {
                 classes.add(PartitionClass.ungeneratable(id, range.label(), is,
-                        "nothing here writes a value whose " + measureOf(of) + " is in this range"));
+                        "no value of this range can be written without a smallest step"));
                 continue;
             }
-            classes.add(inside == null
+            List<FixtureTemplate> values = standingIn(of, inside, type, wrapper, decimal, symbols);
+            classes.add(values.isEmpty()
                     ? PartitionClass.ungeneratable(id, range.label(), is,
-                            "no value of this range can be written without a smallest step")
+                            "nothing here writes a value whose " + measureOf(of) + " is in this range")
                     : PartitionClass.of(id, range.label(), is,
-                            RepresentativeSource.of(written(inside, wrapper, decimal))));
+                            RepresentativeSource.of(values.toArray(new FixtureTemplate[0]))));
         }
         return List.copyOf(classes);
     }
@@ -160,6 +161,33 @@ final class Intervals {
                 range.lo() == null ? null : new Endpoint(range.lo(), range.loInclusive()),
                 range.hi() == null ? null : new Endpoint(range.hi(), range.hiInclusive()),
                 decimal ? Granularity.DENSE : Granularity.DISCRETE);
+    }
+
+    /**
+     * Values of the position that read as {@code inside} on this term, or none where the term is one
+     * nothing here can put a value on.
+     *
+     * <p>A number the term reads out of the value is written into it; a number the term counts of the
+     * value is a value carrying that many, which is {@link Witnesses}'s question rather than this
+     * one's. Asked of it rather than answered here, so that this says a range has no representative
+     * only when the thing that builds them has none to give.
+     */
+    private static List<FixtureTemplate> standingIn(NumericTerm of, BigDecimal inside, Type type,
+                                                    souther.compiler.types.TypeName wrapper,
+                                                    boolean decimal, Symbols symbols) {
+        if (of instanceof NumericTerm.ValueOf) {
+            return List.of(written(inside, wrapper, decimal));
+        }
+        if (inside.stripTrailingZeros().scale() > 0
+                || inside.compareTo(BigDecimal.valueOf(Integer.MAX_VALUE)) > 0) {
+            return List.of();
+        }
+        List<FixtureTemplate> out = new ArrayList<>();
+        for (FixtureTemplate each
+                : Witnesses.ofSize(TypeOps.base(type, symbols), inside.intValue(), symbols, Set.of())) {
+            out.add(Witnesses.wrapped(type, each, symbols));
+        }
+        return List.copyOf(out);
     }
 
     private static FixtureTemplate written(BigDecimal value, souther.compiler.types.TypeName wrapper,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -71,6 +71,11 @@ final class Witnesses {
      * size of zero. A rule asking a collection to hold at least none of anything has asked for no
      * value in particular; a line drawn at zero is the edge the empty one stands on, and it is a
      * value like any other.
+     *
+     * <p>And why what was built is counted rather than taken on trust. A set of three is three values
+     * no two of which are equal, which a type of two values has not got; the two that exist are a
+     * proposal for a floor and are not the count asked for here, and offering them would put a row of
+     * two under a line drawn at three.
      */
     static List<FixtureTemplate> ofSize(Type carrier, int size, Symbols symbols,
                                         Set<TypeName> expanding) {
@@ -80,18 +85,25 @@ final class Witnesses {
                             || carrier instanceof Type.MapOf
                                     ? List.of(FixtureTemplate.collection(List.of())) : List.of();
         }
-        return sized(carrier, size, symbols, expanding).proposals();
+        return sized(carrier, size, symbols, expanding).exactly(size);
     }
 
     /**
      * Why no value of {@code carrier} counting exactly {@code size} was built, or null where one was.
      *
      * <p>The same decision {@link #ofSize} reads, asked for its other half, so that what could not be
-     * built and why are one answer given twice rather than two answers that may disagree.
+     * built and why are one answer given twice rather than two answers that may disagree. Whenever
+     * that one offers nothing this names a reason: a caller left to supply its own default for the
+     * silence would be deciding again what this is here to answer.
      */
     static Generator.UnresolvedCombination.Reason reasonForSize(Type carrier, int size,
                                                                 Symbols symbols) {
-        return sized(carrier, size, symbols, Set.of()).heldBack();
+        if (!ofSize(carrier, size, symbols, Set.of()).isEmpty()) {
+            return null;
+        }
+        Generator.UnresolvedCombination.Reason held =
+                sized(carrier, size, symbols, Set.of()).heldBack();
+        return held == null ? Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE : held;
     }
 
     /**
@@ -106,10 +118,14 @@ final class Witnesses {
      * one standing on it. That is this method's choice and not the other's promise — a caller wanting
      * the floor cleared some other way changes the request made here, and a caller that asked for a
      * count goes on getting the count.
+     *
+     * <p>And why a value short of the minimum is offered where the type has no more to give. It is
+     * the value the rule refuses, put to the decoder so that the refusal is the decoder's and said in
+     * its terms; the caller with a line to stand on takes {@link #ofSize} and gets nothing here.
      */
     static List<FixtureTemplate> holding(Type carrier, int least, Symbols symbols,
                                          Set<TypeName> expanding) {
-        return least <= 0 ? List.of() : ofSize(carrier, least, symbols, expanding);
+        return least <= 0 ? List.of() : sized(carrier, least, symbols, expanding).all();
     }
 
     /**
@@ -118,20 +134,46 @@ final class Witnesses {
      * <p>The same decision {@link #holding} reads, asked for its other half. Written once because the
      * two have to agree: a reader was told a search stopped short of pairings nothing had asked to
      * build, back when this was a second reading of the same conditions.
+     *
+     * <p>Not {@link #reasonForSize}, for the same reason the two halves above are not one method. A
+     * floor nothing was built for is a position offering what it ordinarily offers, and naming a
+     * reason there would put "nothing composes one" under every position that has no floor at all.
      */
     static Generator.UnresolvedCombination.Reason heldBackFor(Type carrier, int least, Symbols symbols) {
-        return reasonForSize(carrier, least, symbols);
+        return least <= 0 ? null : sized(carrier, least, symbols, Set.of()).heldBack();
     }
+
+    /**
+     * A value that was built, and how many of whatever counts it it turned out to hold.
+     *
+     * <p>Carried rather than assumed. A string of five characters is built by writing five and a list
+     * of five by repeating one, but a set of five is five values no two of which are equal and the
+     * type may not have five — so what was asked for and what was made are two numbers, and only the
+     * caller that needs them equal is entitled to require it.
+     */
+    private record Made(FixtureTemplate value, int count) {}
 
     /** What a value of {@code carrier} counting {@code size} comes to: what was built, and what was
      * not. */
-    private record Built(List<FixtureTemplate> proposals,
+    private record Built(List<Made> proposals,
                          Generator.UnresolvedCombination.Reason heldBack) {
 
         static final Built NONE = new Built(List.of(), null);
 
-        static Built of(List<FixtureTemplate> proposals) {
+        static Built of(List<Made> proposals) {
             return new Built(List.copyOf(proposals), null);
+        }
+
+        /** Those holding exactly {@code size}, which is what a line drawn at a count is met by. */
+        List<FixtureTemplate> exactly(int size) {
+            return proposals.stream().filter(each -> each.count() == size)
+                    .map(Made::value).toList();
+        }
+
+        /** All of them, which is what a floor to clear is offered: one short of the floor is a value
+         * the decoder refuses for the reason the floor was written, and that is an answer. */
+        List<FixtureTemplate> all() {
+            return proposals.stream().map(Made::value).toList();
         }
     }
 
@@ -145,7 +187,7 @@ final class Witnesses {
         if (carrier == Type.STRING) {
             return least > MOST_CHARACTERS
                     ? new Built(List.of(), Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE)
-                    : Built.of(List.of(FixtureTemplate.string("x".repeat(least))));
+                    : Built.of(List.of(new Made(FixtureTemplate.string("x".repeat(least)), least)));
         }
         if (!(carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
                 || carrier instanceof Type.MapOf)) {
@@ -157,23 +199,24 @@ final class Witnesses {
         }
         // A list may hold the same element as many times as it needs to.
         if (carrier instanceof Type.ListOf list) {
-            List<FixtureTemplate> out = new ArrayList<>();
+            List<Made> out = new ArrayList<>();
             for (FixtureTemplate each : proposalsFor(list.element(), symbols, expanding)) {
                 List<FixtureTemplate> elements = new ArrayList<>();
                 for (int i = 0; i < least; i++) {
                     elements.add(each);
                 }
-                out.add(FixtureTemplate.collection(elements));
+                out.add(new Made(FixtureTemplate.collection(elements), elements.size()));
             }
             return Built.of(out);
         }
         // A set of three is three elements no two of which are equal, and a map of three is three
         // entries no two of which share a key. The values under a map's keys are free to repeat.
         if (carrier instanceof Type.SetOf set) {
-            List<FixtureTemplate> out = new ArrayList<>();
+            List<Made> out = new ArrayList<>();
             for (FixtureTemplate seed : proposalsFor(set.element(), symbols, expanding)) {
-                out.add(FixtureTemplate.collection(
-                        distinctFrom(seed, set.element(), least, symbols, expanding)));
+                List<FixtureTemplate> elements =
+                        distinctFrom(seed, set.element(), least, symbols, expanding);
+                out.add(new Made(FixtureTemplate.collection(elements), elements.size()));
             }
             return Built.of(out);
         }
@@ -183,7 +226,7 @@ final class Witnesses {
         if (keys.isEmpty() || values.isEmpty()) {
             return Built.NONE;
         }
-        List<FixtureTemplate> out = new ArrayList<>();
+        List<Made> out = new ArrayList<>();
         // Every pair, nearest first. A key's rules and a value's are answered together or not at all —
         // the pair is inside one position, so no search outside can put a key's second proposal beside
         // a value's first — and taking them in step would offer only the pairs whose two proposals
@@ -199,7 +242,7 @@ final class Witnesses {
                         : distinctFrom(keys.get(i), map.key(), least, symbols, expanding)) {
                     entries.add(FixtureTemplate.entry(key, value));
                 }
-                out.add(FixtureTemplate.collection(entries));
+                out.add(new Made(FixtureTemplate.collection(entries), entries.size()));
             }
         }
         return new Built(out, keys.size() * values.size() > out.size()

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -60,16 +60,56 @@ final class Witnesses {
     private static final int MOST_PAIRINGS = 64;
 
     /**
+     * Values of {@code carrier} whose count is exactly {@code size}, or none where this can build none.
+     *
+     * <p>The primitive the other two are asked through, because it is the narrower promise. A caller
+     * holding a line drawn on a count needs the count itself and not a value that merely clears it:
+     * a row at {@code String.length = 5} is a row carrying five characters, and four or six is a row
+     * at some other edge.
+     *
+     * <p>Which is why nothing is the answer at a size of none and the empty value is the answer at a
+     * size of zero. A rule asking a collection to hold at least none of anything has asked for no
+     * value in particular; a line drawn at zero is the edge the empty one stands on, and it is a
+     * value like any other.
+     */
+    static List<FixtureTemplate> ofSize(Type carrier, int size, Symbols symbols,
+                                        Set<TypeName> expanding) {
+        if (size == 0) {
+            return carrier == Type.STRING ? List.of(FixtureTemplate.string(""))
+                    : carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
+                            || carrier instanceof Type.MapOf
+                                    ? List.of(FixtureTemplate.collection(List.of())) : List.of();
+        }
+        return sized(carrier, size, symbols, expanding).proposals();
+    }
+
+    /**
+     * Why no value of {@code carrier} counting exactly {@code size} was built, or null where one was.
+     *
+     * <p>The same decision {@link #ofSize} reads, asked for its other half, so that what could not be
+     * built and why are one answer given twice rather than two answers that may disagree.
+     */
+    static Generator.UnresolvedCombination.Reason reasonForSize(Type carrier, int size,
+                                                                Symbols symbols) {
+        return sized(carrier, size, symbols, Set.of()).heldBack();
+    }
+
+    /**
      * Values of {@code carrier} holding at least {@code least} of whatever counts it, or none where
      * this can build none.
      *
      * <p>The minimum itself and not one element. Recognising {@code >= 3} and then offering a list of
      * one would refuse the row for the reason the empty list was refused, having read the rule and not
      * used it.
+     *
+     * <p>Which is why this asks for exactly the minimum: the cheapest value that clears a floor is the
+     * one standing on it. That is this method's choice and not the other's promise — a caller wanting
+     * the floor cleared some other way changes the request made here, and a caller that asked for a
+     * count goes on getting the count.
      */
     static List<FixtureTemplate> holding(Type carrier, int least, Symbols symbols,
                                          Set<TypeName> expanding) {
-        return decide(carrier, least, symbols, expanding).proposals();
+        return least <= 0 ? List.of() : ofSize(carrier, least, symbols, expanding);
     }
 
     /**
@@ -80,10 +120,10 @@ final class Witnesses {
      * build, back when this was a second reading of the same conditions.
      */
     static Generator.UnresolvedCombination.Reason heldBackFor(Type carrier, int least, Symbols symbols) {
-        return decide(carrier, least, symbols, Set.of()).heldBack();
+        return reasonForSize(carrier, least, symbols);
     }
 
-    /** What a value of {@code carrier} holding {@code least} comes to: what was built, and what was
+    /** What a value of {@code carrier} counting {@code size} comes to: what was built, and what was
      * not. */
     private record Built(List<FixtureTemplate> proposals,
                          Generator.UnresolvedCombination.Reason heldBack) {
@@ -95,7 +135,7 @@ final class Witnesses {
         }
     }
 
-    private static Built decide(Type carrier, int least, Symbols symbols, Set<TypeName> expanding) {
+    private static Built sized(Type carrier, int least, Symbols symbols, Set<TypeName> expanding) {
         if (carrier == null || least <= 0) {
             return Built.NONE;
         }
@@ -305,7 +345,7 @@ final class Witnesses {
 
     /** The value under every name the position wears, which is how it is written where the position
      * declares a newtype rather than what the newtype carries. */
-    private static FixtureTemplate wrapped(Type type, FixtureTemplate bare, Symbols symbols) {
+    static FixtureTemplate wrapped(Type type, FixtureTemplate bare, Symbols symbols) {
         if (!(type instanceof Type.Ref ref) || !(symbols.get(ref.name()) instanceof Ast.Data data)
                 || !data.newtype()) {
             return bare;

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -60,12 +60,30 @@ final class Witnesses {
     private static final int MOST_PAIRINGS = 64;
 
     /**
+     * Values of a count, and whether they are all the values of it there were.
+     *
+     * <p>Two halves of one answer. A caller reading only the first says every value was refused where
+     * some were never built, which is a different thing to tell an author and a different thing for a
+     * measure to record.
+     */
+    record Sized(List<FixtureTemplate> values, Generator.UnresolvedCombination.Reason heldBack) {
+
+        Sized {
+            values = List.copyOf(values);
+        }
+
+        static Sized all(List<FixtureTemplate> values) {
+            return new Sized(values, null);
+        }
+    }
+
+    /**
      * Values of {@code carrier} whose count is exactly {@code size}, or none where this can build none.
      *
-     * <p>The primitive the other two are asked through, because it is the narrower promise. A caller
-     * holding a line drawn on a count needs the count itself and not a value that merely clears it:
-     * a row at {@code String.length = 5} is a row carrying five characters, and four or six is a row
-     * at some other edge.
+     * <p>The narrower of the two promises about a count. A caller holding a line drawn on one needs
+     * the count itself and not a value that merely clears it: a row at {@code String.length = 5} is a
+     * row carrying five characters, and four or six is a row at some other edge. {@link #holding}
+     * reads the same build for what it asks, and neither is written in terms of the other.
      *
      * <p>Which is why nothing is the answer at a size of none and the empty value is the answer at a
      * size of zero. A rule asking a collection to hold at least none of anything has asked for no
@@ -77,15 +95,15 @@ final class Witnesses {
      * proposal for a floor and are not the count asked for here, and offering them would put a row of
      * two under a line drawn at three.
      */
-    static List<FixtureTemplate> ofSize(Type carrier, int size, Symbols symbols,
-                                        Set<TypeName> expanding) {
+    static Sized ofSize(Type carrier, int size, Symbols symbols, Set<TypeName> expanding) {
         if (size == 0) {
-            return carrier == Type.STRING ? List.of(FixtureTemplate.string(""))
+            return Sized.all(carrier == Type.STRING ? List.of(FixtureTemplate.string(""))
                     : carrier instanceof Type.ListOf || carrier instanceof Type.SetOf
                             || carrier instanceof Type.MapOf
-                                    ? List.of(FixtureTemplate.collection(List.of())) : List.of();
+                                    ? List.of(FixtureTemplate.collection(List.of())) : List.of());
         }
-        return sized(carrier, size, symbols, expanding).exactly(size);
+        Built built = sized(carrier, size, symbols, expanding);
+        return new Sized(built.exactly(size), built.heldBack());
     }
 
     /**
@@ -98,12 +116,12 @@ final class Witnesses {
      */
     static Generator.UnresolvedCombination.Reason reasonForSize(Type carrier, int size,
                                                                 Symbols symbols) {
-        if (!ofSize(carrier, size, symbols, Set.of()).isEmpty()) {
+        Sized made = ofSize(carrier, size, symbols, Set.of());
+        if (!made.values().isEmpty()) {
             return null;
         }
-        Generator.UnresolvedCombination.Reason held =
-                sized(carrier, size, symbols, Set.of()).heldBack();
-        return held == null ? Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE : held;
+        return made.heldBack() == null
+                ? Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE : made.heldBack();
     }
 
     /**
@@ -114,14 +132,12 @@ final class Witnesses {
      * one would refuse the row for the reason the empty list was refused, having read the rule and not
      * used it.
      *
-     * <p>Which is why this asks for exactly the minimum: the cheapest value that clears a floor is the
-     * one standing on it. That is this method's choice and not the other's promise — a caller wanting
-     * the floor cleared some other way changes the request made here, and a caller that asked for a
-     * count goes on getting the count.
-     *
-     * <p>And why a value short of the minimum is offered where the type has no more to give. It is
-     * the value the rule refuses, put to the decoder so that the refusal is the decoder's and said in
-     * its terms; the caller with a line to stand on takes {@link #ofSize} and gets nothing here.
+     * <p>So a value is built at the minimum, and a value short of it is offered too where the type has
+     * no more to give: it is the value the rule refuses, put to the decoder so that the refusal is the
+     * decoder's and is said in its terms. Both of those are this method's reading of the build, not
+     * {@link #ofSize}'s — a caller with a line to stand on takes that one, where a set the type has
+     * too few values for comes back as nothing at all. The two read one build and neither is written
+     * in terms of the other, so a cheaper value for a floor cannot move a line.
      */
     static List<FixtureTemplate> holding(Type carrier, int least, Symbols symbols,
                                          Set<TypeName> expanding) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -125,8 +125,13 @@ final class Witnesses {
     }
 
     /**
-     * Values of {@code carrier} holding at least {@code least} of whatever counts it, or none where
-     * this can build none.
+     * What to put to the decoder at a position a rule gives a floor of {@code least}, or nothing where
+     * this can build nothing.
+     *
+     * <p>Proposals and not witnesses, which is the whole of the difference from {@link #ofSize}. What
+     * comes back holds the floor where the type has that much to give and falls short of it where the
+     * type does not, and either way it is the decoder that answers — so a caller reading this as
+     * "values of at least {@code least}" is reading a promise nothing here makes.
      *
      * <p>The minimum itself and not one element. Recognising {@code >= 3} and then offering a list of
      * one would refuse the row for the reason the empty list was refused, having read the rule and not

--- a/souther-compiler/src/test/java/souther/compiler/WhetherASizeCanBeBuiltIsAnsweredByWhatBuildsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/WhetherASizeCanBeBuiltIsAnsweredByWhatBuildsItTest.java
@@ -1,0 +1,177 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.partition.Generator;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Rows at the edges a model draws on a measure taken of a value.
+ *
+ * <p>A line at {@code String.length = 1} is met by a string of one character, and whether one can be
+ * composed is a question about strings. Answered where strings are built, it is an answer every
+ * caller has; answered at each caller, it is an assumption that goes on being true only until the
+ * builder learns something — which is what happened here, and the boundary went on reporting that
+ * nothing composed a value it was by then being handed in another row of the same generation.
+ *
+ * <p>What is held to is the boundary an author sees, not the helper underneath. A test on the helper
+ * would have gone on passing throughout.
+ */
+class WhetherASizeCanBeBuiltIsAnsweredByWhatBuildsItTest {
+
+    /** A model whose one behavior divides on {@code s}, so that a numeric edge is owed beside whatever
+     * the constrained position owes. */
+    private static String model(String declaration, String written) {
+        return """
+                module sz.gen
+
+                data Size = Int
+                    invariant value >= 1
+
+                data Tag = Big | Small
+
+                %s
+
+                behavior label : (c: C, s: Size) -> Tag
+
+                let label (c, s) = if s.value >= 5 then Big else Small
+
+                example label
+                    | (%s, Size(9)) -> Big
+                """.formatted(declaration, written);
+    }
+
+    /** What the generator offers at the boundaries of that behavior. */
+    private static Generator.GenerationResult boundaries(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        assertEquals(List.of(), compilation.diagnostics().values().stream()
+                .flatMap(List::stream).toList(), "the model under test compiles");
+        Map<String, Adequacy.Filling> all = compilation.db()
+                .ask(new Adequacy.Generated(compilation.modules().get(0))).value();
+        assertNotNull(all, "the rows come back");
+        return all.get("label").boundaries();
+    }
+
+    /** The row offered at {@code edge}, as the text an author is handed for its first input. */
+    private static String rowAt(Generator.GenerationResult filled, String edge) {
+        for (Generator.GeneratedRow row : filled.rows()) {
+            if (row.classes().contains(edge)) {
+                return row.inputs().get(0).text();
+            }
+        }
+        return null;
+    }
+
+    /** Why no row was offered at {@code edge}, or null where one was. */
+    private static Generator.UnresolvedCombination.Reason whyNot(Generator.GenerationResult filled,
+                                                                 String edge) {
+        for (Generator.UnresolvedCombination left : filled.unresolved()) {
+            if (left.classes().contains(edge)) {
+                return left.reason();
+            }
+        }
+        return null;
+    }
+
+    // --- a string as long as the line says --------------------------------------------------------
+
+    /**
+     * The edge a minimum on a length draws is a string of that length.
+     *
+     * <p>The value is the one the same generation writes into every other row it offers, which is how
+     * the claim that nothing composed one could be read off the block that made it.
+     */
+    @Test
+    void aLineOnALengthIsMetByAStringOfThatLength() {
+        Generator.GenerationResult filled = boundaries(model("""
+                data C = String
+                    invariant String.length(value) >= 1
+                """, "C(\"abc\")"));
+
+        assertEquals("C(\"x\")", rowAt(filled, "String.length(c) = 1"));
+    }
+
+    /** A line above the smallest one is met at its own length rather than at the smallest. */
+    @Test
+    void aLineFurtherUpIsMetAtItsOwnLength() {
+        Generator.GenerationResult filled = boundaries(model("""
+                data C = String
+                    invariant String.length(value) >= 1 && String.length(value) <= 4
+                """, "C(\"ab\")"));
+
+        assertEquals("C(\"xxxx\")", rowAt(filled, "String.length(c) = 4"));
+    }
+
+    // --- a collection counted the same way --------------------------------------------------------
+
+    /**
+     * A count of elements reaches the same builder a count of characters does.
+     *
+     * <p>Here so that the fix is about what carries a count rather than about strings. Nothing in the
+     * corpora draws this line today, and a repair that worked only for the case that showed the defect
+     * would leave the next carrier to find it again.
+     */
+    @Test
+    void aLineOnAnElementCountIsMetByACollectionOfThatSize() {
+        Generator.GenerationResult filled = boundaries(model("""
+                data C = List<Int>
+                    invariant List.length(value) >= 2
+                """, "C([1, 2, 3])"));
+
+        assertEquals("C([0, 0])", rowAt(filled, "List.length(c) = 2"));
+    }
+
+    // --- built, and then refused ------------------------------------------------------------------
+
+    /**
+     * A value that was composed and refused is said to have been refused.
+     *
+     * <p>The two halves of the answer belong to different things: whether a value of that size exists
+     * to try is what builds values, and whether the model admits it is the decoder's. Collapsed into
+     * one, a type whose format refuses the string a length asked for reports that nothing composes a
+     * string of that length — a claim about strings taken from an opinion about this type.
+     */
+    @Test
+    void aSizedValueTheFormatRefusesIsReportedAsRefusedAndNotAsUnbuildable() {
+        Generator.GenerationResult filled = boundaries(model("""
+                data C = String
+                    invariant String.length(value) >= 2 && String.matches("[0-9]+", value)
+                """, "C(\"123\")"));
+
+        assertEquals(Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
+                whyNot(filled, "String.length(c) = 2"));
+    }
+
+    // --- the position's own content, unchanged ----------------------------------------------------
+
+    /**
+     * A line on the content of a location is still met by writing that number at it.
+     *
+     * <p>The path this shares nothing with. A number read out of a value and a number counted of one
+     * are two questions, and the second learning an answer does not change the first.
+     */
+    @Test
+    void aLineOnTheContentOfALocationIsStillWrittenThere() {
+        Generator.GenerationResult filled = boundaries(model("""
+                data C = String
+                    invariant String.length(value) >= 1
+                """, "C(\"abc\")"));
+
+        assertTrue(filled.rows().stream().anyMatch(row -> row.classes().contains("s = 5")
+                        && row.inputs().get(1).text().equals("Size(5)")),
+                "the edge on `s` is still the number written at `s`");
+        assertTrue(filled.rows().stream().anyMatch(row -> row.classes().contains("s = 1")
+                        && row.inputs().get(1).text().equals("Size(1)")),
+                "and so is the edge its invariant draws");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
@@ -1,0 +1,76 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.check.Symbols;
+import souther.compiler.types.Type;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The two promises about a count, kept apart.
+ *
+ * <p>A caller with a line drawn at a count needs that count; a caller with a floor to clear needs a
+ * value above it. The second is answered by asking for the first today, and the point of writing them
+ * as two is that it need not stay that way. Held here rather than through the report, because a size
+ * larger than a row is worth carrying is one the measure calls undecided before the generator is
+ * asked, so the report has no way to show which half of the answer was given.
+ */
+class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
+
+    private static final Symbols NONE = Symbols.none();
+
+    @Test
+    void aStringOfTheSizeAskedForIsBuilt() {
+        assertEquals(List.of("\"xxx\""),
+                Witnesses.ofSize(Type.STRING, 3, NONE, Set.of()).stream()
+                        .map(FixtureTemplate::text).toList());
+    }
+
+    /**
+     * A count of none is the empty value and not the absence of an answer.
+     *
+     * <p>A line drawn at zero is an edge a row stands on, and the empty string is what stands there.
+     */
+    @Test
+    void aSizeOfZeroIsTheEmptyValue() {
+        assertEquals(List.of("\"\""),
+                Witnesses.ofSize(Type.STRING, 0, NONE, Set.of()).stream()
+                        .map(FixtureTemplate::text).toList());
+        assertEquals(List.of("[]"),
+                Witnesses.ofSize(new Type.ListOf(Type.INT), 0, NONE, Set.of()).stream()
+                        .map(FixtureTemplate::text).toList());
+    }
+
+    /**
+     * A floor of none asks for no value in particular.
+     *
+     * <p>Where the two promises come apart. A rule saying a collection holds at least nothing has said
+     * nothing about the value, and the position's own chooser answers; a line at zero is a place a row
+     * is owed at. One method cannot mean both, which is why there are two.
+     */
+    @Test
+    void aFloorOfNoneAsksForNothingWhereASizeOfZeroAsksForTheEmptyValue() {
+        assertEquals(List.of(), Witnesses.holding(Type.STRING, 0, NONE, Set.of()));
+        assertTrue(!Witnesses.ofSize(Type.STRING, 0, NONE, Set.of()).isEmpty());
+    }
+
+    /** A count past what a row is worth carrying is one nothing composes, and says which it is. */
+    @Test
+    void aSizeNoRowWouldCarrySaysNothingComposesOne() {
+        assertEquals(List.of(), Witnesses.ofSize(Type.STRING, 100_000, NONE, Set.of()));
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                Witnesses.reasonForSize(Type.STRING, 100_000, NONE));
+    }
+
+    /** A carrier nothing counts has no size to build at, and that is not a limit being reached. */
+    @Test
+    void aCarrierNothingCountsHasNoReasonToGive() {
+        assertEquals(List.of(), Witnesses.ofSize(Type.INT, 3, NONE, Set.of()));
+        assertEquals(null, Witnesses.reasonForSize(Type.INT, 3, NONE));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
@@ -67,10 +67,51 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
                 Witnesses.reasonForSize(Type.STRING, 100_000, NONE));
     }
 
-    /** A carrier nothing counts has no size to build at, and that is not a limit being reached. */
+    /** A carrier nothing counts has no size to build at, and says which silence that is. */
     @Test
-    void aCarrierNothingCountsHasNoReasonToGive() {
+    void aCarrierNothingCountsSaysNothingComposesOne() {
         assertEquals(List.of(), Witnesses.ofSize(Type.INT, 3, NONE, Set.of()));
-        assertEquals(null, Witnesses.reasonForSize(Type.INT, 3, NONE));
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                Witnesses.reasonForSize(Type.INT, 3, NONE));
+    }
+
+    /**
+     * A set is as many values as the count asks for, no two of them equal, or it is nothing.
+     *
+     * <p>The type may not have that many. Two booleans are what a floor of three is offered, since a
+     * value the rule refuses is an answer the decoder gives in the rule's own terms; they are not
+     * three of anything, and a line drawn at three met by a row of two is a row standing somewhere
+     * else. What is asked for and what was made are two numbers here, and the caller that needs them
+     * equal is the one that checks.
+     */
+    @Test
+    void aSetIsNothingWhereTheTypeHasFewerValuesThanTheCountAsksFor() {
+        Type set = new Type.SetOf(Type.BOOL);
+
+        assertEquals(List.of("[true, false]"), Witnesses.ofSize(set, 2, NONE, Set.of()).stream()
+                .map(FixtureTemplate::text).toList());
+        assertEquals(List.of(), Witnesses.ofSize(set, 3, NONE, Set.of()));
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                Witnesses.reasonForSize(set, 3, NONE));
+    }
+
+    /** A floor goes on being offered what the type has, which is the value its rule refuses. */
+    @Test
+    void aFloorIsStillOfferedTheValueTheTypeCanReach() {
+        assertEquals(List.of("[true, false]"),
+                Witnesses.holding(new Type.SetOf(Type.BOOL), 3, NONE, Set.of()).stream()
+                        .map(FixtureTemplate::text).toList());
+    }
+
+    /** A map counts its entries, and a key that cannot be told from the others is not one more. */
+    @Test
+    void aMapIsNothingWhereItsKeysRunOutBeforeTheCount() {
+        Type map = new Type.MapOf(Type.BOOL, Type.INT);
+
+        assertTrue(!Witnesses.ofSize(map, 2, NONE, Set.of()).isEmpty(),
+                "two keys are two the type has");
+        assertEquals(List.of(), Witnesses.ofSize(map, 3, NONE, Set.of()));
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                Witnesses.reasonForSize(map, 3, NONE));
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatBuildsASizeSaysWhatItCouldNotBuildTest.java
@@ -15,10 +15,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * The two promises about a count, kept apart.
  *
  * <p>A caller with a line drawn at a count needs that count; a caller with a floor to clear needs a
- * value above it. The second is answered by asking for the first today, and the point of writing them
- * as two is that it need not stay that way. Held here rather than through the report, because a size
- * larger than a row is worth carrying is one the measure calls undecided before the generator is
- * asked, so the report has no way to show which half of the answer was given.
+ * value above it. They read one build and neither is written in terms of the other, so what they have
+ * in common is a property of the builder and not a promise either makes to the other.
+ *
+ * <p>Held here rather than through the report, because a count larger than a row is worth carrying is
+ * one the measure calls undecided before the generator is asked, and the report has no way to show
+ * which half of the answer was given.
  */
 class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
 
@@ -27,7 +29,7 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     @Test
     void aStringOfTheSizeAskedForIsBuilt() {
         assertEquals(List.of("\"xxx\""),
-                Witnesses.ofSize(Type.STRING, 3, NONE, Set.of()).stream()
+                Witnesses.ofSize(Type.STRING, 3, NONE, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
     }
 
@@ -39,10 +41,10 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     @Test
     void aSizeOfZeroIsTheEmptyValue() {
         assertEquals(List.of("\"\""),
-                Witnesses.ofSize(Type.STRING, 0, NONE, Set.of()).stream()
+                Witnesses.ofSize(Type.STRING, 0, NONE, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
         assertEquals(List.of("[]"),
-                Witnesses.ofSize(new Type.ListOf(Type.INT), 0, NONE, Set.of()).stream()
+                Witnesses.ofSize(new Type.ListOf(Type.INT), 0, NONE, Set.of()).values().stream()
                         .map(FixtureTemplate::text).toList());
     }
 
@@ -56,13 +58,13 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     @Test
     void aFloorOfNoneAsksForNothingWhereASizeOfZeroAsksForTheEmptyValue() {
         assertEquals(List.of(), Witnesses.holding(Type.STRING, 0, NONE, Set.of()));
-        assertTrue(!Witnesses.ofSize(Type.STRING, 0, NONE, Set.of()).isEmpty());
+        assertTrue(!Witnesses.ofSize(Type.STRING, 0, NONE, Set.of()).values().isEmpty());
     }
 
     /** A count past what a row is worth carrying is one nothing composes, and says which it is. */
     @Test
     void aSizeNoRowWouldCarrySaysNothingComposesOne() {
-        assertEquals(List.of(), Witnesses.ofSize(Type.STRING, 100_000, NONE, Set.of()));
+        assertEquals(List.of(), Witnesses.ofSize(Type.STRING, 100_000, NONE, Set.of()).values());
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
                 Witnesses.reasonForSize(Type.STRING, 100_000, NONE));
     }
@@ -70,7 +72,7 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     /** A carrier nothing counts has no size to build at, and says which silence that is. */
     @Test
     void aCarrierNothingCountsSaysNothingComposesOne() {
-        assertEquals(List.of(), Witnesses.ofSize(Type.INT, 3, NONE, Set.of()));
+        assertEquals(List.of(), Witnesses.ofSize(Type.INT, 3, NONE, Set.of()).values());
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
                 Witnesses.reasonForSize(Type.INT, 3, NONE));
     }
@@ -88,9 +90,9 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     void aSetIsNothingWhereTheTypeHasFewerValuesThanTheCountAsksFor() {
         Type set = new Type.SetOf(Type.BOOL);
 
-        assertEquals(List.of("[true, false]"), Witnesses.ofSize(set, 2, NONE, Set.of()).stream()
+        assertEquals(List.of("[true, false]"), Witnesses.ofSize(set, 2, NONE, Set.of()).values().stream()
                 .map(FixtureTemplate::text).toList());
-        assertEquals(List.of(), Witnesses.ofSize(set, 3, NONE, Set.of()));
+        assertEquals(List.of(), Witnesses.ofSize(set, 3, NONE, Set.of()).values());
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
                 Witnesses.reasonForSize(set, 3, NONE));
     }
@@ -108,9 +110,9 @@ class WhatBuildsASizeSaysWhatItCouldNotBuildTest {
     void aMapIsNothingWhereItsKeysRunOutBeforeTheCount() {
         Type map = new Type.MapOf(Type.BOOL, Type.INT);
 
-        assertTrue(!Witnesses.ofSize(map, 2, NONE, Set.of()).isEmpty(),
+        assertTrue(!Witnesses.ofSize(map, 2, NONE, Set.of()).values().isEmpty(),
                 "two keys are two the type has");
-        assertEquals(List.of(), Witnesses.ofSize(map, 3, NONE, Set.of()));
+        assertEquals(List.of(), Witnesses.ofSize(map, 3, NONE, Set.of()).values());
         assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
                 Witnesses.reasonForSize(map, 3, NONE));
     }


### PR DESCRIPTION
Closes #593.

A line drawn on a count taken of a value got no row, and the rows the same generation offered were
already standing on it. The capability was not missing — it was decided at the caller.

## What was deciding it

`Generator.probe` read the kind of the term and returned before composing anything:

```java
// a length of five is a string of five characters, and nothing here composes one
if (!(axis.term() instanceof NumericTerm.ValueOf)) {
    return new BoundaryAttempt.Unresolved(new UnresolvedCombination(List.of(label),
            UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE));
}
```

`Witnesses` composes exactly that — `"x".repeat(n)`, a collection of `n` — and the same generation
writes such values into the rows it offers. The sentence stopped being true when a candidate began
being proposed from the rule rather than the carrier alone, and the guard was not revisited.

`Intervals.classesOf` held the same assumption on the partition side, marking every class of a range
of lengths ungeneratable. A behavior whose obligations are all length-shaped was offered no row of
any kind:

```
// generated by `souther examples --generate`: 0 rows to fill what nothing covers.
// no row for `c=1 <= x < 3` in `pick`: no value can be written there
// no row for `String.length(c) = 1` in `pick`: nothing here composes a value at that edge
```

after:

```
//     | "c=1 <= x < 3" : (Code("x")) -> <?>
//     | "String.length(c) = 1" : (Code("x")) -> <?>
//     | "String.length(c) = 5" : (Code("xxxxx")) -> <?>
```

## What this changes

`Witnesses` owns the question and answers both halves of it, as it already did for a floor:

| | what it hands back |
|---|---|
| `holding(carrier, least)` | proposals for a floor of `least`: the count where the type has it, and what the type does have where it has less, for the decoder to refuse in the rule's own terms |
| `ofSize(carrier, size)` | values whose measure is `size`, and nothing where none was built |
| `reasonForSize(carrier, size)` | why no value of that count was built |

`holding` makes no promise about the measure of what it returns — a set of two under a floor of three
is exactly what it is for.

Neither is written in terms of the other: the builder carries the count of each value it made, and
each promise reads that build for itself — `ofSize` keeps what holds the count, `holding` keeps all
of it. That they agree for a string or a list is a property of the one builder rather than a call
from one contract to the other, so a cheaper witness for a floor cannot move a boundary. They differ
already for a set the type has too few values for, and at zero — a rule asking for at least none of anything has asked for no value in
particular, while a line at zero is an edge the empty value stands on, which is one more row on the
corpora.

`Generator.probe` composes through it, puts what comes back through the same `CandidateCheck` as any
other candidate, and settles the position's own number only where the line is on the position's own
content. `Intervals.classesOf` asks it for a class's representative.

## Measured

The bench corpora, with the CLI, since a compile does not run the measure:

| | rows offered | `nothing composes` notes |
|---|---|---|
| `corpus/crm` | 41 → 84 | 78 → 3 |
| `corpus/issuetracker` | 7 → 18 | 11 → 0 |

Diagnostics are unchanged on both. The three remaining notes mean it: a list of one element whose
element is a record nothing proposes a value for.

Five behaviors in `crm` now stop for a different and accurate reason — `lead.reach: ContactPoint`
has no value that can be written — where the guard used to stop them before the row was walked.

## Tests

`WhetherASizeCanBeBuiltIsAnsweredByWhatBuildsItTest` holds the boundary an author sees: a string of
the length the line names, a line further up met at its own length, an element count met by a
collection, a sized value the format refuses reported as refused rather than as unbuildable, and the
numeric path unchanged.

`WhatBuildsASizeSaysWhatItCouldNotBuildTest` holds the owner's own answers, including the two
promises coming apart at zero. A count larger than a row is worth carrying cannot be pinned through
the report: the measure calls such a row undecided before the generator is asked.

`mvn clean test` passes.


