### PR TITLE
Name a value because it can be pointed at, not because something was said of it

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -298,7 +298,7 @@ public final class InvariantChecker {
             Type type = fields.get(field.getKey());
             if (type != null) {
                 c.name(new Core.Read(field.getKey(), field.getValue(), type, NOWHERE),
-                        field.getKey(), type, at, k, symbols, 1, atoms, typeAt);
+                        field.getKey(), type, at, symbols, 1, atoms, typeAt);
             }
         }
         NumericDomain numbers = k.numbers();
@@ -325,9 +325,9 @@ public final class InvariantChecker {
      * field of a field to something, and the bound that leaves on it is read at the path it sits at
      * rather than at the record it happens to be inside.
      */
-    private void name(Core value, String path, Type type, Denotations at, Known k, Symbols symbols,
+    private void name(Core value, String path, Type type, Denotations at, Symbols symbols,
                       int depth, Map<String, String> atoms, Map<String, Type> typeAt) {
-        String atom = terms.atomOf(value, at, k);
+        String atom = terms.atomOf(value, at);
         if (atom != null) {
             atoms.put(path, atom);
             typeAt.put(path, type);
@@ -338,7 +338,7 @@ public final class InvariantChecker {
         }
         for (Map.Entry<String, Type> field : clauses.fieldsOf(data).entrySet()) {
             name(new Core.FieldAccess(value, field.getKey(), field.getValue(), NOWHERE),
-                    path + "." + field.getKey(), field.getValue(), at, k, symbols, depth + 1,
+                    path + "." + field.getKey(), field.getValue(), at, symbols, depth + 1,
                     atoms, typeAt);
         }
     }
@@ -477,8 +477,20 @@ public final class InvariantChecker {
         return new Findings(c.errors, c.warnings, Status.COMPLETE);
     }
 
-    /** Records an analysis that fell over, for a test in this package to read. */
-    private static void gaveUp(String where, RuntimeException why) {
+    /**
+     * Records an analysis that fell over, for a test in this package to read.
+     *
+     * <p>Every place this check swallows a failure comes through here, so what must not be swallowed
+     * is refused in one place. A shape the walk has no rule for is what fail-open is for: the
+     * run-time check stands for the clause, and reporting the walk's limit as the author's problem is
+     * what the policy avoids. {@link Terms.OneKeyTwoKinds} is not that. It says this check called two
+     * values one value, and what it would produce if caught is a behavior with no findings — which
+     * is exactly what a behavior whose invariants all discharge produces.
+     */
+    static void gaveUp(String where, RuntimeException why) {
+        if (why instanceof Terms.OneKeyTwoKinds) {
+            throw why;
+        }
         List<GaveUp> watching = GAVE_UP;
         if (watching != null) {
             watching.add(new GaveUp(where, why));

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -67,8 +67,11 @@ import java.util.Set;
  * asks them in order.
  *
  * <p>The walk mirrors {@link TotalityChecker}: a {@code switch} over {@link Core} threading an
- * immutable environment. It is fail-open — any internal error is swallowed so an analysis bug can
- * never reject a valid program.
+ * immutable environment. It is fail-open for what it cannot analyze — an expression or a shape it
+ * has no rule for is swallowed, so a limit of this analysis can never reject a valid program. It is
+ * not fail-open for this analysis disagreeing with itself: {@link Terms.OneKeyTwoKinds} says one
+ * name was given two values, and swallowing it produces a behavior with no findings, which is what a
+ * behavior whose invariants all discharge produces. That one is rethrown ({@link #gaveUp}).
  */
 public final class InvariantChecker {
 
@@ -76,9 +79,9 @@ public final class InvariantChecker {
      * What one analysis came to.
      *
      * <p>{@code status} is not about the model. It says whether the findings are all of the findings
-     * there were: this check is fail-open, so an analysis that fell over produces exactly what an
-     * analysis that finished and found nothing produces, and a consumer reading only the two lists
-     * cannot tell them apart. Production does not need to — the run-time check is the backstop
+     * there were: this check is fail-open for what it cannot read, so an analysis that fell over on
+     * one of those produces exactly what an analysis that finished and found nothing produces, and a
+     * consumer reading only the two lists cannot tell them apart. Production does not need to — the run-time check is the backstop
      * either way — but a test asserting that a construction is discharged is asserting something
      * about an analysis that ran, and without this it would pass just as well on one that did not.
      */
@@ -244,8 +247,10 @@ public final class InvariantChecker {
      */
     record Seeded(NumericDomain numbers, Map<String, String> atoms, boolean everyClauseRead) {}
 
-    /** {@link Seeded} for one declaration. Never throws: a declaration this cannot read is one whose
-     * fields it says nothing about, which is the same answer as a declaration with no rules. */
+    /** {@link Seeded} for one declaration. A declaration this cannot read is one whose fields it says
+     * nothing about, which is the same answer as a declaration with no rules — so nothing about the
+     * declaration throws. {@link Terms.OneKeyTwoKinds} is not about the declaration and is not
+     * caught ({@link #gaveUp}). */
     static Seeded seedFields(TypeName named, Ast.Data data, Symbols symbols) {
         return seedFields(named, data, symbols, Map.of());
     }
@@ -452,9 +457,10 @@ public final class InvariantChecker {
     private static final SourcePos NOWHERE = new SourcePos(0, 0);
 
     /**
-     * Analyzes one behavior body against the bindings its inputs are. Never throws. A {@code null}
-     * body is one the analysis representation could not be built or typed for, and is not analyzed at
-     * all.
+     * Analyzes one behavior body against the bindings its inputs are. Nothing the body is throws:
+     * a walk that cannot get through one comes back {@code ABANDONED}. {@link Terms.OneKeyTwoKinds}
+     * is not something the body is and is not caught ({@link #gaveUp}). A {@code null} body is one
+     * the analysis representation could not be built or typed for, and is not analyzed at all.
      */
     static Findings analyze(Core body, Map<TypeName, List<Ast.InvariantClause>> invariants,
                             Scope params, Symbols symbols) {

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -33,9 +33,14 @@ import java.util.Set;
  * <p>Three answers, and they are not the same question. Where a value is, is a {@link Location} and
  * is what the seeding writes about. What a value is called, is a key: two expressions with one key
  * compute one value, which is the whole of what the fact set knows. What can be said of a value, is
- * whether a clause read against it could ever be discharged — a location always can, a computed value
- * only where a rule or a guard reaches it — and it is what decides whether a construction is reported
- * at all.
+ * whether a clause read against it could ever be discharged — a location always can, and so does a
+ * number, which is named by whatever computes it; a value of another kind only where a rule or a
+ * guard reaches it — and it is what decides whether a construction is reported at all.
+ *
+ * <p>The middle question does not wait on the third. A value is called something because it can be
+ * pointed at, and what is known of it is a separate matter that may well be nothing. Deciding the
+ * one by the other is circular where it matters most: the first guard about a value would be read
+ * under a naming that guard is what establishes.
  */
 final class Terms {
 
@@ -82,10 +87,19 @@ final class Terms {
         return e;
     }
 
-    /** The affine walk: literals and {@code +}/{@code -} compose; every other node is handed to
+    /**
+     * The affine walk: literals and {@code +}/{@code -} compose; every other node is handed to
      * {@code leaf} (which decides whether it is an atom, a location, or opaque). It takes the leaf
      * rule rather than fixing one because a binding it reads through answers with what that binding
-     * was given. */
+     * was given.
+     *
+     * <p>A node this has a rule for and cannot compose is handed to {@code leaf} as well. Reading the
+     * structure of a value and naming the value are two questions: a variable product is outside the
+     * fragment, and it is still one value, so what a guard states of it is still about the thing the
+     * clause reads. Answering the first question with {@code null} and never asking the second is
+     * what made {@code a * b} name nothing where it is written and something where it is bound —
+     * which is a name changing what can be said of an expression.
+     */
     LinearForm affine(Core raw, java.util.function.Function<Core, LinearForm> leaf) {
         Core e = asOperator(raw);
         if (e instanceof Core.PreservedCall) {
@@ -98,6 +112,13 @@ final class Terms {
                 return LinearForm.constant(folded);
             }
         }
+        LinearForm composed = composed(e, leaf);
+        return composed != null ? composed : leaf.apply(e);
+    }
+
+    /** {@code e} read as arithmetic over what {@code leaf} answers, or {@code null} where this has no
+     * rule for it or the rule it has does not compose. */
+    private LinearForm composed(Core e, java.util.function.Function<Core, LinearForm> leaf) {
         return switch (e) {
             case Core.Int i -> LinearForm.constant(BigDecimal.valueOf(i.value()));
             case Core.Decimal d -> LinearForm.constant(d.value());
@@ -107,7 +128,8 @@ final class Terms {
             case Core.Binary b when b.op() == Ast.BinOp.SUB ->
                     add(affine(b.left(), leaf), affine(b.right(), leaf), true);
             // scalar multiply by a constant (Amount * 2) is linear; `/` and a variable product are not
-            // (a divide truncates for Int, and a variable factor is non-linear), so leave those opaque.
+            // (a divide truncates for Int, and a variable factor is non-linear), so those come back
+            // here as one value rather than as arithmetic over two.
             case Core.Binary b when b.op() == Ast.BinOp.MUL ->
                     scale(affine(b.left(), leaf), affine(b.right(), leaf));
             // A binding an expansion introduced (`let $0_n = n.value in $0_n * 2`) is what an
@@ -115,11 +137,11 @@ final class Terms {
             // wrote.
             case Core.LetIn li -> {
                 LinearForm bound = affine(li.value(), leaf);
-                yield bound == null ? leaf.apply(e) : affine(li.body(),
+                yield bound == null ? null : affine(li.body(),
                         n -> n instanceof Core.Read r && r.binding().equals(li.binder().id())
                                 ? bound : leaf.apply(n));
             }
-            default -> leaf.apply(e);
+            default -> null;
         };
     }
 
@@ -177,7 +199,7 @@ final class Terms {
             if (given != null) {
                 return given;
             }
-            String atom = atomOf(n, at, k);
+            String atom = atomOf(n, at);
             return atom == null ? null : LinearForm.atom(atom);
         });
     }
@@ -237,9 +259,19 @@ final class Terms {
         return subtract ? a.minus(b) : a.plus(b);
     }
 
-    /** The canonical atom key of a numeric location ({@code x}, {@code p.a}, a newtype's value) or of
-     * a size call over a nameable container, or {@code null} if {@code e} is neither. */
-    String atomOf(Core e, Denotations at, Known k) {
+    /**
+     * The canonical atom key of a numeric value: a location ({@code x}, {@code p.a}, a newtype's
+     * value), a size call over a nameable container, or anything else this can name — and
+     * {@code null} where the value is not a number the domain carries, or where nothing here names
+     * it.
+     *
+     * <p>An atom exists because a value can be pointed at, not because anything is known of it. Two
+     * writings of one value are one atom and so one unknown, which is the whole of what an atom
+     * asserts; what is known of it is what a guard states and nothing else. Requiring something to
+     * have been said before a value could be an atom made the first guard about a value the one that
+     * could not be read, since it was read to decide whether that value had a name at all.
+     */
+    String atomOf(Core e, Denotations at) {
         String size = sizeAtomOf(e, arg -> bodyKey(arg, at));
         if (size != null) {
             return size;
@@ -247,14 +279,7 @@ final class Terms {
         if (affineScalarBase(e.type()) == null) {
             return null;
         }
-        // A path rooted at a binding is the atom of what that binding denotes, and only where a clause
-        // could be read against it — otherwise a name would be an atom where the expression it was
-        // given is not one, and the two spellings would answer differently.
-        BindingId root = rootBinding(e);
-        if (root != null && !readable(at.of(root), k)) {
-            return null;
-        }
-        return named(pathKey(e, at), granularityOf(e.type()));
+        return named(bodyKey(e, at), granularityOf(e.type()));
     }
 
     /** {@link #sizeAtom}, with the atom it names recorded as a whole number. A size counts elements,
@@ -282,14 +307,32 @@ final class Terms {
         return name;
     }
 
-    /** {@code key}, with how its values are spaced recorded against it. */
+    /**
+     * One name this gave two kinds of number.
+     *
+     * <p>Apart from everything else the check can fall over on, and for a reason. Those are shapes it
+     * has no rule for, and answering them with silence is what fail-open means. This is the check
+     * disagreeing with itself about one of its own names: two writings it called one value are not
+     * one value, so every relation recorded under that name relates the wrong things. Swallowed, it
+     * produces a body with no findings, which is what a body with nothing to report produces.
+     */
+    static final class OneKeyTwoKinds extends IllegalStateException {
+
+        OneKeyTwoKinds(String message) {
+            super(message);
+        }
+    }
+
+    /** {@code key}, with how its values are spaced recorded against it. A key is what a value is
+     * called and a kind is what the value is, so one key is one kind: two would mean this named two
+     * values alike, and everything recorded under the name would be about neither of them. */
     private String named(String key, Granularity g) {
         if (key == null) {
             return null;
         }
         Granularity had = atomKinds.putIfAbsent(key, g);
         if (had != null && had != g) {
-            throw new IllegalStateException("atom `" + key + "` is " + had + " and " + g);
+            throw new OneKeyTwoKinds("atom `" + key + "` is " + had + " and " + g);
         }
         return key;
     }
@@ -345,17 +388,16 @@ final class Terms {
      * itself, and a container built from one by an operation the table covers names that
      * construction. Anything else names nothing.
      *
-     * <p>The restriction is what ties the flagging to what is said. A location is always named: the
-     * seeding writes about locations, so a clause reading one reads something. A container built by an
-     * operation the table covers is named, since the table is a rule about it. A computed value is
-     * named only where a guard on this path spoke about it — then, and only then, the author has
-     * stated something the clause can be read against, and leaving the construction unreported would
-     * be dropping what they said.
+     * <p>What is named. A location is: the seeding writes about locations, so a clause reading one
+     * reads something. A container built by an operation the table covers is, since the table is a
+     * rule about it. A number is, whatever computes it — the domain carries it, and a clause reading
+     * it reads an unknown the guards may or may not have settled. A value of any other kind is named
+     * only where a guard on this path spoke about it, since a clause reading it has otherwise nothing
+     * to be read against.
      *
-     * <p>A computed value nothing has spoken about is named by nothing, and its construction is
-     * silent. That is this check's flagging policy and not a proof: the run-time check stands for the
-     * whole of such an invariant. Widening it is a matter of naming more values here, which is where
-     * a stated result type or a stdlib rule would enter.
+     * <p>What is not named is not thereby discharged. Its construction is silent, and the silence is
+     * this check's flagging policy rather than a proof: the run-time check stands for the whole of
+     * such an invariant. Widening it is a matter of naming more values here.
      */
     String siteKey(Core e, Denotations at, Known k) {
         // A value written out is not something a guard can be written about: there is nothing to

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * is what the seeding writes about. What a value is called, is a key: two expressions with one key
  * compute one value, which is the whole of what the fact set knows. What can be said of a value, is
  * whether a clause read against it could ever be discharged — a location always can, and so does a
- * number, which is named by whatever computes it; a value of another kind only where a rule or a
+ * number this grammar names, whatever computes it; a value of another kind only where a rule or a
  * guard reaches it — and it is what decides whether a construction is reported at all.
  *
  * <p>The middle question does not wait on the third. A value is called something because it can be
@@ -261,9 +261,10 @@ final class Terms {
 
     /**
      * The canonical atom key of a numeric value: a location ({@code x}, {@code p.a}, a newtype's
-     * value), a size call over a nameable container, or anything else this can name — and
-     * {@code null} where the value is not a number the domain carries, or where nothing here names
-     * it.
+     * value), a size call over a nameable container, or anything else {@link #termKey} names — and
+     * {@code null} where the value is not a number the domain carries, or where the term grammar
+     * names it nothing. A call the representation did not keep standing is the second of those: what
+     * a behavior answered is outside that grammar, so it is no more an atom than it was.
      *
      * <p>An atom exists because a value can be pointed at, not because anything is known of it. Two
      * writings of one value are one atom and so one unknown, which is the whole of what an atom
@@ -390,8 +391,10 @@ final class Terms {
      *
      * <p>What is named. A location is: the seeding writes about locations, so a clause reading one
      * reads something. A container built by an operation the table covers is, since the table is a
-     * rule about it. A number is, whatever computes it — the domain carries it, and a clause reading
-     * it reads an unknown the guards may or may not have settled. A value of any other kind is named
+     * rule about it. A number the term grammar names is, whatever computes it — the domain carries
+     * it, and a clause reading it reads an unknown the guards may or may not have settled. A number
+     * that grammar names nothing, such as what a behavior answered, is not. A value of any other kind
+     * is named
      * only where a guard on this path spoke about it, since a clause reading it has otherwise nothing
      * to be read against.
      *

--- a/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/GuardThresholds.java
@@ -26,7 +26,7 @@ import java.util.List;
  * rows have to be written on both sides of.
  *
  * <p><b>A comparison is read wherever in a condition it is written</b> (spec
- * §a-boundary-is-drawn-on-a-term). Which position the model divides is not a question about the
+ * §boundary-coordinates). Which position the model divides is not a question about the
  * shape of the condition around the comparison, and it was answered as though it were: in
  *
  * <pre>if kind == Domestic &amp;&amp; cost &lt;= 100000</pre>

--- a/souther-compiler/src/test/java/souther/compiler/AnAtomExistsBeforeAnythingIsSaidOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnAtomExistsBeforeAnythingIsSaidOfItTest.java
@@ -1,0 +1,205 @@
+package souther.compiler;
+
+import souther.compiler.diag.Severity;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * A value the invariant-discharge check can point at is one it can point at before anything has been
+ * said about it.
+ *
+ * <p>Two questions, and holding them apart is what this is. Whether a value has a name here is
+ * decided by what computes it: one expression is one value, so two writings of it are one unknown.
+ * Whether anything is known of that value is decided by what the guards state. Deciding the first
+ * question by the answer to the second makes them circular — a guard about a value could only be read
+ * once something had been read about that value — and the first guard about any value is the one that
+ * falls into it.
+ *
+ * <p>What that cost: a guard naming a value the check has no rule about was spent making the value
+ * nameable and its own relation was dropped, so the construction it established was reported; and the
+ * same expression written out rather than named was not even asked, so the construction it did not
+ * establish was silent. Each is checked here against a construction that must be refused, since a
+ * silence that is a proof and a silence that is a value nobody looked at read alike.
+ */
+class AnAtomExistsBeforeAnythingIsSaidOfItTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data NonNeg = Int
+                invariant value >= 0
+            data Fine
+
+            behavior f : (%s) -> NonNeg | Fine
+                constructs NonNeg, Fine
+
+            let f (%s) = {
+                %s
+            }
+            """;
+
+    /** How many warnings the check reports of {@code body}, over inputs {@code params}. */
+    private static long warnings(String params, String names, String body) {
+        return Compiler.compileWithWarnings(MODULE.formatted(params, names, body)).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count();
+    }
+
+    private static final String LIST = "xs: List<Int>, bill: Int";
+
+    /**
+     * The first guard about a value states what it states.
+     *
+     * <p>`List.sum` is a call the check has no rule about, so this guard is the first thing in the
+     * body to mention the value it answers. What follows from it — that the difference is not
+     * negative — follows from the guard alone and from nothing about summing.
+     */
+    @Test
+    void theFirstGuardAboutAValueStatesWhatItStates() {
+        assertEquals(0, warnings(LIST, "xs, bill", """
+                let t = List.sum(xs)
+                    guard t >= bill else Fine
+                    NonNeg(t - bill)"""),
+                "`t >= bill` is what makes `t - bill` non-negative");
+        assertEquals(1, warnings(LIST, "xs, bill", """
+                let t = List.sum(xs)
+                    guard t >= bill else Fine
+                    NonNeg(t - bill - 1)"""),
+                "and one more subtraction is not something it establishes");
+    }
+
+    /** Guards about one value answer the same in either order: what a guard states does not depend on
+     * whether an earlier one happened to mention the same value. */
+    @Test
+    void guardsAboutOneValueAnswerTheSameInEitherOrder() {
+        assertEquals(warnings(LIST, "xs, bill", """
+                let t = List.sum(xs)
+                    guard t >= 0 else Fine
+                    guard t >= bill else Fine
+                    NonNeg(t - bill)"""),
+                warnings(LIST, "xs, bill", """
+                let t = List.sum(xs)
+                    guard t >= bill else Fine
+                    guard t >= 0 else Fine
+                    NonNeg(t - bill)"""),
+                "the same two statements, in the other order");
+    }
+
+    /** Written out or named, one call is one value — in both directions, so that neither spelling is
+     * the one that goes unasked. */
+    @Test
+    void aCallAnswersTheSameWrittenOrNamed() {
+        assertEquals(warnings(LIST, "xs, bill", """
+                guard List.sum(xs) >= bill else Fine
+                    NonNeg(List.sum(xs) - bill)"""),
+                warnings(LIST, "xs, bill", """
+                let t = List.sum(xs)
+                    guard t >= bill else Fine
+                    NonNeg(t - bill)"""),
+                "one value discharged, however it is written");
+        assertEquals(warnings(LIST, "xs, bill", """
+                guard List.sum(xs) >= bill else Fine
+                    NonNeg(List.sum(xs) - bill - 1)"""),
+                warnings(LIST, "xs, bill", """
+                let t = List.sum(xs)
+                    guard t >= bill else Fine
+                    NonNeg(t - bill - 1)"""),
+                "and one value left standing, however it is written");
+    }
+
+    /** A construction from a call no guard mentions is owed its clause. Nothing here says the sum is
+     * not negative, and nothing about the operation says it either. */
+    @Test
+    void aCallNoGuardMentionsIsOwedItsClause() {
+        assertEquals(1, Compiler.compileWithWarnings("""
+                module demo
+
+                data NonNeg = Int
+                    invariant value >= 0
+
+                behavior f : (xs: List<Int>) -> NonNeg
+                    constructs NonNeg
+
+                let f (xs) = {
+                    let t = List.sum(xs)
+                    NonNeg(t)
+                }
+                """).warnings().stream().filter(d -> d.severity() == Severity.WARNING).count(),
+                "the clause is read against the value and nothing discharges it");
+    }
+
+    /**
+     * Moving the call into a helper answers what the call answers.
+     *
+     * <p>The rewrite a reader reaches for when the warning arrives. It is expanded where the check
+     * reads the body, so it is the same value under another name, and a construction it does not
+     * establish is refused through the helper exactly as it is through the call.
+     */
+    @Test
+    void aHelperWrappingTheCallAnswersLikeTheCall() {
+        String tally = "\n\nlet tally (xs: List<Int>): Int = List.sum(xs)";
+        assertEquals(0, Compiler.compileWithWarnings(MODULE.formatted(LIST, "xs, bill", """
+                guard tally(xs) >= bill else Fine
+                    NonNeg(tally(xs) - bill)""") + tally).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count(),
+                "the guard establishes it through the helper");
+        assertEquals(1, Compiler.compileWithWarnings(MODULE.formatted(LIST, "xs, bill", """
+                guard tally(xs) >= bill else Fine
+                    NonNeg(tally(xs) - bill - 1)""") + tally).warnings().stream()
+                .filter(d -> d.severity() == Severity.WARNING).count(),
+                "and does not establish one more subtraction");
+    }
+
+    private static final String PRODUCT = "a: Int, b: Int, bill: Int";
+
+    /**
+     * A product the fragment does not read is still one value.
+     *
+     * <p>The domain declines to relate {@code a * b} to {@code a} and to {@code b}, which is a
+     * decision about arithmetic and not about naming. A guard comparing the product to something is
+     * about the product, and both spellings of it are the same product.
+     */
+    @Test
+    void aProductOutsideTheFragmentIsStillOneValue() {
+        assertEquals(0, warnings(PRODUCT, "a, b, bill", """
+                guard a * b >= bill else Fine
+                    NonNeg(a * b - bill)"""),
+                "written out");
+        assertEquals(0, warnings(PRODUCT, "a, b, bill", """
+                let v = a * b
+                    guard v >= bill else Fine
+                    NonNeg(v - bill)"""),
+                "and named");
+        assertEquals(1, warnings(PRODUCT, "a, b, bill", """
+                guard a * b >= bill else Fine
+                    NonNeg(a * b - bill - 1)"""),
+                "one more subtraction is not established, written out");
+        assertEquals(1, warnings(PRODUCT, "a, b, bill", """
+                let v = a * b
+                    guard v >= bill else Fine
+                    NonNeg(v - bill - 1)"""),
+                "nor named");
+    }
+
+    /**
+     * What the fragment cannot read is the product and not the sum it sits in.
+     *
+     * <p>Reading the whole of {@code a * b + c} as one value would lose the {@code + c}, and with it
+     * everything a guard about {@code c} states. So the two guards compose here, and a construction
+     * one unit past what they establish is still refused.
+     */
+    @Test
+    void aProductInsideArithmeticKeepsTheArithmetic() {
+        assertEquals(0, warnings("a: Int, b: Int, c: Int", "a, b, c", """
+                guard a * b >= 5 else Fine
+                    guard c >= 0 else Fine
+                    NonNeg(a * b + c - 5)"""),
+                "the product is at least five and the rest is not negative");
+        assertEquals(1, warnings("a: Int, b: Int, c: Int", "a, b, c", """
+                guard a * b >= 5 else Fine
+                    guard c >= 0 else Fine
+                    NonNeg(a * b + c - 6)"""),
+                "and neither guard says the sum reaches six");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/AnAtomExistsBeforeAnythingIsSaidOfItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnAtomExistsBeforeAnythingIsSaidOfItTest.java
@@ -69,21 +69,29 @@ class AnAtomExistsBeforeAnythingIsSaidOfItTest {
                 "and one more subtraction is not something it establishes");
     }
 
-    /** Guards about one value answer the same in either order: what a guard states does not depend on
-     * whether an earlier one happened to mention the same value. */
+    /**
+     * Guards about one value answer the same in either order, and what they answer is discharged.
+     *
+     * <p>Both are said rather than only that the two agree. Two orders that both report is agreement
+     * as much as two that both discharge, and it is the answer this is about: the second statement
+     * is what establishes the construction, so an order in which it goes unread is an order in which
+     * the construction is reported.
+     */
     @Test
     void guardsAboutOneValueAnswerTheSameInEitherOrder() {
-        assertEquals(warnings(LIST, "xs, bill", """
+        long spokenFirst = warnings(LIST, "xs, bill", """
                 let t = List.sum(xs)
                     guard t >= 0 else Fine
                     guard t >= bill else Fine
-                    NonNeg(t - bill)"""),
-                warnings(LIST, "xs, bill", """
+                    NonNeg(t - bill)""");
+        long spokenSecond = warnings(LIST, "xs, bill", """
                 let t = List.sum(xs)
                     guard t >= bill else Fine
                     guard t >= 0 else Fine
-                    NonNeg(t - bill)"""),
-                "the same two statements, in the other order");
+                    NonNeg(t - bill)""");
+        assertEquals(0, spokenFirst, "`t >= bill` establishes it, stated second");
+        assertEquals(0, spokenSecond, "and stated first");
+        assertEquals(spokenFirst, spokenSecond, "the same two statements, in the other order");
     }
 
     /** Written out or named, one call is one value — in both directions, so that neither spelling is

--- a/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileInvariantOneDenotationTest.java
@@ -125,11 +125,18 @@ class CompileInvariantOneDenotationTest {
                 "inline and named answer alike");
     }
 
+    /**
+     * A call nothing has said anything about is owed its clause, not excused it.
+     *
+     * <p>Being able to point at a value and knowing something about it are two things. The check
+     * names this call — the two writings of it are one value — and names nothing that settles
+     * {@code value >= 0} of it, which is a clause left standing rather than a clause never asked.
+     */
     @Test
-    void aCallNothingHasSpokenAboutIsSilent() {
-        assertEquals(0, warnings(Compiler.compileWithWarnings(
+    void aCallNothingHasSaidAnythingAboutIsOwedItsClause() {
+        assertEquals(1, warnings(Compiler.compileWithWarnings(
                         EACHES.formatted("Eaches(Int.floorMod(eaches.value, pack.value))"))),
-                "nothing is known of the call, so its construction is left to the run-time check");
+                "the call is a value the clause is read against, and nothing here discharges it");
     }
 
     private static final String GUARDED = """

--- a/souther-compiler/src/test/java/souther/compiler/CompileNamingAnExpressionTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileNamingAnExpressionTest.java
@@ -29,6 +29,7 @@ class CompileNamingAnExpressionTest {
             "c.value + 1",                          // affine over one
             "c.value * 2",                          // a scalar product
             "c.value * n",                          // a variable product, outside the fragment
+            "c.value * n + 1",                      // one inside arithmetic the fragment does read
             "c.value / 2",                          // an integer divide, outside it too
             "Int.add(c.value, 1)",                  // the function form of an operator
             "Int.subtract(c.value, 1)",

--- a/souther-compiler/src/test/java/souther/compiler/check/OneNameIsOneValueTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/OneNameIsOneValueTest.java
@@ -1,0 +1,66 @@
+package souther.compiler.check;
+
+import souther.compiler.core.Core;
+import souther.compiler.diag.SourcePos;
+import souther.compiler.types.BindingId;
+import souther.compiler.types.BindingOwner;
+import souther.compiler.types.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A name the discharge check gives an atom is a name for one value.
+ *
+ * <p>Every relation the numeric domain records is recorded against a name, so two values under one
+ * name is every relation about one of them read as a relation about the other. The kind of number
+ * behind a name is what catches it: a whole number and a dense one are not the same value however
+ * alike they are written.
+ *
+ * <p>Held here because the check is fail-open. A walk that falls over produces what a walk that found
+ * nothing produces, so a contradiction inside the check would arrive as a behavior with no findings —
+ * silence that reads as every invariant discharged. What this holds is that one failure is refused
+ * rather than recorded: the check may be unable to answer for a program, and it may not disagree with
+ * itself about its own names.
+ */
+class OneNameIsOneValueTest {
+
+    private static final SourcePos POS = new SourcePos(1, 1);
+
+    private static BindingId binding() {
+        return new BindingId(new BindingOwner.OfValue("demo", "f"), 0);
+    }
+
+    @Test
+    void oneKeyIsRefusedASecondKindOfNumber() {
+        Terms terms = new Terms(Symbols.none());
+        BindingId binding = binding();
+        Denotations at = Denotations.none().location(binding);
+        String whole = terms.atomOf(new Core.Read("n", binding, Type.INT, POS), at);
+        assertNotNull(whole, "a location is an atom");
+        Terms.OneKeyTwoKinds refused = assertThrows(Terms.OneKeyTwoKinds.class,
+                () -> terms.atomOf(new Core.Read("n", binding, Type.DECIMAL, POS), at),
+                "the same name, standing for a number spaced the other way");
+        assertTrue(refused.getMessage().contains(whole),
+                "and it says which name: " + refused.getMessage());
+    }
+
+    @Test
+    void theCheckDoesNotSwallowItsOwnContradiction() {
+        assertThrows(Terms.OneKeyTwoKinds.class,
+                () -> InvariantChecker.gaveUp("analyze",
+                        new Terms.OneKeyTwoKinds("atom `n` is DISCRETE and DENSE")),
+                "recording it would leave a behavior looking like one with nothing to report");
+    }
+
+    @Test
+    void andStillGivesUpOnAShapeItHasNoRuleFor() {
+        assertDoesNotThrow(() -> InvariantChecker.gaveUp("analyze",
+                        new IllegalStateException("something the walk has no rule for")),
+                "which is what fail-open is for");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckCouldNotReadIsNotWhatItProvedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/WhatTheCheckCouldNotReadIsNotWhatItProvedTest.java
@@ -24,9 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * read off the verdicts rather than off the diagnostics — a difference no test can reach is one that
  * stops being true without anything failing.
  *
- * <p>What made it worth telling apart is {@code Int.max}: it keeps its call where the check reads the
- * body, a call is not a term any clause is read against, and a construction over one is silent
- * however plainly it violates. That silence read as a discharge is what {@code #409} reported.
+ * <p>What is left unread is narrower than it was. A numeric value is named by what computes it, so a
+ * call answering a number is a term and its construction is judged; what stays unread is a value the
+ * domain does not carry and no rule reaches — a string a call handed back, which no guard states a
+ * relation about and no clause folds against.
  */
 class WhatTheCheckCouldNotReadIsNotWhatItProvedTest {
 
@@ -55,31 +56,32 @@ class WhatTheCheckCouldNotReadIsNotWhatItProvedTest {
 
     @Test
     void aValueTheCheckCannotReadIsNotADischarge() {
-        // `value >= 1` does not hold of `Int.max(0, n)` at n <= 0, and nothing here says otherwise.
+        // `String.startsWith` does not hold of `String.trim(s)` at every `s`, and nothing here says
+        // otherwise: the value is a string a call handed back, which nothing states a relation about.
         String source = """
                 module demo
-                data Pos = Int
-                    invariant positive = value >= 1
-                behavior f : (n: Int) -> Pos constructs Pos
-                let f (n) = Pos(Int.max(0, n))
+                data Tag = String
+                    invariant prefixed = String.startsWith("A", value)
+                behavior f : (s: String) -> Tag constructs Tag
+                let f (s) = Tag(String.trim(s))
                 """;
-        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Pos", source),
+        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Tag", source),
                 "the clause was never asked, so it was not answered");
         assertEquals(0, warnings(source), "and nothing is reported of it");
     }
 
     @Test
     void aClauseDischargedBesideOneUnreadIsNotTheInvariantProved() {
-        // `0 <= 1` folds to true and owes nothing; `value >= 1` cannot be read at this value. An
+        // `0 <= 1` folds to true and owes nothing; the prefix clause cannot be read at this value. An
         // invariant is the conjunction of its clauses, so one of them holding is not the invariant.
         String source = """
                 module demo
-                data Pos = Int
-                    invariant mixed = 0 <= 1 && value >= 1
-                behavior f : (n: Int) -> Pos constructs Pos
-                let f (n) = Pos(Int.max(0, n))
+                data Tag = String
+                    invariant mixed = 0 <= 1 && String.startsWith("A", value)
+                behavior f : (s: String) -> Tag constructs Tag
+                let f (s) = Tag(String.trim(s))
                 """;
-        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Pos", source),
+        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Tag", source),
                 "the conjunct left to the run-time check is still left to it");
         assertEquals(0, warnings(source), "and nothing is reported of it");
     }
@@ -88,15 +90,56 @@ class WhatTheCheckCouldNotReadIsNotWhatItProvedTest {
     void oneBranchDischargedBesideOneUnreadIsNotProvedEither() {
         String source = """
                 module demo
-                data Yen = Int
-                    invariant nonNegative = value >= 0
-                behavior f : (n: Int, flag: Bool) -> Yen constructs Yen
-                let f (n, flag) = Yen(if flag then 0 else Int.max(0, n))
+                data Tag = String
+                    invariant prefixed = String.startsWith("A", value)
+                behavior f : (s: String, flag: Bool) -> Tag constructs Tag
+                let f (s, flag) = Tag(if flag then "A" else String.trim(s))
                 """;
-        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Yen", source),
-                "`0` discharges the clause and `Int.max(0, n)` is not read; together they are the"
-                        + " weaker of the two");
+        assertEquals(Verdict.UNREPRESENTABLE, verdictOn("Tag", source),
+                "`\"A\"` discharges the clause and `String.trim(s)` is not read; together they are"
+                        + " the weaker of the two");
         assertEquals(0, warnings(source), "neither reading says the construction may abort");
+    }
+
+    /**
+     * A call answering a number is read, and what is not known of it is owed rather than skipped.
+     *
+     * <p>The one that had to be told apart from a discharge, until a value computed by a call became
+     * a term of its own. Nothing here knows what {@code Int.max} answers and nothing has to: the two
+     * writings of it are one value, which is enough to owe the clause and not enough to settle it.
+     */
+    @Test
+    void aCallAnsweringANumberIsReadAndIsOwedTheClause() {
+        String source = """
+                module demo
+                data Pos = Int
+                    invariant positive = value >= 1
+                behavior f : (n: Int) -> Pos constructs Pos
+                let f (n) = Pos(Int.max(0, n))
+                """;
+        assertEquals(Verdict.UNKNOWN, verdictOn("Pos", source),
+                "`value >= 1` does not hold of `Int.max(0, n)` at n <= 0, and nothing said it does");
+        assertEquals(1, warnings(source), "which is what E2011 reports");
+    }
+
+    /** And a guard about that same call settles it, which is what makes the warning one an author
+     * can answer rather than a limit they are told about. */
+    @Test
+    void aGuardAboutThatCallSettlesIt() {
+        String source = """
+                module demo
+                data Pos = Int
+                    invariant positive = value >= 1
+                data TooSmall
+                behavior f : (n: Int) -> Pos | TooSmall constructs Pos, TooSmall
+                let f (n) = {
+                    guard Int.max(0, n) >= 1 else TooSmall
+                    Pos(Int.max(0, n))
+                }
+                """;
+        assertEquals(Verdict.PROVED, verdictOn("Pos", source),
+                "the guard states of the value exactly what the clause reads of it");
+        assertEquals(0, warnings(source), "so nothing is owed");
     }
 
     @Test

--- a/specification.adoc
+++ b/specification.adoc
@@ -1334,6 +1334,24 @@ let build (rows) = {
 
 A size taken of a container built by an operation is read through that operation, by the rules in <<invariant-discharge-preservation>>. A size taken of anything else — of what a behavior answered — is not a term, and a clause needing it is left to the run-time check.
 
+Beyond those, a term is any number the procedure can name by what computes it. `+List.sum(xs)+` is a term, and so is `+a * b+`, which the arithmetic below does not read. Naming a value says that two writings of it are one value, and says nothing else: nothing follows from `+List.sum+` being a sum, and nothing has to. A `+guard List.sum(xs) >= bill+` states a relation about that value, `+List.sum(xs) - bill+` is arithmetic over it, and the two meet because both mentions of the call are the same value. A term exists before anything is said about it, so the first guard to mention one states what it states, exactly as a later one does.
+
+[,souther]
+----
+data NonNeg = Int
+    invariant value >= 0
+data Fine
+
+behavior settle : (xs: List<Int>, bill: Int) -> NonNeg | Fine
+    constructs NonNeg, Fine
+let settle (xs, bill) = {
+    guard List.sum(xs) >= bill else Fine
+    NonNeg(List.sum(xs) - bill) // discharged: the guard is about this value
+}
+----
+
+A value the procedure cannot name all the way down is not a term. What a behavior answered is named by nothing, so neither is a size taken of it nor arithmetic over it. A value that is not a number the procedure carries is not a term either, unless a guard on the path states something about it — a string a call handed back is named by nothing a clause could be read against, and a construction from one is left to the run-time check.
+
 [,souther]
 ----
 data Q = Int
@@ -1356,7 +1374,7 @@ behavior total : (xs: List<Held>) -> Q
 let total (xs) = List.fold((acc, i) -> acc + i.q, Q(0), xs) // discharged: both are Q
 ----
 
-A binding given a location *is* that location, so `+let c = cart+` makes `+c.quantity+` the term `+cart.quantity+`. A helper is expanded by binding each argument and reading the parameter through that binding (<<invariant-discharge-representation>>), which is why a construction moved into a helper still reads the terms the caller's guards and input types settled. A binding given anything else is a term of its own; where what it was given is arithmetic over terms the procedure names the two are related, and otherwise nothing about it follows.
+A binding given a location *is* that location, so `+let c = cart+` makes `+c.quantity+` the term `+cart.quantity+`. A helper is expanded by binding each argument and reading the parameter through that binding (<<invariant-discharge-representation>>), which is why a construction moved into a helper still reads the terms the caller's guards and input types settled. A binding given anything else is the term that expression is, so a name and the expression it was given are read alike: a guard about either states the same thing about the same value, and a construction from either owes the same clauses.
 
 [,souther]
 ----
@@ -2869,7 +2887,7 @@ A type says the classes. `+Bool+` is two; an optional is `+None+` and `+Some+`; 
 
 A threshold says where one class ends and the next begins. A `+guard+` comparing an input against a constant (<<guard>>) divides the position, because both sides of that comparison hold values a row can write. A `+guard+` comparing one input against another divides neither of them and still draws a line (<<a-comparison-of-two-positions-draws-a-line-between-them>>). Thresholds at one position merge into one partition, intersected with what the position admits: an invariant of `+x >= 0+` and a guard of `+x < 10+` divide the position into `+0 <= x < 10+` and `+10 <= x+`, and nothing below zero, because nothing below zero can be constructed.
 
-[[a-boundary-is-drawn-on-a-term]]*What a line is drawn on is a term's value, which is not always a position — and being ordered is what such a value must be rather than what makes it one (<<a-line-is-drawn-where-the-values-can-carry-one>>).* The terms are the ones the discharge procedure names (<<invariant-discharge-terms>>): the content of a location, and the size of a container or a string taken of one — `+List.length+`, `+String.length+`, `+Set.size+`, `+Map.size+`. So `+data Name = String invariant String.length(value) > 0+` draws a line at a length of 1, and a `+guard String.length(t.name.value) > 3+` draws one at 3 with a 4 beside it, exactly as a bound and a guard on a number do. A line is named by the term it is drawn on — `+String.length(t.name) = 1+` — and an invariant and a guard mean the same line when they take the same measure of the same location. A size is a whole number and is never negative, and neither has to be written down: no row is asked for at a length below zero however the rules about it are phrased.
+[[boundary-coordinates]]*What a line is drawn on is a boundary coordinate, which is not always a position — and being ordered is what such a value must be rather than what makes it one (<<a-line-is-drawn-where-the-values-can-carry-one>>).* A coordinate is the content of a location — a parameter, a field chain, a newtype's wrapped value — or the size of a container or a string taken of one: `+List.length+`, `+String.length+`, `+Set.size+`, `+Map.size+`. Which values divide an input space is its own question, and this states the answer rather than borrowing one: a value some other reading of the model can point at is not thereby an axis rows are asked to cover. So `+data Name = String invariant String.length(value) > 0+` draws a line at a length of 1, and a `+guard String.length(t.name.value) > 3+` draws one at 3 with a 4 beside it, exactly as a bound and a guard on a number do. A line is named by the coordinate it is drawn on — `+String.length(t.name) = 1+` — and an invariant and a guard mean the same line when they take the same measure of the same location. A size is a whole number and is never negative, and neither has to be written down: no row is asked for at a length below zero however the rules about it are phrased.
 
 A position whose values no rule measures still has no classes. A `+String+` nothing says anything about is *not derivable* and is named by the position, not by a length nobody wrote a rule about.
 
@@ -2948,7 +2966,7 @@ A function written where a call takes one is made there and run elsewhere. Evalu
 
 *What the rows establish about a case.* `+specified+` — a row expects this case; `+observed+` — the behavior was seen to answer with it; `+verified+` — a row expected it and the behavior produced it. An input position carries `+executed+` where an output carries `+observed+` (<<example-adequacy>>).
 
-*What the rows reach of the model's own distinctions.* `+partition axes+` is how many positions the model divides at all; `+single-axis+` is how many of those positions' classes some row is in; `+pairs+` counts combinations across two positions, as counts rather than a ratio (<<example-partition>>). `+boundary+` is the lines some rule drew that a row is at, each named by the term it was drawn on (<<a-boundary-is-drawn-on-a-term>>). `+not derivable+` is a position the model draws no line through, which is a fact about the model and not a gap in the rows.
+*What the rows reach of the model's own distinctions.* `+partition axes+` is how many positions the model divides at all; `+single-axis+` is how many of those positions' classes some row is in; `+pairs+` counts combinations across two positions, as counts rather than a ratio (<<example-partition>>). `+boundary+` is the lines some rule drew that a row is at, each named by the coordinate it was drawn on (<<boundary-coordinates>>). `+not derivable+` is a position the model draws no line through, which is a fact about the model and not a gap in the rows.
 
 *Whether a measure has a number.* Three states, and the report's own word for each. `+complete+` — the measure was made and everything it reads was readable, so a gap is a gap. `+partial+` — it was made and something it reads was not, so it shows what it saw and what it could not decide; a line under a partial measure reads `+undecided+`, which is that measure's account of one thing rather than a state of its own. `+unavailable+` — there is no number.
 


### PR DESCRIPTION
Fixes #648.

## What was wrong

The discharge check decided whether a value had a name by asking whether anything was known about it, and asked that question while reading the very guard that would have made it known. One circularity, two symptoms pointing opposite ways:

- `let t = List.sum(xs); guard t >= bill; NonNeg(t - bill)` warned. The guard was spent making `t` nameable and its own relation was dropped, so the construction it establishes was reported.
- `guard List.sum(xs) >= bill; NonNeg(List.sum(xs) - bill - 1)` was silent. An expression not reached through a binding never became an atom however many guards named it, so the construction was not checked at all — sound or not.

Measured rather than assumed. A second guard mentioning the same value first made the warning disappear (`guard t >= 0; guard t >= bill; ...` is silent, its `- 1` variant warns, and swapping the two guards brings the warning back), and no number of guards changed the inline spelling.

## What changed

**`Terms.atomOf` no longer consults `Known`.** Any number is named by what computes it. An atom asserts that two writings of one expression are one value and asserts nothing else; what is known of it is what the guards state. `spoken` still decides readability for values the numeric domain does not carry, which is where a guard is the only thing that can reach them.

**`Terms.affine` hands back a node it has a rule for and cannot compose.** Not a `*` special case: an operator lowering that does not compose returns the node to `leaf`, so a variable product is one value where it is written as well as where it is bound. It is local — `a * b + c` keeps the sum and only the product is the unknown. Without this the asymmetry does not go away, it moves from opaque calls to variable products, in the opposite direction.

**A call answering a number is read, so a construction the guards do not settle is E2011.** Three tests asserting the old silence now assert the warning, and `WhatTheCheckCouldNotReadIsNotWhatItProvedTest` keeps the `UNREPRESENTABLE` distinction on a value the domain does not carry (a string a call handed back). The warning is one an author can answer: a `guard Int.max(0, n) >= 1` discharges it.

**`Terms.named` refusing one key two kinds of number is no longer swallowed.** It is this check contradicting itself about its own names, not a shape it has no rule for. Caught by the fail-open handlers it produces a behavior with no findings, which is what a behavior whose invariants all discharge produces. All three handlers funnel through `InvariantChecker.gaveUp`, so the refusal is stated once.

**The specification states boundary coordinates on their own.** `a-boundary-is-drawn-on-a-term` becomes `boundary-coordinates` and no longer derives its list from `invariant-discharge-terms`. Which values a proof can point at and which values divide an input space are different questions; only the first widened here.

## Tests

`AnAtomExistsBeforeAnythingIsSaidOfItTest` holds the properties, each as a sound/unsound pair so a silence cannot pass for a proof: a first guard states what it states, guards about one value answer the same in either order, a call answers the same written or named, a call no guard mentions is owed its clause, a helper wrapping the call answers like the call, a product outside the fragment is still one value, and a product inside arithmetic keeps the arithmetic.

`OneNameIsOneValueTest` holds that one key is refused a second kind of number, that the check does not swallow that refusal, and that it still gives up on a shape it has no rule for.

`CompileNamingAnExpressionTest` gains `c.value * n + 1` — a lowering that exists and fails, inside arithmetic that does not.

`mvn clean test` across the reactor: 6876 tests, all green.

## Not done here

`Core.Call` / `Core.Apply` are not given an identity. A helper reads because it is expanded into a `PreservedCall`; a call that is not expanded is a separate question. `E2012`–`E2019` are taken by the attempt family, so a future code for what the check cannot represent needs a different number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
