### PR TITLE
Read an input's case at the position it is written at

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
+++ b/souther-compiler/src/main/java/souther/compiler/ExampleVerifier.java
@@ -9,6 +9,7 @@ import souther.compiler.check.BoundaryOutput;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
 import souther.compiler.check.TypeOps;
+import souther.compiler.check.TypeView;
 import souther.compiler.coverage.Probe;
 import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.msg.ExampleMessage;
@@ -634,7 +635,7 @@ public final class ExampleVerifier {
                 state.failed(FailurePhase.INPUT_FIXTURE);
                 return;
             }
-            state.inputCases.add(caseWritten(fixtures, row.inputs().get(i)));
+            state.inputCases.add(caseWritten(fixtures, row.inputs().get(i), ins.get(i).type()));
             state.inputs.add(fixtures.observed(args[i]));
         }
         // validate the expected arm/value against the output cases before running. Which case the row
@@ -726,11 +727,19 @@ public final class ExampleVerifier {
         state.failurePhase = FailurePhase.NONE;
     }
 
-    /** The case an input fixture constructs, or null where its text does not say. A form this cannot
-     * read is not a reason to lose the row: the measure that reads it says it could not classify. */
-    private static TypeName caseWritten(FixtureReader fixtures, Ast.Expr fixture) {
+    /**
+     * The case an input fixture supplies at {@code position}, or null where its text does not say. A
+     * form this cannot read is not a reason to lose the row: the measure that reads it says it could
+     * not classify.
+     *
+     * <p>Read at the position and not off the fixture alone. A position writing its values under a
+     * name divides into what its base divides into, so what a row there supplies is the case under
+     * that name — the same projection, in the direction that reads rather than the one that derives.
+     */
+    private TypeName caseWritten(FixtureReader fixtures, Ast.Expr fixture, Type position) {
         try {
-            return fixtures.constructedCase(fixture);
+            return fixtures.caseUnder(TypeView.of(position, symbols).wrappers().stream()
+                    .map(TypeOps.Layer::named).toList(), fixture);
         } catch (RuntimeException e) {
             if (overspending(e) != null) {
                 throw e;   // the row's budget is gone; it is not a form that could not be read

--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -426,7 +426,28 @@ public final class FixtureReader {
      * spelling or nothing (issue #206).
      */
     TypeName constructedCase(Ast.Expr e) {
-        return constructedCase(e, new LinkedHashSet<>());
+        return constructedCase(e, new LinkedHashSet<>(), List.of());
+    }
+
+    /**
+     * The case a fixture supplies at a position whose values are written under {@code worn}: the same
+     * reading, with those names taken off first.
+     *
+     * <p>Which case constructed the value and which case the position it is written at sees are two
+     * questions, and only one of them is the one above. A {@code data DecisionN = Decision} is the sum
+     * it names; a row there writes {@code DecisionN(Approved { id = 1 })}, which constructs a
+     * {@code DecisionN} and supplies an {@code Approved}. Only the second is a case of the position,
+     * so only the second may be counted at it.
+     *
+     * <p>The other direction of what {@link souther.compiler.partition.Classifier#under} does to an
+     * observation, and it takes the names off on the same terms: only the ones that are there come
+     * off, so a fixture not wearing them is read as it stands rather than decided to be nothing.
+     *
+     * @param worn the names the position writes its values under, outermost first, as
+     *             {@link souther.compiler.check.TypeView} reads them off it
+     */
+    TypeName caseUnder(List<TypeName> worn, Ast.Expr e) {
+        return constructedCase(e, new LinkedHashSet<>(), worn);
     }
 
     /**
@@ -438,29 +459,44 @@ public final class FixtureReader {
      * spread holds — a spread cannot hold an expression — and that name is read where the spread is
      * copied. A closed body therefore ends in the construction, whether it was published itself or
      * named by another value that was.
+     *
+     * <p>{@code worn} are the names still to come off, which is what tells this reading from the
+     * nominal one. They come off where the fixture is the construction wearing them and nowhere else —
+     * a name is followed to what it stands for with the same names still to take off, since where the
+     * fixture is written says nothing about which of them a published value already carries.
      */
-    private TypeName constructedCase(Ast.Expr e, Set<String> followed) {
+    private TypeName constructedCase(Ast.Expr e, Set<String> followed, List<TypeName> worn) {
         return switch (e) {
             case Ast.NewData nd -> nd.typeName().denotes();
-            case Ast.Apply c when neutral.isNewtype(c.written()) -> symbols.resolveCase(c.written());
-            case Ast.LetIn let -> constructedCase(let.body(), followed);
-            case Ast.Var v -> namedCase(v, followed);
+            case Ast.Apply c when neutral.isNewtype(c.written()) -> {
+                TypeName named = symbols.resolveCase(c.written());
+                yield wears(named, c, worn)
+                        ? constructedCase(c.args().get(0), followed, worn.subList(1, worn.size()))
+                        : named;
+            }
+            case Ast.LetIn let -> constructedCase(let.body(), followed, worn);
+            case Ast.Var v -> namedCase(v, followed, worn);
             case null, default -> null;
         };
     }
 
+    /** Whether {@code c} is the outermost name still to come off, holding the one value under it. */
+    private static boolean wears(TypeName named, Ast.Apply c, List<TypeName> worn) {
+        return !worn.isEmpty() && worn.get(0).equals(named) && c.args().size() == 1;
+    }
+
     /** The case a bare name stands for: the type it denotes where it denotes one — a unit case, or a
      * case written bare — and otherwise the case the value or binding it names constructs. */
-    private TypeName namedCase(Ast.Var v, Set<String> followed) {
+    private TypeName namedCase(Ast.Var v, Set<String> followed, List<TypeName> worn) {
         return switch (v.denotes()) {
             case ValueName.OfType named -> named.type();
             case ValueName.Local local -> {
                 Ast.Expr held = bindings.get(local.id());
-                yield held == null ? null : constructedCase(held, followed);
+                yield held == null ? null : constructedCase(held, followed, worn);
             }
             case ValueName.Helper _ -> {
                 Ast.Expr body = followed.add(v.name()) ? valueBody(v.name()) : null;
-                yield body == null ? null : constructedCase(body, followed);
+                yield body == null ? null : constructedCase(body, followed, worn);
             }
             case null, default -> null;
         };

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1735,9 +1735,12 @@ public final class Adequacy {
      * declaration divides two ways comes back as one the model divides no way.
      *
      * <p>The names come off by {@link TypeOps#base}, and what a row wrote at the position has the same
-     * ones taken off it ({@link FixtureReader#caseUnder}) from the other end of the one walk that says
-     * how far a newtype reaches. Derived through the names and observed at them, the two sets never
-     * meet: every row lands outside the set it is counted in.
+     * ones taken off it ({@link FixtureReader#caseUnder}) — the terminal and the layers of the one walk
+     * that says how far a newtype reaches, so neither end decides for itself how far that is.
+     *
+     * <p>Both ends or neither. A denominator read through the names has no member in common with a
+     * numerator answering with the outermost of them, so every row would land outside the set it is
+     * counted in: {@code 1} of {@code 2} covered, and both of the two still owed a row.
      */
     private static Set<TypeName> inputCoverableCases(Type t, Symbols symbols) {
         return casesOfSum(TypeOps.base(t, symbols), symbols);

--- a/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Adequacy.java
@@ -1724,15 +1724,45 @@ public final class Adequacy {
      * it would report the case it produced as one nothing produces.
      */
     /**
-     * The cases a position has to be covered at, which is not quite what a row's expected arm is held
-     * against ({@link TypeOps#outputCases}).
+     * The cases an input position has to be covered at: what it divides into, read through the names
+     * it writes its values under.
      *
      * <p>A position typed as one data has one case, and covering it is not a question: any row at all
      * covers it, so reporting {@code 1/1} everywhere adds a number that is never anything else. What
-     * is worth counting is a position that can be more than one thing. The arm check is wider on
-     * purpose — it uses the single name to catch a row that wrote the wrong one.
+     * is worth counting is a position that can be more than one thing — which a
+     * {@code data DecisionN = Decision} is, since its values are the cases of {@code Decision} under a
+     * name. Asked of the written type, that name is where the reading stops, and a position the
+     * declaration divides two ways comes back as one the model divides no way.
+     *
+     * <p>The names come off by {@link TypeOps#base}, and what a row wrote at the position has the same
+     * ones taken off it ({@link FixtureReader#caseUnder}) from the other end of the one walk that says
+     * how far a newtype reaches. Derived through the names and observed at them, the two sets never
+     * meet: every row lands outside the set it is counted in.
      */
-    private static Set<TypeName> coverableCases(Type t, Symbols symbols) {
+    private static Set<TypeName> inputCoverableCases(Type t, Symbols symbols) {
+        return casesOfSum(TypeOps.base(t, symbols), symbols);
+    }
+
+    /**
+     * The cases the output has to be covered at, which is not quite what a row's expected arm is held
+     * against ({@link TypeOps#outputCases}).
+     *
+     * <p>Not {@link #inputCoverableCases}. The two were one function on the strength of running the
+     * same way, and they are not the same question: an output written under a name is answered with
+     * that name — the arm a row states, the arm a result is read as, and the set the two are held
+     * against all say {@code DecisionN} — so counting its cases here would name arms no row may write.
+     * What a name over a sum means at an output is a question of its own and is not answered here.
+     *
+     * <p>The arm check is wider than this on purpose: it uses the single name of a position that is
+     * not a sum at all to catch a row that wrote the wrong one.
+     */
+    private static Set<TypeName> outputCoverableCases(Type t, Symbols symbols) {
+        return casesOfSum(t, symbols);
+    }
+
+    /** What a sum divides into, and nothing for a type that is not one. The one thing the two
+     *  measures above share; what tells them apart is which type each hands it. */
+    private static Set<TypeName> casesOfSum(Type t, Symbols symbols) {
         return TypeOps.isSumType(t, symbols) ? TypeOps.leafCases(t, symbols) : Set.of();
     }
 
@@ -1749,7 +1779,7 @@ public final class Adequacy {
         // The cases the output type has, less the ones only an arm nothing reaches produces. A case
         // no reachable producer answers with is not a gap in the rows.
         Set<TypeName> declaredOut = souther.compiler.partition.ProducedCases.of(
-                body, plan, reachable.reachable(), coverableCases(sig.outputType(), symbols));
+                body, plan, reachable.reachable(), outputCoverableCases(sig.outputType(), symbols));
         Set<TypeName> specified = new LinkedHashSet<>();
         Set<TypeName> observed = new LinkedHashSet<>();
         Set<TypeName> verified = new LinkedHashSet<>();
@@ -1763,7 +1793,7 @@ public final class Adequacy {
         List<Set<TypeName>> inExcluded = new ArrayList<>(ins.size());
         int[] unreadableIn = new int[ins.size()];
         for (int i = 0; i < ins.size(); i++) {
-            Set<TypeName> declared = coverableCases(ins.get(i), symbols);
+            Set<TypeName> declared = inputCoverableCases(ins.get(i), symbols);
             declaredIn.add(declared);
             inSpecified.add(new LinkedHashSet<>());
             inExecuted.add(new LinkedHashSet<>());

--- a/souther-compiler/src/test/java/souther/compiler/SignatureCoverageReadsAPositionThroughItsNamesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/SignatureCoverageReadsAPositionThroughItsNamesTest.java
@@ -1,0 +1,214 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.observe.InputCaseEvidence;
+import souther.compiler.observe.MeasurementStatus;
+import souther.compiler.observe.OutputCaseEvidence;
+import souther.compiler.query.Adequacy;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Db;
+import souther.compiler.types.TypeName;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What case a row supplied at an input position, where the position writes its values under a name.
+ *
+ * <p>A {@code data DecisionN = Decision} is the sum it names. What it divides into is what
+ * {@code Decision} divides into, and a row at that position writes {@code DecisionN(Approved { .. })}
+ * — so the case it supplied is {@code Approved}, read through the name it is worn under.
+ *
+ * <p>Which case constructed a value and which case a position sees are two questions. The first is
+ * the name the row wrote, and everything that builds the value or holds it against the output's arms
+ * needs it to stay that; the second is the one this measure counts. Read one off the other, the two
+ * cannot both be right for a position wearing a name.
+ */
+class SignatureCoverageReadsAPositionThroughItsNamesTest {
+
+    private static final String DECLARATIONS = """
+            module demo
+
+            data Ok
+
+            data Approved = { id: Int }
+            data Rejected = { why: String }
+            data Decision = Approved | Rejected
+            data DecisionN = Decision
+            data DecisionNN = DecisionN
+            data OtherN = Decision
+
+            behavior bare : (decision: Decision) -> Ok
+                constructs Ok
+            let bare (decision) = Ok
+
+            behavior wrapped : (decision: DecisionN) -> Ok
+                constructs Ok
+            let wrapped (decision) = Ok
+
+            behavior twice : (decision: DecisionNN) -> Ok
+                constructs Ok
+            let twice (decision) = Ok
+
+            behavior makes : (id: Int) -> DecisionN
+                constructs DecisionN, Approved
+            let makes (id) = DecisionN(Approved { id = id })
+            """;
+
+    /** A name over a sum divides the position the way the sum it names does. */
+    @Test
+    void aWrappedSumHasTheCasesTheSumItNamesHas() {
+        InputCaseEvidence wrapped = input("""
+                example wrapped
+                    | (DecisionN(Approved { id = 1 })) -> Ok
+                """, "wrapped");
+
+        assertEquals(List.of("Approved", "Rejected"), names(wrapped.declared()));
+        assertEquals(MeasurementStatus.COMPLETE, wrapped.status());
+    }
+
+    /** The same position, read at the case a row wrote there. */
+    @Test
+    void aRowUnderTheNameSuppliesTheCaseUnderIt() {
+        InputCaseEvidence wrapped = input("""
+                example wrapped
+                    | (DecisionN(Approved { id = 1 })) -> Ok
+                """, "wrapped");
+
+        assertEquals(List.of("Approved"), names(wrapped.specified()));
+        assertEquals(List.of("Rejected"), names(wrapped.unspecified()));
+    }
+
+    /** Each case, so that neither is the one the reader happens to answer with. */
+    @Test
+    void eitherCaseUnderTheNameIsTheCaseItSupplies() {
+        InputCaseEvidence wrapped = input("""
+                example wrapped
+                    | (DecisionN(Rejected { why = "no" })) -> Ok
+                """, "wrapped");
+
+        assertEquals(List.of("Rejected"), names(wrapped.specified()));
+        assertEquals(List.of("Approved"), names(wrapped.unspecified()));
+    }
+
+    /**
+     * A count and the cases beside it say one thing. A reader answering with the name would land
+     * outside the set it is counted in, and both rows would be reported as covering nothing.
+     */
+    @Test
+    void nothingIsSuppliedThatThePositionDoesNotHave() {
+        InputCaseEvidence wrapped = input("""
+                example wrapped
+                    | (DecisionN(Approved { id = 1 })) -> Ok
+                    | (DecisionN(Rejected { why = "no" })) -> Ok
+                """, "wrapped");
+
+        assertTrue(wrapped.declared().containsAll(wrapped.specified()),
+                "what a row supplied is one of the cases the position has: " + wrapped.specified());
+        assertEquals(List.of("Approved", "Rejected"), names(wrapped.specified()));
+        assertEquals(List.of(), names(wrapped.unspecified()));
+    }
+
+    /** The names come off in the order they went on, however many there are. */
+    @Test
+    void namesComeOffToTheSumHoweverManyAreWorn() {
+        InputCaseEvidence twice = input("""
+                example twice
+                    | (DecisionNN(DecisionN(Approved { id = 1 }))) -> Ok
+                """, "twice");
+
+        assertEquals(List.of("Approved", "Rejected"), names(twice.declared()));
+        assertEquals(List.of("Approved"), names(twice.specified()));
+    }
+
+    /**
+     * The name is still what a row constructs. An output written under one is answered with it — the
+     * arm a row states there is held against {@code DecisionN} and nothing else — so a reading that
+     * took the name off wherever it found one would refuse a row that is right.
+     *
+     * <p>What that output's cases are is a question this does not answer and did not move: the
+     * measure says so rather than counting them.
+     */
+    @Test
+    void anOutputUnderANameIsStillAnsweredWithTheName() {
+        String rows = """
+                example makes
+                    | (1) -> DecisionN(Approved { id = 1 })
+                """;
+
+        assertEquals(List.of(), errors(rows));
+        Adequacy.SignatureEvidence makes = signatures(rows).get("makes");
+        assertEquals(MeasurementStatus.NOT_APPLICABLE, makes.output().status());
+        assertEquals(OutputCaseEvidence.Reason.NOT_A_SUM, makes.output().reason());
+    }
+
+    /**
+     * Only the names the position writes its values under come off. Peeling whatever is there until
+     * something recognisable appears would credit a case to a row that named another type, and what
+     * a position admits is a question this measure does not get to answer by reading past it.
+     *
+     * <p>So the row teaches the position nothing: both its cases are still owed a row.
+     */
+    @Test
+    void aNameThePositionDoesNotWriteIsNotComeOffOf() {
+        InputCaseEvidence wrapped = input("""
+                example wrapped
+                    | (OtherN(Approved { id = 1 })) -> Ok
+                """, "wrapped");
+
+        assertFalse(names(wrapped.specified()).contains("Approved"),
+                "a name the position does not write is not read through: " + wrapped.specified());
+        assertEquals(List.of("Approved", "Rejected"), names(wrapped.unspecified()));
+    }
+
+    /** A position written as the sum itself is read the way it always was. */
+    @Test
+    void aBareSumIsUnchanged() {
+        InputCaseEvidence bare = input("""
+                example bare
+                    | (Approved { id = 1 }) -> Ok
+                """, "bare");
+
+        assertEquals(List.of("Approved", "Rejected"), names(bare.declared()));
+        assertEquals(List.of("Approved"), names(bare.specified()));
+    }
+
+    private static InputCaseEvidence input(String rows, String behavior) {
+        Map<String, Adequacy.SignatureEvidence> all = signatures(rows);
+        Adequacy.SignatureEvidence evidence = all.get(behavior);
+        assertEquals(1, evidence.inputs().size());
+        return evidence.inputs().get(0);
+    }
+
+    private static Map<String, Adequacy.SignatureEvidence> signatures(String rows) {
+        Compilation compilation = measured(rows);
+        return compilation.db().ask(new Adequacy.Witnesses(compilation.modules().get(0))).value();
+    }
+
+    private static List<String> errors(String rows) {
+        List<String> codes = new ArrayList<>();
+        for (Db.Found found : measured(rows).db().allReports()) {
+            if (found.report().isError()) {
+                codes.add(found.report().diagnostic().code());
+            }
+        }
+        return codes;
+    }
+
+    private static Compilation measured(String rows) {
+        Compilation compilation = Compilation.ofSource(DECLARATIONS + "\n" + rows, "Main");
+        compilation.measure(Adequacy.Asked.reportOnly());
+        compilation.answerEverything();
+        return compilation;
+    }
+
+    private static List<String> names(java.util.Collection<TypeName> cases) {
+        return cases.stream().map(TypeName::name).toList();
+    }
+}


### PR DESCRIPTION
Closes #642 (a PR onto `develop` does not close it automatically — close by hand after merge).

Signature input coverage was reading which nominal constructor built a fixture and counting that as which case the position sees. For a `data DecisionN = Decision` those are two different names, so a position the declaration divides two ways was reported as one the model divides no way.

Both ends of the measure read the nominal one, which is why widening either alone moves the defect rather than removing it — with the denominator read through the name and nothing else changed, every row lands outside the set it is counted in. So:

* `Adequacy.coverableCases` becomes `inputCoverableCases` / `outputCoverableCases`, sharing `casesOfSum` and differing by which type each hands it. Input reads through the names the position writes its values under; output keeps the old rule.
* `FixtureReader.caseUnder` is the position-relative reading. `constructedCase` is unchanged, because its nominal answer is what picks the shape a fixture is built against and what an expected arm is held to.

The names come off on the same terms `Classifier.under` takes them off an observation, and the denominator's terminal and the numerator's layers are the two halves of one `TypeOps.newtypeSpine`.

## Not in this change

An output written under a name is still answered with that name. Whether signature coverage should read a newtype-over-sum output through its name is a separate question and is stated as unanswered in the javadoc rather than settled by this change.

That a row may write `Approved { id = 1 }` bare, or `OtherN(Approved { .. })`, at a `DecisionN` position is #646. Held at admission, those rows never reach this measure — no filter was added here, which would have made that fix untestable at this measure.

## Verification

* `SignatureCoverageReadsAPositionThroughItsNamesTest`, 8 rules: the coverable set, either case read at the position, a count agreeing with the cases beside it, a doubly-worn name, a name the position does not write not being read through, an output under a name still answered with it, and a bare sum unchanged. 6 of the 8 were red before the change; `aBareSumIsUnchanged` and the output guard were the positive controls.
* `mvn -o clean test` green across all modules.
* The corpus reports are unchanged: every single-value newtype in `souther-examples` wraps a primitive (`Int`, `Decimal`, `String`, `Date`), so no position there is a name over a sum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
