### PR TITLE
Report a refused result at what supplied it, not at the block's parameters

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -475,7 +475,7 @@ public final class Elaborator {
         if (narrowGot == null) {
             throw narrowFailed;   // the narrow type errored and there was no sum to fall back to
         }
-        throw CompileException.of(Diagnostic.at(stepArg.pos())
+        throw CompileException.of(Diagnostic.at(answerRegion(stepArg))
                 .say(new HelperMessage.TheStepAnswersAnotherTypeThanTheAccumulator(fnName,
                         Type.show(narrowGot),
                         Type.show(TypeOps.substitute(declaredStep.result(), bind))))
@@ -1496,6 +1496,33 @@ public final class Elaborator {
             case Ast.Apply c -> c.name().region();
             default -> Region.ofWidth(e.pos(), width(e));
         };
+    }
+
+    /**
+     * What a report about the value a function argument answered with underlines.
+     *
+     * <p>A block answers with its body, and the block's own position is where its parameters start —
+     * so a report drawn there names what the block returned while pointing at what takes its
+     * arguments. The bindings written above the answer are stepped over: a {@code let} holds the
+     * value it binds, which is not the value the block answered with.
+     *
+     * <p>Nothing else is stepped over. An {@code if} and a {@code match} have the type their arms
+     * join to, so no one arm supplied it and the construct is what did. An expansion is left alone
+     * for its own reason: its body is the callee's, and a report drawn inside it names a place the
+     * author did not write this value at.
+     *
+     * <p>A function value written where a block goes is eta-expanded into a block by the time this
+     * is asked, and the expansion it answers with is what stops the descent — the expression that
+     * answered is in that function's own declaration, and the argument is as far as this source
+     * goes.
+     */
+    public static Region answerRegion(Ast.Expr fnArg) {
+        return region(fnArg instanceof Ast.Block block ? answering(block.body()) : fnArg);
+    }
+
+    /** {@code body} with the bindings written above its answer stepped over. */
+    private static Ast.Expr answering(Ast.Expr body) {
+        return body instanceof Ast.LetIn li ? answering(li.body()) : body;
     }
 
     public static int width(Ast.Expr e) {

--- a/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/HelperTyping.java
@@ -9,7 +9,6 @@ import souther.compiler.diag.msg.HelperMessage;
 import souther.compiler.diag.msg.InvariantMessage;
 import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.Region;
-import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
 import java.util.ArrayList;
@@ -545,10 +544,12 @@ public final class HelperTyping {
     }
 
     /** The block a combinator was handed answers with the wrong type, in written types on both sides
-     * (`'b?` / `String`), not in the checker's own spelling. */
+     * (`'b?` / `String`), not in the checker's own spelling. It takes the block rather than a
+     * position, so where the report is drawn is decided here from the value being refused and not by
+     * whichever position a caller had to hand. */
     private static CompileException blockReturnMismatch(Ast.FnDef h, String paramName, Type want,
-                                                        Type got, SourcePos pos) {
-        return CompileException.of(Diagnostic.at(pos)
+                                                        Type got, Ast.Expr block) {
+        return CompileException.of(Diagnostic.at(Elaborator.answerRegion(block))
                 .say(new HelperMessage.TheBlockAnswersAnotherType(paramName, h.name(),
                         Type.show(want), Type.show(got)))
                 .build());
@@ -593,12 +594,12 @@ public final class HelperTyping {
                 // one answering with a plain value. Unifying also pins `'b` for the arguments after
                 // this one. A failure is reported as the mismatch it is, in written types.
                 if (TypeOps.unify(want.result(), got, bind, symbols) instanceof Fit.Disagrees) {
-                    throw blockReturnMismatch(h, paramName, want.result(), got, lambda.pos());
+                    throw blockReturnMismatch(h, paramName, want.result(), got, lambda);
                 }
                 return;
             }
             if (!TypeOps.assignable(got, want.result(), symbols)) {
-                throw blockReturnMismatch(h, paramName, want.result(), got, lambda.pos());
+                throw blockReturnMismatch(h, paramName, want.result(), got, lambda);
             }
         } else if (arg instanceof Ast.Var v
                 && env.of(v.denotes(), v.name()) instanceof Type vt && !(vt instanceof Type.FnOf)) {

--- a/souther-compiler/src/test/java/souther/compiler/diag/AResultReportUnderlinesWhatSuppliedTheValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AResultReportUnderlinesWhatSuppliedTheValueTest.java
@@ -1,0 +1,216 @@
+package souther.compiler.diag;
+
+import souther.compiler.Compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A report about the value a function argument answered with underlines the expression that supplied
+ * that value.
+ *
+ * <p>The value a block answers is its body's, and a block's own position is where its parameters
+ * start. A report that names what the block returned and points at what takes its parameters has the
+ * reader looking at one thing while being told about another — the two are on different lines as soon
+ * as the block is written over more than one.
+ *
+ * <p>A {@code let} written above the answer holds the value it binds and not the block's answer, so
+ * the bindings are stepped over. An {@code if} or a {@code match} is not: its type is the join of its
+ * arms, so no one arm supplied it and the whole construct is what did.
+ *
+ * <p>Where the argument is a function value rather than a block, nothing at this call site made the
+ * value — the expression that did is in the function's own declaration — so the argument is as far as
+ * the source goes.
+ */
+class AResultReportUnderlinesWhatSuppliedTheValueTest {
+
+    private static final String APPLY_TWICE = """
+            module demo
+
+            let applyTwice (f: (Int) -> Int, x: Int) =
+                f(f(x))
+            """;
+
+    private static final String BAG = """
+            module demo
+
+            data Empty
+            data Full = { held: Int }
+            data Bag = Empty | Full
+            """;
+
+    /**
+     * The declared result is concrete, so the block is checked against it directly. The answer is a
+     * literal one line below the parameters that used to be underlined.
+     */
+    @Test
+    void aBlockAnsweringAConcreteResultIsUnderlinedAtItsAnswer() {
+        String source = APPLY_TWICE + """
+
+                let used =
+                    applyTwice(
+                        (n) ->
+                            "not an int"
+                    , 1
+                    )
+                """;
+
+        assertEquals("\"not an int\"", underlined(source, only(source)));
+    }
+
+    /**
+     * The declared result still carries a type variable, so the block is checked by unifying against
+     * it. That is the other of the two branches and it reaches the same report.
+     */
+    @Test
+    void aBlockAnsweringAResultStillCarryingAVariableIsUnderlinedAtItsAnswer() {
+        String source = """
+                module demo
+
+                let picked =
+                    List.filterMap(
+                        (n) ->
+                            1
+                    , [1, 2, 3]
+                    )
+                """;
+
+        assertEquals("1", underlined(source, only(source)));
+    }
+
+    /**
+     * A block written with bindings above its answer. Underlining the body would put the caret on the
+     * {@code let} keyword, which holds the value it binds and not the one the block answered with.
+     */
+    @Test
+    void aBlockWithBindingsAboveItsAnswerIsUnderlinedAtTheAnswer() {
+        String source = APPLY_TWICE + """
+
+                let used =
+                    applyTwice(
+                        (n) -> {
+                            let m = n + 1
+                            "not an int"
+                        }
+                    , 1
+                    )
+                """;
+
+        assertEquals("\"not an int\"", underlined(source, only(source)));
+    }
+
+    /**
+     * Both arms answer the refused type, and neither of them is what supplied it: the type is the
+     * join, which the {@code if} has and its arms do not. Descending into one of them would name an
+     * arm the report is not about.
+     */
+    @Test
+    void aBlockAnsweringWithAJoinIsUnderlinedAtTheConstructThatJoins() {
+        String source = APPLY_TWICE + """
+
+                let used =
+                    applyTwice(
+                        (n) ->
+                            if n > 0 then
+                                "a"
+                            else
+                                "b"
+                    , 1
+                    )
+                """;
+
+        Diagnostic report = only(source);
+        assertEquals("if n > 0 then", lineUnderlined(source, report).trim());
+        assertEquals(1, report.region().sourceSpan(), "a construct is measured from its start");
+    }
+
+    /** A fold's step, written as a block, answers something the accumulator cannot hold. */
+    @Test
+    void aStepAnsweringAnotherTypeThanTheAccumulatorIsUnderlinedAtItsAnswer() {
+        String source = BAG + """
+
+                let summed (ms: List<Int>) =
+                    List.fold(
+                        (acc, m) ->
+                            "not a bag"
+                    , Empty
+                    , ms
+                    )
+                """;
+
+        assertEquals("\"not a bag\"", underlined(source, only(source)));
+    }
+
+    /** The same step with bindings above its answer. */
+    @Test
+    void aStepWithBindingsAboveItsAnswerIsUnderlinedAtTheAnswer() {
+        String source = BAG + """
+
+                let summed (ms: List<Int>) =
+                    List.fold(
+                        (acc, m) -> {
+                            let doubled = m * 2
+                            "not a bag"
+                        }
+                    , Empty
+                    , ms
+                    )
+                """;
+
+        assertEquals("\"not a bag\"", underlined(source, only(source)));
+    }
+
+    /**
+     * A step passed as a function value. The name is eta-expanded into a block before this runs, so
+     * what the check holds is a block whose body is the expansion of the callee — and the expression
+     * that answered is inside that callee, at a place the author did not write this value. The report
+     * stays at the argument.
+     *
+     * <p>This is the row that fails if the expansion is stepped over along with the bindings: it
+     * would move to {@code wrong}'s own body, two definitions up.
+     */
+    @Test
+    void aStepPassedAsAFunctionValueIsUnderlinedAtTheArgumentAndNotInsideTheCallee() {
+        String source = BAG + """
+
+                let wrong (acc: Bag, m: Int): Int =
+                    m
+
+                let summed (ms: List<Int>) =
+                    List.fold(
+                        wrong
+                    , Empty
+                    , ms
+                    )
+                """;
+
+        assertEquals("wrong", lineUnderlined(source, only(source)).trim());
+    }
+
+    /** The one report compiling {@code source} produces. */
+    private static Diagnostic only(String source) {
+        CompileException thrown =
+                assertThrows(CompileException.class, () -> Compiler.compile(source));
+        List<Diagnostic> all = thrown.diagnostics();
+        assertEquals(1, all.size(), "one mistake, one report: " + all);
+        return all.get(0);
+    }
+
+    /** The characters of {@code source} a report's primary region covers. */
+    private static String underlined(String source, Diagnostic report) {
+        Region region = report.region();
+        assertEquals(region.start().line(), region.end().line(),
+                "an expression this test is about is one line's worth");
+        int from = region.start().column() - 1;
+        return lineUnderlined(source, report).substring(from, from + region.sourceSpan());
+    }
+
+    /** The whole source line a report's primary region begins on. */
+    private static String lineUnderlined(String source, Diagnostic report) {
+        return source.lines().toList().get(report.region().start().line() - 1);
+    }
+}

--- a/specification.adoc
+++ b/specification.adoc
@@ -4959,7 +4959,7 @@ Reported at the argument (<<a-function-goes-where-a-function-is-taken>>). Which 
 A fold's block must return the accumulator type Amount, but got Int.
 ----
 
-Reported at the block (<<a-block-answers-the-type-its-position-takes>>): a `+fold+`'s accumulator, a predicate's `+Bool+`, the element type of what is being grown.
+Reported at the expression that supplies the block's result (<<a-block-answers-the-type-its-position-takes>>): a `+fold+`'s accumulator, a predicate's `+Bool+`, the element type of what is being grown. A block's own position is where its parameters start, and the value being refused came from its body, so the report is at the body's answer — past any `+let+` written above it, which holds what it binds and not what the block answered. An `+if+` or a `+match+` the body ends in is that answer: its type is the one its arms join to, so no single arm supplied it.
 
 [#e1806]
 === An argument does not have the type its parameter takes
@@ -4969,7 +4969,7 @@ Reported at the block (<<a-block-answers-the-type-its-position-takes>>): a `+fol
 `List.map`'s element type Amount is not acceptable to the function, which takes Int.
 ----
 
-Reported at the argument (<<an-argument-has-the-type-its-parameter-takes>>).
+Reported at the argument (<<an-argument-has-the-type-its-parameter-takes>>). Where the argument is a `+fold+`'s step and the step is written as a block, it is reported at the expression that supplies the step's result, as <<e1805>> is. Where the step is a function declared elsewhere, nothing at this call made the value it answered with, and the argument is as far as the source goes.
 
 [#e1807]
 === A function binding would need two types


### PR DESCRIPTION
Closes #615.

## What was wrong

A block handed to a function parameter is checked against what that parameter declares, and a mismatch was reported at the block's own position — which is where its parameters start. The message named what the block returned while the caret sat under what takes its arguments.

```
-- FUNCTION  E1805 ----------------------------block.sou:8:9

8|         (n) ->
           ^

The block passed to `f` of `let applyTwice` must return Int, but returns String.
```

`"not an int"` is the String, on line 9.

## It is two sites, not one

The issue reads this as one call site. `Elaborator.resolveStepBinding` draws E1806 the same way — it says what a fold's step answers and points at `(acc, m) ->`:

```
-- FUNCTION  E1806 -----------------------------step.sou:9:9

9|         (acc, m) ->
           ^

`List.foldFrom`'s step answers String, and the accumulator it builds holds Empty.
```

Both reports hold the expression whose type became the refused value and then build a diagnostic from the enclosing callable's position instead.

## What this changes

`Elaborator.answerRegion` is that decision, in one place.

A block answers with its body, so the bindings written above the answer are stepped over: a `let` holds what it binds, not what the block answered. Nothing else is stepped over.

- An `if` and a `match` have the type their arms join to, so the construct supplied it and no single arm did.
- An expansion's body is the callee's. A report drawn inside it names a place the author did not write this value at — which is what the pre-expansion check exists to avoid.

`blockReturnMismatch` now takes the block rather than a `SourcePos`, so where the report is drawn is decided from the value being refused and not by whichever position a caller had to hand.

## The specification said to do it the old way

```
Reported at the block (<<a-block-answers-the-type-its-position-takes>>)
```

So this was not a slip against the written rule but agreement with it. Both catalogue entries now state where the report goes and why, including the `let` and the join.

## Tests

Neither message had a test. The seven rows fix the region as well as the code:

| row | underlines |
| --- | --- |
| E1805, concrete result | `"not an int"` |
| E1805, result still carrying a variable | `1` |
| E1805, bindings above the answer | `"not an int"` |
| E1805, answer is a join | the `if`, width 1 |
| E1806, step written as a block | `"not a bag"` |
| E1806, step with bindings above its answer | `"not a bag"` |
| E1806, step passed as a function value | the argument line |

The last row is the one that fails if an expansion is stepped over: the report moves to `wrong`'s own body, two definitions up. That was confirmed by making the change and watching the row go red.

## Left alone

The caret is one column wide where the argument is a function value. `Elaborator.region` has no `Ast.Expansion` branch and an expansion carries no written name, so the spelling cannot be recovered from it. That is extent rather than anchor, and out of scope here.

The catalogue's sample messages for E1805 and E1806 quote text no producer emits any more. So does the message naming `let filterMap` for a `List.filterMap` call and `List.foldFrom` for a `List.fold` call. That is diagnostic vocabulary, not position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
