### PR TITLE
Compose a representative wherever one is asked for

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/partition/Counts.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Counts.java
@@ -1,5 +1,6 @@
 package souther.compiler.partition;
 
+import souther.compiler.ast.Ast;
 import souther.compiler.numeric.Count;
 import souther.compiler.numeric.Endpoint;
 import souther.compiler.numeric.Place;
@@ -15,6 +16,32 @@ import java.math.BigDecimal;
  * a collection of that many.
  */
 final class Counts {
+
+    /**
+     * The count a fixture settles its position at, reaching through the newtype it may be wrapped
+     * in, or null where it settles none.
+     *
+     * <p>Only a written number. A temporal fixture carries its text and not its count, and it stays
+     * unsettled rather than being read back: what a settled position is for is asking the record's
+     * rules what is left beside it, and those rules are read over the positions the projection
+     * holds — which the temporal ones are not yet.
+     *
+     * <p>Here rather than beside either walk. Both of them settle a field before choosing the next,
+     * and two readings of what a written value counts as are two chances to settle different
+     * things.
+     */
+    static Place writtenIn(Ast.Expr written) {
+        return switch (written) {
+            case Ast.IntLit i -> Count.of(i.value());
+            case Ast.DecimalLit d -> Count.of(d.value());
+            case Ast.Neg n -> {
+                Place inner = writtenIn(n.operand());
+                yield inner == null ? null : Count.number(inner).negate();
+            }
+            case Ast.Apply a when a.args().size() == 1 -> writtenIn(a.args().get(0));
+            case null, default -> null;
+        };
+    }
 
     /**
      * How many {@code min} says there are at least, or 0 where it says nothing about that.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -770,35 +770,13 @@ public final class Generator {
         Map<String, Place> out = new LinkedHashMap<>();
         decided.forEach((path, candidates) -> {
             if (candidates.size() == 1) {
-                Place number = writtenNumber(candidates.get(0).value());
+                Place number = Counts.writtenIn(candidates.get(0).value());
                 if (number != null) {
                     out.put(path, number);
                 }
             }
         });
         return out;
-    }
-
-    /**
-     * The count a fixture settles its position at, reaching through the newtype it may be wrapped in,
-     * or null where it settles none.
-     *
-     * <p>Only a written number. A temporal fixture carries its text and not its count, and it stays
-     * unsettled here rather than being read back: what a settled position is for is asking the
-     * record's rules what is left beside it, and those rules are read over the positions the
-     * projection holds — which the temporal ones are not yet.
-     */
-    private static Place writtenNumber(Ast.Expr written) {
-        return switch (written) {
-            case Ast.IntLit i -> Count.of(i.value());
-            case Ast.DecimalLit d -> Count.of(d.value());
-            case Ast.Neg n -> {
-                Place inner = writtenNumber(n.operand());
-                yield inner == null ? null : Count.number(inner).negate();
-            }
-            case Ast.Apply a when a.args().size() == 1 -> writtenNumber(a.args().get(0));
-            case null, default -> null;
-        };
     }
 
     /** One parameter's value, with the positions the caller fixed already decided. */
@@ -971,7 +949,7 @@ public final class Generator {
         Position position = positions.get(index);
         for (FixtureTemplate candidate : candidatesAt(subject, p, position, settled, decided)) {
             chosen.put(position.path(), candidate);
-            Place number = writtenNumber(candidate.value());
+            Place number = Counts.writtenIn(candidate.value());
             if (number != null) {
                 settled.put(position.path(), number);
             }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -722,9 +722,6 @@ public final class Generator {
                     return new Attempt(null, UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, at,
                             Optional.of(cannot.why()));
                 }
-                case RepresentativeSource.Evaluation.NothingProduced _ -> {
-                    return Attempt.no(UnresolvedCombination.Reason.NO_REASON_RECORDED, at);
-                }
             }
         }
         List<FixtureTemplate> inputs = new ArrayList<>();

--- a/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Generator.java
@@ -35,11 +35,11 @@ import java.util.TreeSet;
  * assertion nobody made.
  *
  * <p>What it reports is not only the rows. A combination it could produce nothing for is said out loud,
- * with which of the four things happened — one of its classes has no values at all, nothing here
- * composed one of the values it has, every value tried was refused at construction, or the search
- * stopped before deciding. A generator that returned only the rows it managed would read as though the
- * rest were covered, and one that gave the same answer to all four would send an author looking for a
- * value that does not exist while a row they could write in a line went unwritten.
+ * with which of the four things happened — the body leaves no class open at some other position,
+ * nothing here composed a value, every value tried was refused at construction, or the search stopped
+ * before deciding. A generator that returned only the rows it managed would read as though the rest
+ * were covered, and one that gave the same answer to all four would send an author looking for a value
+ * that does not exist while a row they could write in a line went unwritten.
  */
 public final class Generator {
 
@@ -120,20 +120,26 @@ public final class Generator {
                                         Optional<String> said) {
 
         public enum Reason {
-            /** One of the classes has no value that can be written for it. */
-            NO_REPRESENTATIVE,
+            /**
+             * Every class at some other position is one the body says it does not answer for, so no
+             * row reaches this combination whatever is written there.
+             *
+             * <p>About the classes a row may be written at and not about the values of the position:
+             * each of those classes has values, and what refuses them is the body. Read as a
+             * position without values, an author is sent looking for a type that has none.
+             */
+            NO_CLASS_OPEN_AT_POSITION,
             /**
              * Nothing here knows how to compose a value of the shape asked for.
              *
-             * <p>Apart from {@code NO_REPRESENTATIVE}, which says the position has no values. This
-             * says the search has no way to write one — a collection of more elements than a row is
-             * worth carrying is the case — and that is a fact about this compiler rather than about
-             * the model. Told apart because the first licenses "no value can be written there" and
-             * this one does not: the edge may be the easiest row in the file to write by hand.
+             * <p>A fact about this compiler rather than about the model — a collection of more
+             * elements than a row is worth carrying is one case of it, and a position nothing built
+             * a value at is another. Which is why no sentence read off it says a value cannot be
+             * written: the row may be the easiest one in the file to write by hand.
              *
-             * <p>Which is why nothing decides this from the shape of the question. A reason read off
-             * the kind of term outlives whatever made it true, and says a value cannot be composed
-             * while the same generation composes one in the row above.
+             * <p>And why nothing decides this from the shape of the question. A reason read off the
+             * kind of term outlives whatever made it true, and says a value cannot be composed while
+             * the same generation composes one in the row above.
              */
             NOTHING_COMPOSES_ONE,
             /** Every value tried was refused at construction. */
@@ -287,7 +293,7 @@ public final class Generator {
                 pairs.remove(seed);
                 singles.remove(seed);
                 unresolved.add(new UnresolvedCombination(labels(axes, seed),
-                        UnresolvedCombination.Reason.NO_REPRESENTATIVE));
+                        UnresolvedCombination.Reason.NO_CLASS_OPEN_AT_POSITION));
                 continue;
             }
             Attempt built = build(subject, axes, where, check);
@@ -338,10 +344,13 @@ public final class Generator {
         return switch (obligation.target()) {
             case BoundaryTarget.AtPlace place -> probeAt(subject, place, check);
             // A line between two positions is not at a count of its own, so the one to write is
-            // handed in. Reached only through `probeBetween`, which is where the caller has it.
-            case BoundaryTarget.EqualTerms line -> new BoundaryAttempt.Unresolved(
-                    new UnresolvedCombination(List.of(line.left() + " = " + line.right()),
-                            UnresolvedCombination.Reason.NO_REPRESENTATIVE));
+            // handed in, and `probeBetween` is where the caller has it. Asked here, the count is
+            // missing rather than absent — which is this compiler calling itself wrongly, and not
+            // something established about the model. Reported as a reason it would read as the
+            // second, and an author would be told a line they can write is one nothing reaches.
+            case BoundaryTarget.EqualTerms line -> throw new IllegalStateException(
+                    "line between " + line.left() + " and " + line.right()
+                            + " was requested without a count: ask `probeBetween`");
         };
     }
 
@@ -364,7 +373,7 @@ public final class Generator {
         if (on == null || against == null) {
             // What this has no way to write, and not a position with no values. The line may be the
             // easiest row in the file to write by hand — two strings of one length are — and
-            // `NO_REPRESENTATIVE` is the answer that licenses "no value can be written there".
+            // Nothing here says the edge cannot be written at: what ran is this compiler's search.
             return new BoundaryAttempt.Unresolved(new UnresolvedCombination(List.of(label),
                     UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE));
         }
@@ -425,12 +434,13 @@ public final class Generator {
     /** A row at a line drawn at one count of one position. */
     private static BoundaryAttempt probeAt(Subject subject, BoundaryTarget.AtPlace place,
                                            CandidateCheck check) {
+        // The obligation was read off this subject's axes, so one it names is one this has. A
+        // subject without it is two structures that disagree, which is not a search result and has
+        // no reading in a report.
         Axis axis = subject.axes().stream().filter(a -> a.id().equals(place.axis())).findFirst()
-                .orElse(null);
-        if (axis == null) {
-            return new BoundaryAttempt.Unresolved(new UnresolvedCombination(List.of(),
-                    UnresolvedCombination.Reason.NO_REPRESENTATIVE));
-        }
+                .orElseThrow(() -> new IllegalStateException(
+                        "boundary names axis " + place.axis() + ", which "
+                                + "this subject has no axis at"));
         String label = place.left() + " = " + place.right();
         Edge edge = edgeOf(axis, place.carrier(), place.at(), subject.symbols());
         if (edge.values().isEmpty()) {
@@ -713,7 +723,7 @@ public final class Generator {
                             Optional.of(cannot.why()));
                 }
                 case RepresentativeSource.Evaluation.NothingProduced _ -> {
-                    return Attempt.no(UnresolvedCombination.Reason.NO_REPRESENTATIVE, at);
+                    return Attempt.no(UnresolvedCombination.Reason.NO_REASON_RECORDED, at);
                 }
             }
         }
@@ -804,7 +814,7 @@ public final class Generator {
                 TermPath.of(subject.parameters().get(p)), subject.symbols(), decided, settled,
                 recipes);
         if (choices.missingAt() != null) {
-            return new Outcome(null, UnresolvedCombination.Reason.NO_REPRESENTATIVE,
+            return new Outcome(null, UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE,
                     choices.missingAt());
         }
         Outcome product = walk(subject, p, choices, recipes, check);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -788,8 +788,7 @@ public final class Partitions {
             case RepresentativeSource.Evaluation.Compose compose ->
                     composed(compose.through(), symbols, expanding).stream()
                             .map(compose::written).toList();
-            case RepresentativeSource.Evaluation.NothingProduced _,
-                 RepresentativeSource.Evaluation.NothingProducible _ -> List.of();
+            case RepresentativeSource.Evaluation.NothingProducible _ -> List.of();
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -801,9 +801,15 @@ public final class Partitions {
      * name is in it only while the value under it is being built, so a type met twice in two
      * branches is composed in both.
      *
-     * <p>Nothing about the rules relating the fields. Each is what stands for it on its own, and
-     * whether they may be held together is the decoder's answer — the same answer every other
-     * candidate this offers is put through.
+     * <p>Each field is chosen against what the record's rules leave it, which is the reading
+     * {@link FieldDomains} makes of them: the range a clause leaves the value, and the floor a
+     * clause counting it puts on what it holds. Chosen from the field's type alone, a record whose
+     * rule asks its list for two is handed one holding none, and the row it was composed for comes
+     * back as one every value tried was refused at.
+     *
+     * <p>Nothing about the clauses relating two fields, which are read where a row is searched for
+     * one position at a time. Whether the values may be held together is the decoder's answer — the
+     * same answer every other candidate this offers is put through.
      */
     private static List<FixtureTemplate> composed(TypeName record, Symbols symbols,
                                                   java.util.Set<TypeName> expanding) {
@@ -816,10 +822,11 @@ public final class Partitions {
         }
         java.util.Set<TypeName> inside = new LinkedHashSet<>(expanding);
         inside.add(record);
+        FieldDomains left = fieldDomainsOf(Type.ref(record), symbols);
         Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
         for (Map.Entry<String, Type> field : fields.entrySet()) {
-            List<FixtureTemplate> stands =
-                    representativesOf(field.getValue(), symbols, null, inside);
+            List<FixtureTemplate> stands = representativesHolding(field.getValue(), symbols,
+                    left.at(field.getKey()), left.heldAt(field.getKey()), inside);
             if (stands.isEmpty()) {
                 return List.of();
             }
@@ -931,15 +938,24 @@ public final class Partitions {
     static List<FixtureTemplate> representativesHolding(Type type, Symbols symbols,
                                                         NumericDomain.Bounds within,
                                                         FieldDomains.Held held) {
+        return representativesHolding(type, symbols, within, held, java.util.Set.of());
+    }
+
+    /** The same, with the names this is already inside the value of, for the same reason
+     *  {@link #representativesOf} carries them. */
+    static List<FixtureTemplate> representativesHolding(Type type, Symbols symbols,
+                                                        NumericDomain.Bounds within,
+                                                        FieldDomains.Held held,
+                                                        java.util.Set<TypeName> expanding) {
         List<FixtureTemplate> candidates = new ArrayList<>();
         // Under every name the position wears, because a floor read off the record says how much the
         // value holds and not what it is written as: a field of a newtype over a list takes a list
         // inside that newtype's own name.
         for (FixtureTemplate bare : Witnesses.holding(TypeOps.base(type, symbols),
-                leastHeld(type, symbols, held), symbols, java.util.Set.of())) {
+                leastHeld(type, symbols, held), symbols, expanding)) {
             candidates.add(Witnesses.wrapped(type, bare, symbols));
         }
-        candidates.addAll(representativesOf(type, symbols, within));
+        candidates.addAll(representativesOf(type, symbols, within, expanding));
         Map<String, FixtureTemplate> once = new LinkedHashMap<>();
         for (FixtureTemplate each : candidates) {
             once.putIfAbsent(each.text(), each);

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -755,11 +755,18 @@ public final class Partitions {
         if (type instanceof Type.OptionOf) {
             return List.of(FixtureTemplate.none());
         }
-        for (PartitionClass each : PartitionClasses.of(type, symbols)) {
+        List<PartitionClass> classes = PartitionClasses.of(type, symbols);
+        for (PartitionClass each : classes) {
             List<FixtureTemplate> stands = standingFor(each.representatives(), symbols, expanding);
             if (!stands.isEmpty()) {
                 return stands;
             }
+        }
+        // Where there were classes, they have answered. Each said nothing can be produced for it and
+        // why, and reading that and then arriving at a value another way is this deciding the classes
+        // were wrong about themselves — the answer they carry is the one an author is shown.
+        if (!classes.isEmpty()) {
+            return List.of();
         }
         // A newtype the model only bounds has no classes — everything outside the bound is refused at
         // construction — but it does have values, and the edge of the bound is one that builds.

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -829,7 +829,8 @@ public final class Partitions {
         }
         java.util.Set<TypeName> inside = new LinkedHashSet<>(expanding);
         inside.add(record);
-        FieldDomains left = fieldDomainsOf(Type.ref(record), symbols);
+        Map<String, Count> settled = new LinkedHashMap<>();
+        FieldDomains left = FieldDomains.of(record, data, symbols, settled);
         Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
         for (Map.Entry<String, Type> field : fields.entrySet()) {
             List<FixtureTemplate> stands = representativesHolding(field.getValue(), symbols,
@@ -837,7 +838,15 @@ public final class Partitions {
             if (stands.isEmpty()) {
                 return List.of();
             }
-            chosen.put(field.getKey(), stands.get(0));
+            FixtureTemplate at = stands.get(0);
+            chosen.put(field.getKey(), at);
+            // Settled, and the rules read again with it in them. A field chosen against the rules as
+            // they stand before anything is settled is chosen against `a < b` with `a` still open,
+            // which leaves `b` its whole range and takes the bottom of it.
+            if (Counts.writtenIn(at.value()) instanceof Count count) {
+                settled.put(field.getKey(), count);
+                left = FieldDomains.of(record, data, symbols, settled);
+            }
         }
         return List.of(FixtureTemplate.record(record, chosen));
     }

--- a/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Partitions.java
@@ -25,6 +25,7 @@ import souther.compiler.types.ValueName;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -748,22 +749,84 @@ public final class Partitions {
         if (type instanceof Type.ListOf || type instanceof Type.SetOf || type instanceof Type.MapOf) {
             return List.of(FixtureTemplate.emptyCollection());
         }
-        List<PartitionClass> classes = PartitionClasses.of(type, symbols);
-        for (PartitionClass each : classes) {
-            // Values, not a class that could produce one. A class whose values are composed has none
-            // to hand over here, and returning its empty list would say the type has no values.
-            if (each.generatable() && !each.representatives().candidates().isEmpty()) {
-                return each.representatives().candidates();
+        // Absence, which every optional holds. Answered here rather than through the classes below
+        // because what the classes say about `Some` is what stands for the element, and asking that
+        // while the element is being built is the element asking for itself.
+        if (type instanceof Type.OptionOf) {
+            return List.of(FixtureTemplate.none());
+        }
+        for (PartitionClass each : PartitionClasses.of(type, symbols)) {
+            List<FixtureTemplate> stands = standingFor(each.representatives(), symbols, expanding);
+            if (!stands.isEmpty()) {
+                return stands;
             }
         }
         // A newtype the model only bounds has no classes — everything outside the bound is refused at
         // construction — but it does have values, and the edge of the bound is one that builds.
-        if (type instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data
-                && data.newtype()) {
-            return insideTheNewtype(ref.name(), symbols, within, expanding).stream()
-                    .map(t -> FixtureTemplate.newtype(ref.name(), t)).toList();
+        if (type instanceof Type.Ref ref && symbols.get(ref.name()) instanceof Ast.Data data) {
+            return data.newtype()
+                    ? insideTheNewtype(ref.name(), symbols, within, expanding).stream()
+                            .map(t -> FixtureTemplate.newtype(ref.name(), t)).toList()
+                    : composed(ref.name(), symbols, expanding);
         }
         return List.of();
+    }
+
+    /**
+     * The values a recipe arrives at, whichever way it arrives at them.
+     *
+     * <p>{@code Values} and {@code Compose} are two ways of writing where a representative comes
+     * from and not two answers about whether there is one, so a reader asking for one takes both
+     * here. Read as a reader's own two questions — is it generatable, and does it hold values — a
+     * class naming a constructor answered yes and then handed over nothing, and the position it
+     * stood at was reported as one no value can be written at (issue #651).
+     */
+    static List<FixtureTemplate> standingFor(RepresentativeSource source, Symbols symbols,
+                                             java.util.Set<TypeName> expanding) {
+        return switch (source.evaluate()) {
+            case RepresentativeSource.Evaluation.Values values -> values.written();
+            case RepresentativeSource.Evaluation.Compose compose ->
+                    composed(compose.through(), symbols, expanding).stream()
+                            .map(compose::written).toList();
+            case RepresentativeSource.Evaluation.NothingProduced _,
+                 RepresentativeSource.Evaluation.NothingProducible _ -> List.of();
+        };
+    }
+
+    /**
+     * A record composed field by field, or nothing where one of its fields has nothing to stand for
+     * it.
+     *
+     * <p>{@code expanding} carries the names this is already inside the value of, so a record
+     * reached from its own field is given up on there rather than composed forever. Path-local: a
+     * name is in it only while the value under it is being built, so a type met twice in two
+     * branches is composed in both.
+     *
+     * <p>Nothing about the rules relating the fields. Each is what stands for it on its own, and
+     * whether they may be held together is the decoder's answer — the same answer every other
+     * candidate this offers is put through.
+     */
+    private static List<FixtureTemplate> composed(TypeName record, Symbols symbols,
+                                                  java.util.Set<TypeName> expanding) {
+        if (expanding.contains(record) || !(symbols.get(record) instanceof Ast.Data data)) {
+            return List.of();
+        }
+        Map<String, Type> fields = TypeOps.fieldTypes(data, symbols);
+        if (fields.isEmpty()) {
+            return List.of();   // a unit has no fields to compose, and is named rather than built
+        }
+        java.util.Set<TypeName> inside = new LinkedHashSet<>(expanding);
+        inside.add(record);
+        Map<String, FixtureTemplate> chosen = new LinkedHashMap<>();
+        for (Map.Entry<String, Type> field : fields.entrySet()) {
+            List<FixtureTemplate> stands =
+                    representativesOf(field.getValue(), symbols, null, inside);
+            if (stands.isEmpty()) {
+                return List.of();
+            }
+            chosen.put(field.getKey(), stands.get(0));
+        }
+        return List.of(FixtureTemplate.record(record, chosen));
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
@@ -37,7 +37,7 @@ public sealed interface RepresentativeSource {
      * <p>One closed answer, and what a reader deciding what to do reads. The cases of this interface
      * are how a recipe is <em>written</em> — a projection sits over another recipe, and reading it
      * means reading what is under it — whereas an {@link Evaluation} is what a reader has to
-     * <em>do</em>, and the two are not the same four things. A reader that asked "is there a
+     * <em>do</em>, and the two are not the same set of things. A reader that asked "is there a
      * constructor", "are there values", "was a reason given" separately would be recovering the
      * variant from three answers, and could meet combinations no recipe can be in.
      */
@@ -54,14 +54,14 @@ public sealed interface RepresentativeSource {
     sealed interface Evaluation {
 
         /** Values ready to be written at the position, in the order to try them, under every name
-         *  it wears. Never empty: nothing to write is one of the two cases below. */
+         *  it wears. Never empty: a class with nothing to write is {@link NothingProducible}. */
         record Values(List<FixtureTemplate> written) implements Evaluation {
 
             public Values {
                 written = List.copyOf(written);
                 if (written.isEmpty()) {
                     throw new IllegalArgumentException(
-                            "no values is `NothingProduced`, which says so");
+                            "no values is `NothingProducible`, which says why");
                 }
             }
         }
@@ -87,10 +87,6 @@ public sealed interface RepresentativeSource {
             }
         }
 
-        /** Nothing was produced for this class and nothing said why. Which is not that the class
-         *  has no values — only that none was arrived at here. */
-        record NothingProduced() implements Evaluation {}
-
         /**
          * Nothing can produce a value for this class, and why.
          *
@@ -110,22 +106,31 @@ public sealed interface RepresentativeSource {
     default boolean buildable() {
         return switch (evaluate()) {
             case Evaluation.Values _, Evaluation.Compose _ -> true;
-            case Evaluation.NothingProduced _, Evaluation.NothingProducible _ -> false;
+            case Evaluation.NothingProducible _ -> false;
         };
     }
 
-    /** Values named outright. Empty is a class nothing here produced a value for and nothing said
-     *  why — which is a different report from {@link Ungeneratable}. */
+    /**
+     * Values named outright, and at least one of them.
+     *
+     * <p>Empty used to be allowed and meant a class nothing produced a value for and nothing said
+     * why. Nothing wrote one — every producer already branched to {@link Ungeneratable} where its
+     * values ran out — and what the state bought was a reader with a fourth answer to give, which
+     * it gave as the position having no value. A class that cannot produce one says why.
+     */
     record Ready(List<FixtureTemplate> values) implements RepresentativeSource {
 
         public Ready {
             values = List.copyOf(values);
+            if (values.isEmpty()) {
+                throw new IllegalArgumentException(
+                        "a class with no values is `Ungeneratable`, which says why");
+            }
         }
 
         @Override
         public Evaluation evaluate() {
-            return values.isEmpty() ? new Evaluation.NothingProduced()
-                    : new Evaluation.Values(values);
+            return new Evaluation.Values(values);
         }
     }
 
@@ -170,8 +175,7 @@ public sealed interface RepresentativeSource {
                 }
                 // Nothing to put a name on. What the inner recipe says stands: a name wrapped round
                 // a value nothing composed does not make one, and does not change why there is none.
-                case Evaluation.NothingProduced _, Evaluation.NothingProducible _ ->
-                        inner.evaluate();
+                case Evaluation.NothingProducible _ -> inner.evaluate();
             };
         }
     }
@@ -191,11 +195,6 @@ public sealed interface RepresentativeSource {
 
     static RepresentativeSource of(List<FixtureTemplate> values) {
         return new Ready(values);
-    }
-
-    /** Nothing produced a value here and nothing said why. */
-    static RepresentativeSource none() {
-        return new Ready(List.of());
     }
 
     /** {@code inner}, written under {@code wrappers} — or {@code inner} itself where the position

--- a/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/RepresentativeSource.java
@@ -101,16 +101,6 @@ public sealed interface RepresentativeSource {
     }
 
     /**
-     * The values ready to be written at the position, or empty where the recipe is not values.
-     *
-     * <p>Derived from the one answer rather than answered beside it, so that a caller wanting
-     * values and a caller wanting to know what to do cannot be told different things.
-     */
-    default List<FixtureTemplate> candidates() {
-        return evaluate() instanceof Evaluation.Values values ? values.written() : List.of();
-    }
-
-    /**
      * Whether a value of this class can be produced at all.
      *
      * <p>Not whether there are values here: a class composed through a constructor has none and is

--- a/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
+++ b/souther-compiler/src/main/java/souther/compiler/partition/Witnesses.java
@@ -330,7 +330,7 @@ final class Witnesses {
                                                           Set<TypeName> expanding) {
         Set<String> written = new LinkedHashSet<>();
         List<FixtureTemplate> out = new ArrayList<>();
-        for (FixtureTemplate each : dividesInto(type, symbols)) {
+        for (FixtureTemplate each : dividesInto(type, symbols, expanding)) {
             if (out.size() >= many) {
                 return List.copyOf(out);
             }
@@ -368,12 +368,11 @@ final class Witnesses {
      * into was written here as well, and the two could differ about how far to look. The reading
      * goes through the names now and hands the values back written under them.
      */
-    private static List<FixtureTemplate> dividesInto(Type type, Symbols symbols) {
+    private static List<FixtureTemplate> dividesInto(Type type, Symbols symbols,
+                                                     Set<TypeName> expanding) {
         List<FixtureTemplate> out = new ArrayList<>();
         for (PartitionClass each : PartitionClasses.of(type, symbols)) {
-            if (each.generatable()) {
-                out.addAll(each.representatives().candidates());
-            }
+            out.addAll(Partitions.standingFor(each.representatives(), symbols, expanding));
         }
         return out;
     }

--- a/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/AdequacyReport.java
@@ -771,8 +771,8 @@ public record AdequacyReport(int schemaVersion, String compilerVersion, Adequacy
     private static String whyUnresolved(souther.compiler.partition.Generator.UnresolvedCombination why) {
         String at = why.subject();
         return switch (why.reason()) {
-            case NO_REPRESENTATIVE -> "no value stands for " + at;
-            case NOTHING_COMPOSES_ONE -> "nothing here composes a value at " + at;
+            case NO_CLASS_OPEN_AT_POSITION -> "the body leaves no class open at " + at;
+            case NOTHING_COMPOSES_ONE -> "nothing here could build a representative for " + at;
             case ALL_CANDIDATES_REJECTED -> "every value tried at " + at + " was refused";
             case SEARCH_LIMIT -> "the search stopped before reaching " + at;
             case NOTHING_TO_BUILD_AGAINST -> "there was nothing to build a candidate against";

--- a/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
+++ b/souther-compiler/src/main/java/souther/compiler/report/GeneratedRows.java
@@ -356,9 +356,10 @@ public final class GeneratedRows {
 
     private static String why(Generator.UnresolvedCombination.Reason reason) {
         return switch (reason) {
-            case NO_REPRESENTATIVE -> "no value can be written there";
+            case NO_CLASS_OPEN_AT_POSITION ->
+                    "the body leaves no class open at another position, so no row reaches this one";
             case NOTHING_COMPOSES_ONE ->
-                    "nothing here composes a value at that edge, which does not make the edge"
+                    "nothing here could build a representative for it, which does not make one"
                             + " unwritable";
             case ALL_CANDIDATES_REJECTED ->
                     "every value tried was refused at construction, which does not make the"

--- a/souther-compiler/src/test/java/souther/compiler/EveryGapTheBuildRefusesGetsAnAnswerTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryGapTheBuildRefusesGetsAnAnswerTest.java
@@ -143,14 +143,11 @@ class EveryGapTheBuildRefusesGetsAnAnswerTest {
                 | "home" : (Domestic) -> Fine
             """;
 
-    /** The same, with a case that carries a field whose value nothing here composes. */
     /**
-     * A case an axis divides and nothing composes a value for.
+     * The same, with a case an axis divides and no value gets past its rules.
      *
-     * <p>A newtype over a record. What stands for the case is a value wrapped in its constructor, so
-     * what it needs is a value of what it wraps — and a record is not one a position hands over: its
-     * fields are composed, which is a composition a class cannot do on its own. A record case of a
-     * sum is composed through its own constructor and is no longer this shape.
+     * <p>The case is composed field by field like any other and every candidate is refused at
+     * construction, so what comes back is a search that ran and a reason for what it found.
      */
     private static final String CARRIED = """
             module example.pay
@@ -158,8 +155,8 @@ class EveryGapTheBuildRefusesGetsAnAnswerTest {
             data Amount = Decimal
                 invariant value >= 0.0m
 
-            data Holder = { holder: Amount }
-            data Card = Holder
+            data Card = { holder: Amount }
+                invariant impossible = holder.value >= 10.0m && holder.value <= 5.0m
             data Cash = { amount: Amount }
             data Payment = Card | Cash
 
@@ -234,8 +231,8 @@ class EveryGapTheBuildRefusesGetsAnAnswerTest {
      * A case an axis divides and nothing composed a value for is answered by the attempt.
      *
      * <p>Not {@code NotSupported}: the strategy took this class and came back with a reason, which is
-     * news of a different kind. What it came back with here is a refusal a hand-written row would
-     * settle, and reading it as "no strategy for this" would say the generator will never offer one.
+     * news of a different kind. Reading it as "no strategy for this" would say the generator will
+     * never offer a row at a class it took and searched.
      */
     @Test
     void aCaseNothingComposedAValueForIsAnsweredByTheAttempt() {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -134,6 +135,19 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
             assertFalse(Partitions.representativesOf(named(each.id()), symbols).isEmpty(),
                     () -> "a record case stands for a value: " + each.id());
         }
+    }
+
+    /**
+     * A recipe of no values is not a recipe.
+     *
+     * <p>Held as one, a class offering nothing and saying nothing about why was a class the search
+     * met and had no reading for, and what it wrote down was read as the position having no value.
+     * A class that cannot produce one says so and says why, which is {@link
+     * RepresentativeSource.Ungeneratable}; there is nothing left for an empty list to mean.
+     */
+    @Test
+    void aRecipeOfNoValuesCannotBeWritten() {
+        assertThrows(IllegalArgumentException.class, () -> RepresentativeSource.of(List.of()));
     }
 
     private static String generated() throws Exception {

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -36,7 +36,8 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
             data Yen = Int invariant value >= 0
             data Ok = { n: Int }
 
-            data Boxed = { x: Int }
+            data Boxed = { a: Int, b: Int }
+                invariant rising = a < b
             data Labelled = { s: String }
             data EveryCaseARecord = Boxed | Labelled
 
@@ -49,7 +50,7 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
                 constructs Ok
             let recordCases (bill, v) = Ok { n = bill.value }
 
-            example recordCases | (Yen(5), Boxed { x = 1 }) -> Ok { n = 5 }
+            example recordCases | (Yen(5), Boxed { a = 1, b = 2 }) -> Ok { n = 5 }
             """;
 
     private final Symbols symbols = Symbols.of(resolved());
@@ -148,6 +149,23 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
             assertFalse(Partitions.representativesOf(named(each.id()), symbols).isEmpty(),
                     () -> "a record case stands for a value: " + each.id());
         }
+    }
+
+    /**
+     * A case whose fields constrain each other is composed against that rule.
+     *
+     * <p>The walk that composes a case as an axis chooses one position at a time, each against what
+     * the record's rules leave it once the ones before it are settled, which is the only way
+     * {@code a < b} is met. Composed here with every field read from the rules as they stand before
+     * anything is chosen, the value handed back is one the decoder refuses — and the position is
+     * back to being one the two strategies disagree about.
+     */
+    @Test
+    void aCaseWhoseFieldsConstrainEachOtherIsComposedAgainstThatRule() {
+        List<FixtureTemplate> stands = Partitions.representativesOf(named("Boxed"), symbols);
+
+        assertTrue(stands.stream().anyMatch(each -> each.text().equals("Boxed { a = 0, b = 1 }")),
+                () -> "each field against what the rules leave it: " + stands);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -1,0 +1,152 @@
+package souther.compiler.partition;
+
+import org.junit.jupiter.api.Test;
+import souther.compiler.Main;
+import souther.compiler.ast.Ast;
+import souther.compiler.check.Resolve;
+import souther.compiler.check.Symbols;
+import souther.compiler.frontend.CstFrontend;
+import souther.compiler.types.Type;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A sum every case of which is a record has values, and every reader that asks for one is told so.
+ *
+ * <p>{@code Values} and {@code Compose} are two ways of arriving at a representative and not two
+ * answers about whether there is one. A reader that took the first and dropped the second reported
+ * a position as having no value in the same report where another reader wrote one — which is issue
+ * #651, and which is one function's answer read in five places.
+ */
+class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
+
+    private static final String MODULE = """
+            module demo
+
+            data Yen = Int invariant value >= 0
+            data Ok = { n: Int }
+
+            data Boxed = { x: Int }
+            data Labelled = { s: String }
+            data EveryCaseARecord = Boxed | Labelled
+
+            data Wrapped = EveryCaseARecord
+
+            behavior recordCases : (bill: Yen, v: EveryCaseARecord) -> Ok
+                constructs Ok
+            let recordCases (bill, v) = Ok { n = bill.value }
+
+            example recordCases | (Yen(5), Boxed { x = 1 }) -> Ok { n = 5 }
+            """;
+
+    private final Symbols symbols = Symbols.of(resolved());
+
+    private static Ast.Module resolved() {
+        Ast.Module parsed = CstFrontend.parse(MODULE);
+        return Resolve.module(parsed, Symbols.of(parsed));
+    }
+
+    private Type named(String name) {
+        return Type.ref(symbols.own(name));
+    }
+
+    private Type sum() {
+        return named("EveryCaseARecord");
+    }
+
+    // --- the position a row is not about ---------------------------------------------------------
+
+    /** The boundary strategy fills every other position, and one that is a sum is one of them. */
+    @Test
+    void aBoundaryRowIsOfferedWhereACompanionPositionIsASumOfRecords() throws Exception {
+        String report = generated();
+
+        List<String> rows = report.lines().filter(line -> line.startsWith("//     | ")).toList();
+        assertTrue(rows.stream().anyMatch(line -> line.contains("bill = 0")),
+                () -> "the row at the boundary is offered: " + rows);
+    }
+
+    /** And the sentence that says otherwise is not printed beside the row that disproves it. */
+    @Test
+    void nothingSaysThePositionHasNoValue() throws Exception {
+        String report = generated();
+
+        assertFalse(report.contains("no value can be written there"),
+                () -> "a case was composed two lines above:\n" + report);
+    }
+
+    // --- the same question, asked by the other readers --------------------------------------------
+
+    /** What an optional holds is what stands for its element, composed or not. */
+    @Test
+    void theSomeOfAnOptionalSumOfRecordsIsGeneratable() {
+        PartitionClass some = PartitionClasses.of(new Type.OptionOf(sum()), symbols).stream()
+                .filter(each -> each.id().equals("Some")).findFirst().orElseThrow();
+
+        assertTrue(some.generatable(),
+                () -> "`Some` stands for a value that composes: " + some.representatives());
+    }
+
+    /** A collection whose rules ask it to hold one is built from what stands for its element. */
+    @Test
+    void aCollectionRequiredToHoldOneOfASumOfRecordsIsBuilt() {
+        List<FixtureTemplate> held =
+                Witnesses.holding(new Type.ListOf(sum()), 1, symbols, Set.of());
+
+        assertFalse(held.isEmpty(), "a list of one is built from a case of the sum");
+    }
+
+    /** Two of them, which is the reading that asks what the type divides into rather than what
+     *  stands for it. */
+    @Test
+    void aSetOfTwoIsBuiltFromTwoCasesOfASumOfRecords() {
+        List<FixtureTemplate> held =
+                Witnesses.holding(new Type.SetOf(sum()), 2, symbols, Set.of());
+
+        assertFalse(held.isEmpty(), "the two cases are two distinct values");
+    }
+
+    /** A name round the sum is a name round what stands for it. */
+    @Test
+    void aNewtypeOverASumOfRecordsHasARepresentative() {
+        List<FixtureTemplate> stands = Partitions.representativesOf(named("Wrapped"), symbols);
+
+        assertTrue(stands.stream().anyMatch(each -> each.text().startsWith("Wrapped(")),
+                () -> "written under the name the position wears: " + stands);
+    }
+
+    // --- what a class says it is, once ------------------------------------------------------------
+
+    /** Every class of the sum offers a representative: none of them is a class nothing produces a
+     *  value for. */
+    @Test
+    void everyCaseOfTheSumStandsForSomething() {
+        for (PartitionClass each : PartitionClasses.of(sum(), symbols)) {
+            assertFalse(Partitions.representativesOf(named(each.id()), symbols).isEmpty(),
+                    () -> "a record case stands for a value: " + each.id());
+        }
+    }
+
+    private static String generated() throws Exception {
+        Path file = Files.createTempDirectory("souther-651").resolve("model.sou");
+        Files.writeString(file, MODULE);
+        PrintStream was = System.out;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            Main.main(new String[] {"examples", file.toString(), "--generate", "--boundaries"});
+        } finally {
+            System.setOut(was);
+        }
+        return out.toString(StandardCharsets.UTF_8);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -90,14 +90,24 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
 
     // --- the same question, asked by the other readers --------------------------------------------
 
-    /** What an optional holds is what stands for its element, composed or not. */
+    /**
+     * What an optional holds is what stands for its element, composed or not.
+     *
+     * <p>Held to the value and not to whether one could be arrived at. A class carrying a recipe
+     * answers yes to that either way, and what went wrong was the step after it: the recipe was
+     * read for values, it had none to hand over, and the class was written down as one nothing can
+     * produce a value for.
+     */
     @Test
-    void theSomeOfAnOptionalSumOfRecordsIsGeneratable() {
+    void theSomeOfAnOptionalSumOfRecordsStandsForAComposedCase() {
         PartitionClass some = PartitionClasses.of(new Type.OptionOf(sum()), symbols).stream()
                 .filter(each -> each.id().equals("Some")).findFirst().orElseThrow();
 
-        assertTrue(some.generatable(),
-                () -> "`Some` stands for a value that composes: " + some.representatives());
+        List<FixtureTemplate> stands =
+                Partitions.standingFor(some.representatives(), symbols, Set.of());
+
+        assertTrue(stands.stream().anyMatch(each -> each.text().startsWith("Boxed {")),
+                () -> "`Some` stands for a case of the element: " + stands);
     }
 
     /** A collection whose rules ask it to hold one is built from what stands for its element. */

--- a/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ACaseComposedForOneReaderIsComposedForEveryReaderTest.java
@@ -42,6 +42,9 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
 
             data Wrapped = EveryCaseARecord
 
+            data Bag = { xs: List<Int> }
+                invariant enough = List.length(xs) >= 2
+
             behavior recordCases : (bill: Yen, v: EveryCaseARecord) -> Ok
                 constructs Ok
             let recordCases (bill, v) = Ok { n = bill.value }
@@ -135,6 +138,23 @@ class ACaseComposedForOneReaderIsComposedForEveryReaderTest {
             assertFalse(Partitions.representativesOf(named(each.id()), symbols).isEmpty(),
                     () -> "a record case stands for a value: " + each.id());
         }
+    }
+
+    /**
+     * A record composed here holds what its own rule says it holds.
+     *
+     * <p>The floor a record puts on a field is read wherever a value is chosen, and composing a
+     * record is choosing one for every field of it. Read off the field's type alone, what comes
+     * back is a value the record refuses at construction, and the row it was composed for is
+     * reported as one every value tried was refused at.
+     */
+    @Test
+    void aComposedRecordHoldsWhatItsOwnRuleAsksFor() {
+        List<FixtureTemplate> stands = Partitions.representativesOf(named("Bag"), symbols);
+
+        assertTrue(stands.stream().anyMatch(each -> each.text().contains("xs = [")
+                        && !each.text().contains("xs = []")),
+                () -> "the floor its rule puts on the field: " + stands);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ALineBetweenTwoPositionsIsStillALineTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ALineBetweenTwoPositionsIsStillALineTest.java
@@ -411,7 +411,7 @@ class ALineBetweenTwoPositionsIsStillALineTest {
         String rows = generated(NO_COMMON_COUNT);
 
         assertTrue(rows.contains("no row for `a = b`"), rows);
-        assertTrue(rows.contains("does not make the edge unwritable"), rows);
+        assertTrue(rows.contains("does not make one unwritable"), rows);
     }
 
     /**
@@ -423,8 +423,8 @@ class ALineBetweenTwoPositionsIsStillALineTest {
      * witness nothing is counted.
      *
      * <p>What is said about that matters more than the absence. Two strings of one length are the
-     * easiest row in the file to write by hand, so the sentence that licenses "no value can be
-     * written there" would be false, and the one written says what this could not do.
+     * easiest row in the file to write by hand, so a sentence saying no value can be written there
+     * would be false, and the one written says what this could not do.
      */
     @Test
     void aLineOnAMeasureIsReadAndPromisedByNothing() {
@@ -434,8 +434,8 @@ class ALineBetweenTwoPositionsIsStillALineTest {
         assertFalse(report.contains("no row is at cmp/String.length(a) = String.length(b)"), report);
         assertTrue(report.contains(
                 "not known to be writable: cmp/String.length(a) = String.length(b)"), report);
-        assertTrue(rows.contains("nothing here composes a value at that edge"), rows);
-        assertTrue(rows.contains("does not make the edge unwritable"), rows);
+        assertTrue(rows.contains("nothing here could build a representative for it"), rows);
+        assertTrue(rows.contains("does not make one unwritable"), rows);
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/ANameGoesBackOnTheWayItCameOffTest.java
@@ -188,7 +188,8 @@ class ANameGoesBackOnTheWayItCameOffTest {
         return at;
     }
 
-    private static List<String> written(PartitionClass each) {
-        return each.representatives().candidates().stream().map(FixtureTemplate::text).toList();
+    private List<String> written(PartitionClass each) {
+        return Partitions.standingFor(each.representatives(), symbols, java.util.Set.of()).stream()
+                .map(FixtureTemplate::text).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -329,6 +329,34 @@ class GeneratorTest {
     }
 
     /**
+     * A position whose classes the body all rules out leaves no row to write anywhere else.
+     *
+     * <p>What that says is about the classes a row may be written at, and not about whether values
+     * of the position exist: every class here has a value, and the body is what refuses them. A
+     * reason that said no value can be written there would send an author looking for a type with
+     * no values.
+     */
+    @Test
+    void aPositionWithNoClassLeftOpenSaysThatAndNotThatNoValueExists() {
+        Symbols symbols = modelOf(TRIP, "submit").symbols();
+        Generator.Subject subject = twoNumbers(symbols,
+                List.of(number("shut", 1)), List.of(number("open", 10), number("wider", 20)));
+        Axis closed = subject.axes().get(0).excluding(List.of("shut"));
+        Generator.Subject shut = new Generator.Subject(subject.inputs(),
+                List.of(closed, subject.axes().get(1)));
+
+        Generator.GenerationResult filled =
+                Generator.fill(shut, List.of(), Generator.CandidateCheck.ANY);
+
+        assertEquals(List.of(), filled.rows(), "no row reaches a position with nothing open at it");
+        assertEquals(
+                List.of(Generator.UnresolvedCombination.Reason.NO_CLASS_OPEN_AT_POSITION,
+                        Generator.UnresolvedCombination.Reason.NO_CLASS_OPEN_AT_POSITION),
+                filled.unresolved().stream().map(Generator.UnresolvedCombination::reason).toList(),
+                () -> "one per combination the closed position takes part in: " + filled.unresolved());
+    }
+
+    /**
      * A class that recorded why nothing was composed for it is not reported as one nothing can be
      * written for.
      *

--- a/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/GeneratorTest.java
@@ -310,48 +310,50 @@ class GeneratorTest {
     }
 
     /**
-     * A class that recorded why nothing was composed for it is not reported as one nothing can be
-     * written for.
+     * An optional whose element is a record is offered a row, which is the value this composes at a
+     * parameter of the same type.
      *
-     * <p>The two license different work. "No value can be written there" tells an author the row does
-     * not exist; what a record case has is a value this composes everywhere else and does not compose
-     * here, which is a row they can write by hand in one line. The class already says which of the two
-     * it is, at the point it is built.
+     * <p>What {@code Some} stands for is what stands for the element, arrived at the way the row
+     * above arrives at a record. Held as values only, the class said it could produce nothing and
+     * the position was reported as one no value can be written at (issue #651).
      */
     @Test
-    void aClassThatSaidWhyNothingWasComposedIsNotReportedAsHavingNoValue() {
+    void anOptionalWhoseElementIsARecordIsOfferedARow() {
         Generator.GenerationResult filled = Generator.fill(
                 modelOf(OPTIONAL_RECORD, "feeOf").subject(), List.of(),
                 Generator.CandidateCheck.ANY);
 
-        Generator.UnresolvedCombination some = filled.unresolved().stream()
-                .filter(each -> each.classes().contains("p.card=Some")).findFirst().orElseThrow();
-        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, some.reason(),
-                "a value this could not compose, not one that cannot exist");
-        assertTrue(some.said().isPresent(), "the reason the class recorded");
-        assertEquals("p.card=Some", some.subject(),
-                "the position, which is what several of these share");
+        assertEquals(List.of(), filled.unresolved(), filled.unresolved().toString());
+        assertTrue(texts(filled).contains("Request { card = Card { number = Amount(0m) } }"),
+                () -> "the element composed, under the optional: " + texts(filled));
     }
 
     /**
-     * What a class records about itself does not claim the value cannot be written either.
+     * A class that recorded why nothing was composed for it is not reported as one nothing can be
+     * written for.
      *
-     * <p>The sentence is the whole of what an author gets, so moving the overclaim out of the reason
-     * and into the words beside it would change nothing. Nothing that ends at an empty list has
-     * established that a value does not exist: {@code Option<Card>} has one, spelled the way the row
-     * above spells a record.
+     * <p>The two license different work. "No value can be written there" tells an author the row does
+     * not exist; what the class recorded is that this composed nothing here, which may be a row they
+     * can write by hand in one line. The class already says which of the two it is, at the point it
+     * is built, and the reason carries what it said rather than a category read off an empty list.
      */
     @Test
-    void whatAClassRecordsDoesNotClaimTheValueCannotBeWritten() {
-        Generator.GenerationResult filled = Generator.fill(modelOf(OPTIONAL_RECORD, "feeOf").subject(),
-                List.of(), Generator.CandidateCheck.ANY);
+    void aClassThatSaidWhyNothingWasComposedIsNotReportedAsHavingNoValue() {
+        Symbols symbols = modelOf(TRIP, "submit").symbols();
+        Generator.Subject subject = twoNumbers(symbols,
+                List.of(PartitionClass.ungeneratable("empty", "empty", _ -> Membership.NO_MATCH,
+                        "no value this position can hold lies inside this range")),
+                List.of(number("high", 10)));
 
-        Generator.UnresolvedCombination some = filled.unresolved().stream()
-                .filter(each -> each.classes().contains("p.card=Some")).findFirst().orElseThrow();
-        String said = some.said().orElse("");
-        assertTrue(said.contains("Card"), "which value it was about, which is " + said);
-        assertFalse(said.contains("can be written"),
-                "an empty list is not a value that cannot be written: " + said);
+        Generator.GenerationResult filled =
+                Generator.fill(subject, List.of(), Generator.CandidateCheck.ANY);
+
+        assertEquals(List.of(), filled.rows(), "nothing was composed at the first position");
+        Generator.UnresolvedCombination only = filled.unresolved().getFirst();
+        assertEquals(Generator.UnresolvedCombination.Reason.NOTHING_COMPOSES_ONE, only.reason(),
+                "a value this could not compose, not one that cannot exist");
+        assertEquals(Optional.of("no value this position can hold lies inside this range"),
+                only.said(), "the sentence the class recorded, and not one made up here");
     }
 
     /**

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhatARuleOnAStringIsMeasuredAtTest.java
@@ -173,11 +173,11 @@ class WhatARuleOnAStringIsMeasuredAtTest {
         for (Axis axis : p.axes()) {
             for (PartitionClass each : axis.classes()) {
                 classes.add(each.label());
-                stands.add(each.generatable()
-                        ? each.representatives().candidates().stream()
-                                .map(FixtureTemplate::text).map(WhatARuleOnAStringIsMeasuredAtTest::bare)
-                                .toList().toString()
-                        : "none");
+                List<FixtureTemplate> made =
+                        Partitions.standingFor(each.representatives(), symbols, java.util.Set.of());
+                stands.add(made.isEmpty() ? "none"
+                        : made.stream().map(FixtureTemplate::text)
+                                .map(WhatARuleOnAStringIsMeasuredAtTest::bare).toList().toString());
             }
             Partitions.obligationsOf(axis, symbols, p.domains().get(axis.term()))
                     .forEach(o -> owed.add(o.side() + " " + o.target().right()));

--- a/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/partition/WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest.java
@@ -216,7 +216,7 @@ class WhyAValueCouldNotBePlacedIsTheClassifiersToSayTest {
         List<PartitionClass> classes = new java.util.ArrayList<>();
         for (int i = 0; i < classifiers.length; i++) {
             classes.add(PartitionClass.of("c" + i, "c" + i, classifiers[i],
-                    RepresentativeSource.none()));
+                    RepresentativeSource.of(FixtureTemplate.integer(i))));
         }
         return List.of(new Axis(real.id(), real.term(), real.type(), classes, real.cuts()));
     }


### PR DESCRIPTION
Closes #651.

A boundary row was given up on where a companion position was a sum with no
unit case, two lines below a row that composed a case of that very sum.

## What was wrong

`RepresentativeSource` says how a value standing for a class is arrived at:
`Values` names them outright, `Compose` names the constructor and leaves the
composition to the walk that composes every other record. Every reader asked
for the first and dropped the second, through a two-step question — is this
class generatable, and does it hold values — that answered yes and then handed
over nothing.

So a sum with a record in every case had nothing standing for it. That answer
was read in five places: the boundary strategy filling the positions a row is
not about, an optional's `Some`, a collection whose rules ask it to hold one,
a newtype over the sum, and the reading that asks what a type divides into.
The class-coverage strategy composed cases all along, because a class named as
an axis puts its constructor where the walk can see it. Whether a value existed
depended on which strategy asked.

## What changed

`Partitions.standingFor` is now the one place a recipe is read. `Values` hands
over its values; `Compose` composes the record field by field and writes it
under the names the position wears. The names this is already inside the value
of are carried down a branch at a time, so a type written in terms of itself is
given up on where it recurs. All five readers go through it, and
`RepresentativeSource.candidates()` is gone so the two-step question cannot be
written again.

The diagnostics were re-cut at the same time. One reason stood for four
findings and its sentence — "no value can be written there" — claimed more than
any of them established. A body that leaves no class open at a position now
says that; a search that composed nothing joins `NOTHING_COMPOSES_ONE`, which
already says what it says without claiming the row cannot be written. The other
two sites were this compiler disagreeing with itself — a line asked for without
the count to write it at, and a boundary naming an axis the subject has none of
— and they throw where they are found instead of being reported as findings
about the model. Nothing left says a value cannot exist: establishing that
takes a judgement about the type, and this generator makes none.

Last, `Ready` no longer takes an empty list. No producer ever wrote one, and
what the state bought was a fourth answer for readers to give — which the one
that gave it read as the position having no value.

## What it looks like now

```
// example recordCases
//     | "v=Labelled" : (Yen(0), Labelled { s = "x" }) -> <?>
//     | "bill = 0" : (Yen(0), Boxed { x = 0 }) -> <?>
```

## Evidence

The five readers are held to the same sum in one test, so no reader can go back
to reading only `Values`. `candidates()` and `generatable()` have no production
reader left.

The four sites of the retired reason were measured before renaming any of them:
none fires anywhere in the suite, with a probe on `ALL_CANDIDATES_REJECTED`
firing 37 times in the same run to show the measurement works. Routes to a
position with no representative were then traced by hand — every inhabited leaf
composes, an empty numeric range is absorbed where the base value is offered
without bounds and where the record's admissible edge is computed, a tuple
position is refused by the front end, and a recursion bottoms out at `None` or
the empty collection. That is why the site joins an existing reason rather than
being given a name of its own.

## Rebased over #650

Composing a record is choosing a value for every field of it, so it is one of
the places the floor a record's rule puts on a field has to be read — the rule
#650 states. The last commit reads it there: a `{ xs: List<Int> }` whose rule
asks for two was being handed a list holding none.

## Two things to know

A model whose sum has a unit case may now be offered more rows than before: the
boundary row used to take the unit case because it was the only thing on offer,
and covered the class gap by accident. It now composes the first case, and the
unit case gets its row. Which class a representative comes from is
representative selection, and how few rows cover the gaps is row minimisation;
neither is touched here.

While tracing this, E1013 turned out to accept recursive collection types whose
invariants remove the empty value it counted on as the base case. Filed
separately as #654.
