### PR TITLE
Say an accumulated type, point at the operand the join was refused at

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BinaryElaborator.java
@@ -124,8 +124,19 @@ public final class BinaryElaborator {
                                     
                                     .say(new TypeMessage.JoinsTwoListsOrTwoStrings(Type.show(lt, rt), Type.show(rt, lt))).build());
                 }
-                yield new Core.Binary(bin.op(), left, right,
-                        Type.list(BottomInfer.unifyElem(lo.element(), ro.element(), bin.pos())), bin.pos());
+                Type element = BottomInfer.unifyElem(lo.element(), ro.element());
+                if (element == null) {
+                    // Both sides are written operands, one level in from what is compared: the
+                    // element types have no source of their own, but the lists holding them do, so
+                    // each is labelled where it is written and the message names neither.
+                    throw CompileException.of(Diagnostic
+                                    .at(bin.pos(), 2)
+                                    .secondary(Elaborator.region(bin.left()), new TypeMessage.ThisListHoldsElementsOf(Type.show(lo.element(), ro.element())))
+                                    .secondary(Elaborator.region(bin.right()), new TypeMessage.ThisListHoldsElementsOf(Type.show(ro.element(), lo.element())))
+                                    .hint(new TypeMessage.MakeEveryElementTheSameType())
+                                    .say(new TypeMessage.TheTwoListsHoldDifferentElements()).build());
+                }
+                yield new Core.Binary(bin.op(), left, right, Type.list(element), bin.pos());
             }
             case EQ, NE -> {
                 Type lt = left.type();

--- a/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/BottomInfer.java
@@ -4,8 +4,6 @@ import souther.compiler.Prelude;
 import souther.compiler.ast.Ast;
 import souther.compiler.diag.CompileException;
 import souther.compiler.diag.Diagnostic;
-import souther.compiler.diag.msg.TypeMessage;
-import souther.compiler.diag.DiagnosticCode;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.ValueName;
@@ -162,18 +160,15 @@ public final class BottomInfer {
         return isBottom(t) ? Type.EMPTY_LIST : t;
     }
 
-    /** The common element type of two list positions — {@link TypeOps#join}, reported as a list
-     * element rather than as a branch: identical types collapse, two data-like types widen to the
-     * union of their cases (so {@code [High] ++ [LowRole]} is a list of both), and a list of each
-     * widens the same way one level in. */
-    static Type unifyElem(Type a, Type b, SourcePos pos) {
-        Type joined = TypeOps.join(a, b);
-        if (joined != null) {
-            return joined;
-        }
-        throw CompileException.of(Diagnostic
-                        .at(pos)
-                        .hint(new TypeMessage.OneElementIsOneAndAnotherIsAnother(Type.show(a), Type.show(b)))
-                        .say(new TypeMessage.TheElementsDoNotAllHaveOneType()).build());
+    /** The common element type of two list positions — {@link TypeOps#join}: identical types
+     * collapse, two data-like types widen to the union of their cases (so {@code [High] ++ [LowRole]}
+     * is a list of both), and a list of each widens the same way one level in. Null where they do not
+     * join.
+     *
+     * <p>It answers rather than reports. What a refusal has to say differs by where the two types
+     * came from — a list literal joins an element against an accumulator, {@code ++} joins two
+     * written operands' element types — and neither is readable here. */
+    static Type unifyElem(Type a, Type b) {
+        return TypeOps.join(a, b);
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Elaborator.java
@@ -321,12 +321,15 @@ public final class Elaborator {
                     arms.add(new Core.ElseArm(arm.clause(), body));
                     Type next = TypeOps.join(joined, body.type());
                     if (next == null) {
-                        throw CompileException.of(Diagnostic
-                                        .at(ic.pos(), 2)
-                                        .secondary(Region.ofWidth(ic.then().pos(), width(ic.then())), new TypeMessage.TheThenBranchProduces(Type.show(then.type())))
-                                        .secondary(Region.ofWidth(arm.body().pos(), width(arm.body())), new TypeMessage.TheElseBranchProduces(Type.show(body.type())))
+                        // An `else` answering per clause folds its arms, so what this arm conflicts
+                        // with is the join of the branches before it and not the `then` branch's
+                        // type — labelling `then` with it named a type the join was not refused at
+                        // and left the arms between them out of the report altogether.
+                        throw CompileException.of(Diagnostic.at(region(arm.body()))
+                                        .say(new TypeMessage.ThisBranchAndThePrecedingOnes(
+                                                Type.show(body.type()), Type.show(joined)))
                                         .hint(new TypeMessage.MakeBothBranchesProduceOneType())
-                                        .say(new TypeMessage.TheBranchesOfThisIfDisagree()).build());
+                                        .build());
                     }
                     joined = next;
                 }
@@ -346,7 +349,24 @@ public final class Elaborator {
                 for (Ast.Expr el : lit.elements()) {
                     Core c = elaborate(el, env, ctx, want);
                     elements.add(c);
-                    elem = elem == null ? c.type() : BottomInfer.unifyElem(elem, c.type(), lit.pos());
+                    if (elem == null) {
+                        elem = c.type();
+                        continue;
+                    }
+                    Type joined = BottomInfer.unifyElem(elem, c.type());
+                    if (joined == null) {
+                        // The element is where the join was refused and is pointed at. What it
+                        // conflicts with is `elem`, the join of the elements before it — one
+                        // element's type only when one has been read, which is a fact about how
+                        // long the list is rather than about where the type came from. It is said
+                        // instead, so `[1, "x", 2]` and `[1, 2, "x"]` are reported the one way.
+                        throw CompileException.of(Diagnostic.at(region(el))
+                                .say(new TypeMessage.ThisElementAndThePrecedingOnes(
+                                        Type.show(c.type()), Type.show(elem)))
+                                .hint(new TypeMessage.MakeEveryElementTheSameType())
+                                .build());
+                    }
+                    elem = joined;
                 }
                 yield new Core.ListLit(elements, Type.list(elem), lit.pos());
             }

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -71,6 +71,7 @@ type.adjust-the-value-or-the-position=Adjust the value so its type matches, or c
 type.the-branches-of-this-if-disagree=The two branches of this `if` produce different types, so the `if` has no single type.
 type.the-then-branch-produces=the `then` branch produces {type}
 type.the-else-branch-produces=the `else` branch produces {type}
+type.this-branch-and-the-preceding-ones=This branch produces {branch}. The preceding branches produce {preceding}.
 type.make-both-branches-produce-one-type=Make both branches produce the same type — wrap one in the case you meant, or handle it upstream.
 
 # non-exhaustive match (E1201)
@@ -89,8 +90,10 @@ name.no-behavior-of-that-name-in-this-pipeline=I cannot find a behavior named `{
 
 # list elements disagree on type
 check.list.title=TYPE MISMATCH
-type.the-elements-do-not-all-have-one-type=The elements of this list do not all have the same type.
-type.one-element-is-one-and-another-is-another=One element is {one} and another is {other}; make every element the same type.
+type.this-element-and-the-preceding-ones=This element has type {element}. The preceding elements have type {preceding}.
+type.the-two-lists-hold-different-elements=`++` joins two lists into one, so the elements of both must have one type.
+type.this-list-holds-elements-of=this list holds elements of {element}
+type.make-every-element-the-same-type=Make every element the same type — widen them to a sum they are cases of, or convert the one that differs.
 
 # a local binding's type annotation (`let x: T = e`)
 name.the-binding-declares-another-type=The binding `{binding}` declares {declares}, but its value is {value}.

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -69,6 +69,7 @@ type.adjust-the-value-or-the-position=値の型を合わせるか、この位置
 # if の2つの分岐が食い違う
 type.the-branches-of-this-if-disagree=この `if` の2つの分岐は異なる型を返しているため、`if` 全体の型が定まりません。
 type.the-then-branch-produces=`then` 分岐は {type} を返します
+type.this-branch-and-the-preceding-ones=この分岐が返す型は {branch} です。それより前の分岐が返す型は {preceding} です。
 type.the-else-branch-produces=`else` 分岐は {type} を返します
 type.make-both-branches-produce-one-type=両方の分岐が同じ型を返すようにしてください。片方を意図したケースで包むか、上流で処理します。
 
@@ -88,8 +89,10 @@ name.no-behavior-of-that-name-in-this-pipeline=このパイプラインに `{nam
 
 # リスト要素の型が揃っていない
 check.list.title=型の不一致
-type.the-elements-do-not-all-have-one-type=このリストの要素の型が揃っていません。
-type.one-element-is-one-and-another-is-another=ある要素は {one}、別の要素は {other} です。すべての要素を同じ型にしてください。
+type.this-element-and-the-preceding-ones=この要素の型は {element} です。それより前の要素の型は {preceding} です。
+type.the-two-lists-hold-different-elements=`++` は2つのリストを1つにするので、両方の要素の型が揃っている必要があります。
+type.this-list-holds-elements-of=このリストが持つ要素は {element} です
+type.make-every-element-the-same-type=すべての要素を同じ型にしてください。両方をそれらをケースに持つ和に広げるか、違う方を変換します。
 
 # 局所束縛の型注釈（`let x: T = e`）
 name.the-binding-declares-another-type=束縛 `{binding}` は {declares} と宣言していますが、値は {value} です。

--- a/souther-compiler/src/test/java/souther/compiler/diag/AJoinFailureNamesTheOperandItRefusedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/AJoinFailureNamesTheOperandItRefusedTest.java
@@ -1,0 +1,226 @@
+package souther.compiler.diag;
+
+import souther.compiler.Compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Where a join is refused, the report is drawn at the operand it was refused at, and the type that
+ * operand conflicts with is labelled only where a written operand has it.
+ *
+ * <p>Which of the two decides is where the type came from, not whether a region could be found for
+ * it. A list literal and an {@code else}'s arms reach the join through an accumulator, and an
+ * accumulator is the join of everything before it — so it is stated in words. That it happens to be
+ * one operand's type when only one has been seen is a fact about the length of the input, and making
+ * the report's shape turn on it would have {@code [1, "x", 2]} and {@code [1, 2, "x"]} reported two
+ * different ways.
+ *
+ * <p>{@code ++} reaches the same join from two written operands, one level in from what it compares.
+ * Both of them have their element type labelled, because both of them have one.
+ */
+class AJoinFailureNamesTheOperandItRefusedTest {
+
+    private static final String ROLES = """
+            module demo
+
+            data Admin
+            data Member
+            data Guest
+            data Role = Admin | Member | Guest
+            """;
+
+    /** Two elements: the second is where the join was refused, and the first is still an accumulator. */
+    @Test
+    void aListOfTwoIsReportedAtTheSecondElement() {
+        String source = """
+                module demo
+
+                let xs =
+                    [ 1
+                    , "a"
+                    ]
+                """;
+        Diagnostic report = only(source);
+
+        assertEquals("\"a\"", underlined(source, report));
+        assertTrue(values(report).contains("String"), values(report).toString());
+        assertTrue(values(report).contains("Int"), values(report).toString());
+    }
+
+    /**
+     * The same list one element longer. The type the third element conflicts with is the join of the
+     * two before it, which is no element's type.
+     */
+    @Test
+    void aListOfThreeNamesTheJoinOfWhatCameBefore() {
+        String source = ROLES + """
+
+                let rs =
+                    [ Admin
+                    , Member
+                    , 1
+                    ]
+                """;
+        Diagnostic report = only(source);
+
+        assertEquals("1", underlined(source, report));
+        assertTrue(values(report).contains("Admin | Member"), values(report).toString());
+    }
+
+    /**
+     * The row that pins the decision: an accumulated type is never labelled, however few elements
+     * went into it. Two and three elements are reported the same way.
+     */
+    @Test
+    void anAccumulatedTypeIsNeverGivenARegion() {
+        String twoElements = """
+                module demo
+
+                let xs = [ 1, "a" ]
+                """;
+        String threeElements = """
+                module demo
+
+                let xs = [ 1, 2, "a" ]
+                """;
+
+        assertEquals(List.of(), only(twoElements).secondary());
+        assertEquals(List.of(), only(threeElements).secondary());
+    }
+
+    /** `++` compares two written operands' element types, so both are labelled. */
+    @Test
+    void concatenationLabelsBothOperands() {
+        String source = """
+                module demo
+
+                let xs = [1] ++ ["a"]
+                """;
+        Diagnostic report = only(source);
+
+        assertEquals(2, report.secondary().size(), "both operands carry their element type");
+        // where each label starts, not how wide it is drawn — the width of a list literal is
+        // <<a-region-is-an-extent>>'s question and is one column here.
+        String written = "let xs = [1] ++ [\"a\"]";
+        assertEquals(List.of(written.indexOf("[1]") + 1, written.indexOf("[\"a\"]") + 1),
+                report.secondary().stream().map(s -> s.region().start().column()).toList());
+        assertTrue(values(report).isEmpty(), "the message names neither type: " + values(report));
+    }
+
+    /**
+     * An {@code else} answering per clause folds its arms the way a list folds its elements, so the
+     * report is at the arm the join was refused at and the type it conflicts with is the join of the
+     * branches before it — here the `then` branch and the first arm, which is neither one's type.
+     */
+    @Test
+    void anElseArmIsReportedAtTheArmAndNamesTheJoinOfWhatCameBefore() {
+        String source = BOUNDED + """
+
+                let pick (n: Int) = {
+                    guard Bounded(n) as b else
+                        | nonNeg -> Blue
+                        | small  -> 1
+                    Red
+                }
+                """;
+        Diagnostic report = only(source);
+
+        assertEquals("1", underlined(source, report));
+        assertTrue(values(report).contains("Blue | Red"), values(report).toString());
+    }
+
+    /**
+     * One arm, so the accumulator holds only the `then` branch's type. It is still stated rather than
+     * labelled: the `then` branch keeps no region of its own here.
+     */
+    @Test
+    void aSingleElseArmIsReportedTheSameWay() {
+        String source = BOUNDED + """
+
+                let pick (n: Int) = {
+                    guard Bounded(n) as b else 1
+                    Red
+                }
+                """;
+        Diagnostic report = only(source);
+
+        assertEquals("1", underlined(source, report));
+        assertEquals(List.of(), report.secondary(), "an accumulator is not an operand to point at");
+        assertTrue(values(report).contains("Red"), values(report).toString());
+    }
+
+    /**
+     * A {@code match} already reports this way and is left alone. It is here so that the three sites
+     * changed are held against the one that was right.
+     */
+    @Test
+    void aMatchIsAlreadyReportedAtTheArmThatWasRefused() {
+        String source = ROLES + """
+
+                data Red
+                data Blue
+                data Colour = Red | Blue
+
+                let pick (r: Role) =
+                    match r with
+                        | Admin -> Red
+                        | Member -> Blue
+                        | Guest -> 1
+                """;
+        Diagnostic report = only(source);
+
+        assertEquals("| Guest -> 1", line(source, report).trim());
+        assertEquals(List.of(), report.secondary());
+        assertTrue(values(report).contains("Blue | Red"), values(report).toString());
+    }
+
+    private static final String BOUNDED = """
+            module demo
+
+            data Red
+            data Blue
+            data Colour = Red | Blue
+
+            data Bounded = Int
+                invariant nonNeg = value >= 0
+                invariant small = value <= 100
+            """;
+
+    /** The one report compiling {@code source} produces. */
+    private static Diagnostic only(String source) {
+        CompileException thrown =
+                assertThrows(CompileException.class, () -> Compiler.compile(source));
+        List<Diagnostic> all = thrown.diagnostics();
+        assertEquals(1, all.size(), "one mistake, one report: " + all);
+        return all.get(0);
+    }
+
+    /** The characters of {@code source} a report's primary region covers. */
+    private static String underlined(String source, Diagnostic report) {
+        return at(source, report.region());
+    }
+
+    /** The whole source line a report's primary region begins on. */
+    private static String line(String source, Diagnostic report) {
+        return source.lines().toList().get(report.region().start().line() - 1);
+    }
+
+    /** The characters of {@code source} {@code region} covers. */
+    private static String at(String source, Region region) {
+        assertEquals(region.start().line(), region.end().line(), "one line's worth");
+        String line = source.lines().toList().get(region.start().line() - 1);
+        int from = region.start().column() - 1;
+        return line.substring(from, from + region.sourceSpan());
+    }
+
+    /** The types a report carries, as it renders them. */
+    private static List<String> values(Diagnostic report) {
+        return report.values().values().stream().map(String::valueOf).toList();
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/msg/TypeMessage.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/msg/TypeMessage.java
@@ -23,16 +23,32 @@ public sealed interface TypeMessage extends Message {
     @Code(DiagnosticCode.E1208)
     record TheBranchesOfThisIfDisagree() implements TypeMessage, Reported {}
 
+    /** An `else` arm the branches were not joinable at, against the join of the branches before it.
+     * An `else` answering per clause folds its arms, so the second type is an accumulator. */
+    @Code(DiagnosticCode.E1208)
+    record ThisBranchAndThePrecedingOnes(String branch, String preceding)
+            implements TypeMessage, Reported {}
+
     record TheThenBranchProduces(String type) implements TypeMessage, Supporting {}
 
     record TheElseBranchProduces(String type) implements TypeMessage, Supporting {}
 
     record MakeBothBranchesProduceOneType() implements TypeMessage, Supporting {}
 
+    /** An element a list's elements were not joinable at, against the join of the ones before it.
+     * The second type is an accumulator and no element's own, so it is said rather than pointed at. */
     @Code(DiagnosticCode.E1318)
-    record TheElementsDoNotAllHaveOneType() implements TypeMessage, Reported {}
+    record ThisElementAndThePrecedingOnes(String element, String preceding)
+            implements TypeMessage, Reported {}
 
-    record OneElementIsOneAndAnotherIsAnother(String one, String other) implements TypeMessage, Supporting {}
+    /** Two lists `++` joins whose element types do not. Both are operands, so both carry a region
+     * and the message names neither. */
+    @Code(DiagnosticCode.E1318)
+    record TheTwoListsHoldDifferentElements() implements TypeMessage, Reported {}
+
+    record ThisListHoldsElementsOf(String element) implements TypeMessage, Supporting {}
+
+    record MakeEveryElementTheSameType() implements TypeMessage, Supporting {}
 
     @Code(DiagnosticCode.E1314)
     record AFieldsMapCannotBeKeyedByThat(String field, String key) implements TypeMessage, Reported {}

--- a/specification.adoc
+++ b/specification.adoc
@@ -4359,7 +4359,14 @@ Reported at the pattern (<<an-or-pattern-binds-the-sum-and-opens-nothing>>). Wha
 The match branches disagree: Submitted vs Int.
 ----
 
-Reported at the `+match+` (<<branches-agree-on-a-type>>). It answers with one value, so its arms produce one type; a union of what they produce is written by declaring it.
+Reported at the arm the arms stopped joining at (<<branches-agree-on-a-type>>). A `+match+` answers with one value, so its arms produce one type; a union of what they produce is written by declaring it.
+
+An `+if+` names both of its branches, there being two of them and each with a type of its own. An `+else+` answering per clause (<<attempt-departures>>) has more, and joins them as a list joins its elements — so it is reported as a list is, at the arm the join was refused at, with the join of the branches before it stated rather than pointed at:
+
+[,text]
+----
+This branch produces Int. The preceding branches produce Blue | Red.
+----
 
 [#e1301]
 === Use of null
@@ -4514,11 +4521,18 @@ Reported at the value (<<a-value-has-the-type-its-position-requires>>). The rule
 
 [,text]
 ----
-The elements of this list do not all have the same type.
-Hint: One element is Amount and another is Int; make every element the same type.
+This element has type Int. The preceding elements have type Amount.
+Hint: Make every element the same type — widen them to a sum they are cases of, or convert the one that differs.
 ----
 
-Reported at the list (<<a-lists-elements-have-one-type>>). A list is `+List<T>+` for a single `+T+`; a sequence of several types is a list of a sum they are cases of.
+Reported at the element the elements stopped joining at (<<a-lists-elements-have-one-type>>). A list is `+List<T>+` for a single `+T+`; a sequence of several types is a list of a sum they are cases of. What that element conflicts with is the join of the elements before it. That is one element's type only where one element has been read, which is a fact about how long the list is and not about where the type came from — so it is stated rather than pointed at, and `+[1, "x", 2]+` and `+[1, 2, "x"]+` are reported the one way.
+
+`{plus}{plus}` reaches the same rule from two written operands rather than from an accumulator, so each list is pointed at and the message names neither type:
+
+[,text]
+----
+`++` joins two lists into one, so the elements of both must have one type.
+----
 
 [#e1319]
 === An operator is given types it is not defined for


### PR DESCRIPTION
Closes #611.

Investigation found that the list diagnostic is one instance of an already inconsistent policy at the callers of `TypeOps.join`. This PR fixes the three incorrect callers; `match` already implements the intended rule and is unchanged.

## The rule

**When a join fails after accumulating evidence, report the source operand at which the join failed, and describe the accumulated type without pretending it belongs to a single operand.**

What decides the shape is where a type came from, not whether a region could be found for it.

| caller | left side reaches the join as | before | after |
| --- | --- | --- | --- |
| `match` | accumulator | at the arm, accumulated said in words | unchanged — the reference |
| list literal | accumulator | at the `[`, both types in a hint, neither attached | at the element, accumulated said in words |
| per-clause `else` | accumulator | `if`'s two labels, left one holding `then.type()` | at the arm, accumulated said in words |
| `++` | two written operands | the list literal's sentence, no labels | both operands labelled, message names neither |

## What was wrong

A list under the opening bracket, with the element the fold stopped at in hand at the call and never crossing into the check:

```
10|     [ loan.copyId
        ^
The elements of this list do not all have the same type.
Hint: One element is String and another is Int; make every element the same type.
```

`IfConstructed` is the one that stated something untrue. It folds its arms but keeps the `if` diagnostic, which has two operands to label, so the left label carries `then.type()` — a type the failed join did not compare — and an arm that widened the accumulator in between never appears:

```
15|     Red
        ^^^
the `then` branch produces Red      <- the join that failed was Red | Blue vs Int

14|         | small  -> 1
                        ^
the `else` branch produces Int      <- `Blue`, on line 13, is in no part of this report
```

`++` borrowed the list literal's sentence and says "this list" under an operator with a list either side of it.

## After

```
11|     , 1
          ^
This element has type Int. The preceding elements have type Admin | Member.

2| let xs = [1] ++ ["a"]
            ^                  this list holds elements of Int
                   ^           this list holds elements of String
`++` joins two lists into one, so the elements of both must have one type.

14|         | small  -> 1
                        ^
This branch produces Int. The preceding branches produce Blue | Red.
```

## Why the accumulated type is never labelled, however short the list

At two elements the accumulator happens to be the first element's type, so labelling it would not be a lie. That is a cardinality coincidence, and keying the report's shape on it makes the same mistake render two ways depending on element order — `[1, "x", 2]` stops at the second element and `[1, 2, "x"]` at the third. The fold's stopping point is order-dependent and cannot be helped; the display model does not have to inherit that.

`++` is the exception because its two types are not an accumulator: they are the element types of two written operands, one level in from what is compared. The lists holding them have regions, so both get one.

## `unifyElem`

It answers with null instead of taking a `SourcePos` and throwing. Handing one position for two types is what let a caller report without knowing which of the two the reader is looking at.

## Specification

E1318 said "Reported at the list", so the code was agreeing with the written rule rather than slipping against it. It now states where the report goes and why, and covers `++`.

E1208 said "Reported at the `match`" while the code already reported at the arm. It now says so, and covers the per-clause `else`.

## Tests

Seven rows — the first tests any of these messages have had. Two of them are the same list at two lengths, which is the decision above; one holds that an accumulated type is given no region at all; one keeps `match` as the reference.

## Not in scope

- **Minority detection.** `[1, 2, "x"]` and `["x", 1, 2]` each have one element disagreeing with two. Naming the element the fold stopped at is order-dependent but honest. Deciding which element is "wrong" is a second pass over data the fold has discarded, and a different diagnostic policy.
- **Expected-type provenance.** `let xs: List<Int> = [1, "a"]` has a declared element type with a written form, stronger than an accumulator — but `elaborate` receives `Type expected` with no region, so it is not in hand at the failure. That is the boundary #613 is about.
- **Extent.** A list literal's region is one column wide, so the `++` labels sit at each operand's start rather than spanning it. That is #612.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
