### PR TITLE
The sweep asks the declaration before it asks the file

### DIFF
--- a/souther-fmt/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
@@ -81,13 +81,19 @@ class EveryDepartureFromTheCanonicalFormIsSomeRulesTest {
             String canonical = form.layout().text();
             List<String> lines = List.of(canonical.split("\n", -1));
             List<String> shapes = shapesOf(form, lines);
+            Declarations standing = Declarations.of(lines);
             for (int i = 0; i < lines.size(); i++) {
+                Map<String, String> locally = standing == null ? null : standing.written(i);
                 for (Map.Entry<String, String> m : written(lines, i).entrySet()) {
                     String text = m.getValue();
                     String shape = shapes.get(i);
                     if (text == null || text.equals(canonical)
                             || seen.contains(m.getKey() + " of " + shape)) {
                         continue;   // this shape is already among them, written this way
+                    }
+                    if (locally != null
+                            && !standing.admits(m.getKey(), locally.get(m.getKey()), i)) {
+                        continue;   // the declaration this line is in already answers no
                     }
                     // The parse is what says the grammar still admits it, and the formatter takes
                     // what it produced rather than the text it came from — the same answer without
@@ -106,6 +112,117 @@ class EveryDepartureFromTheCanonicalFormIsSomeRulesTest {
             }
         }
         return out;
+    }
+
+    /**
+     * A canonical form cut into the declarations it is made of, so that a line written differently
+     * is answered by the declaration it is in rather than by the whole file.
+     *
+     * <p>A candidate differs from its source in one line, and the formatter answers a module by
+     * answering each of its declarations: put back together, a declaration canonicalised on its own
+     * with the header in front is what stands there in the whole. So a declaration whose canonical
+     * form the change did not survive is a change the whole file will not survive either, and that
+     * is a smaller question — for the longest source here, one twenty-first of the text.
+     *
+     * <p>It is used to refuse and never to admit. What is kept is still decided by the whole file,
+     * so nothing here decides what a departure is; the only thing a mistake in it can do is drop a
+     * candidate, which the number of rows says.
+     */
+    private record Declarations(String header, List<List<String>> pieces, List<String> canonical,
+            List<Integer> opensAt) {
+
+        /**
+         * The declarations of {@code lines}: what opens at column zero under a blank line, and the
+         * header everything before the first of them.
+         */
+        static Declarations of(List<String> lines) {
+            List<Integer> opens = new ArrayList<>();
+            for (int i = 0; i < lines.size(); i++) {
+                String line = lines.get(i);
+                boolean opensOne = !line.isBlank() && !line.startsWith(" ")
+                        && !line.startsWith("module") && !line.startsWith("import");
+                if (opensOne && (i == 0 || lines.get(i - 1).isBlank())) {
+                    opens.add(i);
+                }
+            }
+            if (opens.size() < 2) {
+                return null;   // one declaration is the whole file, and there is nothing to save
+            }
+            String header = String.join("\n", lines.subList(0, opens.get(0)));
+            List<List<String>> pieces = new ArrayList<>();
+            List<String> canonical = new ArrayList<>();
+            for (int d = 0; d < opens.size(); d++) {
+                int to = d + 1 < opens.size() ? opens.get(d + 1) : lines.size();
+                List<String> piece = lines.subList(opens.get(d), to);
+                pieces.add(piece);
+                String alone = header + "\n" + String.join("\n", piece);
+                CstParser.Result parsed = CstParser.parse(alone);
+                // A declaration that will not stand on its own, or that the formatter writes
+                // differently when it does, is one this cannot answer for. Its own canonical form
+                // is recorded as absent and every candidate in it goes to the whole file.
+                canonical.add(parsed.errors().isEmpty()
+                        && Formatter.format(parsed.root()).equals(alone) ? alone : null);
+            }
+            return new Declarations(header, pieces, canonical, opens);
+        }
+
+        /** Which declaration line {@code i} is in, or -1 where this cannot answer for it. */
+        private int at(int i) {
+            for (int d = 0; d < opensAt.size(); d++) {
+                int from = opensAt.get(d);
+                int to = d + 1 < opensAt.size() ? opensAt.get(d + 1) : Integer.MAX_VALUE;
+                if (i >= from && i < to) {
+                    // The first line of a declaration and the last are where a blank line written
+                    // in and two lines run together reach the declaration next door, which is a
+                    // question about the file rather than about either of them.
+                    return canonical.get(d) == null ? -1 : d;
+                }
+            }
+            return -1;   // the header
+        }
+
+        /**
+         * Whether writing line {@code i} that way reaches the declaration after it.
+         *
+         * <p>Two of them do: a line run on into the next one, and a blank line written under it.
+         * Written under the last line of a declaration, both are about what stands between two of
+         * them, which is the file's question and not either declaration's. The rest write the line
+         * where it stands.
+         *
+         * <p>What this buys is the refusal below being sound rather than any row: filtering those
+         * two as well leaves this corpus with the same 481, since none of them is admitted here
+         * anyway. It is the local question being a part of the whole one that the refusal rests on,
+         * and for these two it is not.
+         */
+        private boolean reachesTheNextOne(String kind, int i, int d) {
+            int to = d + 1 < opensAt.size() ? opensAt.get(d + 1) : Integer.MAX_VALUE;
+            boolean last = i == to - 1;
+            return last && ("run on into the next line".equals(kind)
+                    || "with a blank line under it".equals(kind));
+        }
+
+        /** Line {@code i} written every way, inside its declaration alone. */
+        Map<String, String> written(int i) {
+            int d = at(i);
+            if (d < 0) {
+                return null;
+            }
+            List<String> piece = pieces.get(d);
+            return EveryDepartureFromTheCanonicalFormIsSomeRulesTest
+                    .written(piece, i - opensAt.get(d));
+        }
+
+        /** Whether {@code local} is still the declaration's canonical form, written that way. */
+        boolean admits(String kind, String local, int i) {
+            int d = at(i);
+            if (d < 0 || local == null || reachesTheNextOne(kind, i, d)) {
+                return true;   // nothing was asked, so nothing is refused
+            }
+            String alone = header + "\n" + local;
+            CstParser.Result parsed = CstParser.parse(alone);
+            return parsed.errors().isEmpty()
+                    && Formatter.format(parsed.root()).equals(canonical.get(d));
+        }
     }
 
     /**

--- a/souther-fmt/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
+++ b/souther-fmt/src/test/java/souther/compiler/fmt/EveryDepartureFromTheCanonicalFormIsSomeRulesTest.java
@@ -6,6 +6,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import souther.compiler.cst.CstParser;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -15,6 +21,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -336,6 +343,58 @@ class EveryDepartureFromTheCanonicalFormIsSomeRulesTest {
         assertTrue(report.whole(),
                 "what is named is not all of it: " + report.deviations() + "\n"
                         + departure.text());
+    }
+
+    /**
+     * These are the departures there are.
+     *
+     * <p>This class is the oracle the rules are held against, and the sweep that fills it now
+     * refuses a candidate on a smaller question than the one that decides it. A refusal that is
+     * wrong takes a departure out of the world, and every other check here would stay green while
+     * it did: the check below asks that each way of writing a line is among them somewhere, which
+     * one candidate of eight hundred answers for. An oracle made faster is an oracle that needs one.
+     *
+     * <p>So what it finds is written down — as the {@code kind of shape} pairs the sweep
+     * deduplicates by, which is the unit it covers in rather than a count, since a count is the
+     * same when one pair leaves and another arrives.
+     *
+     * <p>A pair that stops being found is something dropping a candidate. A pair that arrives is the
+     * canonical form having a shape it did not have. Both are for a reader to look at, and this file
+     * is where they say which it was.
+     */
+    @Test
+    void andTheseAreTheOnesThereAre() throws IOException {
+        List<String> found = new ArrayList<>();
+        departures().forEach(d -> found.add(d.kind() + " of " + d.shape()));
+        java.util.Collections.sort(found);
+
+        List<String> written = recorded();
+
+        List<String> gone = new ArrayList<>(written);
+        gone.removeAll(found);
+        List<String> arrived = new ArrayList<>(found);
+        arrived.removeAll(written);
+        assertEquals(written, found,
+                "no longer found (" + gone.size() + "): " + head(gone)
+                        + "\nnewly found (" + arrived.size() + "): " + head(arrived));
+    }
+
+    /** The first few of them, which is as much as a failure can usefully say. */
+    private static String head(List<String> some) {
+        return some.isEmpty() ? "none"
+                : String.join("\n  ", some.subList(0, Math.min(5, some.size())))
+                        + (some.size() > 5 ? "\n  … and " + (some.size() - 5) + " more" : "");
+    }
+
+    /** The pairs this sweep found when it was last looked at. */
+    private static List<String> recorded() throws IOException {
+        String resource = "every-departure-there-is.txt";
+        try (InputStream in = EveryDepartureFromTheCanonicalFormIsSomeRulesTest.class
+                .getResourceAsStream(resource)) {
+            assertNotNull(in, "the departures this sweep found are not beside it: " + resource);
+            return new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))
+                    .lines().toList();
+        }
     }
 
     /**

--- a/souther-fmt/src/test/resources/souther/compiler/fmt/every-departure-there-is.txt
+++ b/souther-fmt/src/test/resources/souther/compiler/fmt/every-departure-there-is.txt
@@ -1,0 +1,481 @@
+at no column at all of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+at no column at all of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / a group's own break at depth 3 and column 8
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / APPLY_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / CONSTRUCTS_CLAUSE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DEPENDS_CLAUSE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / ELSE_ARM / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_ROW / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / GUARD_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IF_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / INVARIANT_CLAUSE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / a group's own break at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LITERAL_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 3 and column 8
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 5 and column 16
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 3 and column 8
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 5 and column 16
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 4 and column 12
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 5 and column 16
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / TUPLE_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / VAR_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+at no column at all of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of a group's own break / APPLY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+at no column at all of a group's own break / APPLY_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of a group's own break / APPLY_EXPR / a group's own break at depth 2 and column 4
+at no column at all of a group's own break / APPLY_EXPR / a group's own break at depth 3 and column 8
+at no column at all of a group's own break / APPLY_EXPR / a group's own break at depth 4 and column 12
+at no column at all of a group's own break / BINARY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+at no column at all of a group's own break / FIELD_ACCESS / a group's own break at depth 3 and column 8
+at no column at all of a group's own break / IF_EXPR / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+at no column at all of a group's own break / INTRINSIC_BODY / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of a group's own break / LAMBDA_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+at no column at all of a group's own break / LAMBDA_EXPR / a group's own break at depth 3 and column 8
+at no column at all of a group's own break / LIST_EXPR / a group's own break at depth 3 and column 8
+at no column at all of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+at no column at all of a group's own break / TUPLE_EXPR / a group's own break at depth 3 and column 8
+at no column at all of a group's own break / VAR_EXPR / a group's own break at depth 3 and column 8
+at no column at all of a group's own break / VAR_EXPR / a group's own break at depth 4 and column 12
+at no column at all of a group's own break / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+at no column at all of a group's own break / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+at no column at all of a group's own break / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+at no column at all of a group's own break / no place / a group's own break at depth 3 and column 8
+one column back of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column back of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / a group's own break at depth 3 and column 8
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / APPLY_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / CONSTRUCTS_CLAUSE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DEPENDS_CLAUSE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / ELSE_ARM / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_ROW / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / GUARD_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IF_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / INVARIANT_CLAUSE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / a group's own break at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LITERAL_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 3 and column 8
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 5 and column 16
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 3 and column 8
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 5 and column 16
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 4 and column 12
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 5 and column 16
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / TUPLE_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / VAR_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+one column back of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of a group's own break / APPLY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column back of a group's own break / APPLY_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of a group's own break / APPLY_EXPR / a group's own break at depth 2 and column 4
+one column back of a group's own break / APPLY_EXPR / a group's own break at depth 3 and column 8
+one column back of a group's own break / APPLY_EXPR / a group's own break at depth 4 and column 12
+one column back of a group's own break / BINARY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column back of a group's own break / FIELD_ACCESS / a group's own break at depth 3 and column 8
+one column back of a group's own break / IF_EXPR / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+one column back of a group's own break / INTRINSIC_BODY / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of a group's own break / LAMBDA_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+one column back of a group's own break / LAMBDA_EXPR / a group's own break at depth 3 and column 8
+one column back of a group's own break / LIST_EXPR / a group's own break at depth 3 and column 8
+one column back of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column back of a group's own break / TUPLE_EXPR / a group's own break at depth 3 and column 8
+one column back of a group's own break / VAR_EXPR / a group's own break at depth 3 and column 8
+one column back of a group's own break / VAR_EXPR / a group's own break at depth 4 and column 12
+one column back of a group's own break / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column back of a group's own break / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+one column back of a group's own break / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column back of a group's own break / no place / a group's own break at depth 3 and column 8
+one column further in of A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS / nothing / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+one column further in of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+one column further in of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column further in of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+one column further in of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / a group's own break at depth 3 and column 8
+one column further in of A_FILE_ENDS_WITH_ONE_NEWLINE / nothing / the start of the file at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / APPLY_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / CONSTRUCTS_CLAUSE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DEPENDS_CLAUSE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / ELSE_ARM / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_ROW / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / a group's own break at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / GUARD_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IF_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / INVARIANT_CLAUSE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / a group's own break at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LITERAL_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 3 and column 8
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 5 and column 16
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 3 and column 8
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 5 and column 16
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 4 and column 12
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 5 and column 16
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / TUPLE_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / VAR_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 1 and column 0
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+one column further in of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of NOTHING_SHARES_A_COMMENTS_LINE / DATA_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+one column further in of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+one column further in of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+one column further in of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+one column further in of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / a group's own break at depth 1 and column 0
+one column further in of NOTHING_SHARES_A_COMMENTS_LINE / MODULE_HEADER / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+one column further in of NOTHING_SHARES_A_COMMENTS_LINE / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 1 and column 0
+one column further in of a group's own break / APPLY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column further in of a group's own break / APPLY_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of a group's own break / APPLY_EXPR / a group's own break at depth 2 and column 4
+one column further in of a group's own break / APPLY_EXPR / a group's own break at depth 3 and column 8
+one column further in of a group's own break / APPLY_EXPR / a group's own break at depth 4 and column 12
+one column further in of a group's own break / BINARY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column further in of a group's own break / FIELD_ACCESS / a group's own break at depth 3 and column 8
+one column further in of a group's own break / IF_EXPR / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+one column further in of a group's own break / INTRINSIC_BODY / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of a group's own break / LAMBDA_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+one column further in of a group's own break / LAMBDA_EXPR / a group's own break at depth 3 and column 8
+one column further in of a group's own break / LIST_EXPR / a group's own break at depth 3 and column 8
+one column further in of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+one column further in of a group's own break / TUPLE_EXPR / a group's own break at depth 3 and column 8
+one column further in of a group's own break / VAR_EXPR / a group's own break at depth 3 and column 8
+one column further in of a group's own break / VAR_EXPR / a group's own break at depth 4 and column 12
+one column further in of a group's own break / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+one column further in of a group's own break / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+one column further in of a group's own break / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+one column further in of a group's own break / no place / a group's own break at depth 3 and column 8
+one column further in of the start of the file / SOURCE_FILE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 0 and column 0
+one column further in of the start of the file / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 0 and column 0
+run on into the next line of A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS / nothing / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+run on into the next line of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+run on into the next line of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / a group's own break at depth 3 and column 8
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / APPLY_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / CONSTRUCTS_CLAUSE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DEPENDS_CLAUSE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / ELSE_ARM / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / a group's own break at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / GUARD_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IF_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / a group's own break at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LITERAL_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 5 and column 16
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 3 and column 8
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 5 and column 16
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 4 and column 12
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 5 and column 16
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / TUPLE_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / VAR_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+run on into the next line of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+run on into the next line of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+run on into the next line of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / a group's own break at depth 1 and column 0
+run on into the next line of NOTHING_SHARES_A_COMMENTS_LINE / MODULE_HEADER / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+run on into the next line of a group's own break / APPLY_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of a group's own break / APPLY_EXPR / a group's own break at depth 2 and column 4
+run on into the next line of a group's own break / APPLY_EXPR / a group's own break at depth 3 and column 8
+run on into the next line of a group's own break / APPLY_EXPR / a group's own break at depth 4 and column 12
+run on into the next line of a group's own break / FIELD_ACCESS / a group's own break at depth 3 and column 8
+run on into the next line of a group's own break / IF_EXPR / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+run on into the next line of a group's own break / INTRINSIC_BODY / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of a group's own break / LAMBDA_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+run on into the next line of a group's own break / LAMBDA_EXPR / a group's own break at depth 3 and column 8
+run on into the next line of a group's own break / LIST_EXPR / a group's own break at depth 3 and column 8
+run on into the next line of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+run on into the next line of a group's own break / TUPLE_EXPR / a group's own break at depth 3 and column 8
+run on into the next line of a group's own break / VAR_EXPR / a group's own break at depth 3 and column 8
+run on into the next line of a group's own break / VAR_EXPR / a group's own break at depth 4 and column 12
+run on into the next line of a group's own break / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+run on into the next line of a group's own break / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+run on into the next line of a group's own break / no place / a group's own break at depth 3 and column 8
+run on into the next line of the start of the file / SOURCE_FILE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 0 and column 0
+with a blank line under it of A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS / nothing / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a blank line under it of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a blank line under it of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a blank line under it of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a blank line under it of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / a group's own break at depth 3 and column 8
+with a blank line under it of A_FILE_ENDS_WITH_ONE_NEWLINE / nothing / the start of the file at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / APPLY_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / CONSTRUCTS_CLAUSE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DEPENDS_CLAUSE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / ELSE_ARM / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_ROW / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / a group's own break at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / GUARD_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IF_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / INVARIANT_CLAUSE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / a group's own break at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LITERAL_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 3 and column 8
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 5 and column 16
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 3 and column 8
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 5 and column 16
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 4 and column 12
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 5 and column 16
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / TUPLE_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / VAR_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 1 and column 0
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+with a blank line under it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a blank line under it of NOTHING_SHARES_A_COMMENTS_LINE / DATA_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a blank line under it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a blank line under it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a blank line under it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a blank line under it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / a group's own break at depth 1 and column 0
+with a blank line under it of NOTHING_SHARES_A_COMMENTS_LINE / MODULE_HEADER / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a blank line under it of NOTHING_SHARES_A_COMMENTS_LINE / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 1 and column 0
+with a blank line under it of a group's own break / APPLY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a blank line under it of a group's own break / APPLY_EXPR / a group's own break at depth 2 and column 4
+with a blank line under it of a group's own break / APPLY_EXPR / a group's own break at depth 3 and column 8
+with a blank line under it of a group's own break / APPLY_EXPR / a group's own break at depth 4 and column 12
+with a blank line under it of a group's own break / BINARY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a blank line under it of a group's own break / FIELD_ACCESS / a group's own break at depth 3 and column 8
+with a blank line under it of a group's own break / IF_EXPR / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a blank line under it of a group's own break / LAMBDA_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a blank line under it of a group's own break / LAMBDA_EXPR / a group's own break at depth 3 and column 8
+with a blank line under it of a group's own break / LIST_EXPR / a group's own break at depth 3 and column 8
+with a blank line under it of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a blank line under it of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a blank line under it of a group's own break / TUPLE_EXPR / a group's own break at depth 3 and column 8
+with a blank line under it of a group's own break / VAR_EXPR / a group's own break at depth 3 and column 8
+with a blank line under it of a group's own break / VAR_EXPR / a group's own break at depth 4 and column 12
+with a blank line under it of a group's own break / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a blank line under it of a group's own break / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a blank line under it of a group's own break / no place / a group's own break at depth 3 and column 8
+with a blank line under it of the start of the file / SOURCE_FILE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 0 and column 0
+with a blank line under it of the start of the file / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 0 and column 0
+with a space at the end of it of A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS / nothing / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space at the end of it of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space at the end of it of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space at the end of it of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space at the end of it of A_BRACKET_TAKES_A_LINE_OF_ITS_OWN / no place / a group's own break at depth 3 and column 8
+with a space at the end of it of A_FILE_ENDS_WITH_ONE_NEWLINE / nothing / the start of the file at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / APPLY_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / CONSTRUCTS_CLAUSE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DEPENDS_CLAUSE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / ELSE_ARM / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_ROW / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / a group's own break at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / GUARD_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IF_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / INVARIANT_CLAUSE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / a group's own break at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LITERAL_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 3 and column 8
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 5 and column 16
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 3 and column 8
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 5 and column 16
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 4 and column 12
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 5 and column 16
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / TUPLE_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / VAR_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 1 and column 0
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+with a space at the end of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of NOTHING_SHARES_A_COMMENTS_LINE / DATA_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space at the end of it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space at the end of it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space at the end of it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space at the end of it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / a group's own break at depth 1 and column 0
+with a space at the end of it of NOTHING_SHARES_A_COMMENTS_LINE / MODULE_HEADER / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space at the end of it of NOTHING_SHARES_A_COMMENTS_LINE / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 1 and column 0
+with a space at the end of it of a group's own break / APPLY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space at the end of it of a group's own break / APPLY_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of a group's own break / APPLY_EXPR / a group's own break at depth 2 and column 4
+with a space at the end of it of a group's own break / APPLY_EXPR / a group's own break at depth 3 and column 8
+with a space at the end of it of a group's own break / APPLY_EXPR / a group's own break at depth 4 and column 12
+with a space at the end of it of a group's own break / BINARY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space at the end of it of a group's own break / FIELD_ACCESS / a group's own break at depth 3 and column 8
+with a space at the end of it of a group's own break / IF_EXPR / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a space at the end of it of a group's own break / INTRINSIC_BODY / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of a group's own break / LAMBDA_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space at the end of it of a group's own break / LAMBDA_EXPR / a group's own break at depth 3 and column 8
+with a space at the end of it of a group's own break / LIST_EXPR / a group's own break at depth 3 and column 8
+with a space at the end of it of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space at the end of it of a group's own break / TUPLE_EXPR / a group's own break at depth 3 and column 8
+with a space at the end of it of a group's own break / VAR_EXPR / a group's own break at depth 3 and column 8
+with a space at the end of it of a group's own break / VAR_EXPR / a group's own break at depth 4 and column 12
+with a space at the end of it of a group's own break / no place / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space at the end of it of a group's own break / no place / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a space at the end of it of a group's own break / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space at the end of it of a group's own break / no place / a group's own break at depth 3 and column 8
+with a space at the end of it of the start of the file / SOURCE_FILE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 0 and column 0
+with a space at the end of it of the start of the file / a comment / NOTHING_SHARES_A_COMMENTS_LINE at depth 0 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / APPLY_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / BEHAVIOR_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / CONSTRUCTS_CLAUSE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DATA_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / DEPENDS_CLAUSE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / ELSE_ARM / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_ROW / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FN_DEF / a group's own break at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / GUARD_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IF_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / IMPORT_DECL / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / INVARIANT_CLAUSE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / a group's own break at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_STMT / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 3 and column 8
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 5 and column 16
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 3 and column 8
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 5 and column 16
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 4 and column 12
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 5 and column 16
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / TUPLE_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+with a space doubled in it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of NOTHING_SHARES_A_COMMENTS_LINE / DATA_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space doubled in it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space doubled in it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 1 and column 0
+with a space doubled in it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 1 and column 0
+with a space doubled in it of NOTHING_SHARES_A_COMMENTS_LINE / FN_DEF / a group's own break at depth 1 and column 0
+with a space doubled in it of NOTHING_SHARES_A_COMMENTS_LINE / MODULE_HEADER / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 1 and column 0
+with a space doubled in it of a group's own break / APPLY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space doubled in it of a group's own break / APPLY_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of a group's own break / BINARY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space doubled in it of a group's own break / IF_EXPR / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a space doubled in it of a group's own break / INTRINSIC_BODY / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of a group's own break / LAMBDA_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space doubled in it of a group's own break / LAMBDA_EXPR / a group's own break at depth 3 and column 8
+with a space doubled in it of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of a group's own break / MATCH_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space doubled in it of a group's own break / TUPLE_EXPR / a group's own break at depth 3 and column 8
+with a space doubled in it of a group's own break / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space doubled in it of the start of the file / SOURCE_FILE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 0 and column 0
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / APPLY_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / ELSE_ARM / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / EXAMPLE_ROW / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 2 and column 4
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / FAKE_ROW / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / LET_DESTRUCTURE / a group's own break at depth 2 and column 4
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 3 and column 8
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 5 and column 16
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / A_FILE_ENDS_WITH_ONE_NEWLINE at depth 3 and column 8
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 4 and column 12
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 5 and column 16
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 4 and column 12
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / MATCH_CASE / a group's own break at depth 5 and column 16
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / TUPLE_EXPR / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 4 and column 12
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / A_BRACKET_TAKES_A_LINE_OF_ITS_OWN at depth 2 and column 4
+with a space taken out of it of MEMBERS_TAKE_LINES_OF_THEIR_OWN / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space taken out of it of a group's own break / APPLY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space taken out of it of a group's own break / APPLY_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space taken out of it of a group's own break / BINARY_EXPR / A_BLANK_LINE_SEPARATES_TOP_LEVEL_ITEMS at depth 2 and column 4
+with a space taken out of it of a group's own break / INTRINSIC_BODY / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4
+with a space taken out of it of a group's own break / LAMBDA_EXPR / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 3 and column 8
+with a space taken out of it of a group's own break / LAMBDA_EXPR / a group's own break at depth 3 and column 8
+with a space taken out of it of a group's own break / TUPLE_EXPR / a group's own break at depth 3 and column 8
+with a space taken out of it of a group's own break / no place / MEMBERS_TAKE_LINES_OF_THEIR_OWN at depth 2 and column 4


### PR DESCRIPTION
`EveryDepartureFromTheCanonicalFormIsSomeRulesTest` is the longest class in the build. This is where its time went and what it costs now.

## The sweep was quadratic in a source's length

It writes one line of a canonical form differently and asks whether the result canonicalises back. There is a candidate per line, and it asked the question of the whole file each time — so over one source the work is its lines times its length.

The corpus shows it. Measured per source, with the shape bookkeeping the sweep really uses:

```
chars   ms     rows
14527   6328   129
 6300   1027    26
 7999    626     0
 3242    454    66
 1940     39     0
```

The longest source is 67% of a 9.4s sweep for 27% of its 481 rows: 49ms a row, against 6.9ms for the source at a fifth its size. Not because it is worse text — because the same candidate costs more there.

Formatting itself is linear (a source written out 1×, 2×, 4×, 8× costs 18.5ms, 31ms, 60ms, 116ms) and has no hot spot to find: `build` 46% — of which walking the tree is 19%, ordering the places 10%, assigning carriers 16% — `layout` 24%, `resolve` 15%. Six passes over a document, each worth a fifth of it. The quadratic is in the sweep, not under it.

## A declaration is a part of the file, and the formatter treats it as one

Cut a canonical form at its top-level declarations, canonicalise each on its own with the module header in front, and what comes back is what stood there. For every source in this corpus:

```
14527 chars   21 declarations   21 unchanged
 7999          11                11
 6300          12                12
 3242           6                 6
```

So a change inside one declaration that its own canonical form does not survive is one the whole file will not survive either. That is a smaller question — for the longest source, a twenty-first of the text — and it is asked first.

## It refuses, and never admits

```
1,925 candidates
  1,506 asked of their declaration    616ms    1,060 refused
    865 asked of the whole file     3,376ms      481 kept
```

Of the 865 held to the whole file, **97 pass their declaration and fail the file**. The local question is a part of the whole one, not the same question, so what is kept is still decided where it always was. Had the filter been trusted to admit as well as refuse, those 97 would have become rows that are not departures.

Two of the ways a line is written reach the declaration after it — run on into the next line, and a blank line under it — and under a declaration's last line both are about what stands between two of them. Those go straight to the whole file. That is what makes the refusal sound rather than what earns a row: filtering them as well leaves this corpus with the same 481, checked.

## An oracle made faster needs one

The sweep is what the rules are held against, and it now refuses a candidate on a smaller question than the one that decides it. A refusal that is wrong takes a departure out of the world, and nothing here said so: the completeness check asks that each of the eight ways of writing a line is among them somewhere, which one candidate in a hundred answers for, and no check counted what was found. The first commit's comment claiming the number of rows would say it was writing about a number nothing reads.

So the pairs are written down — `kind of shape`, which is the unit the sweep deduplicates by, rather than a count that stays the same when one pair leaves and another arrives. A pair that stops being found is something dropping a candidate; a pair that arrives is the canonical form having a shape it did not have. The failure names which and lists the first few, and the file is where a reader records what they decided.

Inverting the declaration's answer, so that it refuses what it should admit, takes 327 pairs away and this says so. Filtering the two ways that reach the next declaration takes none, which is why they are guarded for soundness rather than for a row.

## What it costs now

```
the class          22.49 / 22.72 / 22.52 s   →   17.26 / 17.37 / 17.28 s
souther-fmt                        24.9 s    →   22.2 s
rows                                 481     →     481
```

Three runs each side. Nothing is asserted differently, and the sweep still ends at the whole file.

## What was measured and not done

Making the formatter faster would take fusing its passes, and none of them is big enough on its own to be worth that on a formatter whose rules are written down.

Remembering which `(kind, shape)` pairs already failed makes the sweep three times faster and comes back with 478 rows instead of 481 — a shape is coarser than what the grammar admits, so the same one is refused on one line and taken on another. That is what leaving it to be met again is for, and it stays.
