### PR TITLE
Stop a condition once its answer is settled

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/ConstEval.java
@@ -71,6 +71,14 @@ public final class ConstEval {
 
     private static Optional<Object> binary(Ast.Binary bin) {
         Optional<Object> l = eval(bin.left());
+        // `&&` and `||` settle on their left operand, and what settles them is the answer whatever
+        // the right operand is. Read eagerly, a right operand this cannot fold would take a settled
+        // condition down with it — so a construction the language calls constant would be checked
+        // where it was written one way and not the other.
+        if (l.orElse(null) instanceof Boolean settled
+                && (bin.op() == Ast.BinOp.AND && !settled || bin.op() == Ast.BinOp.OR && settled)) {
+            return Optional.of(settled);
+        }
         Optional<Object> r = eval(bin.right());
         if (l.isEmpty() || r.isEmpty()) {
             return Optional.empty();

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -1611,15 +1611,32 @@ final class BodyGen {
 
         private void binary(Core.Binary bin) {
             switch (bin.op()) {
+                // Left to right, stopping as soon as the answer is settled. Not an optimisation:
+                // `/` aborts on a zero divisor and `Int` overflows, so a left operand is how the
+                // domain the right one is evaluated in gets narrowed, and `x /= 0 && 100 / x > 1`
+                // is a guard or it is nothing. `iand` and `ior` are the eager conjunction of two
+                // booleans, which is a different operator from the one the language has.
                 case AND -> {
                     genExpr(bin.left());
+                    Label settled = code.newLabel();
+                    Label end = code.newLabel();
+                    code.ifeq(settled);
                     genExpr(bin.right());
-                    code.iand();
+                    code.goto_(end);
+                    code.labelBinding(settled);
+                    code.iconst_0();
+                    code.labelBinding(end);
                 }
                 case OR -> {
                     genExpr(bin.left());
+                    Label settled = code.newLabel();
+                    Label end = code.newLabel();
+                    code.ifne(settled);
                     genExpr(bin.right());
-                    code.ior();
+                    code.goto_(end);
+                    code.labelBinding(settled);
+                    code.iconst_1();
+                    code.labelBinding(end);
                 }
                 // `+ - * /` work on two Int or two Decimal operands (spec
                 // §an-operator-takes-the-types-it-is-defined-for). Int aborts on overflow, and `/` aborts on

--- a/souther-compiler/src/test/java/souther/compiler/AConditionStopsWhenItsAnswerIsSettledTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AConditionStopsWhenItsAnswerIsSettledTest.java
@@ -1,0 +1,60 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@code &&} and {@code ||} evaluate left to right and stop as soon as the answer is settled.
+ *
+ * <p>Which operands run is part of what the operators mean here rather than a choice a backend may
+ * make. Souther has operations that abort — {@code /} on a zero divisor, {@code Int} overflow — so a
+ * left operand is how the domain the right one is evaluated in gets narrowed, and the two strategies
+ * are told apart by whether a program answers at all.
+ *
+ * <p>Which makes {@code x /= 0 && 100 / x > 1} the shape this is about. Evaluated eagerly it is not a
+ * guard at all: the division it exists to make safe runs anyway, and the only way to write the rule
+ * is an {@code if} where a condition was wanted.
+ */
+class AConditionStopsWhenItsAnswerIsSettledTest {
+
+    private static final String CALC = """
+            module demo
+            data N = Int
+            behavior calc : (n: N) -> N constructs N
+            let calc (n) = N { value = %s }
+            """;
+
+    private Object run(String module, long input) throws Exception {
+        BytesClassLoader loader =
+                new BytesClassLoader(Compiler.compile(module), getClass().getClassLoader());
+        Object in = Codecs.decoded(loader, "demo.N", input);
+        Object b = loader.loadClass("demo.Calc$Impl").getDeclaredConstructor().newInstance();
+        return Codecs.encode(loader, "demo.N", Codecs.apply(b, in));
+    }
+
+    /** A false left operand settles a conjunction, so nothing on the right is evaluated. */
+    @Test
+    void aFalseLeftOperandSettlesAConjunction() throws Exception {
+        String source = CALC.formatted("if n.value /= 0 && 100 / n.value > 1 then 1 else 0");
+
+        assertEquals(0L, run(source, 0L));
+    }
+
+    /** A true left operand settles a disjunction. */
+    @Test
+    void aTrueLeftOperandSettlesADisjunction() throws Exception {
+        String source = CALC.formatted("if n.value == 0 || 100 / n.value > 1 then 1 else 0");
+
+        assertEquals(1L, run(source, 0L));
+    }
+
+    /** And where the answer is not settled, the right operand is evaluated as ever. */
+    @Test
+    void anUnsettledConditionStillEvaluatesTheRight() throws Exception {
+        assertEquals(1L, run(CALC.formatted("if n.value /= 0 && 100 / n.value > 1 then 1 else 0"), 5L));
+        assertEquals(0L, run(CALC.formatted("if n.value /= 0 && 100 / n.value > 1 then 1 else 0"), 200L));
+        assertEquals(0L, run(CALC.formatted("if n.value == 0 || 100 / n.value > 1 then 1 else 0"), 200L));
+        assertEquals(1L, run(CALC.formatted("if n.value == 0 || 100 / n.value > 1 then 1 else 0"), 5L));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AConstantConditionStopsWhereTheOperatorDoesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AConstantConditionStopsWhereTheOperatorDoesTest.java
@@ -1,0 +1,61 @@
+package souther.compiler.check;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What the compiler reads as a constant stops where the operator stops.
+ *
+ * <p>`&&` and `||` settle on their left operand, so `false && x` is `false` whatever `x` is — the
+ * value of `x` is not part of the answer and its being unreadable here does not make the answer
+ * unreadable. Read eagerly, a right operand this cannot fold takes a settled condition down with it,
+ * and a construction whose argument the language says is a known constant goes uncheckedto run time.
+ *
+ * <p>Which is a recogniser being incomplete rather than wrong: what it declines to fold it declines
+ * to claim anything about. It is still worth holding to the same rule as the emitter, because the two
+ * answering differently about one expression is what makes a constant check depend on how the
+ * constant was written.
+ */
+class AConstantConditionStopsWhereTheOperatorDoesTest {
+
+    /** An arithmetic overflow is the shape this reads nothing out of. */
+    private static final String UNFOLDABLE = "(9223372036854775807 + 1 == 0)";
+
+    private static String source(String written) {
+        return """
+                module demo
+                data F = Bool
+                    invariant holds = value == true
+                behavior make : (n: Int) -> F constructs F
+                let make (n) = F(%s)
+                """.formatted(written);
+    }
+
+    /** A conjunction settled false is a constant the invariant refuses, and it is refused here. */
+    @Test
+    void aConjunctionSettledByItsLeftIsStillAConstant() {
+        CompileException e = assertThrows(CompileException.class,
+                () -> Compiler.compile(source("false && " + UNFOLDABLE)));
+
+        assertTrue(e.getMessage().contains("holds"), e.getMessage());
+    }
+
+    /** And a disjunction settled true is one it admits, so nothing is reported. */
+    @Test
+    void aDisjunctionSettledByItsLeftIsStillAConstant() {
+        assertDoesNotThrow(() -> Compiler.compile(source("true || " + UNFOLDABLE)));
+    }
+
+    /** Where the left operand does not settle it, the right one is read as ever. */
+    @Test
+    void anUnsettledConditionStillReadsItsRight() {
+        assertThrows(CompileException.class, () -> Compiler.compile(source("true && false")));
+        assertDoesNotThrow(() -> Compiler.compile(source("false || true")));
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -627,6 +627,8 @@ An external representation may contain null, but internal data forbids null. nul
 
 [[an-operator-takes-the-types-it-is-defined-for]]An operator MUST be given the types it is defined for: `+++++` joins two lists or two strings, unary minus takes an `+Int+` or a `+Decimal+`, a comparison takes two ordered values of one type, and `+==+` takes values that have something to compare — a function does not (<<equality>>).
 
+[[a-condition-stops-when-its-answer-is-settled]]`+&&+` and `+||+` evaluate their operands left to right and stop as soon as the answer is settled: a false left operand is the answer of a `+&&+` and a true one is the answer of a `+||+`, and in neither case is the right operand evaluated. Which operands run is part of what the operators mean and not a choice a backend makes — `+/+` aborts on a zero divisor and `+Int+` overflows (<<stdlib-int>>), so `+x /= 0 && 100 / x > 1+` is how a condition narrows what its right side may compute, and evaluated eagerly it would abort at the value it exists to exclude.
+
 [[a-tuple-pattern-matches-its-tuple]]A tuple pattern MUST be written on a tuple, and MUST bind as many names as the tuple has elements.
 
 [[a-field-read-is-declared-by-the-value]]A field read MUST be a field the value has. A sum has no fields of its own — its cases do — and it exposes one only where every case spreads the data declaring it (<<sum-data>>); which case a value is is not known until it is opened.


### PR DESCRIPTION
Closes #607.

`&&` and `||` were emitted as `iand` and `ior` over both operands, so a left operand
narrowed nothing:

```souther
let pick (x) = if x /= 0 && 100 / x > 1 then Safe else Unsafe
```

```
It is:
    aborted: division by zero: 100 / 0
But it needs to be:
    Unsafe
```

`iand` and `ior` are correct JVM code for the eager conjunction of two booleans, and
they are not this operator. Souther has operations that abort — `/` on a zero divisor,
`Int` overflow — so a left operand is how the domain the right one is evaluated in gets
narrowed, and which operands run is part of what the operators mean rather than a choice
the backend makes. Evaluated eagerly the rule cannot be written as a condition at all: it
has to become an `if` where a condition was wanted.

`AND` now jumps past its right operand where the left is false, `OR` where the left is
true, and both keep left-to-right order.

The spec stated this in one place and not the other. The threshold section leaned on
short-circuiting to argue about what an arm is evidence of; the operator section said
nothing, so the rule was only written down where it was being used. It is stated with
the operators now, beside the abort it exists for.

The constant recogniser had the same split. `ConstEval.binary` evaluated both operands
and then looked at the operator, so `false && x` was a constant to the emitter and not to
it wherever `x` is a shape it does not fold — an arithmetic overflow is one. A
construction the language calls constant then went unchecked to run time for how the
constant was written rather than for what it is: `F(false && (9223372036854775807 + 1 ==
0))` compiled where `F`'s invariant refuses `false`. Declining to fold is sound, since
what it declines it claims nothing about; two answers about one expression is what makes
a compile-time check depend on the spelling.

Tests: three rows over the two operators — the settled cases answer instead of aborting,
and the unsettled ones still evaluate the right operand. All 3873 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
