### PR TITLE
Observe a comparison where it runs, not at an arm of its guard

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/Backend.java
@@ -437,15 +437,16 @@ public final class Backend {
             }
         }
         out.putAll(b.ctx.synthClasses());   // escaping lambdas compiled to Fn classes (spec §blocks)
-        // Every arm the plan counted has to be in the bytecode, or the ones that are missing come back
-        // as arms no row goes through. A body the emitter walks without counting its arms is the way
-        // that happens, and it is silent at the site — so it is caught here, where the two can be
-        // compared.
+        // Every site the plan numbered has to be in the bytecode. A missing arm comes back as an arm
+        // no row goes through and a missing comparison as a line no row reached, and both read as the
+        // model being short of rows rather than the measurement being short of probes. A body the
+        // emitter walks without counting is how that happens, and it is silent at the site — so it is
+        // caught here, where the plan and what was emitted can be compared.
         List<Integer> missed = b.ctx.plannedButNotEmitted();
         if (!missed.isEmpty()) {
-            throw new IllegalStateException("the plan counted " + missed.size()
-                    + " arm(s) that nothing emitted: " + missed
-                    + "; a body was walked without counting its arms");
+            throw new IllegalStateException("the plan numbered " + missed.size()
+                    + " site(s) that nothing emitted: " + missed
+                    + "; a body was walked without counting what it holds");
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/BodyGen.java
@@ -599,6 +599,29 @@ final class BodyGen {
          * So it can go at the head of any arm without the arm's own emission having to know it is
          * there, and a measuring build and a shipping build differ by these calls and by nothing else.
          */
+        /**
+         * Records that this comparison produced a value, where it is one a guard's condition is made
+         * of.
+         *
+         * <p>After the value and not before it. What a boundary is met by is the comparison having
+         * answered, and an operand can abort on the way — {@code x /= 0 && 100 / x > 1} is why the
+         * operators stop when the answer is settled in the first place. A probe in front of the
+         * emission would record a comparison that never produced anything as one that did.
+         *
+         * <p>Absent is ordinary here, unlike an arm's: what has a site is every comparison of a
+         * condition this plan instruments, and the emitter walks comparisons everywhere else too.
+         */
+        private void comparisonProbe(Core.Binary comparison) {
+            if (!armsAreCounted || !ctx.measuring()) {
+                return;
+            }
+            ctx.comparisonSiteOf(comparison).ifPresent(site -> {
+                ctx.emitted(site);
+                code.loadConstant(site);
+                code.invokestatic(CD_Probe, "hit", MTD_Probe_hit);
+            });
+        }
+
         private void probe(Core node, int arm) {
             if (!armsAreCounted || !ctx.measuring()) {
                 return;
@@ -726,7 +749,10 @@ final class BodyGen {
                 case Core.ListLit lit -> listLit(lit);
                 case Core.Tuple t -> tuple(t);
                 case Core.TupleGet tg -> tupleGet(tg);
-                case Core.Binary bin -> binary(bin);
+                case Core.Binary bin -> {
+                    binary(bin);
+                    comparisonProbe(bin);
+                }
                 case Core.NewData nd -> newData(nd);
                 case Core.Match m -> match(m, expected);
                 case Core.Call c -> call(c, expected);

--- a/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
+++ b/souther-compiler/src/main/java/souther/compiler/codegen/CodegenContext.java
@@ -149,6 +149,17 @@ final class CodegenContext {
         return arms;
     }
 
+    /**
+     * Where this comparison's value is recorded, or empty where it is not one of a guard's condition.
+     *
+     * <p>Not the loud lookup {@link #probesOf} is. An arm the plan does not hold is a plan made from
+     * other nodes; a comparison it does not hold is any comparison written outside a condition, which
+     * is most of them.
+     */
+    java.util.OptionalInt comparisonSiteOf(souther.compiler.core.Core comparison) {
+        return coverage.comparisonSiteOf(comparison);
+    }
+
     /** Records that one planned arm was emitted. */
     void emitted(int site) {
         emittedSites.add(site);

--- a/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
+++ b/souther-compiler/src/main/java/souther/compiler/coverage/CoverageSites.java
@@ -1,5 +1,6 @@
 package souther.compiler.coverage;
 
+import souther.compiler.ast.Ast;
 import souther.compiler.core.Core;
 import souther.compiler.diag.SourceRef;
 import souther.compiler.types.TypeName;
@@ -69,7 +70,28 @@ public final class CoverageSites {
             /** The arm an attempted construction takes when the value was built. */
             CONSTRUCTED,
             /** An arm it takes when a clause refused. */
-            DEPARTURE
+            DEPARTURE,
+            /**
+             * One comparison of a guard's condition, recorded where it produced its boolean value.
+             *
+             * <p>Not an arm, and counted as one nowhere. A condition stops as soon as its answer is
+             * settled, so which arm a row landed in does not say which of the condition's comparisons
+             * ran: under {@code A && B} the arm where the condition failed is where a row that made
+             * {@code B} false lands and where a row that never reached {@code B} lands. Only an
+             * observation at the comparison separates them.
+             */
+            COMPARISON;
+
+            /** Whether a site of this kind is one of the arms a branch measure counts, and so one a
+             * report can name as an arm no row goes through. */
+            public boolean isArm() {
+                return this != COMPARISON;
+            }
+        }
+
+        /** Whether this is one of the arms a branch measure counts. */
+        public boolean isArm() {
+            return kind.isArm();
         }
     }
 
@@ -95,18 +117,62 @@ public final class CoverageSites {
      * are equal, and a value-keyed map would hand the emitter the wrong arm's probe. The instances
      * here must be the ones the emitter is walking — the same answer, not an equal one.
      */
-    public record Plan(List<Site> sites, List<GuardRef> guards, IdentityHashMap<Core, int[]> byNode) {
+    public record Plan(List<Site> sites, List<GuardRef> guards, IdentityHashMap<Core, int[]> byNode,
+                       IdentityHashMap<Core, Integer> byComparison) {
 
-        public static final Plan NONE = new Plan(List.of(), List.of(), new IdentityHashMap<>());
+        public static final Plan NONE = new Plan(List.of(), List.of(), new IdentityHashMap<>(),
+                new IdentityHashMap<>());
 
         public boolean isEmpty() {
             return sites.isEmpty();
         }
 
         /** The probe numbers of {@code node}'s arms, in the order the emitter emits them, or null
-         * where this node has none. An entry is {@link #NO_SITE} where that arm answers nothing. */
+         * where this node has none. An entry is {@link #NO_SITE} where that arm answers nothing.
+         *
+         * <p>Arms only, and positional. A comparison's site is not in here and must not be put in
+         * here: the emitter and the readers index this array by an arm's place among its siblings,
+         * and anything else in it lights a neighbour's probe. */
         public int[] probesOf(Core node) {
             return byNode.get(node);
+        }
+
+        /**
+         * Where a comparison's value is recorded, for a comparison that has such a site.
+         *
+         * <p>Empty is an ordinary answer. What gets a site is decided from the shape of the code —
+         * every comparison of a guard's condition — while whether a line is drawn on one is decided
+         * later and from more: a comparison the partition reads nothing off keeps its site and nobody
+         * asks about it. The emitter walks comparisons in both cases and asks this of each.
+         */
+        public java.util.OptionalInt comparisonSiteOf(Core comparison) {
+            Integer site = byComparison.get(comparison);
+            return site == null ? java.util.OptionalInt.empty() : java.util.OptionalInt.of(site);
+        }
+
+        /**
+         * The same, where the caller's own construction says there is one.
+         *
+         * <p>A guard-origin boundary is read off a comparison of a condition this plan instruments,
+         * so the site was planned before the line was. Absent here is not a boundary that cannot be
+         * measured — it is this plan and the reader that found the comparison disagreeing about what
+         * a condition is made of, which no measurement should paper over.
+         */
+        public int requireComparisonSiteOf(Core comparison) {
+            Integer site = byComparison.get(comparison);
+            if (site == null) {
+                throw new IllegalStateException(
+                        "no comparison site was planned at " + comparison.pos()
+                                + "; a line is read off a comparison this plan does not hold");
+            }
+            return site;
+        }
+
+        /** The arms of one behavior, which is what a branch measure counts. */
+        public List<Site> arms(String behavior) {
+            return sites.stream()
+                    .filter(site -> site.behavior().equals(behavior) && site.isArm())
+                    .toList();
         }
 
         public Site site(int index) {
@@ -121,7 +187,8 @@ public final class CoverageSites {
         for (Map.Entry<String, Core> body : behaviorBodies.entrySet()) {
             walk.behavior(body.getKey(), body.getValue());
         }
-        return new Plan(List.copyOf(walk.sites), List.copyOf(walk.guards), walk.byNode);
+        return new Plan(List.copyOf(walk.sites), List.copyOf(walk.guards), walk.byNode,
+                walk.byComparison);
     }
 
     private static final class Walk {
@@ -130,6 +197,7 @@ public final class CoverageSites {
         private final List<Site> sites = new ArrayList<>();
         private final List<GuardRef> guards = new ArrayList<>();
         private final IdentityHashMap<Core, int[]> byNode = new IdentityHashMap<>();
+        private final IdentityHashMap<Core, Integer> byComparison = new IdentityHashMap<>();
         private final IdentityHashMap<Core, Boolean> answering = new IdentityHashMap<>();
         private String behavior;
         private int ordinal;
@@ -254,6 +322,7 @@ public final class CoverageSites {
                     if (then != NO_SITE || els != NO_SITE) {
                         guards.add(new GuardRef(behavior, then, els,
                                 new SourceRef(sourceId, iff.pos())));
+                        comparisons(iff.cond());
                     }
                 }
                 case Core.Match m -> {
@@ -278,6 +347,39 @@ public final class CoverageSites {
                     }
                     byNode.put(ic, arms);
                 }
+            }
+        }
+
+        /**
+         * Every comparison one condition is made of, numbered where the code says one is.
+         *
+         * <p>Read off the shape of the condition and nothing else. Which of these a line is later
+         * drawn on takes the behavior's parameters and the module's symbols to answer, and neither is
+         * here — nor should be. A plan's numbering has to be a function of the bodies alone, because
+         * the emitter builds one plan and a measurement builds another and the two are the same
+         * numbering or the probes mean nothing. So this is deliberately wider than what gets read: a
+         * comparison no boundary is drawn on keeps a site nobody asks about, which costs two
+         * instructions in a measuring build and keeps the numbering answerable without the partition.
+         *
+         * <p>Descends through {@code &&} and {@code ||} only, because that is what a condition is
+         * built out of and what the reader of lines walks. Anything else is where the condition's
+         * operands stop.
+         */
+        private void comparisons(Core condition) {
+            if (condition instanceof Core.Binary binary
+                    && (binary.op() == Ast.BinOp.AND || binary.op() == Ast.BinOp.OR)) {
+                comparisons(binary.left());
+                comparisons(binary.right());
+                return;
+            }
+            // Numbered once. A node reached twice is one comparison written once, and a second number
+            // for it would be a site the emitter never lights — which is the shape of a real omission
+            // and would be reported as one.
+            if (condition instanceof Core.Binary comparison
+                    && !byComparison.containsKey(comparison)) {
+                byComparison.put(comparison,
+                        site(Site.Kind.COMPARISON, comparison.op().toString(), comparison,
+                                comparison));
             }
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BoundaryObligation.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BoundaryObligation.java
@@ -9,24 +9,12 @@ import souther.compiler.observe.ObservedValue;
  * held in a query answer without dragging the classes and their classifiers along with it.
  *
  * <p>An obligation from an invariant is met by a row whose value is the boundary. One from a guard is
- * not: the guard has to have been evaluated as well, because a value can reach the input of a
- * behavior without reaching the comparison that cares about it.
- *
- * @param witnessed whether an arm of the guard could stand as evidence for a row written here. False
- *                  where the comparison sits inside a condition whose arms do not separate the rows
- *                  that reached it from the rows that did not — a second operand of {@code &&} has
- *                  no such arm on the side where it is false. The obligation is still an obligation:
- *                  the line is the model's and a row at it is a row somebody should write. What is
- *                  missing is a way for this build to see that they did, which is why it is carried
- *                  here rather than by leaving the obligation out
+ * not: the comparison has to have produced a value as well, because a value can reach the input of a
+ * behavior without reaching the comparison that cares about it. Which row did that is read off the
+ * site the guard's origin carries, and every guard origin has one.
  */
 public record BoundaryObligation(AxisId axis, OriginRef origin, BoundarySide side,
-                                 ObservedValue value, boolean witnessed) {
-
-    public BoundaryObligation(AxisId axis, OriginRef origin, BoundarySide side,
-                              ObservedValue value) {
-        this(axis, origin, side, value, true);
-    }
+                                 ObservedValue value) {
 
     public enum BoundarySide {
         /** The largest value on the low side of the cut. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -31,12 +31,13 @@ import java.util.List;
  * the line at a hundred thousand went unread, and the position came back as one the model divides
  * no way — two tokens from the comparison that divides it.
  *
- * <p>What the condition does decide is which arm stands as evidence that a comparison was
- * evaluated. Under {@code A && B} an overseas request takes the else arm without {@code cost}
- * having been compared, so that arm proves nothing about the second operand; the arm where the
- * whole condition held proves both. That is carried per comparison as a {@link OriginRef
- * .GuardOrigin.Witness}, and an edge no arm can witness is reported as one nothing measured rather
- * than dropped — the line is the model's either way.
+ * <p>Whether a comparison ran is not something the arms answer. A condition stops as soon as it is
+ * settled, so under {@code A && B} an overseas request takes the else arm without {@code cost} having
+ * been compared — and so does a request whose cost was compared and found too high. Each comparison
+ * carries the site its own value is recorded at, which is what a line is measured against. What the
+ * shape of the condition does decide is which arm a row that reached the comparison can be in, and
+ * that is a question about the classes either side of the line: it is carried as a {@link OriginRef
+ * .GuardOrigin.Witness} and read by {@link GuardEdge}.
  *
  * <p>Three readers are kept apart here and are easy to run together. Which comparisons exist is
  * {@link #comparisonsIn}; which positions a comparison names at all is {@link #mentioned}; which
@@ -120,11 +121,9 @@ public final class GuardThresholds {
     /**
      * Every position a condition compares, however the condition is written.
      *
-     * <p>Names them and no more. What a comparison inside a conjunction would need before it could be
-     * a line is which arm witnesses it having been evaluated, and that is not answered here — a
-     * threshold recorded without it is an obligation nobody can discharge. So this establishes only
-     * that the model draws something at this position, which is exactly what {@code not derivable}
-     * would otherwise deny.
+     * <p>Names them and no more. Whether a line can be drawn on one is {@link #termOf}'s narrower
+     * question, and this establishes only that the model draws something at this position — which is
+     * exactly what {@code not derivable} would otherwise deny.
      */
     private static List<Guards.Unread> comparedIn(Core e, List<Core> read, List<String> parameters,
                                                   Symbols symbols) {
@@ -368,6 +367,10 @@ public final class GuardThresholds {
         if (guard == null) {
             return null;   // no site for this `if`: nothing could answer for it
         }
+        // The plan numbered every comparison of an instrumented condition before anything read a line
+        // off one, so this is here. Required rather than looked up leniently: a line whose comparison
+        // has no site is this reader and the plan disagreeing about what a condition is made of.
+        int site = plan.requireComparisonSiteOf(comparison);
         if (below == null) {
             // An equality singles the value out instead. Recorded as that rather than as a place to
             // cut, because the values either side of it are not a distinction the model has drawn.
@@ -375,7 +378,8 @@ public final class GuardThresholds {
                 return null;
             }
             singled.add(new Guards.Singled(term, value,
-                    new OriginRef.GuardOrigin(guard, new SourceRef(guard.at().sourceId(), iff.pos()),
+                    new OriginRef.GuardOrigin(guard, site,
+                            new SourceRef(guard.at().sourceId(), iff.pos()),
                             true, placed.witness(), op == Ast.BinOp.EQ, true)));
             return term.path();
         }
@@ -383,7 +387,8 @@ public final class GuardThresholds {
         // question as which class the value falls in: `x <= c` and `x > c` agree about the second.
         boolean holds = op == Ast.BinOp.LE || op == Ast.BinOp.GE;
         out.add(new Threshold(term, value, below,
-                new OriginRef.GuardOrigin(guard, new SourceRef(guard.at().sourceId(), iff.pos()),
+                new OriginRef.GuardOrigin(guard, site,
+                        new SourceRef(guard.at().sourceId(), iff.pos()),
                         below, placed.witness(), holds)));
         // Which side of the line the line's own value is on does not say which arm is which. `x <= c`
         // and `x > c` agree about the first and take opposite halves, so the arms are read off the

--- a/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/OriginRef.java
@@ -39,56 +39,48 @@ public sealed interface OriginRef {
      * writing the value: the comparison has to have been evaluated. A row can hand the behavior the
      * exact threshold and never reach the guard that cares about it.
      *
-     * @param guard             which {@code if} — by the arms it owns, so a hit set answers whether
-     *                          it ran
+     * @param guard             which {@code if} — by the arms it owns, which is what says which
+     *                          class of the partition a row landed in
+     * @param site              where the comparison's own value is recorded. Required, and this is
+     *                          what meeting the line is measured against: a row met it by getting the
+     *                          comparison to answer, which is not what any arm records. A condition
+     *                          stops as soon as it is settled, so under {@code A && B} the arm where
+     *                          the condition failed holds rows that made {@code B} false and rows
+     *                          that never reached {@code B}
      * @param valueBelongsBelow which side of the line the cut value itself is on. It decides which
      *                          neighbour is the other class's edge: {@code <= 3000} leaves 3001 over
      *                          there, {@code < 3000} leaves 2999.
-     * @param witness           which arms of the {@code if} prove this comparison was evaluated.
-     *                          Both, where the comparison is the whole condition. Under {@code A &&
-     *                          B} only {@code then} proves the second operand ran, and under
-     *                          {@code A || B} only {@code else} does — so a row that landed in the
-     *                          other arm has shown nothing about this line, however its value reads
-     * @param holdsAtTheValue   whether the comparison is true at the line's own value, which is what
-     *                          says which side of it a row would have to be on to reach a witnessing
-     *                          arm. Not derivable from {@code valueBelongsBelow}: {@code x <= c} and
-     *                          {@code x > c} agree about the class the value is in and disagree here
+     * @param witness           which arms of the {@code if} a row reaching this comparison can land
+     *                          in. Not what says the comparison ran — {@code site} is — but what says
+     *                          which arm's edge is this comparison's to draw, which is a question
+     *                          about the classes either side of the line
+     * @param holdsAtTheValue   whether the comparison is true at the line's own value. Not derivable
+     *                          from {@code valueBelongsBelow}: {@code x <= c} and {@code x > c} agree
+     *                          about the class the value is in and disagree here
      */
-    record GuardOrigin(souther.compiler.coverage.CoverageSites.GuardRef guard, SourceRef at,
-                       boolean valueBelongsBelow, Witness witness, boolean holdsAtTheValue,
-                       boolean singles) implements OriginRef {
+    record GuardOrigin(souther.compiler.coverage.CoverageSites.GuardRef guard, int site,
+                       SourceRef at, boolean valueBelongsBelow, Witness witness,
+                       boolean holdsAtTheValue, boolean singles) implements OriginRef {
 
-        public GuardOrigin(souther.compiler.coverage.CoverageSites.GuardRef guard, SourceRef at,
-                           boolean valueBelongsBelow, Witness witness, boolean holdsAtTheValue) {
-            this(guard, at, valueBelongsBelow, witness, holdsAtTheValue, false);
+        public GuardOrigin(souther.compiler.coverage.CoverageSites.GuardRef guard, int site,
+                           SourceRef at, boolean valueBelongsBelow, Witness witness,
+                           boolean holdsAtTheValue) {
+            this(guard, site, at, valueBelongsBelow, witness, holdsAtTheValue, false);
         }
 
-        /** Which arms prove the comparison ran. */
+        /** Which arms a row that reached this comparison can be in. */
         public enum Witness {
-            /** Reaching either arm proves it: the comparison is on the leftmost spine. */
+            /** Either: the comparison is on the leftmost spine, so it runs whatever the condition
+             * comes to. */
             BOTH,
             /** Only the arm the whole condition is true on, which is a conjunction. */
             THEN,
             /** Only the arm it is false on, which is a disjunction. */
             ELSE,
-            /**
-             * Neither, which a condition mixing {@code &&} and {@code ||} leaves.
-             *
-             * <p>Not a claim that no row reaches the comparison — rows reach it all the time. It is
-             * that no arm of this {@code if} separates the rows that did from the rows that did not,
-             * so nothing this build records can tell them apart.
-             */
+            /** Neither on its own, which a condition mixing {@code &&} and {@code ||} leaves: a row
+             * that reached the comparison can be in either arm, so neither arm's edge is this
+             * comparison's alone. */
             NEITHER
-        }
-
-        /** Whether an arm could witness a row written at a value the comparison is {@code true} at. */
-        public boolean witnessedWhereItHolds(boolean holds) {
-            return switch (witness) {
-                case BOTH -> true;
-                case THEN -> holds;
-                case ELSE -> !holds;
-                case NEITHER -> false;
-            };
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -500,8 +500,7 @@ public final class Partitions {
             for (OriginRef origin : cut.origins()) {
                 if (reachable) {
                     out.add(new BoundaryObligation(axis.id(), origin,
-                            BoundaryObligation.BoundarySide.AT, cut.value(),
-                            witnessed(origin, true)));
+                            BoundaryObligation.BoundarySide.AT, cut.value()));
                 }
                 // A line that singles a value out has no neighbour to ask for: the values either
                 // side of it are one class, so a row over there is a row the class's own already is.
@@ -515,38 +514,17 @@ public final class Partitions {
                         domain.successor(cut.value()).filter(next -> holds(within, next))
                                 .ifPresent(next -> out.add(new BoundaryObligation(
                                         axis.id(), origin,
-                                        BoundaryObligation.BoundarySide.ABOVE, next,
-                                        witnessed(origin, false))));
+                                        BoundaryObligation.BoundarySide.ABOVE, next)));
                     } else {
                         domain.predecessor(cut.value()).filter(before -> holds(within, before))
                                 .ifPresent(before -> out.add(new BoundaryObligation(
                                         axis.id(), origin,
-                                        BoundaryObligation.BoundarySide.BELOW, before,
-                                        witnessed(origin, false))));
+                                        BoundaryObligation.BoundarySide.BELOW, before)));
                     }
                 }
             }
         }
         return List.copyOf(out);
-    }
-
-    /**
-     * Whether an arm could stand as evidence for a row written at this obligation's value.
-     *
-     * <p>An invariant's line needs no arm: writing the value is how it is met. A guard's needs the
-     * arm that proves its comparison ran, and which arm that is depends on where the comparison sits
-     * in the condition — so what is asked is whether the arm on this side of the line is one of
-     * them.
-     *
-     * @param atTheValue whether this obligation is the line's own value rather than its neighbour,
-     *                   which is what decides whether the comparison holds where the row would sit
-     */
-    private static boolean witnessed(OriginRef origin, boolean atTheValue) {
-        if (!(origin instanceof OriginRef.GuardOrigin guard)) {
-            return true;
-        }
-        return guard.witnessedWhereItHolds(
-                atTheValue == guard.holdsAtTheValue());
     }
 
     /** Whether a value invented one step off a line is one the position can hold. */

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -704,8 +704,11 @@ public final class Adequacy {
 
             Map<String, BranchEvidence> out = new LinkedHashMap<>();
             for (Ast.BehaviorDef behavior : prepared.value().behaviors()) {
-                List<souther.compiler.coverage.CoverageSites.Site> arms = plan.sites().stream()
-                        .filter(site -> site.behavior().equals(behavior.name())).toList();
+                // The arms, and not every site of the behavior. A comparison of a guard's condition
+                // has a site of its own and is not a fork a row is in or out of, so counting it here
+                // would report an arm the body does not have.
+                List<souther.compiler.coverage.CoverageSites.Site> arms =
+                        plan.arms(behavior.name());
                 Observed observed = byTarget.getOrDefault(behavior.name(), Observed.NONE);
                 BranchEvidence.Reason absent =
                         whyNoArms(behavior.name(), withBodies, measured, observed);

--- a/souther-compiler/src/main/java/souther/compiler/query/BoundaryAssessment.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/BoundaryAssessment.java
@@ -60,18 +60,7 @@ public record BoundaryAssessment(BoundaryObligation obligation, Coverage coverag
              *  comparison. Never a reason for an invariant's line. */
             ARMS_UNREADABLE(MeasurementStatus.NOT_MEASURED),
             /** No row names this behavior. */
-            NO_ROWS(MeasurementStatus.NOT_MEASURED),
-            /**
-             * No arm of the guard separates the rows that reached the comparison from the rows that
-             * did not.
-             *
-             * <p>The second operand of a {@code &&} has this on the side where it is false: the arm
-             * a row there lands in is the one every other way of failing the condition lands in too.
-             * Never a reason for an invariant's line, and never a claim that the line is not owed —
-             * a row at it is still a row somebody should write, and this build has no way to see
-             * that they did.
-             */
-            NO_ARM_WITNESSES_IT(MeasurementStatus.NOT_MEASURED);
+            NO_ROWS(MeasurementStatus.NOT_MEASURED);
 
             private final MeasurementStatus status;
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -357,12 +357,6 @@ final class Coverages {
             BoundaryObligation obligation, Axis axis, List<String> parameters,
             souther.compiler.query.Adequacy.Observed observed, boolean armsAsked) {
         List<RowOutcome> rows = observed.rows();
-        // Asked before the rows are, because no row could answer it. Reading the rows first would
-        // report "no row is at this value" about a value no row can be seen to be at.
-        if (!obligation.witnessed()) {
-            return new BoundaryAssessment.Coverage.NotMeasured(
-                    BoundaryAssessment.Coverage.Reason.NO_ARM_WITNESSES_IT);
-        }
         boolean guard = obligation.origin() instanceof OriginRef.GuardOrigin;
         BoundaryAssessment.Coverage.Reason absent = guard
                 ? whyNoGuardLine(rows, armsAsked, observed.armsUnseen(), observed.someRowsUnseen())
@@ -484,13 +478,18 @@ final class Coverages {
     private enum Met { YES, NO, UNREADABLE, UNDECIDED }
 
     /**
-     * Whether a row wrote the boundary value <em>and</em> got as far as the comparison that cares
-     * about it.
+     * Whether a row wrote the boundary value <em>and</em> got the comparison that cares about it to
+     * produce a value.
      *
      * <p>Both, because either alone is a different claim. A row can hand a behavior exactly 100000 and
      * take an earlier branch that never reaches {@code cost <= 100000}, and counting that as having
-     * tried the boundary would report a rule as exercised that nothing has run. Reaching either arm of
-     * the {@code if} is enough: the comparison was evaluated to get to either one.
+     * tried the boundary would report a rule as exercised that nothing has run.
+     *
+     * <p>Asked of the comparison's own site and of no arm. A condition stops as soon as its answer is
+     * settled, so which arm a row landed in is not an answer about which of the condition's
+     * comparisons ran: under {@code A && B} the arm the condition failed on holds the rows that made
+     * {@code B} false and the rows that never reached {@code B}. Reading the arms here credited the
+     * second kind and could not credit the first.
      */
     private static Met evaluatedAt(Axis axis, List<String> parameters, List<RowOutcome> rows,
                                    ObservedValue boundary, OriginRef.GuardOrigin origin) {
@@ -501,8 +500,7 @@ final class Coverages {
                 case NumericTerm.Reading.NotNumber _ -> { }
                 case NumericTerm.Reading.Number number -> {
                     if (sameNumber(number.value(), boundary)
-                            && (row.hits().contains(origin.guard().siteIndexThen())
-                                    || row.hits().contains(origin.guard().siteIndexElse()))) {
+                            && row.hits().contains(origin.site())) {
                         return Met.YES;
                     }
                 }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -590,16 +590,6 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
                             b -> whyNoBoundary(b.coverage())),
                     undecided == 0 ? "" : "   (" + undecided + " undecided: a value was not read)"));
         }
-        // Named, and not only counted. The line is one somebody should still write; what is missing
-        // is a way for this build to see that they did, and an author who cannot tell which edge that
-        // is has been told a number and no work.
-        for (BoundaryAssessment b : partition.boundaries()) {
-            if (b.coverage() instanceof BoundaryAssessment.Coverage.NotMeasured absent
-                    && absent.reason() == BoundaryAssessment.Coverage.Reason.NO_ARM_WITNESSES_IT) {
-                out.append(String.format("      · not measurable: %s = %s (%s)%n",
-                        b.axis(), b.value(), b.origin()));
-            }
-        }
         for (Adequacy.Finding f : behavior.of(Adequacy.Kind.BOUNDARY_UNMET)) {
             out.append(String.format("      · no row is at %s = %s (%s)%n",
                     f.args().get(0), f.args().get(1), f.args().get(2)));
@@ -775,8 +765,6 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
             case ARMS_NOT_ASKED -> "the arms were not asked for";
             case ARMS_UNREADABLE -> "the arms could not be measured";
             case NO_ROWS -> "no row names this behavior";
-            case NO_ARM_WITNESSES_IT ->
-                    "no arm of the guard shows the comparison ran at this value";
         };
     }
 

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
@@ -192,7 +192,7 @@
               },
               "status": { "$ref": "#/$defs/status" },
               "reason": {
-                "description": "Why there is no answer, present exactly where `status` is `unavailable`. `arms_not_asked`, `arms_unreadable` and `no_arm_witnesses_it` belong to a guard's line only, which is met by reaching the comparison rather than by writing the value; an invariant's line is met by writing it and is never waiting on the arms. `no_arm_witnesses_it` is the comparison sitting inside a condition whose arms do not separate the rows that reached it from the rows that did not — the second operand of an `&&` on the side where it is false — so the line is owed and this build cannot see it met.",
+                "description": "Why there is no answer, present exactly where `status` is `unavailable`. `arms_not_asked` and `arms_unreadable` belong to a guard's line only, which is met by getting the comparison to produce a value rather than by writing the value; an invariant's line is met by writing it and is never waiting on the instrumentation. `no_arm_witnesses_it` was a guard's line whose comparison sat inside a condition whose arms did not separate the rows that reached it from the rows that did not — the second operand of an `&&` on the side where it is false. No compiler writes it any more: the comparison carries a site of its own and is observed where it runs. It is here because reports of this version were written carrying it, and a version says what its documents may carry rather than what is emitted today.",
                 "enum": ["arms_not_asked", "arms_unreadable", "no_rows", "no_arm_witnesses_it"]
               }
             }

--- a/souther-compiler/src/test/java/souther/compiler/AComparisonInsideAConjunctionIsStillTheModelsLineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AComparisonInsideAConjunctionIsStillTheModelsLineTest.java
@@ -3,10 +3,16 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Adequacy;
+import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.report.AdequacyReport;
 
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -17,11 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * comparison in front of it and used to get neither. Nothing about the model differs, so nothing
  * about what the rows owe should.
  *
- * <p>What does differ is what an arm proves. Under {@code A && B}, reaching either arm proves
- * {@code A} was evaluated and only the {@code then} arm proves {@code B} was — so a row landing where
- * {@code B} is false has shown nothing about {@code B}, and the edge on that side is one the sites
- * this build has cannot decide. That is a fact about the instrumentation, and it is said as one
- * rather than by leaving the edge out.
+ * <p>Both sides of the line are owed, including the one a row reaches by making the comparison false.
+ * Under {@code A && B} that row lands in {@code else}, where a row that never got to {@code B} lands
+ * too — so the arms do not decide it and the comparison is observed where it runs instead.
  */
 class AComparisonInsideAConjunctionIsStillTheModelsLineTest {
 
@@ -91,17 +95,31 @@ class AComparisonInsideAConjunctionIsStillTheModelsLineTest {
     }
 
     /**
-     * The edge on the other side is not owed as though a row could show it.
+     * And so is the edge on the other side, which is the one a conjunction used to lose.
      *
      * <p>A row at 100001 takes the {@code else} arm, which under a conjunction is also where a row
-     * taking it for the other comparison's sake lands. Nothing separates them, so no row establishes
-     * this edge and asking for one is asking for work nobody can finish.
+     * taking it for the other comparison's sake lands. The arms do not separate them; the site at the
+     * comparison does, so the edge is owed the same as the one beside it.
      */
     @Test
-    void theEdgeNoArmWitnessesIsSaidToBeUnmeasurable() {
-        String block = blockOf("inAConjunction");
+    void theEdgeOnTheOtherSideIsOwedTheSame() {
+        assertEquals(new BoundaryAssessment.Coverage.Missed(),
+                coverageAt("inAConjunction", "inAConjunction/r.cost", "100001"));
+    }
 
-        assertFalse(block.contains("no row is at inAConjunction/r.cost = 100001"), block);
-        assertTrue(block.contains("100001"), block);
+    /** What the rows established about one line of one behavior. */
+    private static BoundaryAssessment.Coverage coverageAt(String behavior, String axis,
+                                                          String value) {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, List<BoundaryAssessment>> boundaries =
+                compilation.db().ask(new Adequacy.Boundaries("example.repro")).value();
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries.get(behavior).stream()
+                .filter(line -> line.axis().equals(axis) && line.value().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no line at " + axis + " = " + value))
+                .coverage();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest.java
@@ -3,10 +3,15 @@ package souther.compiler;
 import org.junit.jupiter.api.Test;
 
 import souther.compiler.query.Adequacy;
+import souther.compiler.query.BoundaryAssessment;
 import souther.compiler.query.Compilation;
 import souther.compiler.report.AdequacyReport;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -89,11 +94,22 @@ class APositionThisDidNotReadIsNotOneTheModelSaysNothingAboutTest {
     /** A position a comparison names, in a form nothing reads. */
     @Test
     void aPositionComparedInsideAConjunctionIsSaidToBeUnread() {
-        String block = blockOf("inAConjunction");
+        assertTrue(linesOf("inAConjunction").stream()
+                        .anyMatch(line -> line.axis().equals("inAConjunction/r.cost")),
+                "the body compares it two lines above, so a line was read on it");
+        assertFalse(blockOf("inAConjunction").contains("not derivable: r.cost"),
+                "the body compares it two lines above: " + blockOf("inAConjunction"));
+    }
 
-        assertTrue(block.contains("r.cost"), block);
-        assertFalse(block.contains("not derivable: r.cost"),
-                "the body compares it two lines above: " + block);
+    /** Every line one behavior's rules drew, which is what says the position was read at all. */
+    private static List<BoundaryAssessment> linesOf(String behavior) {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, List<BoundaryAssessment>> boundaries =
+                compilation.db().ask(new Adequacy.Boundaries("example.repro")).value();
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries.get(behavior);
     }
 
     /** A position nothing compares, which is the sentence the other one was borrowing. */

--- a/souther-compiler/src/test/java/souther/compiler/AnArmDoesNotSayWhetherAComparisonRanTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnArmDoesNotSayWhetherAComparisonRanTest.java
@@ -1,0 +1,150 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.BoundaryAssessment;
+import souther.compiler.query.Compilation;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * A boundary a guard draws is met by the row that reached the comparison, which no arm can say.
+ *
+ * <p>Under {@code A && B} the {@code else} arm is where a row that made {@code B} false lands and
+ * where a row that never got to {@code B} lands. So an arm hit is neither necessary nor sufficient
+ * evidence that a particular comparison produced a value, and a measure that reads one for the other
+ * is wrong in both directions: it credits a row that skipped the comparison, and it cannot credit a
+ * row that ran it.
+ *
+ * <p>Two positions, so that the operand in front of the boundary's own comparison can be made false
+ * independently of it. With one position the two cannot be told apart in a row at all.
+ */
+class AnArmDoesNotSayWhetherAComparisonRanTest {
+
+    private static final String MODULE = "example.gate";
+
+    private static final String MODEL = """
+            module example.gate
+
+            data Request = { rank: Int, cost: Int }
+
+            data Auto
+            data Manual
+
+            behavior gate : (r: Request) -> Auto | Manual
+                constructs Auto, Manual
+            let gate (r) =
+                if r.rank >= 0 && r.cost <= 100000 then Auto else Manual
+
+            example gate
+                | "one row" : (Request { rank = RANK, cost = COST }) -> OUT
+            """;
+
+    /** Every line of {@code gate}, as measured against the one row this model has. */
+    private static List<BoundaryAssessment> linesFor(String rank, String cost, String out) {
+        Compilation compilation = Compilation.ofSource(
+                MODEL.replace("RANK", rank).replace("COST", cost).replace("OUT", out), "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, List<BoundaryAssessment>> boundaries =
+                compilation.db().ask(new Adequacy.Boundaries(MODULE)).value();
+        assertNotNull(boundaries, "the model under test compiles");
+        return boundaries.get("gate");
+    }
+
+    /** What the rows established about one line, named the way a report names it. */
+    private static BoundaryAssessment.Coverage coverageOf(List<BoundaryAssessment> lines,
+                                                          String axis, String value) {
+        return lines.stream()
+                .filter(line -> line.axis().equals(axis) && line.value().equals(value))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "no line at " + axis + " = " + value + " among " + labels(lines)))
+                .coverage();
+    }
+
+    private static List<String> labels(List<BoundaryAssessment> lines) {
+        return lines.stream().map(line -> line.axis() + " = " + line.value()).toList();
+    }
+
+    /**
+     * The pair that settles it: one value, one arm, two answers.
+     *
+     * <p>Both rows write 100001 and both land in {@code else}. One made {@code r.cost <= 100000}
+     * false to get there and the other never reached it, and the edge is met by the first and not by
+     * the second. Everything an arm records is the same between them, so nothing read off the arms
+     * can tell them apart — which is why the comparison is observed where it runs.
+     */
+    @Test
+    void oneValueAndOneArmAreNotOneAnswer() {
+        assertEquals(new BoundaryAssessment.Coverage.Hit(),
+                coverageOf(linesFor("0", "100001", "Manual"), "gate/r.cost", "100001"),
+                "the comparison produced false, which is reaching it");
+        assertEquals(new BoundaryAssessment.Coverage.Missed(),
+                coverageOf(linesFor("-1", "100001", "Manual"), "gate/r.cost", "100001"),
+                "the comparison never ran, and the row lands in the same arm");
+    }
+
+    /** A row that reached the comparison and made it true meets the line's own value. */
+    @Test
+    void aRowThatMadeTheComparisonTrueMeetsTheValue() {
+        assertEquals(new BoundaryAssessment.Coverage.Hit(),
+                coverageOf(linesFor("0", "100000", "Auto"), "gate/r.cost", "100000"));
+    }
+
+    /**
+     * A row that never reached the comparison does not meet it, however it reads.
+     *
+     * <p>The row writes the boundary value and lands in {@code else}, which is the whole of what the
+     * arms record — and {@code r.cost <= 100000} did not run, because {@code r.rank >= 0} settled the
+     * condition first.
+     */
+    @Test
+    void aRowThatSkippedTheComparisonDoesNotMeetTheValue() {
+        assertEquals(new BoundaryAssessment.Coverage.Missed(),
+                coverageOf(linesFor("-1", "100000", "Manual"), "gate/r.cost", "100000"));
+    }
+
+    /**
+     * Every line of this guard is one the rows can be measured against.
+     *
+     * <p>Four of them — each cut and the neighbour on its other side — and none waiting on an arm to
+     * witness it. Asked over the whole list rather than of the one line the other tests name, so that
+     * a line quietly dropped shows up here as a count.
+     */
+    @Test
+    void everyLineIsMeasured() {
+        List<BoundaryAssessment> lines = linesFor("0", "100001", "Manual");
+
+        assertEquals(List.of("gate/r.rank = 0", "gate/r.rank = -1",
+                        "gate/r.cost = 100000", "gate/r.cost = 100001"),
+                labels(lines));
+        for (BoundaryAssessment line : lines) {
+            assertNull(line.reason(), line.label() + " was measured");
+        }
+    }
+
+    /** And the new observation is not an arm: the branch measure counts the two arms it always
+     * counted. */
+    @Test
+    void theComparisonIsNotCountedAsAnArm() {
+        Compilation compilation = Compilation.ofSource(
+                MODEL.replace("RANK", "0").replace("COST", "100001").replace("OUT", "Manual"),
+                "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, Adequacy.BranchEvidence> branches =
+                compilation.db().ask(new Adequacy.BranchCoverage(MODULE)).value();
+        assertNotNull(branches, "the model under test compiles");
+
+        assertEquals(List.of("then", "else"),
+                branches.get("gate").all().stream()
+                        .map(souther.compiler.coverage.CoverageSites.Site::label).toList());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EverySchemaWordIsAccountedForTest.java
@@ -89,6 +89,14 @@ class EverySchemaWordIsAccountedForTest {
         }
     }
 
+    /** The kinds of site a branch measure counts, spelled by the writer's own encoder. */
+    private static Set<String> armWords() {
+        return Arrays.stream(CoverageSites.Site.Kind.values())
+                .filter(CoverageSites.Site.Kind::isArm)
+                .map(AdequacyReport::word)
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+    }
+
     /** What a document may say a status is. Two of the compiler's four states share one of them. */
     private static final Set<String> STATUS_WORDS =
             new LinkedHashSet<>(List.of("complete", "partial", "unavailable"));
@@ -113,10 +121,14 @@ class EverySchemaWordIsAccountedForTest {
             new Vocabulary("status", List.of("$defs", "status"), STATUS_WORDS),
             new Vocabulary("branch.reason", List.of("$defs", "branch", "properties", "reason"),
                     Adequacy.BranchEvidence.Reason.class),
+            // The arms, which is fewer than the kinds a site has. A comparison of a guard's condition
+            // is a site and not a fork a row is in or out of, so it never reaches this field —
+            // projected off the same predicate the measure uses rather than listed here, so that an
+            // arm kind added later still has to teach the schema its word.
             new Vocabulary("branch.unreached[].kind",
                     List.of("$defs", "branch", "properties", "unreached", "items", "properties",
                             "kind"),
-                    CoverageSites.Site.Kind.class),
+                    CoverageSites.Site.Kind.class, armWords(), Set.of()),
             new Vocabulary("partition.axesMeasure.reason",
                     List.of("$defs", "partition", "properties", "axesMeasure", "properties",
                             "reason"),
@@ -137,10 +149,14 @@ class EverySchemaWordIsAccountedForTest {
                     List.of("$defs", "partition", "properties", "boundaries", "items", "properties",
                             "side"),
                     BoundaryObligation.BoundarySide.class),
+            // `no_arm_witnesses_it` was what a guard's line came back as where the arms could not
+            // separate the rows that reached its comparison from the rows that did not. The
+            // comparison is observed where it runs now, so nothing produces the word — and reports of
+            // this version were written carrying it, and a version says what its documents may carry.
             new Vocabulary("partition.boundaries[].reason",
                     List.of("$defs", "partition", "properties", "boundaries", "items", "properties",
                             "reason"),
-                    BoundaryAssessment.Coverage.Reason.class),
+                    BoundaryAssessment.Coverage.Reason.class, Set.of("no_arm_witnesses_it")),
             new Vocabulary("partition.pairs.reason",
                     List.of("$defs", "partition", "properties", "pairs", "properties", "reason"),
                     PartitionEvidence.PairSpace.Reason.class),

--- a/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/coverage/ProbedBytecodeTest.java
@@ -84,8 +84,9 @@ class ProbedBytecodeTest {
      * The arms a run takes, read off a run.
      *
      * <p>Three inputs, each going a different way through the two guards. Each has to come back with a
-     * different set, and between them they have to reach every arm the plan counted — which is what
-     * makes this about the arms and not about three calls that happened to return.
+     * different set, and between them they have to reach every site the plan numbered — the arms and
+     * the comparisons of the guards' conditions — which is what makes this about what was recorded
+     * and not about three calls that happened to return.
      */
     @Test
     void aRunRecordsTheArmsItTook() {
@@ -105,7 +106,7 @@ class ProbedBytecodeTest {
         between.addAll(cheap);
         between.addAll(dear);
         assertEquals(plan.sites().size(), between.size(),
-                "between them the three rows reach every arm the plan counted");
+                "between them the three rows reach every site the plan numbered");
     }
 
     /** A hit belongs to the thread that made it. Rows are evaluated on their own workers, and a set

--- a/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ProbeMappingTest.java
@@ -92,7 +92,7 @@ class ProbeMappingTest {
         longer.add(new CoverageSites.Site(extra.behavior(), extra.kind(), "phantom", extra.at(),
                 real.sites().size(), real.sites().size(), extra.fingerprint()));
         CoverageSites.Plan overcounted =
-                new CoverageSites.Plan(longer, real.guards(), real.byNode());
+                new CoverageSites.Plan(longer, real.guards(), real.byNode(), real.byComparison());
 
         IllegalStateException stopped = assertThrows(IllegalStateException.class,
                 () -> Backend.generate(in.lowered(), in.scope(), in.typePackages(), in.sigs(),


### PR DESCRIPTION
Closes #617.

A guard-arm hit is neither necessary nor sufficient evidence that a particular comparison produced a
value. Boundary coverage read one for the other, and was wrong in both directions.

## The two failures

**An arm could not credit a row that ran the comparison.** Under `A && B`, a row that made `B` false
lands in `else` — and so does a row that never reached `B`. The edge on that side came back as
`no_arm_witnesses_it`: an obligation nobody could discharge.

**An arm credited a row that skipped it.** This half was not in the issue when it was written and is
the more serious of the two. Under

```souther
let gate (r) =
    if r.rank >= 0 && r.cost <= 100000 then Auto else Manual
```

a row `{rank = -1, cost = 100000}` never evaluates `r.cost <= 100000`, lands in `else`, and carried
the boundary value — which was enough. The edge at 100000 was reported met. A `not measured` at least
exposes its own uncertainty; this says a rule was exercised that nothing ran.

Both come from the same fact: the only thing a run recorded was which arm a row went through, and
since #607 made the operators stop when the answer is settled, that is not an answer about which of a
condition's comparisons ran. #602 taught the obligation-generating tier the difference and left the
row-reading tier with the old rule.

## What changed

`CoverageSites` numbers a comparison site for every comparison of an instrumented guard's condition,
from the shape of the code alone. It has to be decided that way: the emitter builds one plan and a
measurement builds another, so site identity stays a pure function of `(sourceId, bodies)`. Boundary
eligibility needs the behavior's parameters and the module's symbols and stays in the partition tier,
so some planned sites carry no obligation — deliberate over-planning, not a leak.

`BodyGen` emits the probe **after** the comparison has produced its value. An operand can abort —
`x /= 0 && 100 / x > 1` is the example the operators exist for — and a comparison whose operand
aborted produced nothing to observe.

`GuardOrigin` holds the site as required, so the invariant is a type boundary:

```
a comparison that owns a guard-origin boundary obligation
  ⇒ it has a comparison-evaluation site
```

An obligation is made only where `guardOf` found a `GuardRef`, and such an `if` had its condition
numbered. `Plan.comparisonSiteOf` stays optional — the emitter walks comparisons written anywhere —
while `requireComparisonSiteOf` throws where a line is read off a comparison the plan does not hold.

`Coverages.evaluatedAt` reads the site and no arm. The arm-witnessability gate goes with it:
`Partitions.witnessed`, `BoundaryObligation.witnessed`, and the early return in
`Coverages.coverageOf` that ran before the rows were read. That return is why replacing the arms
inside `evaluatedAt` on its own would have left the first failure exactly where it was.

`Witness` stays, narrowed to what it now answers — which arm a row that reached the comparison can be
in, which is what says whose edge a line draws. Branch adequacy reads `Plan.arms(behavior)` rather
than every site, and `probesOf(node)` remains an arm-only positional contract.

## Tests

`AnArmDoesNotSayWhetherAComparisonRanTest` is the acceptance test. Its centre is a pair with nothing
to tell it apart in what the arms record:

| row | comparison | edge |
|---|---|---|
| `rank = 0, cost = 100001` | produced false | 100001 met |
| `rank = -1, cost = 100001` | never ran | 100001 not met |

Same value, same `else` arm, different answers. No reading of `(value, arm)` produces that. Beside it,
`{0, 100000}` met and `{-1, 100000}` not met — the false positive above — and the branch measure still
counting two arms.

`AComparisonInsideAConjunctionIsStillTheModelsLineTest` keeps the other half: its `r.cost = 100001`
goes from `not measured` to an ordinary unmet edge.

Two existing tests moved off matching printed report text and onto the `BoundaryAssessment` verdicts,
which is what they were claiming.

That the planned sites and the comparisons a line is read off agree is not asserted anywhere — it is
enforced. `requireComparisonSiteOf` throws where the two disagree and `Backend` throws where a planned
site reaches no bytecode, so a green run of the corpus is the evidence.

## Compatibility

`no_arm_witnesses_it` leaves `Coverage.Reason` and joins the retired words of adequacy schema 1. A
producer that stops emitting a word is not a schema that stops accepting it, and reports of this
version were written carrying it. `branch.unreached[].kind` gains no word: the vocabulary is now
projected off `Site.Kind::isArm`, so a comparison cannot reach that field and an arm kind added later
still has to teach the schema its word. `BOUNDARY_VERSION` is unchanged — a coverage plan is not in
shipped bytecode and no language rule is narrowed.

## Verification

`mvn clean install` on the rebased branch: syntax 87, runtime 109, compiler 3972, fmt 2190, lsp 202,
bench 1. No failures, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
