### PR TITLE
Read a floor on how much a field holds wherever the rule stating it is written

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/FieldDomains.java
@@ -27,9 +27,12 @@ public final class FieldDomains {
 
     /** Nothing known of any field. */
     public static final FieldDomains NONE =
-            new FieldDomains(Map.of(), false, true, NumericDomain.top(), () -> true);
+            new FieldDomains(Map.of(), Map.of(), false, true, NumericDomain.top(), () -> true);
 
     private final Map<String, NumericDomain.Bounds> byField;
+    /** What each field has to hold, kept apart from what each field is. Same numbers, different
+     * question — see {@link Held}. */
+    private final Map<String, NumericDomain.Bounds> heldByField;
     private final boolean infeasible;
     /** Whether the reading that produced these bounds ran to the end. Kept because it is what that
      * reading knows about itself: a walk that fell over produces the same empty domain as a value
@@ -39,10 +42,12 @@ public final class FieldDomains {
     private final java.util.function.BooleanSupplier reading;
     private volatile Boolean everyRuleRead;
 
-    private FieldDomains(Map<String, NumericDomain.Bounds> byField, boolean infeasible,
+    private FieldDomains(Map<String, NumericDomain.Bounds> byField,
+                         Map<String, NumericDomain.Bounds> heldByField, boolean infeasible,
                          boolean seeded, NumericDomain numbers,
                          java.util.function.BooleanSupplier reading) {
         this.byField = byField;
+        this.heldByField = heldByField;
         this.infeasible = infeasible;
         this.seeded = seeded;
         this.numbers = numbers;
@@ -91,14 +96,59 @@ public final class FieldDomains {
                 out.put(field, bounds);
             }
         });
+        // Resolved here rather than handed over as atoms. An atom is a name the seeding gave a shape
+        // and means nothing once the reading that named it is gone, so a caller holding one could
+        // only ask the domain it came from — which is this one, while it is still here.
+        Map<String, NumericDomain.Bounds> holds = new LinkedHashMap<>();
+        seeded.held().forEach((field, atom) -> {
+            if (data.newtype()) {
+                return;
+            }
+            NumericDomain.Bounds bounds = seeded.numbers().boundsOf(atom);
+            if (!bounds.isEmpty()) {
+                holds.put(field, bounds);
+            }
+        });
         // Classifying the rules is a second reading of every one of them, and the bounds are the
         // whole of what a caller filling a row needs. Asked when the answer is, and not before.
-        return new FieldDomains(Map.copyOf(out), seeded.numbers().isBottom(),
+        return new FieldDomains(Map.copyOf(out), Map.copyOf(holds), seeded.numbers().isBottom(),
                 seeded.everyClauseRead(), seeded.numbers(),
                 // Classifying the rules is a second reading of every one of them. Asked when the
                 // answer is, and not before: a caller filling a row wants the bounds and nothing
                 // else.
                 () -> InvariantChecker.everyRuleRead(named, data, symbols));
+    }
+
+    /**
+     * How much a value at a position has to hold, which is not what the value there is.
+     *
+     * <p>Its own type because the numbers are the same numbers. {@code >= 2} at a field is a range of
+     * that field's values where the field is a number, and a count of what it holds where a rule
+     * counts it — and a caller handed a bare {@link NumericDomain.Bounds} has nothing to stop it
+     * reading one as the other. There is one such mistake in this already: the atom a size rule
+     * bounds is the size's, and writing it under the field is how a list would come to be told it
+     * must be at least 2.
+     */
+    public record Held(NumericDomain.Bounds bounds) {
+
+        public Held {
+            if (bounds == null) {
+                throw new IllegalArgumentException("a floor with no bounds is no floor");
+            }
+        }
+    }
+
+    /**
+     * What the rules say the value at {@code path} holds, or {@code null} where they count it in no
+     * way this read.
+     *
+     * <p>Read off the measure the position's own type names ({@link NumericMeasures#takenOf}), so a
+     * field this can answer for is one whose values are counted by something. A field of a number has
+     * no such measure and is answered by {@link #at} instead; the two never speak about one field.
+     */
+    public Held heldAt(String path) {
+        NumericDomain.Bounds bounds = heldByField.get(path);
+        return bounds == null ? null : new Held(bounds);
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/InvariantChecker.java
@@ -240,12 +240,17 @@ public final class InvariantChecker {
      * bounds that field on its own; and both land in one domain over the same atoms, which is what
      * lets a bound reach one field through another.
      *
+     * @param atoms the atom each field's own value is, for the fields that are numbers
+     * @param held the atom the count of each field is, for the fields whose values are counted by
+     *             something. A field is in one of these two or in neither, never in both: what
+     *             names a number is its own value and what names a list is how much of it there is
      * @param everyClauseRead whether every clause of the declaration was taken into the domain. False
      *                        where one could not be typed or held nothing this reads — the bounds are
      *                        then weaker than what the declaration actually says, and a caller
      *                        turning one into an obligation has to know that
      */
-    record Seeded(NumericDomain numbers, Map<String, String> atoms, boolean everyClauseRead) {}
+    record Seeded(NumericDomain numbers, Map<String, String> atoms, Map<String, String> held,
+                  boolean everyClauseRead) {}
 
     /** {@link Seeded} for one declaration. A declaration this cannot read is one whose fields it says
      * nothing about, which is the same answer as a declaration with no rules — so nothing about the
@@ -295,15 +300,16 @@ public final class InvariantChecker {
             }
         } catch (RuntimeException why) {
             gaveUp("seedFields " + named.name(), why);
-            return new Seeded(NumericDomain.top(), Map.of(), false);
+            return new Seeded(NumericDomain.top(), Map.of(), Map.of(), false);
         }
         Map<String, String> atoms = new LinkedHashMap<>();
         Map<String, Type> typeAt = new LinkedHashMap<>();
+        Map<String, String> held = new LinkedHashMap<>();
         for (Map.Entry<String, BindingId> field : bindings.entrySet()) {
             Type type = fields.get(field.getKey());
             if (type != null) {
                 c.name(new Core.Read(field.getKey(), field.getValue(), type, NOWHERE),
-                        field.getKey(), type, at, symbols, 1, atoms, typeAt);
+                        field.getKey(), type, at, symbols, 1, atoms, typeAt, held);
             }
         }
         NumericDomain numbers = k.numbers();
@@ -319,7 +325,7 @@ public final class InvariantChecker {
                     NumericDomain.Rel.EQ,
                     Map.of(atom, c.terms.granularityOf(type)));
         }
-        return new Seeded(numbers, atoms, read);
+        return new Seeded(numbers, atoms, held, read);
     }
 
     /**
@@ -331,11 +337,19 @@ public final class InvariantChecker {
      * rather than at the record it happens to be inside.
      */
     private void name(Core value, String path, Type type, Denotations at, Symbols symbols,
-                      int depth, Map<String, String> atoms, Map<String, Type> typeAt) {
+                      int depth, Map<String, String> atoms, Map<String, Type> typeAt,
+                      Map<String, String> held) {
         String atom = terms.atomOf(value, at);
         if (atom != null) {
             atoms.put(path, atom);
             typeAt.put(path, type);
+        }
+        // And what a rule counting this position spoke about, which is not what the position is. A
+        // list is no number and has no atom above; the count of it has one, and a reader asking how
+        // much the position holds is asking about that one.
+        String counted = terms.takenAtomOf(value, type, at);
+        if (counted != null) {
+            held.put(path, counted);
         }
         if (depth > FIELDS_SEEDED || !(type instanceof Type.Ref ref)
                 || !(symbols.get(ref.name()) instanceof Ast.Data data) || data.newtype()) {
@@ -344,7 +358,7 @@ public final class InvariantChecker {
         for (Map.Entry<String, Type> field : clauses.fieldsOf(data).entrySet()) {
             name(new Core.FieldAccess(value, field.getKey(), field.getValue(), NOWHERE),
                     path + "." + field.getKey(), field.getValue(), at, symbols, depth + 1,
-                    atoms, typeAt);
+                    atoms, typeAt, held);
         }
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Terms.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Terms.java
@@ -294,6 +294,30 @@ final class Terms {
         return named(shared(sizeKey(size, container)), Granularity.DISCRETE);
     }
 
+    /**
+     * The atom a rule counting {@code e} would have bounded, or null where there is no such atom.
+     *
+     * <p>Written because the identity is not the field's name. A size is keyed on the shape
+     * {@code length(<what the container keys as>)}, and what the container keys as is a location —
+     * {@code demo.Bag.fields.0} and not {@code xs} — so a caller spelling that shape itself would be
+     * agreeing with this by hand at every place it asked. What a value of a type is counted by is
+     * {@link NumericMeasures}' answer, and the container's key is {@link #bodyKey}'s, and this is the
+     * two of them put together in the one order they go together in.
+     *
+     * <p>Recognised and not made. {@link #sizeKeyOf} names a shape whether or not anything has
+     * spoken about it, which is what a clause reading one needs; a reader asking what was said about
+     * a field wants the name a clause already gave it, and answering with a fresh one would put an
+     * atom nothing bounds into the domain and call that an answer.
+     */
+    String takenAtomOf(Core e, Type type, Denotations at) {
+        ValueName.Stdlib counts = NumericMeasures.takenOf(type, symbols);
+        if (counts == null) {
+            return null;
+        }
+        String container = bodyKey(e, at);
+        return container == null ? null : shapes.get(sizeKey(counts, container));
+    }
+
     /** {@code shape} under the name it goes by here, so that what reads it reads the name. */
     private String shared(String shape) {
         if (shape == null) {

--- a/souther-compiler/src/main/java/souther/compiler/partition/Counts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Counts.java
@@ -1,6 +1,7 @@
 package souther.compiler.partition;
 
 import souther.compiler.numeric.Count;
+import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.Place;
 
 import java.math.BigDecimal;
@@ -14,6 +15,26 @@ import java.math.BigDecimal;
  * a collection of that many.
  */
 final class Counts {
+
+    /**
+     * How many {@code min} says there are at least, or 0 where it says nothing about that.
+     *
+     * <p>One reading, because a floor is written on a type and on the record that has a value of it
+     * as a field, and the two have to come to the same number from the same end. An end the range
+     * stops short of is the next count up: a rule reading {@code > 3} is met by four and not by
+     * three, and a caller reading the number and dropping whether the end is one of the range's own
+     * has a floor one short of what was written.
+     */
+    static int leastFrom(Endpoint min) {
+        if (min == null) {
+            return 0;
+        }
+        int at = asSize(min.at());
+        if (at < 0) {
+            return 0;
+        }
+        return min.inclusive() ? at : at + 1;
+    }
 
     /** {@code at} as a number of things, or -1 where it is not one. A count is whole and no larger
      * than the values there are to count, so a number outside that is a size nothing carries. */

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -840,11 +840,15 @@ public final class Generator {
                                                          Map<String, List<FixtureTemplate>> decided,
                                                          Map<String, RepresentativeSource.Evaluation.Compose> recipes) {
         List<Position> found = new ArrayList<>();
-        positionsUnder(subject.types().get(p), TermPath.of(subject.parameters().get(p)),
-                subject.symbols(), 0, found, decided.keySet(), recipes);
+        TermPath root = TermPath.of(subject.parameters().get(p));
+        Type declared = subject.types().get(p);
+        positionsUnder(declared, root, subject.symbols(), 0, found, decided.keySet(), recipes);
+        FieldDomains rules = rulesOf(declared, subject.symbols(), Map.of());
         UnresolvedCombination.Reason held = null;
         for (Position each : found) {
-            UnresolvedCombination.Reason here = Partitions.notBuilt(each.type(), subject.symbols());
+            String field = fieldUnder(root, each.path());
+            UnresolvedCombination.Reason here = Partitions.notBuilt(each.type(), subject.symbols(),
+                    field == null ? null : rules.heldAt(field));
             // Nothing of the shape having been built outranks some of it having been: the first says
             // the search never had what the rule asks for, and a reader owed one sentence is owed that.
             if (here == UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE) {
@@ -1072,15 +1076,34 @@ public final class Generator {
         // A position the caller fixed holds nothing back: it was given the value it is to take.
         List<List<FixtureTemplate>> reserves = new ArrayList<>(
                 java.util.Collections.nCopies(paths.size(), List.<FixtureTemplate>of()));
-        // One reading of the parameter, not one per record inside it. A clause on the outer record
-        // says what is left for a position two levels down, and a reading rebuilt at the inner record
-        // has never seen it.
-        FieldDomains left = type instanceof Type.Ref ref
-                && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()
-                ? FieldDomains.of(ref.name(), data, symbols, under(at, settled)) : FieldDomains.NONE;
-        String missing = choicesUnder(type, at, symbols, 0, paths, values, reserves, left, at, recipes);
+        String missing = choicesUnder(type, at, symbols, 0, paths, values, reserves,
+                rulesOf(type, symbols, under(at, settled)), at, recipes);
         return missing != null ? Choices.missing(missing)
                 : new Choices(paths, values, reserves, null);
+    }
+
+    /**
+     * The rules of the record a parameter is, or nothing where it is not one.
+     *
+     * <p>One reading of the parameter, not one per record inside it. A clause on the outer record
+     * says what is left for a position two levels down, and a reading rebuilt at the inner record
+     * has never seen it.
+     *
+     * <p>Written once because two readers want it: what a position is offered, and why a position
+     * offered less than its rules allow. Those are the two halves of one floor and they were the two
+     * halves this was already asymmetric about.
+     */
+    private static FieldDomains rulesOf(Type type, Symbols symbols, Map<String, Count> settled) {
+        return type instanceof Type.Ref ref
+                && symbols.get(ref.name()) instanceof Ast.Data data && !data.newtype()
+                ? FieldDomains.of(ref.name(), data, symbols, settled) : FieldDomains.NONE;
+    }
+
+    /** What a position under a parameter is called where the parameter's own rules name it, or null
+     * where the position is the parameter itself. */
+    private static String fieldUnder(TermPath root, String path) {
+        String prefix = root + ".";
+        return path.startsWith(prefix) ? path.substring(prefix.length()) : null;
     }
 
     /** The settled positions of one parameter, named the way the reading of that parameter names
@@ -1124,9 +1147,10 @@ public final class Generator {
             }
             return null;
         }
-        souther.compiler.numeric.NumericDomain.Bounds here =
-                at.fields().isEmpty() ? null : left.at(String.join(".", at.fields()));
-        List<FixtureTemplate> stands = Partitions.representativesOf(type, symbols, here);
+        String field = at.fields().isEmpty() ? null : String.join(".", at.fields());
+        souther.compiler.numeric.NumericDomain.Bounds here = field == null ? null : left.at(field);
+        List<FixtureTemplate> stands = Partitions.representativesHolding(type, symbols, here,
+                field == null ? null : left.heldAt(field));
         if (stands.isEmpty()) {
             // Nothing could be written at all: a position of a type nothing stands for. Which is not
             // the same as a value that was written and refused, and reporting it as one sends the

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -831,19 +831,27 @@ public final class Generator {
         // the rules allow was offered. A position that read a count past what a row is built to carry,
         // or that has more pairings than are built at once, held something back, and saying so is the
         // difference between a fact about the model and a fact about this.
-        UnresolvedCombination.Reason held = heldBack(subject, p, decided, recipes);
+        UnresolvedCombination.Reason held = heldBack(subject, p, decided, settled, recipes);
         return held == null ? product : new Outcome(null, held, null);
     }
 
-    /** Why a position of this parameter offered less than its rules allow, or null where none did. */
+    /**
+     * Why a position of this parameter offered less than its rules allow, or null where none did.
+     *
+     * <p>Under the same settled positions the values were chosen against. A rule counting one field
+     * against another asks for nothing in particular until the row fixes the other, so a reading
+     * without them answers about a rule this row is no longer under — and would say "every value
+     * tried was refused" of a position whose values were never built.
+     */
     private static UnresolvedCombination.Reason heldBack(Subject subject, int p,
                                                          Map<String, List<FixtureTemplate>> decided,
+                                                         Map<String, Place> settled,
                                                          Map<String, RepresentativeSource.Evaluation.Compose> recipes) {
         List<Position> found = new ArrayList<>();
         TermPath root = TermPath.of(subject.parameters().get(p));
         Type declared = subject.types().get(p);
         positionsUnder(declared, root, subject.symbols(), 0, found, decided.keySet(), recipes);
-        FieldDomains rules = rulesOf(declared, subject.symbols(), Map.of());
+        FieldDomains rules = rulesOf(declared, subject.symbols(), under(root, settled));
         UnresolvedCombination.Reason held = null;
         for (Position each : found) {
             String field = fieldUnder(root, each.path());
@@ -983,15 +991,11 @@ public final class Generator {
             return fixed;
         }
         TermPath at = TermPath.of(subject.parameters().get(p));
-        Type parameter = subject.types().get(p);
-        FieldDomains left = parameter instanceof Type.Ref ref
-                && subject.symbols().get(ref.name()) instanceof Ast.Data data && !data.newtype()
-                ? FieldDomains.of(ref.name(), data, subject.symbols(), under(at, settled))
-                : FieldDomains.NONE;
-        String under = position.path().equals(at.toString()) ? null
-                : position.path().substring(at.toString().length() + 1);
+        FieldDomains left = rulesOf(subject.types().get(p), subject.symbols(), under(at, settled));
+        String field = fieldUnder(at, position.path());
         return Partitions.displacedRepresentativesOf(position.type(), subject.symbols(),
-                under == null ? null : left.at(under));
+                field == null ? null : left.at(field),
+                field == null ? null : left.heldAt(field));
     }
 
     /** The positions under one parameter, in the order they are composed. The same rule

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -900,14 +900,16 @@ public final class Partitions {
      * write.
      */
     static List<FixtureTemplate> displacedRepresentativesOf(Type type, Symbols symbols,
-                                                            NumericDomain.Bounds within) {
-        List<FixtureTemplate> base = new ArrayList<>(representativesOf(type, symbols, within));
+                                                            NumericDomain.Bounds within,
+                                                            FieldDomains.Held held) {
+        List<FixtureTemplate> base =
+                new ArrayList<>(representativesHolding(type, symbols, within, held));
         // What a position holds back for the product search's second pass is on offer here from the
         // start. This pass runs only where both of those have already failed, and a position keeping
         // a value from the last search there is a value nothing will ever be tried at.
-        for (FixtureTemplate held : inReserve(type, symbols, within)) {
-            if (base.stream().noneMatch(each -> each.text().equals(held.text()))) {
-                base.add(held);
+        for (FixtureTemplate kept : inReserve(type, symbols, within)) {
+            if (base.stream().noneMatch(each -> each.text().equals(kept.text()))) {
+                base.add(kept);
             }
         }
         Type numeric = TypeOps.numericBase(type, symbols);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -785,9 +785,25 @@ public final class Partitions {
         if (sized == null || sized.min() == null) {
             return 0;
         }
-        // A count is a whole number, so the end a size bound leaves is one the rule admits.
-        int least = Counts.asSize(sized.min().value());
-        return least <= 0 ? 0 : least;
+        return Counts.leastFrom(sized.min().at());
+    }
+
+    /**
+     * The same, where the record the position sits in has a rule about it too.
+     *
+     * <p>The higher of the two, because both are rules the construction has to satisfy. A value
+     * clearing one and not the other is refused as surely as one clearing neither, so reading either
+     * alone offers a value something refuses — which is the whole of #650 read from the other side:
+     * the type's floor was the only one a position was ever asked for, and a field whose floor was
+     * its record's got the value that holds nothing.
+     *
+     * <p>Both readings end at {@link Counts#leastFrom}, so what a floor comes to as a count is
+     * settled once. A second reading here could put a record's {@code > 3} at three while the type's
+     * came to four, and the two would disagree about one rule written twice.
+     */
+    static int leastHeld(Type type, Symbols symbols, FieldDomains.Held held) {
+        return Math.max(leastHeld(type, symbols),
+                held == null ? 0 : Counts.leastFrom(held.bounds().min()));
     }
 
     /**
@@ -802,9 +818,15 @@ public final class Partitions {
      *
      * <p>Asked only where nothing was written. It re-reads what a position could have offered, and a
      * row that was written has no reason to pay for that.
+     *
+     * <p>{@code held} for the same reason {@link #representativesHolding} takes one: the floor this
+     * reads is the floor that was built against, and a reading here that knew only the type would
+     * say "every value tried was refused" of a position whose values were never built.
      */
-    static Generator.UnresolvedCombination.Reason notBuilt(Type type, Symbols symbols) {
-        return Witnesses.heldBackFor(TypeOps.base(type, symbols), leastHeld(type, symbols), symbols);
+    static Generator.UnresolvedCombination.Reason notBuilt(Type type, Symbols symbols,
+                                                            FieldDomains.Held held) {
+        return Witnesses.heldBackFor(TypeOps.base(type, symbols), leastHeld(type, symbols, held),
+                symbols);
     }
 
     /**
@@ -831,6 +853,36 @@ public final class Partitions {
         }
         Count stepped = Count.number(from).plus(index);
         return holdsCount(range, stepped) ? stepped : null;
+    }
+
+    /**
+     * The same, with what a floor asks for offered ahead of it.
+     *
+     * <p>Both, and the floor first. Each is what one rule was read to produce and which of them the
+     * whole of the rules admits is the decoder's answer, so neither withdraws the other — the same
+     * reading {@link #insideTheNewtype} makes of a newtype carrying a floor, made here of a position
+     * whose floor is its record's. What the order decides is not which is right: the search over a
+     * row's positions is bounded, so a position offering the value that holds nothing first spends
+     * an assignment on a value the rule refuses, and rows at positions the rule has nothing to do
+     * with are what runs out.
+     */
+    static List<FixtureTemplate> representativesHolding(Type type, Symbols symbols,
+                                                        NumericDomain.Bounds within,
+                                                        FieldDomains.Held held) {
+        List<FixtureTemplate> candidates = new ArrayList<>();
+        // Under every name the position wears, because a floor read off the record says how much the
+        // value holds and not what it is written as: a field of a newtype over a list takes a list
+        // inside that newtype's own name.
+        for (FixtureTemplate bare : Witnesses.holding(TypeOps.base(type, symbols),
+                leastHeld(type, symbols, held), symbols, java.util.Set.of())) {
+            candidates.add(Witnesses.wrapped(type, bare, symbols));
+        }
+        candidates.addAll(representativesOf(type, symbols, within));
+        Map<String, FixtureTemplate> once = new LinkedHashMap<>();
+        for (FixtureTemplate each : candidates) {
+            once.putIfAbsent(each.text(), each);
+        }
+        return List.copyOf(once.values());
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileExampleGenerateTest.java
@@ -545,6 +545,11 @@ class CompileExampleGenerateTest {
      * <p>The choices multiply, so a row is tried at a bounded number of assignments. Past that bound
      * the ones not reached were not refused — nothing was written and nothing built — and calling them
      * refused tells an author their model rules out a combination it does not.
+     *
+     * <p>What refuses every value here is a pattern the record states about one field, which nothing
+     * derives a value from: the field's own type says its values are x's, and the record wants y's.
+     * A rule counting the field would not do — a floor is read now, and the value built for it is
+     * one this model would accept.
      */
     @Test
     void whatTheSearchDidNotReachIsNotReportedAsRefused() {
@@ -567,7 +572,7 @@ class CompileExampleGenerateTest {
                 data Flag = Yes | No
 
                 data Req = { %sflag: Flag }
-                    invariant String.length(a.value) > 1000
+                    invariant String.matches("y+", a.value)
 
                 data Ok = { n: Int }
 
@@ -810,4 +815,89 @@ class CompileExampleGenerateTest {
         assertEquals("", GeneratedRows.of("example.trip", generated(covered), false,
                 SourceNameResolver.identity()));
     }
+
+    /**
+     * A floor a settled sibling made concrete is offered where the value is chosen, too.
+     *
+     * <p>The value at a position is chosen twice over: once with every position taking its value
+     * knowing only what the caller settled, and again a position at a time, each from what is left
+     * once the ones before it are asserted. A rule counting one field against another asks for
+     * nothing in particular in the first pass — {@code n} could be anything the domain keeps — and
+     * asks for something definite in the second, once {@code n} has been chosen. A second pass
+     * reading only what its siblings leave a <em>number</em> offers the list that holds nothing,
+     * which is the value the rule refuses.
+     *
+     * <p>The edge is on {@code bill}, so nothing settles {@code n} from outside and the row has to
+     * choose it. {@code n} cannot be zero and the domain keeps no hole, so the first pass offers a
+     * zero the model refuses and the row is left to the second.
+     */
+    @Test
+    void aFloorReachedByChoosingASiblingFirstIsOfferedThere() {
+        String correlated = """
+                module example.paired
+
+                data Yen = Int
+                    invariant value >= 0
+
+                data Count = Int
+                    invariant within = value >= 0 && value <= 5
+                    invariant notNone = value /= 0
+
+                data Paired = { n: Count, xs: List<Int> }
+                    invariant enough = List.length(xs) >= n.value
+
+                data Accepted = { at: String }
+
+                behavior submit : (bill: Yen, request: Paired) -> Accepted
+                    constructs Accepted
+
+                let submit (bill, request) = Accepted { at = "now" }
+                """;
+        Adequacy.Filling filling = generated(correlated).get("submit");
+
+        Generator.GeneratedRow atTheEdge = filling.boundaries().rows().stream()
+                .filter(row -> row.classes().contains("bill = 0")).findFirst().orElse(null);
+        assertNotNull(atTheEdge, "the edge on `bill` is a row somebody can write: "
+                + filling.boundaries().unresolved());
+        assertEquals("Paired { n = Count(5), xs = [0, 0, 0, 0, 0] }",
+                atTheEdge.inputs().get(1).text(),
+                "as many elements as the n this row settled on asks for");
+    }
+
+    /**
+     * And why nothing was built reads that floor too, where the edge is what made it concrete.
+     *
+     * <p>The row is at {@code n}'s upper edge, so the list it needs is a hundred thousand long —
+     * more than a row is built to carry. What is owed is "nothing here composes one", which is about
+     * this compiler; "every value tried was refused" would send an author looking for the rule that
+     * refuses the empty list, and the rule that refuses it is the one this row settled.
+     */
+    @Test
+    void aFloorAnEdgeMadeConcreteIsWhyNothingWasBuilt() {
+        String correlated = """
+                module example.paired
+
+                data Count = Int
+                    invariant within = value >= 0 && value <= 100000
+
+                data Paired = { n: Count, xs: List<Int> }
+                    invariant enough = List.length(xs) >= n.value
+
+                data Accepted = { at: String }
+
+                behavior submit : (request: Paired) -> Accepted
+                    constructs Accepted
+
+                let submit (request) = Accepted { at = "now" }
+                """;
+        Generator.GenerationResult edges = generated(correlated).get("submit").boundaries();
+
+        Generator.UnresolvedCombination atTheTop = edges.unresolved().stream()
+                .filter(left -> left.subject().contains("100000")).findFirst().orElse(null);
+        assertNotNull(atTheTop, "the top edge is owed a row and got none: " + edges.unresolved()
+                + " rows " + inputs(edges));
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                atTheTop.reason(), atTheTop.toString());
+    }
+
 }

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
@@ -26,6 +26,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest {
 
     private static FieldDomains domainsIn(String source, String type) {
+        return domainsIn(source, type, java.util.Map.of());
+    }
+
+    private static FieldDomains domainsIn(String source, String type,
+                                          java.util.Map<String, Count> settled) {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         String module = compilation.modules().get(0);
@@ -34,7 +39,45 @@ class AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest {
         TypeName named = new TypeName(module, type);
         Ast.Data data = (Ast.Data) symbols.get(named);
         assertNotNull(data, "no `" + type + "` in " + module);
-        return FieldDomains.of(named, data, symbols);
+        return FieldDomains.of(named, data, symbols, settled);
+    }
+
+    private static final String AGAINST_A_SIBLING = """
+            module example.bag
+
+            data Bag =
+                { n: Int
+                , xs: List<Int>
+                }
+                invariant enough = List.length(xs) >= n
+            """;
+
+    /** A rule counting one field against another asks for nothing in particular until something says
+     * what the other is: a count is never negative, and that is the whole of what is left of the
+     * rule while {@code n} is open. */
+    @Test
+    void aFloorStatedAgainstASiblingAsksForNothingWhileTheSiblingIsOpen() {
+        FieldDomains.Held held = domainsIn(AGAINST_A_SIBLING, "Bag").heldAt("xs");
+
+        assertNotNull(held, "a count of no less than none is still what the domain holds");
+        assertEquals(0, BigDecimal.ZERO.compareTo(Count.number(held.bounds().min().at()).at()),
+                "and none of them is a list any value meets");
+    }
+
+    /**
+     * And is one once the sibling is settled, which is what settling a field is for.
+     *
+     * <p>The same projection {@link FieldDomains#at} has always made of a number beside a settled
+     * number, asked of how much a value holds. A caller reading this without the settled fields gets
+     * the answer above — no floor — for a position that has one.
+     */
+    @Test
+    void aFloorStatedAgainstASettledSiblingIsAFloor() {
+        FieldDomains.Held held = domainsIn(AGAINST_A_SIBLING, "Bag",
+                java.util.Map.of("n", Count.of(7L))).heldAt("xs");
+
+        assertNotNull(held, "seven is what the list has to hold once n is seven");
+        assertEquals(0, BigDecimal.valueOf(7).compareTo(Count.number(held.bounds().min().at()).at()));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest.java
@@ -1,0 +1,84 @@
+package souther.compiler.check;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.numeric.Count;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.TypeName;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * How much a field has to hold, where the record it sits in is what says so.
+ *
+ * <p>A rule counting a field — {@code List.length(xs) >= 2} — bounds the count and not the field, so
+ * it reaches the domain under an atom of its own and a reader asking what the field can hold is told
+ * nothing. That is a different question from {@link FieldDomains#at}, which answers what the value at
+ * a position is, and the two are kept apart here because the same numbers stand for different things.
+ */
+class AFieldsFloorIsTheRecordsRuleAboutWhatItHoldsTest {
+
+    private static FieldDomains domainsIn(String source, String type) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        assertNotNull(symbols, "the model did not compile");
+        TypeName named = new TypeName(module, type);
+        Ast.Data data = (Ast.Data) symbols.get(named);
+        assertNotNull(data, "no `" + type + "` in " + module);
+        return FieldDomains.of(named, data, symbols);
+    }
+
+    @Test
+    void aRecordsCountRuleIsWhatItsFieldHasToHold() {
+        FieldDomains domains = domainsIn("""
+                module example.bag
+
+                data Bag =
+                    { xs: List<Int>
+                    }
+                    invariant atLeastTwo = List.length(xs) >= 2
+                """, "Bag");
+
+        FieldDomains.Held held = domains.heldAt("xs");
+        assertNotNull(held, "the record says how much the list holds");
+        assertEquals(0, BigDecimal.valueOf(2).compareTo(Count.number(held.bounds().min().at()).at()),
+                "two, which is what the rule counts");
+        assertTrue(held.bounds().min().inclusive(), "and a list of two is one the rule admits");
+    }
+
+    /**
+     * A field is in one of the two answers or in neither, and never in both.
+     *
+     * <p>The numbers are the same numbers, so a caller that could get both from one field would be a
+     * caller that has to decide which of them a bound is about. What settles it is the position's own
+     * type: a number is its own value and a list is counted by how much of it there is.
+     */
+    @Test
+    void aFieldIsEitherANumberOrSomethingCountedAndNotBoth() {
+        FieldDomains domains = domainsIn("""
+                module example.mixed
+
+                data Mixed =
+                    { n: Int
+                    , xs: List<Int>
+                    }
+                    invariant bigEnough = n >= 5
+                    invariant atLeastTwo = List.length(xs) >= 2
+                """, "Mixed");
+
+        assertNotNull(domains.at("n"), "a number is bounded as the value it is");
+        assertNull(domains.heldAt("n"), "and nothing counts what a number holds");
+        assertNotNull(domains.heldAt("xs"), "a list is bounded by how much of it there is");
+        assertNull(domains.at("xs"), "and a list is no number to bound");
+    }
+
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorHoldsWhereverItIsWrittenTest.java
@@ -1,0 +1,132 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.FieldDomains;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+import souther.compiler.types.Type;
+import souther.compiler.types.TypeName;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * How much a position has to hold, where two things can say so.
+ *
+ * <p>A rule counting a value is written either on that value's own type or on the record that has it
+ * as a field, and both are rules the construction has to satisfy. Read one of them and a position is
+ * offered a value the other refuses — which is #650, where a field's list was offered the empty one
+ * because the floor was the record's and only the type's was read.
+ */
+class AFloorHoldsWhereverItIsWrittenTest {
+
+    private record Model(Symbols symbols, String module) {
+
+        FieldDomains domainsOf(String type) {
+            TypeName named = new TypeName(module, type);
+            Ast.Data data = (Ast.Data) symbols.get(named);
+            assertNotNull(data, "no `" + type + "`");
+            return FieldDomains.of(named, data, symbols);
+        }
+
+        Type ref(String type) {
+            return new Type.Ref(new TypeName(module, type));
+        }
+    }
+
+    private static Model modelOf(String source) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        assertNotNull(symbols, "the model did not compile");
+        return new Model(symbols, module);
+    }
+
+    /** The record's rule, at a field whose own type says nothing. */
+    @Test
+    void aRecordsRuleIsAFloorAtTheFieldItCounts() {
+        Model model = modelOf("""
+                module example.bag
+
+                data Bag =
+                    { xs: List<Int>
+                    }
+                    invariant atLeastTwo = List.length(xs) >= 2
+                """);
+
+        assertEquals(2, Partitions.leastHeld(new Type.ListOf(Type.INT), model.symbols(),
+                model.domainsOf("Bag").heldAt("xs")));
+    }
+
+    /** And the type's own rule where the record says nothing, which is the reading that already
+     * worked and has to keep working. */
+    @Test
+    void aTypesOwnRuleIsStillAFloorWhereNoRecordSpeaks() {
+        Model model = modelOf("""
+                module example.bag
+
+                data NonEmpty = List<Int>
+                    invariant atLeastOne = List.length(value) >= 1
+
+                data Bag = { xs: NonEmpty }
+                """);
+
+        assertEquals(1, Partitions.leastHeld(model.ref("NonEmpty"), model.symbols(),
+                model.domainsOf("Bag").heldAt("xs")));
+    }
+
+    /**
+     * And the higher of the two where both speak.
+     *
+     * <p>Both are rules the construction has to satisfy, so a value clearing one and not the other is
+     * refused as surely as one clearing neither. Taking the record's alone would offer a list of two
+     * where the type asks for three; taking the type's alone is #650 again.
+     */
+    @Test
+    void theHigherOfTheTwoIsWhatHasToHold() {
+        Model model = modelOf("""
+                module example.bag
+
+                data AtLeastThree = List<Int>
+                    invariant atLeastThree = List.length(value) >= 3
+
+                data Bag =
+                    { xs: AtLeastThree
+                    }
+                    invariant atLeastTwo = List.length(xs.value) >= 2
+                """);
+
+        assertEquals(3, Partitions.leastHeld(model.ref("AtLeastThree"), model.symbols(),
+                model.domainsOf("Bag").heldAt("xs")));
+    }
+
+    /**
+     * A rule bounding only a sum of two counts is a floor under neither of them.
+     *
+     * <p>Either list may hold nothing as long as the other does not, so the value that holds nothing
+     * is one the rule admits at both positions. Held because a reading that finds a floor here is one
+     * that would put a floor under every field a rule so much as names.
+     */
+    @Test
+    void aRuleOverASumOfTwoCountsIsAFloorUnderNeither() {
+        Model model = modelOf("""
+                module example.duplicate
+
+                data Possible =
+                    { accounts: List<Int>
+                    , contacts: List<Int>
+                    }
+                    invariant oneOfThem = List.length(accounts) + List.length(contacts) >= 1
+                """);
+        FieldDomains domains = model.domainsOf("Possible");
+
+        assertEquals(0, Partitions.leastHeld(new Type.ListOf(Type.INT), model.symbols(),
+                domains.heldAt("accounts")), "an empty list of accounts stands beside a contact");
+        assertEquals(0, Partitions.leastHeld(new Type.ListOf(Type.INT), model.symbols(),
+                domains.heldAt("contacts")), "and the same the other way round");
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest.java
@@ -1,0 +1,123 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Why nothing was written, where a floor asks for more than a row is built to carry.
+ *
+ * <p>Two sentences are being kept apart. "Every value tried was refused" is about the model and sends
+ * a reader looking for the rule that refuses them; "nothing here composes one" is about this compiler,
+ * and a list of a hundred thousand is a value somebody could write and this will not. Which of the two
+ * a position gets was read off its type alone, so a floor written on the record that has the position
+ * got the wrong one — the same asymmetry as #650, in the half that explains rather than builds.
+ */
+class AFloorNothingBuildsIsSaidTheSameWhereverItIsWrittenTest {
+
+    /**
+     * The second parameter builds nothing, so the reason the row gives is that parameter's.
+     *
+     * <p>Only that one. A check refusing everything has the first parameter fail first, and the row
+     * then reports the first parameter's reason — which is a fact about a `Bool` and would be the
+     * same sentence whatever the second parameter's rules said.
+     */
+    private static final Generator.CandidateCheck REFUSED =
+            (parameter, _) -> parameter == 1 ? Optional.of("refused") : Optional.empty();
+
+    private static Generator.UnresolvedCombination.Reason reasonFor(String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Ast.Module prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        assertNotNull(prepared, "the model did not compile");
+        Ast.SpecBehavior spec = (Ast.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        Sig sig = sigs.get(behavior);
+        Partitions.Partitioning partitioning = Partitions.of(spec, sig, symbols, Exclusions.NONE);
+        Generator.GenerationResult filled = Generator.fill(new Generator.Subject(
+                new BehaviorInputs(spec.params().stream().map(Ast.Param::name).toList(),
+                        sig.inputTypes(), symbols),
+                partitioning.axes()), List.of(), REFUSED);
+        assertFalse(filled.unresolved().isEmpty(), "nothing was written and nothing said why");
+        return filled.unresolved().get(0).reason();
+    }
+
+    private static final String NEWTYPE = """
+            module example.huge
+
+            data Huge = List<Int>
+                invariant vast = List.length(value) >= 100000
+
+            data Ok = { n: Int }
+
+            behavior countThem : (flag: Bool, h: Huge) -> Ok
+                constructs Ok
+
+            let countThem (flag, h) = Ok { n = List.length(h.value) }
+            """;
+
+    private static final String RECORD = """
+            module example.huge
+
+            data HugeBag =
+                { xs: List<Int>
+                }
+                invariant vast = List.length(xs) >= 100000
+
+            data Ok = { n: Int }
+
+            behavior countThem : (flag: Bool, h: HugeBag) -> Ok
+                constructs Ok
+
+            let countThem (flag, h) = Ok { n = List.length(h.xs) }
+            """;
+
+    /** The reading that already worked, held so the one below is read as the record's floor arriving
+     * rather than as the sentence changing. */
+    @Test
+    void aTypesOwnFloorNothingBuildsSaysNothingComposesOne() {
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                reasonFor(NEWTYPE, "countThem"));
+    }
+
+    @Test
+    void aRecordsFloorNothingBuildsSaysTheSame() {
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
+                reasonFor(RECORD, "countThem"));
+    }
+
+    /** And a position with no floor at all keeps the sentence about the model: its values were built
+     * and something refused them. */
+    @Test
+    void aPositionWithNoFloorStillSaysItsValuesWereRefused() {
+        assertEquals(Generator.UnresolvedCombination.Reason.ALL_CANDIDATES_REJECTED,
+                reasonFor("""
+                        module example.plain
+
+                        data Bag = { xs: List<Int> }
+
+                        data Ok = { n: Int }
+
+                        behavior countThem : (flag: Bool, bag: Bag) -> Ok
+                            constructs Ok
+
+                        let countThem (flag, bag) = Ok { n = List.length(bag.xs) }
+                        """, "countThem"));
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/APositionWithAFloorIsOfferedAValueThatMeetsItTest.java
@@ -1,0 +1,266 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Sig;
+import souther.compiler.check.Symbols;
+import souther.compiler.query.Bodies;
+import souther.compiler.query.Compilation;
+import souther.compiler.query.Shapes;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * What a position is offered where a rule says how much it holds.
+ *
+ * <p>The value built for the floor, and built first. A position offering the value that holds
+ * nothing before the one the rule asks for is a position whose first assignment is refused, and the
+ * search that walks assignments is bounded — so which of them comes first is not a matter of taste.
+ */
+class APositionWithAFloorIsOfferedAValueThatMeetsItTest {
+
+    private static Generator.Subject subjectOf(String source, String behavior) {
+        Compilation compilation = Compilation.ofSource(source, "Main");
+        compilation.answerEverything();
+        String module = compilation.modules().get(0);
+        Ast.Module prepared = compilation.db().ask(new Shapes.Prepared(module)).value();
+        Map<String, Sig> sigs = compilation.db().ask(new Bodies.Signatures(module)).value();
+        Symbols symbols = compilation.db().ask(new Shapes.Scope(module)).value();
+        assertNotNull(prepared, "the model did not compile");
+        Ast.SpecBehavior spec = (Ast.SpecBehavior) prepared.behaviors().stream()
+                .filter(b -> b.name().equals(behavior)).findFirst().orElseThrow();
+        Sig sig = sigs.get(behavior);
+        Partitions.Partitioning partitioning = Partitions.of(spec, sig, symbols, Exclusions.NONE);
+        return new Generator.Subject(
+                new BehaviorInputs(spec.params().stream().map(Ast.Param::name).toList(),
+                        sig.inputTypes(), symbols),
+                partitioning.axes());
+    }
+
+    /** The value at the position the row wrote, which is the one the search reached first. */
+    private static String firstValueAt(String source, String behavior, int position) {
+        Generator.GenerationResult filled =
+                Generator.fill(subjectOf(source, behavior), List.of(), Generator.CandidateCheck.ANY);
+        assertEquals(List.of(), filled.unresolved(), "nothing should have gone unresolved");
+        return filled.rows().get(0).inputs().get(position).text();
+    }
+
+    /**
+     * A count of two is a list of two, and not a list of one that the rule then refuses.
+     *
+     * <p>Two rather than one, so that a position offered a single element for every floor is not
+     * mistaken for one that read the rule.
+     */
+    @Test
+    void aListFieldIsOfferedAsManyElementsAsTheRecordAsksFor() {
+        assertEquals("Bag { xs = [0, 0] }", firstValueAt("""
+                module example.bag
+
+                data Bag =
+                    { xs: List<Int>
+                    }
+                    invariant atLeastTwo = List.length(xs) >= 2
+
+                data Ok = { n: Int }
+
+                behavior countThem : (flag: Bool, bag: Bag) -> Ok
+                    constructs Ok
+
+                let countThem (flag, bag) = Ok { n = List.length(bag.xs) }
+                """, "countThem", 1));
+    }
+
+    /** And a string of three where the record counts its characters, which is the same rule read
+     * through the measure the position's own type names rather than through anything about lists. */
+    @Test
+    void aStringFieldIsOfferedAsManyCharactersAsTheRecordAsksFor() {
+        assertEquals("Named { name = \"xxx\" }", firstValueAt("""
+                module example.named
+
+                data Named =
+                    { name: String
+                    }
+                    invariant longEnough = String.length(name) >= 3
+
+                data Ok = { n: Int }
+
+                behavior measureIt : (flag: Bool, who: Named) -> Ok
+                    constructs Ok
+
+                let measureIt (flag, who) = Ok { n = String.length(who.name) }
+                """, "measureIt", 1));
+    }
+
+    /** A field of a field is answered like a field: the floor is read at the path it was left at,
+     * which is where {@link souther.compiler.check.FieldDomains#at} already reads a number's. */
+    @Test
+    void aFieldOfAFieldIsOfferedTheSame() {
+        assertEquals("Outer { inner = Inner { xs = [0, 0] } }", firstValueAt("""
+                module example.nested
+
+                data Inner =
+                    { xs: List<Int>
+                    }
+                    invariant atLeastTwo = List.length(xs) >= 2
+
+                data Outer = { inner: Inner }
+
+                data Ok = { n: Int }
+
+                behavior countThem : (flag: Bool, o: Outer) -> Ok
+                    constructs Ok
+
+                let countThem (flag, o) = Ok { n = List.length(o.inner.xs) }
+                """, "countThem", 1));
+    }
+
+    /**
+     * A set of two is two elements no two of which are equal, which is not a list of two repeated.
+     *
+     * <p>Held because what a floor comes to is the measure's answer and not the list's. A machinery
+     * that filled every collection by repeating one element would meet {@code List.length} and leave
+     * a set of one under a line drawn at two.
+     */
+    @Test
+    void aSetFieldIsOfferedAsManyDistinctElementsAsTheRecordAsksFor() {
+        assertEquals("Tagged { tags = [0, 1] }", firstValueAt("""
+                module example.tagged
+
+                data Tagged =
+                    { tags: Set<Int>
+                    }
+                    invariant atLeastTwo = Set.size(tags) >= 2
+
+                data Ok = { n: Int }
+
+                behavior countThem : (flag: Bool, t: Tagged) -> Ok
+                    constructs Ok
+
+                let countThem (flag, t) = Ok { n = Set.size(t.tags) }
+                """, "countThem", 1));
+    }
+
+    /** And a map of two is two entries no two of which share a key, which is the same measure asked
+     * of the third collection the rules can count. Keyed by a string, which is what a map crossing
+     * the boundary is keyed by (E1314). */
+    @Test
+    void aMapFieldIsOfferedAsManyEntriesAsTheRecordAsksFor() {
+        assertEquals("Priced { by = [(\"x\", 0), (\"xx\", 0)] }", firstValueAt("""
+                module example.priced
+
+                data Priced =
+                    { by: Map<String, Int>
+                    }
+                    invariant atLeastTwo = Map.size(by) >= 2
+
+                data Ok = { n: Int }
+
+                behavior countThem : (flag: Bool, p: Priced) -> Ok
+                    constructs Ok
+
+                let countThem (flag, p) = Ok { n = Map.size(p.by) }
+                """, "countThem", 1));
+    }
+
+    /**
+     * A floor the rule does not stand on is the next count up.
+     *
+     * <p>Four characters and not three. The reading that turns an end into a count is one function,
+     * and this is the record's floor arriving through it — a second reading here could take the
+     * number and drop whether the end is one the rule admits.
+     */
+    @Test
+    void aFloorWrittenStrictlyIsMetByTheNextCountUp() {
+        assertEquals("Named { name = \"xxxx\" }", firstValueAt("""
+                module example.named
+
+                data Named =
+                    { name: String
+                    }
+                    invariant longerThanThree = String.length(name) > 3
+
+                data Ok = { n: Int }
+
+                behavior measureIt : (flag: Bool, who: Named) -> Ok
+                    constructs Ok
+
+                let measureIt (flag, who) = Ok { n = String.length(who.name) }
+                """, "measureIt", 1));
+    }
+
+    /**
+     * Where both the type and the record say how much, the value holds the higher of the two.
+     *
+     * <p>Both are rules the construction has to satisfy, so this is neither floor on its own. Written
+     * both ways round because the two are combined and not chosen between: a reading that preferred
+     * the record's would build two here, and one that preferred the type's would build two below.
+     */
+    @Test
+    void theRecordsFloorWinsWhereItIsTheHigher() {
+        assertEquals("Box { xs = AtLeastTwo([0, 0, 0]) }", firstValueAt("""
+                module example.box
+
+                data AtLeastTwo = List<Int>
+                    invariant atLeastTwo = List.length(value) >= 2
+
+                data Box =
+                    { xs: AtLeastTwo
+                    }
+                    invariant atLeastThree = List.length(xs.value) >= 3
+
+                data Ok = { n: Int }
+
+                behavior countThem : (flag: Bool, b: Box) -> Ok
+                    constructs Ok
+
+                let countThem (flag, b) = Ok { n = List.length(b.xs.value) }
+                """, "countThem", 1));
+    }
+
+    @Test
+    void theTypesFloorWinsWhereItIsTheHigher() {
+        assertEquals("Box { xs = AtLeastThree([0, 0, 0]) }", firstValueAt("""
+                module example.box
+
+                data AtLeastThree = List<Int>
+                    invariant atLeastThree = List.length(value) >= 3
+
+                data Box =
+                    { xs: AtLeastThree
+                    }
+                    invariant atLeastTwo = List.length(xs.value) >= 2
+
+                data Ok = { n: Int }
+
+                behavior countThem : (flag: Bool, b: Box) -> Ok
+                    constructs Ok
+
+                let countThem (flag, b) = Ok { n = List.length(b.xs.value) }
+                """, "countThem", 1));
+    }
+
+    /** Where nothing counts the position, the value that holds nothing is still what stands for it.
+     * Held so that the rows above are read as the rule doing it. */
+    @Test
+    void aListNoRuleCountsIsStillOfferedTheEmptyOne() {
+        assertEquals("Bag { xs = [] }", firstValueAt("""
+                module example.bag
+
+                data Bag =
+                    { xs: List<Int>
+                    }
+
+                data Ok = { n: Int }
+
+                behavior countThem : (flag: Bool, bag: Bag) -> Ok
+                    constructs Ok
+
+                let countThem (flag, bag) = Ok { n = List.length(bag.xs) }
+                """, "countThem", 1));
+    }
+}


### PR DESCRIPTION
Closes #650.

A rule counting a field — `List.length(xs) >= 1` on the record that has `xs` — was read into the numeric domain and then had no way back to the field, so `--generate` offered the value that holds nothing, the construction refused it, and because a row fills every position at once the refusal took every other position's boundary row with it.

```
- // no row for `bill = 0` in `wrappedList`: every value tried was refused at construction, ...
+ //     | "bill = 0" : (Yen(0), Bag { xs = [0] }) -> <?>
```

## Where it was lost

The same rule written on the field's own type already built. So did a number bounded by the record's own invariant, at any depth — `data Scalar = { n: Int } invariant n >= 5` answers at `Scalar { n = 5 }`. What was missing was neither the record reading its fields nor collections in particular: the reading that names each field names the ones that are numbers, and a rule counting a list bounds the count rather than the list. The bound was in the domain the whole time, under an atom no reader could ask for.

`String.length(name) >= 3` fails identically, and so does a field of a field, so the line is not collections. It is whether the measure `NumericMeasures.takenOf` names for the position's type has a floor the position can be asked for.

## What this does

`Terms.takenAtomOf` names that atom, from the measure the type gives and the key the container has. It recognises rather than interns: naming a shape creates it, and a reader asking what was said about a field would otherwise be handed an atom nothing bounds. The key is a location — `demo.Bag.fields.0`, not `xs` — so this is the one place that puts the two halves together.

`seedFields` records it per field path, and `FieldDomains` resolves it to bounds while the reading that named it is still alive, since an atom means nothing afterwards. It comes out as `Held`, its own type: the numbers are the same numbers, and a bare `Bounds` gives a caller nothing to stop it reading how much a value holds as what the value is. A field is in `at` or in `heldAt`, never in both.

`Partitions.leastHeld` takes the higher of the type's floor and the record's — both are rules the construction has to satisfy, so a value clearing one and not the other is refused either way. A newtype and a record are no longer separate readings; they are one floor with two places it can come from. What an end comes to as a count is `Counts.leastFrom`, which both go through, so `> 3` cannot be four on one side and three on the other.

Both halves of the answer read that one floor:

- what a position is offered puts the value built for the floor ahead of the one the carrier stands for, which is the assembly `insideTheNewtype` already made. The order is not taste — the search over a row's positions is bounded.
- why nothing was built reads it too. `notBuilt` knowing only the type said "every value tried was refused" of a position whose values were never built, which is a sentence about the model where the fact is about this compiler. Its narrow form is replaced rather than left beside the new one.

The measure decides what a floor comes to, so a set of two is two elements no two of which are equal and a map of two is two entries no two of which share a key.

## What is not here

Upper bounds on a measure, element domains carried into a collection, and the shape of row composition. A row losing its other boundary rows follows from a row filling every position at once, and goes away when the floor arrives. A floor no value can meet — `Set<Bool>` with `Set.size >= 3` — is the other side and is left as it is.

A floor this cannot resolve to a number, such as one stated against another field, propagates nothing and behaves as before.

## Verification

`mvn clean test` green on every module, and each of the two commits builds and tests green on its own.

The new tests were held to failing first. One of them failed for the wrong reason to begin with — the refusing `CandidateCheck` refused every parameter, so the row reported the leading `Bool`'s reason rather than the position under test — and was aimed at the position before being trusted. The six added last were written after their code, so they were checked against the floor disabled: seven of nine went red, including the merge case dropping from three elements to two, and the two that stayed green are the controls that should not move.

Every layer has a control that does not move: no rule counting the position still offers the empty one, no floor still says "every value tried was refused", a rule bounding only `List.length(a) + List.length(b)` is a floor under neither, and a floor already on the type is not lowered by a smaller one on the record.

souther-examples is byte-identical before and after against this branch's merge base, so nothing was pushed out of the bounded search. It is also not evidence that the new path ran: the corpus has nine record-field measure rules and all of them are on result types, which `--generate` never composes. The reproduction and the unit tests carry that half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
