### PR TITLE
Read a construction's own invariant of the value the row wrote

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -728,7 +728,7 @@ public final class FixtureReader {
      *  is why it is not asked of a decoder: one reads a whole number where a `Decimal` stands, and a
      *  row writing `1` there wrote an `Int`. */
     private static boolean spells(ObservedValue v, TypeName name) {
-        return name.name().equals(ValueRendering.primitiveNamed(v));
+        return name.primitiveKind() != null && name.primitiveKind() == ValueRendering.primitiveOf(v);
     }
 
     private boolean each(List<Asserted> elements, Type element) {

--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -522,7 +522,28 @@ public final class FixtureReader {
             }
             fields.put(f.getKey(), new Asserted.Value(new ObservedValue.Absent()));
         }
-        return new Asserted.Built(built, fields);
+        Asserted.Built whole = new Asserted.Built(built, fields);
+        admitsItself(whole, nd, built);
+        return whole;
+    }
+
+    /**
+     * A construction's own invariant, over the value it states.
+     *
+     * <p>The same two stages a newtype goes through, for the same reason. Whether every field states
+     * what this type declares it to be is asked of what the row wrote; only where it does is there a
+     * value of this type to ask the invariant about, and only there can building one read nothing as
+     * something else. A row whose field states another type is not a value whose invariant failed —
+     * it is the disagreement it reports, and asking a rule about a value nobody wrote would answer
+     * for a value nobody wrote.
+     */
+    private void admitsItself(Asserted.Built whole, Ast.NewData nd, TypeName built) {
+        if (TypeOps.effectiveInvariants(declared(built), symbols).isEmpty()
+                || !states(whole, Type.ref(built))) {
+            return;
+        }
+        decode(FixtureShape.of(Type.ref(built), symbols),
+                neutral.shaped(raw(nd, Type.ref(built), Admission.HELD), Type.ref(built)));
     }
 
     private Asserted assertedApply(Ast.Apply c, Type position) {

--- a/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
+++ b/souther-compiler/src/main/java/souther/compiler/FixtureReader.java
@@ -714,15 +714,6 @@ public final class FixtureReader {
         return true;
     }
 
-    private boolean each(List<Asserted> elements, Type element) {
-        for (Asserted e : elements) {
-            if (!states(e, element)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     /** The name a written value wears, or null where it wears none. */
     private static TypeName named(Asserted a) {
         return switch (a) {
@@ -733,17 +724,22 @@ public final class FixtureReader {
         };
     }
 
-    /** Whether a written value with no parts is how {@code name} is spelled. */
+    /** Whether a written value with no parts is of {@code name}. Asked of what the row wrote, which
+     *  is why it is not asked of a decoder: one reads a whole number where a `Decimal` stands, and a
+     *  row writing `1` there wrote an `Int`. */
     private static boolean spells(ObservedValue v, TypeName name) {
-        return switch (name.name()) {
-            case "Int" -> v instanceof ObservedValue.Integer;
-            case "String" -> v instanceof ObservedValue.Text;
-            case "Bool" -> v instanceof ObservedValue.Bool;
-            case "Decimal" -> v instanceof ObservedValue.Decimal || v instanceof ObservedValue.Integer;
-            case "Date", "Time", "DateTime", "Instant" -> v instanceof ObservedValue.Temporal;
-            default -> false;
-        };
+        return name.name().equals(ValueRendering.primitiveNamed(v));
     }
+
+    private boolean each(List<Asserted> elements, Type element) {
+        for (Asserted e : elements) {
+            if (!states(e, element)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
 
     /** Whether a type is one whose values have no parts, so a value of it is settled by the one value
      *  standing there and a decoder for it reads no position but its own. */

--- a/souther-compiler/src/main/java/souther/compiler/ValueMatch.java
+++ b/souther-compiler/src/main/java/souther/compiler/ValueMatch.java
@@ -101,9 +101,9 @@ final class ValueMatch {
         // answer for every reader of it. A row writing `1` where a `Decimal` came out wrote an `Int`
         // — the difference is written in the language, and reading a whole number as an amount is
         // what a boundary does and not what a row did.
-        String stated = ValueRendering.primitiveNamed(v);
-        String answered = ValueRendering.primitiveNamed(o);
-        if (stated == null || answered == null || !stated.equals(answered)) {
+        Type.Prim stated = ValueRendering.primitiveOf(v);
+        Type.Prim answered = ValueRendering.primitiveOf(o);
+        if (stated == null || stated != answered) {
             return v instanceof ObservedValue.Unit x && o instanceof ObservedValue.Unit y
                     && x.type().equals(y.type())
                     ? null : new Mismatch(path, Reason.TYPE, a, o, position);

--- a/souther-compiler/src/main/java/souther/compiler/ValueMatch.java
+++ b/souther-compiler/src/main/java/souther/compiler/ValueMatch.java
@@ -97,27 +97,31 @@ final class ValueMatch {
             return v instanceof ObservedValue.Absent && o instanceof ObservedValue.Absent
                     ? null : new Mismatch(path, Reason.ABSENCE, a, o, position);
         }
+        // Of one type before anything else, and which type a written value with no parts is has one
+        // answer for every reader of it. A row writing `1` where a `Decimal` came out wrote an `Int`
+        // — the difference is written in the language, and reading a whole number as an amount is
+        // what a boundary does and not what a row did.
+        String stated = ValueRendering.primitiveNamed(v);
+        String answered = ValueRendering.primitiveNamed(o);
+        if (stated == null || answered == null || !stated.equals(answered)) {
+            return v instanceof ObservedValue.Unit x && o instanceof ObservedValue.Unit y
+                    && x.type().equals(y.type())
+                    ? null : new Mismatch(path, Reason.TYPE, a, o, position);
+        }
         return switch (v) {
-            case ObservedValue.Bool x -> o instanceof ObservedValue.Bool y
-                    ? same(path, x.value() == y.value(), a, o, position) : new Mismatch(path, Reason.TYPE, a, o, position);
-            case ObservedValue.Integer x -> o instanceof ObservedValue.Integer y
-                    ? same(path, x.value() == y.value(), a, o, position) : new Mismatch(path, Reason.TYPE, a, o, position);
+            case ObservedValue.Bool x ->
+                    same(path, x.value() == ((ObservedValue.Bool) o).value(), a, o, position);
+            case ObservedValue.Integer x ->
+                    same(path, x.value() == ((ObservedValue.Integer) o).value(), a, o, position);
             // A decimal is the amount it stands for, so two that differ only in scale are one amount
             // — the rule `Values.equal` states for the run-time values.
-            case ObservedValue.Decimal x -> o instanceof ObservedValue.Decimal y
-                    ? same(path, x.value().compareTo(y.value()) == 0, a, o, position)
-                    : new Mismatch(path, Reason.TYPE, a, o, position);
-            case ObservedValue.Text x -> o instanceof ObservedValue.Text y
-                    ? same(path, x.value().equals(y.value()), a, o, position) : new Mismatch(path, Reason.TYPE, a, o, position);
-            // Kept apart from text, so a row writing a date as a string is told the two are of
-            // different types rather than being read as one.
-            case ObservedValue.Temporal x -> o instanceof ObservedValue.Temporal y
-                    ? same(path, x.iso().equals(y.iso()), a, o, position) : new Mismatch(path, Reason.TYPE, a, o, position);
-            case ObservedValue.Unit x -> o instanceof ObservedValue.Unit y && x.type().equals(y.type())
-                    ? null : new Mismatch(path, Reason.TYPE, a, o, position);
-            case ObservedValue.Constructed _, ObservedValue.Sequence _, ObservedValue.Mapping _,
-                    ObservedValue.Absent _, ObservedValue.Unknown _, ObservedValue.Truncated _ ->
-                    new Mismatch(path, Reason.UNREADABLE, a, o, position);
+            case ObservedValue.Decimal x -> same(path,
+                    x.value().compareTo(((ObservedValue.Decimal) o).value()) == 0, a, o, position);
+            case ObservedValue.Text x ->
+                    same(path, x.value().equals(((ObservedValue.Text) o).value()), a, o, position);
+            case ObservedValue.Temporal x ->
+                    same(path, x.iso().equals(((ObservedValue.Temporal) o).iso()), a, o, position);
+            default -> new Mismatch(path, Reason.UNREADABLE, a, o, position);
         };
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/ValueRendering.java
+++ b/souther-compiler/src/main/java/souther/compiler/ValueRendering.java
@@ -116,7 +116,7 @@ final class ValueRendering {
             case ObservedValue.Text t -> "\"" + t.value() + "\"";
             // Written as the construction a fixture writes one with, so it is never read as the text
             // that spells it — which is the difference a row writing a date as a string is told about.
-            case ObservedValue.Temporal t -> typeShown(t) + "(\"" + t.iso() + "\")";
+            case ObservedValue.Temporal t -> primitiveNamed(t) + "(\"" + t.iso() + "\")";
             case ObservedValue.Unit u -> u.type().name();
             case ObservedValue.Absent _ -> "None";
             case ObservedValue.Constructed c -> constructed(c);
@@ -160,17 +160,25 @@ final class ValueRendering {
     }
 
     /**
-     * What the value is, named as the language names it — what a mismatch says when the two sides
-     * differ by their type rather than by their contents.
+     * Which primitive a value with no parts is of, or null where it has parts.
+     *
+     * <p>Answered once, here, because three readers want it and each would otherwise answer it for
+     * itself: whether a row wrote a value of a position's type, whether two values are of one type,
+     * and what to call them where they are not. A reader that worked it out on its own worked it out
+     * from what it had — and one of them had a decoder, which reads a whole number where a
+     * {@code Decimal} stands because a boundary carries one that way. What a row wrote is not that:
+     * {@code 1} is an {@code Int} and {@code 1m} is a {@code Decimal}, and the language makes that
+     * difference written.
+     *
+     * <p>A temporal is which one its text spells. An observation keeps the ISO form rather than the
+     * class it arrived in, and the four spell themselves apart.
      */
-    String typeShown(ObservedValue v) {
+    static String primitiveNamed(ObservedValue v) {
         return switch (v) {
             case ObservedValue.Bool _ -> "Bool";
             case ObservedValue.Integer _ -> "Int";
             case ObservedValue.Decimal _ -> "Decimal";
             case ObservedValue.Text _ -> "String";
-            // Which temporal it is, read off the text it was kept as: an observation holds the ISO
-            // form rather than the class it arrived in, and these four spell themselves apart.
             case ObservedValue.Temporal t -> {
                 String iso = t.iso();
                 if (iso.endsWith("Z")) {
@@ -178,12 +186,28 @@ final class ValueRendering {
                 }
                 yield iso.contains("T") ? "DateTime" : iso.contains("-") ? "Date" : "Time";
             }
+            case ObservedValue.Unit _, ObservedValue.Constructed _, ObservedValue.Absent _,
+                    ObservedValue.Sequence _, ObservedValue.Mapping _, ObservedValue.Unknown _,
+                    ObservedValue.Truncated _ -> null;
+        };
+    }
+
+    /**
+     * What the value is, named as the language names it — what a mismatch says when the two sides
+     * differ by their type rather than by their contents.
+     */
+    String typeShown(ObservedValue v) {
+        String primitive = primitiveNamed(v);
+        if (primitive != null) {
+            return primitive;
+        }
+        return switch (v) {
             case ObservedValue.Unit u -> u.type().name();
             case ObservedValue.Constructed c -> c.type().name();
             case ObservedValue.Absent _ -> "None";
             case ObservedValue.Sequence _ -> "a collection";
             case ObservedValue.Mapping _ -> "a map";
-            case ObservedValue.Unknown _, ObservedValue.Truncated _ -> "unread";
+            default -> "unread";
         };
     }
 }

--- a/souther-compiler/src/main/java/souther/compiler/ValueRendering.java
+++ b/souther-compiler/src/main/java/souther/compiler/ValueRendering.java
@@ -116,7 +116,7 @@ final class ValueRendering {
             case ObservedValue.Text t -> "\"" + t.value() + "\"";
             // Written as the construction a fixture writes one with, so it is never read as the text
             // that spells it — which is the difference a row writing a date as a string is told about.
-            case ObservedValue.Temporal t -> primitiveNamed(t) + "(\"" + t.iso() + "\")";
+            case ObservedValue.Temporal t -> primitiveOf(t).shown() + "(\"" + t.iso() + "\")";
             case ObservedValue.Unit u -> u.type().name();
             case ObservedValue.Absent _ -> "None";
             case ObservedValue.Constructed c -> constructed(c);
@@ -173,18 +173,19 @@ final class ValueRendering {
      * <p>A temporal is which one its text spells. An observation keeps the ISO form rather than the
      * class it arrived in, and the four spell themselves apart.
      */
-    static String primitiveNamed(ObservedValue v) {
+    static Type.Prim primitiveOf(ObservedValue v) {
         return switch (v) {
-            case ObservedValue.Bool _ -> "Bool";
-            case ObservedValue.Integer _ -> "Int";
-            case ObservedValue.Decimal _ -> "Decimal";
-            case ObservedValue.Text _ -> "String";
+            case ObservedValue.Bool _ -> Type.Prim.BOOL;
+            case ObservedValue.Integer _ -> Type.Prim.INT;
+            case ObservedValue.Decimal _ -> Type.Prim.DECIMAL;
+            case ObservedValue.Text _ -> Type.Prim.STRING;
             case ObservedValue.Temporal t -> {
                 String iso = t.iso();
                 if (iso.endsWith("Z")) {
-                    yield "Instant";
+                    yield Type.Prim.INSTANT;
                 }
-                yield iso.contains("T") ? "DateTime" : iso.contains("-") ? "Date" : "Time";
+                yield iso.contains("T") ? Type.Prim.DATETIME
+                        : iso.contains("-") ? Type.Prim.DATE : Type.Prim.TIME;
             }
             case ObservedValue.Unit _, ObservedValue.Constructed _, ObservedValue.Absent _,
                     ObservedValue.Sequence _, ObservedValue.Mapping _, ObservedValue.Unknown _,
@@ -197,9 +198,9 @@ final class ValueRendering {
      * differ by their type rather than by their contents.
      */
     String typeShown(ObservedValue v) {
-        String primitive = primitiveNamed(v);
+        Type.Prim primitive = primitiveOf(v);
         if (primitive != null) {
-            return primitive;
+            return primitive.shown();   // the one table a primitive is spelled from
         }
         return switch (v) {
             case ObservedValue.Unit u -> u.type().name();

--- a/souther-compiler/src/test/java/souther/compiler/AConstructionMeansWhatItsFormMeansTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AConstructionMeansWhatItsFormMeansTest.java
@@ -35,6 +35,8 @@ class AConstructionMeansWhatItsFormMeansTest {
                 invariant List.length(value) >= 1
             data Amounts = List<AmountN>
             data Wrapped = Receipt
+            data Span = { from: Int, to: Int }
+                invariant from <= to
             data Boxed = { held: AmountN? }
             data Receipt = { total: AmountN }
             data Held = { total: AmountN, note: String? }
@@ -67,6 +69,10 @@ class AConstructionMeansWhatItsFormMeansTest {
             behavior boxedOf : (n: Int) -> Boxed
                 constructs Boxed, AmountN
             let boxedOf (n) = Boxed { held = AmountN(n) }
+
+            behavior widen : (s: Span) -> Span
+                constructs Span
+            let widen (s) = Span { from = s.from, to = s.to + 1 }
 
             behavior positiveOf : (n: Int) -> Positive
                 constructs Positive
@@ -280,6 +286,21 @@ class AConstructionMeansWhatItsFormMeansTest {
                 example boxedOf
                     | (1) -> Boxed { held = None }
                 """);
+    }
+
+    @Test
+    void aRecordReadsItsOwnInvariantToo() {
+        // A construction's invariant is its own, as a newtype's is, and it is read of the value the
+        // row wrote once every field states what this type declares it to be. Reading it only where
+        // something was built through a decoder left it to whether that path happened to run.
+        holds("""
+                example widen
+                    | (Span { from = 1, to = 1 }) -> Span { from = 1, to = 2 }
+                """);
+        assertTrue(couldNotBuild("""
+                example widen
+                    | (Span { from = 1, to = 2 }) -> Span { from = 5, to = 1 }
+                """).contains("invariant"), "the row is told its own construction refused it");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/AConstructionMeansWhatItsFormMeansTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AConstructionMeansWhatItsFormMeansTest.java
@@ -39,7 +39,8 @@ class AConstructionMeansWhatItsFormMeansTest {
                 invariant from <= to
             data Priced = { at: Decimal }
                 invariant at > 0m
-            data Stamped = { at: DateTime }
+            data Stamped = { from: DateTime, to: DateTime }
+                invariant from <= to
             data Boxed = { held: AmountN? }
             data Receipt = { total: AmountN }
             data Held = { total: AmountN, note: String? }
@@ -83,7 +84,8 @@ class AConstructionMeansWhatItsFormMeansTest {
 
             behavior stampedOf : (n: Int) -> Stamped
                 constructs Stamped
-            let stampedOf (n) = Stamped { at = DateTime("2026-07-20T09:00") }
+            let stampedOf (n) = Stamped { from = DateTime("2026-07-20T09:00"),
+                to = DateTime("2026-07-21T09:00") }
 
             behavior positiveOf : (n: Int) -> Positive
                 constructs Positive
@@ -337,16 +339,27 @@ class AConstructionMeansWhatItsFormMeansTest {
 
     @Test
     void oneTemporalIsNotAnother() {
-        // `Date` and `DateTime` were one written form to this reading, so a row could write either
-        // where the other stands.
+        // The four temporals were one written form to this reading, so a row could write any of them
+        // where another stands. `Stamped` carries an invariant so the gate in front of it is the one
+        // being asked: reading a `Date` as a value of a `DateTime` field is what would put it through
+        // that field's decoder and report the row for a rule about a value it never wrote.
         holds("""
                 example stampedOf
-                    | (1) -> Stamped { at = DateTime("2026-07-20T09:00") }
+                    | (1) -> Stamped { from = DateTime("2026-07-20T09:00"),
+                        to = DateTime("2026-07-21T09:00") }
                 """);
-        doesNotHold("""
+        Diagnostic d = only("""
                 example stampedOf
-                    | (1) -> Stamped { at = Date("2026-07-20") }
+                    | (1) -> Stamped { from = Date("2026-07-20"),
+                        to = DateTime("2026-07-21T09:00") }
                 """);
+        assertEquals("E1905", d.code(), d.said().toString());
+        assertTrue(d.notes().stream().anyMatch(note ->
+                        note.said() instanceof ExampleMessage.TheTwoAreOfDifferentTypes(
+                                String at, String stated, String answered)
+                                && at.equals("$.from") && stated.equals("Date")
+                                && answered.equals("DateTime")),
+                "which two temporals it is between: " + d.notes());
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/AConstructionMeansWhatItsFormMeansTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AConstructionMeansWhatItsFormMeansTest.java
@@ -37,6 +37,9 @@ class AConstructionMeansWhatItsFormMeansTest {
             data Wrapped = Receipt
             data Span = { from: Int, to: Int }
                 invariant from <= to
+            data Priced = { at: Decimal }
+                invariant at > 0m
+            data Stamped = { at: DateTime }
             data Boxed = { held: AmountN? }
             data Receipt = { total: AmountN }
             data Held = { total: AmountN, note: String? }
@@ -73,6 +76,14 @@ class AConstructionMeansWhatItsFormMeansTest {
             behavior widen : (s: Span) -> Span
                 constructs Span
             let widen (s) = Span { from = s.from, to = s.to + 1 }
+
+            behavior pricedOf : (n: Int) -> Priced
+                constructs Priced
+            let pricedOf (n) = Priced { at = 1m }
+
+            behavior stampedOf : (n: Int) -> Stamped
+                constructs Stamped
+            let stampedOf (n) = Stamped { at = DateTime("2026-07-20T09:00") }
 
             behavior positiveOf : (n: Int) -> Positive
                 constructs Positive
@@ -301,6 +312,41 @@ class AConstructionMeansWhatItsFormMeansTest {
                 example widen
                     | (Span { from = 1, to = 2 }) -> Span { from = 5, to = 1 }
                 """).contains("invariant"), "the row is told its own construction refused it");
+    }
+
+    @Test
+    void anInvariantIsNotReadOfAValueTheRowDidNotWrite() {
+        // The other half of the rule above, and the one that says which of the two a failure is.
+        // `-1` at a `Decimal` field is an `Int`: the row wrote a value of another type, which is the
+        // disagreement it reports. Reading it as the amount a boundary would have made of it and then
+        // asking `at > 0m` would report a rule broken by a value nobody wrote.
+        holds("""
+                example pricedOf
+                    | (1) -> Priced { at = 1m }
+                """);
+        doesNotHold("""
+                example pricedOf
+                    | (1) -> Priced { at = -1 }
+                """);
+        // And the same reading, where no invariant is involved at all.
+        doesNotHold("""
+                example pricedOf
+                    | (1) -> Priced { at = 1 }
+                """);
+    }
+
+    @Test
+    void oneTemporalIsNotAnother() {
+        // `Date` and `DateTime` were one written form to this reading, so a row could write either
+        // where the other stands.
+        holds("""
+                example stampedOf
+                    | (1) -> Stamped { at = DateTime("2026-07-20T09:00") }
+                """);
+        doesNotHold("""
+                example stampedOf
+                    | (1) -> Stamped { at = Date("2026-07-20") }
+                """);
     }
 
     @Test


### PR DESCRIPTION
A regression from #658, found while scoping what I had reported there as a pre-existing gap. It is not one — the two sides of a row had come to answer differently about the same value.

## What it does

```souther
data Span = { from: Int, to: Int }
    invariant from <= to
```

| where the value stands | before #658 | after #658 |
|---|---|---|
| an input | E1903 `invariant violated on demo.Span` | E1903 (unchanged) |
| an expected value | E1903 | **E1905, the row is reported as disagreeing** |

`Span { from = 5, to = 1 }` is a value that cannot exist. Expected of a behavior, it was reported as a value the behavior did not answer with.

## Why it moved

A record's invariant is not among the constraints its derived decoder carries — `CodecGen.invariantsOf` returns `Invariants.NONE` for anything that is not a newtype. It is run when the value is *constructed*, which the decode used to do on the way past. #658 stopped putting a record through its decoder, so nothing constructed one and nothing read the rule.

Reading `invariantsOf` and not the construction is how I came to report this as never having been checked. The input side, which still refuses it, is the evidence that it was.

## What changed

The same two stages a newtype goes through, for the same reason.

1. Whether every field states what this type declares it to be is asked of what the row wrote.
2. Only where it does is there a value of this type for the invariant to be about — and only there can constructing one read nothing as something else.

A row whose field states another type has not failed an invariant. `Receipt { total = 1 }` at a field declaring an `AmountN` is the disagreement it reports (E1905), and asking a rule about the value it would have been coerced into would answer for a value nobody wrote.

## Checked

`AConstructionMeansWhatItsFormMeansTest.aRecordReadsItsOwnInvariantToo` fixes both directions. Full `mvn clean test` green: 4320 in the compiler module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
