### PR TITLE
Say what a generator has no strategy for as that

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationOutcome.java
@@ -48,10 +48,13 @@ public sealed interface GenerationOutcome {
          *
          * <p><b>Which the words have to carry too.</b> A sentence saying nothing composes an input
          * for an arm is read as there being no input that reaches it, and an author who writes the
-         * row in one line has been told something false — the row for a case somebody added to an
-         * enumeration is two lines, and this said no input for it could be composed (issue #643).
-         * So each of these says what is missing here, and what a reader does about it is write the
-         * row that this cannot.
+         * row by hand has been told something false (issue #643). So each of these says what is
+         * missing here, and what a reader does about it is write the row that this cannot.
+         *
+         * <p>Including where what is missing is upstream of the strategies. No axis at a position
+         * is no classes <em>derived</em> there, and the position may well have cases — the one this
+         * is written for is a sum past the axis limit, whose cases are in the declaration and in no
+         * partition. Said as there being no classes, it is the model that reads as having none.
          */
         public enum Reason {
 
@@ -67,7 +70,7 @@ public sealed interface GenerationOutcome {
 
             /** The position the case belongs to is not one any axis was derived at. */
             NO_AXIS_AT_THIS_POSITION("no axis was derived at the position this case belongs to, so"
-                    + " there are no classes here to compose a row from");
+                    + " no classes were derived there to compose a row from");
 
             private final String said;
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/GenerationOutcome.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GenerationOutcome.java
@@ -45,18 +45,29 @@ public sealed interface GenerationOutcome {
          *
          * <p>Each of these is a strategy that could exist and does not. None of them says the gap
          * cannot be met, and none is read as evidence about the model.
+         *
+         * <p><b>Which the words have to carry too.</b> A sentence saying nothing composes an input
+         * for an arm is read as there being no input that reaches it, and an author who writes the
+         * row in one line has been told something false — the row for a case somebody added to an
+         * enumeration is two lines, and this said no input for it could be composed (issue #643).
+         * So each of these says what is missing here, and what a reader does about it is write the
+         * row that this cannot.
          */
         public enum Reason {
 
             /** Nothing composes an input for the sake of the path it would take through a body. */
-            NO_STRATEGY_FOR_AN_ARM("nothing here composes an input for the arm it would reach"),
+            NO_STRATEGY_FOR_AN_ARM(
+                    "rows here are composed for classes and for boundaries, and nothing composes"
+                            + " one for the sake of an arm"),
 
             /** Nothing searches for an input by the output it produces. */
             NO_STRATEGY_FOR_AN_OUTPUT_CASE(
-                    "nothing here searches for an input by the case it would answer with"),
+                    "rows here are composed from what the input positions divide into, and nothing"
+                            + " searches for one by the case it would answer with"),
 
             /** The position the case belongs to is not one any axis was derived at. */
-            NO_AXIS_AT_THIS_POSITION("no axis was derived at the position this case belongs to");
+            NO_AXIS_AT_THIS_POSITION("no axis was derived at the position this case belongs to, so"
+                    + " there are no classes here to compose a row from");
 
             private final String said;
 

--- a/souther-compiler/src/test/java/souther/compiler/EveryGapTheBuildRefusesGetsAnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryGapTheBuildRefusesGetsAnAnswerTest.java
@@ -264,6 +264,32 @@ class EveryGapTheBuildRefusesGetsAnAnswerTest {
                 "and one past it is not something anything here takes");
     }
 
+    /**
+     * And what each of them says is what is missing here.
+     *
+     * <p>The words, because the words are the contract at this point. This type's own javadoc says
+     * these are strategies that could exist and do not, and that none of them says the gap cannot
+     * be met — while the sentence for an arm said nothing composes an input for it, of a row an
+     * author writes in two lines (issue #643). A reader who writes that row must not be
+     * contradicting the report.
+     *
+     * <p>Held one by one rather than by a rule over the strings, because there is no property of a
+     * sentence that says it is about a compiler. What there is, is a person reading each of them
+     * next to what it is written for.
+     */
+    @Test
+    void eachReasonSaysWhatIsMissingHereRatherThanWhatCannotExist() {
+        assertEquals("rows here are composed for classes and for boundaries, and nothing composes"
+                        + " one for the sake of an arm",
+                GenerationOutcome.NotSupported.Reason.NO_STRATEGY_FOR_AN_ARM.said());
+        assertEquals("rows here are composed from what the input positions divide into, and nothing"
+                        + " searches for one by the case it would answer with",
+                GenerationOutcome.NotSupported.Reason.NO_STRATEGY_FOR_AN_OUTPUT_CASE.said());
+        assertEquals("no axis was derived at the position this case belongs to, so there are no"
+                        + " classes here to compose a row from",
+                GenerationOutcome.NotSupported.Reason.NO_AXIS_AT_THIS_POSITION.said());
+    }
+
     @Test
     void aCaseOfTheOutputIsNotSupported() {
         List<GenerationOutcome> outputs = filling(compiled(KIND), "example.kind", "pick").gaps()

--- a/souther-compiler/src/test/java/souther/compiler/EveryGapTheBuildRefusesGetsAnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryGapTheBuildRefusesGetsAnAnswerTest.java
@@ -285,8 +285,11 @@ class EveryGapTheBuildRefusesGetsAnAnswerTest {
         assertEquals("rows here are composed from what the input positions divide into, and nothing"
                         + " searches for one by the case it would answer with",
                 GenerationOutcome.NotSupported.Reason.NO_STRATEGY_FOR_AN_OUTPUT_CASE.said());
-        assertEquals("no axis was derived at the position this case belongs to, so there are no"
-                        + " classes here to compose a row from",
+        // A position past the axis limit has its cases in the declaration and in no partition, so
+        // what is missing is a derivation and not the classes. Said as there being none, the
+        // sentence is about the model again — the thing the other two stopped doing.
+        assertEquals("no axis was derived at the position this case belongs to, so no classes were"
+                        + " derived there to compose a row from",
                 GenerationOutcome.NotSupported.Reason.NO_AXIS_AT_THIS_POSITION.said());
     }
 


### PR DESCRIPTION
`--generate` said of an uncovered arm that nothing composes an input for it. Splitting a case out of an enumeration and running it reports:

```
// nothing offers a row for `case 沖縄` in `送料を求める`: nothing here composes an input for the arm it would reach
```

while the row is two lines, and writing it closes the gap:

```souther
    | "沖縄・一般・5000未満" :
        (注文 { 番号 = 注文番号("0000-000010"), 合計 = 商品合計(4999), 地域 = 沖縄, 会員 = 一般 })
            -> 送料あり { 金額 = 1200 }
```

`GenerationOutcome.NotSupported.Reason` already documents itself as "a strategy that could exist and does not", and that "none of them says the gap cannot be met". Its words said the opposite. Each of the three now says what is missing here:

```
// nothing offers a row for `case 沖縄` in `送料を求める`: rows here are composed for classes and for boundaries, and nothing composes one for the sake of an arm
```

The words are the contract at this point, so they are held one by one in `EveryGapTheBuildRefusesGetsAnAnswerTest` — there is no property of a sentence that says it is about a compiler, and what there is, is a person reading each of them next to what it is written for.

Closes #643