### PR TITLE
Make partition derivation exhaustive

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/Shape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Shape.java
@@ -24,8 +24,25 @@ import java.util.Set;
  * through it, which is what left a {@code data StageN = Stage} with no classes while the line drawn
  * on the same position read straight through the name.
  *
+ * <p><b>This is a total classification, and some of its cases are not value shapes.</b> A reading
+ * that answers "a record", "a sum", "a list" for the types it knows and nothing for the rest is the
+ * defect, not the base case: what a reader does with a type it cannot interpret is decided by the
+ * reader, and every reader has decided it silently. So the failures to determine a shape are cases
+ * here, of the same standing as the shapes, and a reader answering all of them has answered every
+ * type it can be handed.
+ *
+ * <p>Which is why {@link Uninhabited}, {@link Bottom}, {@link Erroneous}, {@link Undecided} and
+ * {@link Unresolved} are five cases and not one {@code Unknown}. Two of them say something about the
+ * values — no value arrives, or the element type of an empty collection is not fixed yet — and three
+ * say something about this compiler. Collapsing them would put a reader in the position of having to
+ * tell a semantic fact from an analysis failure after the distinction was thrown away, which is the
+ * shape of the defect this exists to remove: a position nothing could read was reported as one the
+ * model divides no way.
+ *
  * <p>Nothing here says what a position divides into or what may be written at it. Those are
- * questions asked of a shape, by readers that must answer every case of it.
+ * questions asked of a shape, by readers that must answer every case of it — and a reader that finds
+ * itself writing this switch out again wants a question of its own asked once, the way
+ * {@link Carrier#ofValue} asks whether a line can be drawn, rather than a copy of this one.
  */
 public sealed interface Shape {
 
@@ -80,27 +97,49 @@ public sealed interface Shape {
         }
     }
 
+    // --- what the values are, where they are nothing --------------------------------------------
+
     /**
-     * A type variable: what stands here is decided by each application, so nothing about the values
-     * at this position is settled yet.
+     * {@code Never}: no value arrives here at all. A fact about the values and not about this
+     * compiler — an arm answering {@code unreachable} contributes none, and a position no value
+     * reaches is not a position a row could be asked for.
      *
-     * <p>Not {@link Nothing}. A variable will be some type, and a reader that meets one is early
-     * rather than at a position there is nothing to say about.
+     * <p>Told apart from every case below because those say the shape could not be worked out,
+     * whereas this is the shape: there is nothing to divide because there is nothing.
+     */
+    record Uninhabited() implements Shape {}
+
+    /**
+     * {@code Nothing}: the element type of an empty collection, which the position it flows into
+     * fixes (ADR-0028). Not yet a value shape and not a failure either — it is a shape a later
+     * position decides, so a reader that meets one is early.
+     */
+    record Bottom() implements Shape {}
+
+    // --- where this compiler could not say what the values are ----------------------------------
+
+    /**
+     * The type of something the compiler could not work out. A fact about this compilation: the
+     * module carrying it has already been told why, and nothing here may report a second thing
+     * about the position on the strength of it.
+     */
+    record Erroneous() implements Shape {}
+
+    /**
+     * A type variable: which type stands here is decided by each application, so the shape is not
+     * determined at the point this was asked.
+     *
+     * <p>Not {@link Unresolved}. Nothing was looked up and failed — there is no name yet to look up.
      */
     record Undecided() implements Shape {}
 
     /**
-     * The bottom of an empty collection, the type of an expression that answers nothing, and the
-     * type of something the compiler could not work out. Grouped because no reader tells them apart:
-     * each stands for a type rather than being one, and the module carrying the third has already
-     * been told why.
-     */
-    record Nothing() implements Shape {}
-
-    /**
      * A name that denotes no declaration this can read, or a newtype whose {@code value} it could
-     * not reach. Its own case rather than {@link Nothing}: what is missing is a declaration, which
-     * is a fact about what was resolved and not about the values at the position.
+     * not reach — a declaration reachable from itself ends the walk with the name still on.
+     *
+     * <p>Its own case because the provenance differs from {@link Undecided}: this one was looked up.
+     * The interpretation was attempted and did not reach a terminal shape, which is a different
+     * thing for a reader to report and a different thing for anyone to fix.
      */
     record Unresolved(TypeName name) implements Shape {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Shape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Shape.java
@@ -1,0 +1,106 @@
+package souther.compiler.check;
+
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * What a type is, once the names wrapped round it are off.
+ *
+ * <p>{@link Type} is sealed and can be switched exhaustively already, and one place does
+ * ({@code TypeOps.answers}). That exhaustiveness runs out exactly where the readers of a position go
+ * wrong: {@link Type.Ref} is one constructor standing for four things — a unit data, a record, a sum,
+ * and a newtype — so a walk that has answered every constructor of {@code Type} has still not
+ * answered every kind of position. This splits that one constructor, which is the whole reason it
+ * exists.
+ *
+ * <p><b>There is no newtype case, and there must not be one.</b> A newtype is the value it wraps
+ * (spec §primitives), so what a position is, is what its base is; the names it wears are how that
+ * value is written and observed at this position, and they belong to {@link TypeView#wrappers}
+ * rather than here. A {@code Newtype} case would let each reader decide again whether to look
+ * through it, which is what left a {@code data StageN = Stage} with no classes while the line drawn
+ * on the same position read straight through the name.
+ *
+ * <p>Nothing here says what a position divides into or what may be written at it. Those are
+ * questions asked of a shape, by readers that must answer every case of it.
+ */
+public sealed interface Shape {
+
+    /** A primitive, written as itself. */
+    record Scalar(Type.Prim prim) implements Shape {}
+
+    /** A data with no contents: one value, which is which case it is. */
+    record Unit(TypeName name) implements Shape {}
+
+    /** A data with fields, and what they are. */
+    record Product(TypeName name, Map<String, Type> fields) implements Shape {
+        public Product {
+            fields = Map.copyOf(fields);
+        }
+    }
+
+    /** A declared sum, {@code data S = A | B}. */
+    record Sum(TypeName name) implements Shape {}
+
+    /** A union nobody named — what a branch widened to, or a behavior's written answer. Told apart
+     *  from {@link Sum} because it has no declaration to be read off. */
+    record Cases(Set<TypeName> members) implements Shape {
+        public Cases {
+            members = Set.copyOf(members);
+        }
+    }
+
+    /** A {@code List} or a {@code Set}, and what it holds. Which of the two is the declared type's
+     *  to say — the values are the same either way, and how they are written is not. */
+    record Sequence(Kind kind, Type element) implements Shape {
+
+        public enum Kind { LIST, SET }
+    }
+
+    /** A {@code Map}, by what it is keyed by and what it holds. */
+    record Mapping(Type key, Type value) implements Shape {}
+
+    /** An {@code Option}, and what it holds when it holds anything. */
+    record Optional(Type element) implements Shape {}
+
+    /** A tuple, which carries values through a computation and crosses nothing. */
+    record Tuple(List<Type> elements) implements Shape {
+        public Tuple {
+            elements = List.copyOf(elements);
+        }
+    }
+
+    /** A function. */
+    record Function(List<Type> params, Type result) implements Shape {
+        public Function {
+            params = List.copyOf(params);
+        }
+    }
+
+    /**
+     * A type variable: what stands here is decided by each application, so nothing about the values
+     * at this position is settled yet.
+     *
+     * <p>Not {@link Nothing}. A variable will be some type, and a reader that meets one is early
+     * rather than at a position there is nothing to say about.
+     */
+    record Undecided() implements Shape {}
+
+    /**
+     * The bottom of an empty collection, the type of an expression that answers nothing, and the
+     * type of something the compiler could not work out. Grouped because no reader tells them apart:
+     * each stands for a type rather than being one, and the module carrying the third has already
+     * been told why.
+     */
+    record Nothing() implements Shape {}
+
+    /**
+     * A name that denotes no declaration this can read, or a newtype whose {@code value} it could
+     * not reach. Its own case rather than {@link Nothing}: what is missing is a declaration, which
+     * is a fact about what was resolved and not about the values at the position.
+     */
+    record Unresolved(TypeName name) implements Shape {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/Shape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Shape.java
@@ -44,23 +44,40 @@ import java.util.Set;
  * itself writing this switch out again wants a question of its own asked once, the way
  * {@link Carrier#ofValue} asks whether a line can be drawn, rather than a copy of this one.
  */
-public sealed interface Shape {
+public sealed interface Shape permits Shape.PartitionInputShape, Shape.Cases, Shape.Tuple,
+        Shape.Function, Shape.Uninhabited, Shape.Bottom, Shape.Erroneous, Shape.Undecided {
+
+    /**
+     * The shapes a position carrying a value can have.
+     *
+     * <p>A subset of the classification and not a second one: these are the same cases, grouped so
+     * that a reader over positions can be held to all of them and to nothing else. What admits a
+     * shape into it is the reader's own contract — the partition walk decides for itself, rather
+     * than deriving the set from what a signature or a field admits, because those two disagree
+     * (an {@code Option} may be a field and may not be a parameter) and neither is this question.
+     *
+     * <p>{@link Unresolved} is a member. It is a shape a position legitimately has — a declaration
+     * reachable from itself compiles — and what a reader does with it is answer that it could not
+     * be interpreted. Leaving it out would put a compiling model through a path that throws.
+     */
+    sealed interface PartitionInputShape extends Shape
+            permits Scalar, Product, Sum, Sequence, Unit, Mapping, Optional, Unresolved {}
 
     /** A primitive, written as itself. */
-    record Scalar(Type.Prim prim) implements Shape {}
+    record Scalar(Type.Prim prim) implements PartitionInputShape {}
 
     /** A data with no contents: one value, which is which case it is. */
-    record Unit(TypeName name) implements Shape {}
+    record Unit(TypeName name) implements PartitionInputShape {}
 
     /** A data with fields, and what they are. */
-    record Product(TypeName name, Map<String, Type> fields) implements Shape {
+    record Product(TypeName name, Map<String, Type> fields) implements PartitionInputShape {
         public Product {
             fields = Map.copyOf(fields);
         }
     }
 
     /** A declared sum, {@code data S = A | B}. */
-    record Sum(TypeName name) implements Shape {}
+    record Sum(TypeName name) implements PartitionInputShape {}
 
     /** A union nobody named — what a branch widened to, or a behavior's written answer. Told apart
      *  from {@link Sum} because it has no declaration to be read off. */
@@ -72,16 +89,16 @@ public sealed interface Shape {
 
     /** A {@code List} or a {@code Set}, and what it holds. Which of the two is the declared type's
      *  to say — the values are the same either way, and how they are written is not. */
-    record Sequence(Kind kind, Type element) implements Shape {
+    record Sequence(Kind kind, Type element) implements PartitionInputShape {
 
         public enum Kind { LIST, SET }
     }
 
     /** A {@code Map}, by what it is keyed by and what it holds. */
-    record Mapping(Type key, Type value) implements Shape {}
+    record Mapping(Type key, Type value) implements PartitionInputShape {}
 
     /** An {@code Option}, and what it holds when it holds anything. */
-    record Optional(Type element) implements Shape {}
+    record Optional(Type element) implements PartitionInputShape {}
 
     /** A tuple, which carries values through a computation and crosses nothing. */
     record Tuple(List<Type> elements) implements Shape {
@@ -141,5 +158,5 @@ public sealed interface Shape {
      * The interpretation was attempted and did not reach a terminal shape, which is a different
      * thing for a reader to report and a different thing for anyone to fix.
      */
-    record Unresolved(TypeName name) implements Shape {}
+    record Unresolved(TypeName name) implements PartitionInputShape {}
 }

--- a/souther-compiler/src/main/java/souther/compiler/check/Shape.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Shape.java
@@ -69,10 +69,14 @@ public sealed interface Shape permits Shape.PartitionInputShape, Shape.Cases, Sh
     /** A data with no contents: one value, which is which case it is. */
     record Unit(TypeName name) implements PartitionInputShape {}
 
-    /** A data with fields, and what they are. */
+    /** A data with fields, and what they are, in the order the declaration writes them.
+     *
+     *  <p>The order is part of the answer, not an accident of the map: what a report names first
+     *  and which field a row is built for first are read off it. So the copy keeps it — an
+     *  unordered one would leave every reader depending on a hash. */
     record Product(TypeName name, Map<String, Type> fields) implements PartitionInputShape {
         public Product {
-            fields = Map.copyOf(fields);
+            fields = java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(fields));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeView.java
@@ -1,0 +1,108 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import java.util.List;
+
+/**
+ * A position's type, read once: what it is, and what it is written as.
+ *
+ * <p>The two are not the same question and were being answered by whoever needed them. A
+ * {@code data StageN = Stage} is a sum — its values are the sum's cases under a name — and it is
+ * written {@code StageN(Prospecting)}. The reader that drew a line on it read through the name; the
+ * reader that asked what it divides into stopped at the name; and the position came back as one the
+ * model does not divide, which is the opposite of what the declaration says (issue #631).
+ *
+ * <p>So the interpretation happens here and nowhere else:
+ *
+ * <ul>
+ *   <li>{@link #shape} is what the position <em>is</em>, with every name off. A reader answering
+ *       every case of a {@link Shape} has answered every kind of position, which switching on
+ *       {@link Type} does not achieve — {@code Type.Ref} is one constructor for four things.
+ *   <li>{@link #wrappers} is what the position is <em>written as</em>: the names a value wears,
+ *       outermost first. A representative is built by putting them back on, and an observation is
+ *       read by taking them off. Both directions stay available because nominality is the point of
+ *       a newtype — {@code StageN(Prospecting)} is what the row writes, and {@code Prospecting} is
+ *       what classifies it.
+ *   <li>{@link #declared} is the type as the signature wrote it, for anything that reports the
+ *       position back to an author.
+ * </ul>
+ *
+ * <p><b>A reader does not re-decide any of this.</b> Asking {@code symbols.get(ref.name())} again
+ * to find out whether a name is a newtype is the defect this exists to remove, not a shortcut around
+ * it.
+ *
+ * @param declared the type the signature wrote
+ * @param wrappers the newtype names worn over {@link #shape}, outermost first; empty for a type
+ *                 written under no name of its own
+ * @param shape    what the value is, with those names off
+ */
+public record TypeView(Type declared, List<TypeOps.Layer> wrappers, Shape shape) {
+
+    public TypeView {
+        wrappers = List.copyOf(wrappers);
+    }
+
+    /**
+     * How {@code type} is to be read at a position.
+     *
+     * <p>The names come off first, by the one walk that decides how far a newtype reaches
+     * ({@link TypeOps#newtypeSpine}), so this cannot disagree with the carrier or the range about
+     * where a value's base is.
+     */
+    public static TypeView of(Type type, Symbols symbols) {
+        TypeOps.NewtypeSpine spine = TypeOps.newtypeSpine(type, symbols);
+        return new TypeView(type, spine.layers(), shapeOf(spine.terminal(), symbols));
+    }
+
+    /** Whether any name is worn over the shape — which is a fact about how the value is written,
+     *  never about what it is. */
+    public boolean isWrapped() {
+        return !wrappers.isEmpty();
+    }
+
+    /**
+     * What {@code terminal} is. Exhaustive over {@link Type}, and over the declarations a
+     * {@link Type.Ref} can denote — no {@code default} in either, so a constructor added to
+     * {@code Type} or a declaration form added to {@code Ast} stops compiling here until it has
+     * been said what kind of position it is.
+     *
+     * <p>{@code terminal} has already had its newtype names taken off. A {@code Ref} that is still a
+     * newtype here is one whose {@code value} the walk could not reach, which is a name that
+     * resolved to nothing usable rather than a shape.
+     */
+    private static Shape shapeOf(Type terminal, Symbols symbols) {
+        return switch (terminal) {
+            case Type.Prim prim -> new Shape.Scalar(prim);
+            case Type.Nothing _, Type.Never _, Type.Erroneous _ -> new Shape.Nothing();
+            case Type.Var _, Type.MetaVar _ -> new Shape.Undecided();
+            case Type.Union union -> new Shape.Cases(union.members());
+            case Type.ListOf list -> new Shape.Sequence(Shape.Sequence.Kind.LIST, list.element());
+            case Type.SetOf set -> new Shape.Sequence(Shape.Sequence.Kind.SET, set.element());
+            case Type.MapOf map -> new Shape.Mapping(map.key(), map.value());
+            case Type.OptionOf option -> new Shape.Optional(option.element());
+            case Type.TupleOf tuple -> new Shape.Tuple(tuple.elements());
+            case Type.FnOf fn -> new Shape.Function(fn.params(), fn.result());
+            case Type.Ref ref -> denoted(ref.name(), symbols);
+        };
+    }
+
+    /**
+     * What a name stands for. {@code Ast.Def} permits three declarations and all three are answered
+     * here, so a fourth stops compiling rather than arriving as a name that denotes nothing.
+     *
+     * <p>A newtype arriving here is one the spine stopped on — its {@code value} was not declared,
+     * so there is no base to read a shape from.
+     */
+    private static Shape denoted(TypeName name, Symbols symbols) {
+        return switch (symbols.get(name)) {
+            case Ast.SumData _ -> new Shape.Sum(name);
+            case Ast.UnitData _ -> new Shape.Unit(name);
+            case Ast.Data data when data.newtype() -> new Shape.Unresolved(name);
+            case Ast.Data data -> new Shape.Product(name, TypeOps.fieldTypes(data, symbols));
+            case null -> new Shape.Unresolved(name);
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/check/TypeView.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/TypeView.java
@@ -76,7 +76,9 @@ public record TypeView(Type declared, List<TypeOps.Layer> wrappers, Shape shape)
     private static Shape shapeOf(Type terminal, Symbols symbols) {
         return switch (terminal) {
             case Type.Prim prim -> new Shape.Scalar(prim);
-            case Type.Nothing _, Type.Never _, Type.Erroneous _ -> new Shape.Nothing();
+            case Type.Never _ -> new Shape.Uninhabited();
+            case Type.Nothing _ -> new Shape.Bottom();
+            case Type.Erroneous _ -> new Shape.Erroneous();
             case Type.Var _, Type.MetaVar _ -> new Shape.Undecided();
             case Type.Union union -> new Shape.Cases(union.members());
             case Type.ListOf list -> new Shape.Sequence(Shape.Sequence.Kind.LIST, list.element());

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -22,9 +22,18 @@ import java.util.Set;
  * @param excluded the ids of the classes the body says it does not answer for. Still classes — the
  *                 position's values are still divided this way, and a report says so — and not ones a
  *                 row can be written at, since reaching one is E1911
+ * @param pending  where nothing has answered for this position yet, what the structural reading
+ *                 found — and so what this position is left with if nothing else answers. Null on
+ *                 an axis that already has evidence, which needs no fallback.
+ *
+ *                 <p>Carried here rather than beside: the reason and the position it is about are
+ *                 one fact, and holding them in two lists joined afterwards by the spelling of a
+ *                 path is how a reason came to be recovered by string match. A reason travels with
+ *                 the position or it is a reason about whatever the strings happened to pair it
+ *                 with.
  */
 public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
-                   List<Cut> cuts, Set<String> excluded) {
+                   List<Cut> cuts, Set<String> excluded, StructuralInspection pending) {
 
     public Axis {
         classes = List.copyOf(classes);
@@ -33,13 +42,25 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
     }
 
     public Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
-                List<Cut> cuts) {
-        this(id, term, type, classes, cuts, Set.of());
+                List<Cut> cuts, Set<String> excluded) {
+        this(id, term, type, classes, cuts, excluded, null);
     }
 
-    /** A position the model does not divide. Kept, so a report can name what it could not measure. */
-    public static Axis notDerivable(AxisId id, NumericTerm term, Type type) {
-        return new Axis(id, term, type, List.of(), List.of());
+    public Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
+                List<Cut> cuts) {
+        this(id, term, type, classes, cuts, Set.of(), null);
+    }
+
+    /**
+     * A position nothing has answered for yet, and what the structural reading found.
+     *
+     * <p>Not a position the model does not divide. A rule a body writes may still draw a line on it,
+     * and only where none does is {@code found} what a report says — an absence where the structure
+     * ran out, and what stopped the reading where it did not.
+     */
+    public static Axis pendingAt(AxisId id, NumericTerm term, Type type,
+                                 StructuralInspection found) {
+        return new Axis(id, term, type, List.of(), List.of(), Set.of(), found);
     }
 
     /** Where the value this axis is about sits, which is where a row is walked to before the term is
@@ -57,7 +78,7 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
     public Axis excluding(Collection<String> ids) {
         Set<String> here = ids.stream().filter(id -> classOf(id) != null)
                 .collect(java.util.stream.Collectors.toCollection(java.util.LinkedHashSet::new));
-        return here.isEmpty() ? this : new Axis(id, term, type, classes, cuts, here);
+        return here.isEmpty() ? this : new Axis(id, term, type, classes, cuts, here, pending);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -63,6 +63,25 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
         return new Axis(id, term, type, List.of(), List.of(), Set.of(), found);
     }
 
+    /**
+     * The same position, measured at another number.
+     *
+     * <p>A transition rather than a constructor at the call site. What a body's rules add is a term,
+     * classes and cuts; everything else about the position was settled by the reading that made
+     * this one, and a caller rebuilding an axis from its parts drops whatever it did not think to
+     * name. What went that way was {@link #pending}: a position whose elements could not be reached
+     * came back out of the second phase with nothing to say it had ever stopped, and was reported
+     * as one the model divides no way.
+     */
+    public Axis measuredAt(AxisId id, NumericTerm term) {
+        return new Axis(id, term, type, classes, cuts, excluded, pending);
+    }
+
+    /** The same position, with what a body's rules divided it into and the lines they drew. */
+    public Axis carrying(List<PartitionClass> classes, List<Cut> cuts) {
+        return new Axis(id, term, type, classes, cuts, excluded, pending);
+    }
+
     /** Where the value this axis is about sits, which is where a row is walked to before the term is
      * read off it. Not what the axis is: two terms can be taken of one location, and {@link #id()}
      * is the one that tells them apart. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Axis.java
@@ -33,7 +33,7 @@ import java.util.Set;
  *                 with.
  */
 public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> classes,
-                   List<Cut> cuts, Set<String> excluded, StructuralInspection pending) {
+                   List<Cut> cuts, Set<String> excluded, StructuralInspection.Pending pending) {
 
     public Axis {
         classes = List.copyOf(classes);
@@ -59,7 +59,7 @@ public record Axis(AxisId id, NumericTerm term, Type type, List<PartitionClass> 
      * ran out, and what stopped the reading where it did not.
      */
     public static Axis pendingAt(AxisId id, NumericTerm term, Type type,
-                                 StructuralInspection found) {
+                                 StructuralInspection.Pending found) {
         return new Axis(id, term, type, List.of(), List.of(), Set.of(), found);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BehaviorInputs.java
@@ -1,0 +1,96 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.Shape;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.observe.RowOutcome;
+import souther.compiler.types.Type;
+
+import java.util.List;
+
+/**
+ * What a behavior takes: what its inputs are called, what they are declared to be, and what those
+ * names denote.
+ *
+ * <p>One value because reading a row at a position needs all three. A path names a parameter and
+ * the fields under it, a row's values arrive in the order the parameters are declared, and how a
+ * value at a position is written — the names it wears — is what the declared types say. Given only
+ * the first two, a reader walks a row by taking fields off values, which is right until a field
+ * sits under a name.
+ *
+ * <p>And because the same three are what a row is generated from. Two spellings of what a behavior
+ * takes are two chances to read a position differently, which is the shape of every defect this
+ * package has been fixing: {@link Generator.Subject} is these inputs and the axes derived at them.
+ */
+public record BehaviorInputs(List<String> parameters, List<Type> types, Symbols symbols) {
+
+    public BehaviorInputs {
+        parameters = List.copyOf(parameters);
+        types = List.copyOf(types);
+    }
+
+    /** Which input {@code path} starts at, or -1 where the behavior has no such parameter. */
+    int indexOf(TermPath path) {
+        int at = parameters.indexOf(path.head());
+        return at < types.size() ? at : -1;
+    }
+
+    /**
+     * The value this row put at {@code path}, or null where it did not put a readable one there.
+     *
+     * <p>The one walk into a row's values, done with the declared types beside them. A field of a
+     * record is reached through the names the record is written under: {@code data SlotN = Slot} is
+     * one position whose fields a partition is derived at, and a row writes
+     * {@code SlotN(Slot { flag = true })}. The path never spells those names — a newtype is not a
+     * step — so what reads the path takes them off. Walked on the values alone, the derivation
+     * reached a field that the reading of a row could not, and every row at such a position came
+     * back unreadable.
+     *
+     * <p><b>On the way and not at the end.</b> What comes back is the value as the position wears
+     * it, names and all. Which names the position itself is written under is what tells a class
+     * from another there ({@link Classifier#under}), so a walk that went on peeling would answer a
+     * classifier with a value it no longer recognises — and the reading of what a position is would
+     * have lost how it is written, one layer down from where this branch put it back.
+     *
+     * <p>An observation that stopped is handed on rather than walked into. It is not a record and
+     * there is nothing under it, but it is also not a chain that leads nowhere: it is the reason
+     * this position has no value, and it says that itself.
+     *
+     * <p>Which leaves null for the walk's own answer, and only that: a record that does not hold
+     * the field named next, or a position whose type is not a record at all. The path and the type
+     * disagree, and no observation says why because nothing went wrong with one.
+     */
+    public ObservedValue valueAt(RowOutcome row, TermPath path) {
+        int at = indexOf(path);
+        if (at < 0 || at >= row.inputs().size()) {
+            return null;
+        }
+        ObservedValue value = row.inputs().get(at);
+        Type here = types.get(at);
+        for (String field : path.fields()) {
+            if (value.unread() != null) {
+                return value;
+            }
+            TypeView view = TypeView.of(here, symbols);
+            value = Classifier.inside(
+                    view.wrappers().stream().map(TypeOps.Layer::named).toList(), value);
+            if (value.unread() != null) {
+                return value;
+            }
+            if (!(view.shape() instanceof Shape.Product product)
+                    || !(value instanceof ObservedValue.Constructed constructed)) {
+                return null;
+            }
+            Type next = product.fields().get(field);
+            ObservedValue held = constructed.field(field);
+            if (next == null || held == null) {
+                return null;
+            }
+            value = held;
+            here = next;
+        }
+        return value;
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BlockReason.java
@@ -1,0 +1,81 @@
+package souther.compiler.partition;
+
+/**
+ * Why a derivation did not finish, in this compiler's own terms.
+ *
+ * <p>Not {@link UndividedPosition.Reason}. That one is the vocabulary an adequacy document writes,
+ * which is a promise to whoever reads the document about which cases they can tell apart; this one
+ * is a record of what this compiler could not do. The two are deliberately not the same set, and
+ * keeping them the same type is what froze this one: a reason could not be made more precise
+ * without widening a published vocabulary, so the pressure was always back towards a word coarse
+ * enough to already exist.
+ *
+ * <p>Split apart, the two move at their own speeds. A capability gained here removes a case here
+ * and need not remove a word out there, which other cases may still be reaching; and a distinction
+ * worth recording here need not be a distinction the document promises.
+ *
+ * <p>Sealed, and projected to the public vocabulary by one exhaustive switch with no
+ * {@code default} ({@link #reported()}). A reason added here and not said out there stops the
+ * compile rather than arriving in a report as a word chosen because it was nearest.
+ */
+public sealed interface BlockReason {
+
+    /**
+     * The type at the position could not be interpreted: a name denoting no declaration, or a
+     * declaration reachable from itself. Such a model compiles, so this is a position a report is
+     * asked about and cannot be answered for.
+     */
+    record TypeUnresolved() implements BlockReason {}
+
+    /** The walk stopped before reaching what is under the position. */
+    record DepthLimit() implements BlockReason {}
+
+    /**
+     * The shape at the position holds values this cannot reach into, and which reaching is missing
+     * is which of {@link Traversal} it is.
+     *
+     * <p>Held apart rather than made one word, because what would lift each is a different piece of
+     * work: choosing among however many elements a sequence holds, choosing whether an optional
+     * holds one, and deciding what part of a mapping a rule is even about. Reporting them alike
+     * would let one of them being implemented read as all three.
+     */
+    record UnsupportedTraversal(Traversal traversal) implements BlockReason {}
+
+    /** What a derivation would have to be able to reach into. */
+    enum Traversal {
+
+        /** The elements of a {@code List} or a {@code Set} (issue #626). */
+        SEQUENCE_ELEMENT,
+
+        /** The value an {@code Option} holds when it holds one. */
+        OPTIONAL_VALUE,
+
+        /**
+         * What a {@code Map} holds. One case and not two, because which of a key and a value a rule
+         * would be about has not been decided — and a distinction invented here would be a promise
+         * about a semantics nobody has written.
+         */
+        MAPPING_CONTENT
+    }
+
+    /**
+     * The word an adequacy document writes for {@code reason}.
+     *
+     * <p>Deliberately coarser: what a reader of the document is promised is which kind of thing
+     * stopped the derivation, not which capability this compiler is missing this month. Three
+     * traversals are one word out there because a reader cannot act on the difference — the model
+     * is the same either way, and which of them this compiler cannot walk is this compiler's news.
+     *
+     * <p>In one place rather than answered per case, because a coarsening is only reviewable where
+     * the collapses are visible together: what wants checking is which reasons share a word, and a
+     * method on each case shows a reader one mapping at a time. No {@code default}, so a reason
+     * added above stops the compile here until it has been said what a report calls it.
+     */
+    static UndividedPosition.Reason reported(BlockReason reason) {
+        return switch (reason) {
+            case TypeUnresolved _ -> UndividedPosition.Reason.TYPE_UNRESOLVED;
+            case DepthLimit _ -> UndividedPosition.Reason.DEPTH_LIMIT;
+            case UnsupportedTraversal _ -> UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL;
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BlockReason.java
@@ -14,9 +14,10 @@ package souther.compiler.partition;
  * and need not remove a word out there, which other cases may still be reaching; and a distinction
  * worth recording here need not be a distinction the document promises.
  *
- * <p>Sealed, and projected to the public vocabulary by one exhaustive switch with no
- * {@code default} ({@link #reported()}). A reason added here and not said out there stops the
- * compile rather than arriving in a report as a word chosen because it was nearest.
+ * <p>This knows nothing about how it is reported. Which word a document writes for one of these is
+ * {@link ReportedReason}'s, so a second surface may say more of the same reason without this having
+ * an opinion, and so the direction stays one way: a published vocabulary does not reach back into
+ * what this compiler is allowed to know.
  */
 public sealed interface BlockReason {
 
@@ -58,24 +59,4 @@ public sealed interface BlockReason {
         MAPPING_CONTENT
     }
 
-    /**
-     * The word an adequacy document writes for {@code reason}.
-     *
-     * <p>Deliberately coarser: what a reader of the document is promised is which kind of thing
-     * stopped the derivation, not which capability this compiler is missing this month. Three
-     * traversals are one word out there because a reader cannot act on the difference — the model
-     * is the same either way, and which of them this compiler cannot walk is this compiler's news.
-     *
-     * <p>In one place rather than answered per case, because a coarsening is only reviewable where
-     * the collapses are visible together: what wants checking is which reasons share a word, and a
-     * method on each case shows a reader one mapping at a time. No {@code default}, so a reason
-     * added above stops the compile here until it has been said what a report calls it.
-     */
-    static UndividedPosition.Reason reported(BlockReason reason) {
-        return switch (reason) {
-            case TypeUnresolved _ -> UndividedPosition.Reason.TYPE_UNRESOLVED;
-            case DepthLimit _ -> UndividedPosition.Reason.DEPTH_LIMIT;
-            case UnsupportedTraversal _ -> UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL;
-        };
-    }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/BlockReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BlockReason.java
@@ -42,6 +42,31 @@ public sealed interface BlockReason {
      */
     record UnsupportedTraversal(Traversal traversal) implements BlockReason {}
 
+    /**
+     * A comparison naming the position is written in a form no reader here takes apart: the
+     * position inside an expression the terms do not name, or a threshold written as something
+     * other than a constant.
+     *
+     * <p>Whichever rule wrote it. An invariant's clause and a {@code guard}'s comparison are two
+     * producers of one kind of evidence (spec §example-partition), and what stopped each of them is
+     * the same fact about this compiler.
+     */
+    record UnreadComparisonForm() implements BlockReason {}
+
+    /** A comparison naming the position is against values no line is drawn on here — the carrier,
+     *  asked of the carrier. */
+    record UnreadComparisonDomain() implements BlockReason {}
+
+    /**
+     * The comparison relates two positions rather than dividing one.
+     *
+     * <p>Nothing is missing from the carrier: both sides are ordered, and a line drawn on either
+     * against a number would be read. What is missing is a class about two positions, which a
+     * partition of one is not — so a line like this is settled beside the partition rather than in
+     * it, and the position it names is left with no class of its own from this rule.
+     */
+    record ComparisonBetweenPositions() implements BlockReason {}
+
     /** What a derivation would have to be able to reach into. */
     enum Traversal {
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
@@ -1,0 +1,37 @@
+package souther.compiler.partition;
+
+/**
+ * What the rules written about a position, beyond the ends its own type states, came to.
+ *
+ * <p>The second phase of the cuts. A {@code guard} says where a behavior does something else, and
+ * both sides of that line hold values a row can write — so a position its type left whole is
+ * divided here, and a position nothing divides is one this phase also had nothing for.
+ *
+ * <p>Three answers and not two, for the reason the structural reading has three: a rule was
+ * written about this position and could not be turned into a line, which is neither evidence nor
+ * the absence of anything. Told apart, a report says what would have to change; run together, the
+ * position comes back as one the model divides no way, which is the opposite of what the rule in
+ * front of it says.
+ *
+ * <p><b>Whichever rule wrote it.</b> A {@code guard}'s comparison and a newtype's invariant are two
+ * producers of one kind of evidence (spec §example-partition), so {@link Blocked} is what either
+ * of them was left unread as. The reader is told the same thing about both and does not have to
+ * know which wrote it.
+ */
+public sealed interface BodyCutInspection {
+
+    /** A rule drew a line through the position's values, and the axis carries it. */
+    record Evidence() implements BodyCutInspection {}
+
+    /** Every rule reaching the position was read, and none of them divided it. */
+    record Exhausted() implements BodyCutInspection {}
+
+    /**
+     * A rule was written about the position and nothing here turned it into a line.
+     *
+     * <p>Not a verdict on the position. Something else may still answer for it — this is what it
+     * would be left with — and what {@code why} names is a capability, so a report saying it is
+     * telling an author what to wait for rather than what the model says.
+     */
+    record Blocked(BlockReason why) implements BodyCutInspection {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/BodyCutInspection.java
@@ -23,7 +23,15 @@ public sealed interface BodyCutInspection {
     /** A rule drew a line through the position's values, and the axis carries it. */
     record Evidence() implements BodyCutInspection {}
 
-    /** Every rule reaching the position was read, and none of them divided it. */
+    /**
+     * The rules this phase read about the position were all understood, and none of them divided
+     * it.
+     *
+     * <p>What was read, and not what could be written. A rule in a form no reader here takes apart
+     * is {@link Blocked} and says so; a rule nothing looks for at all is neither, and no case of
+     * this could say it. So this is a producer's answer about its own reading, which is what
+     * anything reading it may say — never that no line exists at the position.
+     */
     record Exhausted() implements BodyCutInspection {}
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Classifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Classifier.java
@@ -1,7 +1,9 @@
 package souther.compiler.partition;
 
 import souther.compiler.observe.ObservedValue;
+import souther.compiler.types.TypeName;
 
+import java.util.List;
 import java.util.function.Predicate;
 
 /**
@@ -39,5 +41,47 @@ public interface Classifier {
     /** Recognises nothing: a class that exists but cannot be told from another by looking. */
     static Classifier none() {
         return _ -> Membership.NO_MATCH;
+    }
+
+    /**
+     * One that reads the value inside the names the position writes it under.
+     *
+     * <p>The other direction of the same fact a representative is written by. A position declaring
+     * {@code data StageN = Stage} divides into the cases of {@code Stage}, a row writes
+     * {@code StageN(Prospecting)}, and what arrives is the construction with the case one inside
+     * it. A class asking what case it is has to be asked of the case.
+     *
+     * <p>Only the names that are there come off. A value that is not wearing them is handed to
+     * {@code inner} as it stands, which answers for it — the alternative is deciding here that a
+     * value belongs to no class, which is a judgement the classes make.
+     *
+     * @param worn the names, outermost first, as {@code TypeView} reads them off the position
+     */
+    static Classifier under(List<TypeName> worn, Classifier inner) {
+        if (worn.isEmpty()) {
+            return inner;
+        }
+        return value -> inner.membershipOf(inside(worn, value));
+    }
+
+    /** The value under {@code worn}: a newtype is observed as its construction, whose one field is
+     *  {@code value} (spec §data). */
+    private static ObservedValue inside(List<TypeName> worn, ObservedValue value) {
+        ObservedValue at = value;
+        for (TypeName name : worn) {
+            if (!(at instanceof ObservedValue.Constructed constructed)
+                    || !name.equals(constructed.type())) {
+                return at;
+            }
+            ObservedValue held = constructed.field("value");
+            if (held == null) {
+                // The construction is there and what it holds is not, which is what an observation
+                // stopped one layer down leaves. Handed on as it stands: why there is no value is
+                // the observation's to say and not something to be read off the outside of it.
+                return at;
+            }
+            at = held;
+        }
+        return at;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Classifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Classifier.java
@@ -64,9 +64,16 @@ public interface Classifier {
         return value -> inner.membershipOf(inside(worn, value));
     }
 
-    /** The value under {@code worn}: a newtype is observed as its construction, whose one field is
-     *  {@code value} (spec §data). */
-    private static ObservedValue inside(List<TypeName> worn, ObservedValue value) {
+    /**
+     * The value under {@code worn}: a newtype is observed as its construction, whose one field is
+     * {@code value} (spec §data).
+     *
+     * <p>The one place an observation has names taken off it. What a row wrote is what arrives, and
+     * every reader that walks into one — a class asking which case it is, a walk on its way to a
+     * field under it — takes them off the same way and by name, so that a record whose own field is
+     * called {@code value} is never mistaken for a name worn over one.
+     */
+    static ObservedValue inside(List<TypeName> worn, ObservedValue value) {
         ObservedValue at = value;
         for (TypeName name : worn) {
             if (!(at instanceof ObservedValue.Constructed constructed)

--- a/souther-compiler/src/main/java/souther/compiler/partition/CutEvidence.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/CutEvidence.java
@@ -1,0 +1,41 @@
+package souther.compiler.partition;
+
+import java.util.List;
+
+/**
+ * The lines the rules on a position drew through its values, where they drew any.
+ *
+ * <p>Two cases rather than a list that may be empty, because something else is true only where
+ * there are lines. Whether a row can be written at an edge depends on rules this could not read
+ * elsewhere in the value the position sits in — a question about the edges, which a position with
+ * no edges does not have. Carried beside a possibly-empty list, "uncertain" was a word that meant
+ * nothing on its own and was kept true or false by whoever set it.
+ */
+public sealed interface CutEvidence {
+
+    /** No rule drew a line through this position's values. */
+    record None() implements CutEvidence {}
+
+    /**
+     * The lines, and whether a row at one of them may turn out to be unwritable.
+     *
+     * @param cuts      never empty: no lines is {@link None}, which says so
+     * @param uncertain whether some rule reaching the value this position sits in was not read, so
+     *                  that a row written at one of these edges may be refused for a reason this
+     *                  cannot see. About the edges and about nothing else
+     */
+    record Present(List<Cut> cuts, boolean uncertain) implements CutEvidence {
+
+        public Present {
+            cuts = List.copyOf(cuts);
+            if (cuts.isEmpty()) {
+                throw new IllegalArgumentException("no cuts is `None`, which says so");
+            }
+        }
+    }
+
+    /** The lines as a list, for a reader that only counts them. */
+    default List<Cut> cuts() {
+        return this instanceof Present present ? present.cuts() : List.of();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -674,35 +674,34 @@ public final class Generator {
      */
     private static Attempt build(Subject subject, List<Axis> axes, int[] where, CandidateCheck check) {
         Map<String, List<FixtureTemplate>> decided = new LinkedHashMap<>();
-        Map<String, souther.compiler.types.TypeName> shapes = new LinkedHashMap<>();
+        Map<String, RepresentativeSource.Evaluation.Compose> recipes = new LinkedHashMap<>();
         for (int i = 0; i < axes.size(); i++) {
-            PartitionClass here = axes.get(i).classes().get(where[i]);
-            List<FixtureTemplate> candidates = here.representatives().candidates();
-            if (candidates.isEmpty() && here.shape().isPresent()) {
-                // Not a value but which value: the walk below builds one of this shape at this
-                // position, field by field, the way it builds every other record.
-                shapes.put(axes.get(i).path().toString(), here.shape().get());
-                continue;
+            String path = axes.get(i).path().toString();
+            String at = label(axes.get(i), where[i]);
+            switch (axes.get(i).classes().get(where[i]).representatives().evaluate()) {
+                case RepresentativeSource.Evaluation.Values values ->
+                        decided.put(path, values.written());
+                // Not a value but how one is arrived at: the walk below builds one at this position,
+                // field by field, the way it builds every other record, and this writes what was
+                // built under the names the position wears.
+                case RepresentativeSource.Evaluation.Compose compose -> recipes.put(path, compose);
+                // What the class said about itself. A class that recorded why nothing was produced
+                // for it knows something this does not, and the two answers are not the same claim:
+                // one is that nothing was arrived at, and the other is that nothing can be. Read as
+                // the first, a case somebody can write in one line is reported as a row that does
+                // not exist.
+                case RepresentativeSource.Evaluation.NothingProducible cannot -> {
+                    return new Attempt(null, UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, at,
+                            Optional.of(cannot.why()));
+                }
+                case RepresentativeSource.Evaluation.NothingProduced _ -> {
+                    return Attempt.no(UnresolvedCombination.Reason.NO_REPRESENTATIVE, at);
+                }
             }
-            if (candidates.isEmpty()) {
-                // What the class said about itself, where it said anything. A class that recorded why
-                // nothing was produced for it knows something this does not, and the two answers are
-                // not the same claim: one is that the position has no values, and the other is that
-                // this did not compose one of the values it has. Read as the first, a case somebody
-                // can write in one line is reported as a row that does not exist.
-                String at = label(axes.get(i), where[i]);
-                return here.generationFailure()
-                        .map(why -> new Attempt(null,
-                                UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, at,
-                                Optional.of(why)))
-                        .orElseGet(() -> Attempt.no(
-                                UnresolvedCombination.Reason.NO_REPRESENTATIVE, at));
-            }
-            decided.put(axes.get(i).path().toString(), candidates);
         }
         List<FixtureTemplate> inputs = new ArrayList<>();
         for (int p = 0; p < subject.parameters().size() && p < subject.types().size(); p++) {
-            Outcome tried = valueFor(subject, p, axes, decided, shapes, check);
+            Outcome tried = valueFor(subject, p, axes, decided, recipes, check);
             if (tried.value() == null) {
                 return Attempt.no(tried.reason(), tried.detail());
             }
@@ -722,7 +721,7 @@ public final class Generator {
      */
     private static Outcome valueFor(Subject subject, int p, List<Axis> axes,
                                     Map<String, List<FixtureTemplate>> decided,
-                                    Map<String, souther.compiler.types.TypeName> shapes,
+                                    Map<String, RepresentativeSource.Evaluation.Compose> recipes,
                                     CandidateCheck check) {
         TermPath at = TermPath.of(subject.parameters().get(p));
         Map<String, List<FixtureTemplate>> here = new LinkedHashMap<>();
@@ -732,7 +731,7 @@ public final class Generator {
                 here.put(axis.path().toString(), decided.get(axis.path().toString()));
             }
         }
-        return valueAt(subject, p, here, settledIn(here), shapes, check);
+        return valueAt(subject, p, here, settledIn(here), recipes, check);
     }
 
     /**
@@ -781,16 +780,16 @@ public final class Generator {
     private static Outcome valueAt(Subject subject, int p,
                                    Map<String, List<FixtureTemplate>> decided,
                                    Map<String, Place> settled,
-                                   Map<String, souther.compiler.types.TypeName> shapes,
+                                   Map<String, RepresentativeSource.Evaluation.Compose> recipes,
                                    CandidateCheck check) {
         Choices choices = choicesOf(subject.types().get(p),
                 TermPath.of(subject.parameters().get(p)), subject.symbols(), decided, settled,
-                shapes);
+                recipes);
         if (choices.missingAt() != null) {
             return new Outcome(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
                     choices.missingAt());
         }
-        Outcome product = walk(subject, p, choices, shapes, check);
+        Outcome product = walk(subject, p, choices, recipes, check);
         if (product.value() != null) {
             return product;
         }
@@ -798,7 +797,7 @@ public final class Generator {
         // two of them was satisfied only where the lists happened to already hold a pair that does.
         // Asked again choosing one position at a time, each from what is left once the ones before it
         // are asserted, which is the only way `a < b` is met in general.
-        Outcome conditioned = conditioned(subject, p, decided, settled, shapes, check);
+        Outcome conditioned = conditioned(subject, p, decided, settled, recipes, check);
         if (conditioned.value() != null) {
             return conditioned;
         }
@@ -814,17 +813,17 @@ public final class Generator {
         // the rules allow was offered. A position that read a count past what a row is built to carry,
         // or that has more pairings than are built at once, held something back, and saying so is the
         // difference between a fact about the model and a fact about this.
-        UnresolvedCombination.Reason held = heldBack(subject, p, decided, shapes);
+        UnresolvedCombination.Reason held = heldBack(subject, p, decided, recipes);
         return held == null ? product : new Outcome(null, held, null);
     }
 
     /** Why a position of this parameter offered less than its rules allow, or null where none did. */
     private static UnresolvedCombination.Reason heldBack(Subject subject, int p,
                                                          Map<String, List<FixtureTemplate>> decided,
-                                                         Map<String, souther.compiler.types.TypeName> shapes) {
+                                                         Map<String, RepresentativeSource.Evaluation.Compose> recipes) {
         List<Position> found = new ArrayList<>();
         positionsUnder(subject.types().get(p), TermPath.of(subject.parameters().get(p)),
-                subject.symbols(), 0, found, decided.keySet(), shapes);
+                subject.symbols(), 0, found, decided.keySet(), recipes);
         UnresolvedCombination.Reason held = null;
         for (Position each : found) {
             UnresolvedCombination.Reason here = Partitions.notBuilt(each.type(), subject.symbols());
@@ -855,12 +854,12 @@ public final class Generator {
     private static Outcome conditioned(Subject subject, int p,
                                        Map<String, List<FixtureTemplate>> decided,
                                        Map<String, Place> settled,
-                                       Map<String, souther.compiler.types.TypeName> shapes,
+                                       Map<String, RepresentativeSource.Evaluation.Compose> recipes,
                                        CandidateCheck check) {
         Type type = subject.types().get(p);
         TermPath at = TermPath.of(subject.parameters().get(p));
         List<Position> found = new ArrayList<>();
-        positionsUnder(type, at, subject.symbols(), 0, found, decided.keySet(), shapes);
+        positionsUnder(type, at, subject.symbols(), 0, found, decided.keySet(), recipes);
         // What the caller fixed goes first, so that everything chosen after it is chosen beside it.
         // A class stands for one value and a boundary is one value, and neither is worth deciding
         // after the positions whose range it settles.
@@ -869,7 +868,7 @@ public final class Generator {
         positions.addAll(found.stream().filter(each -> !decided.containsKey(each.path())).toList());
         Budget budget = new Budget();
         FixtureTemplate built = descend(subject, p, positions, 0, new LinkedHashMap<>(),
-                new LinkedHashMap<>(settled), decided, shapes, check, budget);
+                new LinkedHashMap<>(settled), decided, recipes, check, budget);
         if (built != null) {
             return new Outcome(built, null, null);
         }
@@ -922,14 +921,14 @@ public final class Generator {
                                            Map<String, FixtureTemplate> chosen,
                                            Map<String, Place> settled,
                                            Map<String, List<FixtureTemplate>> decided,
-                                           Map<String, souther.compiler.types.TypeName> shapes,
+                                           Map<String, RepresentativeSource.Evaluation.Compose> recipes,
                                            CandidateCheck check, Budget budget) {
         if (index == positions.size()) {
             if (!budget.spend()) {
                 return null;
             }
             FixtureTemplate whole = compose(subject.types().get(p),
-                    TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0, shapes);
+                    TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0, recipes);
             return whole != null && check.refuse(p, whole).isEmpty() ? whole : null;
         }
         Position position = positions.get(index);
@@ -940,7 +939,7 @@ public final class Generator {
                 settled.put(position.path(), number);
             }
             FixtureTemplate found = descend(subject, p, positions, index + 1, chosen, settled,
-                    decided, shapes, check, budget);
+                    decided, recipes, check, budget);
             if (found != null) {
                 return found;
             }
@@ -977,19 +976,19 @@ public final class Generator {
      * {@link #choicesUnder} walks, so that the two agree about where a row chooses anything. */
     private static void positionsUnder(Type type, TermPath at, Symbols symbols, int depth,
                                        List<Position> out, java.util.Set<String> decided,
-                                       Map<String, souther.compiler.types.TypeName> shapes) {
+                                       Map<String, RepresentativeSource.Evaluation.Compose> recipes) {
         if (decided.contains(at.toString())) {
             out.add(new Position(at.toString(), type));
             return;
         }
-        type = shaped(type, at, shapes);
+        type = shaped(type, at, recipes);
         if (depth < MAX_DEPTH && type instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
             Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
             if (!fields.isEmpty()) {
                 for (Map.Entry<String, Type> field : fields.entrySet()) {
                     positionsUnder(field.getValue(), at.then(field.getKey()), symbols,
-                            depth + 1, out, decided, shapes);
+                            depth + 1, out, decided, recipes);
                 }
                 return;
             }
@@ -1047,7 +1046,7 @@ public final class Generator {
     private static Choices choicesOf(Type type, TermPath at, Symbols symbols,
                                      Map<String, List<FixtureTemplate>> decided,
                                      Map<String, Place> settled,
-                                     Map<String, souther.compiler.types.TypeName> shapes) {
+                                     Map<String, RepresentativeSource.Evaluation.Compose> recipes) {
         List<String> paths = new ArrayList<>(decided.keySet());
         List<List<FixtureTemplate>> values = new ArrayList<>(decided.values());
         // A position the caller fixed holds nothing back: it was given the value it is to take.
@@ -1059,7 +1058,7 @@ public final class Generator {
         FieldDomains left = type instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()
                 ? FieldDomains.of(ref.name(), data, symbols, under(at, settled)) : FieldDomains.NONE;
-        String missing = choicesUnder(type, at, symbols, 0, paths, values, reserves, left, at, shapes);
+        String missing = choicesUnder(type, at, symbols, 0, paths, values, reserves, left, at, recipes);
         return missing != null ? Choices.missing(missing)
                 : new Choices(paths, values, reserves, null);
     }
@@ -1088,18 +1087,18 @@ public final class Generator {
                                        List<String> paths, List<List<FixtureTemplate>> values,
                                        List<List<FixtureTemplate>> reserves,
                                        FieldDomains left, TermPath root,
-                                       Map<String, souther.compiler.types.TypeName> shapes) {
+                                       Map<String, RepresentativeSource.Evaluation.Compose> recipes) {
         if (paths.contains(at.toString())) {
             return null;   // an axis decides here
         }
-        type = shaped(type, at, shapes);
+        type = shaped(type, at, recipes);
         if (depth < MAX_DEPTH && type instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
             Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
             if (!fields.isEmpty()) {
                 for (Map.Entry<String, Type> field : fields.entrySet()) {
                     String missing = choicesUnder(field.getValue(), at.then(field.getKey()), symbols,
-                            depth + 1, paths, values, reserves, left, root, shapes);
+                            depth + 1, paths, values, reserves, left, root, recipes);
                     if (missing != null) {
                         return missing;
                     }
@@ -1131,9 +1130,9 @@ public final class Generator {
      * something it does not.
      */
     private static Type shaped(Type type, TermPath at,
-                               Map<String, souther.compiler.types.TypeName> shapes) {
-        souther.compiler.types.TypeName named = shapes.get(at.toString());
-        return named == null ? type : Type.ref(named);
+                               Map<String, RepresentativeSource.Evaluation.Compose> recipes) {
+        RepresentativeSource.Evaluation.Compose compose = recipes.get(at.toString());
+        return compose == null ? type : Type.ref(compose.through());
     }
 
     /** What came of trying the assignments for one parameter: its value, or why there is none. */
@@ -1155,9 +1154,9 @@ public final class Generator {
      * position would otherwise take rows away from the rest.
      */
     private static Outcome walk(Subject subject, int p, Choices choices,
-                                Map<String, souther.compiler.types.TypeName> shapes,
+                                Map<String, RepresentativeSource.Evaluation.Compose> recipes,
                                 CandidateCheck check) {
-        Outcome tried = over(subject, p, choices.at(), choices.values(), shapes, check);
+        Outcome tried = over(subject, p, choices.at(), choices.values(), recipes, check);
         // Only where the ordinary assignments ran out. A search that stopped at the bound has not
         // tried them all, and starting a wider one in front of the ones it never reached would spend
         // what is left on assignments further from what the model says the row is about, while the
@@ -1166,14 +1165,14 @@ public final class Generator {
                 || tried.reason() != UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED) {
             return tried;
         }
-        return over(subject, p, choices.at(), choices.widened(), shapes, check);
+        return over(subject, p, choices.at(), choices.widened(), recipes, check);
     }
 
     /** One pass over one set of choices, from the assignment where every position takes its first
      * value outward. */
     private static Outcome over(Subject subject, int p, List<String> at,
                                 List<List<FixtureTemplate>> values,
-                                Map<String, souther.compiler.types.TypeName> shapes,
+                                Map<String, RepresentativeSource.Evaluation.Compose> recipes,
                                 CandidateCheck check) {
         int positions = at.size();
         ArrayDeque<int[]> next = new ArrayDeque<>();
@@ -1191,7 +1190,7 @@ public final class Generator {
                 chosen.put(at.get(i), values.get(i).get(assignment[i]));
             }
             FixtureTemplate built = compose(subject.types().get(p),
-                    TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0, shapes);
+                    TermPath.of(subject.parameters().get(p)), chosen, subject.symbols(), 0, recipes);
             if (built != null && check.refuse(p, built).isEmpty()) {
                 return new Outcome(built, null, null);
             }
@@ -1215,16 +1214,25 @@ public final class Generator {
                 : new Outcome(null, UnresolvedCombination.Reason.SEARCH_LIMIT, null);
     }
 
-    /** The value at one position: what the assignment chose there, or a record built out of its
-     * fields. Null only where the walk that collected the choices and this one disagree. */
+    /**
+     * The value at one position: what the assignment chose there, or a record built out of its
+     * fields. Null only where the walk that collected the choices and this one disagree.
+     *
+     * <p>What was built is handed back to the recipe that said how to build it, which puts on the
+     * names the position writes its values under. The composing and the writing are one recipe
+     * because they are one fact about the position: a class of {@code data DecisionN = Decision}
+     * composes an {@code Approved} and the row carries {@code DecisionN(Approved { id = 1 })}.
+     * Composed without that, the row carries a value of a type the parameter does not declare.
+     */
     private static FixtureTemplate compose(Type type, TermPath at, Map<String, FixtureTemplate> chosen,
                                            Symbols symbols, int depth,
-                                           Map<String, souther.compiler.types.TypeName> shapes) {
+                                           Map<String, RepresentativeSource.Evaluation.Compose> recipes) {
         FixtureTemplate here = chosen.get(at.toString());
         if (here != null) {
             return here;
         }
-        type = shaped(type, at, shapes);
+        RepresentativeSource.Evaluation.Compose recipe = recipes.get(at.toString());
+        type = shaped(type, at, recipes);
         if (depth < MAX_DEPTH && type instanceof Type.Ref ref
                 && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
             Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
@@ -1232,13 +1240,14 @@ public final class Generator {
                 Map<String, FixtureTemplate> built = new LinkedHashMap<>();
                 for (Map.Entry<String, Type> field : fields.entrySet()) {
                     FixtureTemplate value = compose(field.getValue(), at.then(field.getKey()), chosen,
-                            symbols, depth + 1, shapes);
+                            symbols, depth + 1, recipes);
                     if (value == null) {
                         return null;
                     }
                     built.put(field.getKey(), value);
                 }
-                return FixtureTemplate.record(ref.name(), built);
+                FixtureTemplate record = FixtureTemplate.record(ref.name(), built);
+                return recipe == null ? record : recipe.written(record);
             }
         }
         return null;

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -59,13 +59,29 @@ public final class Generator {
 
     /** The behavior a row would be written for: what its inputs are called, what they are, and where
      * the model divides them. */
-    public record Subject(List<String> parameters, List<Type> types, List<Axis> axes,
-                          Symbols symbols) {
+    public record Subject(BehaviorInputs inputs, List<Axis> axes) {
 
         public Subject {
-            parameters = List.copyOf(parameters);
-            types = List.copyOf(types);
             axes = List.copyOf(axes);
+        }
+
+        /**
+         * The same three facts a row is read by, which is the point of holding one value.
+         *
+         * <p>Written out here as well, a row would be generated from one reading of what the
+         * behavior takes and read back by another — and how a position is written is exactly what
+         * the two came to disagree about.
+         */
+        public List<String> parameters() {
+            return inputs.parameters();
+        }
+
+        public List<Type> types() {
+            return inputs.types();
+        }
+
+        public Symbols symbols() {
+            return inputs.symbols();
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -3,8 +3,10 @@ package souther.compiler.partition;
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Carrier;
 import souther.compiler.check.FieldDomains;
+import souther.compiler.check.Shape;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Place;
 import souther.compiler.observe.Classification;
@@ -982,16 +984,18 @@ public final class Generator {
             return;
         }
         type = shaped(type, at, recipes);
-        if (depth < MAX_DEPTH && type instanceof Type.Ref ref
-                && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
-            Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
-            if (!fields.isEmpty()) {
-                for (Map.Entry<String, Type> field : fields.entrySet()) {
-                    positionsUnder(field.getValue(), at.then(field.getKey()), symbols,
-                            depth + 1, out, decided, recipes);
-                }
-                return;
+        // Read the way the walk that derived the axes reads it, so that the two agree about where
+        // the positions are. A record under a name is a record: `data SlotN = Slot` has the fields
+        // of `Slot`, and a generator that stopped at the name had no positions where the derivation
+        // had two.
+        Shape shape = TypeView.of(type, symbols).shape();
+        if (depth < MAX_DEPTH && shape instanceof Shape.Product product
+                && !product.fields().isEmpty()) {
+            for (Map.Entry<String, Type> field : product.fields().entrySet()) {
+                positionsUnder(field.getValue(), at.then(field.getKey()), symbols,
+                        depth + 1, out, decided, recipes);
             }
+            return;
         }
         out.add(new Position(at.toString(), type));
     }
@@ -1092,19 +1096,17 @@ public final class Generator {
             return null;   // an axis decides here
         }
         type = shaped(type, at, recipes);
-        if (depth < MAX_DEPTH && type instanceof Type.Ref ref
-                && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
-            Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
-            if (!fields.isEmpty()) {
-                for (Map.Entry<String, Type> field : fields.entrySet()) {
-                    String missing = choicesUnder(field.getValue(), at.then(field.getKey()), symbols,
-                            depth + 1, paths, values, reserves, left, root, recipes);
-                    if (missing != null) {
-                        return missing;
-                    }
+        Shape shape = TypeView.of(type, symbols).shape();
+        if (depth < MAX_DEPTH && shape instanceof Shape.Product product
+                && !product.fields().isEmpty()) {
+            for (Map.Entry<String, Type> field : product.fields().entrySet()) {
+                String missing = choicesUnder(field.getValue(), at.then(field.getKey()), symbols,
+                        depth + 1, paths, values, reserves, left, root, recipes);
+                if (missing != null) {
+                    return missing;
                 }
-                return null;
             }
+            return null;
         }
         souther.compiler.numeric.NumericDomain.Bounds here =
                 at.fields().isEmpty() ? null : left.at(String.join(".", at.fields()));
@@ -1232,23 +1234,25 @@ public final class Generator {
             return here;
         }
         RepresentativeSource.Evaluation.Compose recipe = recipes.get(at.toString());
-        type = shaped(type, at, recipes);
-        if (depth < MAX_DEPTH && type instanceof Type.Ref ref
-                && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()) {
-            Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
-            if (!fields.isEmpty()) {
-                Map<String, FixtureTemplate> built = new LinkedHashMap<>();
-                for (Map.Entry<String, Type> field : fields.entrySet()) {
-                    FixtureTemplate value = compose(field.getValue(), at.then(field.getKey()), chosen,
-                            symbols, depth + 1, recipes);
-                    if (value == null) {
-                        return null;
-                    }
-                    built.put(field.getKey(), value);
+        TypeView view = TypeView.of(shaped(type, at, recipes), symbols);
+        if (depth < MAX_DEPTH && view.shape() instanceof Shape.Product product
+                && !product.fields().isEmpty()) {
+            Map<String, FixtureTemplate> built = new LinkedHashMap<>();
+            for (Map.Entry<String, Type> field : product.fields().entrySet()) {
+                FixtureTemplate value = compose(field.getValue(), at.then(field.getKey()), chosen,
+                        symbols, depth + 1, recipes);
+                if (value == null) {
+                    return null;
                 }
-                FixtureTemplate record = FixtureTemplate.record(ref.name(), built);
-                return recipe == null ? record : recipe.written(record);
+                built.put(field.getKey(), value);
             }
+            // Under the names the position is written with, which the reading that found the fields
+            // took off to find them. A row at a `data SlotN = Slot` carries `SlotN(Slot { ... })`,
+            // and a value composed without them is of a type the parameter does not declare.
+            FixtureTemplate record = RepresentativeSource.under(
+                    view.wrappers().stream().map(TypeOps.Layer::named).toList(),
+                    FixtureTemplate.record(product.name(), built));
+            return recipe == null ? record : recipe.written(record);
         }
         return null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -148,7 +148,7 @@ public final class GuardThresholds {
             List<TermPath> named = new ArrayList<>();
             mentioned(binary.left(), parameters, symbols, named);
             mentioned(binary.right(), parameters, symbols, named);
-            UndividedPosition.Reason why = why(binary, parameters, symbols);
+            BlockReason why = why(binary, parameters, symbols);
             for (TermPath each : named) {
                 if (out.stream().noneMatch(had -> had.at().equals(each))) {
                     out.add(new UnreadRule(each, why));
@@ -191,8 +191,8 @@ public final class GuardThresholds {
      * expression the terms do not name, or a threshold written as something other than a constant —
      * and each of the three is a different piece of work.
      */
-    private static UndividedPosition.Reason why(Core.Binary comparison, List<String> parameters,
-                                                Symbols symbols) {
+    private static BlockReason why(Core.Binary comparison, List<String> parameters,
+                                   Symbols symbols) {
         boolean leftNames = !mentionedIn(comparison.left(), parameters, symbols).isEmpty();
         boolean rightNames = !mentionedIn(comparison.right(), parameters, symbols).isEmpty();
         // Which limit stopped this is asked of what the sides name, not of how far the derivation
@@ -200,11 +200,11 @@ public final class GuardThresholds {
         // set of values of one — and that is as true of `x < y + 1` as of `x < y`, where reading it
         // off the derivation loses the second position entirely and answers with the carrier.
         if (leftNames && rightNames) {
-            return UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE;
+            return new BlockReason.ComparisonBetweenPositions();
         }
         Core named = leftNames ? comparison.left() : comparison.right();
         if (termOf(named, parameters, symbols) == null) {
-            return UndividedPosition.Reason.UNSUPPORTED_SYNTAX;   // the position is inside something
+            return new BlockReason.UnreadComparisonForm();   // the position is inside something
         }
         // The carrier, asked of the carrier. `at < DateTime(...)` stops because nothing draws a line
         // on a date-time; `p.x < 1 + 2` stops because the other side is not a form a threshold is
@@ -212,8 +212,8 @@ public final class GuardThresholds {
         // Reading this off the side that did name a position calls the second one a carrier problem
         // and sends an author after a domain that is already there.
         return orderable(named.type(), symbols)
-                ? UndividedPosition.Reason.UNSUPPORTED_SYNTAX
-                : UndividedPosition.Reason.UNSUPPORTED_DOMAIN;
+                ? new BlockReason.UnreadComparisonForm()
+                : new BlockReason.UnreadComparisonDomain();
     }
 
     private static List<TermPath> mentionedIn(Core e, List<String> parameters, Symbols symbols) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -1,0 +1,300 @@
+package souther.compiler.partition;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Carrier;
+import souther.compiler.check.InvariantBound;
+import souther.compiler.check.NumericMeasures;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
+import souther.compiler.codegen.InvariantConstraints;
+import souther.compiler.diag.SourceRef;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.Place;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * What a position's own type and rules say about it, asked once and answered whole.
+ *
+ * <p>Two producers answer here — the classes the type states, and the lines its rules draw — and a
+ * caller cannot ask one without the other. That is the point of the type: {@link Exhausted} is not
+ * "there were no classes", it is <b>both were asked and neither had anything</b>, and only that
+ * licenses going on to ask what is under the position. Asked separately, the walk decided when
+ * local evidence had run out by looking at two empty lists, and any reader that forgot one of them
+ * would have concluded it from half the evidence.
+ *
+ * <p>The reading and the answer are apart. {@link LocalReading} is what the position was seen to
+ * be — its term, what its rules leave it, what could not be read — and is the same value in either
+ * case, because one reading produced both.
+ */
+public sealed interface LocalInspection {
+
+    /** What the position was read as, which is the same whether anything came of it. */
+    LocalReading reading();
+
+    /**
+     * Something the position's own type or rules said: classes, lines, or both.
+     *
+     * <p>Never neither. A value of this carrying no classes and no cuts would be an exhaustion
+     * dressed as evidence, and the phase after this one would never be reached for it.
+     */
+    record Evidence(LocalReading reading, List<PartitionClass> classes, CutEvidence cuts)
+            implements LocalInspection {
+
+        public Evidence {
+            classes = List.copyOf(classes);
+            if (classes.isEmpty() && cuts instanceof CutEvidence.None) {
+                throw new IllegalArgumentException(
+                        "neither classes nor cuts is `Exhausted`, which is a different answer");
+            }
+        }
+    }
+
+    /**
+     * Both producers were asked and neither answered.
+     *
+     * <p>A proof rather than a report: what makes it constructible is having asked, and what it
+     * licenses is the structural question after it. It says nothing about whether the position
+     * divides — the rules a body writes have not been read yet.
+     */
+    record Exhausted(LocalReading reading) implements LocalInspection {}
+
+    /**
+     * The one reading.
+     *
+     * @param view   the position's type, read once
+     * @param path   where the position sits, which a term is named by
+     * @param placed the value the position is inside, or null where it is a parameter itself
+     */
+    static LocalInspection inspect(TypeView view, TermPath path, Symbols symbols,
+                                   Partitions.Placed placed) {
+        Type type = view.declared();
+        // Which number this position is measured at, and what its rules leave that number. Asked
+        // together because they are one reading: whether a rule bounds the length of a string is how
+        // it is known that the length is the number being measured.
+        Carrier carried = Carrier.ofValue(type, symbols);
+        ValueName.Stdlib taken = NumericMeasures.takenOf(type, symbols);
+        // What the rules are about, and only then what the type could carry. A position has one
+        // axis, and a `String` is the one type that can be measured two ways — its own order, and
+        // the length of it — so which of them the model wrote about is what decides. Read off the
+        // carrier first, every rule anybody ever wrote about the length of a string would have
+        // become a rule about the string.
+        TypeBounds.Bounds sized = taken == null ? null
+                : TypeBounds.of(type, symbols, Carrier.WHOLE, taken);
+        boolean bySize = sized != null && !sized.isEmpty();
+        NumericTerm term = bySize ? new NumericTerm.SizeOf(taken, path) : new NumericTerm.ValueOf(path);
+        TypeBounds.Bounds own = bySize ? sized
+                : carried == null ? null : TypeBounds.of(type, symbols, carried, null);
+        // A value whose rules contradict has no positions to cover: every edge of every field of it
+        // is a row nobody can write, which is not the same answer as a field nothing bounds.
+        boolean nothingExists = placed != null && placed.domains().infeasible();
+        // A record's rule relates the numbers its fields hold, so it reaches the term that is one of
+        // them and no other: a cap on a field says nothing about how long the string beside it is.
+        NumericDomain.Bounds projected = placed == null || !(term instanceof NumericTerm.ValueOf)
+                ? null : placed.at(path);
+        // Two questions of one pair of readings, and they do not have one answer. What the term's
+        // values can be is every rule about it intersected; where it is divided is only where its own
+        // type draws a line, because a clause relating two fields is not a partition of one of them.
+        NumericDomain.Bounds admissible = nothingExists ? null
+                : TypeBounds.admissible(own, projected, term);
+        LocalReading reading = new LocalReading(term, admissible,
+                unreadBoundsAt(path, type, symbols, carried, taken));
+
+        // What the type declares, crossed with what the position can hold. Neither reading is the
+        // other's input: a case the rules refuse is still a case of the type, and it is here that
+        // it stops being a class of this position.
+        List<PartitionClass> classes =
+                constructibleAt(PartitionClasses.of(view, symbols), view, admissible, symbols);
+        TypeBounds.Bounds axis = nothingExists ? null : axisBounds(own, projected);
+        List<Cut> cuts = nothingExists ? List.of()
+                : cutsOf(type, axis, own, placed == null ? null : placed.value());
+        if (classes.isEmpty() && cuts.isEmpty()) {
+            return new Exhausted(reading);
+        }
+        // Whether a row can be written at an edge is a question about the whole value the position
+        // sits in, so it is answered once for the parameter. A rule this could not read is a way that
+        // value can be refused, wherever in it the rule is written.
+        CutEvidence drawn = cuts.isEmpty() ? new CutEvidence.None()
+                : new CutEvidence.Present(cuts,
+                        placed != null && !placed.domains().allRulesRead());
+        return new Evidence(reading, classes, drawn);
+    }
+
+    /**
+     * The classes of {@code declared} the position can hold a value of.
+     *
+     * <p>Two facts crossed, and they are separate facts. That a type declares a case is read off
+     * the declaration; that a value of it can stand at <em>this</em> position is what the rules on
+     * the position leave. A {@code data StageI = Stage invariant value >= Qualified} declares three
+     * cases and holds two of them: {@code StageI(Prospecting)} is refused at construction (E1903)
+     * by the same rule, so a class for it is a row nobody can write.
+     *
+     * <p>Crossed here rather than by handing the bounds to the reading that produces them. Each of
+     * the two is a function of the position and neither is a function of the other, so nothing
+     * depends on which is worked out first — and a producer that took the other's output would grow
+     * a dependency that only shows up as an admissible case coming back when someone tidies the
+     * order.
+     *
+     * <p>Dropped rather than kept and marked. What a body declines to answer for is still a class
+     * of the position's values and is reported as excluded ({@link Axis#excluding}); a case the
+     * position cannot hold is not one of its values at all, and the classes of an axis are over the
+     * values it has.
+     *
+     * @param within what the rules on the position leave its values, or null where nothing bounds
+     *               them
+     */
+    private static List<PartitionClass> constructibleAt(List<PartitionClass> declared, TypeView view,
+                                                        NumericDomain.Bounds within,
+                                                        Symbols symbols) {
+        if (within == null || declared.isEmpty()
+                || !(Carrier.ofValue(view.declared(), symbols) instanceof Carrier.Ordinal order)) {
+            return declared;   // no order for a rule to name a value on, so nothing is taken away
+        }
+        Set<String> refused = new LinkedHashSet<>();
+        for (TypeName each : order.cases()) {
+            Place at = order.at(each);
+            if (at != null && !within.admits(at)) {
+                refused.add(PartitionClasses.idOfCase(each));
+            }
+        }
+        return refused.isEmpty() ? declared
+                : declared.stream().filter(each -> !refused.contains(each.id())).toList();
+    }
+
+    /**
+     * The rules on this position's own type that say where its value stops and that nothing here
+     * turned into an end.
+     *
+     * <p>The invariant's half of what a {@code guard}'s comparison is asked in {@link
+     * GuardThresholds#comparedIn}. Both draw lines (ADR-0090) and both can be written in a form this
+     * does not read, and only one of them was saying so — a bound it dropped left the position
+     * looking like one no rule bounds, which is what the declaration above it denies.
+     *
+     * @param carried what the value is read on, or null where nothing here draws a line on it
+     * @param measure the operation a number is taken by, or null where none is
+     */
+    private static List<UnreadRule> unreadBoundsAt(TermPath path, Type type, Symbols symbols,
+                                                   Carrier carried, ValueName measure) {
+        List<UnreadRule> out = new ArrayList<>();
+        for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
+            for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
+                for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
+                    UndividedPosition.Reason why = whyUnread(each, carried, measure);
+                    // Once per position, as a comparison is: what a reader has to lift is the first
+                    // limit in the way, and a second clause behind it says nothing further.
+                    if (why != null && out.isEmpty()) {
+                        out.add(new UnreadRule(path, why));
+                    }
+                }
+            }
+        }
+        return List.copyOf(out);
+    }
+
+    /** What stopped one clause from being an end, or null where nothing did — either because it was
+     * read, or because it is not a rule about where the value stops. */
+    private static UndividedPosition.Reason whyUnread(Ast.Expr clause, Carrier carried,
+                                                      ValueName measure) {
+        if (InvariantBound.statesAnEnd(clause, null)) {
+            if (carried == null) {
+                // The value is ordered — it is compared in the clause — and this reads no line on
+                // what carries it. The carrier, asked of the carrier, as a guard's is.
+                return UndividedPosition.Reason.UNSUPPORTED_DOMAIN;
+            }
+            return InvariantBound.of(clause, carried).isPresent()
+                    ? null : UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
+        }
+        if (measure != null && InvariantBound.statesAnEnd(clause, measure)) {
+            // A size is a whole number whatever it is a size of, so nothing here is about a carrier.
+            return InvariantBound.ofSize(clause, measure).isPresent() ? null
+                    : UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
+        }
+        return null;
+    }
+
+    /**
+     * Where the position is divided: the type's own bound, taken in to where the record it sits in
+     * stops.
+     *
+     * <p>Only taken in. A record's rule moves an edge the type already has; it does not put one on a
+     * position the type left open. An {@code Int} nobody bounded stays a position the model draws no
+     * line through, which is what a report says of it (ADR-0090) — giving it an edge here would make
+     * a rule relating two fields into a partition of one of them.
+     *
+     * <p>So this is not what the position can hold, and reading it as that is how a cap written on
+     * the record alone became invisible: see {@link TypeBounds#admissible}.
+     */
+    private static TypeBounds.Bounds axisBounds(TypeBounds.Bounds own,
+                                                NumericDomain.Bounds projected) {
+        if (own == null || projected == null) {
+            return own;
+        }
+        // The value moves and the names do not: a record narrowing an edge does not take it away
+        // from the rule that put one there, and which record did the narrowing is said beside it.
+        return new TypeBounds.Bounds(
+                own.min() == null ? null
+                        : new TypeBounds.End(Endpoint.lower(own.min().at(), projected.min()),
+                                own.min().from()),
+                own.max() == null ? null
+                        : new TypeBounds.End(Endpoint.upper(own.max().at(), projected.max()),
+                                own.max().from()),
+                own.carrier());
+    }
+
+    /**
+     * The cuts of a position whose range is already settled.
+     *
+     * @param bounds where the position stops, the record it sits in taken into account
+     * @param own    where its own type stops, so that an end the record moved can say so
+     * @param within the record, or null at a position that is not a field of one
+     */
+    private static List<Cut> cutsOf(Type type, TypeBounds.Bounds bounds, TypeBounds.Bounds own,
+                                    TypeName within) {
+        if (bounds == null || bounds.isEmpty() || !(type instanceof Type.Ref)) {
+            return List.of();
+        }
+        Map<String, Cut> byValue = new LinkedHashMap<>();
+        cut(byValue, bounds.min(), own == null ? null : own.min(), "min",
+                bounds.carrier(), within);
+        cut(byValue, bounds.max(), own == null ? null : own.max(), "max",
+                bounds.carrier(), within);
+        return List.copyOf(byValue.values());
+    }
+
+    /** One end as a cut, owed once to each rule that put it there. */
+    private static void cut(Map<String, Cut> into, TypeBounds.End end, TypeBounds.End own,
+                            String clause, Carrier carrier, TypeName within) {
+        if (end == null) {
+            return;
+        }
+        // Taken in, which a record can do by moving the end or by taking away the value it stops
+        // at. `low < high` under one `[0, 1]` leaves `low` the same 1 and no longer holding it, and
+        // that is the record's doing as much as a smaller number would have been.
+        boolean moved = own != null && !own.at().equals(end.at());
+        for (TypeName from : end.from()) {
+            put(into, carrier, end.value(), from, clause, moved ? within : null);
+        }
+    }
+
+    private static void put(Map<String, Cut> into, Carrier carrier, Place at, TypeName type,
+                            String clause, TypeName narrowedBy) {
+        OriginRef origin = new OriginRef.InvariantOrigin(Optional.<SourceRef>empty(), type, clause);
+        if (narrowedBy != null) {
+            origin = new OriginRef.NarrowedOrigin(origin, narrowedBy);
+        }
+        OriginRef each = origin;
+        Cut cut = Cut.at(carrier, at, origin);
+        into.merge(cut.key(), cut, (had, _) -> had.and(each));
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -190,7 +190,7 @@ public sealed interface LocalInspection {
         for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
             for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
                 for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
-                    UndividedPosition.Reason why = whyUnread(each, carried, measure);
+                    BlockReason why = whyUnread(each, carried, measure);
                     // Once per position, as a comparison is: what a reader has to lift is the first
                     // limit in the way, and a second clause behind it says nothing further.
                     if (why != null && out.isEmpty()) {
@@ -204,21 +204,20 @@ public sealed interface LocalInspection {
 
     /** What stopped one clause from being an end, or null where nothing did — either because it was
      * read, or because it is not a rule about where the value stops. */
-    private static UndividedPosition.Reason whyUnread(Ast.Expr clause, Carrier carried,
-                                                      ValueName measure) {
+    private static BlockReason whyUnread(Ast.Expr clause, Carrier carried, ValueName measure) {
         if (InvariantBound.statesAnEnd(clause, null)) {
             if (carried == null) {
                 // The value is ordered — it is compared in the clause — and this reads no line on
                 // what carries it. The carrier, asked of the carrier, as a guard's is.
-                return UndividedPosition.Reason.UNSUPPORTED_DOMAIN;
+                return new BlockReason.UnreadComparisonDomain();
             }
             return InvariantBound.of(clause, carried).isPresent()
-                    ? null : UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
+                    ? null : new BlockReason.UnreadComparisonForm();
         }
         if (measure != null && InvariantBound.statesAnEnd(clause, measure)) {
             // A size is a whole number whatever it is a size of, so nothing here is about a carrier.
             return InvariantBound.ofSize(clause, measure).isPresent() ? null
-                    : UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
+                    : new BlockReason.UnreadComparisonForm();
         }
         return null;
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -73,12 +73,19 @@ public sealed interface LocalInspection {
     /**
      * The one reading.
      *
-     * @param view   the position's type, read once
+     * <p>Takes the proof rather than the reading. A position outside what a partition may be
+     * derived from cannot be handed to this — which is the point of {@link PartitionInput}, and was
+     * not true of it while the walk asked for the proof only after this had answered: a shape the
+     * boundary should have refused arrived here, produced classes, and never reached the check that
+     * exists to make that disagreement loud.
+     *
+     * @param input  the position, proved to be one a partition may be derived from
      * @param path   where the position sits, which a term is named by
      * @param placed the value the position is inside, or null where it is a parameter itself
      */
-    static LocalInspection inspect(TypeView view, TermPath path, Symbols symbols,
+    static LocalInspection inspect(PartitionInput input, TermPath path, Symbols symbols,
                                    Partitions.Placed placed) {
+        TypeView view = input.view();
         Type type = view.declared();
         // Which number this position is measured at, and what its rules leave that number. Asked
         // together because they are one reading: whether a rule bounds the length of a string is how

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalInspection.java
@@ -27,8 +27,8 @@ import java.util.Set;
 /**
  * What a position's own type and rules say about it, asked once and answered whole.
  *
- * <p>Two producers answer here — the classes the type states, and the lines its rules draw — and a
- * caller cannot ask one without the other. That is the point of the type: {@link Exhausted} is not
+ * <p>Two producers answer here — the classes the type states, and the lines its rules draw — and
+ * what a caller gets is both or neither. That is the point of the type: {@link Exhausted} is not
  * "there were no classes", it is <b>both were asked and neither had anything</b>, and only that
  * licenses going on to ask what is under the position. Asked separately, the walk decided when
  * local evidence had run out by looking at two empty lists, and any reader that forgot one of them

--- a/souther-compiler/src/main/java/souther/compiler/partition/LocalReading.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/LocalReading.java
@@ -1,0 +1,32 @@
+package souther.compiler.partition;
+
+import souther.compiler.numeric.NumericDomain;
+
+import java.util.List;
+
+/**
+ * What reading a position's own type and rules comes to, whatever it found.
+ *
+ * <p>One value because it is one reading. These three are not what the reading concluded — they are
+ * what it saw on the way, and they are the same whether it came back with evidence or with nothing.
+ * Held once, they cannot come to differ: copied into each answer, the day somebody works out
+ * {@link #admissible} differently for a position that has classes is a day the compiler contradicts
+ * itself about where the same values stop.
+ *
+ * @param term       which number the position is measured at: what it holds, or what its rules take
+ *                   of it. Always one — a position is an axis's worth of something even where
+ *                   nothing divides it, and the axis is named after this
+ * @param admissible what every rule reaching the position leaves its values, or null where nothing
+ *                   bounds them. Not where it is divided: a cap the record alone imposes stops the
+ *                   values without drawing a line through them
+ * @param unread     the rules written here that this could not turn into an end. A fact about those
+ *                   rules and not about the position, which is why it travels beside the answer
+ *                   rather than in it
+ */
+public record LocalReading(NumericTerm term, NumericDomain.Bounds admissible,
+                           List<UnreadRule> unread) {
+
+    public LocalReading {
+        unread = List.copyOf(unread);
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClass.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClass.java
@@ -1,9 +1,5 @@
 package souther.compiler.partition;
 
-import souther.compiler.types.TypeName;
-
-import java.util.Optional;
-
 /**
  * One equivalence class of an input position: a set of values expected to behave the same way.
  *
@@ -12,56 +8,27 @@ import java.util.Optional;
  * cannot be built is still a class: rows that reach it still count, and only the generator has to say
  * it cannot fill the gap.
  *
- * @param id                a name stable within its axis, used to compare one run against another
- * @param label             what to call it in a report
- * @param classifier        whether a value the rows already carry is in this class
- * @param representatives   values that could stand for it, in the order to try them
- * @param generationFailure why nothing can be produced, when nothing can
- * @param shape             the constructor a value for this class has to be built through, where the
- *                          class has values and cannot name one. A record's fields are chosen one at
- *                          a time against the rules relating them, which is the generator's walk and
- *                          not a list this could hold — so what is held is which constructor, and the
- *                          walk that composes every other record composes this one. Not the position's
- *                          type: the declared type is still the sum, and only the value being built
- *                          is narrowed
+ * @param id              a name stable within its axis, used to compare one run against another
+ * @param label           what to call it in a report
+ * @param classifier      whether a value the rows already carry is in this class
+ * @param representatives how a value standing for it is arrived at
  */
 public record PartitionClass(String id, String label, Classifier classifier,
-                             RepresentativeSource representatives,
-                             Optional<String> generationFailure,
-                             Optional<TypeName> shape) {
-
-    public PartitionClass {
-        generationFailure = generationFailure == null ? Optional.empty() : generationFailure;
-        shape = shape == null ? Optional.empty() : shape;
-    }
-
-    public PartitionClass(String id, String label, Classifier classifier,
-                          RepresentativeSource representatives,
-                          Optional<String> generationFailure) {
-        this(id, label, classifier, representatives, generationFailure, Optional.empty());
-    }
+                             RepresentativeSource representatives) {
 
     public static PartitionClass of(String id, String label, Classifier classifier,
                                     RepresentativeSource representatives) {
-        return new PartitionClass(id, label, classifier, representatives, Optional.empty());
-    }
-
-    /** A class whose values are composed through {@code shape} rather than named here. */
-    public static PartitionClass composed(String id, String label, Classifier classifier,
-                                          TypeName shape) {
-        return new PartitionClass(id, label, classifier, RepresentativeSource.none(),
-                Optional.empty(), Optional.of(shape));
+        return new PartitionClass(id, label, classifier, representatives);
     }
 
     /** A class nothing can produce a value for, and why. */
     public static PartitionClass ungeneratable(String id, String label, Classifier classifier,
                                                String why) {
-        return new PartitionClass(id, label, classifier, RepresentativeSource.none(),
-                Optional.of(why));
+        return new PartitionClass(id, label, classifier,
+                new RepresentativeSource.Ungeneratable(why));
     }
 
     public boolean generatable() {
-        return generationFailure.isEmpty()
-                && (shape.isPresent() || !representatives.candidates().isEmpty());
+        return representatives.buildable();
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -1,0 +1,169 @@
+package souther.compiler.partition;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Shape;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The classes a type states its values fall into, read through every name they are written under.
+ *
+ * <p>The one producer of class evidence. What a position divides into, what a witness of a type
+ * varies over, and what values stand for one of its cases were three readings of one declaration,
+ * and they disagreed about how far to look through a name.
+ */
+final class PartitionClasses {
+
+    static List<PartitionClass> of(Type type, Symbols symbols) {
+        return of(TypeView.of(type, symbols), symbols);
+    }
+
+    /**
+     * The class evidence this producer derives from a position's type, read through every name it
+     * is written under.
+     *
+     * <p>Through the names, because a newtype is the value it wraps (spec §primitives): a
+     * {@code data StageN = Stage} is the sum {@code Stage} and divides into its cases. Which is not
+     * what this asked before — it asked whether the type it was handed was a sum, stopped at the
+     * name, and reported a position the model divides three ways as one it divides no way (issue
+     * #631). The line drawn on that same position read straight through the name, so the two
+     * readings of one declaration disagreed.
+     *
+     * <p>And under them, because that is how a row writes the value. The names come off to say what
+     * the position is and go back on to say what stands at it — one fact, read from
+     * {@link TypeView} once, rather than each reader deciding again how far to look.
+     *
+     * <p><b>Empty is this producer having no class evidence, and never that the position has no
+     * classes.</b> The two read the same and are not the same claim: the second is a statement
+     * about the model, and it is not one this is in a position to make — the rules a body writes
+     * have not been read, and what is under the position has not been asked. A
+     * {@link Shape.Unresolved} answers empty here and is reported as a type this could not
+     * interpret, which the structural reading after this one supplies. Making the conclusion here
+     * is the defect the whole protocol is against, in one function.
+     *
+     * <p>Exhaustive over {@link Shape}, with no {@code default}, so that a shape added later stops
+     * this compiling rather than arriving as a position this quietly has no evidence about.
+     *
+     * <p>Nothing about the rules on the position. What its type declares and what its rules leave
+     * it able to hold are two facts, and this is the first of them — crossed with the second by
+     * {@link LocalInspection}, which is where a case the model refuses stops being a class.
+     */
+    static List<PartitionClass> of(TypeView view, Symbols symbols) {
+        List<TypeName> worn = view.wrappers().stream().map(TypeOps.Layer::named).toList();
+        return switch (view.shape()) {
+            // A `Bool` is two values. No other primitive has classes to read off its type: what a
+            // number's rules leave is a range with edges — everything outside a newtype's invariant
+            // is refused at construction (E1903), so there is no class on the other side to cover —
+            // and what does divide a number is a threshold, which is read from a body and not here.
+            case Shape.Scalar scalar -> scalar.prim() == Type.Prim.BOOL
+                    ? eitherWay(worn) : List.of();
+            case Shape.Sum sum -> caseClasses(Type.ref(sum.name()), worn, symbols);
+            case Shape.Cases cases -> caseClasses(Type.union(cases.members()), worn, symbols);
+            case Shape.Optional optional -> heldOrNot(optional.element(), worn, symbols);
+            // Shapes whose types state no division of their own. A record is made of positions and a
+            // collection holds its values inside something — what that comes to is the structural
+            // reading's answer, not this one's — and a unit data has one value, which no class of
+            // this producer's tells from another.
+            case Shape.Product _, Shape.Unit _, Shape.Sequence _, Shape.Mapping _,
+                 Shape.Tuple _, Shape.Function _,
+            // And the five that are not value shapes: nothing here was interpreted, so there is
+            // nothing to read classes off. What that means for the position is said where the
+            // provenance is, which is what the shape carries into the phase after this one.
+                 Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _,
+                 Shape.Unresolved _ -> List.of();
+        };
+    }
+
+    /** The two values of a {@code Bool}, under the names the position writes them under. */
+    private static List<PartitionClass> eitherWay(List<TypeName> worn) {
+        return List.of(
+                PartitionClass.of("true", "true",
+                        Classifier.under(worn, Classifier.byShape(v -> isBool(v, true))),
+                        RepresentativeSource.under(worn,
+                                RepresentativeSource.of(FixtureTemplate.bool(true)))),
+                PartitionClass.of("false", "false",
+                        Classifier.under(worn, Classifier.byShape(v -> isBool(v, false))),
+                        RepresentativeSource.under(worn,
+                                RepresentativeSource.of(FixtureTemplate.bool(false)))));
+    }
+
+    /** Whether an optional holds anything, which is the one division its type makes. */
+    private static List<PartitionClass> heldOrNot(Type element, List<TypeName> worn,
+                                                  Symbols symbols) {
+        List<FixtureTemplate> some = Partitions.representativesOf(element, symbols);
+        return List.of(
+                PartitionClass.of("None", "None",
+                        Classifier.under(worn,
+                                Classifier.byShape(v -> v instanceof ObservedValue.Absent)),
+                        RepresentativeSource.under(worn,
+                                RepresentativeSource.of(FixtureTemplate.none()))),
+                some.isEmpty()
+                        ? PartitionClass.ungeneratable("Some", "Some",
+                                Classifier.under(worn, Classifier.byShape(
+                                        v -> !(v instanceof ObservedValue.Absent))),
+                                "nothing here composed a value of " + Type.show(element))
+                        : PartitionClass.of("Some", "Some",
+                                Classifier.under(worn, Classifier.byShape(
+                                        v -> !(v instanceof ObservedValue.Absent))),
+                                RepresentativeSource.under(worn,
+                                        RepresentativeSource.of(some))));
+    }
+
+    /** A sum's cases, each a class, under the names the position writes them under. */
+    private static List<PartitionClass> caseClasses(Type sum, List<TypeName> worn,
+                                                    Symbols symbols) {
+        List<PartitionClass> cases = new ArrayList<>();
+        for (TypeName leaf : TypeOps.leafCases(sum, symbols)) {
+            cases.add(caseClass(leaf, worn, symbols));
+        }
+        return cases;
+    }
+
+    /** What a case's class is called, in one place: a reading that decides which cases the position
+     *  holds names the same classes the reading above builds. */
+    static String idOfCase(TypeName leaf) {
+        return leaf.name();
+    }
+
+    private static PartitionClass caseClass(TypeName leaf, List<TypeName> worn, Symbols symbols) {
+        Classifier is = Classifier.under(worn, Classifier.byShape(v -> switch (v) {
+            case ObservedValue.Unit u -> leaf.equals(u.type());
+            case ObservedValue.Constructed c -> leaf.equals(c.type());
+            default -> false;
+        }));
+        if (!(symbols.get(leaf) instanceof Ast.Data data)) {
+            return PartitionClass.of(idOfCase(leaf), leaf.name(), is,   // naming it builds it
+                    RepresentativeSource.under(worn,
+                            RepresentativeSource.of(FixtureTemplate.unitCase(leaf))));
+        }
+        if (data.newtype()) {
+            List<FixtureTemplate> inner = Partitions.insideTheNewtype(leaf, symbols);
+            return inner.isEmpty()
+                    ? PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is,
+                            "nothing here composed a value of what `" + leaf.name() + "` wraps")
+                    : PartitionClass.of(idOfCase(leaf), leaf.name(), is,
+                            RepresentativeSource.under(worn, RepresentativeSource.under(
+                                    List.of(leaf), RepresentativeSource.of(inner))));
+        }
+        // A record case is written field by field, which is the generator's composition. So the class
+        // names the constructor and the generator does the composing — the same walk every other
+        // record goes through, rules between the fields and all. Under the position's names either
+        // way: what is composed is an `Approved`, and what the row writes is `DecisionN(Approved
+        // { id = 1 })`.
+        return PartitionClass.of(idOfCase(leaf), leaf.name(), is,
+                RepresentativeSource.under(worn, new RepresentativeSource.Composed(leaf)));
+    }
+
+    private static boolean isBool(ObservedValue v, boolean expected) {
+        return v instanceof ObservedValue.Bool b && b.value() == expected;
+    }
+
+    private PartitionClasses() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionClasses.java
@@ -15,9 +15,14 @@ import java.util.List;
 /**
  * The classes a type states its values fall into, read through every name they are written under.
  *
- * <p>The one producer of class evidence. What a position divides into, what a witness of a type
- * varies over, and what values stand for one of its cases were three readings of one declaration,
- * and they disagreed about how far to look through a name.
+ * <p>The one reading of what a declaration states. What a position divides into, what a witness of
+ * a type varies over, and what values stand for one of its cases were three readings of one
+ * declaration, and they disagreed about how far to look through a name.
+ *
+ * <p>Classes read off a type, and not every class there is: what a body's comparisons divide a
+ * position into is read where those are ({@link Intervals}, and the values a {@code guard} singles
+ * out), and both kinds end up on one axis. So an empty answer here is this reading finding nothing
+ * stated, which the phase that owns it says ({@link LocalInspection}).
  */
 final class PartitionClasses {
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionInput.java
@@ -8,6 +8,10 @@ import souther.compiler.types.Type;
 /**
  * A position the partition derivation may be asked about, and proof that it is one.
  *
+ * <p>Package-private, cases and all, so that holding one is the proof rather than a claim about
+ * one: a public record is a canonical constructor anything can call, and a proof anything can write
+ * down is not one.
+ *
  * <p>Holding one of these is the proof. The derivation asks whether a position divides, and answers
  * that it does not — {@code Absent} — only where every producer it has was asked and none of them
  * answered. Which producers those are is a fact about this compiler; what this type adds is the
@@ -26,7 +30,7 @@ import souther.compiler.types.Type;
  * measured over here. Written out, a boundary that starts admitting a new shape stops this compiling
  * until the partition semantics of that shape have been decided.
  */
-public record PartitionInput(TypeView view, Shape.PartitionInputShape shape) {
+record PartitionInput(TypeView view, Shape.PartitionInputShape shape) {
 
     /**
      * How {@code type} is read at a position the derivation is about.
@@ -34,14 +38,14 @@ public record PartitionInput(TypeView view, Shape.PartitionInputShape shape) {
      * <p>Exhaustive over {@link Shape}, with no {@code default}: a sixteenth case stops this
      * compiling rather than arriving somewhere further down as a position nothing divides.
      */
-    public static PartitionInput of(Type type, Symbols symbols) {
+    static PartitionInput of(Type type, Symbols symbols) {
         return of(TypeView.of(type, symbols));
     }
 
     /** The same, of a position already read. The reading is the expensive half and the walk has one
      *  of them per position, so what asks about the shape and what asks about the names it is
      *  written under ask of the same reading. */
-    public static PartitionInput of(TypeView view) {
+    static PartitionInput of(TypeView view) {
         return new PartitionInput(view, admitted(view));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionInput.java
@@ -9,15 +9,15 @@ import souther.compiler.types.Type;
  * A position the partition derivation may be asked about, and proof that it is one.
  *
  * <p>Holding one of these is the proof. The derivation asks whether a position divides, and answers
- * that it does not — {@code Absent} — only where it has looked everywhere there was to look. What
- * "everywhere" is depends on the position being one a value can stand at in the first place, and
- * that premise used to be nowhere: the walk took a {@link Type}, and a type it had no arm for fell
- * through the bottom of a chain of {@code if}s into the same answer as a position the model really
- * does not divide.
+ * that it does not — {@code Absent} — only where every producer it has was asked and none of them
+ * answered. Which producers those are is a fact about this compiler; what this type adds is the
+ * premise underneath it, that the position is one a value can stand at at all. That premise used to
+ * be nowhere: the walk took a {@link Type}, and a type it had no arm for fell through the bottom of
+ * a chain of {@code if}s into the same answer as a position the model really does not divide.
  *
  * <p>So the premise is the input's type rather than a check the walk repeats. A shape outside the
- * set cannot be carried here, so nothing downstream has to ask again, and {@code Absent} needs only
- * the evidence phases to have been exhausted.
+ * set cannot be carried here, so nothing downstream has to ask again, and what is left for an
+ * absence is that the evidence phases were exhausted ({@link PendingPosition}).
  *
  * <p><b>The set is this package's, not the boundary's.</b> Which types reach a behavior's parameter
  * and which reach a data's field are two rules that disagree — an {@code Option} may be a field and

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionInput.java
@@ -35,7 +35,13 @@ public record PartitionInput(TypeView view, Shape.PartitionInputShape shape) {
      * compiling rather than arriving somewhere further down as a position nothing divides.
      */
     public static PartitionInput of(Type type, Symbols symbols) {
-        TypeView view = TypeView.of(type, symbols);
+        return of(TypeView.of(type, symbols));
+    }
+
+    /** The same, of a position already read. The reading is the expensive half and the walk has one
+     *  of them per position, so what asks about the shape and what asks about the names it is
+     *  written under ask of the same reading. */
+    public static PartitionInput of(TypeView view) {
         return new PartitionInput(view, admitted(view));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/PartitionInput.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PartitionInput.java
@@ -1,0 +1,67 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.Shape;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeView;
+import souther.compiler.types.Type;
+
+/**
+ * A position the partition derivation may be asked about, and proof that it is one.
+ *
+ * <p>Holding one of these is the proof. The derivation asks whether a position divides, and answers
+ * that it does not — {@code Absent} — only where it has looked everywhere there was to look. What
+ * "everywhere" is depends on the position being one a value can stand at in the first place, and
+ * that premise used to be nowhere: the walk took a {@link Type}, and a type it had no arm for fell
+ * through the bottom of a chain of {@code if}s into the same answer as a position the model really
+ * does not divide.
+ *
+ * <p>So the premise is the input's type rather than a check the walk repeats. A shape outside the
+ * set cannot be carried here, so nothing downstream has to ask again, and {@code Absent} needs only
+ * the evidence phases to have been exhausted.
+ *
+ * <p><b>The set is this package's, not the boundary's.</b> Which types reach a behavior's parameter
+ * and which reach a data's field are two rules that disagree — an {@code Option} may be a field and
+ * may not be a parameter — and neither of them is the question "what may a partition be derived
+ * from". Deriving this set from either would make a change over there silently change what is
+ * measured over here. Written out, a boundary that starts admitting a new shape stops this compiling
+ * until the partition semantics of that shape have been decided.
+ */
+public record PartitionInput(TypeView view, Shape.PartitionInputShape shape) {
+
+    /**
+     * How {@code type} is read at a position the derivation is about.
+     *
+     * <p>Exhaustive over {@link Shape}, with no {@code default}: a sixteenth case stops this
+     * compiling rather than arriving somewhere further down as a position nothing divides.
+     */
+    public static PartitionInput of(Type type, Symbols symbols) {
+        TypeView view = TypeView.of(type, symbols);
+        return new PartitionInput(view, admitted(view));
+    }
+
+    private static Shape.PartitionInputShape admitted(TypeView view) {
+        return switch (view.shape()) {
+            case Shape.PartitionInputShape admissible -> admissible;
+            // Refused where a signature or a field is read, each by an exhaustive switch of its own
+            // (SignatureBoundary, CodecShape), so a value of one reaching here is this compiler
+            // disagreeing with itself about what a position can be — not a model to report on.
+            case Shape.Cases _, Shape.Tuple _, Shape.Function _, Shape.Uninhabited _,
+                 Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _ ->
+                    throw unreachableInput(view);
+        };
+    }
+
+    /**
+     * A shape that cannot stand at a position and did.
+     *
+     * <p>Not a refusal, not a derivation that stopped, and nothing a reader of a model can act on.
+     * The boundary that admits what crosses and this one are separate exhaustive readings, and one
+     * of them has let through what the other says cannot arrive.
+     */
+    private static IllegalStateException unreachableInput(TypeView view) {
+        return new IllegalStateException(
+                "`" + Type.show(view.declared()) + "` reads as " + view.shape()
+                        + " at a position a partition is derived from; the boundary that admits a"
+                        + " position and this disagree about what may stand at one");
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -114,7 +114,7 @@ public final class Partitions {
             // each record is how `interval.startsAt < cap` stopped reaching `interval.startsAt`.
             Type type = sig.inputTypes().get(i);
             walk(behavior.name(), TermPath.of(behavior.params().get(i).name()), type,
-                    0, symbols, found, new Placed(nameOf(type), fieldDomainsOf(type, symbols)),
+                    0, symbols, found, new Placed(heldIn(type, symbols), fieldDomainsOf(type, symbols)),
                     domains, uncertain, unread);
         }
         found.replaceAll(axis -> axis.excluding(
@@ -609,16 +609,20 @@ public final class Partitions {
             // positions still to be answered for, and each carries what it is left with if nothing
             // answers.
             case LocalInspection.Exhausted _ -> {
-                StructuralInspection found = StructuralInspection.of(
-                        input.shape(), depth < MAX_DEPTH);
-                if (found instanceof StructuralInspection.Children children) {
-                    for (Map.Entry<String, Type> field : children.under().entrySet()) {
-                        walk(behavior, path.then(field.getKey()), field.getValue(), depth + 1,
-                                symbols, out, placed, domains, uncertain, unread);
+                switch (StructuralInspection.of(input.shape(), depth < MAX_DEPTH)) {
+                    // The one answer that takes the position away: what is under it is what the
+                    // classes belong to, and this position is not carried further.
+                    case StructuralInspection.Children children -> {
+                        for (Map.Entry<String, Type> field : children.under().entrySet()) {
+                            walk(behavior, path.then(field.getKey()), field.getValue(), depth + 1,
+                                    symbols, out, placed, domains, uncertain, unread);
+                        }
                     }
-                    return;
+                    // A leaf and a block are both positions still to be answered for, and each
+                    // carries what it is left with if nothing answers.
+                    case StructuralInspection.Pending pending ->
+                            out.add(Axis.pendingAt(id, term, type, pending));
                 }
-                out.add(Axis.pendingAt(id, term, type, found));
             }
         }
     }
@@ -635,14 +639,44 @@ public final class Partitions {
         }
     }
 
-    private static TypeName nameOf(Type type) {
-        return type instanceof Type.Ref ref ? ref.name() : null;
+    /** The record a position holds, through the names it is written under: a value of
+     *  {@code data SlotN = Slot} is a {@code Slot}, and the clauses relating its fields are
+     *  {@code Slot}'s. */
+    private static TypeName recordIn(Type type, Symbols symbols) {
+        return TypeView.of(type, symbols).shape() instanceof Shape.Product product
+                ? product.name() : null;
     }
 
-    /** What the record a field sits in leaves each of its fields able to hold. */
+    /**
+     * What the record a field sits in leaves each of its fields able to hold.
+     *
+     * <p>Of the record, and not of a name written over it. A clause relating two fields is written
+     * on the declaration that has them, so a position of {@code data PairN = Pair} is bounded by
+     * {@code Pair}'s clauses — read off the written name, the walk descended into the fields of a
+     * record whose rules about them it had just dropped.
+     */
     private static FieldDomains fieldDomainsOf(Type type, Symbols symbols) {
-        return type instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data
-                ? FieldDomains.of(ref.name(), data, symbols) : FieldDomains.NONE;
+        TypeName held = heldIn(type, symbols);
+        return held != null && symbols.get(held) instanceof Ast.Data data
+                ? FieldDomains.of(held, data, symbols) : FieldDomains.NONE;
+    }
+
+    /**
+     * The declaration whose rules reach the position: the record under the names where there is
+     * one, and the declaration as written where there is not.
+     *
+     * <p>A position that is not a record has no fields for a clause to relate, and its own rules
+     * still say what a reading of them could not turn into a range — which is what keeps an edge it
+     * refuses from being called writable. So the answer falls back to the name the signature wrote
+     * rather than to nothing.
+     */
+    private static TypeName heldIn(Type type, Symbols symbols) {
+        TypeName record = recordIn(type, symbols);
+        return record != null ? record : nameOf(type);
+    }
+
+    private static TypeName nameOf(Type type) {
+        return type instanceof Type.Ref ref ? ref.name() : null;
     }
 
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -157,8 +157,14 @@ public final class Partitions {
      * ones the walk did not finish, which is the one thing the axes cannot say for themselves: an
      * axis that was never descended into looks exactly like one there was nothing under.
      */
-    /** One position, and what the rules written about it came to. Held together because the two are
-     *  read at the same place and a report is the fold of them. */
+    /**
+     * One position, and what the rules written about it came to.
+     *
+     * <p>Paired where both are in hand rather than rejoined afterwards by how a path is spelled.
+     * What holds the two to one position is {@link #keep} making them together — the type says they
+     * travel together, not that they are of the same position — and that is the whole of the
+     * difference from a list of reasons matched to a list of positions later.
+     */
     private record Measured(Axis axis, BodyCutInspection body) {}
 
     /** The axis, and the body's answer about it — a line it drew, nothing, or a rule about it that

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -2,9 +2,11 @@ package souther.compiler.partition;
 
 import souther.compiler.ast.Ast;
 import souther.compiler.check.Carrier;
+import souther.compiler.check.Shape;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
 import souther.compiler.check.FieldDomains;
 import souther.compiler.check.InvariantBound;
 import souther.compiler.check.NumericMeasures;
@@ -526,7 +528,10 @@ public final class Partitions {
                              List<Axis> out, Placed placed,
                              Map<NumericTerm, NumericDomain.Bounds> domains,
                              java.util.Set<NumericTerm> uncertain, List<UnreadRule> unread) {
-        List<PartitionClass> classes = classesOf(type, symbols);
+        // Once, and every phase asks of this reading: what classes the type states, and what is
+        // under the position where it states none, are two questions put to one reading of it.
+        TypeView read = TypeView.of(type, symbols);
+        List<PartitionClass> declared = classesOf(read, symbols);
         // Which number this position is measured at, and what its rules leave that number. Asked
         // together because they are one reading: whether a rule bounds the length of a string is how
         // it is known that the length is the number being measured.
@@ -554,6 +559,10 @@ public final class Partitions {
         if (admissible != null && !admissible.isEmpty()) {
             domains.put(term, admissible);
         }
+        // What the type declares, crossed with what the position can hold. Neither reading is the
+        // other's input: a case the rules refuse is still a case of the type, and it is here that
+        // it stops being a class of this position.
+        List<PartitionClass> classes = constructibleAt(declared, read, admissible, symbols);
         Bounds axis = nothingExists ? null : axisBounds(own, projected);
         List<Cut> cuts = nothingExists ? List.of()
                 : cutsOf(type, axis, own, placed == null ? null : placed.value());
@@ -571,7 +580,7 @@ public final class Partitions {
         // positions. The answer is not a verdict: a leaf and a block are both positions still to be
         // answered for, and each carries what it is left with if nothing answers.
         StructuralInspection found = StructuralInspection.of(
-                PartitionInput.of(type, symbols).shape(), depth < MAX_DEPTH);
+                PartitionInput.of(read).shape(), depth < MAX_DEPTH);
         if (found instanceof StructuralInspection.Children children) {
             for (Map.Entry<String, Type> field : children.under().entrySet()) {
                 walk(behavior, path.then(field.getKey()), field.getValue(), depth + 1, symbols, out,
@@ -761,64 +770,182 @@ public final class Partitions {
     // --- what a type divides its values into ------------------------------------------------------
 
     static List<PartitionClass> classesOf(Type type, Symbols symbols) {
-        if (type == Type.BOOL) {
-            return List.of(
-                    PartitionClass.of("true", "true", Classifier.byShape(v -> isBool(v, true)),
-                            RepresentativeSource.of(FixtureTemplate.bool(true))),
-                    PartitionClass.of("false", "false", Classifier.byShape(v -> isBool(v, false)),
-                            RepresentativeSource.of(FixtureTemplate.bool(false))));
-        }
-        if (type instanceof Type.OptionOf option) {
-            List<FixtureTemplate> some = representativesOf(option.element(), symbols);
-            return List.of(
-                    PartitionClass.of("None", "None",
-                            Classifier.byShape(v -> v instanceof ObservedValue.Absent),
-                            RepresentativeSource.of(FixtureTemplate.none())),
-                    some.isEmpty()
-                            ? PartitionClass.ungeneratable("Some", "Some",
-                                    Classifier.byShape(v -> !(v instanceof ObservedValue.Absent)),
-                                    "nothing here composed a value of "
-                                            + Type.show(option.element()))
-                            : PartitionClass.of("Some", "Some",
-                                    Classifier.byShape(v -> !(v instanceof ObservedValue.Absent)),
-                                    () -> some));
-        }
-        if (TypeOps.isSumType(type, symbols)) {
-            List<PartitionClass> cases = new ArrayList<>();
-            for (TypeName leaf : TypeOps.leafCases(type, symbols)) {
-                cases.add(caseClass(leaf, symbols));
-            }
-            return cases;
-        }
-        // A numeric newtype's invariant does not divide the values a row can write. Everything outside
-        // it is refused at construction (E1903), so there is no class on the other side to cover — the
-        // bound leaves a boundary to reach, not a partition to fill. What does divide the values a row
-        // can write is a threshold a behavior compares against, which is read from the body.
-        return List.of();
+        return classesOf(TypeView.of(type, symbols), symbols);
     }
 
-    private static PartitionClass caseClass(TypeName leaf, Symbols symbols) {
-        Classifier is = Classifier.byShape(v -> switch (v) {
+    /**
+     * The class evidence this producer derives from a position's type, read through every name it
+     * is written under.
+     *
+     * <p>Through the names, because a newtype is the value it wraps (spec §primitives): a
+     * {@code data StageN = Stage} is the sum {@code Stage} and divides into its cases. Which is not
+     * what this asked before — it asked whether the type it was handed was a sum, stopped at the
+     * name, and reported a position the model divides three ways as one it divides no way (issue
+     * #631). The line drawn on that same position read straight through the name, so the two
+     * readings of one declaration disagreed.
+     *
+     * <p>And under them, because that is how a row writes the value. The names come off to say what
+     * the position is and go back on to say what stands at it — one fact, read from
+     * {@link TypeView} once, rather than each reader deciding again how far to look.
+     *
+     * <p><b>Empty is this producer having no class evidence, and never that the position has no
+     * classes.</b> The two read the same and are not the same claim: the second is a statement
+     * about the model, and it is not one this is in a position to make — the rules a body writes
+     * have not been read, and what is under the position has not been asked. A
+     * {@link Shape.Unresolved} answers empty here and is reported as a type this could not
+     * interpret, which the structural reading after this one supplies. Making the conclusion here
+     * is the defect the whole protocol is against, in one function.
+     *
+     * <p>Exhaustive over {@link Shape}, with no {@code default}, so that a shape added later stops
+     * this compiling rather than arriving as a position this quietly has no evidence about.
+     *
+     * <p>Nothing about the rules on the position. What its type declares and what its rules leave
+     * it able to hold are two facts, and this is the first of them — crossed with the second by
+     * {@link #constructibleAt}, which is where a case the model refuses stops being a class.
+     */
+    static List<PartitionClass> classesOf(TypeView view, Symbols symbols) {
+        List<TypeName> worn = view.wrappers().stream().map(TypeOps.Layer::named).toList();
+        return switch (view.shape()) {
+            // A `Bool` is two values. No other primitive has classes to read off its type: what a
+            // number's rules leave is a range with edges — everything outside a newtype's invariant
+            // is refused at construction (E1903), so there is no class on the other side to cover —
+            // and what does divide a number is a threshold, which is read from a body and not here.
+            case Shape.Scalar scalar -> scalar.prim() == Type.Prim.BOOL
+                    ? eitherWay(worn) : List.of();
+            case Shape.Sum sum -> caseClasses(Type.ref(sum.name()), worn, symbols);
+            case Shape.Cases cases -> caseClasses(Type.union(cases.members()), worn, symbols);
+            case Shape.Optional optional -> heldOrNot(optional.element(), worn, symbols);
+            // Shapes whose types state no division of their own. A record is made of positions and a
+            // collection holds its values inside something — what that comes to is the structural
+            // reading's answer, not this one's — and a unit data has one value, which no class of
+            // this producer's tells from another.
+            case Shape.Product _, Shape.Unit _, Shape.Sequence _, Shape.Mapping _,
+                 Shape.Tuple _, Shape.Function _,
+            // And the five that are not value shapes: nothing here was interpreted, so there is
+            // nothing to read classes off. What that means for the position is said where the
+            // provenance is, which is what the shape carries into the phase after this one.
+                 Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _,
+                 Shape.Unresolved _ -> List.of();
+        };
+    }
+
+    /** The two values of a {@code Bool}, under the names the position writes them under. */
+    private static List<PartitionClass> eitherWay(List<TypeName> worn) {
+        return List.of(
+                PartitionClass.of("true", "true",
+                        Classifier.under(worn, Classifier.byShape(v -> isBool(v, true))),
+                        RepresentativeSource.under(worn,
+                                RepresentativeSource.of(FixtureTemplate.bool(true)))),
+                PartitionClass.of("false", "false",
+                        Classifier.under(worn, Classifier.byShape(v -> isBool(v, false))),
+                        RepresentativeSource.under(worn,
+                                RepresentativeSource.of(FixtureTemplate.bool(false)))));
+    }
+
+    /** Whether an optional holds anything, which is the one division its type makes. */
+    private static List<PartitionClass> heldOrNot(Type element, List<TypeName> worn,
+                                                  Symbols symbols) {
+        List<FixtureTemplate> some = representativesOf(element, symbols);
+        return List.of(
+                PartitionClass.of("None", "None",
+                        Classifier.under(worn,
+                                Classifier.byShape(v -> v instanceof ObservedValue.Absent)),
+                        RepresentativeSource.under(worn,
+                                RepresentativeSource.of(FixtureTemplate.none()))),
+                some.isEmpty()
+                        ? PartitionClass.ungeneratable("Some", "Some",
+                                Classifier.under(worn, Classifier.byShape(
+                                        v -> !(v instanceof ObservedValue.Absent))),
+                                "nothing here composed a value of " + Type.show(element))
+                        : PartitionClass.of("Some", "Some",
+                                Classifier.under(worn, Classifier.byShape(
+                                        v -> !(v instanceof ObservedValue.Absent))),
+                                RepresentativeSource.under(worn,
+                                        RepresentativeSource.of(some))));
+    }
+
+    /** A sum's cases, each a class, under the names the position writes them under. */
+    private static List<PartitionClass> caseClasses(Type sum, List<TypeName> worn,
+                                                    Symbols symbols) {
+        List<PartitionClass> cases = new ArrayList<>();
+        for (TypeName leaf : TypeOps.leafCases(sum, symbols)) {
+            cases.add(caseClass(leaf, worn, symbols));
+        }
+        return cases;
+    }
+
+    /**
+     * The classes of {@code declared} the position can hold a value of.
+     *
+     * <p>Two facts crossed, and they are separate facts. That a type declares a case is read off
+     * the declaration; that a value of it can stand at <em>this</em> position is what the rules on
+     * the position leave. A {@code data StageI = Stage invariant value >= Qualified} declares three
+     * cases and holds two of them: {@code StageI(Prospecting)} is refused at construction (E1903)
+     * by the same rule, so a class for it is a row nobody can write.
+     *
+     * <p>Crossed here rather than by handing the bounds to the reading above. Each of the two is a
+     * function of the position and neither is a function of the other, so nothing depends on which
+     * is worked out first — and a producer that took the other's output would grow a dependency
+     * that only shows up as an admissible case coming back when someone tidies the order.
+     *
+     * <p>Dropped rather than kept and marked. What a body declines to answer for is still a class
+     * of the position's values and is reported as excluded ({@link Axis#excluding}); a case the
+     * position cannot hold is not one of its values at all, and the classes of an axis are over the
+     * values it has.
+     *
+     * @param within what the rules on the position leave its values, or null where nothing bounds
+     *               them
+     */
+    static List<PartitionClass> constructibleAt(List<PartitionClass> declared, TypeView view,
+                                                NumericDomain.Bounds within, Symbols symbols) {
+        if (within == null || declared.isEmpty()
+                || !(Carrier.ofValue(view.declared(), symbols) instanceof Carrier.Ordinal order)) {
+            return declared;   // no order for a rule to name a value on, so nothing is taken away
+        }
+        java.util.Set<String> refused = new java.util.LinkedHashSet<>();
+        for (TypeName each : order.cases()) {
+            Place at = order.at(each);
+            if (at != null && !within.admits(at)) {
+                refused.add(idOfCase(each));
+            }
+        }
+        return refused.isEmpty() ? declared
+                : declared.stream().filter(each -> !refused.contains(each.id())).toList();
+    }
+
+    /** What a case's class is called, in one place: a reading that decides which cases the position
+     *  holds names the same classes the reading above builds. */
+    private static String idOfCase(TypeName leaf) {
+        return leaf.name();
+    }
+
+    private static PartitionClass caseClass(TypeName leaf, List<TypeName> worn, Symbols symbols) {
+        Classifier is = Classifier.under(worn, Classifier.byShape(v -> switch (v) {
             case ObservedValue.Unit u -> leaf.equals(u.type());
             case ObservedValue.Constructed c -> leaf.equals(c.type());
             default -> false;
-        });
+        }));
         if (!(symbols.get(leaf) instanceof Ast.Data data)) {
-            return PartitionClass.of(leaf.name(), leaf.name(), is,
-                    RepresentativeSource.of(FixtureTemplate.unitCase(leaf)));   // naming it builds it
+            return PartitionClass.of(idOfCase(leaf), leaf.name(), is,   // naming it builds it
+                    RepresentativeSource.under(worn,
+                            RepresentativeSource.of(FixtureTemplate.unitCase(leaf))));
         }
         if (data.newtype()) {
             List<FixtureTemplate> inner = insideTheNewtype(leaf, symbols);
             return inner.isEmpty()
-                    ? PartitionClass.ungeneratable(leaf.name(), leaf.name(), is,
+                    ? PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is,
                             "nothing here composed a value of what `" + leaf.name() + "` wraps")
-                    : PartitionClass.of(leaf.name(), leaf.name(), is,
-                            () -> inner.stream().map(t -> FixtureTemplate.newtype(leaf, t)).toList());
+                    : PartitionClass.of(idOfCase(leaf), leaf.name(), is,
+                            RepresentativeSource.under(worn, RepresentativeSource.under(
+                                    List.of(leaf), RepresentativeSource.of(inner))));
         }
         // A record case is written field by field, which is the generator's composition. So the class
         // names the constructor and the generator does the composing — the same walk every other
-        // record goes through, rules between the fields and all.
-        return PartitionClass.composed(leaf.name(), leaf.name(), is, leaf);
+        // record goes through, rules between the fields and all. Under the position's names either
+        // way: what is composed is an `Approved`, and what the row writes is `DecisionN(Approved
+        // { id = 1 })`.
+        return PartitionClass.of(idOfCase(leaf), leaf.name(), is,
+                RepresentativeSource.under(worn, new RepresentativeSource.Composed(leaf)));
     }
 
     // --- reading an invariant's bounds -------------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -285,10 +285,10 @@ public final class Partitions {
                 // everything else. Ranges here would ask the rows for a distinction between the two
                 // sides of a value the behavior treats alike.
                 NumericDomain.Bounds only = domainOf(base, term);
-                keep(out, measured, new Axis(axis.id(), term, axis.type(),
+                keep(out, measured, axis.carrying(
                         singledClasses(points, term, axis.type(), only, symbols),
-                        mergedPoints(axis.cuts(), points, term.carrierAt(axis.type(), symbols)))
-                        .excluding(axis.excluded()), new BodyCutInspection.Evidence(), rules);
+                        mergedPoints(axis.cuts(), points, term.carrierAt(axis.type(), symbols))),
+                        new BodyCutInspection.Evidence(), rules);
                 continue;
             }
             if (here.isEmpty()) {
@@ -303,8 +303,7 @@ public final class Partitions {
                 }
                 term = drawn;
                 here = thresholds.stream().filter(t -> t.term().equals(drawn)).toList();
-                axis = new Axis(new AxisId(axis.id().behavior(), drawn.toString()), drawn,
-                        axis.type(), axis.classes(), axis.cuts(), axis.excluded());
+                axis = axis.measuredAt(new AxisId(axis.id().behavior(), drawn.toString()), drawn);
             }
             // What this term's values can be, which is the type's bound already narrowed by whatever
             // the record it sits in says about it. Reading the type again here would put a threshold
@@ -341,9 +340,9 @@ public final class Partitions {
             // a rule that went unread either: what it says was understood. So the answer there is
             // that the rules were exhausted, which is what keeps `Blocked` meaning that a
             // comparison could not be interpreted rather than everything that came to nothing.
-            keep(out, measured, new Axis(axis.id(), term, axis.type(),
+            keep(out, measured, axis.measuredAt(axis.id(), term).carrying(
                     classes.isEmpty() ? axis.classes() : classes,
-                    merged(axis.cuts(), reachable, carrier)).excluding(axis.excluded()),
+                    merged(axis.cuts(), reachable, carrier)),
                     reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
         }
         return new Partitioning(out, base.omitted(), domainsOf(base, out), base.uncertain(),
@@ -579,8 +578,14 @@ public final class Partitions {
                              java.util.Set<NumericTerm> uncertain, List<UnreadRule> unread) {
         // Once, and every phase asks of this reading: what the position's own type and rules say,
         // and what is under it where they say nothing, are two questions put to one reading of it.
-        TypeView read = TypeView.of(type, symbols);
-        LocalInspection local = LocalInspection.inspect(read, path, symbols, placed);
+        //
+        // The proof first, and before anything is read off the position. A shape a partition is not
+        // derived from is this compiler disagreeing with itself about what may stand at a position,
+        // and it is refused here — asked after the local phase instead, a position that produced
+        // classes was never checked at all, and the one case the type exists to make loud was the
+        // one that stayed quiet.
+        PartitionInput input = PartitionInput.of(TypeView.of(type, symbols));
+        LocalInspection local = LocalInspection.inspect(input, path, symbols, placed);
         LocalReading reading = local.reading();
         for (UnreadRule each : reading.unread()) {
             if (unread.stream().noneMatch(had -> had.equals(each))) {
@@ -605,7 +610,7 @@ public final class Partitions {
             // answers.
             case LocalInspection.Exhausted _ -> {
                 StructuralInspection found = StructuralInspection.of(
-                        PartitionInput.of(read).shape(), depth < MAX_DEPTH);
+                        input.shape(), depth < MAX_DEPTH);
                 if (found instanceof StructuralInspection.Children children) {
                     for (Map.Entry<String, Type> field : children.under().entrySet()) {
                         walk(behavior, path.then(field.getKey()), field.getValue(), depth + 1,

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -121,13 +121,13 @@ public final class Partitions {
                 excluded.at(axis.path()).stream().map(TypeName::name).toList()));
         List<Axis> kept = new ArrayList<>();
         List<OmittedAxis> omitted = new ArrayList<>();
-        int measured = 0;
+        int counted = 0;
         for (Axis axis : found) {
             if (!axis.measurable()) {
                 kept.add(axis);   // kept so a report can name what it could not measure
-            } else if (measured < MAX_AXES) {
+            } else if (counted < MAX_AXES) {
                 kept.add(axis);
-                measured++;
+                counted++;
             } else {
                 // Whether this one was carrying an obligation is decided here and not later. A cut is
                 // where a boundary comes from, and an axis dropped before `withThresholds` never gets
@@ -139,15 +139,13 @@ public final class Partitions {
         }
         // A position undivided because a rule about it went unread says that here, without waiting
         // for a body: a type bounded by a rule this cannot read is one whether or not any behavior
-        // compares it.
-        List<UndividedPosition> undivided = new ArrayList<>();
-        for (UndividedPosition each : undividedIn(kept)) {
-            UndividedPosition.Reason why = unread.stream()
-                    .filter(one -> one.at().equals(each.at())).map(UnreadRule::why)
-                    .findFirst().orElse(null);
-            undivided.add(why == null ? each : each.because(why));
+        // compares it. Nothing has compared anything yet, so what the rules came to is whether one
+        // of them was left unread — settled beside each axis, as it is once a body has spoken.
+        List<Measured> measured = new ArrayList<>();
+        for (Axis axis : kept) {
+            keep(new ArrayList<>(), measured, axis, null, unread);
         }
-        return new Partitioning(kept, omitted, domains, uncertain, undivided,
+        return new Partitioning(kept, omitted, domains, uncertain, undividedIn(measured),
                 List.copyOf(unread), List.of());
     }
 
@@ -159,13 +157,51 @@ public final class Partitions {
      * ones the walk did not finish, which is the one thing the axes cannot say for themselves: an
      * axis that was never descended into looks exactly like one there was nothing under.
      */
-    private static List<UndividedPosition> undividedIn(List<Axis> axes) {
+    /** One position, and what the rules written about it came to. Held together because the two are
+     *  read at the same place and a report is the fold of them. */
+    private record Measured(Axis axis, BodyCutInspection body) {}
+
+    /** The axis, and the body's answer about it — a line it drew, nothing, or a rule about it that
+     *  went unread. Kept beside the axis rather than looked up afterwards by how its path is
+     *  spelled. */
+    private static void keep(List<Axis> out, List<Measured> measured, Axis axis,
+                             BodyCutInspection drew, List<UnreadRule> rules) {
+        out.add(axis);
+        if (drew != null) {
+            measured.add(new Measured(axis, drew));
+            return;
+        }
+        BlockReason unread = rules.stream().filter(one -> one.at().equals(axis.path()))
+                .map(UnreadRule::why).findFirst().orElse(null);
+        measured.add(new Measured(axis, unread == null ? new BodyCutInspection.Exhausted()
+                : new BodyCutInspection.Blocked(unread)));
+    }
+
+    /**
+     * What each position is left with, folded from the two readings that were made of it.
+     *
+     * <p>Nothing is searched for here. Both answers were settled where the position was read — the
+     * structural one on the axis, the rules' one beside it — and this only says which of them a
+     * report is owed, so a reason recovered here by matching a path would be a reading happening
+     * twice.
+     *
+     * <p>The structural reason outranks the rules': where the walk could not reach into what the
+     * position holds, a rule naming something inside it is a second description of that same stop
+     * and the first is the cause (issue #626).
+     */
+    private static List<UndividedPosition> undividedIn(List<Measured> measured) {
         List<UndividedPosition> out = new ArrayList<>();
-        for (Axis axis : axes) {
+        for (Measured each : measured) {
+            Axis axis = each.axis();
             if (axis.measurable()) {
                 continue;
             }
-            out.add(axis.pending() instanceof StructuralInspection.Blocked blocked
+            if (axis.pending() instanceof StructuralInspection.Blocked blocked) {
+                out.add(UndividedPosition.cannotDerive(axis.path(),
+                        ReportedReason.of(blocked.why())));
+                continue;
+            }
+            out.add(each.body() instanceof BodyCutInspection.Blocked blocked
                     ? UndividedPosition.cannotDerive(axis.path(),
                             ReportedReason.of(blocked.why()))
                     : UndividedPosition.absent(axis.path()));
@@ -229,7 +265,17 @@ public final class Partitions {
                                               List<UnreadRule> unread,
                                               List<GuardThresholds.Guards.Singled> singled,
                                               List<BoundaryObligation> between) {
+        // Both producers of one kind of evidence. What a body compared and what a type's own rules
+        // bound are read by different readers and answer the same question, so a position either of
+        // them wrote about and neither could turn into a line is named once, whichever wrote it.
+        List<UnreadRule> rules = new ArrayList<>(base.unread());
+        for (UnreadRule each : unread) {
+            if (rules.stream().noneMatch(had -> had.equals(each))) {
+                rules.add(each);
+            }
+        }
         List<Axis> out = new ArrayList<>();
+        List<Measured> measured = new ArrayList<>();
         for (Axis axis : base.axes()) {
             NumericTerm declared = axis.term();
             NumericTerm term = declared;
@@ -242,10 +288,10 @@ public final class Partitions {
                 // everything else. Ranges here would ask the rows for a distinction between the two
                 // sides of a value the behavior treats alike.
                 NumericDomain.Bounds only = domainOf(base, term);
-                out.add(new Axis(axis.id(), term, axis.type(),
+                keep(out, measured, new Axis(axis.id(), term, axis.type(),
                         singledClasses(points, term, axis.type(), only, symbols),
                         mergedPoints(axis.cuts(), points, term.carrierAt(axis.type(), symbols)))
-                        .excluding(axis.excluded()));
+                        .excluding(axis.excluded()), new BodyCutInspection.Evidence(), rules);
                 continue;
             }
             if (here.isEmpty()) {
@@ -255,7 +301,7 @@ public final class Partitions {
                 // for it to be about, and dropping the threshold would lose a line the body draws.
                 NumericTerm drawn = axis.measurable() ? null : soleTermAt(thresholds, axis.path());
                 if (drawn == null) {
-                    out.add(axis);
+                    keep(out, measured, axis, null, rules);
                     continue;
                 }
                 term = drawn;
@@ -293,31 +339,18 @@ public final class Partitions {
                             term, axis.type(), symbols);
             // Through `excluding`, so that a class list replaced by the intervals a threshold cuts
             // keeps only the exclusions it still has classes for.
-            out.add(new Axis(axis.id(), term, axis.type(),
+            //
+            // A rule read and left outside what the position holds divided nothing, and it is not
+            // a rule that went unread either: what it says was understood. So the answer there is
+            // that the rules were exhausted, which is what keeps `Blocked` meaning that a
+            // comparison could not be interpreted rather than everything that came to nothing.
+            keep(out, measured, new Axis(axis.id(), term, axis.type(),
                     classes.isEmpty() ? axis.classes() : classes,
-                    merged(axis.cuts(), reachable, carrier)).excluding(axis.excluded()));
-        }
-        // Both producers of one kind of evidence. What a body compared and what a type's own rules
-        // bound are read by different readers and answer the same question, so a position either of
-        // them wrote about and neither could turn into a line is named once, whichever wrote it.
-        List<UnreadRule> rules = new ArrayList<>(base.unread());
-        for (UnreadRule each : unread) {
-            if (rules.stream().noneMatch(had -> had.equals(each))) {
-                rules.add(each);
-            }
-        }
-        // The structural reason travels on the axis, so nothing is recovered from the earlier pass
-        // by matching how a path is spelled. What is still joined here is a rule this could not
-        // read, which is about a rule rather than about the position and has nowhere else to live.
-        List<UndividedPosition> undivided = new ArrayList<>();
-        for (UndividedPosition each : undividedIn(out)) {
-            UndividedPosition.Reason unreadHere = rules.stream()
-                    .filter(one -> one.at().equals(each.at())).map(UnreadRule::why)
-                    .findFirst().orElse(null);
-            undivided.add(unreadHere == null ? each : each.because(unreadHere));
+                    merged(axis.cuts(), reachable, carrier)).excluding(axis.excluded()),
+                    reachable.isEmpty() ? null : new BodyCutInspection.Evidence(), rules);
         }
         return new Partitioning(out, base.omitted(), domainsOf(base, out), base.uncertain(),
-                undivided, List.copyOf(rules), between);
+                undividedIn(measured), List.copyOf(rules), between);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -522,167 +522,76 @@ public final class Partitions {
         return List.copyOf(out);
     }
 
-    /** One position: measured where the model divides it or bounds it, taken apart where it is a
-     * record, and recorded as not derivable where it is neither. */
+    /**
+     * One position, answered by the phases in the order that decides it.
+     *
+     * <p>The local reading first, whole: the classes the type states and the lines its rules draw
+     * come back as one answer, so what "local evidence ran out" means is a value rather than two
+     * empty lists to be noticed. Only where it ran out is the position asked what it is made of —
+     * a position its own type answered for is not descended into, whatever is under it, and that
+     * precedence is the arm this is written in rather than the order of two {@code if}s.
+     *
+     * <p>Of the structural answers only {@code Children} takes the position away: the walk goes on
+     * without it, and the classes belong to what is underneath. A leaf and a block both leave the
+     * position standing, pending what a body's rules say later.
+     *
+     * <p><b>A position with local evidence and children is intended and unreachable today.</b> Only
+     * a product has children, and a product carries neither classes — its type states no division —
+     * nor cuts, having no order for a rule to name a value on. So which of the two wins is a
+     * decision about a state the language cannot currently be in. It is written as a decision all
+     * the same: a field-level partition, a guard-derived class on a record, or an invariant over a
+     * whole product would inhabit it, and an implementation that descended because the position is
+     * structural would then lose evidence it had already read.
+     */
     private static void walk(String behavior, TermPath path, Type type, int depth, Symbols symbols,
                              List<Axis> out, Placed placed,
                              Map<NumericTerm, NumericDomain.Bounds> domains,
                              java.util.Set<NumericTerm> uncertain, List<UnreadRule> unread) {
-        // Once, and every phase asks of this reading: what classes the type states, and what is
-        // under the position where it states none, are two questions put to one reading of it.
+        // Once, and every phase asks of this reading: what the position's own type and rules say,
+        // and what is under it where they say nothing, are two questions put to one reading of it.
         TypeView read = TypeView.of(type, symbols);
-        List<PartitionClass> declared = classesOf(read, symbols);
-        // Which number this position is measured at, and what its rules leave that number. Asked
-        // together because they are one reading: whether a rule bounds the length of a string is how
-        // it is known that the length is the number being measured.
-        Measured measured = measure(path, type, symbols);
-        for (UnreadRule each : measured.unread()) {
+        LocalInspection local = LocalInspection.inspect(read, path, symbols, placed);
+        LocalReading reading = local.reading();
+        for (UnreadRule each : reading.unread()) {
             if (unread.stream().noneMatch(had -> had.equals(each))) {
                 unread.add(each);
             }
         }
-        NumericTerm term = measured.term();
+        NumericTerm term = reading.term();
         AxisId id = AxisId.of(behavior, term);
-        Bounds own = measured.bounds();
-        // A value whose rules contradict has no positions to cover: every edge of every field of it
-        // is a row nobody can write, which is not the same answer as a field nothing bounds.
-        boolean nothingExists = placed != null && placed.domains().infeasible();
-        // A record's rule relates the numbers its fields hold, so it reaches the term that is one of
-        // them and no other: a cap on a field says nothing about how long the string beside it is.
-        NumericDomain.Bounds projected = placed == null || !(term instanceof NumericTerm.ValueOf)
-                ? null : placed.at(path);
-        // Two questions of one pair of readings, and they do not have one answer. What the term's
-        // values can be is every rule about it intersected; where it is divided is only where its own
-        // type draws a line, because a clause relating two fields is not a partition of one of them.
-        NumericDomain.Bounds admissible = nothingExists ? null
-                : admissibleBounds(own, projected, term);
-        if (admissible != null && !admissible.isEmpty()) {
-            domains.put(term, admissible);
+        if (reading.admissible() != null && !reading.admissible().isEmpty()) {
+            domains.put(term, reading.admissible());
         }
-        // What the type declares, crossed with what the position can hold. Neither reading is the
-        // other's input: a case the rules refuse is still a case of the type, and it is here that
-        // it stops being a class of this position.
-        List<PartitionClass> classes = constructibleAt(declared, read, admissible, symbols);
-        Bounds axis = nothingExists ? null : axisBounds(own, projected);
-        List<Cut> cuts = nothingExists ? List.of()
-                : cutsOf(type, axis, own, placed == null ? null : placed.value());
-        // Whether a row can be written at an edge is a question about the whole value the position
-        // sits in, so it is answered once for the parameter. A rule this could not read is a way that
-        // value can be refused, wherever in it the rule is written.
-        if (!cuts.isEmpty() && placed != null && !placed.domains().allRulesRead()) {
-            uncertain.add(term);
-        }
-        if (!classes.isEmpty() || !cuts.isEmpty()) {
-            out.add(new Axis(id, term, type, classes, cuts));
-            return;
-        }
-        // Local evidence is exhausted, so what is asked next is whether the position is made of
-        // positions. The answer is not a verdict: a leaf and a block are both positions still to be
-        // answered for, and each carries what it is left with if nothing answers.
-        StructuralInspection found = StructuralInspection.of(
-                PartitionInput.of(read).shape(), depth < MAX_DEPTH);
-        if (found instanceof StructuralInspection.Children children) {
-            for (Map.Entry<String, Type> field : children.under().entrySet()) {
-                walk(behavior, path.then(field.getKey()), field.getValue(), depth + 1, symbols, out,
-                        placed, domains, uncertain, unread);
-            }
-            return;
-        }
-        out.add(Axis.pendingAt(id, term, type, found));
-    }
-
-    /** A position's number, what its own rules leave it, and which of those rules said nothing this
-     * could read. */
-    private record Measured(NumericTerm term, Bounds bounds, List<UnreadRule> unread) {
-
-        Measured(NumericTerm term, Bounds bounds) {
-            this(term, bounds, List.of());
-        }
-    }
-
-    /**
-     * The rules on this position's own type that say where its value stops and that nothing here
-     * turned into an end.
-     *
-     * <p>The invariant's half of what a {@code guard}'s comparison is asked in {@link
-     * GuardThresholds#comparedIn}. Both draw lines (ADR-0090) and both can be written in a form this
-     * does not read, and only one of them was saying so — a bound it dropped left the position
-     * looking like one no rule bounds, which is what the declaration above it denies.
-     *
-     * @param carried what the value is read on, or null where nothing here draws a line on it
-     * @param measure the operation a number is taken by, or null where none is
-     */
-    private static List<UnreadRule> unreadBoundsAt(TermPath path, Type type, Symbols symbols,
-                                                   Carrier carried, ValueName measure) {
-        List<UnreadRule> out = new ArrayList<>();
-        for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
-            for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
-                for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
-                    UndividedPosition.Reason why = whyUnread(each, carried, measure);
-                    // Once per position, as a comparison is: what a reader has to lift is the first
-                    // limit in the way, and a second clause behind it says nothing further.
-                    if (why != null && out.isEmpty()) {
-                        out.add(new UnreadRule(path, why));
-                    }
+        switch (local) {
+            case LocalInspection.Evidence evidence -> {
+                if (evidence.cuts() instanceof CutEvidence.Present drawn && drawn.uncertain()) {
+                    uncertain.add(term);
                 }
+                out.add(new Axis(id, term, type, evidence.classes(), evidence.cuts().cuts()));
+            }
+            // Both local producers were asked and neither answered, which is what licenses asking
+            // what is under the position. The answer is not a verdict: a leaf and a block are both
+            // positions still to be answered for, and each carries what it is left with if nothing
+            // answers.
+            case LocalInspection.Exhausted _ -> {
+                StructuralInspection found = StructuralInspection.of(
+                        PartitionInput.of(read).shape(), depth < MAX_DEPTH);
+                if (found instanceof StructuralInspection.Children children) {
+                    for (Map.Entry<String, Type> field : children.under().entrySet()) {
+                        walk(behavior, path.then(field.getKey()), field.getValue(), depth + 1,
+                                symbols, out, placed, domains, uncertain, unread);
+                    }
+                    return;
+                }
+                out.add(Axis.pendingAt(id, term, type, found));
             }
         }
-        return List.copyOf(out);
     }
 
-    /** What stopped one clause from being an end, or null where nothing did — either because it was
-     * read, or because it is not a rule about where the value stops. */
-    private static UndividedPosition.Reason whyUnread(Ast.Expr clause, Carrier carried,
-                                                      ValueName measure) {
-        if (InvariantBound.statesAnEnd(clause, null)) {
-            if (carried == null) {
-                // The value is ordered — it is compared in the clause — and this reads no line on
-                // what carries it. The carrier, asked of the carrier, as a guard's is.
-                return UndividedPosition.Reason.UNSUPPORTED_DOMAIN;
-            }
-            return InvariantBound.of(clause, carried).isPresent()
-                    ? null : UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
-        }
-        if (measure != null && InvariantBound.statesAnEnd(clause, measure)) {
-            // A size is a whole number whatever it is a size of, so nothing here is about a carrier.
-            return InvariantBound.ofSize(clause, measure).isPresent() ? null
-                    : UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
-        }
-        return null;
-    }
-
-    /**
-     * Which number a position is measured at.
-     *
-     * <p>What it holds, where that is a number. Otherwise what its rules take of it — and only where
-     * they take something: a string nobody wrote a rule about is a position the model draws no line
-     * through, and naming its length there would put a term in the report that nobody wrote.
-     */
-    private static Measured measure(TermPath path, Type type, Symbols symbols) {
-        Carrier carried = Carrier.ofValue(type, symbols);
-        ValueName.Stdlib of = NumericMeasures.takenOf(type, symbols);
-        List<UnreadRule> unread = unreadBoundsAt(path, type, symbols, carried, of);
-        // What the rules are about, and only then what the type could carry. A position has one
-        // axis, and a `String` is the one type that can be measured two ways — its own order, and
-        // the length of it — so which of them the model wrote about is what decides. Read off the
-        // carrier first, every rule anybody ever wrote about the length of a string would have
-        // become a rule about the string.
-        if (of != null) {
-            Bounds sized = boundsOf(type, symbols, Carrier.WHOLE, of);
-            if (sized != null && !sized.isEmpty()) {
-                return new Measured(new NumericTerm.SizeOf(of, path), sized, unread);
-            }
-        }
-        if (carried != null) {
-            return new Measured(new NumericTerm.ValueOf(path),
-                    boundsOf(type, symbols, carried, null), unread);
-        }
-        return new Measured(new NumericTerm.ValueOf(path), null, unread);
-    }
 
     /** The value a position is inside: what it is called, and what its rules leave each position of
      * it able to hold. */
-    private record Placed(TypeName value, FieldDomains domains) {
+    record Placed(TypeName value, FieldDomains domains) {
 
         /** What is left for the position at {@code path}, which is read from the value this is of. */
         NumericDomain.Bounds at(TermPath path) {
@@ -701,406 +610,6 @@ public final class Partitions {
                 ? FieldDomains.of(ref.name(), data, symbols) : FieldDomains.NONE;
     }
 
-    /**
-     * Where the position is divided: the type's own bound, taken in to where the record it sits in
-     * stops.
-     *
-     * <p>Only taken in. A record's rule moves an edge the type already has; it does not put one on a
-     * position the type left open. An {@code Int} nobody bounded stays a position the model draws no
-     * line through, which is what a report says of it (ADR-0090) — giving it an edge here would make
-     * a rule relating two fields into a partition of one of them.
-     *
-     * <p>So this is not what the position can hold, and reading it as that is how a cap written on
-     * the record alone became invisible: see {@link #admissibleBounds}.
-     */
-    private static Bounds axisBounds(Bounds own, NumericDomain.Bounds projected) {
-        if (own == null || projected == null) {
-            return own;
-        }
-        // The value moves and the names do not: a record narrowing an edge does not take it away
-        // from the rule that put one there, and which record did the narrowing is said beside it.
-        return new Bounds(
-                own.min() == null ? null
-                        : new End(Endpoint.lower(own.min().at(), projected.min()), own.min().from()),
-                own.max() == null ? null
-                        : new End(Endpoint.upper(own.max().at(), projected.max()), own.max().from()),
-                own.carrier());
-    }
-
-    /**
-     * What the position can hold: every rule reaching it, intersected.
-     *
-     * <p>An end survives from whichever side has one, because a value outside it is refused whether
-     * the type said so or the record did. That is the difference from {@link #axisBounds}: a cap the
-     * record alone imposes is not a line dividing this position, and it is still where its values
-     * stop — so a guard beyond it divides nothing and is no edge either.
-     *
-     * <p>Numbers and no names. An end here says where the values stop; which rule put it there is a
-     * cut's question, and answering it from a projection would name a rule that never mentioned this
-     * position on its own.
-     */
-    private static NumericDomain.Bounds admissibleBounds(Bounds own, NumericDomain.Bounds projected) {
-        return admissibleBounds(own, projected, null);
-    }
-
-    /**
-     * The same, with what the term itself guarantees taken in.
-     *
-     * <p>A size is never negative and nothing has to write that down (spec
-     * §invariant-discharge-terms). Kept here with the rules rather than at the boundary that reads
-     * them, so that a guard at zero is refused its neighbour below by the same intersection that
-     * refuses one outside an invariant.
-     */
-    private static NumericDomain.Bounds admissibleBounds(Bounds own, NumericDomain.Bounds projected,
-                                                         NumericTerm term) {
-        NumericDomain.Bounds intrinsic = term == null ? null : term.ownBounds();
-        if (own == null) {
-            return intrinsic;   // not a number of its own, so only what the term guarantees
-        }
-        Endpoint min = own.min() == null ? null : own.min().at();
-        Endpoint max = own.max() == null ? null : own.max().at();
-        NumericDomain.Bounds read = projected == null ? new NumericDomain.Bounds(min, max)
-                : new NumericDomain.Bounds(Endpoint.lower(min, projected.min()),
-                        Endpoint.upper(max, projected.max()));
-        return intrinsic == null ? read
-                : new NumericDomain.Bounds(Endpoint.lower(read.min(), intrinsic.min()),
-                        Endpoint.upper(read.max(), intrinsic.max()));
-    }
-
-    // --- what a type divides its values into ------------------------------------------------------
-
-    static List<PartitionClass> classesOf(Type type, Symbols symbols) {
-        return classesOf(TypeView.of(type, symbols), symbols);
-    }
-
-    /**
-     * The class evidence this producer derives from a position's type, read through every name it
-     * is written under.
-     *
-     * <p>Through the names, because a newtype is the value it wraps (spec §primitives): a
-     * {@code data StageN = Stage} is the sum {@code Stage} and divides into its cases. Which is not
-     * what this asked before — it asked whether the type it was handed was a sum, stopped at the
-     * name, and reported a position the model divides three ways as one it divides no way (issue
-     * #631). The line drawn on that same position read straight through the name, so the two
-     * readings of one declaration disagreed.
-     *
-     * <p>And under them, because that is how a row writes the value. The names come off to say what
-     * the position is and go back on to say what stands at it — one fact, read from
-     * {@link TypeView} once, rather than each reader deciding again how far to look.
-     *
-     * <p><b>Empty is this producer having no class evidence, and never that the position has no
-     * classes.</b> The two read the same and are not the same claim: the second is a statement
-     * about the model, and it is not one this is in a position to make — the rules a body writes
-     * have not been read, and what is under the position has not been asked. A
-     * {@link Shape.Unresolved} answers empty here and is reported as a type this could not
-     * interpret, which the structural reading after this one supplies. Making the conclusion here
-     * is the defect the whole protocol is against, in one function.
-     *
-     * <p>Exhaustive over {@link Shape}, with no {@code default}, so that a shape added later stops
-     * this compiling rather than arriving as a position this quietly has no evidence about.
-     *
-     * <p>Nothing about the rules on the position. What its type declares and what its rules leave
-     * it able to hold are two facts, and this is the first of them — crossed with the second by
-     * {@link #constructibleAt}, which is where a case the model refuses stops being a class.
-     */
-    static List<PartitionClass> classesOf(TypeView view, Symbols symbols) {
-        List<TypeName> worn = view.wrappers().stream().map(TypeOps.Layer::named).toList();
-        return switch (view.shape()) {
-            // A `Bool` is two values. No other primitive has classes to read off its type: what a
-            // number's rules leave is a range with edges — everything outside a newtype's invariant
-            // is refused at construction (E1903), so there is no class on the other side to cover —
-            // and what does divide a number is a threshold, which is read from a body and not here.
-            case Shape.Scalar scalar -> scalar.prim() == Type.Prim.BOOL
-                    ? eitherWay(worn) : List.of();
-            case Shape.Sum sum -> caseClasses(Type.ref(sum.name()), worn, symbols);
-            case Shape.Cases cases -> caseClasses(Type.union(cases.members()), worn, symbols);
-            case Shape.Optional optional -> heldOrNot(optional.element(), worn, symbols);
-            // Shapes whose types state no division of their own. A record is made of positions and a
-            // collection holds its values inside something — what that comes to is the structural
-            // reading's answer, not this one's — and a unit data has one value, which no class of
-            // this producer's tells from another.
-            case Shape.Product _, Shape.Unit _, Shape.Sequence _, Shape.Mapping _,
-                 Shape.Tuple _, Shape.Function _,
-            // And the five that are not value shapes: nothing here was interpreted, so there is
-            // nothing to read classes off. What that means for the position is said where the
-            // provenance is, which is what the shape carries into the phase after this one.
-                 Shape.Uninhabited _, Shape.Bottom _, Shape.Erroneous _, Shape.Undecided _,
-                 Shape.Unresolved _ -> List.of();
-        };
-    }
-
-    /** The two values of a {@code Bool}, under the names the position writes them under. */
-    private static List<PartitionClass> eitherWay(List<TypeName> worn) {
-        return List.of(
-                PartitionClass.of("true", "true",
-                        Classifier.under(worn, Classifier.byShape(v -> isBool(v, true))),
-                        RepresentativeSource.under(worn,
-                                RepresentativeSource.of(FixtureTemplate.bool(true)))),
-                PartitionClass.of("false", "false",
-                        Classifier.under(worn, Classifier.byShape(v -> isBool(v, false))),
-                        RepresentativeSource.under(worn,
-                                RepresentativeSource.of(FixtureTemplate.bool(false)))));
-    }
-
-    /** Whether an optional holds anything, which is the one division its type makes. */
-    private static List<PartitionClass> heldOrNot(Type element, List<TypeName> worn,
-                                                  Symbols symbols) {
-        List<FixtureTemplate> some = representativesOf(element, symbols);
-        return List.of(
-                PartitionClass.of("None", "None",
-                        Classifier.under(worn,
-                                Classifier.byShape(v -> v instanceof ObservedValue.Absent)),
-                        RepresentativeSource.under(worn,
-                                RepresentativeSource.of(FixtureTemplate.none()))),
-                some.isEmpty()
-                        ? PartitionClass.ungeneratable("Some", "Some",
-                                Classifier.under(worn, Classifier.byShape(
-                                        v -> !(v instanceof ObservedValue.Absent))),
-                                "nothing here composed a value of " + Type.show(element))
-                        : PartitionClass.of("Some", "Some",
-                                Classifier.under(worn, Classifier.byShape(
-                                        v -> !(v instanceof ObservedValue.Absent))),
-                                RepresentativeSource.under(worn,
-                                        RepresentativeSource.of(some))));
-    }
-
-    /** A sum's cases, each a class, under the names the position writes them under. */
-    private static List<PartitionClass> caseClasses(Type sum, List<TypeName> worn,
-                                                    Symbols symbols) {
-        List<PartitionClass> cases = new ArrayList<>();
-        for (TypeName leaf : TypeOps.leafCases(sum, symbols)) {
-            cases.add(caseClass(leaf, worn, symbols));
-        }
-        return cases;
-    }
-
-    /**
-     * The classes of {@code declared} the position can hold a value of.
-     *
-     * <p>Two facts crossed, and they are separate facts. That a type declares a case is read off
-     * the declaration; that a value of it can stand at <em>this</em> position is what the rules on
-     * the position leave. A {@code data StageI = Stage invariant value >= Qualified} declares three
-     * cases and holds two of them: {@code StageI(Prospecting)} is refused at construction (E1903)
-     * by the same rule, so a class for it is a row nobody can write.
-     *
-     * <p>Crossed here rather than by handing the bounds to the reading above. Each of the two is a
-     * function of the position and neither is a function of the other, so nothing depends on which
-     * is worked out first — and a producer that took the other's output would grow a dependency
-     * that only shows up as an admissible case coming back when someone tidies the order.
-     *
-     * <p>Dropped rather than kept and marked. What a body declines to answer for is still a class
-     * of the position's values and is reported as excluded ({@link Axis#excluding}); a case the
-     * position cannot hold is not one of its values at all, and the classes of an axis are over the
-     * values it has.
-     *
-     * @param within what the rules on the position leave its values, or null where nothing bounds
-     *               them
-     */
-    static List<PartitionClass> constructibleAt(List<PartitionClass> declared, TypeView view,
-                                                NumericDomain.Bounds within, Symbols symbols) {
-        if (within == null || declared.isEmpty()
-                || !(Carrier.ofValue(view.declared(), symbols) instanceof Carrier.Ordinal order)) {
-            return declared;   // no order for a rule to name a value on, so nothing is taken away
-        }
-        java.util.Set<String> refused = new java.util.LinkedHashSet<>();
-        for (TypeName each : order.cases()) {
-            Place at = order.at(each);
-            if (at != null && !within.admits(at)) {
-                refused.add(idOfCase(each));
-            }
-        }
-        return refused.isEmpty() ? declared
-                : declared.stream().filter(each -> !refused.contains(each.id())).toList();
-    }
-
-    /** What a case's class is called, in one place: a reading that decides which cases the position
-     *  holds names the same classes the reading above builds. */
-    private static String idOfCase(TypeName leaf) {
-        return leaf.name();
-    }
-
-    private static PartitionClass caseClass(TypeName leaf, List<TypeName> worn, Symbols symbols) {
-        Classifier is = Classifier.under(worn, Classifier.byShape(v -> switch (v) {
-            case ObservedValue.Unit u -> leaf.equals(u.type());
-            case ObservedValue.Constructed c -> leaf.equals(c.type());
-            default -> false;
-        }));
-        if (!(symbols.get(leaf) instanceof Ast.Data data)) {
-            return PartitionClass.of(idOfCase(leaf), leaf.name(), is,   // naming it builds it
-                    RepresentativeSource.under(worn,
-                            RepresentativeSource.of(FixtureTemplate.unitCase(leaf))));
-        }
-        if (data.newtype()) {
-            List<FixtureTemplate> inner = insideTheNewtype(leaf, symbols);
-            return inner.isEmpty()
-                    ? PartitionClass.ungeneratable(idOfCase(leaf), leaf.name(), is,
-                            "nothing here composed a value of what `" + leaf.name() + "` wraps")
-                    : PartitionClass.of(idOfCase(leaf), leaf.name(), is,
-                            RepresentativeSource.under(worn, RepresentativeSource.under(
-                                    List.of(leaf), RepresentativeSource.of(inner))));
-        }
-        // A record case is written field by field, which is the generator's composition. So the class
-        // names the constructor and the generator does the composing — the same walk every other
-        // record goes through, rules between the fields and all. Under the position's names either
-        // way: what is composed is an `Approved`, and what the row writes is `DecisionN(Approved
-        // { id = 1 })`.
-        return PartitionClass.of(idOfCase(leaf), leaf.name(), is,
-                RepresentativeSource.under(worn, new RepresentativeSource.Composed(leaf)));
-    }
-
-    // --- reading an invariant's bounds -------------------------------------------------------------
-
-    /** What a newtype's invariant says about the range of its value. */
-    /**
-     * One end of a range, and every name that put it there.
-     *
-     * <p>Names, plural. Two layers can state the same bound — a wrapper repeating what it wraps — and
-     * they are two rules a row could be owed to, which is the accounting a cut already keeps. Holding
-     * one would drop an obligation rather than a line of text.
-     */
-    private record End(Endpoint at, List<TypeName> from) {
-
-        Place value() {
-            return at.at();
-        }
-
-        /**
-         * This end, or {@code other} where it is the stronger, or both where they agree.
-         *
-         * <p>Which number survives and whether the value is one of the range's own are the same
-         * question asked of {@link Endpoint}, so that this and the domain cannot disagree about it.
-         * Where the two are at one number both names are kept: each is a rule the line is owed to,
-         * however far into the range each of them reaches.
-         */
-        static End tighter(End had, End one, boolean upper) {
-            if (one == null) {
-                return had;
-            }
-            if (had == null) {
-                return one;
-            }
-            Endpoint at = upper ? Endpoint.upper(had.at(), one.at()) : Endpoint.lower(had.at(), one.at());
-            if (had.value().compareTo(one.value()) != 0) {
-                return at == had.at() ? had : one;
-            }
-            List<TypeName> both = new ArrayList<>(had.from());
-            one.from().stream().filter(n -> !both.contains(n)).forEach(both::add);
-            return new End(at, List.copyOf(both));
-        }
-    }
-
-    /**
-     * What a newtype's rules leave the value between, and which of the names it wears said so.
-     *
-     * <p>The layer is kept because a boundary is reported by the rule that drew it, and a value
-     * wearing two names is bounded by rules written on either. Read off the outermost name, an edge
-     * that `Minute` drew would be reported as `StartMinute`'s.
-     */
-    private record Bounds(End min, End max, Carrier carrier) {
-
-        boolean isEmpty() {
-            return min == null && max == null;
-        }
-
-        /** Whether the values here have no smallest step, which is what decides where a strict bound
-         *  leaves an end. */
-        boolean decimal() {
-            return carrier == Carrier.DENSE;
-        }
-    }
-
-    /** What a numeric newtype's own rules leave its value between, for a caller that is asking about
-     * the value and not about anything taken of it. */
-    private static Bounds boundsOf(Type type, Symbols symbols) {
-        return boundsOf(type, symbols, Carrier.ofValue(type, symbols), null);
-    }
-
-    /**
-     * @param carrier what the clauses' values are read on, or null where nothing here reads them
-     * @param measure the operation the number is taken by, or null where the number is the value
-     *                itself
-     */
-    private static Bounds boundsOf(Type type, Symbols symbols, Carrier carrier, ValueName measure) {
-        if (carrier == null) {
-            return null;
-        }
-        End min = null;
-        End max = null;
-        // Every name the value wears, not the outermost one. A rule written on the type a newtype
-        // wraps bounds the value as much as one written on the newtype does, and the two intersect:
-        // `Inner: value >= 0` under `Outer: value <= 10` is a range of `[0, 10]`, and neither layer
-        // alone says so. How far that reaches is asked of `TypeOps` rather than walked again here,
-        // and every layer that put an end where it is is kept, because each is a rule a row is owed.
-        for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
-            for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
-                for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
-                    InvariantBound read = (measure == null ? InvariantBound.of(each, carrier)
-                            : InvariantBound.ofSize(each, measure)).orElse(null);
-                    if (read == null) {
-                        continue;
-                    }
-                    End end = new End(read.end(), List.of(layer.named()));
-                    if (read.lower()) {
-                        min = End.tighter(min, end, false);
-                    } else {
-                        max = End.tighter(max, end, true);
-                    }
-                }
-            }
-        }
-        return new Bounds(min, max, carrier);
-    }
-
-    /** The cuts of a position, each carrying the rule that drew it. */
-    /**
-     * The cuts of a position whose range is already settled.
-     *
-     * @param bounds where the position stops, the record it sits in taken into account
-     * @param own    where its own type stops, so that an end the record moved can say so
-     * @param within the record, or null at a position that is not a field of one
-     */
-    private static List<Cut> cutsOf(Type type, Bounds bounds, Bounds own, TypeName within) {
-        if (bounds == null || bounds.isEmpty() || !(type instanceof Type.Ref)) {
-            return List.of();
-        }
-        Map<String, Cut> byValue = new LinkedHashMap<>();
-        cut(byValue, bounds.min(), own == null ? null : own.min(), "min",
-                bounds.carrier(), within);
-        cut(byValue, bounds.max(), own == null ? null : own.max(), "max",
-                bounds.carrier(), within);
-        return List.copyOf(byValue.values());
-    }
-
-    /** One end as a cut, owed once to each rule that put it there. */
-    private static void cut(Map<String, Cut> into, End end, End own, String clause, Carrier carrier,
-                            TypeName within) {
-        if (end == null) {
-            return;
-        }
-        // Taken in, which a record can do by moving the end or by taking away the value it stops
-        // at. `low < high` under one `[0, 1]` leaves `low` the same 1 and no longer holding it, and
-        // that is the record's doing as much as a smaller number would have been.
-        boolean moved = own != null && !own.at().equals(end.at());
-        for (TypeName from : end.from()) {
-            put(into, carrier, end.value(), from, clause, moved ? within : null);
-        }
-    }
-
-    /** Whether an end is somewhere other than where the type's own rule left it. */
-    private static boolean moved(BigDecimal own, BigDecimal effective) {
-        return own != null && own.compareTo(effective) != 0;
-    }
-
-    private static void put(Map<String, Cut> into, Carrier carrier, Place at, TypeName type,
-                            String clause, TypeName narrowedBy) {
-        OriginRef origin = new OriginRef.InvariantOrigin(Optional.<SourceRef>empty(), type, clause);
-        if (narrowedBy != null) {
-            origin = new OriginRef.NarrowedOrigin(origin, narrowedBy);
-        }
-        OriginRef each = origin;
-        Cut cut = Cut.at(carrier, at, origin);
-        into.merge(cut.key(), cut, (had, _) -> had.and(each));
-    }
 
     // --- small helpers ----------------------------------------------------------------------------
 
@@ -1170,7 +679,7 @@ public final class Partitions {
         if (type instanceof Type.ListOf || type instanceof Type.SetOf || type instanceof Type.MapOf) {
             return List.of(FixtureTemplate.emptyCollection());
         }
-        List<PartitionClass> classes = classesOf(type, symbols);
+        List<PartitionClass> classes = PartitionClasses.of(type, symbols);
         for (PartitionClass each : classes) {
             // Values, not a class that could produce one. A class whose values are composed has none
             // to hand over here, and returning its empty list would say the type has no values.
@@ -1203,7 +712,7 @@ public final class Partitions {
         if (counts == null) {
             return 0;
         }
-        Bounds sized = boundsOf(type, symbols, Carrier.WHOLE, counts);
+        TypeBounds.Bounds sized = TypeBounds.of(type, symbols, Carrier.WHOLE, counts);
         if (sized == null || sized.min() == null) {
             return 0;
         }
@@ -1246,7 +755,7 @@ public final class Partitions {
         if (base == null) {
             return null;
         }
-        NumericDomain.Bounds range = admissibleBounds(boundsOf(type, symbols), null);
+        NumericDomain.Bounds range = TypeBounds.admissible(TypeBounds.of(type, symbols), null);
         Place from = inside(range, base == Type.DECIMAL ? Carrier.DENSE : Carrier.WHOLE);
         if (from == null || base != Type.INT) {
             return from != null && index == 0 ? from : null;
@@ -1284,7 +793,7 @@ public final class Partitions {
         if (numeric == null) {
             return List.copyOf(base);
         }
-        NumericDomain.Bounds range = admissibleBounds(boundsOf(type, symbols), within);
+        NumericDomain.Bounds range = TypeBounds.admissible(TypeBounds.of(type, symbols), within);
         Carrier carrier = numeric == Type.INT ? Carrier.WHOLE : Carrier.DENSE;
         Place step = displaced(range, carrier);
         if (step == null) {
@@ -1340,11 +849,11 @@ public final class Partitions {
      * one of them is how a value that holds everywhere came to be written in one place and not the
      * other.
      */
-    private static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols) {
+    static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols) {
         return insideTheNewtype(newtype, symbols, null, java.util.Set.of());
     }
 
-    private static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols,
+    static List<FixtureTemplate> insideTheNewtype(TypeName newtype, Symbols symbols,
                                                           NumericDomain.Bounds within,
                                                           java.util.Set<TypeName> expanding) {
         // Already inside this one's own value, so the type is written in terms of itself and there is
@@ -1357,8 +866,8 @@ public final class Partitions {
         Type base = TypeOps.newtypeInner(newtype, symbols);
         List<FixtureTemplate> candidates = new ArrayList<>();
 
-        Bounds own = boundsOf(new Type.Ref(newtype), symbols);
-        NumericDomain.Bounds bounds = admissibleBounds(own, within);
+        TypeBounds.Bounds own = TypeBounds.of(new Type.Ref(newtype), symbols);
+        NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
         Place held = bounds == null || bounds.isEmpty() ? null : inside(bounds, own.carrier());
         if (held != null) {
             candidates.add(FixtureTemplate.on(own.carrier(), held));
@@ -1426,8 +935,8 @@ public final class Partitions {
                 || !data.newtype()) {
             return List.of();
         }
-        Bounds own = boundsOf(type, symbols);
-        NumericDomain.Bounds bounds = admissibleBounds(own, within);
+        TypeBounds.Bounds own = TypeBounds.of(type, symbols);
+        NumericDomain.Bounds bounds = TypeBounds.admissible(own, within);
         // The far end has to be a value the position holds. Where the range stops short of it there
         // is nothing there to hold back, and a dense order has no value beside it to hold back
         // instead — what is inside is already what the first tier offers.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -192,19 +192,10 @@ public final class Partitions {
     private static List<UndividedPosition> undividedIn(List<Measured> measured) {
         List<UndividedPosition> out = new ArrayList<>();
         for (Measured each : measured) {
-            Axis axis = each.axis();
-            if (axis.measurable()) {
-                continue;
+            PendingPosition pending = PendingPosition.of(each.axis());
+            if (pending != null) {
+                out.add(pending.complete(each.body()));
             }
-            if (axis.pending() instanceof StructuralInspection.Blocked blocked) {
-                out.add(UndividedPosition.cannotDerive(axis.path(),
-                        ReportedReason.of(blocked.why())));
-                continue;
-            }
-            out.add(each.body() instanceof BodyCutInspection.Blocked blocked
-                    ? UndividedPosition.cannotDerive(axis.path(),
-                            ReportedReason.of(blocked.why()))
-                    : UndividedPosition.absent(axis.path()));
         }
         return List.copyOf(out);
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -105,7 +105,6 @@ public final class Partitions {
         List<Axis> found = new ArrayList<>();
         Map<NumericTerm, NumericDomain.Bounds> domains = new LinkedHashMap<>();
         java.util.Set<NumericTerm> uncertain = new java.util.LinkedHashSet<>();
-        java.util.Set<String> stopped = new java.util.LinkedHashSet<>();
         List<UnreadRule> unread = new ArrayList<>();
         for (int i = 0; i < sig.inputTypes().size() && i < behavior.params().size(); i++) {
             // One reading per parameter, not one per record met on the way down. A clause on the
@@ -114,7 +113,7 @@ public final class Partitions {
             Type type = sig.inputTypes().get(i);
             walk(behavior.name(), TermPath.of(behavior.params().get(i).name()), type,
                     0, symbols, found, new Placed(nameOf(type), fieldDomainsOf(type, symbols)),
-                    domains, uncertain, stopped, unread);
+                    domains, uncertain, unread);
         }
         found.replaceAll(axis -> axis.excluding(
                 excluded.at(axis.path()).stream().map(TypeName::name).toList()));
@@ -140,7 +139,7 @@ public final class Partitions {
         // for a body: a type bounded by a rule this cannot read is one whether or not any behavior
         // compares it.
         List<UndividedPosition> undivided = new ArrayList<>();
-        for (UndividedPosition each : undividedIn(kept, stopped)) {
+        for (UndividedPosition each : undividedIn(kept)) {
             UndividedPosition.Reason why = unread.stream()
                     .filter(one -> one.at().equals(each.at())).map(UnreadRule::why)
                     .findFirst().orElse(null);
@@ -158,16 +157,15 @@ public final class Partitions {
      * ones the walk did not finish, which is the one thing the axes cannot say for themselves: an
      * axis that was never descended into looks exactly like one there was nothing under.
      */
-    private static List<UndividedPosition> undividedIn(List<Axis> axes,
-                                                       java.util.Set<String> stopped) {
+    private static List<UndividedPosition> undividedIn(List<Axis> axes) {
         List<UndividedPosition> out = new ArrayList<>();
         for (Axis axis : axes) {
             if (axis.measurable()) {
                 continue;
             }
-            out.add(stopped.contains(axis.path().toString())
+            out.add(axis.pending() instanceof StructuralInspection.Blocked blocked
                     ? UndividedPosition.cannotDerive(axis.path(),
-                            UndividedPosition.Reason.DEPTH_LIMIT)
+                            ReportedReason.of(blocked.why()))
                     : UndividedPosition.absent(axis.path()));
         }
         return List.copyOf(out);
@@ -306,14 +304,15 @@ public final class Partitions {
                 rules.add(each);
             }
         }
+        // The structural reason travels on the axis, so nothing is recovered from the earlier pass
+        // by matching how a path is spelled. What is still joined here is a rule this could not
+        // read, which is about a rule rather than about the position and has nowhere else to live.
         List<UndividedPosition> undivided = new ArrayList<>();
-        for (UndividedPosition each : undividedIn(out, java.util.Set.of())) {
-            UndividedPosition had = base.undivided().stream()
-                    .filter(before -> before.at().equals(each.at())).findFirst().orElse(each);
-            UndividedPosition.Reason stopped = rules.stream()
+        for (UndividedPosition each : undividedIn(out)) {
+            UndividedPosition.Reason unreadHere = rules.stream()
                     .filter(one -> one.at().equals(each.at())).map(UnreadRule::why)
                     .findFirst().orElse(null);
-            undivided.add(stopped == null ? had : had.because(stopped));
+            undivided.add(unreadHere == null ? each : each.because(unreadHere));
         }
         return new Partitioning(out, base.omitted(), domainsOf(base, out), base.uncertain(),
                 undivided, List.copyOf(rules), between);
@@ -526,8 +525,7 @@ public final class Partitions {
     private static void walk(String behavior, TermPath path, Type type, int depth, Symbols symbols,
                              List<Axis> out, Placed placed,
                              Map<NumericTerm, NumericDomain.Bounds> domains,
-                             java.util.Set<NumericTerm> uncertain,
-                             java.util.Set<String> stopped, List<UnreadRule> unread) {
+                             java.util.Set<NumericTerm> uncertain, List<UnreadRule> unread) {
         List<PartitionClass> classes = classesOf(type, symbols);
         // Which number this position is measured at, and what its rules leave that number. Asked
         // together because they are one reading: whether a rule bounds the length of a string is how
@@ -569,19 +567,19 @@ public final class Partitions {
             out.add(new Axis(id, term, type, classes, cuts));
             return;
         }
-        Map<String, Type> fields = productFields(type, symbols);
-        if (!fields.isEmpty() && depth >= MAX_DEPTH) {
-            // A record this never went into. What is under it may divide, and nothing here looked.
-            stopped.add(path.toString());
-        }
-        if (!fields.isEmpty() && depth < MAX_DEPTH) {
-            for (Map.Entry<String, Type> field : fields.entrySet()) {
+        // Local evidence is exhausted, so what is asked next is whether the position is made of
+        // positions. The answer is not a verdict: a leaf and a block are both positions still to be
+        // answered for, and each carries what it is left with if nothing answers.
+        StructuralInspection found = StructuralInspection.of(
+                PartitionInput.of(type, symbols).shape(), depth < MAX_DEPTH);
+        if (found instanceof StructuralInspection.Children children) {
+            for (Map.Entry<String, Type> field : children.under().entrySet()) {
                 walk(behavior, path.then(field.getKey()), field.getValue(), depth + 1, symbols, out,
-                        placed, domains, uncertain, stopped, unread);
+                        placed, domains, uncertain, unread);
             }
             return;
         }
-        out.add(Axis.notDerivable(id, term, type));
+        out.add(Axis.pendingAt(id, term, type, found));
     }
 
     /** A position's number, what its own rules leave it, and which of those rules said nothing this
@@ -758,16 +756,6 @@ public final class Partitions {
         return intrinsic == null ? read
                 : new NumericDomain.Bounds(Endpoint.lower(read.min(), intrinsic.min()),
                         Endpoint.upper(read.max(), intrinsic.max()));
-    }
-
-    /** A record's fields, or nothing where the type is not one. A newtype is not taken apart: its
-     * {@code value} is the same position it is. */
-    private static Map<String, Type> productFields(Type type, Symbols symbols) {
-        if (type instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data
-                && !data.newtype()) {
-            return TypeOps.fieldTypes(data, symbols);
-        }
-        return Map.of();
     }
 
     // --- what a type divides its values into ------------------------------------------------------

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -1,21 +1,24 @@
 package souther.compiler.partition;
 
 /**
- * A position every producer has been asked about that none of them answered, and what it is left
- * with so far.
+ * A position the local producers were all asked about that none of them answered, and what it is
+ * left with so far.
  *
- * <p>The step before a verdict, and the only way to one. Holding one of these is already three
- * facts: the position was read, its own type and rules produced no evidence, and the structural
- * reading has said whether it stopped. What is missing is what the rules written about the position
- * came to — {@link #complete} takes that and nothing else, and what comes back is what a report
- * says.
+ * <p>The step before a verdict, and the only way to an absence. Holding one of these is already
+ * three facts: the position was read, the producers of local evidence came back with nothing, and
+ * the structural reading has said whether it stopped. What is missing is what the rules written
+ * about the position came to, which {@link #complete} takes.
  *
  * <p>Which is what makes an absence a conclusion rather than a default. Written as a value anything
  * could construct, "the model divides this position no way" was one line of a caller away from
  * every position that happened to have an empty list beside it, and the whole protocol exists
  * because that line was easy to write.
+ *
+ * <p>Package-private, cases and all, so that the chain cannot be started halfway through from
+ * outside. Inside this package it is a discipline like any other and the tests hold it; outside,
+ * there is no {@code Leaf} to make and so no absence to reach.
  */
-public sealed interface PendingPosition {
+sealed interface PendingPosition {
 
     TermPath at();
 
@@ -55,10 +58,11 @@ public sealed interface PendingPosition {
     /**
      * What the position comes to, once what the rules said about it is known.
      *
-     * <p>The whole phase's answer and not one producer's. A {@code guard}'s comparison and a
-     * newtype's invariant are two producers of one kind of evidence, and {@link BodyCutInspection}
-     * is what came of asking them — so completing one of these cannot be done by whichever producer
-     * happens to have finished.
+     * <p>The phase's answer and not one producer's. A {@code guard}'s comparison and a newtype's
+     * invariant are two producers of one kind of evidence, and {@link BodyCutInspection} is what
+     * came of asking them — which is why this takes one of those rather than a list of lines and a
+     * reason beside it. What makes it the phase's answer is where it is produced, not this
+     * signature: a caller inside this package can still build one out of half a reading.
      *
      * <p>The structural reason outranks the rules'. Where the walk could not reach into what a
      * position holds, a rule naming something inside it describes that same stop from the other end
@@ -79,8 +83,9 @@ public sealed interface PendingPosition {
             case Leaf _ -> switch (body) {
                 case BodyCutInspection.Blocked blocked ->
                         UndividedPosition.cannotDerive(at(), ReportedReason.of(blocked.why()));
-                // Every producer asked, none of them stopped, and none of them found anything.
-                // Which is the only way to an absence, and is what one means.
+                // The producers of both phases asked, none of them stopped, and none of them found
+                // anything. Which is the only way to an absence, and is what one means: what those
+                // readers read, rather than a claim about what could have been written.
                 case BodyCutInspection.Exhausted _ -> UndividedPosition.absentAfter(this);
                 case BodyCutInspection.Evidence _ -> throw new IllegalStateException("unreachable");
             };

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -1,0 +1,89 @@
+package souther.compiler.partition;
+
+/**
+ * A position every producer has been asked about that none of them answered, and what it is left
+ * with so far.
+ *
+ * <p>The step before a verdict, and the only way to one. Holding one of these is already three
+ * facts: the position was read, its own type and rules produced no evidence, and the structural
+ * reading has said whether it stopped. What is missing is what the rules written about the position
+ * came to — {@link #complete} takes that and nothing else, and what comes back is what a report
+ * says.
+ *
+ * <p>Which is what makes an absence a conclusion rather than a default. Written as a value anything
+ * could construct, "the model divides this position no way" was one line of a caller away from
+ * every position that happened to have an empty list beside it, and the whole protocol exists
+ * because that line was easy to write.
+ */
+public sealed interface PendingPosition {
+
+    TermPath at();
+
+    /**
+     * Nothing under the position, and nothing stopped the reading of it.
+     *
+     * <p>Not an absence. Whether the position divides is still open — the rules a body writes have
+     * not been read at this point — and this is the one state from which an absence can follow.
+     */
+    record Leaf(TermPath at) implements PendingPosition {}
+
+    /**
+     * The structural reading stopped, and this is what the position is left with unless something
+     * else answers for it.
+     *
+     * <p>Carried rather than reported: a rule a body writes may still draw a line on this same
+     * position, and where one does the position is measured and this is never said.
+     */
+    record Blocked(TermPath at, BlockReason why) implements PendingPosition {}
+
+    /**
+     * What is still to be answered for at {@code axis}, or null where the axis has evidence.
+     *
+     * <p>Null and not a case, because a position with evidence is not pending anything: it is
+     * measured, and the question this type is about does not arise for it. Which is also why
+     * {@link #complete} refuses a body that says it drew a line — two readings would then disagree
+     * about whether this position has evidence.
+     */
+    static PendingPosition of(Axis axis) {
+        if (axis.measurable()) {
+            return null;
+        }
+        return axis.pending() instanceof StructuralInspection.Blocked blocked
+                ? new Blocked(axis.path(), blocked.why()) : new Leaf(axis.path());
+    }
+
+    /**
+     * What the position comes to, once what the rules said about it is known.
+     *
+     * <p>The whole phase's answer and not one producer's. A {@code guard}'s comparison and a
+     * newtype's invariant are two producers of one kind of evidence, and {@link BodyCutInspection}
+     * is what came of asking them — so completing one of these cannot be done by whichever producer
+     * happens to have finished.
+     *
+     * <p>The structural reason outranks the rules'. Where the walk could not reach into what a
+     * position holds, a rule naming something inside it describes that same stop from the other end
+     * and the first is the cause (issue #626). So a {@link Blocked} completes as itself whatever
+     * the rules came to, and only a {@link Leaf} can reach an absence.
+     */
+    default UndividedPosition complete(BodyCutInspection body) {
+        if (body instanceof BodyCutInspection.Evidence) {
+            // A line was drawn and the axis carrying it says it has none. Nothing a reader of a
+            // model can act on: two readings of one position disagree about whether it has
+            // evidence, and answering either way would report one of them as the model.
+            throw new IllegalStateException(
+                    "the rules drew a line at " + at() + " and its axis has no evidence");
+        }
+        return switch (this) {
+            case Blocked blocked ->
+                    UndividedPosition.cannotDerive(at(), ReportedReason.of(blocked.why()));
+            case Leaf _ -> switch (body) {
+                case BodyCutInspection.Blocked blocked ->
+                        UndividedPosition.cannotDerive(at(), ReportedReason.of(blocked.why()));
+                // Every producer asked, none of them stopped, and none of them found anything.
+                // Which is the only way to an absence, and is what one means.
+                case BodyCutInspection.Exhausted _ -> UndividedPosition.absentAfter(this);
+                case BodyCutInspection.Evidence _ -> throw new IllegalStateException("unreachable");
+            };
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/PendingPosition.java
@@ -51,8 +51,15 @@ sealed interface PendingPosition {
         if (axis.measurable()) {
             return null;
         }
-        return axis.pending() instanceof StructuralInspection.Blocked blocked
-                ? new Blocked(axis.path(), blocked.why()) : new Leaf(axis.path());
+        return switch (axis.pending()) {
+            case StructuralInspection.Leaf _ -> new Leaf(axis.path());
+            case StructuralInspection.Blocked blocked -> new Blocked(axis.path(), blocked.why());
+            // A position with no evidence that was never read. Nothing about a model follows from
+            // it — an answer here would be this compiler's state written down as what the model
+            // divides, which is the sentence the whole protocol is against.
+            case null -> throw new IllegalStateException(
+                    "nothing was read at " + axis.path() + " and it has no evidence");
+        };
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
@@ -1,0 +1,37 @@
+package souther.compiler.partition;
+
+/**
+ * The word an adequacy document writes for a reason a derivation stopped.
+ *
+ * <p>Between the two vocabularies and belonging to neither. {@link BlockReason} records what this
+ * compiler could not do and does not know how it is reported; {@link UndividedPosition.Reason} is
+ * what a document promises its reader they can tell apart and does not know what produced it. A
+ * projection owned by either would be that one reaching into the other, which is the direction the
+ * split was made to stop.
+ *
+ * <p>So a second surface — a diagnostic that says more than the document does — is another
+ * projection beside this one rather than a change to what a reason is.
+ */
+final class ReportedReason {
+
+    /**
+     * Deliberately coarser than what it is given. What a reader of a document is promised is which
+     * kind of thing stopped the derivation, not which capability this compiler is missing this
+     * month: three missing traversals are one word, because the model reads the same whichever of
+     * them it was.
+     *
+     * <p>One switch rather than an answer on each case, because a coarsening is only reviewable
+     * where the collapses are visible together. No {@code default}, so a reason added and not said
+     * stops the compile rather than arriving in a report as the nearest word that already existed.
+     */
+    static UndividedPosition.Reason of(BlockReason reason) {
+        return switch (reason) {
+            case BlockReason.TypeUnresolved _ -> UndividedPosition.Reason.TYPE_UNRESOLVED;
+            case BlockReason.DepthLimit _ -> UndividedPosition.Reason.DEPTH_LIMIT;
+            case BlockReason.UnsupportedTraversal _ ->
+                    UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL;
+        };
+    }
+
+    private ReportedReason() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/ReportedReason.java
@@ -12,7 +12,7 @@ package souther.compiler.partition;
  * <p>So a second surface — a diagnostic that says more than the document does — is another
  * projection beside this one rather than a change to what a reason is.
  */
-final class ReportedReason {
+public final class ReportedReason {
 
     /**
      * Deliberately coarser than what it is given. What a reader of a document is promised is which
@@ -24,12 +24,18 @@ final class ReportedReason {
      * where the collapses are visible together. No {@code default}, so a reason added and not said
      * stops the compile rather than arriving in a report as the nearest word that already existed.
      */
-    static UndividedPosition.Reason of(BlockReason reason) {
+    public static UndividedPosition.Reason of(BlockReason reason) {
         return switch (reason) {
             case BlockReason.TypeUnresolved _ -> UndividedPosition.Reason.TYPE_UNRESOLVED;
             case BlockReason.DepthLimit _ -> UndividedPosition.Reason.DEPTH_LIMIT;
             case BlockReason.UnsupportedTraversal _ ->
                     UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL;
+            case BlockReason.UnreadComparisonForm _ ->
+                    UndividedPosition.Reason.UNSUPPORTED_SYNTAX;
+            case BlockReason.UnreadComparisonDomain _ ->
+                    UndividedPosition.Reason.UNSUPPORTED_DOMAIN;
+            case BlockReason.ComparisonBetweenPositions _ ->
+                    UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE;
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
@@ -34,7 +34,7 @@ public sealed interface RepresentativeSource {
      * What arriving at a value of this class comes to, with every name the position wears already
      * taken into account.
      *
-     * <p>One closed answer, and the only thing a reader decides from. The cases of this interface
+     * <p>One closed answer, and what a reader deciding what to do reads. The cases of this interface
      * are how a recipe is <em>written</em> — a projection sits over another recipe, and reading it
      * means reading what is under it — whereas an {@link Evaluation} is what a reader has to
      * <em>do</em>, and the two are not the same four things. A reader that asked "is there a

--- a/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
@@ -1,29 +1,233 @@
 package souther.compiler.partition;
 
+import souther.compiler.types.TypeName;
+
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The values that could stand for one equivalence class, in the order they should be tried.
+ * How a value standing for one equivalence class is arrived at.
  *
- * <p>More than one, because building a candidate can fail for a reason that is about the combination
- * and not about the class: two classes each covering a wide range, whose chosen representatives happen
- * to break a constraint that relates them. A generator that held one value per class would call that
- * combination impossible when another value would have built.
+ * <p>A recipe rather than a list of values, because the ways of arriving at one are not the same
+ * kind of thing. Some classes name their values outright. A class whose values are records names
+ * the constructor instead — a record's fields are chosen one at a time against the rules relating
+ * them, which is the generator's walk and not a list anything here could hold. And a value at a
+ * position written under a name is that value with the name put back on, which is neither of the
+ * first two but a projection over one of them.
  *
- * <p>Empty where nothing can be produced. That is a fact about generation, not about the class — the
- * class is still counted, and rows that already reach it still count.
+ * <p>The projection is why this is an algebra and not a list with two things beside it. A name can
+ * be put on a value that does not exist yet: {@code Composed(Approved)} under {@code DecisionN} is
+ * a row of {@code DecisionN(Approved { id = 1 })}, decided before anything has composed the
+ * {@code Approved}. Held as an empty list of values with an optional constructor beside it, the
+ * names had nowhere to be at all, and what reached a row declaring {@code DecisionN} was an
+ * {@code Approved} — which is not a value of it.
+ *
+ * <p>More than one value, where there are values, because building a candidate can fail for a
+ * reason that is about the combination and not about the class: two classes each covering a wide
+ * range, whose chosen representatives happen to break a constraint that relates them. A generator
+ * that held one value per class would call that combination impossible when another value would
+ * have built.
  */
-@FunctionalInterface
-public interface RepresentativeSource {
+public sealed interface RepresentativeSource {
 
-    List<FixtureTemplate> candidates();
+    /**
+     * What arriving at a value of this class comes to, with every name the position wears already
+     * taken into account.
+     *
+     * <p>One closed answer, and the only thing a reader decides from. The cases of this interface
+     * are how a recipe is <em>written</em> — a projection sits over another recipe, and reading it
+     * means reading what is under it — whereas an {@link Evaluation} is what a reader has to
+     * <em>do</em>, and the two are not the same four things. A reader that asked "is there a
+     * constructor", "are there values", "was a reason given" separately would be recovering the
+     * variant from three answers, and could meet combinations no recipe can be in.
+     */
+    Evaluation evaluate();
 
-    static RepresentativeSource of(FixtureTemplate... values) {
-        List<FixtureTemplate> templates = List.of(values);
-        return () -> templates;
+    /**
+     * What a reader does about one class: take these values, compose one this way, or report that
+     * there is none.
+     *
+     * <p>Closed and flat. A projection is not a case here because it is not something to do — it is
+     * accounted for in what the other cases carry, which is what makes putting the names back on
+     * the one thing it is.
+     */
+    sealed interface Evaluation {
+
+        /** Values ready to be written at the position, in the order to try them, under every name
+         *  it wears. Never empty: nothing to write is one of the two cases below. */
+        record Values(List<FixtureTemplate> written) implements Evaluation {
+
+            public Values {
+                written = List.copyOf(written);
+                if (written.isEmpty()) {
+                    throw new IllegalArgumentException(
+                            "no values is `NothingProduced`, which says so");
+                }
+            }
+        }
+
+        /**
+         * A value composed through {@code through}, field by field, and written under
+         * {@code worn}.
+         *
+         * <p>{@code through} is not the position's type: the declared type is still the sum, and
+         * only the value being built is narrowed. {@code worn} is what the position writes that
+         * value under, outermost first — a fact about the position rather than about the
+         * constructor.
+         */
+        record Compose(TypeName through, List<TypeName> worn) implements Evaluation {
+
+            public Compose {
+                worn = List.copyOf(worn);
+            }
+
+            /** What was composed, under the names the position writes it under. */
+            public FixtureTemplate written(FixtureTemplate composed) {
+                return under(worn, composed);
+            }
+        }
+
+        /** Nothing was produced for this class and nothing said why. Which is not that the class
+         *  has no values — only that none was arrived at here. */
+        record NothingProduced() implements Evaluation {}
+
+        /**
+         * Nothing can produce a value for this class, and why.
+         *
+         * <p>What the class knows about itself. A reader told only that there are no values would
+         * report a case somebody can write in one line as a row that does not exist.
+         */
+        record NothingProducible(String why) implements Evaluation {}
     }
 
+    /**
+     * The values ready to be written at the position, or empty where the recipe is not values.
+     *
+     * <p>Derived from the one answer rather than answered beside it, so that a caller wanting
+     * values and a caller wanting to know what to do cannot be told different things.
+     */
+    default List<FixtureTemplate> candidates() {
+        return evaluate() instanceof Evaluation.Values values ? values.written() : List.of();
+    }
+
+    /**
+     * Whether a value of this class can be produced at all.
+     *
+     * <p>Not whether there are values here: a class composed through a constructor has none and is
+     * produced all the same. That is a fact about generation either way, and never about the class
+     * — the class is still counted, and rows that already reach it still count.
+     */
+    default boolean buildable() {
+        return switch (evaluate()) {
+            case Evaluation.Values _, Evaluation.Compose _ -> true;
+            case Evaluation.NothingProduced _, Evaluation.NothingProducible _ -> false;
+        };
+    }
+
+    /** Values named outright. Empty is a class nothing here produced a value for and nothing said
+     *  why — which is a different report from {@link Ungeneratable}. */
+    record Ready(List<FixtureTemplate> values) implements RepresentativeSource {
+
+        public Ready {
+            values = List.copyOf(values);
+        }
+
+        @Override
+        public Evaluation evaluate() {
+            return values.isEmpty() ? new Evaluation.NothingProduced()
+                    : new Evaluation.Values(values);
+        }
+    }
+
+    /** A class whose values are composed through {@code through}, field by field, by the walk that
+     *  composes every other record. */
+    record Composed(TypeName through) implements RepresentativeSource {
+
+        @Override
+        public Evaluation evaluate() {
+            return new Evaluation.Compose(through, List.of());
+        }
+    }
+
+    /**
+     * The same recipe, written under the names the position wears, outermost first.
+     *
+     * <p>A newtype is the value it wraps, so what a position divides into is read through the names
+     * — and what a row writes is the value with those names back on. Both directions are the same
+     * fact, which is why the projection sits over the recipe rather than being spelled by whoever
+     * happened to need it: a class of {@code data StageN = Stage} offers {@code StageN(Prospecting)}
+     * and a class of {@code data DecisionN = Decision} composes an {@code Approved} and hands back
+     * {@code DecisionN(Approved { id = 1 })}, by one rule.
+     */
+    record Projected(RepresentativeSource inner, List<TypeName> wrappers)
+            implements RepresentativeSource {
+
+        public Projected {
+            wrappers = List.copyOf(wrappers);
+        }
+
+        @Override
+        public Evaluation evaluate() {
+            return switch (inner.evaluate()) {
+                case Evaluation.Values values -> new Evaluation.Values(
+                        values.written().stream().map(each -> under(wrappers, each)).toList());
+                // The names go on outside whatever the inner recipe already wears, which is the
+                // order they were read off the position in.
+                case Evaluation.Compose compose -> {
+                    List<TypeName> both = new ArrayList<>(wrappers);
+                    both.addAll(compose.worn());
+                    yield new Evaluation.Compose(compose.through(), both);
+                }
+                // Nothing to put a name on. What the inner recipe says stands: a name wrapped round
+                // a value nothing composed does not make one, and does not change why there is none.
+                case Evaluation.NothingProduced _, Evaluation.NothingProducible _ ->
+                        inner.evaluate();
+            };
+        }
+    }
+
+    /** A class nothing can produce a value for, and why. */
+    record Ungeneratable(String why) implements RepresentativeSource {
+
+        @Override
+        public Evaluation evaluate() {
+            return new Evaluation.NothingProducible(why);
+        }
+    }
+
+    static RepresentativeSource of(FixtureTemplate... values) {
+        return new Ready(List.of(values));
+    }
+
+    static RepresentativeSource of(List<FixtureTemplate> values) {
+        return new Ready(values);
+    }
+
+    /** Nothing produced a value here and nothing said why. */
     static RepresentativeSource none() {
-        return List::of;
+        return new Ready(List.of());
+    }
+
+    /** {@code inner}, written under {@code wrappers} — or {@code inner} itself where the position
+     *  wears no name, so that a recipe carries no projection over nothing. */
+    static RepresentativeSource under(List<TypeName> wrappers, RepresentativeSource inner) {
+        return wrappers.isEmpty() ? inner : new Projected(inner, wrappers);
+    }
+
+    /**
+     * A value under the names it is written with, outermost first.
+     *
+     * <p>The one spelling of putting them back on. What a row writes and what a value composed
+     * later is written as are the same operation, and two spellings of it are two chances to
+     * disagree about which name goes outside.
+     */
+    static FixtureTemplate under(List<TypeName> worn, FixtureTemplate value) {
+        FixtureTemplate at = value;
+        // Innermost last: the names were read off the position outermost first, so they go back on
+        // in the order that leaves the outermost outside.
+        for (int i = worn.size() - 1; i >= 0; i--) {
+            at = FixtureTemplate.newtype(worn.get(i), at);
+        }
+        return at;
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/partition/RowClasses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RowClasses.java
@@ -24,27 +24,19 @@ public final class RowClasses {
 
     /** Where each axis's value fell, for the axes that have classes. An axis the model only bounds
      * has nothing to fall into and is left out. */
-    public static Map<AxisId, Classification> of(RowOutcome row, List<String> parameters,
+    public static Map<AxisId, Classification> of(RowOutcome row, BehaviorInputs where,
                                                  List<Axis> axes) {
         Map<AxisId, Classification> out = new LinkedHashMap<>();
         for (Axis axis : axes) {
             if (!axis.derivable()) {
                 continue;
             }
-            out.put(axis.id(), classify(row, parameters, axis));
+            out.put(axis.id(), classify(row, where, axis));
         }
         return Map.copyOf(out);
     }
 
-    /** The value this row put at {@code path}, or null where it did not put a readable one there.
-     * What a boundary asks of a row: not which class it fell in, but whether it was the value. */
-    public static ObservedValue valueAt(RowOutcome row, List<String> parameters, TermPath path) {
-        int at = parameters.indexOf(path.head());
-        if (at < 0 || at >= row.inputs().size()) {
-            return null;
-        }
-        return walk(row.inputs().get(at), path.fields());
-    }
+
 
     /**
      * Which class the row's value at {@code axis} fell in, or why none of them could say.
@@ -56,13 +48,12 @@ public final class RowClasses {
      * a construction this saw nothing wrong with, and the reason came out as the one the last line
      * had to guess.
      */
-    private static Classification classify(RowOutcome row, List<String> parameters, Axis axis) {
-        int at = parameters.indexOf(axis.path().head());
-        if (at < 0 || at >= row.inputs().size()) {
+    private static Classification classify(RowOutcome row, BehaviorInputs where, Axis axis) {
+        ObservedValue value = where.valueAt(row, axis.path());
+        if (value == null && where.indexOf(axis.path()) < 0) {
             return Classification.unreadable(Incompleteness.Code.VALUE_UNREADABLE,
                     axis.id().behavior(), axis.id().term());
         }
-        ObservedValue value = walk(row.inputs().get(at), axis.path().fields());
         // Kept rather than returned on, and not acted on either. A class may read less of a value
         // than the one after it, so one saying it could not read says nothing about the rest —
         // including that the rest cannot hold it. An incompleteness is what is left once no class
@@ -101,38 +92,6 @@ public final class RowClasses {
         // measurement failure for a defect in the partition.
         throw new IllegalStateException("no class of " + axis.id() + " holds a value it read: "
                 + value);
-    }
-
-    /**
-     * The value at the end of a field chain, or null where the chain does not lead anywhere. A
-     * newtype is never a step — the path never names its {@code value} — so what is walked here is
-     * only a record's fields.
-     *
-     * <p>An observation that stopped is handed on rather than walked into. It is not a record and
-     * there is nothing under it, but it is also not a chain that leads nowhere: it is the reason
-     * this position has no value, and it says that itself. Read as somewhere the walk could not go,
-     * a limit that ran out one field short of a position came back as a value nobody could read —
-     * the same observation the walk returns as it stands when the path happens to end on it.
-     *
-     * <p>Which leaves null for the walk's own answer, and only that: a record that does not hold the
-     * field named next, or a value that was read and is not a record at all. The path and the shape
-     * disagree, and no observation says why because nothing went wrong with one.
-     */
-    private static ObservedValue walk(ObservedValue from, List<String> fields) {
-        ObservedValue at = from;
-        for (String field : fields) {
-            if (at.unread() != null) {
-                return at;
-            }
-            if (!(at instanceof ObservedValue.Constructed constructed)) {
-                return null;
-            }
-            at = constructed.field(field);
-            if (at == null) {
-                return null;
-            }
-        }
-        return at;
     }
 
     private RowClasses() {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/StructuralInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StructuralInspection.java
@@ -37,6 +37,17 @@ import java.util.Map;
 public sealed interface StructuralInspection {
 
     /**
+     * The answers that leave the position standing.
+     *
+     * <p>Named because what happens next depends on it and nothing else: a position still to be
+     * answered for goes on to the rules a body writes, and a position made of positions is given up
+     * in favour of what is under it. Read as "not {@link Children}", the two arms of that were a
+     * condition anybody could get the wrong way round — and getting it wrong the quiet way turns a
+     * position nothing has read into one nothing divides.
+     */
+    sealed interface Pending extends StructuralInspection permits Leaf, Blocked {}
+
+    /**
      * The position is not made of positions.
      *
      * <p>Says that and only that. Whether it divides is still open — the rules a body writes have
@@ -44,7 +55,7 @@ public sealed interface StructuralInspection {
      * nothing answers is an absence. Reading it as one here puts back the defect the protocol
      * removes.
      */
-    record Leaf() implements StructuralInspection {}
+    record Leaf() implements Pending {}
 
     /** The position is made of these, each of which is read the same way — in the order the
      *  declaration writes them, which is the order they are walked and reported in. */
@@ -64,7 +75,7 @@ public sealed interface StructuralInspection {
      * reported. What it does not do is let a rule about what is <em>inside</em> stand in for
      * reaching inside.
      */
-    record Blocked(BlockReason why) implements StructuralInspection {}
+    record Blocked(BlockReason why) implements Pending {}
 
     /**
      * What is under {@code shape}, or why nothing can be.

--- a/souther-compiler/src/main/java/souther/compiler/partition/StructuralInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StructuralInspection.java
@@ -46,10 +46,11 @@ public sealed interface StructuralInspection {
      */
     record Leaf() implements StructuralInspection {}
 
-    /** The position is made of these, each of which is read the same way. */
+    /** The position is made of these, each of which is read the same way — in the order the
+     *  declaration writes them, which is the order they are walked and reported in. */
     record Children(Map<String, Type> under) implements StructuralInspection {
         public Children {
-            under = Map.copyOf(under);
+            under = java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(under));
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/StructuralInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StructuralInspection.java
@@ -22,18 +22,27 @@ import java.util.Map;
  * turned into a report of a position the model does not divide; that conclusion needs the phases
  * after this one to have finished too.
  *
- * <p>{@link Blocked} is not open in the same way, and the asymmetry is the point. What stops a
- * derivation here is a reaching this compiler cannot make or a type it could not interpret, and no
- * rule written in a body lifts either. A threshold inside a list is the reason the elements would
- * have to be reached, not a way of not having to reach them.
+ * <p><b>{@link Blocked} is not a conclusion either.</b> It is the reason this position would be
+ * left with if nothing else answered for it, and something else still might: a bare
+ * {@code List<Item>} cannot have its elements reached, and a {@code guard List.length(items) < 3}
+ * draws a line on that same position all the same. So a block is a pending position carrying a
+ * fallback, exactly as a leaf is a pending position carrying none, and the two differ only in what
+ * is reported when the phases after this one find nothing.
+ *
+ * <p>{@link Children} is the one answer that is not pending, and that asymmetry is the existing
+ * semantics rather than an oversight: a position made of positions is given up in favour of what is
+ * under it, before any rule a body writes has been read. Which is why the evidence that decides a
+ * descent and the evidence that completes an axis are not the same set.
  */
 public sealed interface StructuralInspection {
 
     /**
      * The position is not made of positions.
      *
-     * <p>Says that and only that. See the type's own note: this is not "no axis can be derived",
-     * and reading it as one puts back the defect the whole protocol removes.
+     * <p>Says that and only that. Whether it divides is still open — the rules a body writes have
+     * not been read — so this is a position still to be answered for, and what it becomes if
+     * nothing answers is an absence. Reading it as one here puts back the defect the protocol
+     * removes.
      */
     record Leaf() implements StructuralInspection {}
 
@@ -44,8 +53,16 @@ public sealed interface StructuralInspection {
         }
     }
 
-    /** The derivation stopped, and {@code why} is what stopped it. Terminal: nothing read later
-     *  lifts any of these. */
+    /**
+     * There is something under the position and this could not reach it, or the type could not be
+     * interpreted at all.
+     *
+     * <p>{@code why} is the reason this position is left with if nothing else answers for it, not a
+     * verdict. A rule a body writes may still draw a line on this same position — a length, a size
+     * — and where one does, that is what the position is measured at and this reason is never
+     * reported. What it does not do is let a rule about what is <em>inside</em> stand in for
+     * reaching inside.
+     */
     record Blocked(BlockReason why) implements StructuralInspection {}
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/StructuralInspection.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/StructuralInspection.java
@@ -1,0 +1,88 @@
+package souther.compiler.partition;
+
+import souther.compiler.check.Shape;
+import souther.compiler.types.Type;
+
+import java.util.Map;
+
+/**
+ * Whether a position is made of positions, asked after the position itself has been read.
+ *
+ * <p><b>A continuation and not a classifier.</b> The derivation reads what a position's own type
+ * says first — the classes it divides into, the ends its rules put on it — and only where that says
+ * nothing does it ask what is under the position. So this is reached after local evidence is
+ * exhausted, never instead of it, and an answer here says nothing about what the local reading
+ * found. A {@code Sum} answers {@link Leaf}, and a {@code Sum} is the position most likely to have
+ * had classes: the answer means the sum is not made of positions, not that nothing divides it.
+ *
+ * <p><b>{@link Leaf} is not an absence.</b> It says there is no structural continuation and nothing
+ * else. Whether the position divides is still open when one comes back, because the rules a
+ * behavior's body writes have not been read yet — a bare {@code List<String>} nothing bounds is a
+ * leaf until a {@code guard List.length(t.names) > 0} draws a line on it. Nothing here may be
+ * turned into a report of a position the model does not divide; that conclusion needs the phases
+ * after this one to have finished too.
+ *
+ * <p>{@link Blocked} is not open in the same way, and the asymmetry is the point. What stops a
+ * derivation here is a reaching this compiler cannot make or a type it could not interpret, and no
+ * rule written in a body lifts either. A threshold inside a list is the reason the elements would
+ * have to be reached, not a way of not having to reach them.
+ */
+public sealed interface StructuralInspection {
+
+    /**
+     * The position is not made of positions.
+     *
+     * <p>Says that and only that. See the type's own note: this is not "no axis can be derived",
+     * and reading it as one puts back the defect the whole protocol removes.
+     */
+    record Leaf() implements StructuralInspection {}
+
+    /** The position is made of these, each of which is read the same way. */
+    record Children(Map<String, Type> under) implements StructuralInspection {
+        public Children {
+            under = Map.copyOf(under);
+        }
+    }
+
+    /** The derivation stopped, and {@code why} is what stopped it. Terminal: nothing read later
+     *  lifts any of these. */
+    record Blocked(BlockReason why) implements StructuralInspection {}
+
+    /**
+     * What is under {@code shape}, or why nothing can be.
+     *
+     * <p>Exhaustive over the shapes a position can have, with no {@code default}. Every one is
+     * answered here, so a shape admitted later is a compile error rather than a position that
+     * quietly has nothing under it.
+     *
+     * @param shape   the position's shape, already proved to be one a partition is derived from
+     * @param deeper  whether the walk may still go down, which only a position made of positions
+     *                can be stopped by
+     */
+    static StructuralInspection of(Shape.PartitionInputShape shape, boolean deeper) {
+        return switch (shape) {
+            // Made of positions, and read one level down — unless the walk has gone as deep as it
+            // goes, which is a reaching this compiler declines rather than a record with nothing in
+            // it.
+            case Shape.Product product -> deeper ? new Children(product.fields())
+                    : new Blocked(new BlockReason.DepthLimit());
+            // Holds its values inside something. Which reaching is missing is kept apart, because
+            // what would lift each is different work.
+            case Shape.Sequence _ ->
+                    new Blocked(new BlockReason.UnsupportedTraversal(
+                            BlockReason.Traversal.SEQUENCE_ELEMENT));
+            case Shape.Optional _ ->
+                    new Blocked(new BlockReason.UnsupportedTraversal(
+                            BlockReason.Traversal.OPTIONAL_VALUE));
+            case Shape.Mapping _ ->
+                    new Blocked(new BlockReason.UnsupportedTraversal(
+                            BlockReason.Traversal.MAPPING_CONTENT));
+            // Nothing was interpreted, so there is nothing to be made of. A model carrying one
+            // compiles, which is why this is answered rather than refused.
+            case Shape.Unresolved _ -> new Blocked(new BlockReason.TypeUnresolved());
+            // Not made of positions. A value of one of these is one value — which is a different
+            // statement from the position having no classes, and this makes neither.
+            case Shape.Scalar _, Shape.Unit _, Shape.Sum _ -> new Leaf();
+        };
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/TypeBounds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/TypeBounds.java
@@ -1,0 +1,163 @@
+package souther.compiler.partition;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Carrier;
+import souther.compiler.check.InvariantBound;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeOps;
+import souther.compiler.codegen.InvariantConstraints;
+import souther.compiler.numeric.Endpoint;
+import souther.compiler.numeric.NumericDomain;
+import souther.compiler.numeric.Place;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+import souther.compiler.types.ValueName;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What the rules written on a type leave a value of it between, and which of the names it wears
+ * said so.
+ *
+ * <p>Read here rather than by whoever needs it, because two things need it and they are not the
+ * same reader: what a position is divided and bounded at, and what values can be produced to stand
+ * for it. Each working it out for itself is how a reading of one invariant came to mean two things.
+ */
+final class TypeBounds {
+
+    /**
+     * One end of a range, and every name that put it there.
+     *
+     * <p>Names, plural. Two layers can state the same bound — a wrapper repeating what it wraps — and
+     * they are two rules a row could be owed to, which is the accounting a cut already keeps. Holding
+     * one would drop an obligation rather than a line of text.
+     */
+    record End(Endpoint at, List<TypeName> from) {
+
+        Place value() {
+            return at.at();
+        }
+
+        /**
+         * This end, or {@code other} where it is the stronger, or both where they agree.
+         *
+         * <p>Which number survives and whether the value is one of the range's own are the same
+         * question asked of {@link Endpoint}, so that this and the domain cannot disagree about it.
+         * Where the two are at one number both names are kept: each is a rule the line is owed to,
+         * however far into the range each of them reaches.
+         */
+        static End tighter(End had, End one, boolean upper) {
+            if (one == null) {
+                return had;
+            }
+            if (had == null) {
+                return one;
+            }
+            Endpoint at = upper ? Endpoint.upper(had.at(), one.at()) : Endpoint.lower(had.at(), one.at());
+            if (had.value().compareTo(one.value()) != 0) {
+                return at == had.at() ? had : one;
+            }
+            List<TypeName> both = new ArrayList<>(had.from());
+            one.from().stream().filter(n -> !both.contains(n)).forEach(both::add);
+            return new End(at, List.copyOf(both));
+        }
+    }
+
+    /**
+     * What a newtype's rules leave the value between, and which of the names it wears said so.
+     *
+     * <p>The layer is kept because a boundary is reported by the rule that drew it, and a value
+     * wearing two names is bounded by rules written on either. Read off the outermost name, an edge
+     * that `Minute` drew would be reported as `StartMinute`'s.
+     */
+    record Bounds(End min, End max, Carrier carrier) {
+
+        boolean isEmpty() {
+            return min == null && max == null;
+        }
+    }
+
+    /** What a numeric newtype's own rules leave its value between, for a caller that is asking about
+     * the value and not about anything taken of it. */
+    static Bounds of(Type type, Symbols symbols) {
+        return of(type, symbols, Carrier.ofValue(type, symbols), null);
+    }
+
+    /**
+     * @param carrier what the clauses' values are read on, or null where nothing here reads them
+     * @param measure the operation the number is taken by, or null where the number is the value
+     *                itself
+     */
+    static Bounds of(Type type, Symbols symbols, Carrier carrier, ValueName measure) {
+        if (carrier == null) {
+            return null;
+        }
+        End min = null;
+        End max = null;
+        // Every name the value wears, not the outermost one. A rule written on the type a newtype
+        // wraps bounds the value as much as one written on the newtype does, and the two intersect:
+        // `Inner: value >= 0` under `Outer: value <= 10` is a range of `[0, 10]`, and neither layer
+        // alone says so. How far that reaches is asked of `TypeOps` rather than walked again here,
+        // and every layer that put an end where it is is kept, because each is a rule a row is owed.
+        for (TypeOps.Layer layer : TypeOps.newtypeChain(type, symbols)) {
+            for (Ast.InvariantClause clause : TypeOps.effectiveInvariants(layer.data(), symbols)) {
+                for (Ast.Expr each : InvariantConstraints.clauses(clause.expr())) {
+                    InvariantBound read = (measure == null ? InvariantBound.of(each, carrier)
+                            : InvariantBound.ofSize(each, measure)).orElse(null);
+                    if (read == null) {
+                        continue;
+                    }
+                    End end = new End(read.end(), List.of(layer.named()));
+                    if (read.lower()) {
+                        min = End.tighter(min, end, false);
+                    } else {
+                        max = End.tighter(max, end, true);
+                    }
+                }
+            }
+        }
+        return new Bounds(min, max, carrier);
+    }
+
+    /**
+     * What the position can hold: every rule reaching it, intersected, with what the term itself
+     * guarantees taken in.
+     *
+     * <p>An end survives from whichever side has one, because a value outside it is refused whether
+     * the type said so or the record did. That is the difference from {@link LocalInspection}'s axis bounds: a cap the
+     * record alone imposes is not a line dividing this position, and it is still where its values
+     * stop — so a guard beyond it divides nothing and is no edge either.
+     *
+     * <p>Numbers and no names. An end here says where the values stop; which rule put it there is a
+     * cut's question, and answering it from a projection would name a rule that never mentioned this
+     * position on its own.
+     *
+     * <p>A size is never negative and nothing has to write that down (spec
+     * §invariant-discharge-terms). Kept here with the rules rather than at the boundary that reads
+     * them, so that a guard at zero is refused its neighbour below by the same intersection that
+     * refuses one outside an invariant.
+     */
+    static NumericDomain.Bounds admissible(Bounds own, NumericDomain.Bounds projected,
+                                           NumericTerm term) {
+        NumericDomain.Bounds intrinsic = term == null ? null : term.ownBounds();
+        if (own == null) {
+            return intrinsic;   // not a number of its own, so only what the term guarantees
+        }
+        Endpoint min = own.min() == null ? null : own.min().at();
+        Endpoint max = own.max() == null ? null : own.max().at();
+        NumericDomain.Bounds read = projected == null ? new NumericDomain.Bounds(min, max)
+                : new NumericDomain.Bounds(Endpoint.lower(min, projected.min()),
+                        Endpoint.upper(max, projected.max()));
+        return intrinsic == null ? read
+                : new NumericDomain.Bounds(Endpoint.lower(read.min(), intrinsic.min()),
+                        Endpoint.upper(read.max(), intrinsic.max()));
+    }
+
+    /** The same, of a position no term of its own is measured at. */
+    static NumericDomain.Bounds admissible(Bounds own, NumericDomain.Bounds projected) {
+        return admissible(own, projected, null);
+    }
+
+    private TypeBounds() {}
+}

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -60,11 +60,17 @@ public record UndividedPosition(TermPath at, Why why) {
     }
 
     /**
-     * What stopped the derivation.
+     * What stopped the derivation, in the words a document is written in.
      *
-     * <p>Each of these is a fact about this compiler. They are told apart because they are lifted by
-     * different work: one wants a reader for a form of condition, one wants the walk to go deeper,
-     * and a report that named neither could not say which.
+     * <p>Each of these is a fact about this compiler, said at the coarseness a reader of a document
+     * is promised. They are told apart because they are lifted by different work: one wants a
+     * reader for a form of condition, one wants the walk to go deeper, and a report that named
+     * neither could not say which.
+     *
+     * <p>Not the cause itself. What a producer recorded is a {@link BlockReason}, and one of these
+     * is what {@link ReportedReason} projects it to — three missing traversals arrive here as one
+     * word. So a reader of this knows which kind of thing stopped the derivation and not which
+     * capability was missing.
      */
     public enum Reason {
         /** A comparison this position is named by sits inside a condition this does not read. */
@@ -98,13 +104,19 @@ public record UndividedPosition(TermPath at, Why why) {
         UNSUPPORTED_TRAVERSAL
     }
 
-    /** The absence, of a position that has been completed. The argument is the proof: nothing can
-     *  call this that has not asked every producer, because nothing else can make one. */
+    /**
+     * The absence, of a position that has been completed.
+     *
+     * <p>The argument is the proof. A {@link PendingPosition} is made from a position whose local
+     * producers all came back with nothing, and only completing one reaches this — so what cannot
+     * happen is an absence written by a reader that did not ask. Outside this package there is
+     * neither a way to make one of those nor a name for this.
+     */
     static UndividedPosition absentAfter(PendingPosition proven) {
         return new UndividedPosition(proven.at(), Why.Absent.PROVEN);
     }
 
-    public static UndividedPosition cannotDerive(TermPath at, Reason reason) {
+    static UndividedPosition cannotDerive(TermPath at, Reason reason) {
         return new UndividedPosition(at, new Why.CannotDerive(reason));
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -50,7 +50,21 @@ public record UndividedPosition(TermPath at, Why why) {
          */
         UNSUPPORTED_PARTITION_SHAPE,
         /** The walk stopped before it reached the fields under this position. */
-        DEPTH_LIMIT
+        DEPTH_LIMIT,
+        /**
+         * The type at this position could not be interpreted, so nothing about its values is
+         * established. A model carrying one compiles, which is why this is a word a report writes
+         * rather than a state nothing reaches.
+         */
+        TYPE_UNRESOLVED,
+        /**
+         * The position holds its values inside something this does not reach into — the elements of
+         * a collection, what an optional holds, what a map holds. One word for all of them: which
+         * reaching is missing is a fact about this compiler, and the model reads the same either
+         * way. What this compiler could not do is told apart internally
+         * ({@link BlockReason.UnsupportedTraversal}).
+         */
+        UNSUPPORTED_TRAVERSAL
     }
 
     public static UndividedPosition absent(TermPath at) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -77,6 +77,21 @@ public record UndividedPosition(TermPath at, Why why) {
 
     /** The same position, with a reason where it had none. A position already carrying one keeps it:
      * what stopped the walk first is what a reader has to lift first. */
+    /**
+     * The same position with {@code reason} where nothing has been said yet, and unchanged where
+     * something has.
+     *
+     * <p>Fills rather than replaces, and that is a precedence: a reason already here came from the
+     * reading that stopped at this position, and one offered now comes from a reader of some rule
+     * that names it. Where the two describe one stop they describe it from different ends — the
+     * elements of a collection cannot be reached, and a comparison naming a position inside one
+     * cannot be turned into a line — and the first is the cause.
+     *
+     * <p>Load-bearing only since the structural reading began answering with reasons of its own.
+     * Before that it answered {@link Why.Absent} everywhere but the depth limit, so whatever a rule
+     * reader offered was what a report said, and a threshold on a list element was reported as a
+     * comparison this cannot read rather than as elements this cannot reach.
+     */
     public UndividedPosition because(Reason reason) {
         return why instanceof Why.Absent ? cannotDerive(at, reason) : this;
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UndividedPosition.java
@@ -9,9 +9,10 @@ package souther.compiler.partition;
  * for the line their own body draws.
  *
  * <p>So the absence is a value that has to be produced rather than the default reading of an empty
- * result. {@link Absent} is only written where the walk ran to the end and found nothing; where it
- * stopped, or where something named the position and this could not turn it into a line,
- * {@link CannotDerive} says so and carries which.
+ * result. {@link Why.Absent} is produced by {@link PendingPosition#complete} and nowhere else, from
+ * a position whose structural reading did not stop and whose rules were all read and drew nothing —
+ * which is what the word means. Where the reading stopped, or where something named the position
+ * and this could not turn it into a line, {@link Why.CannotDerive} says so and carries which.
  *
  * @param at  the position, spelled the way a report names it
  * @param why whether the model draws nothing here or this could not read what it draws
@@ -21,8 +22,38 @@ public record UndividedPosition(TermPath at, Why why) {
     /** Which of the two it is. */
     public sealed interface Why {
 
-        /** The walk finished and the model divides this position no way at all. */
-        record Absent() implements Why {}
+        /**
+         * Every producer was asked, none of them stopped, and none of them divided the position:
+         * the model divides it no way at all.
+         *
+         * <p>A class with no way to make one rather than a record, because what it says is a
+         * conclusion about a model and the only thing entitled to draw it is the completion of a
+         * {@link PendingPosition}. Anything able to write {@code new Absent()} is able to say the
+         * model divides a position no way without having asked anything, which is the sentence this
+         * whole protocol exists to stop being cheap to write.
+         */
+        final class Absent implements Why {
+
+            /** The one, reached through {@link PendingPosition#complete}. */
+            static final Absent PROVEN = new Absent();
+
+            private Absent() {}
+
+            @Override
+            public boolean equals(Object other) {
+                return other instanceof Absent;
+            }
+
+            @Override
+            public int hashCode() {
+                return Absent.class.hashCode();
+            }
+
+            @Override
+            public String toString() {
+                return "Absent";
+            }
+        }
 
         /** Something is written here that this did not read, so nothing is established either way. */
         record CannotDerive(Reason reason) implements Why {}
@@ -67,33 +98,14 @@ public record UndividedPosition(TermPath at, Why why) {
         UNSUPPORTED_TRAVERSAL
     }
 
-    public static UndividedPosition absent(TermPath at) {
-        return new UndividedPosition(at, new Why.Absent());
+    /** The absence, of a position that has been completed. The argument is the proof: nothing can
+     *  call this that has not asked every producer, because nothing else can make one. */
+    static UndividedPosition absentAfter(PendingPosition proven) {
+        return new UndividedPosition(proven.at(), Why.Absent.PROVEN);
     }
 
     public static UndividedPosition cannotDerive(TermPath at, Reason reason) {
         return new UndividedPosition(at, new Why.CannotDerive(reason));
-    }
-
-    /** The same position, with a reason where it had none. A position already carrying one keeps it:
-     * what stopped the walk first is what a reader has to lift first. */
-    /**
-     * The same position with {@code reason} where nothing has been said yet, and unchanged where
-     * something has.
-     *
-     * <p>Fills rather than replaces, and that is a precedence: a reason already here came from the
-     * reading that stopped at this position, and one offered now comes from a reader of some rule
-     * that names it. Where the two describe one stop they describe it from different ends — the
-     * elements of a collection cannot be reached, and a comparison naming a position inside one
-     * cannot be turned into a line — and the first is the cause.
-     *
-     * <p>Load-bearing only since the structural reading began answering with reasons of its own.
-     * Before that it answered {@link Why.Absent} everywhere but the depth limit, so whatever a rule
-     * reader offered was what a report said, and a threshold on a list element was reported as a
-     * comparison this cannot read rather than as elements this cannot reach.
-     */
-    public UndividedPosition because(Reason reason) {
-        return why instanceof Why.Absent ? cannotDerive(at, reason) : this;
     }
 
     public boolean isAbsent() {

--- a/souther-compiler/src/main/java/souther/compiler/partition/UnreadRule.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/UnreadRule.java
@@ -15,6 +15,8 @@ package souther.compiler.partition;
  * what the declaration says.
  *
  * @param at  the position, spelled the way a report names it
- * @param why what would have to change before this rule could be a line
+ * @param why what would have to change before this rule could be a line, in this compiler's own
+ *            terms. Which word a report writes for it is {@link ReportedReason}'s, so a capability
+ *            gained here need not move a published vocabulary
  */
-public record UnreadRule(TermPath at, UndividedPosition.Reason why) {}
+public record UnreadRule(TermPath at, BlockReason why) {}

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -370,7 +370,7 @@ final class Witnesses {
      */
     private static List<FixtureTemplate> dividesInto(Type type, Symbols symbols) {
         List<FixtureTemplate> out = new ArrayList<>();
-        for (PartitionClass each : Partitions.classesOf(type, symbols)) {
+        for (PartitionClass each : PartitionClasses.of(type, symbols)) {
             if (each.generatable()) {
                 out.addAll(each.representatives().candidates());
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -358,29 +358,21 @@ final class Witnesses {
         return List.copyOf(out);
     }
 
-    /** The values a type divides into, under every name it wears: a {@code Bool} is two of them and a
+    /**
+     * The values a type divides into, under every name it wears: a {@code Bool} is two of them and a
      * sum is its cases. Empty where the type is not divided, which is where a range or a length is
-     * what tells its values apart instead. */
+     * what tells its values apart instead.
+     *
+     * <p>Asked once. This used to ask again of what the names wrap and put them back on itself,
+     * because the reading it asks stopped at a name — so the same rule about what a newtype divides
+     * into was written here as well, and the two could differ about how far to look. The reading
+     * goes through the names now and hands the values back written under them.
+     */
     private static List<FixtureTemplate> dividesInto(Type type, Symbols symbols) {
         List<FixtureTemplate> out = new ArrayList<>();
         for (PartitionClass each : Partitions.classesOf(type, symbols)) {
             if (each.generatable()) {
                 out.addAll(each.representatives().candidates());
-            }
-        }
-        if (!out.isEmpty()) {
-            return out;
-        }
-        // A newtype divides where what it wraps does, and the values are written under its name.
-        Type carrier = TypeOps.base(type, symbols);
-        if (carrier == null || carrier.equals(type)) {
-            return List.of();
-        }
-        for (PartitionClass each : Partitions.classesOf(carrier, symbols)) {
-            if (each.generatable()) {
-                for (FixtureTemplate value : each.representatives().candidates()) {
-                    out.add(wrapped(type, value, symbols));
-                }
             }
         }
         return out;

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1569,7 +1569,8 @@ public final class Adequacy {
             // above — and the walk stopping short is the one reason that comes from neither.
             List<List<Object>> unread = new ArrayList<>();
             for (souther.compiler.partition.UnreadRule each : partition.unread()) {
-                unread.add(List.<Object>of(each.at().toString(), said(each.why())));
+                unread.add(List.<Object>of(each.at().toString(),
+                        said(souther.compiler.partition.ReportedReason.of(each.why()))));
             }
             for (souther.compiler.partition.UndividedPosition position : partition.notDerivable()) {
                 if (position.why() instanceof souther.compiler.partition.UndividedPosition.Why

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1602,6 +1602,9 @@ public final class Adequacy {
                 case UNSUPPORTED_PARTITION_SHAPE ->
                         "the comparison relates it to another position rather than dividing it";
                 case DEPTH_LIMIT -> "the walk stopped before reaching what is under it";
+                case TYPE_UNRESOLVED -> "its type could not be worked out here";
+                case UNSUPPORTED_TRAVERSAL ->
+                        "its values are held inside something this does not reach into";
             };
         }
 

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -544,8 +544,9 @@ public final class Adequacy {
             if (building == null) {
                 return null;
             }
-            Generator.Subject subject = new Generator.Subject(parameters, sig.inputTypes(),
-                    partitioning.axes(), symbols);
+            Generator.Subject subject = new Generator.Subject(
+                    new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
+                            symbols), partitioning.axes());
             Generator.CandidateCheck check =
                     (at, candidate) -> building.refuse(sig.ins().get(at), candidate.value());
             return new Coverages.Probe() {
@@ -1323,17 +1324,19 @@ public final class Adequacy {
             }
             List<RowOutcome> rows = observed.rows();
             List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
+            // One reading of what the behavior takes, for both halves of this: the rows already
+            // written are read by it, and the rows offered are generated from it.
+            souther.compiler.partition.BehaviorInputs inputs =
+                    new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
+                            symbols);
             souther.compiler.partition.Partitions.Partitioning partitioning =
                     Coverages.partitioningOf(spec, sig, symbols, body, plan, excluded);
-            Generator.Subject subject = new Generator.Subject(parameters, sig.inputTypes(),
-                    partitioning.axes(), symbols);
+            Generator.Subject subject = new Generator.Subject(inputs, partitioning.axes());
             Generator.CandidateCheck check = building == null ? Generator.CandidateCheck.ANY
                     : (at, candidate) -> building.refuse(sig.ins().get(at), candidate.value());
 
             List<Map<AxisId, Classification>> existing = rows.stream()
-                    .map(row -> RowClasses.of(row, new souther.compiler.partition.BehaviorInputs(
-                            parameters, sig.inputTypes(), symbols),
-                            partitioning.axes())).toList();
+                    .map(row -> RowClasses.of(row, inputs, partitioning.axes())).toList();
             return Generator.fill(subject, existing, check);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -508,6 +508,9 @@ public final class Adequacy {
                 souther.compiler.coverage.CoverageSites.Plan plan, Observed observed,
                 boolean armsAsked, FixtureReader.Construction building, Exclusions excluded) {
             List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
+            souther.compiler.partition.BehaviorInputs inputs =
+                    new souther.compiler.partition.BehaviorInputs(parameters, sig.inputTypes(),
+                            symbols);
             souther.compiler.partition.Partitions.Partitioning partitioning =
                     Coverages.partitioningOf(spec, sig, symbols, body, plan, excluded);
             Coverages.Probe probe = probing(partitioning, sig, symbols, parameters, building);
@@ -520,12 +523,11 @@ public final class Adequacy {
                 if (!axis.measurable()) {
                     continue;
                 }
-                out.addAll(Coverages.assess(axis, parameters, observed, symbols, armsAsked,
+                out.addAll(Coverages.assess(axis, inputs, observed, armsAsked,
                         partitioning.edgeIsKnownWritable(axis.term()), probe,
                         partitioning.domains().get(axis.term())));
             }
-            out.addAll(Coverages.assessBetween(partitioning, parameters, observed, armsAsked,
-                    probe));
+            out.addAll(Coverages.assessBetween(partitioning, inputs, observed, armsAsked, probe));
             return List.copyOf(out);
         }
 
@@ -1329,7 +1331,9 @@ public final class Adequacy {
                     : (at, candidate) -> building.refuse(sig.ins().get(at), candidate.value());
 
             List<Map<AxisId, Classification>> existing = rows.stream()
-                    .map(row -> RowClasses.of(row, parameters, partitioning.axes())).toList();
+                    .map(row -> RowClasses.of(row, new souther.compiler.partition.BehaviorInputs(
+                            parameters, sig.inputTypes(), symbols),
+                            partitioning.axes())).toList();
             return Generator.fill(subject, existing, check);
         }
     }

--- a/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Coverages.java
@@ -21,6 +21,7 @@ import souther.compiler.partition.NumericTerm;
 import souther.compiler.partition.OriginRef;
 import souther.compiler.partition.PartitionClass;
 import souther.compiler.partition.Partitions;
+import souther.compiler.partition.BehaviorInputs;
 import souther.compiler.partition.RowClasses;
 
 import java.util.ArrayList;
@@ -49,6 +50,10 @@ final class Coverages {
                                                   Core body, CoverageSites.Plan plan,
                                                   Exclusions excluded) {
         List<String> parameters = behavior.params().stream().map(Ast.Param::name).toList();
+        // What a row's values are, where they sit and what they are written as, read together:
+        // a field under a name is reached by taking the name off, and a walk given the paths
+        // alone reaches nothing where the derivation reaches a field.
+        BehaviorInputs where = new BehaviorInputs(parameters, sig.inputTypes(), symbols);
         Partitions.Partitioning partitioning = Partitions.of(behavior, sig, symbols, excluded);
         if (body == null) {
             return partitioning;
@@ -71,13 +76,17 @@ final class Coverages {
                                 List<BoundaryAssessment> boundaries, Exclusions excluded) {
         List<RowOutcome> rows = observed.rows();
         List<String> parameters = behavior.params().stream().map(Ast.Param::name).toList();
+        // What a row's values are, where they sit and what they are written as, read together:
+        // a field under a name is reached by taking the name off, and a walk given the paths
+        // alone reaches nothing where the derivation reaches a field.
+        BehaviorInputs where = new BehaviorInputs(parameters, sig.inputTypes(), symbols);
         Partitions.Partitioning partitioning =
                 partitioningOf(behavior, sig, symbols, body, plan, excluded);
 
         List<PartitionEvidence.AxisCoverage> axes = new ArrayList<>();
 
         List<Axis> divided = new ArrayList<>();
-        Readings readings = Readings.of(rows, parameters, partitioning.axes(),
+        Readings readings = Readings.of(rows, where, partitioning.axes(),
                 observed.someRowsUnseen());
         for (Axis axis : partitioning.axes()) {
             if (!axis.measurable()) {
@@ -132,11 +141,11 @@ final class Coverages {
      */
     private record Readings(List<Map<AxisId, Classification>> byRow, boolean someRowsUnseen) {
 
-        static Readings of(List<RowOutcome> rows, List<String> parameters, List<Axis> axes,
+        static Readings of(List<RowOutcome> rows, BehaviorInputs where, List<Axis> axes,
                            boolean someRowsUnseen) {
             List<Map<AxisId, Classification>> read = new ArrayList<>();
             for (RowOutcome row : rows) {
-                read.add(RowClasses.of(row, parameters, axes));
+                read.add(RowClasses.of(row, where, axes));
             }
             return new Readings(List.copyOf(read), someRowsUnseen);
         }
@@ -308,17 +317,17 @@ final class Coverages {
      * @param probe     null where the module's classes or the runtime are not there to build against
      */
     static List<BoundaryAssessment> assess(
-            Axis axis, List<String> parameters, souther.compiler.query.Adequacy.Observed observed,
-            Symbols symbols, boolean armsAsked, boolean knownWritable, Probe probe,
+            Axis axis, BehaviorInputs where, souther.compiler.query.Adequacy.Observed observed,
+            boolean armsAsked, boolean knownWritable, Probe probe,
             souther.compiler.numeric.NumericDomain.Bounds within) {
         List<RowOutcome> rows = observed.rows();
         // Keyed by the line rather than by the reading of it. A guard inside a non-recursive helper
         // is read once per call of that helper, and the rows do not owe the same edge twice for
         // having been offered it twice; what each reading saw is merged below.
         java.util.SequencedMap<Line, BoundaryAssessment> out = new java.util.LinkedHashMap<>();
-        for (BoundaryObligation each : Partitions.obligationsOf(axis, symbols, within)) {
+        for (BoundaryObligation each : Partitions.obligationsOf(axis, where.symbols(), within)) {
             BoundaryAssessment.Coverage coverage =
-                    coverageOf(each, axis, parameters, symbols, observed, armsAsked);
+                    coverageOf(each, axis, where, observed, armsAsked);
             BoundaryAssessment.Attempt attempt = attemptAt(each, coverage, probe);
             BoundaryAssessment made = new BoundaryAssessment(each, coverage,
                     writabilityOf(coverage, knownWritable, attempt), attempt);
@@ -391,7 +400,7 @@ final class Coverages {
 
     /** Whether a row sits at one boundary, and whether that could be told. */
     private static BoundaryAssessment.Coverage coverageOf(
-            BoundaryObligation obligation, Axis axis, List<String> parameters, Symbols symbols,
+            BoundaryObligation obligation, Axis axis, BehaviorInputs where,
             souther.compiler.query.Adequacy.Observed observed, boolean armsAsked) {
         List<RowOutcome> rows = observed.rows();
         boolean guard = obligation.origin() instanceof OriginRef.GuardOrigin;
@@ -403,12 +412,11 @@ final class Coverages {
         }
         Met met = switch (obligation.target()) {
             case BoundaryTarget.AtPlace place -> guard
-                    ? evaluatedAt(axis, parameters, rows, symbols, place.at(),
+                    ? evaluatedAt(axis, where, rows, place.at(),
                             (OriginRef.GuardOrigin) obligation.origin())
-                    : writtenAt(axis, parameters, rows, symbols, place.at());
+                    : writtenAt(axis, where, rows, place.at());
             case BoundaryTarget.EqualTerms line ->
-                    heldBetween(line, parameters, rows,
-                            (OriginRef.GuardOrigin) obligation.origin());
+                    heldBetween(line, where, rows, (OriginRef.GuardOrigin) obligation.origin());
         };
         return verdictOf(met, guard, observed);
     }
@@ -425,7 +433,7 @@ final class Coverages {
      * is reported and not counted, the same account any other unpromised edge gets.
      */
     static List<BoundaryAssessment> assessBetween(
-            Partitions.Partitioning partitioning, List<String> parameters,
+            Partitions.Partitioning partitioning, BehaviorInputs where,
             souther.compiler.query.Adequacy.Observed observed, boolean armsAsked, Probe probe) {
         List<RowOutcome> rows = observed.rows();
         // Keyed by the line the author drew, the way a line at a place is. A guard inside a
@@ -439,7 +447,7 @@ final class Coverages {
                     whyNoGuardLine(rows, armsAsked, observed.armsUnseen(), observed.someRowsUnseen());
             BoundaryAssessment.Coverage coverage = absent != null
                     ? new BoundaryAssessment.Coverage.NotMeasured(absent)
-                    : verdictOf(heldBetween(line, parameters, rows,
+                    : verdictOf(heldBetween(line, where, rows,
                             (OriginRef.GuardOrigin) each.origin()), true, observed);
             // A place both positions admit is what a row on the line writes. Read once: it is what a
             // candidate is built at, and what proves the line writable where the two are independent.
@@ -519,14 +527,14 @@ final class Coverages {
      * is what the domain this was found in is made of — and two values of different types are never
      * equal however much the numbers inside them agree.
      */
-    private static Met heldBetween(BoundaryTarget.EqualTerms line, List<String> parameters,
+    private static Met heldBetween(BoundaryTarget.EqualTerms line, BehaviorInputs where,
                                    List<RowOutcome> rows, OriginRef.GuardOrigin origin) {
         boolean unreadable = false;
         for (RowOutcome row : rows) {
             NumericTerm.Reading on = line.on()
-                    .read(RowClasses.valueAt(row, parameters, line.on().path()), line.carrier());
+                    .read(where.valueAt(row, line.on().path()), line.carrier());
             NumericTerm.Reading against = line.against()
-                    .read(RowClasses.valueAt(row, parameters, line.against().path()), line.carrier());
+                    .read(where.valueAt(row, line.against().path()), line.carrier());
             if (on instanceof NumericTerm.Reading.Missing
                     || against instanceof NumericTerm.Reading.Missing) {
                 unreadable = true;
@@ -669,12 +677,11 @@ final class Coverages {
      * {@code B} false and the rows that never reached {@code B}. Reading the arms here credited the
      * second kind and could not credit the first.
      */
-    private static Met evaluatedAt(Axis axis, List<String> parameters, List<RowOutcome> rows,
-                                   Symbols symbols, Place boundary,
-                                   OriginRef.GuardOrigin origin) {
+    private static Met evaluatedAt(Axis axis, BehaviorInputs where, List<RowOutcome> rows,
+                                   Place boundary, OriginRef.GuardOrigin origin) {
         boolean unreadable = false;
         for (RowOutcome row : rows) {
-            switch (readingFor(axis, parameters, symbols, row)) {
+            switch (readingFor(axis, where, row)) {
                 case NumericTerm.Reading.Missing _ -> unreadable = true;
                 case NumericTerm.Reading.NotNumber _ -> { }
                 case NumericTerm.Reading.Number number -> {
@@ -688,11 +695,11 @@ final class Coverages {
         return unreadable ? Met.UNREADABLE : Met.NO;
     }
 
-    private static Met writtenAt(Axis axis, List<String> parameters, List<RowOutcome> rows,
-                                 Symbols symbols, Place boundary) {
+    private static Met writtenAt(Axis axis, BehaviorInputs where, List<RowOutcome> rows,
+                                 Place boundary) {
         boolean unreadable = false;
         for (RowOutcome row : rows) {
-            switch (readingFor(axis, parameters, symbols, row)) {
+            switch (readingFor(axis, where, row)) {
                 case NumericTerm.Reading.Missing _ -> unreadable = true;
                 case NumericTerm.Reading.NotNumber _ -> { }
                 case NumericTerm.Reading.Number number -> {
@@ -721,10 +728,9 @@ final class Coverages {
      * its position as a row nobody could read — which is the answer {@code Intervals} already gives
      * a class asked the same question, and it has to be the same answer.
      */
-    private static NumericTerm.Reading readingFor(Axis axis, List<String> parameters,
-                                                  Symbols symbols, RowOutcome row) {
-        return axis.term().read(RowClasses.valueAt(row, parameters, axis.path()),
-                axis.term().carrierAt(axis.type(), symbols));
+    private static NumericTerm.Reading readingFor(Axis axis, BehaviorInputs where, RowOutcome row) {
+        return axis.term().read(where.valueAt(row, axis.path()),
+                axis.term().carrierAt(axis.type(), where.symbols()));
     }
 
     private Coverages() {}

--- a/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
+++ b/souther-compiler/src/main/resources/souther/adequacy-schema-1.json
@@ -252,8 +252,8 @@
             "properties": {
               "position": { "type": "string" },
               "reason": {
-                "description": "`unsupported_syntax` is an expression the terms do not name; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `depth_limit` is the walk stopping before it reached the position.",
-                "enum": ["unsupported_syntax", "unsupported_domain", "unsupported_partition_shape", "depth_limit"]
+                "description": "`unsupported_syntax` is an expression the terms do not name; `unsupported_domain` is a comparison against values no line can be drawn on; `unsupported_partition_shape` is a comparison relating two positions rather than dividing one; `depth_limit` is the walk stopping before it reached the position; `type_unresolved` is a type at the position that could not be worked out; `unsupported_traversal` is values held inside something the walk does not reach into. Every one of them is a fact about the compiler and none is a fact about the model.",
+                "enum": ["unsupported_syntax", "unsupported_domain", "unsupported_partition_shape", "depth_limit", "type_unresolved", "unsupported_traversal"]
               }
             }
           }

--- a/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AGenerationThatWentOnDoesNotSayItStoppedTest.java
@@ -71,8 +71,9 @@ class AGenerationThatWentOnDoesNotSayItStoppedTest {
         Ast.SpecBehavior spec = (Ast.SpecBehavior) prepared.behaviors().stream()
                 .filter(b -> b.name().equals("submit")).findFirst().orElseThrow();
         Sig sig = sigs.get("submit");
-        return new Generator.Subject(spec.params().stream().map(Ast.Param::name).toList(),
-                sig.inputTypes(), Partitions.of(spec, sig, symbols, Exclusions.NONE).axes(), symbols);
+        return new Generator.Subject(new souther.compiler.partition.BehaviorInputs(
+                spec.params().stream().map(Ast.Param::name).toList(), sig.inputTypes(), symbols),
+                Partitions.of(spec, sig, symbols, Exclusions.NONE).axes());
     }
 
     private static String written(Generator.GenerationResult result) {

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleBoundaryTest.java
@@ -204,7 +204,12 @@ class CompileExampleBoundaryTest {
         assertNotNull(all);
         PartitionEvidence keep = all.get("keep");
 
-        assertEquals(List.of(UndividedPosition.absent(TermPath.of("note"))), keep.notDerivable(),
+        // Read rather than built to compare against. An absence is what completing a position
+        // produces and nothing outside that can make one, which is the whole of what the word is
+        // worth — so this asks the answer what it is.
+        assertEquals(1, keep.notDerivable().size());
+        assertEquals(TermPath.of("note"), keep.notDerivable().get(0).at());
+        assertTrue(keep.notDerivable().get(0).isAbsent(),
                 "the model divides it no way, which is established rather than assumed");
         assertEquals(List.of(), keep.axes());
         assertEquals(List.of(), keep.boundaries());

--- a/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
@@ -138,8 +138,21 @@ class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
         assertEquals(new Shape.Tuple(List.of(Type.INT, Type.STRING)),
                 view(Type.tuple(List.of(Type.INT, Type.STRING))).shape());
         assertEquals(new Shape.Undecided(), view(Type.var("'a")).shape());
-        assertEquals(new Shape.Nothing(), view(Type.NOTHING).shape());
-        assertEquals(new Shape.Nothing(), view(Type.ERRONEOUS).shape());
+    }
+
+    /**
+     * The five that are not value shapes, each answered as itself. Two say something about the
+     * values and three about this compiler, and a reader downstream may only tell them apart if
+     * they arrive apart — which is the whole reason a position nothing could read stopped being
+     * reported as one the model divides no way.
+     */
+    @Test
+    void aShapeThisCouldNotDetermineSaysWhichOfTheFiveItIs() {
+        assertEquals(new Shape.Uninhabited(), view(Type.NEVER).shape());
+        assertEquals(new Shape.Bottom(), view(Type.NOTHING).shape());
+        assertEquals(new Shape.Erroneous(), view(Type.ERRONEOUS).shape());
+        assertEquals(new Shape.Undecided(), view(Type.var("'a")).shape());
+        assertEquals(new Shape.Unresolved(symbols.own("Cyclic")), view("Cyclic").shape());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest.java
@@ -1,0 +1,158 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.Type;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a position is, and what it is written as, read once and answered apart.
+ *
+ * <p>The two used to be worked out by whoever needed them, and they disagreed: a
+ * {@code data StageN = Stage} was a sum to the reader that drew a line on it and an opaque name to
+ * the reader that asked what it divides into. The first half of that is fixed by there being no
+ * newtype case to stop at — a name is never a shape — and the second half by the names staying
+ * reachable, since a row writes {@code StageN(Prospecting)} and nothing else would build.
+ */
+class OneReadingSaysWhatAPositionIsAndHowItIsWrittenTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Prospecting
+            data Qualified
+            data Won
+            data Stage = Prospecting | Qualified | Won
+
+            data StageN = Stage
+            data StageNN = StageN
+            data Flag = Bool
+            data Count = Int
+            data Cyclic = Cyclic
+
+            data Slot = { hour: Int, room: String }
+            data SlotN = Slot
+            """;
+
+    private final Symbols symbols = Symbols.of(resolved());
+
+    private static Ast.Module resolved() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    private TypeView view(String name) {
+        return TypeView.of(Type.ref(symbols.own(name)), symbols);
+    }
+
+    private TypeView view(Type type) {
+        return TypeView.of(type, symbols);
+    }
+
+    // --- a name is never a shape ----------------------------------------------------------------
+
+    /** The reading issue #631 is about. What the position is, is what the name wraps. */
+    @Test
+    void aNewtypeOverASumIsThatSum() {
+        assertEquals(new Shape.Sum(symbols.own("Stage")), view("StageN").shape());
+    }
+
+    @Test
+    void aNewtypeOverAPrimitiveIsThatPrimitive() {
+        assertEquals(new Shape.Scalar(Type.Prim.BOOL), view("Flag").shape());
+        assertEquals(new Shape.Scalar(Type.Prim.INT), view("Count").shape());
+    }
+
+    @Test
+    void aNewtypeOverARecordIsThatRecord() {
+        Shape.Product product = assertInstanceOf(Shape.Product.class, view("SlotN").shape());
+        assertEquals(symbols.own("Slot"), product.name());
+        assertEquals(java.util.Set.of("hour", "room"), product.fields().keySet());
+    }
+
+    /** Every layer comes off, so what a reader sees does not depend on how many names were written
+     *  round the value. */
+    @Test
+    void everyNameComesOffWhateverTheDepth() {
+        assertEquals(view("Stage").shape(), view("StageN").shape());
+        assertEquals(view("Stage").shape(), view("StageNN").shape());
+    }
+
+    /** There is no case to hold a newtype, so no reader can be handed one and decide for itself
+     *  whether to look through it. Held over the shapes a name is written over here. */
+    @Test
+    void noShapeIsANewtype() {
+        for (String name : new String[] {"StageN", "StageNN", "Flag", "Count", "SlotN"}) {
+            Shape shape = view(name).shape();
+            assertFalse(shape instanceof Shape.Unresolved,
+                    name + " reads as a shape rather than as a name this could not resolve");
+        }
+    }
+
+    // --- and the names stay reachable -----------------------------------------------------------
+
+    /** A row writes `StageN(Prospecting)`, so what the position is written as has to survive the
+     *  reading that says what it is. */
+    @Test
+    void theNamesWornAreKeptOutermostFirst() {
+        assertEquals(List.of("StageNN", "StageN"),
+                view("StageNN").wrappers().stream().map(l -> l.named().name()).toList());
+        assertEquals(List.of("StageN"),
+                view("StageN").wrappers().stream().map(l -> l.named().name()).toList());
+    }
+
+    @Test
+    void aTypeUnderNoNameWearsNone() {
+        assertTrue(view("Stage").wrappers().isEmpty());
+        assertFalse(view("Stage").isWrapped());
+        assertTrue(view("StageN").isWrapped());
+    }
+
+    @Test
+    void theDeclaredTypeIsWhatTheSignatureWrote() {
+        assertEquals(Type.ref(symbols.own("StageN")), view("StageN").declared());
+    }
+
+    // --- the shapes a position can have ---------------------------------------------------------
+
+    @Test
+    void eachTypeConstructorReadsAsItsOwnShape() {
+        assertEquals(new Shape.Scalar(Type.Prim.STRING), view(Type.STRING).shape());
+        assertEquals(new Shape.Unit(symbols.own("Won")), view("Won").shape());
+        assertEquals(new Shape.Sum(symbols.own("Stage")), view("Stage").shape());
+        assertEquals(new Shape.Sequence(Shape.Sequence.Kind.LIST, Type.INT),
+                view(Type.list(Type.INT)).shape());
+        assertEquals(new Shape.Sequence(Shape.Sequence.Kind.SET, Type.INT),
+                view(Type.set(Type.INT)).shape());
+        assertEquals(new Shape.Mapping(Type.STRING, Type.INT),
+                view(Type.map(Type.STRING, Type.INT)).shape());
+        assertEquals(new Shape.Optional(Type.INT), view(Type.option(Type.INT)).shape());
+        assertEquals(new Shape.Tuple(List.of(Type.INT, Type.STRING)),
+                view(Type.tuple(List.of(Type.INT, Type.STRING))).shape());
+        assertEquals(new Shape.Undecided(), view(Type.var("'a")).shape());
+        assertEquals(new Shape.Nothing(), view(Type.NOTHING).shape());
+        assertEquals(new Shape.Nothing(), view(Type.ERRONEOUS).shape());
+    }
+
+    @Test
+    void aUnionNobodyNamedIsItsMembers() {
+        Type union = Type.union(java.util.Set.of(symbols.own("Won"), symbols.own("Qualified")));
+        assertEquals(new Shape.Cases(java.util.Set.of(symbols.own("Won"), symbols.own("Qualified"))),
+                view(union).shape());
+    }
+
+    /** A name reachable from itself ends the walk. There is no base to read, so the shape says the
+     *  name resolved to nothing usable rather than standing in for a value. */
+    @Test
+    void aNewtypeReachingItselfIsUnresolvedRatherThanAShape() {
+        assertEquals(new Shape.Unresolved(symbols.own("Cyclic")), view("Cyclic").shape());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/diag/EveryShippedMessageCatalogIsCompleteAndValidTest.java
@@ -60,7 +60,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * shape, because the checks that read a catalog line by line are only as good as the format they
  * assume {@link Properties} was given.
  */
-class EveryShippedMessageCatalogIsCompleteAndValidTest {
+public class EveryShippedMessageCatalogIsCompleteAndValidTest {
 
     /** Where the bundle {@link Messages} reads lives, as a path under a module's resources. */
     private static final String PACKAGE = "souther/compiler/diag";
@@ -875,7 +875,7 @@ class EveryShippedMessageCatalogIsCompleteAndValidTest {
     }
 
     /** Every module's main sources. Any module may name a message key. */
-    static List<Path> mainSources() throws IOException {
+    public static List<Path> mainSources() throws IOException {
         List<Path> sources = new ArrayList<>();
         for (Path root : moduleDirectories("java")) {
             try (Stream<Path> walk = Files.walk(root)) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ABoundaryRowWearsEveryNameThePositionDeclaresTest.java
@@ -98,8 +98,8 @@ class ABoundaryRowWearsEveryNameThePositionDeclaresTest {
 
         List<String> names = new ArrayList<>();
         spec.params().forEach(each -> names.add(each.name()));
-        Generator.Subject subject = new Generator.Subject(names,
-                sigs.get(spec.name()).inputTypes(), p.axes(), symbols);
+        Generator.Subject subject = new Generator.Subject(
+                new BehaviorInputs(names, sigs.get(spec.name()).inputTypes(), symbols), p.axes());
 
         List<String> out = new ArrayList<>();
         for (Axis axis : p.axes()) {

--- a/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AComparisonThisDoesNotReadIsStillNoticedTest.java
@@ -154,7 +154,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     @Test
     void aPositionNamedInsideAnExpressionIsStillNoticed() {
         assertEquals(List.of(new UnreadRule(TermPath.of("p").then("x"),
-                        UndividedPosition.Reason.UNSUPPORTED_SYNTAX)),
+                        new BlockReason.UnreadComparisonForm())),
                 read("p: Pair", "p.x + 1 < 10").unread());
     }
 
@@ -169,9 +169,9 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     void twoPositionsComparedWithEachOtherSayWhichLimitThatIs() {
         assertEquals(List.of(
                         new UnreadRule(TermPath.of("p").then("x"),
-                                UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE),
+                                new BlockReason.ComparisonBetweenPositions()),
                         new UnreadRule(TermPath.of("p").then("y"),
-                                UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE)),
+                                new BlockReason.ComparisonBetweenPositions())),
                 read("p: Pair", "p.x < p.y").unread());
     }
 
@@ -189,7 +189,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
 
         assertEquals(1, guards.thresholds().size(), guards.thresholds().toString());
         assertEquals(List.of(new UnreadRule(TermPath.of("p").then("x"),
-                        UndividedPosition.Reason.UNSUPPORTED_SYNTAX)),
+                        new BlockReason.UnreadComparisonForm())),
                 guards.unread());
     }
 
@@ -204,9 +204,9 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     void aRelationWithArithmeticOnOneSideIsStillARelation() {
         assertEquals(List.of(
                         new UnreadRule(TermPath.of("p").then("x"),
-                                UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE),
+                                new BlockReason.ComparisonBetweenPositions()),
                         new UnreadRule(TermPath.of("p").then("y"),
-                                UndividedPosition.Reason.UNSUPPORTED_PARTITION_SHAPE)),
+                                new BlockReason.ComparisonBetweenPositions())),
                 read("p: Pair", "p.x < p.y + 1").unread());
     }
 
@@ -221,7 +221,7 @@ class AComparisonThisDoesNotReadIsStillNoticedTest {
     @Test
     void aReadableCarrierAgainstAnUnreadableSideIsNotACarrierProblem() {
         assertEquals(List.of(new UnreadRule(TermPath.of("p").then("x"),
-                        UndividedPosition.Reason.UNSUPPORTED_SYNTAX)),
+                        new BlockReason.UnreadComparisonForm())),
                 read("p: Pair", "p.x < 1 + 2").unread());
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADeclaredCaseIsNotYetAClassThePositionHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADeclaredCaseIsNotYetAClassThePositionHoldsTest.java
@@ -1,0 +1,89 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Symbols;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.types.Type;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a type declares and what a position can hold are two facts, crossed once.
+ *
+ * <p>{@code data StageI = Stage invariant value >= Qualified} declares three cases and holds two of
+ * them: {@code StageI(Prospecting)} is refused at construction by the rule that says so. A class for
+ * it would be a row nobody can write, asked for by the same report that has the rule in front of it.
+ *
+ * <p>Both halves are asserted because the crossing is only worth anything if the two are apart. The
+ * reading of the declaration does not consult a rule, and the rule does not decide what the
+ * declaration says — so neither is the other's input, and no order of working them out changes the
+ * answer. Written as one reading handing its output to the other, the case comes back the day
+ * somebody tidies the order.
+ */
+class ADeclaredCaseIsNotYetAClassThePositionHoldsTest {
+
+    private static final String MODEL = """
+            module demo
+
+            data Ok
+            data Prospecting
+            data Qualified
+            data Won
+            data Stage = Prospecting | Qualified | Won
+            data StageI = Stage invariant value >= Qualified
+
+            behavior boundStage : (x: StageI) -> Ok constructs Ok
+            let boundStage (x) = Ok
+
+            behavior guardStage : (x: Stage) -> Ok constructs Ok
+            let guardStage (x) = { guard x < Qualified else Ok
+                Ok }
+            """;
+
+    private final Symbols symbols = Symbols.of(resolved());
+
+    private static Ast.Module resolved() {
+        Ast.Module parsed = CstFrontend.parse(MODEL);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    /** The declaration's own answer, which the rule on the newtype does not enter into. */
+    @Test
+    void theTypeDeclaresEveryCaseWhateverItsRulesSay() {
+        assertEquals(List.of("Prospecting", "Qualified", "Won"),
+                Partitions.classesOf(Type.ref(symbols.own("StageI")), symbols).stream()
+                        .map(PartitionClass::id).toList());
+    }
+
+    /** And the position holds the ones its rules leave. */
+    @Test
+    void thePositionHoldsTheCasesItsRulesAdmit() {
+        assertEquals(List.of("Qualified", "Won"), measured("boundStage"));
+    }
+
+    /** A {@code guard} takes no case away: it cuts the same order and everything either side of the
+     *  cut is still a value the position holds. */
+    @Test
+    void aLineDrawnByABodyTakesNoCaseAway() {
+        assertEquals(List.of("Prospecting", "Qualified", "Won"), measured("guardStage"));
+    }
+
+    private static List<String> measured(String behavior) {
+        Compilation compilation = Compilation.ofSource(MODEL, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        PartitionEvidence evidence = compilation.db()
+                .ask(new Adequacy.Coverage("demo")).value().get(behavior);
+        assertNotNull(evidence, behavior + " was measured");
+        return evidence.axes().get(0).classes();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ADeclaredCaseIsNotYetAClassThePositionHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ADeclaredCaseIsNotYetAClassThePositionHoldsTest.java
@@ -60,7 +60,7 @@ class ADeclaredCaseIsNotYetAClassThePositionHoldsTest {
     @Test
     void theTypeDeclaresEveryCaseWhateverItsRulesSay() {
         assertEquals(List.of("Prospecting", "Qualified", "Won"),
-                Partitions.classesOf(Type.ref(symbols.own("StageI")), symbols).stream()
+                PartitionClasses.of(Type.ref(symbols.own("StageI")), symbols).stream()
                         .map(PartitionClass::id).toList());
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALeafIsNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALeafIsNotAnAbsenceTest.java
@@ -60,7 +60,7 @@ class ALeafIsNotAnAbsenceTest {
     void aSumIsALeafAndASumIsWhatDivides() {
         assertInstanceOf(StructuralInspection.Leaf.class, under(named("Stage")));
 
-        assertFalse(Partitions.classesOf(named("Stage"), symbols).isEmpty(),
+        assertFalse(PartitionClasses.of(named("Stage"), symbols).isEmpty(),
                 "the same position divides three ways, which the leaf above did not deny");
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALeafIsNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALeafIsNotAnAbsenceTest.java
@@ -95,7 +95,13 @@ class ALeafIsNotAnAbsenceTest {
 
     // --- and what stops the derivation -------------------------------------------------------------
 
-    /** Issue #626, as this protocol states it: the shape is understood and the reaching is not made. */
+    /**
+     * Issue #626, as this protocol states it: the shape is understood and the reaching is not made.
+     *
+     * <p>A fallback and not a verdict. The same position takes a line from
+     * {@code guard List.length(items) < 3}, and where one is drawn this reason is never reported —
+     * what a block refuses is a rule about what is inside standing in for reaching inside.
+     */
     @Test
     void aSequenceIsBlockedOnReachingItsElements() {
         assertEquals(new StructuralInspection.Blocked(new BlockReason.UnsupportedTraversal(

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALeafIsNotAnAbsenceTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALeafIsNotAnAbsenceTest.java
@@ -1,0 +1,149 @@
+package souther.compiler.partition;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Shape;
+import souther.compiler.check.Symbols;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Whether a position is made of positions, and what that answer does not say.
+ *
+ * <p>The reading this protocol exists to stop is a leaf being read as a position the model does not
+ * divide. Everything here is written round that: the answer for a {@code Sum} is a leaf, and a
+ * {@code Sum} is exactly the position that does divide.
+ */
+class ALeafIsNotAnAbsenceTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Prospecting
+            data Won
+            data Stage = Prospecting | Won
+            data StageN = Stage
+            data Cyclic = Cyclic
+            data Slot = { hour: Int, room: String }
+            """;
+
+    private final Symbols symbols = Symbols.of(resolved());
+
+    private static Ast.Module resolved() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    private StructuralInspection under(Type type) {
+        return StructuralInspection.of(PartitionInput.of(type, symbols).shape(), true);
+    }
+
+    private Type named(String name) {
+        return Type.ref(symbols.own(name));
+    }
+
+    // --- a leaf says one thing ------------------------------------------------------------------
+
+    /**
+     * The row that fixes the distinction. A sum answers "not made of positions", and a sum is the
+     * position most likely to have had classes — so a reader that took this for "nothing divides
+     * it" would be wrong about the clearest case there is.
+     */
+    @Test
+    void aSumIsALeafAndASumIsWhatDivides() {
+        assertInstanceOf(StructuralInspection.Leaf.class, under(named("Stage")));
+
+        assertFalse(Partitions.classesOf(named("Stage"), symbols).isEmpty(),
+                "the same position divides three ways, which the leaf above did not deny");
+    }
+
+    @Test
+    void aScalarAndAUnitAreLeavesToo() {
+        assertInstanceOf(StructuralInspection.Leaf.class, under(Type.INT));
+        assertInstanceOf(StructuralInspection.Leaf.class, under(named("Prospecting")));
+    }
+
+    /** A leaf carries nothing, so there is nothing in it for a reader to turn into a conclusion. */
+    @Test
+    void aLeafCarriesNoReason() {
+        assertEquals(new StructuralInspection.Leaf(), under(named("Stage")));
+    }
+
+    // --- what is made of positions ---------------------------------------------------------------
+
+    @Test
+    void aRecordIsItsFields() {
+        StructuralInspection.Children children =
+                assertInstanceOf(StructuralInspection.Children.class, under(named("Slot")));
+        assertEquals(java.util.Set.of("hour", "room"), children.under().keySet());
+    }
+
+    /** A record the walk may not go into is a reaching declined, not a record with nothing in it. */
+    @Test
+    void aRecordTheWalkMayNotEnterIsBlockedRatherThanALeaf() {
+        StructuralInspection stopped = StructuralInspection.of(
+                PartitionInput.of(named("Slot"), symbols).shape(), false);
+        assertEquals(new StructuralInspection.Blocked(new BlockReason.DepthLimit()), stopped);
+    }
+
+    // --- and what stops the derivation -------------------------------------------------------------
+
+    /** Issue #626, as this protocol states it: the shape is understood and the reaching is not made. */
+    @Test
+    void aSequenceIsBlockedOnReachingItsElements() {
+        assertEquals(new StructuralInspection.Blocked(new BlockReason.UnsupportedTraversal(
+                        BlockReason.Traversal.SEQUENCE_ELEMENT)),
+                under(Type.list(named("Slot"))));
+        assertEquals(new StructuralInspection.Blocked(new BlockReason.UnsupportedTraversal(
+                        BlockReason.Traversal.SEQUENCE_ELEMENT)),
+                under(Type.set(named("Slot"))));
+    }
+
+    /** Each of the three is its own reaching, so implementing one does not read as all three. */
+    @Test
+    void theOtherTwoReachingsAreToldApartFromIt() {
+        assertEquals(new StructuralInspection.Blocked(new BlockReason.UnsupportedTraversal(
+                        BlockReason.Traversal.OPTIONAL_VALUE)),
+                under(Type.option(Type.INT)));
+        assertEquals(new StructuralInspection.Blocked(new BlockReason.UnsupportedTraversal(
+                        BlockReason.Traversal.MAPPING_CONTENT)),
+                under(Type.map(Type.STRING, Type.INT)));
+    }
+
+    /** A declaration reachable from itself: interpreted as far as it goes, which is not far enough. */
+    @Test
+    void aTypeThisCouldNotInterpretIsBlockedRatherThanALeaf() {
+        assertEquals(new StructuralInspection.Blocked(new BlockReason.TypeUnresolved()),
+                under(named("Cyclic")));
+    }
+
+    /** A name round a position changes neither what is under it nor whether anything is. */
+    @Test
+    void aNameRoundAPositionChangesNothingHere() {
+        assertEquals(under(named("Stage")), under(named("StageN")));
+    }
+
+    // --- the answers a leaf and a block are not -----------------------------------------------------
+
+    /**
+     * Nothing here answers whether the position divides. A conclusion of that kind needs the phases
+     * after this one, and the type offers no way to reach one from here — held as a test so that
+     * adding such a way is a change somebody has to make on purpose.
+     */
+    @Test
+    void nothingHereAnswersWhetherThePositionDivides() {
+        for (java.lang.reflect.Method method : StructuralInspection.class.getMethods()) {
+            assertFalse(UndividedPosition.class.isAssignableFrom(method.getReturnType()),
+                    "`" + method.getName() + "` turns a structural answer into a report of a"
+                            + " position the model does not divide, which it cannot know");
+        }
+        assertTrue(StructuralInspection.class.isSealed());
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -1,0 +1,194 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeView;
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.observe.ObservedValue;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.report.GeneratedRows;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name comes off to say what a position is and goes back on to say what stands at it.
+ *
+ * <p>The two directions are one fact and have to be read as one. A {@code data DecisionN = Decision}
+ * divides into {@code Decision}'s cases — which is the reading that stopped at the name before
+ * (issue #631) — and a row at that position writes {@code DecisionN(Approved { id = 1 })}, which is
+ * that reading run backwards. Three things have to hold together for an axis to be worth anything:
+ * the classes are derived, a value for one is written under the names, and a value somebody already
+ * wrote is read back into its class. Any one of them alone is an axis nothing can be measured at.
+ *
+ * <p>Which is why the wrapper order is pinned against written-out values in both directions rather
+ * than against each other. Put on and taken off by the same wrong order, a round trip through the
+ * two would agree with itself and every row would carry {@code DecisionN(DecisionNN(...))}.
+ */
+class ANameGoesBackOnTheWayItCameOffTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Ok
+            data Rejected
+            data Approved = { id: Int }
+            data Decision = Approved | Rejected
+            data DecisionN = Decision
+            data DecisionNN = DecisionN
+
+            behavior run : (x: DecisionN) -> Ok constructs Ok
+            let run (x) = Ok
+            """;
+
+    private final Symbols symbols = Symbols.of(resolved());
+
+    private static Ast.Module resolved() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    private TypeName named(String name) {
+        return symbols.own(name);
+    }
+
+    private PartitionClass classOf(String type, String id) {
+        return Partitions.classesOf(Type.ref(named(type)), symbols).stream()
+                .filter(each -> each.id().equals(id)).findFirst().orElseThrow();
+    }
+
+    // --- the names, read off ---------------------------------------------------------------------
+
+    /** What the reading says the position wears, which everything below is the two directions of. */
+    @Test
+    void theNamesAreReadOffOutermostFirst() {
+        assertEquals(List.of("DecisionNN", "DecisionN"),
+                TypeView.of(Type.ref(named("DecisionNN")), symbols).wrappers().stream()
+                        .map(layer -> layer.named().name()).toList());
+    }
+
+    // --- and put back on -------------------------------------------------------------------------
+
+    /** A value the class names, under one name and under two. */
+    @Test
+    void aNamedValueIsWrittenUnderEveryNameThePositionWears() {
+        assertEquals(List.of("DecisionN(Rejected)"),
+                written(classOf("DecisionN", "Rejected")));
+        assertEquals(List.of("DecisionNN(DecisionN(Rejected))"),
+                written(classOf("DecisionNN", "Rejected")));
+    }
+
+    /**
+     * And a value nothing has composed yet, which is what the projection is for.
+     *
+     * <p>{@code Approved} is a record, so the class names the constructor and the generator composes
+     * the fields. The names still belong to the position, and they are carried until there is a
+     * value to put them on.
+     */
+    @Test
+    void aComposedValueCarriesTheNamesUntilThereIsSomethingToPutThemOn() {
+        RepresentativeSource.Evaluation.Compose compose = assertInstanceOf(
+                RepresentativeSource.Evaluation.Compose.class,
+                classOf("DecisionNN", "Approved").representatives().evaluate());
+
+        assertEquals(named("Approved"), compose.through());
+        assertEquals(List.of(named("DecisionNN"), named("DecisionN")), compose.worn());
+        assertEquals("DecisionNN(DecisionN(Approved { id = 1 }))",
+                compose.written(FixtureTemplate.record(named("Approved"),
+                        Map.of("id", FixtureTemplate.integer(1)))).text());
+    }
+
+    // --- and taken off again ---------------------------------------------------------------------
+
+    /**
+     * A row's value read back into its class, at the same two depths.
+     *
+     * <p>The observation is written out here rather than made by writing a fixture and observing it:
+     * a value built by the direction under test would agree with it whichever order the names went
+     * on in.
+     */
+    @Test
+    void aValueWrittenUnderTheNamesIsReadBackThroughThem() {
+        ObservedValue approved = new ObservedValue.Constructed(named("Approved"),
+                Map.of("id", new ObservedValue.Integer(1)));
+
+        assertInstanceOf(Membership.Match.class, classOf("DecisionN", "Approved").classifier()
+                .membershipOf(wearing(approved, "DecisionN")));
+        assertInstanceOf(Membership.Match.class, classOf("DecisionNN", "Approved").classifier()
+                .membershipOf(wearing(approved, "DecisionNN", "DecisionN")));
+        assertInstanceOf(Membership.NoMatch.class, classOf("DecisionNN", "Rejected").classifier()
+                .membershipOf(wearing(approved, "DecisionNN", "DecisionN")));
+    }
+
+    /** And the names are taken off in the order they were written, not in whatever order arrives. */
+    @Test
+    void namesInTheWrongOrderAreNotTheNamesThePositionWears() {
+        ObservedValue approved = new ObservedValue.Constructed(named("Approved"),
+                Map.of("id", new ObservedValue.Integer(1)));
+
+        assertInstanceOf(Membership.NoMatch.class, classOf("DecisionNN", "Approved").classifier()
+                .membershipOf(wearing(approved, "DecisionN", "DecisionNN")));
+    }
+
+    // --- and the same three, through a whole compilation -----------------------------------------
+
+    /**
+     * The class the model divides the position into, the row written for it, and a row already
+     * written read back — end to end, where each of the three is a different reader.
+     */
+    @Test
+    void aRowIsWrittenUnderTheNameAndReadBackThroughIt() {
+        Compilation compilation = Compilation.ofSource(MODULE, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        PartitionEvidence evidence = compilation.db()
+                .ask(new Adequacy.Coverage("demo")).value().get("run");
+
+        assertEquals(List.of("Approved", "Rejected"), evidence.axes().get(0).classes());
+        String rows = GeneratedRows.of(compilation, "demo", "run", true,
+                SourceNameResolver.identity());
+        assertTrue(rows.contains("DecisionN(Approved { id = 0 })"), rows);
+        assertTrue(rows.contains("DecisionN(Rejected)"), rows);
+    }
+
+    /** And what an author already wrote is counted, which is the direction a generated row cannot
+     *  show. */
+    @Test
+    void aRowAnAuthorWroteIsCountedAtTheClassItIsIn() {
+        Compilation compilation = Compilation.ofSource(MODULE + """
+                example run
+                    | (DecisionN(Approved { id = 1 })) -> Ok
+                """, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        PartitionEvidence evidence = compilation.db()
+                .ask(new Adequacy.Coverage("demo")).value().get("run");
+
+        assertEquals(java.util.Set.of("Approved"), evidence.axes().get(0).covered());
+    }
+
+    /** The observation of {@code value} written under {@code names}, outermost first. */
+    private ObservedValue wearing(ObservedValue value, String... names) {
+        ObservedValue at = value;
+        for (int i = names.length - 1; i >= 0; i--) {
+            at = new ObservedValue.Constructed(named(names[i]), Map.of("value", at));
+        }
+        return at;
+    }
+
+    private static List<String> written(PartitionClass each) {
+        return each.representatives().candidates().stream().map(FixtureTemplate::text).toList();
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -65,7 +65,7 @@ class ANameGoesBackOnTheWayItCameOffTest {
     }
 
     private PartitionClass classOf(String type, String id) {
-        return Partitions.classesOf(Type.ref(named(type)), symbols).stream()
+        return PartitionClasses.of(Type.ref(named(type)), symbols).stream()
                 .filter(each -> each.id().equals(id)).findFirst().orElseThrow();
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionAPartitionIsDerivedFromIsProvedToBeOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionAPartitionIsDerivedFromIsProvedToBeOneTest.java
@@ -24,6 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * <p>The set is the partition's own. It is not the set a signature admits, nor the set a field
  * admits — those two disagree with each other — so a shape is written out here and a boundary that
  * starts admitting a new one stops this compiling.
+ *
+ * <p>That the walk goes through it is the signature of {@link LocalInspection#inspect} and not
+ * anything here: the phase takes the proof, so a position can be read only after being admitted.
+ * These rows are what admitting one comes to. Asked for the proof after the local phase had
+ * answered, the one shape that produces classes without being admissible — a union nobody named —
+ * would have gone round it, which is the disagreement the whole type is for.
  */
 class APositionAPartitionIsDerivedFromIsProvedToBeOneTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionAPartitionIsDerivedFromIsProvedToBeOneTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionAPartitionIsDerivedFromIsProvedToBeOneTest.java
@@ -1,0 +1,140 @@
+package souther.compiler.partition;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Shape;
+import souther.compiler.check.Symbols;
+import souther.compiler.diag.CompileException;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * That a position is one a partition can be derived from is carried by the input rather than
+ * rechecked, so nothing downstream has to ask and nothing downstream can answer wrongly.
+ *
+ * <p>The set is the partition's own. It is not the set a signature admits, nor the set a field
+ * admits — those two disagree with each other — so a shape is written out here and a boundary that
+ * starts admitting a new one stops this compiling.
+ */
+class APositionAPartitionIsDerivedFromIsProvedToBeOneTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Ok
+            data Prospecting
+            data Won
+            data Stage = Prospecting | Won
+            data StageN = Stage
+            data Cyclic = Cyclic
+            data Slot = { hour: Int, room: String }
+            """;
+
+    private final Symbols symbols = Symbols.of(resolved());
+
+    private static Ast.Module resolved() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    private Shape.PartitionInputShape admit(Type type) {
+        return PartitionInput.of(type, symbols).shape();
+    }
+
+    private Type named(String name) {
+        return Type.ref(symbols.own(name));
+    }
+
+    // --- what a partition may be derived from ---------------------------------------------------
+
+    @Test
+    void everyShapeAValueCanStandAtIsAdmitted() {
+        assertInstanceOf(Shape.Scalar.class, admit(Type.INT));
+        assertInstanceOf(Shape.Unit.class, admit(named("Ok")));
+        assertInstanceOf(Shape.Sum.class, admit(named("Stage")));
+        assertInstanceOf(Shape.Product.class, admit(named("Slot")));
+        assertInstanceOf(Shape.Sequence.class, admit(Type.list(Type.INT)));
+        assertInstanceOf(Shape.Mapping.class, admit(Type.map(Type.STRING, Type.INT)));
+        assertInstanceOf(Shape.Optional.class, admit(Type.option(Type.INT)));
+    }
+
+    /** A name is off before the shape is read, so the position a partition is derived from is the
+     *  same one whether or not the model wrote a name round it (issue #631). */
+    @Test
+    void aNameRoundAPositionDoesNotChangeWhatItIsDerivedFrom() {
+        assertEquals(admit(named("Stage")), admit(named("StageN")));
+    }
+
+    /**
+     * A declaration reachable from itself compiles, so a position typed by one arrives here. It is
+     * admitted — what a reader does with it is say it could not be interpreted, and a compiling
+     * model must not take a path that throws.
+     */
+    @Test
+    void aTypeThisCouldNotInterpretIsAdmittedRatherThanRefused() {
+        assertInstanceOf(Shape.Unresolved.class, admit(named("Cyclic")));
+    }
+
+    // --- and what cannot stand at one ------------------------------------------------------------
+
+    /**
+     * The seven a position cannot have. Each is refused where a signature or a field is read, so one
+     * arriving here is this compiler disagreeing with itself — which is said as that, and never as a
+     * model that divides nothing.
+     */
+    @Test
+    void aShapeNoPositionCanHaveIsThisCompilerDisagreeingWithItself() {
+        List<Type> unreachable = List.of(
+                Type.union(java.util.Set.of(symbols.own("Prospecting"), symbols.own("Won"))),
+                Type.tuple(List.of(Type.INT, Type.STRING)),
+                Type.fn(List.of(Type.INT), Type.INT),
+                Type.NEVER,
+                Type.NOTHING,
+                Type.ERRONEOUS,
+                Type.var("'a"));
+        for (Type type : unreachable) {
+            IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                    () -> admit(type), Type.show(type) + " cannot stand at a position");
+            assertTrue(thrown.getMessage().contains("disagree"),
+                    "says the two readings disagree rather than reporting on the model: "
+                            + thrown.getMessage());
+        }
+    }
+
+    // --- and the boundary really does keep them out ----------------------------------------------
+
+    /**
+     * The set above is written out independently of the boundary's, which is what keeps a change
+     * there from silently changing what is measured here. Independence costs a check that the two
+     * still meet: a shape this calls unreachable has to be one the boundary refuses, or a model
+     * would reach the throw.
+     *
+     * <p>Two of the seven, at the two ways in — a parameter and a field.
+     */
+    @Test
+    void theBoundaryRefusesWhatThisCallsUnreachable() {
+        assertThrows(CompileException.class, () -> souther.compiler.Compiler.compile("""
+                module demo
+                data Ok
+                behavior run : (x: (Int, String)) -> Ok constructs Ok
+                let run (x) = Ok
+                """), "a tuple parameter never reaches a partition");
+
+        assertThrows(CompileException.class, () -> souther.compiler.Compiler.compile("""
+                module demo
+                data Ok
+                data Holder = { f: (Int) -> Int }
+                behavior run : (h: Holder) -> Ok constructs Ok
+                let run (h) = Ok
+                """), "a function field never reaches a partition");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionUnderANameIsReachedThroughItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionUnderANameIsReachedThroughItTest.java
@@ -1,0 +1,140 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+import souther.compiler.report.GeneratedRows;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A record under a name is a record, and everything that reaches into one goes through the name.
+ *
+ * <p>{@link souther.compiler.check.TypeView} says a {@code data SlotN = Slot} is the product
+ * {@code Slot}, so the derivation takes the position apart and the axes are at its fields. That is
+ * one of four readings of the same position, and the other three are what a measure is made of:
+ * a row writes {@code SlotN(Slot { flag = true })} and something has to read it back, something has
+ * to write one, and the clauses relating the record's fields have to reach them.
+ *
+ * <p>Held together because three of them were missing while the first was there. The axis was
+ * derived and no row could be classified at it, no row could be generated for it, and the record's
+ * own rules about its fields were dropped on the way in — a position measured by a measure that
+ * could not measure it.
+ *
+ * <p>Against the bare form in every row, because that is what the claim is: a name is how a value
+ * is written and not what it is, so the two forms are measured alike.
+ */
+class APositionUnderANameIsReachedThroughItTest {
+
+    private static final String FLAGS = """
+            module demo
+
+            data Ok
+            data Slot = { flag: Bool }
+            data SlotN = Slot
+
+            behavior bare : (x: Slot) -> Ok constructs Ok
+            let bare (x) = Ok
+
+            behavior wrapped : (x: SlotN) -> Ok constructs Ok
+            let wrapped (x) = Ok
+
+            example bare
+                | (Slot { flag = true }) -> Ok
+
+            example wrapped
+                | (SlotN(Slot { flag = true })) -> Ok
+            """;
+
+    /** A record whose clauses relate its fields, which is what a position wearing a name would drop
+     *  on the way to them. */
+    private static final String PAIRS = """
+            module demo
+
+            data Ok
+            data N = Int invariant value >= 0 && value <= 10
+            data Pair = { low: N, high: N } invariant low.value < high.value
+            data PairN = Pair
+
+            behavior bare : (p: Pair) -> Ok constructs Ok
+            let bare (p) = Ok
+
+            behavior wrapped : (p: PairN) -> Ok constructs Ok
+            let wrapped (p) = Ok
+            """;
+
+    private static Compilation measured(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static PartitionEvidence evidence(Compilation compilation, String behavior) {
+        PartitionEvidence found = compilation.db()
+                .ask(new Adequacy.Coverage("demo")).value().get(behavior);
+        assertNotNull(found, behavior + " was measured");
+        return found;
+    }
+
+    /** Derive: the position is taken apart at the fields of what the name is written over. */
+    @Test
+    void theFieldsUnderTheNameAreWhereThePositionDivides() {
+        Compilation compilation = measured(FLAGS);
+
+        assertEquals(List.of("x.flag"), evidence(compilation, "wrapped").axes().stream()
+                .map(PartitionEvidence.AxisCoverage::path).toList());
+        assertEquals(List.of("true", "false"),
+                evidence(compilation, "wrapped").axes().get(0).classes());
+    }
+
+    /** Read: a row that wrote the value under the name is counted at the class it is in. */
+    @Test
+    void aRowWrittenUnderTheNameIsReadBackThroughIt() {
+        Compilation compilation = measured(FLAGS);
+
+        assertEquals(Set.of("true"), evidence(compilation, "wrapped").axes().get(0).covered());
+        assertEquals(evidence(compilation, "bare").axes().get(0).covered(),
+                evidence(compilation, "wrapped").axes().get(0).covered(),
+                "a name is how a value is written, not what it is");
+    }
+
+    /** Write: what the row for the class nothing covers is, which is the value under the name. */
+    @Test
+    void aRowOfferedForThePositionIsWrittenUnderTheName() {
+        String rows = GeneratedRows.of(measured(FLAGS), "demo", "wrapped", true,
+                SourceNameResolver.identity());
+
+        assertTrue(rows.contains("(SlotN(Slot { flag = false }))"), rows);
+    }
+
+    /**
+     * And the rules the record writes about its fields reach them.
+     *
+     * <p>Read off the name instead, a wrapped record has no clauses at all: the boundaries its
+     * fields owe come from the ends its own rules leave them, and the rows built for those have to
+     * hold the clause relating the two. Both are counted here, and the second is what a generated
+     * row shows — a `low` at the top of its range beside a `high` that is still above it.
+     */
+    @Test
+    void theRulesARecordWritesAboutItsFieldsReachThemUnderAName() {
+        Compilation compilation = measured(PAIRS);
+
+        assertEquals(evidence(compilation, "bare").boundaries().size(),
+                evidence(compilation, "wrapped").boundaries().size(),
+                "the same record is bounded the same way under a name");
+        assertTrue(evidence(compilation, "wrapped").boundaries().size() >= 4);
+
+        String rows = GeneratedRows.of(compilation, "demo", "wrapped", true,
+                SourceNameResolver.identity());
+        assertTrue(rows.contains("(PairN(Pair { low = N(9), high = N(10) }))"), rows);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -50,7 +50,7 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
                 List.of());
     }
 
-    private static Axis pending(StructuralInspection found) {
+    private static Axis pending(StructuralInspection.Pending found) {
         return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL, found);
     }
 
@@ -61,6 +61,14 @@ class AnAbsenceIsWhatCompletingAPositionProducesTest {
     @Test
     void aPositionWithEvidenceIsNotPending() {
         assertNull(PendingPosition.of(measured()));
+    }
+
+    /** And a position with no evidence that nothing read is not answered for at all: what would be
+     *  said of it is this compiler's state, written down as what the model divides. */
+    @Test
+    void aPositionNothingReadIsNotAnsweredFor() {
+        assertThrows(IllegalStateException.class, () -> PendingPosition.of(
+                new Axis(ID, new NumericTerm.ValueOf(AT), Type.BOOL, List.of(), List.of())));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -27,10 +27,15 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  * nothing could turn into a line. What all of those have in common is that they say something about
  * this compiler, and the sentence they produced says something about the model.
  *
- * <p>So the chain is the type. A position is read; where every producer of local evidence came back
- * with nothing it becomes a {@link PendingPosition}; and only completing one of those with what the
- * rules came to produces a verdict. An absence is the one arm of that where nothing stopped and
- * nothing was found, and there is no other way to one.
+ * <p>So the chain is the type. A position is read; where the producers of local evidence came back
+ * with nothing it becomes a {@link PendingPosition}; and completing one of those with what the
+ * rules came to is what produces the absence. It is the one arm where nothing stopped and nothing
+ * was found.
+ *
+ * <p>What is held here is that arm and its neighbours. That nothing outside this package can start
+ * the chain halfway through is the visibility of {@link PendingPosition}, which no test in this
+ * package can show — the scan below is a tripwire over where the one absence is named, not a proof
+ * that it cannot be reached another way.
  */
 class AnAbsenceIsWhatCompletingAPositionProducesTest {
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnAbsenceIsWhatCompletingAPositionProducesTest.java
@@ -1,0 +1,157 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.EveryShippedMessageCatalogIsCompleteAndValidTest;
+import souther.compiler.types.Type;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * "The model divides this position no way" is the end of a chain, not a value anything can write.
+ *
+ * <p>It was a value anything could write, and everything that could not answer wrote it: a walk
+ * that fell out of the bottom of a chain of conditions, a reader that stopped at a name, a rule
+ * nothing could turn into a line. What all of those have in common is that they say something about
+ * this compiler, and the sentence they produced says something about the model.
+ *
+ * <p>So the chain is the type. A position is read; where every producer of local evidence came back
+ * with nothing it becomes a {@link PendingPosition}; and only completing one of those with what the
+ * rules came to produces a verdict. An absence is the one arm of that where nothing stopped and
+ * nothing was found, and there is no other way to one.
+ */
+class AnAbsenceIsWhatCompletingAPositionProducesTest {
+
+    private static final TermPath AT = TermPath.of("x");
+
+    private static final AxisId ID = AxisId.of("run", new NumericTerm.ValueOf(AT));
+
+    private static Axis measured() {
+        return new Axis(ID, new NumericTerm.ValueOf(AT), Type.BOOL,
+                List.of(PartitionClass.of("true", "true", Classifier.none(),
+                        RepresentativeSource.of(FixtureTemplate.bool(true)))),
+                List.of());
+    }
+
+    private static Axis pending(StructuralInspection found) {
+        return Axis.pendingAt(ID, new NumericTerm.ValueOf(AT), Type.BOOL, found);
+    }
+
+    // --- what can be pending at all -------------------------------------------------------------
+
+    /** A position with evidence is not pending anything, so there is nothing to complete and no way
+     *  to an absence from it. */
+    @Test
+    void aPositionWithEvidenceIsNotPending() {
+        assertNull(PendingPosition.of(measured()));
+    }
+
+    @Test
+    void aPositionWithoutEvidenceIsPendingWhatItsStructureFound() {
+        assertEquals(new PendingPosition.Leaf(AT),
+                PendingPosition.of(pending(new StructuralInspection.Leaf())));
+        assertEquals(new PendingPosition.Blocked(AT, new BlockReason.TypeUnresolved()),
+                PendingPosition.of(pending(
+                        new StructuralInspection.Blocked(new BlockReason.TypeUnresolved()))));
+    }
+
+    // --- and what completing one comes to -------------------------------------------------------
+
+    /** The one arm that reaches an absence: nothing under the position, and every rule about it
+     *  read and drawing nothing. */
+    @Test
+    void aLeafWhoseRulesWereAllReadAndDrewNothingIsAnAbsence() {
+        UndividedPosition done = new PendingPosition.Leaf(AT)
+                .complete(new BodyCutInspection.Exhausted());
+
+        assertTrue(done.isAbsent());
+        assertEquals(AT, done.at());
+    }
+
+    /** A rule about the position that went unread is what it is left with, and not an absence. */
+    @Test
+    void aLeafWhoseRuleWentUnreadSaysThat() {
+        UndividedPosition done = new PendingPosition.Leaf(AT)
+                .complete(new BodyCutInspection.Blocked(new BlockReason.UnreadComparisonForm()));
+
+        assertFalse(done.isAbsent());
+        assertEquals(new UndividedPosition.Why.CannotDerive(
+                UndividedPosition.Reason.UNSUPPORTED_SYNTAX), done.why());
+    }
+
+    /**
+     * A reading that stopped stays what the position is left with, whatever the rules came to.
+     *
+     * <p>Both rows, because the precedence is only visible where the other side has something to
+     * say: where the walk could not reach into what a position holds, a rule naming something
+     * inside it describes the same stop from the other end, and the first is the cause (issue
+     * #626).
+     */
+    @Test
+    void aReadingThatStoppedOutranksWhatTheRulesCameTo() {
+        PendingPosition blocked = new PendingPosition.Blocked(AT,
+                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.SEQUENCE_ELEMENT));
+        UndividedPosition.Why expected = new UndividedPosition.Why.CannotDerive(
+                UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL);
+
+        assertEquals(expected, blocked.complete(new BodyCutInspection.Exhausted()).why());
+        assertEquals(expected, blocked.complete(
+                new BodyCutInspection.Blocked(new BlockReason.UnreadComparisonForm())).why());
+    }
+
+    /** A line drawn at a position whose axis says it has none is two readings disagreeing, and
+     *  neither of them is a thing to report about a model. */
+    @Test
+    void aLineDrawnAtAPositionWithNoEvidenceIsNotAnswered() {
+        assertThrows(IllegalStateException.class, () -> new PendingPosition.Leaf(AT)
+                .complete(new BodyCutInspection.Evidence()));
+        assertThrows(IllegalStateException.class, () -> new PendingPosition
+                .Blocked(AT, new BlockReason.DepthLimit())
+                .complete(new BodyCutInspection.Evidence()));
+    }
+
+    // --- and nothing else makes one -------------------------------------------------------------
+
+    /**
+     * Held over the sources, because what it says cannot be said in a test: outside this package
+     * the absence has no constructor to call and no instance to name, and inside it the one
+     * instance is reached through the completion.
+     *
+     * <p>A tripwire. Naming the field from a third place in this package defeats it, and that is
+     * the line this fails on.
+     */
+    @Test
+    void theAbsenceIsNamedOnlyWhereItIsProduced() throws IOException {
+        List<Path> sources = EveryShippedMessageCatalogIsCompleteAndValidTest.mainSources();
+        assertFalse(sources.isEmpty(), "found no sources at all — the scan missed the tree");
+
+        Set<String> naming = new TreeSet<>();
+        Set<String> producing = new TreeSet<>();
+        for (Path source : sources) {
+            String text = Files.readString(source, StandardCharsets.UTF_8);
+            if (text.contains("Absent.PROVEN")) {
+                naming.add(source.getFileName().toString());
+            }
+            if (text.contains("absentAfter(")) {
+                producing.add(source.getFileName().toString());
+            }
+        }
+
+        assertEquals(Set.of("UndividedPosition.java"), naming,
+                "the one absence is named where it is declared");
+        assertEquals(Set.of("UndividedPosition.java", "PendingPosition.java"), producing,
+                "and is produced by completing a position, which is what makes it a conclusion");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AnObservationSaysTheSameThingWhereverThePathMeetsItTest.java
@@ -67,7 +67,7 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
 
     private static final String POSITION = "request.interval.startsAt";
 
-    private record Read(List<Axis> axes, List<String> parameters, RowOutcome row) {}
+    private record Read(List<Axis> axes, BehaviorInputs inputs, RowOutcome row) {}
 
     private static Read read() {
         Compilation compilation = Compilation.ofSource(MODEL, "Main");
@@ -90,7 +90,9 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
                 .ask(Output.Examples.asked(compilation.db(), module,
                         compilation.sourceIds().get(0))).value();
         assertNotNull(observed);
-        return new Read(partitioning.axes(), parameters, observed.rows().get(0));
+        return new Read(partitioning.axes(),
+                new BehaviorInputs(parameters, sigs.get("book").inputTypes(), symbols),
+                observed.rows().get(0));
     }
 
     /** The row it read, with the request's {@code interval} replaced by whatever stands there. */
@@ -115,7 +117,7 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
     }
 
     private static Incompleteness.Code why(Read read, RowOutcome row) {
-        Map<AxisId, Classification> classes = RowClasses.of(row, read.parameters(), read.axes());
+        Map<AxisId, Classification> classes = RowClasses.of(row, read.inputs(), read.axes());
         Classification where = classes.entrySet().stream()
                 .filter(e -> e.getKey().term().equals(POSITION))
                 .map(Map.Entry::getValue).findFirst()
@@ -191,12 +193,11 @@ class AnObservationSaysTheSameThingWhereverThePathMeetsItTest {
         Read read = read();
 
         assertInstanceOf(ObservedValue.Truncated.class,
-                RowClasses.valueAt(givingInterval(read, intervalHolding(read,
-                        new ObservedValue.Truncated())), read.parameters(), position(read)),
+                read.inputs().valueAt(givingInterval(read, intervalHolding(read,
+                        new ObservedValue.Truncated())), position(read)),
                 "the limit was reached at the position");
         assertInstanceOf(ObservedValue.Truncated.class,
-                RowClasses.valueAt(givingInterval(read, new ObservedValue.Truncated()),
-                        read.parameters(), position(read)),
+                read.inputs().valueAt(givingInterval(read, new ObservedValue.Truncated()), position(read)),
                 "the limit was reached one field above the position");
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -195,7 +195,8 @@ class GeneratorTest {
         for (long each : candidates) {
             values.add(FixtureTemplate.integer(each));
         }
-        return PartitionClass.of(id, id, _ -> Membership.NO_MATCH, () -> values);
+        return PartitionClass.of(id, id, _ -> Membership.NO_MATCH,
+                RepresentativeSource.of(values));
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -105,7 +105,8 @@ class GeneratorTest {
         Sig sig = sigs.get(behavior);
         List<String> parameters = spec.params().stream().map(Ast.Param::name).toList();
         Partitions.Partitioning partitioning = Partitions.of(spec, sig, symbols, Exclusions.NONE);
-        return new Model(new Generator.Subject(parameters, sig.inputTypes(), partitioning.axes(), symbols),
+        return new Model(new Generator.Subject(
+                new BehaviorInputs(parameters, sig.inputTypes(), symbols), partitioning.axes()),
                 symbols);
     }
 
@@ -186,8 +187,9 @@ class GeneratorTest {
                 List.of());
         Axis b = new Axis(new AxisId("f", "b"), new NumericTerm.ValueOf(TermPath.of("b")), Type.INT, right,
                 List.of());
-        return new Generator.Subject(List.of("a", "b"), List.of(Type.INT, Type.INT), List.of(a, b),
-                symbols);
+        return new Generator.Subject(
+                new BehaviorInputs(List.of("a", "b"), List.of(Type.INT, Type.INT), symbols),
+                List.of(a, b));
     }
 
     private static PartitionClass number(String id, long... candidates) {
@@ -364,8 +366,8 @@ class GeneratorTest {
         Symbols symbols = modelOf(TRIP, "submit").symbols();
         Axis only = new Axis(new AxisId("f", "a"), new NumericTerm.ValueOf(TermPath.of("a")), Type.INT,
                 List.of(number("low", 1), number("high", 9)), List.of());
-        Generator.Subject subject = new Generator.Subject(List.of("a"), List.of(Type.INT),
-                List.of(only), symbols);
+        Generator.Subject subject = new Generator.Subject(
+                new BehaviorInputs(List.of("a"), List.of(Type.INT), symbols), List.of(only));
 
         Generator.GenerationResult filled =
                 Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY);

--- a/souther-compiler/src/test/java/souther/compiler/partition/LocalEvidenceIsAskedOfBothProducersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/LocalEvidenceIsAskedOfBothProducersTest.java
@@ -59,7 +59,8 @@ class LocalEvidenceIsAskedOfBothProducersTest {
     }
 
     private LocalInspection inspect(String type) {
-        return LocalInspection.inspect(TypeView.of(Type.ref(symbols.own(type)), symbols),
+        return LocalInspection.inspect(
+                PartitionInput.of(TypeView.of(Type.ref(symbols.own(type)), symbols)),
                 TermPath.of("x"), symbols, null);
     }
 

--- a/souther-compiler/src/test/java/souther/compiler/partition/LocalEvidenceIsAskedOfBothProducersTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/LocalEvidenceIsAskedOfBothProducersTest.java
@@ -1,0 +1,123 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Symbols;
+import souther.compiler.check.TypeView;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.Type;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What a position's own type and rules say is one answer, and it comes from asking both producers.
+ *
+ * <p>The classes a type states and the lines its rules draw were two lists, and "local evidence has
+ * run out" was a caller noticing that both were empty. Anything that read one of them and went on
+ * would have concluded it from half the evidence — and what follows from that conclusion is the
+ * whole rest of the derivation, since only an exhausted local reading licenses asking what is under
+ * the position.
+ *
+ * <p>So {@code Exhausted} is a value nothing but the reading can produce, and {@code Evidence}
+ * cannot be built empty. These hold that from the outside: the three shapes of local answer, and
+ * the two ways of writing one that says nothing while claiming to say something.
+ *
+ * <p>Over the positions the language can currently be in, which is the whole claim. A position
+ * carrying both local evidence and children would say something further about the precedence, and
+ * no model can be written that has one — only products have children, and a product carries neither
+ * classes nor cuts. Building one out of a hand-made {@code Shape} would fix the implementation's
+ * product space rather than the language's, so the rows here are the reachable ones.
+ */
+class LocalEvidenceIsAskedOfBothProducersTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Prospecting
+            data Qualified
+            data Won
+            data Stage = Prospecting | Qualified | Won
+
+            data Amount = Int invariant value >= 100
+            data Plain = Int
+            data Slot = { hour: Int, room: String }
+            """;
+
+    private final Symbols symbols = Symbols.of(resolved());
+
+    private static Ast.Module resolved() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    private LocalInspection inspect(String type) {
+        return LocalInspection.inspect(TypeView.of(Type.ref(symbols.own(type)), symbols),
+                TermPath.of("x"), symbols, null);
+    }
+
+    /** A type that states cases: evidence, and no line drawn through them. */
+    @Test
+    void classesAndNoLineIsEvidence() {
+        LocalInspection.Evidence found =
+                assertInstanceOf(LocalInspection.Evidence.class, inspect("Stage"));
+
+        assertEquals(List.of("Prospecting", "Qualified", "Won"),
+                found.classes().stream().map(PartitionClass::id).toList());
+        assertInstanceOf(CutEvidence.None.class, found.cuts());
+    }
+
+    /** A rule that says where the values stop: evidence, and no class either side of the line —
+     *  everything outside it is refused at construction. */
+    @Test
+    void aLineAndNoClassIsEvidenceToo() {
+        LocalInspection.Evidence found =
+                assertInstanceOf(LocalInspection.Evidence.class, inspect("Amount"));
+
+        assertEquals(List.of(), found.classes());
+        assertInstanceOf(CutEvidence.Present.class, found.cuts());
+        assertTrue(found.cuts().cuts().size() >= 1);
+    }
+
+    /** Neither producer had anything, which is the answer that licenses asking what is under the
+     *  position — and is not the same as either of them being empty. */
+    @Test
+    void neitherIsExhausted() {
+        assertInstanceOf(LocalInspection.Exhausted.class, inspect("Plain"));
+        assertInstanceOf(LocalInspection.Exhausted.class, inspect("Slot"));
+    }
+
+    /** The reading is there either way: what the position is measured at is not a thing only a
+     *  position with evidence has. */
+    @Test
+    void theReadingIsTheSameValueWhicheverAnswerItIs() {
+        for (String type : List.of("Stage", "Amount", "Plain", "Slot")) {
+            LocalReading reading = inspect(type).reading();
+            assertNotNull(reading.term(), type + " is measured at some term");
+            assertNotNull(reading.unread(), type + " says which of its rules went unread");
+        }
+    }
+
+    /** An answer that says nothing cannot be written as one that says something. */
+    @Test
+    void anEmptyEvidenceIsNotAnAnswer() {
+        LocalReading reading = inspect("Plain").reading();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> new LocalInspection.Evidence(reading, List.of(), new CutEvidence.None()));
+    }
+
+    /** And neither can no lines at all be written as lines. */
+    @Test
+    void noCutsIsNotAPresentCut() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CutEvidence.Present(List.of(), false));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
@@ -417,8 +417,10 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
         for (String behavior : behaviors) {
             PartitionEvidence evidence = coverage.get(behavior);
             assertNotNull(evidence, behavior + " was measured");
+            // Through the projection a report goes through, which is what this table is of: what
+            // this compiler could not do is recorded in its own words and said in the document's.
             UndividedPosition.Reason unread = evidence.unread().isEmpty() ? null
-                    : evidence.unread().get(0).why();
+                    : ReportedReason.of(evidence.unread().get(0).why());
             out.put(behavior, new Measured(evidence.axes().size(),
                     evidence.boundaries().size(), unread));
         }

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
@@ -44,7 +44,7 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
      * @param obligations lines some rule drew that a row is owed at
      * @param unread      what stopped a rule being read, or null where nothing did
      */
-    private record Measured(int axes, int obligations, String unread) {}
+    private record Measured(int axes, int obligations, UndividedPosition.Reason unread) {}
 
     /** A carrier read all the way through: an axis, the line and the value beside it where the
      *  values step, and nothing left unread. */
@@ -418,23 +418,12 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
         for (String behavior : behaviors) {
             PartitionEvidence evidence = coverage.get(behavior);
             assertNotNull(evidence, behavior + " was measured");
-            String unread = evidence.unread().isEmpty() ? null
-                    : said(evidence.unread().get(0).why());
+            UndividedPosition.Reason unread = evidence.unread().isEmpty() ? null
+                    : evidence.unread().get(0).why();
             out.put(behavior, new Measured(evidence.axes().size(),
                     evidence.boundaries().size(), unread));
         }
         return out;
-    }
-
-    /** The reason as the report writes it, so a cell says what an author would read. */
-    private static String said(UndividedPosition.Reason reason) {
-        return switch (reason) {
-            case UNSUPPORTED_SYNTAX -> "a comparison here is written in a form this does not read";
-            case UNSUPPORTED_DOMAIN -> "it is compared against values no line can be drawn on here";
-            case UNSUPPORTED_PARTITION_SHAPE ->
-                    "the comparison relates it to another position rather than dividing it";
-            case DEPTH_LIMIT -> "the walk stopped before reaching what is under it";
-        };
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneCarrierTableAnswersForEveryOrderedTypeTest.java
@@ -251,23 +251,27 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
         expected.put("guardDayWrapped", read(2));
         expected.put("guardMomentWrapped", read(2));
         expected.put("guardTextWrapped", read(1));
-        // Not what the bare position answers, and not what this row is about. The line is drawn —
-        // the carrier is asked of what the name wraps, as it is for every other newtype here — and
-        // the classes are gone: a newtype over a sum loses the sum's cases, because the classes
-        // reader stops at the name instead of reading what it wraps. Written down as it is rather
-        // than as it should be, because changing it is a different reader's work, and left in the
-        // table so that fixing it is a cell that stops matching.
-        expected.put("guardStageWrapped", new Measured(0, 2, null));
+        // What the bare position answers. The classes reader reads through the name now, as the
+        // carrier always did, so the cell that was a name changing what a rule means is a cell that
+        // says the two forms are one.
+        expected.put("guardStageWrapped", readBesideItsClasses(2));
 
         assertEquals(expected, measured(expected.keySet()));
     }
 
     /**
-     * The same rule written as an invariant, which draws a line and no class.
+     * The same rule written as an invariant, which draws a line and adds no class.
      *
      * <p>Everything outside a bound is refused at construction, so there is no class on the far side
-     * to cover and the position has one edge worth a row (ADR-0090) — which is why every cell here
-     * has no axis and the {@code guard} cells above have one.
+     * to cover and the position has one edge worth a row (ADR-0090) — which is why the cells over a
+     * range have no axis and the {@code guard} cells above have one.
+     *
+     * <p>The enumeration is the exception, and it is the bound adding nothing rather than the bound
+     * being read differently: an enumeration's type states its cases whatever any rule says, so the
+     * axis is there before the invariant is read. What the invariant does is take away the cases
+     * outside it — {@code value >= Qualified} leaves two of the three — because a class is a set of
+     * values the position holds, and a class for a value refused at construction is a row nobody
+     * can write.
      */
     @Test
     void anInvariantsBoundIsDrawnOnTheSameCarriers() {
@@ -277,10 +281,11 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
         expected.put("boundDay", new Measured(0, 1, null));
         expected.put("boundMoment", new Measured(0, 1, null));
         expected.put("boundText", new Measured(0, 1, null));
-        expected.put("boundStage", new Measured(0, 1, null));
+        expected.put("boundStage", new Measured(1, 1, null));
 
         assertEquals(expected, measured(expected.keySet()));
     }
+
 
     /**
      * And the two rows say the same thing about the same carriers.
@@ -310,29 +315,23 @@ class OneCarrierTableAnswersForEveryOrderedTypeTest {
      * And a name wrapped round the values does not change the answer.
      *
      * <p>A newtype is the value it carries, so a rule about it is the rule about what it wraps. The
-     * enumeration is left out here and not silently passed over: the line is drawn on both forms and
-     * only the wrapped one loses its classes, which is the classes reader stopping at the name and
-     * not the carrier table. The cell above says so, and this row would say it as a carrier problem.
+     * enumeration is a row here like the rest: it used to be the one carrier where the two forms
+     * differed, because the reader that drew the line read through the name and the reader that
+     * asked what the position divides into stopped at it (issue #631). One reading answers both
+     * now, so the row that recorded the disagreement is the row that holds it closed.
      */
     @Test
     void aNameWrappedRoundTheValuesDoesNotChangeWhatIsMeasured() {
         Map<String, Measured> all = measured(List.of(
                 "guardWholeBare", "guardDenseBare", "guardDayBare", "guardMomentBare",
-                "guardTextBare",
+                "guardTextBare", "guardStageBare",
                 "guardWholeWrapped", "guardDenseWrapped", "guardDayWrapped", "guardMomentWrapped",
-                "guardTextWrapped"));
+                "guardTextWrapped", "guardStageWrapped"));
 
-        for (String carrier : List.of("Whole", "Dense", "Day", "Moment", "Text")) {
+        for (String carrier : List.of("Whole", "Dense", "Day", "Moment", "Text", "Stage")) {
             assertEquals(all.get("guard" + carrier + "Bare"), all.get("guard" + carrier + "Wrapped"),
                     carrier + ": a newtype is the value it carries");
         }
-        // The half of it that does hold of the enumeration, asked here so that the exception above
-        // is the classes and nothing more: the same line, drawn on the same carrier, either side of
-        // the name.
-        Map<String, Measured> stage = measured(List.of("guardStageBare", "guardStageWrapped"));
-        assertEquals(stage.get("guardStageBare").obligations(),
-                stage.get("guardStageWrapped").obligations(),
-                "Stage: a newtype is the value it carries, whatever the classes reader does");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/OneProjectionWritesTheWordADocumentReadsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/OneProjectionWritesTheWordADocumentReadsTest.java
@@ -1,0 +1,77 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.EveryShippedMessageCatalogIsCompleteAndValidTest;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * The word an adequacy document writes is written in one place.
+ *
+ * <p>{@link BlockReason} is what this compiler could not do and {@link UndividedPosition.Reason} is
+ * what a document promises its reader they can tell apart. The two are kept at different speeds on
+ * purpose: a capability gained here removes a case here and need not move a published vocabulary.
+ * That only holds while one projection sits between them — a second producer naming a published
+ * word is a reader deciding for itself what the document says, and the coarsening stops being
+ * reviewable in one place.
+ *
+ * <p>Held over the sources because it is not a thing a type can say. The published words are an
+ * enum and anything can name one; what is being held is that nothing does.
+ *
+ * <p>A tripwire and not a proof. A constant lifted into a field, or a switch that returns one from
+ * somewhere else, defeats it — and the reading that would have to be added first is the one this
+ * fails on.
+ */
+class OneProjectionWritesTheWordADocumentReadsTest {
+
+    @Test
+    void nothingButTheProjectionNamesAPublishedReason() throws IOException {
+        List<Path> sources = EveryShippedMessageCatalogIsCompleteAndValidTest.mainSources();
+        assertFalse(sources.isEmpty(), "found no sources at all — the scan missed the tree");
+
+        Set<String> naming = new TreeSet<>();
+        for (Path source : sources) {
+            String text = Files.readString(source, StandardCharsets.UTF_8);
+            if (text.contains("UndividedPosition.Reason.")) {
+                naming.add(source.getFileName().toString());
+            }
+        }
+
+        assertEquals(Set.of("ReportedReason.java"), naming,
+                "a published reason is written by the one projection; a producer naming one has"
+                        + " decided for itself what the document says");
+    }
+
+    /** And the projection answers every reason there is, which the switch holds — this says the
+     *  switch is reached at all, over the cases a reader here can name. */
+    @Test
+    void everyInternalReasonHasAWordToBeSaidIn() {
+        List<BlockReason> all = List.of(
+                new BlockReason.TypeUnresolved(),
+                new BlockReason.DepthLimit(),
+                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.SEQUENCE_ELEMENT),
+                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.OPTIONAL_VALUE),
+                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.MAPPING_CONTENT),
+                new BlockReason.UnreadComparisonForm(),
+                new BlockReason.UnreadComparisonDomain(),
+                new BlockReason.ComparisonBetweenPositions());
+
+        for (BlockReason each : all) {
+            assertFalse(ReportedReason.of(each) == null, each + " has a word");
+        }
+        assertEquals(1, all.stream().map(ReportedReason::of).distinct().toList().stream()
+                        .filter(word -> word == UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL)
+                        .count(),
+                "the three traversals are one word, which is the coarsening this projection is for");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/RowClassesTest.java
@@ -57,7 +57,7 @@ class RowClassesTest {
             }
             """;
 
-    private record Read(List<Axis> axes, List<String> parameters, List<RowOutcome> rows) {}
+    private record Read(List<Axis> axes, BehaviorInputs inputs, List<RowOutcome> rows) {}
 
     private static Read read(String source) {
         Compilation compilation = Compilation.ofSource(source, "Main");
@@ -83,7 +83,9 @@ class RowClassesTest {
                 .ask(Output.Examples.asked(compilation.db(), module,
                         compilation.sourceIds().get(0))).value();
         assertNotNull(observed);
-        return new Read(partitioning.axes(), parameters, observed.rows());
+        return new Read(partitioning.axes(),
+                new BehaviorInputs(parameters, sigs.get("submit").inputTypes(), symbols),
+                observed.rows());
     }
 
     private static Classification at(Map<AxisId, Classification> classes, String path) {
@@ -102,7 +104,7 @@ class RowClassesTest {
                 """);
 
         Map<AxisId, Classification> classes =
-                RowClasses.of(read.rows().get(0), read.parameters(), read.axes());
+                RowClasses.of(read.rows().get(0), read.inputs(), read.axes());
 
         assertEquals(new Classification.Classified("Domestic"), at(classes, "request.kind"));
         assertEquals(new Classification.Classified("request.cost/0 <= x <= 100"),
@@ -118,7 +120,7 @@ class RowClassesTest {
                 """);
 
         Map<AxisId, Classification> classes =
-                RowClasses.of(read.rows().get(0), read.parameters(), read.axes());
+                RowClasses.of(read.rows().get(0), read.inputs(), read.axes());
 
         assertEquals(new Classification.Classified("Overseas"), at(classes, "request.kind"));
         assertEquals(new Classification.Classified("request.cost/100 < x"),
@@ -135,7 +137,7 @@ class RowClassesTest {
                 """);
 
         Map<AxisId, Classification> classes =
-                RowClasses.of(read.rows().get(0), read.parameters(), read.axes());
+                RowClasses.of(read.rows().get(0), read.inputs(), read.axes());
 
         assertTrue(classes.keySet().stream().noneMatch(a -> a.term().equals("request.memo")),
                 "a plain String is not divided, so there is no class to be in");
@@ -162,7 +164,7 @@ class RowClassesTest {
                 List.of(new ObservedValue.Constructed(request.type(), broken)), row.hits(), row.stepsSpent());
 
         Map<AxisId, Classification> classes =
-                RowClasses.of(damaged, read.parameters(), read.axes());
+                RowClasses.of(damaged, read.inputs(), read.axes());
 
         assertEquals(new Classification.Classified("Domestic"), at(classes, "request.kind"),
                 "the readable field still answers");
@@ -182,7 +184,7 @@ class RowClassesTest {
         assertEquals(List.of(), row.inputs(), "the fixture never built");
 
         Map<AxisId, Classification> classes =
-                RowClasses.of(row, read.parameters(), read.axes());
+                RowClasses.of(row, read.inputs(), read.axes());
 
         assertTrue(classes.values().stream().noneMatch(Classification::isClassified));
     }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
@@ -1,0 +1,106 @@
+package souther.compiler.partition;
+
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.PartitionEvidence;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Models that end a derivation different ways, each reported as what actually happened.
+ *
+ * <p>They are here together because they are the failure modes the protocol is for, and each
+ * of them was one sentence before: a position the model does not divide. Read as a table, the rows
+ * say that the report follows the evidence — what was found, what could not be interpreted, what
+ * could not be reached, and what a rule in a body answered for after the structure ran out.
+ */
+class WhatStoppedADerivationIsWhatIsReportedTest {
+
+    private static PartitionEvidence measured(String model, String behavior) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        Map<String, PartitionEvidence> coverage =
+                compilation.db().ask(new Adequacy.Coverage("demo")).value();
+        assertNotNull(coverage, "the model under test compiles");
+        PartitionEvidence evidence = coverage.get(behavior);
+        assertNotNull(evidence, behavior + " was measured");
+        return evidence;
+    }
+
+    private static UndividedPosition.Why whyAt(PartitionEvidence evidence, String position) {
+        return evidence.notDerivable().stream()
+                .filter(each -> each.at().toString().equals(position))
+                .map(UndividedPosition::why)
+                .findFirst().orElse(null);
+    }
+
+    /**
+     * A declaration reachable from itself compiles, so its position is measured. Nothing about its
+     * values could be worked out, and that is what is said — rather than that the model divides it
+     * no way, which is a claim about the model this compiler is in no position to make.
+     */
+    @Test
+    void aTypeThisCouldNotInterpretIsSaidToBeThatRatherThanAnAbsence() {
+        UndividedPosition.Why why = whyAt(measured("""
+                module demo
+                data Ok
+                data Cyclic = Cyclic
+                behavior run : (x: Cyclic) -> Ok constructs Ok
+                let run (x) = Ok
+                """, "run"), "x");
+
+        assertEquals(new UndividedPosition.Why.CannotDerive(
+                UndividedPosition.Reason.TYPE_UNRESOLVED), why);
+    }
+
+    /**
+     * Issue #626. The threshold is on a list element, and the elements cannot be reached. What was
+     * reported is that the comparison is written in a form this does not read, which is a different
+     * cause — the form is read perfectly well, and it names a position under a collection.
+     */
+    @Test
+    void aThresholdOnAnElementSaysTheElementsCouldNotBeReached() {
+        UndividedPosition.Why why = whyAt(measured("""
+                module demo
+                data Ok
+                data Item = { charge: Int }
+                behavior run : (items: List<Item>) -> Ok constructs Ok
+                let run (items) =
+                    { guard List.length(List.filter((i) -> i.charge >= 21000, items)) < 1 else Ok
+                      Ok }
+                """, "run"), "items");
+
+        assertEquals(new UndividedPosition.Why.CannotDerive(
+                UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL), why);
+    }
+
+    /**
+     * And the other side of that. A collection's elements cannot be reached either, and a rule that
+     * measures the collection itself still draws its line — so a block is what a position is left
+     * with rather than a verdict on it, and this row is what stops that being forgotten.
+     */
+    @Test
+    void aRuleMeasuringTheCollectionItselfIsStillMeasured() {
+        PartitionEvidence evidence = measured("""
+                module demo
+                data Ok
+                data Item = { charge: Int }
+                behavior run : (items: List<Item>) -> Ok constructs Ok
+                let run (items) = { guard List.length(items) < 3 else Ok
+                    Ok }
+                """, "run");
+
+        assertEquals(1, evidence.axes().size(), "the length is a line on the position itself");
+        assertTrue(evidence.boundaries().size() >= 1, "and it owes rows at its edges");
+        assertEquals(List.of(), evidence.notDerivable(),
+                "so nothing is left to report about the position");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
@@ -83,6 +83,34 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
     }
 
     /**
+     * Issue #631. A sum under a name is that sum, so the position divides into its cases — where
+     * before it came back as one the model divides no way, which is the opposite of what the
+     * declaration says. Nothing about the reading of the model changed to make this true: the line
+     * a {@code guard} drew on the same position always read through the name, and it is the reading
+     * that asks what a position divides into that stopped there.
+     *
+     * <p>What the row is written as, and what a row already written is read back through, are
+     * {@link ANameGoesBackOnTheWayItCameOffTest}'s — an axis needs all three.
+     */
+    @Test
+    void aSumUnderANameDividesIntoTheCasesItWraps() {
+        PartitionEvidence evidence = measured("""
+                module demo
+                data Ok
+                data Rejected
+                data Approved = { id: Int }
+                data Decision = Approved | Rejected
+                data DecisionN = Decision
+                behavior run : (x: DecisionN) -> Ok constructs Ok
+                let run (x) = Ok
+                """, "run");
+
+        assertEquals(List.of("Approved", "Rejected"), evidence.axes().get(0).classes());
+        assertEquals(List.of(), evidence.notDerivable(),
+                "so there is nothing left to report about the position");
+    }
+
+    /**
      * And the other side of that. A collection's elements cannot be reached either, and a rule that
      * measures the collection itself still draws its line — so a block is what a position is left
      * with rather than a verdict on it, and this row is what stops that being forgotten.

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatStoppedADerivationIsWhatIsReportedTest.java
@@ -83,6 +83,34 @@ class WhatStoppedADerivationIsWhatIsReportedTest {
     }
 
     /**
+     * And a rule the second phase read and could do nothing with does not take the first phase's
+     * answer away.
+     *
+     * <p>The elements of the list cannot be reached, which is what the position is left with. A
+     * body then compares the length against a number outside what a length can be: the comparison
+     * is understood — it is a threshold, on a term this measures — and it divides nothing, because
+     * no value of the position is on the far side of it.
+     *
+     * <p>So the position comes back to the same place it was, and what it is left with is what it
+     * was left with. It came back an absence instead, because the axis was rebuilt from its parts
+     * when the second phase moved it and the parts did not include what the first phase found.
+     */
+    @Test
+    void aRuleThatDividedNothingLeavesThePositionWithWhatItHad() {
+        UndividedPosition.Why why = whyAt(measured("""
+                module demo
+                data Ok
+                data Item = { charge: Int }
+                behavior run : (items: List<Item>) -> Ok constructs Ok
+                let run (items) = { guard List.length(items) < -1 else Ok
+                    Ok }
+                """, "run"), "items");
+
+        assertEquals(new UndividedPosition.Why.CannotDerive(
+                UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL), why);
+    }
+
+    /**
      * Issue #631. A sum under a name is that sum, so the position divides into its cases — where
      * before it came back as one the model divides no way, which is the opposite of what the
      * declaration says. Nothing about the reading of the model changed to make this true: the line

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyADerivationStoppedIsNotWhatAReportPromisesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyADerivationStoppedIsNotWhatAReportPromisesTest.java
@@ -27,7 +27,7 @@ class WhyADerivationStoppedIsNotWhatAReportPromisesTest {
     void everyMissingTraversalIsOneWordInAReport() {
         for (BlockReason.Traversal traversal : BlockReason.Traversal.values()) {
             assertEquals(UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL,
-                    BlockReason.reported(new BlockReason.UnsupportedTraversal(traversal)),
+                    ReportedReason.of(new BlockReason.UnsupportedTraversal(traversal)),
                     traversal + " is reported as a traversal this does not make");
         }
     }
@@ -36,9 +36,9 @@ class WhyADerivationStoppedIsNotWhatAReportPromisesTest {
     @Test
     void theOthersAreTheirOwnWord() {
         assertEquals(UndividedPosition.Reason.TYPE_UNRESOLVED,
-                BlockReason.reported(new BlockReason.TypeUnresolved()));
+                ReportedReason.of(new BlockReason.TypeUnresolved()));
         assertEquals(UndividedPosition.Reason.DEPTH_LIMIT,
-                BlockReason.reported(new BlockReason.DepthLimit()));
+                ReportedReason.of(new BlockReason.DepthLimit()));
     }
 
     /**
@@ -63,7 +63,7 @@ class WhyADerivationStoppedIsNotWhatAReportPromisesTest {
                 new BlockReason.TypeUnresolved(),
                 new BlockReason.DepthLimit(),
                 new BlockReason.UnsupportedTraversal(BlockReason.Traversal.SEQUENCE_ELEMENT)}) {
-            assertNotNull(BlockReason.reported(reason), reason + " is reported as something");
+            assertNotNull(ReportedReason.of(reason), reason + " is reported as something");
         }
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyADerivationStoppedIsNotWhatAReportPromisesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyADerivationStoppedIsNotWhatAReportPromisesTest.java
@@ -1,0 +1,69 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Two vocabularies, on purpose. What this compiler could not do is recorded as precisely as it is
+ * worth recording; what a document promises its reader they can tell apart is coarser, and moves
+ * when a reader would act on the difference rather than when a capability changes here.
+ *
+ * <p>Held as one type, the coarse one governed the precise one: a reason could not be made sharper
+ * without widening a published vocabulary, so the pressure was always back to a word that already
+ * existed. The projection is what keeps them apart while keeping them honest.
+ */
+class WhyADerivationStoppedIsNotWhatAReportPromisesTest {
+
+    /**
+     * The collapse, written down where it can be reviewed. Three missing traversals are one word a
+     * report writes, because a reader of the report cannot act on which of them it was — the model
+     * is the same either way.
+     */
+    @Test
+    void everyMissingTraversalIsOneWordInAReport() {
+        for (BlockReason.Traversal traversal : BlockReason.Traversal.values()) {
+            assertEquals(UndividedPosition.Reason.UNSUPPORTED_TRAVERSAL,
+                    BlockReason.reported(new BlockReason.UnsupportedTraversal(traversal)),
+                    traversal + " is reported as a traversal this does not make");
+        }
+    }
+
+    /** And the ones a reader can act on differently keep their own word. */
+    @Test
+    void theOthersAreTheirOwnWord() {
+        assertEquals(UndividedPosition.Reason.TYPE_UNRESOLVED,
+                BlockReason.reported(new BlockReason.TypeUnresolved()));
+        assertEquals(UndividedPosition.Reason.DEPTH_LIMIT,
+                BlockReason.reported(new BlockReason.DepthLimit()));
+    }
+
+    /**
+     * Which traversals are told apart here is a claim about what would lift each: choosing among a
+     * sequence's elements, choosing whether an optional holds one, and deciding what part of a
+     * mapping a rule is about are three pieces of work. Written out so that collapsing two of them
+     * is a change to this test rather than a quiet edit.
+     */
+    @Test
+    void theTraversalsToldApartAreTheOnesLiftedByDifferentWork() {
+        assertEquals(Set.of(BlockReason.Traversal.SEQUENCE_ELEMENT,
+                        BlockReason.Traversal.OPTIONAL_VALUE,
+                        BlockReason.Traversal.MAPPING_CONTENT),
+                Set.of(BlockReason.Traversal.values()));
+    }
+
+    /** Every reason has a word. The compiler holds this — the projection carries no {@code default}
+     *  — and this says so where a reader looks for it. */
+    @Test
+    void everyReasonHasAWord() {
+        for (BlockReason reason : new BlockReason[] {
+                new BlockReason.TypeUnresolved(),
+                new BlockReason.DepthLimit(),
+                new BlockReason.UnsupportedTraversal(BlockReason.Traversal.SEQUENCE_ELEMENT)}) {
+            assertNotNull(BlockReason.reported(reason), reason + " is reported as something");
+        }
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
@@ -68,7 +68,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
                 | (Request { kind = Domestic, cost = Amount(50), plain = 1 }) -> Submitted
             """;
 
-    private record Read(List<Axis> axes, List<String> parameters, RowOutcome row) {}
+    private record Read(List<Axis> axes, BehaviorInputs inputs, RowOutcome row) {}
 
     private static Read read() {
         Compilation compilation = Compilation.ofSource(MODEL, "Main");
@@ -91,7 +91,9 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
                 .ask(Output.Examples.asked(compilation.db(), module,
                         compilation.sourceIds().get(0))).value();
         assertNotNull(observed);
-        return new Read(partitioning.axes(), parameters, observed.rows().get(0));
+        return new Read(partitioning.axes(),
+                new BehaviorInputs(parameters, sigs.get("submit").inputTypes(), symbols),
+                observed.rows().get(0));
     }
 
     /** The row it read, with one of the request's fields replaced. */
@@ -116,7 +118,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
     }
 
     private static Classification at(Read read, RowOutcome row, String path) {
-        Map<AxisId, Classification> classes = RowClasses.of(row, read.parameters(), read.axes());
+        Map<AxisId, Classification> classes = RowClasses.of(row, read.inputs(), read.axes());
         return classes.entrySet().stream().filter(e -> e.getKey().term().equals(path))
                 .map(Map.Entry::getValue).findFirst()
                 .orElseThrow(() -> new AssertionError("no axis at " + path));
@@ -189,7 +191,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
         RowOutcome row = giving(read, "plain", new ObservedValue.Text("x"));
 
         assertThrows(IllegalStateException.class,
-                () -> RowClasses.of(row, read.parameters(), read.axes()));
+                () -> RowClasses.of(row, read.inputs(), read.axes()));
     }
 
     /** And a value every class could read still lands where it did. */
@@ -236,7 +238,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
                 _ -> Membership.MATCH);
 
         assertEquals(new Classification.Classified("c2"),
-                RowClasses.of(read.row(), read.parameters(), axes).values().iterator().next());
+                RowClasses.of(read.row(), read.inputs(), axes).values().iterator().next());
     }
 
     /**
@@ -254,7 +256,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
                 _ -> Membership.NO_MATCH, _ -> Membership.NO_MATCH);
 
         IllegalStateException thrown = assertThrows(IllegalStateException.class,
-                () -> RowClasses.of(read.row(), read.parameters(), axes));
+                () -> RowClasses.of(read.row(), read.inputs(), axes));
         org.junit.jupiter.api.Assertions.assertTrue(
                 thrown.getMessage().contains("holds a value it read"), thrown.getMessage());
     }
@@ -274,7 +276,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
                 _ -> new Membership.Incomplete(Incompleteness.Code.VALUE_UNREADABLE));
 
         IllegalStateException thrown = assertThrows(IllegalStateException.class,
-                () -> RowClasses.of(read.row(), read.parameters(), axes));
+                () -> RowClasses.of(read.row(), read.inputs(), axes));
         org.junit.jupiter.api.Assertions.assertTrue(
                 thrown.getMessage().contains("disagree about why"), thrown.getMessage());
     }

--- a/souther-compiler/src/test/java/souther/compiler/report/AWordTheSchemaAdmitsIsOneADocumentCarriesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/report/AWordTheSchemaAdmitsIsOneADocumentCarriesTest.java
@@ -1,0 +1,64 @@
+package souther.compiler.report;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.diag.SourceNameResolver;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The two words this branch added to the published vocabulary, in a document.
+ *
+ * <p>The schema says which words a {@code notDerivable} reason may be, and a test next door holds
+ * that list against the enum it spells. Neither of them says a word is ever written: a vocabulary
+ * and a document are different things, and a word promised by one and emitted by neither is what
+ * that test was written after.
+ *
+ * <p>So these are the two models the words are for, taken to the document a build reads. A
+ * declaration reachable from itself is a type this could not work out; a threshold on a list's
+ * elements is values held inside something the walk does not reach into. Both compile, which is why
+ * a report is asked about them at all.
+ *
+ * <p>The version is unchanged by their arrival, and the schema says why in its own words: a word
+ * added to an enumerated field is one no earlier document carried, so a document written before it
+ * existed is still a document of this version.
+ */
+class AWordTheSchemaAdmitsIsOneADocumentCarriesTest {
+
+    private static String reportOf(String model) {
+        Compilation compilation = Compilation.ofSource(model, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return AdequacyReport.of(compilation).json(SourceNameResolver.identity());
+    }
+
+    @Test
+    void aTypeThisCouldNotWorkOutIsWrittenAsThatWord() {
+        String json = reportOf("""
+                module demo
+                data Ok
+                data Cyclic = Cyclic
+                behavior run : (x: Cyclic) -> Ok constructs Ok
+                let run (x) = Ok
+                """);
+
+        assertTrue(json.contains("\"type_unresolved\""), json);
+    }
+
+    @Test
+    void valuesHeldInsideSomethingUnreachedAreWrittenAsThatWord() {
+        String json = reportOf("""
+                module demo
+                data Ok
+                data Item = { charge: Int }
+                behavior run : (items: List<Item>) -> Ok constructs Ok
+                let run (items) =
+                    { guard List.length(List.filter((i) -> i.charge >= 21000, items)) < 1 else Ok
+                      Ok }
+                """);
+
+        assertTrue(json.contains("\"unsupported_traversal\""), json);
+    }
+}


### PR DESCRIPTION
A position the derivation could not answer for was reported as a position the model does not divide. Five issues in a row were that one sentence — #602, #610, #629, #631, #626 — each fixed where it was found, each coming back one reader over. What they have in common is that a report about a model was produced by a reader that had run out, and nothing in the code told the two apart.

So the walk is a protocol now. Each phase answers as a value, an answer says which of the two it is, and the sentence "the model divides this position no way" is what completing the last of them produces.

```
Type
 ↓ TypeView            what the position is, and what it is written as, read once
 ↓ PartitionInput      proof that a value can stand at it at all
 ↓ LocalInspection     Evidence(classes, cuts) | Exhausted
 ↓ StructuralInspection Children | Leaf | Blocked(reason)
 ↓ BodyCutInspection   Evidence | Exhausted | Blocked(reason)
 ↓ PendingPosition.complete
                       Derived | CannotDerive(reason) | Absent
```

## The four cases it is for

| case | before | after | what it holds |
| --- | --- | --- | --- |
| a declaration reachable from itself | Absent | TYPE_UNRESOLVED | not knowing is not a fact about the model |
| a threshold on a list's elements (#626) | UNSUPPORTED_SYNTAX | UNSUPPORTED_TRAVERSAL | the cause follows where the reading stopped |
| `guard List.length(items) < 3` | Derived | Derived | a pending block is still rescued by evidence at the same position |
| a sum under a name (#631) | Absent | Derived | reading through a name reaches the readers that need it |

#626 was fixed by the walk running on the structural answer rather than by anything aimed at it. What did it was a precedence that had never been exercised: a reason from the reading that stopped outranks one offered by a reader of some rule that names the position.

## What each commit closes

- **Read a position's type once** — `TypeView` says what a position is and what it is written as. `Type.Ref` was one constructor for four things, so a walk that answered every constructor had still not answered every kind of position. Fifteen shapes, five of which are ways of not having determined one.
- **Prove a position is one a partition can be derived from** — the premise `Absent` needs, in the input's type rather than in a check the walk repeats.
- **Say a block is the reason a position would be left with** — a leaf and a block are both pending; they differ in what is reported if nothing else answers.
- **Preserve nominal projection in partition classes** — `data DecisionN = Decision` divides into `Decision`'s cases, a row writes `DecisionN(Approved { id = 1 })`, and a row already written is read back through the same names. `RepresentativeSource` became an algebra so that a name can be carried over a value nothing has composed yet.
- **Make local partition inspection explicit** — the classes a type states and the lines its rules draw come back as one answer, so "local evidence ran out" is a value and not two empty lists to be noticed.
- **Settle why a rule could not be a line where the rule is read** — the reasons a comparison stopped are `BlockReason`s, recorded by the producer and projected to the published word in one place.
- **Make an absence what completing a position produces** — `Why.Absent` has no constructor to call; it is reached through a `PendingPosition`, which is package-private cases and all.
- **Say of the derivation only what its types forbid otherwise** — an audit of the universal claims in the protocol's own words. It found the hole above: closing the terminal value was not enough while the introduction rules of the proof were public.

## What it does not change

No report changes. The examples corpus was rendered with the jar from `develop` and with the jar from this branch, and every module's output is identical apart from the sentence issue #626 is about. The reason the corpus has no wrapped sum at an input position is why the two readings stayed apart for so long — the tests are what hold it.

`schemaVersion` stays at 1. The schema states its own rule: a change that removes or renames anything raises it, and a word added to an enumerated field does not, since a document written before that word existed is still a document of this version. Two words were added — `type_unresolved` and `unsupported_traversal` — and both are now asserted to reach a document rather than only to exist in the vocabulary.

## Follow-ups

- #642 — a newtype over a sum loses signature case coverage. The same nominal projection at a different measure, with its own pair of readers; widening one alone reports one of two covered and neither of the two covered.
- #643 — `--generate` says nothing composes an input for an arm, where what holds is that no strategy composes one for the sake of an arm. `GenerationOutcome.NotSupported.Reason` already documents itself as the first and its words say the second.
- The class producer and the value producer still call each other. A class needs a representative value and a representative value needs classes, so the recursion is real and moving the code does not remove it.

Nothing here closes an issue automatically; #631 and #626 are closed by hand after this merges.
