### PR TITLE
The document set belongs to the session, not to the request

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/DocCommand.java
@@ -42,10 +42,21 @@ public final class DocCommand {
     }
 
     static int run(String[] args, PrintStream out, PrintStream err, Caller caller, ClassLoader loader) {
+        return run(args, out, err, Documents.on(caller, loader));
+    }
+
+    /**
+     * The same, over a set of documents that was read already.
+     *
+     * <p>Reading them is what this command costs, and a caller that answers more than one question
+     * from them reads them once. A one-shot invocation makes a set and lets it go with the process;
+     * a server that stays up holds one for as long as it is asked.
+     */
+    static int run(String[] args, PrintStream out, PrintStream err, Documents documents) {
         // Taken together, because the names they publish are one name space and a name resolving
         // against it is what a search asks first. Which document a name reaches is settled by the
         // two of them being held at once, not by the order this reads them.
-        Documents documents = Documents.on(caller, loader);
+        Caller caller = documents.caller();
         SpecDocument spec = documents.spec();
         LibraryDocs shipped = documents.shipped();
         if (args.length == 0) {

--- a/souther-compiler/src/main/java/souther/compiler/doc/Documents.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/Documents.java
@@ -17,11 +17,18 @@ package souther.compiler.doc;
  */
 final class Documents {
 
+    private final Caller caller;
     private final SpecDocument spec;
     private final LibraryDocs shipped;
 
-    /** The two of them, refusing a name they would both answer for. */
-    Documents(SpecDocument spec, LibraryDocs shipped) {
+    /**
+     * The two of them, refusing a name they would both answer for.
+     *
+     * <p>The caller is held here rather than passed beside this. Both documents are spelled for a
+     * caller when they are read, so a set is already one caller's, and a reader handed the set and
+     * told a different caller would be offered what it cannot do.
+     */
+    Documents(Caller caller, SpecDocument spec, LibraryDocs shipped) {
         // One way round is every collision: a key both hold is a spec name, so asking the shipped
         // topics for each of the specification's names is asking about all of them.
         for (String name : spec.names()) {
@@ -31,13 +38,25 @@ final class Documents {
                         + " same words: `" + name + "` and `" + topic.name() + "`");
             }
         }
+        this.caller = caller;
         this.spec = spec;
         this.shipped = shipped;
     }
 
-    /** The bundled specification and everything {@code loader} carries, answered as {@code caller}. */
+    /**
+     * The bundled specification and everything {@code loader} carries, answered as {@code caller}.
+     *
+     * <p>This reads the specification and every shipped doc set, which is what a set costs to make
+     * and is why one is made for as long as it will be asked from rather than for each question.
+     * Nothing it is built from moves while a process runs.
+     */
     static Documents on(Caller caller, ClassLoader loader) {
-        return new Documents(SpecDocument.bundled(caller), LibraryDocs.on(loader, caller));
+        return new Documents(caller, SpecDocument.bundled(caller), LibraryDocs.on(loader, caller));
+    }
+
+    /** Who these were read for, and who is to be offered what they can do next. */
+    Caller caller() {
+        return caller;
     }
 
     SpecDocument spec() {

--- a/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
@@ -260,8 +260,18 @@ public final class McpServer {
     private McpServer() {}
 
     public static int serve(InputStream in, OutputStream out) {
+        return serve(in, out, McpServer.class.getClassLoader());
+    }
+
+    /** The same, over the doc sets {@code loader} carries. */
+    static int serve(InputStream in, OutputStream out, ClassLoader loader) {
         BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         PrintWriter writer = new PrintWriter(out, true, StandardCharsets.UTF_8);
+        // What this session answers from. The specification and the shipped doc sets do not move
+        // while the process is up, so they are read here rather than for each question: built per
+        // request, a server that is asked a hundred of them parses the specification a hundred
+        // times. It lives as long as the loop below does and goes when it does.
+        Documents documents = Documents.on(Caller.MCP, loader);
         try {
             String line;
             while ((line = reader.readLine()) != null) {
@@ -279,7 +289,7 @@ public final class McpServer {
                 if (id == null) {
                     continue; // A notification expects silence, whatever its method.
                 }
-                writer.println(JSON.writeValueAsString(respond(request, id)));
+                writer.println(JSON.writeValueAsString(respond(request, id, documents)));
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -287,7 +297,7 @@ public final class McpServer {
         return 0;
     }
 
-    private static ObjectNode respond(JsonNode request, JsonNode id) {
+    private static ObjectNode respond(JsonNode request, JsonNode id, Documents documents) {
         String method = request.get("method") == null ? "" : request.get("method").asString();
         return switch (method) {
             case "initialize" -> result(id, initializeResult(request.get("params")));
@@ -301,7 +311,7 @@ public final class McpServer {
                     yield error(id, -32602, invalid);
                 }
                 try {
-                    yield result(id, call(request.get("params")));
+                    yield result(id, call(request.get("params"), documents));
                 } catch (RuntimeException e) {
                     yield result(id, failed(e.getClass().getSimpleName()
                             + (e.getMessage() == null ? "" : ": " + e.getMessage())));
@@ -415,7 +425,7 @@ public final class McpServer {
      * <p>The command is told it is answering an MCP client, so that what it offers next is a tool
      * call rather than a shell command the caller has no way to run.
      */
-    private static ObjectNode call(JsonNode params) {
+    private static ObjectNode call(JsonNode params, Documents documents) {
         String tool = params == null || params.get("name") == null ? "" : params.get("name").asString();
         JsonNode arguments = params == null ? null : params.get("arguments");
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
@@ -427,12 +437,12 @@ public final class McpServer {
                         ? new String[]{"--search", argument(arguments, "term")}
                         : new String[]{"--search", argument(arguments, "term"),
                                 "--limit", String.valueOf(limit.asInt())};
-                yield DocCommand.run(args, stream, stream, Caller.MCP);
+                yield DocCommand.run(args, stream, stream, documents);
             }
             case "doc_read" -> {
                 String name = argument(arguments, "name");
                 yield DocCommand.run(name.isEmpty() ? new String[]{} : new String[]{name},
-                        stream, stream, Caller.MCP);
+                        stream, stream, documents);
             }
             case "stdlib_api" -> {
                 String name = argument(arguments, "name");

--- a/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
+++ b/souther-compiler/src/main/java/souther/compiler/doc/McpServer.java
@@ -257,6 +257,36 @@ public final class McpServer {
         }
     }
 
+    /**
+     * One run of this server, and the documents it answers from.
+     *
+     * <p>The set belongs to the session rather than to a request. The specification and the shipped
+     * doc sets do not move while a process is up, so a server that reads them for each question it
+     * is asked reads the same 486KB of AsciiDoc again for each question.
+     *
+     * <p>It is read on the first question that wants it rather than when the session opens. A
+     * session asked only what this server can do never reads a document, and a doc set that refuses
+     * to be read — two documents answering for one name — fails the call that wanted it rather than
+     * the server: a tool that blows up is that call's failure, which is what the tool dispatch
+     * below is written to hold and what building this up front would have taken away from it.
+     */
+    private static final class Session {
+
+        private final ClassLoader loader;
+        private Documents documents;
+
+        private Session(ClassLoader loader) {
+            this.loader = loader;
+        }
+
+        private Documents documents() {
+            if (documents == null) {
+                documents = Documents.on(Caller.MCP, loader);
+            }
+            return documents;
+        }
+    }
+
     private McpServer() {}
 
     public static int serve(InputStream in, OutputStream out) {
@@ -267,11 +297,7 @@ public final class McpServer {
     static int serve(InputStream in, OutputStream out, ClassLoader loader) {
         BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         PrintWriter writer = new PrintWriter(out, true, StandardCharsets.UTF_8);
-        // What this session answers from. The specification and the shipped doc sets do not move
-        // while the process is up, so they are read here rather than for each question: built per
-        // request, a server that is asked a hundred of them parses the specification a hundred
-        // times. It lives as long as the loop below does and goes when it does.
-        Documents documents = Documents.on(Caller.MCP, loader);
+        Session session = new Session(loader);
         try {
             String line;
             while ((line = reader.readLine()) != null) {
@@ -289,7 +315,7 @@ public final class McpServer {
                 if (id == null) {
                     continue; // A notification expects silence, whatever its method.
                 }
-                writer.println(JSON.writeValueAsString(respond(request, id, documents)));
+                writer.println(JSON.writeValueAsString(respond(request, id, session)));
             }
         } catch (IOException e) {
             throw new UncheckedIOException(e);
@@ -297,7 +323,7 @@ public final class McpServer {
         return 0;
     }
 
-    private static ObjectNode respond(JsonNode request, JsonNode id, Documents documents) {
+    private static ObjectNode respond(JsonNode request, JsonNode id, Session session) {
         String method = request.get("method") == null ? "" : request.get("method").asString();
         return switch (method) {
             case "initialize" -> result(id, initializeResult(request.get("params")));
@@ -311,7 +337,7 @@ public final class McpServer {
                     yield error(id, -32602, invalid);
                 }
                 try {
-                    yield result(id, call(request.get("params"), documents));
+                    yield result(id, call(request.get("params"), session));
                 } catch (RuntimeException e) {
                     yield result(id, failed(e.getClass().getSimpleName()
                             + (e.getMessage() == null ? "" : ": " + e.getMessage())));
@@ -425,7 +451,7 @@ public final class McpServer {
      * <p>The command is told it is answering an MCP client, so that what it offers next is a tool
      * call rather than a shell command the caller has no way to run.
      */
-    private static ObjectNode call(JsonNode params, Documents documents) {
+    private static ObjectNode call(JsonNode params, Session session) {
         String tool = params == null || params.get("name") == null ? "" : params.get("name").asString();
         JsonNode arguments = params == null ? null : params.get("arguments");
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
@@ -437,12 +463,12 @@ public final class McpServer {
                         ? new String[]{"--search", argument(arguments, "term")}
                         : new String[]{"--search", argument(arguments, "term"),
                                 "--limit", String.valueOf(limit.asInt())};
-                yield DocCommand.run(args, stream, stream, documents);
+                yield DocCommand.run(args, stream, stream, session.documents());
             }
             case "doc_read" -> {
                 String name = argument(arguments, "name");
                 yield DocCommand.run(name.isEmpty() ? new String[]{} : new String[]{name},
-                        stream, stream, documents);
+                        stream, stream, session.documents());
             }
             case "stdlib_api" -> {
                 String name = argument(arguments, "name");

--- a/souther-compiler/src/test/java/souther/compiler/doc/ALongAnswerArrivesInPartsThatJoinBackUpTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ALongAnswerArrivesInPartsThatJoinBackUpTest.java
@@ -1,12 +1,22 @@
 package souther.compiler.doc;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.json.JsonMapper;
 
-import java.io.ByteArrayInputStream;
+import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +25,7 @@ import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,9 +40,55 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * handed a document in pieces has been handed the document only if none of it was dropped between
  * them and none of it was said twice.
  */
+@Timeout(120)
 class ALongAnswerArrivesInPartsThatJoinBackUpTest {
 
     private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /**
+     * One session, held open for the whole of this class.
+     *
+     * <p>A client asks a long answer for its parts one after another, each request carrying the
+     * cursor the last one answered with, and it asks them of a session it already has. Opening one
+     * per request would be a client this protocol does not have, and would put the reading of the
+     * documents — which is what answering costs — inside the walk being measured here.
+     *
+     * <p>Requests and responses are one for one and in order, so writing a line and reading a line
+     * is the whole of the exchange.
+     */
+    private static PrintWriter SESSION;
+    private static BufferedReader ANSWERS;
+    private static Thread SERVER;
+
+    /** How many requests this session has been sent, which is where a request's id comes from. */
+    private static int asked;
+
+    /**
+     * The documents the checks that do not go through the protocol read, held for the same reason
+     * the session is: what is under test is how an answer is cut, not what it costs to find one.
+     */
+    private static Documents DOCUMENTS;
+
+    @BeforeAll
+    static void openTheSession() throws IOException {
+        DOCUMENTS = Documents.on(Caller.MCP,
+                ALongAnswerArrivesInPartsThatJoinBackUpTest.class.getClassLoader());
+        PipedOutputStream toServer = new PipedOutputStream();
+        PipedInputStream serverReads = new PipedInputStream(toServer, 1 << 16);
+        PipedInputStream fromServer = new PipedInputStream(1 << 20);
+        PipedOutputStream serverWrites = new PipedOutputStream(fromServer);
+        SESSION = new PrintWriter(new OutputStreamWriter(toServer, StandardCharsets.UTF_8), true);
+        ANSWERS = new BufferedReader(new InputStreamReader(fromServer, StandardCharsets.UTF_8));
+        SERVER = new Thread(() -> McpServer.serve(serverReads, serverWrites), "mcp-session");
+        SERVER.setDaemon(true);
+        SERVER.start();
+    }
+
+    @AfterAll
+    static void closeTheSession() throws InterruptedException {
+        SESSION.close();   // the server's reader sees the end of the stream and the loop returns
+        SERVER.join(10_000);
+    }
 
     /** What a part that is not the last one ends with, and the cursor that carries it on. */
     private static final Pattern CARRIES_ON = carriesOn("doc_read");
@@ -256,7 +313,7 @@ class ALongAnswerArrivesInPartsThatJoinBackUpTest {
     private String printed(String name) {
         ByteArrayOutputStream captured = new ByteArrayOutputStream();
         PrintStream stream = new PrintStream(captured, true, StandardCharsets.UTF_8);
-        DocCommand.run(new String[]{name}, stream, stream, Caller.MCP);
+        DocCommand.run(new String[]{name}, stream, stream, DOCUMENTS);
         return captured.toString(StandardCharsets.UTF_8);
     }
 
@@ -273,20 +330,23 @@ class ALongAnswerArrivesInPartsThatJoinBackUpTest {
     }
 
     private JsonNode called(String tool, String arguments) {
-        ByteArrayInputStream in = new ByteArrayInputStream(
-                ("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\""
-                        + tool + "\",\"arguments\":" + arguments + "}}\n")
-                        .getBytes(StandardCharsets.UTF_8));
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        McpServer.serve(in, out);
-        return JSON.readTree(out.toString(StandardCharsets.UTF_8).strip());
+        SESSION.println("{\"jsonrpc\":\"2.0\",\"id\":" + (++asked)
+                + ",\"method\":\"tools/call\",\"params\":{\"name\":\""
+                + tool + "\",\"arguments\":" + arguments + "}}");
+        try {
+            String answered = ANSWERS.readLine();
+            assertNotNull(answered, "the session ended before it answered");
+            return JSON.readTree(answered);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
     }
 
     @Test
     void everyLongAnswerThereIsJoinsBackUp() {
         ByteArrayOutputStream listed = new ByteArrayOutputStream();
         DocCommand.run(new String[]{}, new PrintStream(listed, true, StandardCharsets.UTF_8),
-                new PrintStream(listed, true, StandardCharsets.UTF_8), Caller.MCP);
+                new PrintStream(listed, true, StandardCharsets.UTF_8), DOCUMENTS);
 
         List<String> cut = new ArrayList<>();
         for (String line : listed.toString(StandardCharsets.UTF_8).split("\n")) {

--- a/souther-compiler/src/test/java/souther/compiler/doc/ANameIsResolvedRatherThanRankedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ANameIsResolvedRatherThanRankedTest.java
@@ -185,7 +185,7 @@ class ANameIsResolvedRatherThanRankedTest {
         LibraryDocs shipped = shipping("cli", "commands.md", "# Commands\n\nWhat this library takes.\n");
 
         IllegalStateException refused = assertThrows(IllegalStateException.class,
-                () -> new Documents(spec, shipped));
+                () -> new Documents(Caller.CLI, spec, shipped));
 
         assertTrue(refused.getMessage().contains("cli-commands")
                         && refused.getMessage().contains("cli/commands"),

--- a/souther-compiler/src/test/java/souther/compiler/doc/ASessionReadsItsDocumentsOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ASessionReadsItsDocumentsOnceTest.java
@@ -1,0 +1,123 @@
+package souther.compiler.doc;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A session reads the documents it answers from once.
+ *
+ * <p>The specification is 486KB of AsciiDoc and the shipped doc sets are every file on the class
+ * path under their index, and reading them is what answering costs. A server that reads them for
+ * each question it is asked pays that for each question: the documents cannot have moved, because a
+ * bundled resource and a class path do not move while a process runs.
+ *
+ * <p>What is held to is the reading rather than the time it takes. A count is what a regression
+ * here looks like — the set built where a request is served rather than where a session is — and it
+ * says so whatever the machine it runs on. A duration would have to be given a threshold, and a
+ * threshold loose enough not to fail on a slow machine is loose enough to pass on a server that
+ * reads the specification for every question.
+ */
+class ASessionReadsItsDocumentsOnceTest {
+
+    /**
+     * A loader that counts what is asked of it, over the one the tests run under.
+     *
+     * <p>{@code getResources} is what a doc set is found by, so it is the reading this counts.
+     * Everything else is passed through, this being a loader the documents are actually read from
+     * rather than one standing in for it.
+     */
+    private static final class Counting extends ClassLoader {
+
+        private final AtomicInteger asked = new AtomicInteger();
+
+        private Counting(ClassLoader parent) {
+            super(parent);
+        }
+
+        @Override
+        public Enumeration<URL> getResources(String name) throws IOException {
+            asked.incrementAndGet();
+            return super.getResources(name);
+        }
+    }
+
+    private static String reads(int n) {
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < n; i++) {
+            b.append("{\"jsonrpc\":\"2.0\",\"id\":").append(i + 1)
+                    .append(",\"method\":\"tools/call\",\"params\":{\"name\":\"doc_read\","
+                            + "\"arguments\":{\"name\":\"purpose\"}}}\n");
+        }
+        return b.toString();
+    }
+
+    private static int answered(String responses) {
+        return responses.strip().isEmpty() ? 0 : responses.strip().split("\n").length;
+    }
+
+    @Test
+    void howeverManyQuestionsItIsAsked() {
+        Counting loader = new Counting(ASessionReadsItsDocumentsOnceTest.class.getClassLoader());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        McpServer.serve(new ByteArrayInputStream(reads(20).getBytes(StandardCharsets.UTF_8)),
+                out, loader);
+
+        assertEquals(20, answered(out.toString(StandardCharsets.UTF_8)),
+                "the session answered every question, so this is not counting a session that stopped");
+        assertEquals(1, loader.asked.get(),
+                "the doc sets were looked for once per question rather than once per session");
+    }
+
+    @Test
+    void andOneQuestionCostsOneReadingToo() {
+        Counting loader = new Counting(ASessionReadsItsDocumentsOnceTest.class.getClassLoader());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        McpServer.serve(new ByteArrayInputStream(reads(1).getBytes(StandardCharsets.UTF_8)),
+                out, loader);
+
+        assertEquals(1, answered(out.toString(StandardCharsets.UTF_8)));
+        assertEquals(1, loader.asked.get(),
+                "and a session of one is the same session, not a special case");
+    }
+
+    private static String printed(String[] args, Documents documents) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream stream = new PrintStream(out, true, StandardCharsets.UTF_8);
+        assertEquals(0, DocCommand.run(args, stream, stream, documents));
+        return out.toString(StandardCharsets.UTF_8);
+    }
+
+    /**
+     * A command handed no documents reads them itself, and answers what it answers when it is
+     * handed some. A one-shot invocation is still one, and which of the two read the documents is
+     * where they came from rather than what they say.
+     */
+    @Test
+    void aCommandWithNoDocumentsOfItsOwnReadsThemItselfAndSaysTheSame() {
+        Counting loader = new Counting(ASessionReadsItsDocumentsOnceTest.class.getClassLoader());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        PrintStream stream = new PrintStream(out, true, StandardCharsets.UTF_8);
+
+        int code = DocCommand.run(new String[]{"purpose"}, stream, stream, Caller.CLI, loader);
+
+        assertEquals(0, code);
+        assertTrue(out.size() > 0, "there is an answer to compare");
+        assertEquals(printed(new String[]{"purpose"}, Documents.on(Caller.CLI, loader)),
+                out.toString(StandardCharsets.UTF_8),
+                "the answer is the same whether the documents were handed over or read here");
+        assertEquals(2, loader.asked.get(), "one reading each, and no more");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/doc/ASessionReadsItsDocumentsOnceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/doc/ASessionReadsItsDocumentsOnceTest.java
@@ -7,9 +7,17 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.IOException;
 import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Enumeration;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -119,5 +127,78 @@ class ASessionReadsItsDocumentsOnceTest {
                 out.toString(StandardCharsets.UTF_8),
                 "the answer is the same whether the documents were handed over or read here");
         assertEquals(2, loader.asked.get(), "one reading each, and no more");
+    }
+
+    private static final JsonMapper JSON = JsonMapper.builder().build();
+
+    /** {@code initialize} and {@code tools/list}: what a client asks before it asks anything. */
+    private static final String OPENING = """
+            {"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}
+            {"jsonrpc":"2.0","id":2,"method":"tools/list"}
+            """;
+
+    /**
+     * A session asked only what this server can do never reads a document.
+     *
+     * <p>Read when the session opens rather than when a document is wanted, every one of these
+     * would pay for the specification to say what its tools are called.
+     */
+    @Test
+    void andASessionAskedOnlyWhatItCanDoReadsNothing() {
+        Counting loader = new Counting(ASessionReadsItsDocumentsOnceTest.class.getClassLoader());
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        McpServer.serve(new ByteArrayInputStream(OPENING.getBytes(StandardCharsets.UTF_8)),
+                out, loader);
+
+        assertEquals(2, answered(out.toString(StandardCharsets.UTF_8)),
+                "both were answered, so this is not counting a session that never started");
+        assertEquals(0, loader.asked.get(), "and neither of them read a document");
+    }
+
+    /** A jar shipping the doc set {@code no} with a topic named {@code no/null}. */
+    private static URL aDocSetNamedLikeASpecificationSection() throws IOException {
+        Path jar = Files.createTempDirectory("collidingdocset").resolve("colliding-1.0.jar");
+        try (JarOutputStream out = new JarOutputStream(Files.newOutputStream(jar))) {
+            out.putNextEntry(new JarEntry("META-INF/souther-docs/sets"));
+            out.write("no\n".getBytes(StandardCharsets.UTF_8));
+            out.putNextEntry(new JarEntry("META-INF/souther-docs/no/index"));
+            out.write("null.md\n".getBytes(StandardCharsets.UTF_8));
+            out.putNextEntry(new JarEntry("META-INF/souther-docs/no/null.md"));
+            out.write("# Nothing\n\nThe words `no null` are already a section of the specification.\n"
+                    .getBytes(StandardCharsets.UTF_8));
+        }
+        return jar.toUri().toURL();
+    }
+
+    /**
+     * A doc set that refuses to be read is the failure of the call that wanted it.
+     *
+     * <p>{@code no/null} and the specification's {@code no-null} are one name to resolve, which
+     * {@link Documents} refuses rather than settle by which of them it happened to read first. Read
+     * when the session opens, that refusal would be the server failing to start, and a client would
+     * lose the tools it can still use — every answer that does not come from a document, and the
+     * listing that would have told it which those are.
+     */
+    @Test
+    void andADocSetThatRefusesToBeReadFailsTheCallAndNotTheSession() throws IOException {
+        try (URLClassLoader shipping = new URLClassLoader(
+                new URL[]{aDocSetNamedLikeASpecificationSection()}, null)) {
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+            McpServer.serve(new ByteArrayInputStream(
+                    (OPENING + reads(1)).getBytes(StandardCharsets.UTF_8)), out, shipping);
+
+            String[] said = out.toString(StandardCharsets.UTF_8).strip().split("\n");
+            assertEquals(3, said.length, "the session answered all three");
+            JsonNode opened = JSON.readTree(said[0]);
+            assertTrue(opened.get("result") != null && opened.get("error") == null,
+                    "the server started: " + said[0]);
+            assertTrue(JSON.readTree(said[1]).get("result").get("tools").size() > 0,
+                    "and said what it can do: " + said[1]);
+            JsonNode read = JSON.readTree(said[2]);
+            assertTrue(read.get("result").get("isError").asBoolean(),
+                    "and the read is what failed: " + said[2]);
+        }
     }
 }


### PR DESCRIPTION
Closes #592.

Two commits. The first is the server; the second is a test that had been modelling a client the protocol does not have.

## The document set belongs to the session

`McpServer.serve` reads requests in a loop for as long as the server is up, and every answer went through `DocCommand.run`, which built the document set from scratch: the 486KB specification read and parsed again, and every shipped doc set found on the class path again, for each question. Nothing it is derived from can have moved — a bundled resource and a class path are what they are for the life of a process.

The CLI never showed this. `souther doc <name>` is one process answering one question, so process lifetime and request lifetime are the same thing there and building the documents per request costs nothing. The MCP server is where the two came apart, and where a coupling that was always in the code became a cost.

So the fix gives the value an owner rather than a cache. The session owns the set and reads it on the first question that wants one; the command takes one when handed one and reads its own when not. Nothing is memoised on `(Caller, ClassLoader)`: there is no invalidation to decide, no map to grow, and no `ClassLoader` to hold weakly, because the set goes when the session it belongs to does.

Read where the session opens instead, the lifetime would have taken *when it can fail* with it. A doc set that refuses to be read — two documents answering for one name — is a call's failure, and the tool dispatch says so in as many words: a tool that blows up must not cost a client the questions after it. It would also have made every session pay for the specification, including the ones that only ask what this server can do; `initialize` and `tools/list` read nothing.

`Documents` now holds the `Caller` it was read for. Both documents are spelled for a caller as they are read, so a set is already one caller's; passing the set and the caller side by side is two things that can disagree.

```
fifty reads over one session      1,393 ms  →  47 ms
one read                              27 ms  →  0.9 ms
```

## What holds it is a count, not a clock

`ASessionReadsItsDocumentsOnceTest` serves twenty questions over one session through a `ClassLoader` that counts what is asked of it, and holds that the doc sets were looked for once. Built per request it answers twenty — checked by making that change and watching it fail with `expected: <1> but was: <20>`.

A duration would need a threshold, and a threshold loose enough not to fail on a slow machine is loose enough to pass on a server that reads the specification for every question.

Two more hold what the lifetime must not take with it: a session asked only what the server can do reads no document, and a session over a doc set colliding with a specification name starts, says what it can do, and fails the read. Both were run against a version that reads when the session opens — the first answers 1 where it wants 0, and the second never gets an answer at all.

`McpServer.serve` gains a package-private overload taking a `ClassLoader`, the same seam `DocCommand.run` already has, so the loader under test is the one the documents are actually read from.

## The walk had no session

`ALongAnswerArrivesInPartsThatJoinBackUpTest` follows a long answer to its end by asking for each next part with the cursor the last one gave back. For each of those parts it opened a server, sent one request and closed it. A cursor is only worth carrying to a session that is still there, so what it was driving was not a client this protocol has — and it put the reading of the documents inside the walk it was measuring.

It now holds one session for the class and writes a line to it per request. The checks that do not go through the protocol read from one set for the same reason: what is under test is how an answer is cut, not what it costs to find one.

Nothing is asserted differently and the walk is the same 328 documents.

```
everyLongAnswerThereIsJoinsBackUp   10.8s  →  0.15s
the class                           12.3s  →  0.9s
souther.compiler.doc                21.7s  →  12.9s
the compiler's suite, serial        74.5s  →  66.0s
its longest class      ALongAnswer 13.7s  →  CompileTotality 7.1s
```

## The build is the same length

54.3s before and after. The compiler module's floor fell from 13.7s to 7.1s and the whole of that is now hidden under souther-fmt's 24.9s, which is where the build's critical path has moved. That is a separate thing, and it is the formatter's own speed rather than anything about how the tests are arranged.
