### PR TITLE
Point an argument's type mismatch at the argument

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -2,6 +2,7 @@ package souther.compiler;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.check.CallElaborator;
+import souther.compiler.check.Elaborator;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
 import souther.compiler.observe.Limits;
@@ -974,7 +975,7 @@ public final class FixtureReader {
             if (c.args().size() != 1 || !(c.args().get(0) instanceof Ast.StringLit lit)) {
                 throw new FixtureException("`" + c.written() + "` takes one written string");
             }
-            return CallElaborator.parseTemporal(c.written(), lit.value(), c.pos());
+            return CallElaborator.parseTemporal(c.written(), lit.value(), Elaborator.region(lit));
         }
         if (!neutral.isNewtype(c.written())) {
             String reached = helperKey(c);

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -162,6 +162,7 @@ public final class CallElaborator {
             arity(call, params.size());
         }
         Map<String, Type> bind = settledByValues(call, params, kept.result(), expected, ca::type, ctx);
+        requireValueArgs(call, params, ca, bind);
         for (int i = 0; i < params.size(); i++) {
             if (params.get(i) instanceof Type.FnOf declared) {
                 Type.FnOf at = (Type.FnOf) TypeOps.substitute(declared, bind);
@@ -172,12 +173,6 @@ public final class CallElaborator {
                 // kept because its meaning belongs to whoever reads it, not to this.
                 TypeOps.unify(declared.result(), answered, bind, ctx.symbols(),
                         call.pos(), "argument " + (i + 1) + " of " + call.written());
-            }
-        }
-        for (int i = 0; i < params.size(); i++) {
-            if (!(params.get(i) instanceof Type.FnOf)) {
-                ca.requireTyped(i, TypeOps.substitute(params.get(i), bind),
-                        "argument " + (i + 1) + " of " + call.written());
             }
         }
         return new Core.PreservedCall(call.denotes(), ca.cores(),
@@ -412,15 +407,22 @@ public final class CallElaborator {
      *       bound from the context before the step is checked (issue #70). With no function
      *       argument nothing waits, and pinning anyway would answer an argument mismatch against
      *       the type the context wanted rather than the one the declaration asks for;</li>
-     *   <li>type the value arguments and unify each with its declared parameter;</li>
+     *   <li>type the value arguments, settle what they say of the signature's variables, and
+     *       require each of them against the parameter it was given to;</li>
      *   <li>type the function arguments last, against parameter types the earlier arguments
      *       settled. A failure that is genuinely an empty-collection seed nothing typed — one that
      *       reported the unresolved bottom — is re-pointed at the seed rather than at the
      *       arithmetic the bottom reached; an unrelated error in the step is rethrown untouched
      *       (issue #70);</li>
-     *   <li>require each value argument against its settled parameter type, and substitute into
-     *       the declared result.</li>
+     *   <li>substitute into the declared result.</li>
      * </ol>
+     *
+     * <p>The value arguments are required before a function argument is typed because a function
+     * argument is typed against what they settled. Where one of them does not fit, what the
+     * signature says the function takes was worked out from a type the call does not have — and a
+     * body checked against that reports something wrong with the block, which is the reader's cue
+     * to look at a block that is not the problem. Held in the other order, {@code List.sortBy(x ->
+     * String.length(x), n)} on an {@code n} that is no list answers about {@code String.length}.
      *
      * <p>Arity is the caller's to check first, in its own words; this throws where the two
      * disagree rather than walking off the shorter list.
@@ -434,6 +436,7 @@ public final class CallElaborator {
         }
         Map<String, Type> bind = settledByValues(call, signature.params(), signature.result(),
                 expected, ca::type, ctx);
+        requireValueArgs(call, signature.params(), ca, bind);
         try {
             for (int i = 0; i < args.size(); i++) {
                 if (signature.params().get(i) instanceof Type.FnOf declaredStep) {
@@ -453,14 +456,20 @@ public final class CallElaborator {
             }
             throw CompileException.of(b.say(new NameMessage.TheElementTypeCannotBeInferredHere()).build());
         }
-        for (int i = 0; i < args.size(); i++) {
-            Type param = signature.params().get(i);
+        return new Applied(TypeOps.substitute(signature.result(), bind), bind);
+    }
+
+    /** Each value argument held to the parameter it was given to, at its own position — the
+     * refusal {@link #settledByValues} leaves to whoever has the argument in hand. */
+    private static void requireValueArgs(Ast.Apply call, List<Type> params, CallArgs ca,
+                                         Map<String, Type> bind) {
+        for (int i = 0; i < params.size(); i++) {
+            Type param = params.get(i);
             if (!(param instanceof Type.FnOf)) {
                 ca.requireTyped(i, TypeOps.substitute(param, bind),
                         "argument " + (i + 1) + " of " + call.written());
             }
         }
-        return new Applied(TypeOps.substitute(signature.result(), bind), bind);
     }
 
     static Type typeOfCall(CallArgs ca, Ast.Apply call, Scope env, CheckContext ctx, Type expected) {

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -5,6 +5,7 @@ import souther.compiler.ast.Ast;
 import souther.compiler.core.Core;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.Region;
 import souther.compiler.diag.msg.DeclarationMessage;
 import souther.compiler.diag.msg.DataMessage;
 import souther.compiler.diag.msg.NameMessage;
@@ -233,9 +234,12 @@ public final class CallElaborator {
             (Type.mentions(stated[i], BottomInfer::answersNoValue) ? bottoms : stating).add(i);
         }
         stating.addAll(bottoms);
+        // What an argument settles, and not whether it fits: that is required of each argument once
+        // the substitution is complete, and required there because that is where the argument itself
+        // is in hand. A refusal from here would name the argument in words and point at the callee,
+        // the two being as far apart as an argument list is long.
         for (int i : stating) {
-            TypeOps.unify(params.get(i), stated[i], bind, ctx.symbols(),
-                    call.pos(), "argument " + (i + 1) + " of " + call.written());
+            TypeOps.bindVars(params.get(i), stated[i], bind, ctx.symbols());
         }
         return bind;
     }
@@ -686,20 +690,22 @@ public final class CallElaborator {
             throw CompileException.of(Diagnostic
                             .at(call.name().region()).say(new TypeMessage.ATemporalTakesAWrittenString(call.written())).build());
         }
-        parseTemporal(call.written(), lit.value(), call.pos());
+        parseTemporal(call.written(), lit.value(), Elaborator.region(lit));
         return isDate ? Type.DATE : Type.DATETIME;
     }
 
-    /** Parses a written temporal, reporting a malformed one against {@code pos}. Returns the parsed
-     * value so the backend and the example verifier share this one reading of the text. */
-    public static Object parseTemporal(String fn, String text, SourcePos pos) {
+    /** Parses a written temporal, reporting a malformed one against {@code at} — the text the
+     * message quotes, which is the part of the form a reader cannot work out from the message.
+     * Returns the parsed value so the backend and the example verifier share this one reading of
+     * the text. */
+    public static Object parseTemporal(String fn, String text, Region at) {
         try {
             return fn.equals("Date")
                     ? java.time.LocalDate.parse(text)
                     : java.time.LocalDateTime.parse(text);
         } catch (java.time.format.DateTimeParseException _) {
             throw CompileException.of(Diagnostic
-                            .at(pos, fn.length()).say(new TypeMessage.ThatIsNotATemporalOfThatKind(fn, text)).build());
+                            .at(at).say(new TypeMessage.ThatIsNotATemporalOfThatKind(fn, text)).build());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -609,6 +609,24 @@ public final class TypeOps {
      */
     public static void unify(Type param, Type arg, Map<String, Type> bindings,
                              Symbols symbols, SourcePos pos, String what) {
+        unify(param, arg, bindings, symbols, pos, what, true);
+    }
+
+    /**
+     * What {@code arg} settles of the variables {@code param} carries, refusing nothing.
+     *
+     * <p>For a caller that requires each argument afterwards, against the parameter type this walk
+     * settled and at the argument's own position. Refusing here as well would answer the same
+     * mismatch twice, and this reading is the one with no argument in its hands: it is given two
+     * types and the position of the call they belong to, so the caret it can offer is the callee's
+     * — which is the one part of the line a reader has already been told is not the problem.
+     */
+    public static void bindVars(Type param, Type arg, Map<String, Type> bindings, Symbols symbols) {
+        unify(param, arg, bindings, symbols, null, null, false);
+    }
+
+    private static void unify(Type param, Type arg, Map<String, Type> bindings,
+                              Symbols symbols, SourcePos pos, String what, boolean refusing) {
         switch (param) {
             case Type.Var v -> {
                 Type bound = bindings.get(v.name());
@@ -619,36 +637,37 @@ public final class TypeOps {
                     bindings.put(v.name(), arg);
                 } else if (arg == Type.NOTHING) {
                     // the empty bottom absorbs into the concrete binding already learned
-                } else if (!assignable(arg, bound, symbols) && !assignable(bound, arg, symbols)) {
+                } else if (refusing && !assignable(arg, bound, symbols)
+                        && !assignable(bound, arg, symbols)) {
                     throw CompileException.of(Diagnostic
                                     .at(pos)
                                     .diff(Type.show(arg, bound), Type.show(bound, arg)).say(new TypeMessage.ItExpectedOneTypeAndGotAnother(what, Type.show(bound), Type.show(arg))).build());
                 }
             }
             case Type.ListOf p when arg instanceof Type.ListOf a ->
-                    unify(p.element(), a.element(), bindings, symbols, pos, what);
+                    unify(p.element(), a.element(), bindings, symbols, pos, what, refusing);
             case Type.MapOf p when arg instanceof Type.MapOf a -> {
-                unify(p.key(), a.key(), bindings, symbols, pos, what);
-                unify(p.value(), a.value(), bindings, symbols, pos, what);
+                unify(p.key(), a.key(), bindings, symbols, pos, what, refusing);
+                unify(p.value(), a.value(), bindings, symbols, pos, what, refusing);
             }
             case Type.SetOf p when arg instanceof Type.SetOf a ->
-                    unify(p.element(), a.element(), bindings, symbols, pos, what);
+                    unify(p.element(), a.element(), bindings, symbols, pos, what, refusing);
             case Type.OptionOf p when arg instanceof Type.OptionOf a ->
-                    unify(p.element(), a.element(), bindings, symbols, pos, what);
+                    unify(p.element(), a.element(), bindings, symbols, pos, what, refusing);
             case Type.TupleOf p when arg instanceof Type.TupleOf a
                     && p.elements().size() == a.elements().size() -> {
                 for (int i = 0; i < p.elements().size(); i++) {
-                    unify(p.elements().get(i), a.elements().get(i), bindings, symbols, pos, what);
+                    unify(p.elements().get(i), a.elements().get(i), bindings, symbols, pos, what, refusing);
                 }
             }
             case Type.FnOf p when arg instanceof Type.FnOf a && p.params().size() == a.params().size() -> {
                 for (int i = 0; i < p.params().size(); i++) {
-                    unify(p.params().get(i), a.params().get(i), bindings, symbols, pos, what);
+                    unify(p.params().get(i), a.params().get(i), bindings, symbols, pos, what, refusing);
                 }
-                unify(p.result(), a.result(), bindings, symbols, pos, what);
+                unify(p.result(), a.result(), bindings, symbols, pos, what, refusing);
             }
             default -> {
-                if (!assignable(arg, param, symbols)) {
+                if (refusing && !assignable(arg, param, symbols)) {
                     throw CompileException.of(Diagnostic
                                     .at(pos)
                                     .diff(Type.show(arg, param), Type.show(param, arg)).say(new TypeMessage.ItExpectedOneTypeAndGotAnother(what, Type.show(param), Type.show(arg))).build());

--- a/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImportedNameTest.java
@@ -137,7 +137,7 @@ class CompileImportedNameTest {
                 behavior go : (i: In) -> Out constructs Out
                 let go (i) = Out { t = trim(i.n) }
                 """));
-        assertTrue(e.getMessage().contains("of trim:"), e.getMessage());
+        assertTrue(e.getMessage().contains("argument 1 of trim "), e.getMessage());
         assertTrue(!e.getMessage().contains("String.trim"), e.getMessage());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/check/ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest.java
@@ -18,10 +18,10 @@ import souther.compiler.diag.Region;
  * its arguments are written from its callee, so the two can be a page apart. What the reader cannot
  * recover from the message is the operand, and that is what the caret is for.
  *
- * <p>Which region a report gets is not decided by its code. Three paths type a call — a kernel
- * applied against its declared signature, a helper expanded, a behavior called by name — and two of
- * them already answer with the argument. The rows below hold all three to one rule, so a path added
- * later is held to it too.
+ * <p>Which region a report gets is not decided by its code. The rows below cover the three paths a
+ * call written in a body is typed by — a kernel applied against its declared signature, a helper
+ * expanded, a behavior called by name — which answered three different ways for one code and one
+ * kind of failure. They are the paths that exist now; a fourth is not held to anything here.
  */
 class ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest {
 
@@ -57,6 +57,32 @@ class ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest {
 
         assertEquals("String.length", underlined(source, regionOf(source)),
                 "argument 2 is `String.length(b)` on line 8, not the callee on line 6");
+    }
+
+    /**
+     * A block is typed against what the value arguments settled, so a value argument that does not
+     * fit is refused before the block is reached.
+     *
+     * <p>Otherwise the block is checked against a parameter type worked out from a type the call
+     * does not have, and what it reports is something wrong inside the block — which is a second
+     * wrong place to send the reader, and one the message does not even name the argument in.
+     */
+    @Test
+    void aValueArgumentIsRefusedBeforeTheBlockThatWasTypedFromIt() {
+        String source = """
+                module demo
+
+                behavior sorted : (n: Int) -> List<Int>
+
+                let sorted (n) =
+                    List.sortBy(
+                        x -> String.length(x),
+                        n
+                    )
+                """;
+
+        assertEquals("n", underlined(source, regionOf(source)),
+                "`n` is what does not fit; `String.length(x)` is a block typed from it");
     }
 
     /** A helper is expanded rather than applied, and answers with the argument already. */

--- a/souther-compiler/src/test/java/souther/compiler/check/ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest.java
@@ -1,0 +1,121 @@
+package souther.compiler.check;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Region;
+
+/**
+ * A report about a value that did not fit points at the value, not at the form that asked for it.
+ *
+ * <p>The message names the operand in words — {@code argument 2 of String.append}, the text a
+ * temporal was written as — and a reader who has the message still has to find the operand. Where
+ * the caret sits under the form, that search crosses lines: an argument list has no bound on how far
+ * its arguments are written from its callee, so the two can be a page apart. What the reader cannot
+ * recover from the message is the operand, and that is what the caret is for.
+ *
+ * <p>Which region a report gets is not decided by its code. Three paths type a call — a kernel
+ * applied against its declared signature, a helper expanded, a behavior called by name — and two of
+ * them already answer with the argument. The rows below hold all three to one rule, so a path added
+ * later is held to it too.
+ */
+class ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest {
+
+    /** The text {@code region} underlines, cut out of {@code source}. */
+    private static String underlined(String source, Region region) {
+        String line = source.split("\n", -1)[region.start().line() - 1];
+        int from = region.start().column() - 1;
+        int to = region.end().line() == region.start().line()
+                ? region.end().column() - 1 : line.length();
+        return line.substring(Math.min(from, line.length()), Math.min(to, line.length()));
+    }
+
+    private static Region regionOf(String source) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(source));
+        return e.diagnostic().region();
+    }
+
+    /** The argument is written three lines below the callee, so nothing but the argument's own
+     *  position puts the caret on a line the reader has to look at. */
+    @Test
+    void aKernelsArgumentIsUnderlinedWhereItIsWritten() {
+        String source = """
+                module demo
+
+                behavior notice : (a: String, b: String) -> String
+
+                let notice (a, b) =
+                    String.append(
+                        a,
+                        String.length(b)
+                    )
+                """;
+
+        assertEquals("String.length", underlined(source, regionOf(source)),
+                "argument 2 is `String.length(b)` on line 8, not the callee on line 6");
+    }
+
+    /** A helper is expanded rather than applied, and answers with the argument already. */
+    @Test
+    void anExpandedHelpersArgumentIsPointedAtWhereItIsWritten() {
+        String source = """
+                module demo
+
+                let shout (s: String): String = s
+
+                behavior notice : (a: String) -> String
+
+                let notice (a) =
+                    shout(
+                        String.length(a)
+                    )
+                """;
+
+        assertEquals(9, regionOf(source).start().line(),
+                "the argument is on line 9 and the callee on line 8");
+    }
+
+    /** A behavior is called against what it declares, and answers with the argument already. */
+    @Test
+    void aCalledBehaviorsArgumentIsUnderlinedWhereItIsWritten() {
+        String source = """
+                module demo
+
+                behavior shout : (s: String) -> String
+
+                behavior notice : (x: String) -> String
+                    depends on shout
+
+                let notice (x, shout) =
+                    shout(
+                        String.length(x)
+                    )
+                """;
+
+        assertEquals("String.length", underlined(source, regionOf(source)),
+                "argument 1 is `String.length(x)` on line 10, not the callee on line 9");
+    }
+
+    /** The text that would not parse is what the message quotes, so it is what the caret covers. */
+    @Test
+    void aTemporalThatWouldNotParseIsUnderlinedAtTheTextItWasWrittenAs() {
+        String source = """
+                module demo
+
+                data Out = { on: Date }
+
+                behavior closedOn : (n: Int) -> Out constructs Out
+
+                let closedOn (n) = Out {
+                    on = Date("2026-02-30")
+                }
+                """;
+
+        assertEquals("\"2026-02-30\"", underlined(source, regionOf(source)),
+                "the message quotes `2026-02-30`, so the caret covers it rather than `Date`");
+    }
+}


### PR DESCRIPTION
Closes #605.

An argument whose type did not fit was reported with the caret under the callee, so on a call written down the page the message named `argument 2` and the region named line 6.

## Where the region came from

Not from the diagnostic code, and not from the kind of failure. Three paths type a call, and each answered differently:

| written | path | region |
|---|---|---|
| `String.append(a, String.length(b))` | `settledByValues` → `TypeOps.unify`, at `call.pos()` | callee |
| `shout(String.length(a))`, a helper | `Substitution.hold` | argument |
| `shout(...)`, a behavior called by name | `CallArgs.require` → `Elaborator.requireType` | argument |

Two of the three already point at the argument. The third does not because `settledByValues` — the walk that settles the signature's type variables — refuses as well, and it is handed two types and the position of the call. The argument survives only as the words in the `what` string.

The check it refuses with is one `applySignature` runs again three lines later: `requireTyped` requires each non-function argument against the parameter type the walk settled, at the argument's own position. That one never ran.

## What changed

`TypeOps.bindVars` settles variables and refuses nothing; `settledByValues` calls it. The refusal stays where the argument is in hand.

`parseTemporal` takes a `Region` rather than a `SourcePos`, and its two callers pass the literal's. The message quotes the text, so the caret covers the text.

```
8|         String.length(b)
           ^^^^^^^^^^^^^

argument 2 of String.append does not have the type it needs here.
```

```
8|     on = Date("2026-02-30")
                 ^^^^^^^^^^^^

`2026-02-30` is not a Date.
```

## What it does not change

The set of programs refused. `requireTyped` runs the same `assignable` on the settled parameter type for every non-function parameter. `unify`'s variable branch is the one asymmetry — it checks both directions where `requireTyped` checks one — and the case it admits is one `requireTyped` already rejects today.

E1318 is left alone. Which of two elements is the offending one is a question the list rule has to answer first, and the message currently declines to ("One element is String and another is Int").

The caret covers `String.length`, not `String.length(b)`: `Ast.Apply` carries a start position and no end, so the whole call is not a region anything can name yet. The frontend has it — a CST node answers `start()` and `end()`, and `AstBuilder` reads only the start — so carrying it is a change of its own.

## Tests

`ADiagnosticPointsAtTheOperandThatSuppliedTheValueTest` holds all three call paths and the temporal to one rule. The kernel and temporal rows were red before this change; the helper and behavior rows were green before it and are the positive control that the rows are not empty probes.

`CompileImportedNameTest` asserted `of trim:`, the colon belonging to the sentence this no longer reaches. It now asserts `argument 1 of trim `, and its point — that the report quotes `trim` and not `String.trim` — is unchanged.

`mvn clean install` is green across the reactor: souther-compiler 3893, souther-fmt 2190, souther-lsp 202, souther-syntax 87, souther-runtime 109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
