### PR TITLE
Answer a solve with the types, not with a report about them

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
@@ -84,22 +84,17 @@ public final class BottomInfer {
     }
 
     /** Best-effort: bind the type variables of {@code result} from an {@code expected} type the context
-     * pushed down, into {@code bind}. Unifies into a scratch copy and merges only on success, so an
-     * expected type that does not fit the result leaves {@code bind} untouched and the ordinary checks
-     * report the mismatch rather than this throwing early. Shared by the checker's call typing and the
-     * backend's fold materialisation so both pin the same accumulator type (issue #70). */
+     * pushed down, into {@code bind}. An expected type that does not fit the result leaves
+     * {@code bind} untouched and the ordinary checks report the mismatch rather than this refusing
+     * early — which is what a solve that does not fit leaves behind anyway, so nothing is asked of
+     * the walk here beyond its own contract. Shared by the checker's call typing and the backend's
+     * fold materialisation so both pin the same accumulator type. */
     public static void pinResultTypeVars(Type result, Type expected, Map<String, Type> bind,
-                                         Symbols symbols, SourcePos pos, String what) {
+                                         Symbols symbols) {
         if (expected == null) {
             return;
         }
-        Map<String, Type> probe = new HashMap<>(bind);
-        try {
-            TypeOps.unify(result, expected, probe, symbols, pos, what);
-            bind.putAll(probe);
-        } catch (CompileException _) {
-            // the expected type does not fit this result; leave bind untouched
-        }
+        TypeOps.unify(result, expected, bind, symbols);
     }
 
     /** Whether a step-typing error is the unresolved-bottom error (an operand/branch reported as the

--- a/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/CallElaborator.java
@@ -116,8 +116,7 @@ public final class CallElaborator {
         }
         Type declared = entry.signature().result();
         Map<String, Type> bindings = new HashMap<>();
-        BottomInfer.pinResultTypeVars(declared, expected, bindings, ctx.symbols(),
-                v.pos(), "the type of " + lib.qualified());
+        BottomInfer.pinResultTypeVars(declared, expected, bindings, ctx.symbols());
         return new Core.Call(new ReachName.OfLibrary(lib), List.of(),
                 TypeOps.toBottom(TypeOps.substitute(declared, bindings)), v.pos());
     }
@@ -171,8 +170,15 @@ public final class CallElaborator {
                 // signature and nothing more. The fold rule that reads a step's result as an
                 // accumulator to grow is one operation's meaning, and an operation kept standing is
                 // kept because its meaning belongs to whoever reads it, not to this.
-                TypeOps.unify(declared.result(), answered, bind, ctx.symbols(),
-                        call.pos(), "argument " + (i + 1) + " of " + call.written());
+                //
+                // Refused here rather than inside the walk, and by the sentence a value argument is
+                // refused by: both kinds of argument are one rule, and this is the reader that
+                // still has the argument to point at.
+                if (TypeOps.unify(declared.result(), answered, bind, ctx.symbols())
+                        instanceof Fit.Disagrees d) {
+                    throw Elaborator.doesNotFit(call.args().get(i), d.actual(), d.expected(),
+                            "argument " + (i + 1) + " of " + call.written());
+                }
             }
         }
         return new Core.PreservedCall(call.denotes(), ca.cores(),
@@ -210,8 +216,7 @@ public final class CallElaborator {
                                              CheckContext ctx) {
         Map<String, Type> bind = new HashMap<>();
         if (params.stream().anyMatch(Type.FnOf.class::isInstance)) {
-            BottomInfer.pinResultTypeVars(result, expected, bind, ctx.symbols(),
-                    call.pos(), "result of " + call.written());
+            BottomInfer.pinResultTypeVars(result, expected, bind, ctx.symbols());
         }
         // Each value argument is asked once, here, in the order it is written. What the ordering
         // below decides is which of them settles a variable first, and nothing about how many times

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -652,14 +652,14 @@ public final class Elaborator {
         if (declaredResult != null) {
             // What the body answers decides a variable the arguments left open — a result the
             // signature relates to a function parameter rather than to a value one.
-            decided.decide(declaredResult, body.type(), ctx.symbols(), ex.pos(),
+            decide(decided, declaredResult, ex.body(), body.type(), ctx.symbols(),
                     "the result of `" + shown(ex) + "`");
             if (ex.callee() instanceof ValueName.Local) {
                 // A function the caller supplied, expanded where the callee applies it. What it was
                 // declared to answer is what the caller was held to when it handed the function
                 // over, so a body answering something else is the caller's error and is reported
                 // here — a helper's own declared return is its promise, and is reported against it.
-                decided.hold(declaredResult, body.type(), ctx.symbols(), ex.pos(),
+                hold(decided, declaredResult, ex.body(), body.type(), ctx.symbols(),
                         "what `" + shown(ex) + "` was given to answer");
             }
             type = decided.settle(declaredResult);
@@ -710,7 +710,7 @@ public final class Elaborator {
                 Type declared = TypeOps.resolveParamType(b.declaredType(), ctx.symbols());
                 // The argument is held to everything the declaration states, whether or not the
                 // callee's body ever reads it, and however many variables stand inside it.
-                decided.constrain(declared, value.type(), ctx.symbols(), b.value().pos(),
+                constrain(decided, declared, b.value(), value.type(), ctx.symbols(),
                         argument(ex, b.binder().name()));
                 Type required = decided.zonk(declared);
                 if (states(required)) {
@@ -758,7 +758,7 @@ public final class Elaborator {
                 // relates a function parameter to the rest of what it wrote — `(f: ('a) -> Bool):
                 // List<'a>` answers a list of what the function takes — so what the function says
                 // about a variable is what that variable is at every other position of the call.
-                decided.constrain(declared, arrives, ctx.symbols(), g.value().pos(),
+                constrain(decided, declared, g.value(), arrives, ctx.symbols(),
                         argument(ex, "a function"));
                 continue;
             }
@@ -769,9 +769,9 @@ public final class Elaborator {
             if (takes == null) {
                 continue;   // nothing says what it takes, and its own body does not either
             }
-            decided.constrain(declared,
+            constrain(decided, declared, g.value(),
                     elaborateFunctionValue(g.value(), takes, env, ctx).type(), ctx.symbols(),
-                    g.value().pos(), argument(ex, "a function"));
+                    argument(ex, "a function"));
         }
     }
 
@@ -1270,12 +1270,76 @@ public final class Elaborator {
     static void requireType(Ast.Expr e, Type actual, Type expected,
                                     Symbols symbols, String what) {
         if (!TypeOps.assignable(actual, expected, symbols)) {   // a case widens to its sum (spec §sum-data)
+            throw doesNotFit(e, actual, expected, what);
+        }
+    }
+
+    /**
+     * The report for a value that does not have the type its position states, drawn at the operand
+     * that supplied it.
+     *
+     * <p>One rule, so one sentence. Every check that refuses a value for this reason builds its
+     * report here rather than writing a second one beside it: which of two sentences a reader gets
+     * would otherwise depend on which check ran, and that is not something a reader can see.
+     */
+    static CompileException doesNotFit(Ast.Expr operand, Type actual, Type expected, String what) {
+        return CompileException.of(Diagnostic
+                        .at(region(operand))
+                        .diff(Type.show(actual, expected), Type.show(expected, actual))
+                        .hint(new TypeMessage.AdjustTheValueOrThePosition())
+                        .say(new TypeMessage.ItDoesNotHaveTheTypeItNeedsHere(what)).build());
+    }
+
+    /**
+     * Reads {@code actual} against {@code declared} for this application: records what it says about
+     * the variables {@code declared} carries, and holds it to everything {@code declared} states.
+     *
+     * <p>A variable is a hole, not a licence. {@code List<'a>} says the value is a list and leaves
+     * what it holds open; {@code Map<String, 'a>} says it is a map with String keys. So an argument
+     * is held to the constructors, the arities and the ground positions of a declared type however
+     * many variables stand inside it — and only the positions a variable stands at are free.
+     *
+     * <p>A variable takes the first type it is read at, and every later reading must agree. The
+     * empty-collection bottom is the one exception, in both directions: it settles nothing, so a
+     * variable standing at the bottom is widened by a later concrete reading and a bottom reading
+     * leaves a concrete one alone (ADR-0028). That is what lets an empty seed take its element type
+     * from the argument that decided it rather than from itself.
+     *
+     * <p>A disagreement is the caller's error and is reported here rather than swallowed on the
+     * grounds that another pass would report it too: what {@link Substitution} holds is the whole
+     * signature at once, so it is the only reader that can see two positions of one variable
+     * disagree. Reported here rather than inside it because this is what still has {@code operand}.
+     */
+    static void constrain(Substitution decided, Type declared, Ast.Expr operand, Type actual,
+                          Symbols symbols, String what) {
+        decide(decided, declared, operand, actual, symbols, what);
+        hold(decided, declared, operand, actual, symbols, what);
+    }
+
+    /** What {@code actual} says about the variables {@code declared} carries, refusing a variable
+     * this application has already read at a type that does not go with this one. */
+    static void decide(Substitution decided, Type declared, Ast.Expr operand, Type actual,
+                       Symbols symbols, String what) {
+        if (decided.decide(declared, actual, symbols) instanceof Fit.Disagrees d) {
             throw CompileException.of(Diagnostic
-                            .at(region(e))
-                            
-                            .diff(Type.show(actual, expected), Type.show(expected, actual))
-                            .hint(new TypeMessage.AdjustTheValueOrThePosition())
-                            .say(new TypeMessage.ItDoesNotHaveTheTypeItNeedsHere(what)).build());
+                            .at(region(operand))
+                            .diff(Type.show(d.actual(), d.expected()), Type.show(d.expected(), d.actual()))
+                            .say(new TypeMessage.ItExpectedOneTypeAndGotAnother(what,
+                                    Type.show(d.expected(), d.actual()),
+                                    Type.show(d.actual(), d.expected()))).build());
+        }
+    }
+
+    /** {@code actual} held to what {@code declared} states, recording nothing about its variables. */
+    static void hold(Substitution decided, Type declared, Ast.Expr operand, Type actual,
+                     Symbols symbols, String what) {
+        if (decided.hold(declared, actual, symbols) instanceof Fit.Disagrees d) {
+            throw CompileException.of(Diagnostic
+                            .at(region(operand))
+                            .diff(Type.show(d.actual(), d.expected()), Type.show(d.expected(), d.actual()))
+                            .say(new DeclarationMessage.ItExpectsAnotherType(what,
+                                    Type.show(d.expected(), d.actual()),
+                                    Type.show(d.actual(), d.expected()))).build());
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Fit.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Fit.java
@@ -1,0 +1,34 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+
+/**
+ * What a solving walk makes of one type read against another: they fit, or two positions disagree.
+ *
+ * <p>A walk knows which two types did not go together. It does not know which operand supplied
+ * either of them, where that operand is written, or what a reader should be told — those are the
+ * elaborator's, which still has the expression in hand when it asks. A walk that answered with a
+ * report instead would have to be given a position and a sentence before the answer was known, and
+ * every caller that only wanted to know whether the types fit would assemble both and throw them
+ * away.
+ *
+ * <p>So the answer carries the types and nothing else, and the diagnostic is chosen from it by
+ * whoever owns the operand — the same shape {@link ArithmeticCheck} takes for the same reason.
+ */
+sealed interface Fit {
+
+    /** The one answer that says nothing further, so it is one value rather than one per walk. */
+    Fit FITS = new Fits();
+
+    /** {@code arg} is admissible where {@code param} was written, and what it settled stands. */
+    record Fits() implements Fit {}
+
+    /**
+     * {@code expected} was already stated at this position — by the declaration, or by an earlier
+     * reading of the variable standing there — and {@code actual} does not go with it.
+     *
+     * <p>Both are written in the caller's terms rather than the walk's: they are the types a reader
+     * would be shown, at the position that disagreed, not the outermost pair the walk started from.
+     */
+    record Disagrees(Type expected, Type actual) implements Fit {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperParams.java
@@ -778,8 +778,10 @@ final class HelperParams {
                     for (int i = 0; i < lambda.params().size(); i++) {
                         Type t = new BodyTyping(symbols, reqSigs, recursiveHelperFns, freshening)
                                 .typeOf(lambda.params().get(i), lambda.body(), inner, step.result());
-                        if (t != null) {   // a position the lambda's body leaves open says nothing
-                            decided.decide(step.params().get(i), t, symbols, ex.pos(), "closure");
+                        if (t != null   // a position the lambda's body leaves open says nothing
+                                && decided.decide(step.params().get(i), t, symbols)
+                                        instanceof Fit.Disagrees) {
+                            return new Substitution();   // it does not agree; settle nothing from it
                         }
                     }
                     // What it answers is a position of the signature too. `(f: (Int) -> 'a, x: 'a)`
@@ -787,11 +789,13 @@ final class HelperParams {
                     // takes would carry one of those and drop the other.
                     Type answers = typed(lambda.body(), walking(env, lambda,
                             decided.zonk(step) instanceof Type.FnOf f ? f : step));
-                    if (answers != null) {
-                        decided.decide(step.result(), answers, symbols, ex.pos(), "closure result");
+                    if (answers != null
+                            && decided.decide(step.result(), answers, symbols)
+                                    instanceof Fit.Disagrees) {
+                        return new Substitution();   // it does not agree; settle nothing from it
                     }
                 } catch (CompileException _) {
-                    return new Substitution();   // it does not agree; settle nothing from it
+                    return new Substitution();   // it could not be typed; settle nothing from it
                 }
             }
             return decided;
@@ -900,11 +904,11 @@ final class HelperParams {
          * same rule one step in. Only the positions its body determines are answered; the rest stay
          * the variables the signature wrote, which unify against anything.
          */
-        private void solveFromClosure(Ast.Expr arg, Type.FnOf step, Scope env,
-                                      Map<String, Type> bind, Ast.Apply call) {
+        private Fit solveFromClosure(Ast.Expr arg, Type.FnOf step, Scope env,
+                                     Map<String, Type> bind) {
             if (!(arg instanceof Ast.Block lambda)
                     || lambda.params().size() != step.params().size()) {
-                return;
+                return Fit.FITS;
             }
             // What the arguments beside it have settled, as the closure sees it: its parameters are
             // in force over its body at those types, and its result is what the body is asked for.
@@ -918,9 +922,13 @@ final class HelperParams {
                 if (t != null) {
                     // only a position the closure's body settled: unifying an undetermined one
                     // against the variable the signature wrote would bind that variable to itself
-                    TypeOps.unify(step.params().get(i), t, bind, symbols, call.pos(), "closure");
+                    Fit fit = TypeOps.unify(step.params().get(i), t, bind, symbols);
+                    if (fit instanceof Fit.Disagrees) {
+                        return fit;
+                    }
                 }
             }
+            return Fit.FITS;
         }
 
         /**
@@ -959,8 +967,7 @@ final class HelperParams {
                     // carries a variable this walk minted says as much as a stated one: the variable
                     // is this parameter's, so solving the callee's against it is what links the two
                     // positions the body read together.
-                    BottomInfer.pinResultTypeVars(sig.result(), expected, bind, symbols, call.pos(),
-                            "result of " + call.written());
+                    BottomInfer.pinResultTypeVars(sig.result(), expected, bind, symbols);
                 }
                 // The stages `CallElaborator.applySignature` types a call in, in that order and
                 // for its reason: an argument that is not a closure binds the variables, and the
@@ -973,18 +980,20 @@ final class HelperParams {
                         continue;   // a closure waits for the stage below; this argument is the one
                     }               // being typed, and typing it is the question being worked out
                     Type actual = typed(arg, env);
-                    if (actual != null) {
-                        TypeOps.unify(param, actual, bind, symbols, call.pos(), "argument");
+                    if (actual != null
+                            && TypeOps.unify(param, actual, bind, symbols) instanceof Fit.Disagrees) {
+                        return sig.params();   // the call does not fit; the check reports it
                     }
                 }
                 for (int i = 0; i < call.args().size(); i++) {
                     Ast.Expr arg = call.args().get(i);
-                    if (sig.params().get(i) instanceof Type.FnOf step && !mentions(arg, target)) {
-                        solveFromClosure(arg, step, env, bind, call);
+                    if (sig.params().get(i) instanceof Type.FnOf step && !mentions(arg, target)
+                            && solveFromClosure(arg, step, env, bind) instanceof Fit.Disagrees) {
+                        return sig.params();   // the call does not fit; the check reports it
                     }
                 }
             } catch (CompileException _) {
-                return sig.params();   // the call does not fit its signature; the check reports it
+                return sig.params();   // an argument could not be typed; the check reports it
             }
             // What this call decided for the variables it left open, and over it what this walk
             // solved. The decision belongs to the call, so every parameter reading it reads the same

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -506,9 +506,11 @@ public final class HelperTyping {
             try {
                 Type at = Elaborator.typeOf(inliner.inline(call.args().get(i), inliner.bodyOf(h.name())),
                         env, new CheckContext(symbols, null, reqs));
-                TypeOps.unify(declared.get(i), at, bind, symbols, call.pos(), "argument " + (i + 1));
+                if (TypeOps.unify(declared.get(i), at, bind, symbols) instanceof Fit.Disagrees) {
+                    return;   // the argument does not fit; leave it to the inlined check
+                }
             } catch (CompileException _) {
-                return;   // can't pin the types here; leave it to the inlined check
+                return;   // can't type the argument here; leave it to the inlined check
             }
         }
         for (int i = 0; i < declared.size(); i++) {
@@ -590,9 +592,7 @@ public final class HelperTyping {
                 // what there is to check: `'b?` accepts a block answering with an optional and rejects
                 // one answering with a plain value. Unifying also pins `'b` for the arguments after
                 // this one. A failure is reported as the mismatch it is, in written types.
-                try {
-                    TypeOps.unify(want.result(), got, bind, symbols, lambda.pos(), "block result");
-                } catch (CompileException _) {
+                if (TypeOps.unify(want.result(), got, bind, symbols) instanceof Fit.Disagrees) {
                     throw blockReturnMismatch(h, paramName, want.result(), got, lambda.pos());
                 }
                 return;

--- a/souther-compiler/src/main/java/souther/compiler/check/Substitution.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Substitution.java
@@ -1,11 +1,5 @@
 package souther.compiler.check;
 
-import souther.compiler.diag.CompileException;
-import souther.compiler.diag.Diagnostic;
-import souther.compiler.diag.msg.DeclarationMessage;
-import souther.compiler.diag.msg.TypeMessage;
-import souther.compiler.diag.DiagnosticCode;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingOwner;
 import souther.compiler.types.Type;
 
@@ -58,31 +52,6 @@ final class Substitution {
     }
 
     /**
-     * Reads {@code actual} against {@code declared}: records what it says about the variables
-     * {@code declared} carries, and holds it to everything {@code declared} states.
-     *
-     * <p>A variable is a hole, not a licence. {@code List<'a>} says the value is a list and leaves
-     * what it holds open; {@code Map<String, 'a>} says it is a map with String keys. So an argument
-     * is held to the constructors, the arities and the ground positions of a declared type however
-     * many variables stand inside it — and only the positions a variable stands at are free.
-     *
-     * <p>A variable takes the first type it is read at, and every later reading must agree. The
-     * empty-collection bottom is the one exception, in both directions: it settles nothing, so a
-     * variable standing at the bottom is widened by a later concrete reading and a bottom reading
-     * leaves a concrete one alone (ADR-0028). That is what lets an empty seed take its element type
-     * from the argument that decided it rather than from itself.
-     *
-     * <p>A disagreement is the caller's error and is reported here, at {@code pos}. It is not
-     * swallowed on the grounds that another pass would report it too: what this holds is the whole
-     * signature at once, so it is the only reader that can see two positions of one variable
-     * disagree.
-     */
-    void constrain(Type declared, Type actual, Symbols symbols, SourcePos pos, String what) {
-        decide(declared, actual, symbols, pos, what);
-        hold(declared, actual, symbols, pos, what);
-    }
-
-    /**
      * Holds {@code actual} to what {@code declared} states, and records nothing.
      *
      * <p>For evidence read off an argument on its own rather than at what the signature settled: what
@@ -91,14 +60,9 @@ final class Substitution {
      * the application settles them at, so what its body answers under them is not what this
      * application decided.
      */
-    void hold(Type declared, Type actual, Symbols symbols, SourcePos pos, String what) {
-        if (fits(actual, declared, symbols)) {
-            return;
-        }
-        Type stated = settle(declared);
-        throw CompileException.of(Diagnostic
-                        .at(pos)
-                        .diff(Type.show(actual, stated), Type.show(stated, actual)).say(new DeclarationMessage.ItExpectsAnotherType(what, Type.show(stated, actual), Type.show(actual, stated))).build());
+    Fit hold(Type declared, Type actual, Symbols symbols) {
+        return fits(actual, declared, symbols)
+                ? Fit.FITS : new Fit.Disagrees(settle(declared), actual);
     }
 
     /**
@@ -160,10 +124,15 @@ final class Substitution {
 
     /**
      * Records what {@code actual} says about the variables {@code declared} carries, and states
-     * nothing about whether the two agree — for a reader that is working out what it holds rather
-     * than checking a value against it.
+     * nothing about whether the two shapes agree — for a reader that is working out what it holds
+     * rather than checking a value against it. That question is {@link #hold}'s.
+     *
+     * <p>What it does answer is a variable this application has already read at a type that does not
+     * go with this one: two readings of one variable, which is the one disagreement only a reader
+     * holding the whole signature can see. The types are answered rather than reported, because
+     * where a reader is sent belongs to whoever still has the operand.
      */
-    void decide(Type declared, Type actual, Symbols symbols, SourcePos pos, String what) {
+    Fit decide(Type declared, Type actual, Symbols symbols) {
         // Neither side is written through first. A variable already decided is still the variable
         // this reading is about, and writing what it stands for in its place would leave nothing for
         // a later, more definite reading to rebind — which is what a first reading carrying the
@@ -171,58 +140,63 @@ final class Substitution {
         Type left = declared;
         Type right = actual;
         if (left instanceof Type.MetaVar m) {
-            bind(m, right, symbols, pos, what);
-            return;
+            return bind(m, right, symbols);
         }
         // The other side carries what this one left open: a declared `List<Int>` read against a
         // result still standing at a variable says what that variable is.
         if (right instanceof Type.MetaVar m) {
-            bind(m, left, symbols, pos, what);
-            return;
+            return bind(m, left, symbols);
         }
         // Position by position where the two shapes line up. Where they do not there is no variable
         // here to decide, and whether they agree is {@link #fits}'s question.
         switch (left) {
             case Type.ListOf l -> {
                 if (right instanceof Type.ListOf a) {
-                    decide(l.element(), a.element(), symbols, pos, what);
+                    return decide(l.element(), a.element(), symbols);
                 }
             }
             case Type.SetOf s -> {
                 if (right instanceof Type.SetOf a) {
-                    decide(s.element(), a.element(), symbols, pos, what);
+                    return decide(s.element(), a.element(), symbols);
                 }
             }
             case Type.OptionOf o -> {
                 if (right instanceof Type.OptionOf a) {
-                    decide(o.element(), a.element(), symbols, pos, what);
+                    return decide(o.element(), a.element(), symbols);
                 }
             }
             case Type.MapOf m -> {
                 if (right instanceof Type.MapOf a) {
-                    decide(m.key(), a.key(), symbols, pos, what);
-                    decide(m.value(), a.value(), symbols, pos, what);
+                    Fit key = decide(m.key(), a.key(), symbols);
+                    return key instanceof Fit.Disagrees ? key : decide(m.value(), a.value(), symbols);
                 }
             }
             case Type.TupleOf t -> {
                 if (right instanceof Type.TupleOf a
                         && t.elements().size() == a.elements().size()) {
                     for (int i = 0; i < t.elements().size(); i++) {
-                        decide(t.elements().get(i), a.elements().get(i), symbols, pos, what);
+                        Fit at = decide(t.elements().get(i), a.elements().get(i), symbols);
+                        if (at instanceof Fit.Disagrees) {
+                            return at;
+                        }
                     }
                 }
             }
             case Type.FnOf f -> {
                 if (right instanceof Type.FnOf a && f.params().size() == a.params().size()) {
                     for (int i = 0; i < f.params().size(); i++) {
-                        decide(f.params().get(i), a.params().get(i), symbols, pos, what);
+                        Fit at = decide(f.params().get(i), a.params().get(i), symbols);
+                        if (at instanceof Fit.Disagrees) {
+                            return at;
+                        }
                     }
-                    decide(f.result(), a.result(), symbols, pos, what);
+                    return decide(f.result(), a.result(), symbols);
                 }
             }
             // Nothing inside it to descend into, so nothing here decides a variable.
             case Type.Leaf _ -> { }
         }
+        return Fit.FITS;
     }
 
     /** {@code t} with every variable this has decided written into it. One still open is left
@@ -257,7 +231,7 @@ final class Substitution {
         return Type.mentions(zonk(t), x -> x instanceof Type.MetaVar);
     }
 
-    private void bind(Type.MetaVar m, Type reading, Symbols symbols, SourcePos pos, String what) {
+    private Fit bind(Type.MetaVar m, Type reading, Symbols symbols) {
         // What the reading stands for, not how it was written. A variable another application
         // decided is that decision here, and comparing the variable itself would find every reading
         // through one to disagree with every other.
@@ -267,7 +241,7 @@ final class Substitution {
             // that would have to hold itself. It stays open, and the reading that said so settles
             // nothing rather than being taken as a disagreement — the same answer {@link Readings}
             // gives the same question.
-            return;
+            return Fit.FITS;
         }
         Substitution owner = owning(m);
         Type held = owner.at(m);
@@ -275,10 +249,10 @@ final class Substitution {
             if (!(at instanceof Type.MetaVar other) || at(other) == null) {
                 owner.decided.put(m, at);
             }
-            return;
+            return Fit.FITS;
         }
         if (at instanceof Type.Nothing || open(at) || open(held)) {
-            return;   // the bottom settles nothing, and neither does a reading still open
+            return Fit.FITS;   // the bottom settles nothing, and neither does a reading still open
         }
         // A reading that carried the bottom said what the value was made of and not what it holds —
         // `Option.withDefault([], xs)` reads the variable as a list of nothing first — so a later
@@ -287,15 +261,13 @@ final class Substitution {
         if (Type.mentions(held, x -> x instanceof Type.Nothing)
                 && TypeOps.assignable(held, at, symbols)) {
             owner.decided.put(m, at);
-            return;
+            return Fit.FITS;
         }
         Type stands = zonk(held);
         if (TypeOps.assignable(at, stands, symbols) || TypeOps.assignable(stands, at, symbols)) {
-            return;
+            return Fit.FITS;
         }
-        throw CompileException.of(Diagnostic
-                        .at(pos)
-                        .diff(Type.show(at, held), Type.show(held, at)).say(new TypeMessage.ItExpectedOneTypeAndGotAnother(what, Type.show(held, at), Type.show(at, held))).build());
+        return new Fit.Disagrees(held, at);
     }
 
     /** Every variable still open read as the bottom, at every depth. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Substitution.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Substitution.java
@@ -131,6 +131,15 @@ final class Substitution {
      * go with this one: two readings of one variable, which is the one disagreement only a reader
      * holding the whole signature can see. The types are answered rather than reported, because
      * where a reader is sent belongs to whoever still has the operand.
+     *
+     * <p>A reading that disagrees leaves behind what it decided before it got there. Unlike
+     * {@link TypeOps#unify}, which settles a caller's map and so has to leave it as the caller left
+     * it, this settles what the application already owns: what a walk decides is the application's
+     * decision from the moment it is made, and a reading that turned out to disagree does not
+     * un-decide the positions before it. So a caller that goes on after {@code Disagrees} is
+     * carrying an application whose readings did not all agree, which is not something to build a
+     * type from. Every caller today either refuses at once or drops the whole {@code Substitution},
+     * and a caller that wants to do neither is asking for something this does not offer.
      */
     Fit decide(Type declared, Type actual, Symbols symbols) {
         // Neither side is written through first. A variable already decided is still the variable

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeOps.java
@@ -9,7 +9,6 @@ import souther.compiler.diag.msg.TypeMessage;
 import souther.compiler.diag.msg.ModuleMessage;
 import souther.compiler.diag.msg.DataMessage;
 import souther.compiler.diag.DiagnosticCode;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.types.BindingId;
 import souther.compiler.types.LeafScalar;
 import souther.compiler.types.BindingOwner;
@@ -19,6 +18,7 @@ import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -606,10 +606,23 @@ public final class TypeOps {
      * its element; a concrete parameter just requires the argument to be assignable. This is what
      * monomorphises a generic intrinsic — {@code values(m: Map<String, 'a>): List<'a>} learns
      * {@code 'a} from the map so {@link #substitute} can resolve the {@code List<'a>} result.
+     *
+     * <p>Answers with the two types that disagreed rather than a report about them. Which operand
+     * supplied either type, where it is written and what a reader is told are the caller's, and the
+     * caller is what still has the expression in hand.
+     *
+     * <p>A walk that does not fit settles nothing. It stops at the first position that disagrees,
+     * so whatever it had settled before that was settled by a reading it went on to refuse, and a
+     * caller reading the map afterwards cannot tell those from what was there before.
      */
-    public static void unify(Type param, Type arg, Map<String, Type> bindings,
-                             Symbols symbols, SourcePos pos, String what) {
-        unify(param, arg, bindings, symbols, pos, what, true);
+    public static Fit unify(Type param, Type arg, Map<String, Type> bindings, Symbols symbols) {
+        Map<String, Type> settled = new HashMap<>(bindings);
+        Fit fit = unify(param, arg, settled, symbols, true);
+        if (fit instanceof Fit.Disagrees) {
+            return fit;
+        }
+        bindings.putAll(settled);
+        return fit;
     }
 
     /**
@@ -617,16 +630,18 @@ public final class TypeOps {
      *
      * <p>For a caller that requires each argument afterwards, against the parameter type this walk
      * settled and at the argument's own position. Refusing here as well would answer the same
-     * mismatch twice, and this reading is the one with no argument in its hands: it is given two
-     * types and the position of the call they belong to, so the caret it can offer is the callee's
-     * — which is the one part of the line a reader has already been told is not the problem.
+     * mismatch twice, and this reading is the one with no argument in its hands.
+     *
+     * <p>Reading every position rather than stopping at the first that disagrees is the difference:
+     * a position this cannot settle says nothing about the ones beside it, and refusing is not this
+     * walk's question.
      */
     public static void bindVars(Type param, Type arg, Map<String, Type> bindings, Symbols symbols) {
-        unify(param, arg, bindings, symbols, null, null, false);
+        unify(param, arg, bindings, symbols, false);
     }
 
-    private static void unify(Type param, Type arg, Map<String, Type> bindings,
-                              Symbols symbols, SourcePos pos, String what, boolean refusing) {
+    private static Fit unify(Type param, Type arg, Map<String, Type> bindings,
+                             Symbols symbols, boolean refusing) {
         switch (param) {
             case Type.Var v -> {
                 Type bound = bindings.get(v.name());
@@ -639,41 +654,50 @@ public final class TypeOps {
                     // the empty bottom absorbs into the concrete binding already learned
                 } else if (refusing && !assignable(arg, bound, symbols)
                         && !assignable(bound, arg, symbols)) {
-                    throw CompileException.of(Diagnostic
-                                    .at(pos)
-                                    .diff(Type.show(arg, bound), Type.show(bound, arg)).say(new TypeMessage.ItExpectedOneTypeAndGotAnother(what, Type.show(bound), Type.show(arg))).build());
+                    return new Fit.Disagrees(bound, arg);
                 }
             }
-            case Type.ListOf p when arg instanceof Type.ListOf a ->
-                    unify(p.element(), a.element(), bindings, symbols, pos, what, refusing);
-            case Type.MapOf p when arg instanceof Type.MapOf a -> {
-                unify(p.key(), a.key(), bindings, symbols, pos, what, refusing);
-                unify(p.value(), a.value(), bindings, symbols, pos, what, refusing);
+            case Type.ListOf p when arg instanceof Type.ListOf a -> {
+                return unify(p.element(), a.element(), bindings, symbols, refusing);
             }
-            case Type.SetOf p when arg instanceof Type.SetOf a ->
-                    unify(p.element(), a.element(), bindings, symbols, pos, what, refusing);
-            case Type.OptionOf p when arg instanceof Type.OptionOf a ->
-                    unify(p.element(), a.element(), bindings, symbols, pos, what, refusing);
+            case Type.MapOf p when arg instanceof Type.MapOf a -> {
+                Fit key = unify(p.key(), a.key(), bindings, symbols, refusing);
+                if (key instanceof Fit.Disagrees) {
+                    return key;
+                }
+                return unify(p.value(), a.value(), bindings, symbols, refusing);
+            }
+            case Type.SetOf p when arg instanceof Type.SetOf a -> {
+                return unify(p.element(), a.element(), bindings, symbols, refusing);
+            }
+            case Type.OptionOf p when arg instanceof Type.OptionOf a -> {
+                return unify(p.element(), a.element(), bindings, symbols, refusing);
+            }
             case Type.TupleOf p when arg instanceof Type.TupleOf a
                     && p.elements().size() == a.elements().size() -> {
                 for (int i = 0; i < p.elements().size(); i++) {
-                    unify(p.elements().get(i), a.elements().get(i), bindings, symbols, pos, what, refusing);
+                    Fit at = unify(p.elements().get(i), a.elements().get(i), bindings, symbols, refusing);
+                    if (at instanceof Fit.Disagrees) {
+                        return at;
+                    }
                 }
             }
             case Type.FnOf p when arg instanceof Type.FnOf a && p.params().size() == a.params().size() -> {
                 for (int i = 0; i < p.params().size(); i++) {
-                    unify(p.params().get(i), a.params().get(i), bindings, symbols, pos, what, refusing);
+                    Fit at = unify(p.params().get(i), a.params().get(i), bindings, symbols, refusing);
+                    if (at instanceof Fit.Disagrees) {
+                        return at;
+                    }
                 }
-                unify(p.result(), a.result(), bindings, symbols, pos, what, refusing);
+                return unify(p.result(), a.result(), bindings, symbols, refusing);
             }
             default -> {
                 if (refusing && !assignable(arg, param, symbols)) {
-                    throw CompileException.of(Diagnostic
-                                    .at(pos)
-                                    .diff(Type.show(arg, param), Type.show(param, arg)).say(new TypeMessage.ItExpectedOneTypeAndGotAnother(what, Type.show(param), Type.show(arg))).build());
+                    return new Fit.Disagrees(param, arg);
                 }
             }
         }
+        return Fit.FITS;
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/check/AFailedSolveCommitsNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFailedSolveCommitsNothingTest.java
@@ -53,6 +53,24 @@ class AFailedSolveCommitsNothingTest {
         assertEquals(Type.STRING, bind.get("'a"));
     }
 
+    /**
+     * What the contract says is that the map is as the caller left it, which is not the same as
+     * empty. A walk that emptied it on the way out would answer this test's first case and still
+     * take away what another reading had settled before this one was tried.
+     */
+    @Test
+    void whatWasSettledBeforeTheWalkIsStillThereAfterwards() {
+        Map<String, Type> bind = new HashMap<>();
+        bind.put("'settled", Type.STRING);
+        Type param = Type.tuple(List.of(Type.var("'a"), Type.INT));
+        Type arg = Type.tuple(List.of(Type.BOOL, Type.STRING));
+
+        assertInstanceOf(Fit.Disagrees.class, TypeOps.unify(param, arg, bind, Symbols.none()));
+
+        assertEquals(Map.of("'settled", Type.STRING), bind,
+                "a walk that did not fit left the map as " + bind);
+    }
+
     /** The answer names the position that disagreed, not the pair the walk started from — the two
      * types a reader is shown are the ones that did not go together. */
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/AFailedSolveCommitsNothingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFailedSolveCommitsNothingTest.java
@@ -1,0 +1,69 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a solving walk leaves behind when it does not fit.
+ *
+ * <p>A walk settles variables as it goes and stops at the first position that disagrees, so the
+ * positions it had already settled were settled by a reading the walk went on to refuse. Every
+ * caller that tries a solve it may not keep reads the same map afterwards, and a caller cannot tell
+ * a variable this walk settled from one that was there before. So a walk that does not fit settles
+ * nothing.
+ */
+class AFailedSolveCommitsNothingTest {
+
+    /** {@code ('a, Int)} read against {@code (String, Bool)}: the first position settles
+     * {@code 'a}, the second disagrees. The disagreement is the whole answer, so {@code 'a} was
+     * never settled. */
+    @Test
+    void aVariableSettledBeforeTheDisagreementIsNotKept() {
+        Map<String, Type> bind = new HashMap<>();
+        Type param = Type.tuple(List.of(Type.var("'a"), Type.INT));
+        Type arg = Type.tuple(List.of(Type.STRING, Type.BOOL));
+
+        Fit fit = TypeOps.unify(param, arg, bind, Symbols.none());
+
+        assertInstanceOf(Fit.Disagrees.class, fit);
+        assertTrue(bind.isEmpty(),
+                "a walk that did not fit settled " + bind + " on the way to refusing");
+    }
+
+    /** The same walk when it does fit keeps what it settled — the contract is about failure, and
+     * a success that settled nothing would be no contract at all. */
+    @Test
+    void aWalkThatFitsKeepsWhatItSettled() {
+        Map<String, Type> bind = new HashMap<>();
+        Type param = Type.tuple(List.of(Type.var("'a"), Type.INT));
+        Type arg = Type.tuple(List.of(Type.STRING, Type.INT));
+
+        Fit fit = TypeOps.unify(param, arg, bind, Symbols.none());
+
+        assertInstanceOf(Fit.Fits.class, fit);
+        assertEquals(Type.STRING, bind.get("'a"));
+    }
+
+    /** The answer names the position that disagreed, not the pair the walk started from — the two
+     * types a reader is shown are the ones that did not go together. */
+    @Test
+    void theAnswerCarriesTheTypesAtThePositionThatDisagreed() {
+        Type param = Type.tuple(List.of(Type.var("'a"), Type.INT));
+        Type arg = Type.tuple(List.of(Type.STRING, Type.BOOL));
+
+        Fit.Disagrees d = assertInstanceOf(Fit.Disagrees.class,
+                TypeOps.unify(param, arg, new HashMap<>(), Symbols.none()));
+
+        assertEquals(Type.INT, d.expected());
+        assertEquals(Type.BOOL, d.actual());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AKeptCallsFunctionArgumentIsRefusedWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AKeptCallsFunctionArgumentIsRefusedWhereItIsWrittenTest.java
@@ -1,0 +1,81 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.diag.msg.TypeMessage;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.ConstructionOrigin;
+import souther.compiler.types.ReachName;
+import souther.compiler.types.ValueName;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A kept call refuses its function argument where the argument is written.
+ *
+ * <p>Both kinds of argument are held to the signature in one method, and they are one rule: a value
+ * given to a position it does not fit. A value argument is refused at its own region and a function
+ * argument was refused at the callee, because the check the second one goes through is handed two
+ * types and the call's position rather than the argument. The path a reader reaches this on is the
+ * discharge representation, where the language's own operations are kept standing.
+ */
+class AKeptCallsFunctionArgumentIsRefusedWhereItIsWrittenTest {
+
+    private static final SourcePos CALL = new SourcePos(1, 1);
+    private static final SourcePos ARGUMENT = new SourcePos(3, 5);
+
+    /**
+     * {@code List.flatMap : (('a) -> List<'b>, List<'a>) -> List<'b>} — the function argument is
+     * declared to answer a list, and this one answers an Int. The block is written two lines below
+     * the callee, so only the block's own position puts the caret on a line the reader has to look
+     * at.
+     */
+    @Test
+    void aBlockThatAnswersTheWrongTypeIsUnderlinedWhereItIsWritten() {
+        Ast.Binders binders = new Ast.Binders(new BindingOwner.OfValue("demo", "test"));
+        Ast.Block answersAnInt = new Ast.Block(List.of(binders.binder("x", ARGUMENT)),
+                new Ast.IntLit(1, ARGUMENT), ARGUMENT);
+        Ast.Expr call = new Ast.Apply("List.flatMap", new ValueName.Stdlib("List", "flatMap"),
+                new ReachName.OfLibrary(new ValueName.Stdlib("List", "flatMap")),
+                List.of(answersAnInt, new Ast.ListLit(List.of(new Ast.IntLit(2, CALL)), CALL)),
+                ConstructionOrigin.own(), CALL);
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Elaborator.elaborate(call, Scope.NONE, CheckContext.of(Symbols.none())
+                        .preserving(Preserved.byTheLanguagesOwnOperations())));
+
+        assertEquals(ARGUMENT.line(), e.diagnostic().region().start().line(),
+                "the block is on line " + ARGUMENT.line() + " and the callee on line "
+                        + CALL.line());
+    }
+
+    /**
+     * And it is refused by the sentence a value argument is refused by. Which of two sentences a
+     * reader gets is not something a reader can see, so one rule states itself one way.
+     */
+    @Test
+    void itIsRefusedBySameSentenceAsAValueArgument() {
+        Ast.Binders binders = new Ast.Binders(new BindingOwner.OfValue("demo", "test"));
+        Ast.Block answersAnInt = new Ast.Block(List.of(binders.binder("x", ARGUMENT)),
+                new Ast.IntLit(1, ARGUMENT), ARGUMENT);
+        Ast.Expr call = new Ast.Apply("List.flatMap", new ValueName.Stdlib("List", "flatMap"),
+                new ReachName.OfLibrary(new ValueName.Stdlib("List", "flatMap")),
+                List.of(answersAnInt, new Ast.ListLit(List.of(new Ast.IntLit(2, CALL)), CALL)),
+                ConstructionOrigin.own(), CALL);
+
+        CompileException e = assertThrows(CompileException.class,
+                () -> Elaborator.elaborate(call, Scope.NONE, CheckContext.of(Symbols.none())
+                        .preserving(Preserved.byTheLanguagesOwnOperations())));
+
+        TypeMessage.ItDoesNotHaveTheTypeItNeedsHere said = assertInstanceOf(
+                TypeMessage.ItDoesNotHaveTheTypeItNeedsHere.class, e.diagnostic().said());
+        assertEquals("argument 1 of List.flatMap", said.what());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/ASignatureIsNotInstantiatedPerUseTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/ASignatureIsNotInstantiatedPerUseTest.java
@@ -44,8 +44,7 @@ class ASignatureIsNotInstantiatedPerUseTest {
     void aVariableTheExpectedTypeSettledComesBackAsThatType() {
         Prelude.Signature get = Prelude.entry("List.get").signature();
         Map<String, Type> bind = new HashMap<>();
-        BottomInfer.pinResultTypeVars(get.result(), Type.option(Type.var("$0")), bind,
-                null, POS, "result");
+        BottomInfer.pinResultTypeVars(get.result(), Type.option(Type.var("$0")), bind, null);
         assertEquals(Type.var("$0"), bind.get("'a"));
         assertEquals(Type.list(Type.var("$0")), TypeOps.substitute(get.params().get(1), bind));
     }

--- a/souther-compiler/src/test/java/souther/compiler/check/AnExpansionRefusesAnArgumentWhereItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AnExpansionRefusesAnArgumentWhereItIsWrittenTest.java
@@ -1,0 +1,56 @@
+package souther.compiler.check;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Region;
+
+/**
+ * An expansion refuses an argument at the argument, not at the call that carried it.
+ *
+ * <p>What holds an application to the signature it instantiated is the one reader that sees every
+ * position of one variable at once, so it is the only one that can refuse two readings that
+ * disagree. It was given the two types and a position of the form it was reading, and answered
+ * there. The argument is what supplied the type it refused, and the caller reading it still has the
+ * argument.
+ */
+class AnExpansionRefusesAnArgumentWhereItIsWrittenTest {
+
+    /** The text {@code region} underlines, cut out of {@code source}. */
+    private static String underlined(String source, Region region) {
+        String line = source.split("\n", -1)[region.start().line() - 1];
+        int from = region.start().column() - 1;
+        int to = region.end().line() == region.start().line()
+                ? region.end().column() - 1 : line.length();
+        return line.substring(Math.min(from, line.length()), Math.min(to, line.length()));
+    }
+
+    private static Region regionOf(String source) {
+        CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(source));
+        return e.diagnostic().region();
+    }
+
+    @Test
+    void anArgumentHeldToWhatTheBindingDeclaresIsUnderlinedWhole() {
+        String source = """
+                module demo
+
+                let twice (n: Int): Int = n + n
+
+                behavior notice : (a: String, b: String) -> Int
+
+                let notice (a, b) =
+                    twice(
+                        String.append(a, b)
+                    )
+                """;
+
+        assertEquals("String.append", underlined(source, regionOf(source)),
+                "the argument is `String.append(a, b)`, so the caret covers it rather than its "
+                        + "first character");
+    }
+}


### PR DESCRIPTION
Closes #613.

A type operation knew which two types did not go together, and was made to decide
the report as well: it was handed a `SourcePos` and an English sentence before the
answer was known, and threw a rendered `Diagnostic` from inside the solving walk.
The position it could offer was whatever the caller had spare, and which operand
the report was about survived only as prose.

## What changed

`Fit` — the answer a solving walk gives. `Fits`, or `Disagrees(expected, actual)`
carrying the two types at the position that disagreed. No source, no wording. It
takes the shape `ArithmeticCheck` already takes in this package, for the same
reason: the answer carries what was broken, and the diagnostic is chosen from it
rather than re-derived beside it.

`TypeOps.unify(param, arg, bindings, symbols)` returns a `Fit`. `SourcePos` and
`String what` are gone, and so is the `SourcePos` import.

`Substitution.decide` and `hold` return a `Fit`. `constrain` moved out of
`Substitution` into `Elaborator`, where it still bundles the two rules but each one
states itself once and draws its report at the operand. `Substitution` now imports
nothing from `diag`.

`Elaborator` gained the three reporting functions — `doesNotFit`, `decide`, `hold`
— so one rule has one sentence and every region comes from an operand.

**A failed solve commits nothing.** The walk stopped at the first position that
disagreed and left behind whatever it had bound on the way there, which a caller
could not tell from what was in the map before. `pinResultTypeVars` was already
working around it with a scratch copy; the copy is the contract, so it is written
where the walk is and the workaround is gone.

## What a reader sees

An argument held to what an expansion's binding declares is now underlined whole
rather than at its first character:

```
-- TYPE MISMATCH  E1317 -------------------------exp.sou:9:9

9|         String.append(a, b)
           ^^^^^^^^^^^^^
```

A kept call's function argument is refused where the block is written, by the
sentence a value argument is refused by, instead of at the callee by a second
sentence.

## Tests

- `AFailedSolveCommitsNothingTest` — a variable settled before the disagreement is
  not kept, a walk that fits keeps what it settled, and the answer names the
  position that disagreed rather than the pair the walk started from.
- `AKeptCallsFunctionArgumentIsRefusedWhereItIsWrittenTest` — the block is
  underlined where it is written, and refused by the same sentence as a value
  argument.
- `AnExpansionRefusesAnArgumentWhereItIsWrittenTest` — the argument's whole region,
  not its first character.

`mvn clean install`: 6515 tests, all green.

## Left out on purpose

`BottomInfer.reportsUnresolvedBottom` stays. It recovers a structural fact by
matching a regular expression against a rendered type string, which is this same
boundary pointing the wrong way — but the exception it inspects comes from
elaborating a whole step body at arbitrary depth, not from a solve, so a failure
value at this boundary does not supply what that caller asks for. Removing it needs
an unresolved bottom to be reported structurally wherever it arises.

The block-result report at `HelperTyping:594` is anchored at the lambda by a
diagnostic the caller builds after catching, so this change does not move it —
#615. The list-element mismatch is #611, which is blocked on a different question:
what source evidence corresponds to an accumulated element type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
