### PR TITLE
Answer with every error a compilation found

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/Compiler.java
+++ b/souther-compiler/src/main/java/souther/compiler/Compiler.java
@@ -215,19 +215,19 @@ public final class Compiler {
         compilation.measure(measure);
         Db db = compilation.db();
 
-        CompileException structural = compilation.firstError(compilation.structuralReports());
+        CompileException structural = compilation.failure(compilation.structuralReports());
         if (structural != null) {
             throw structural;
         }
 
         db.ask(new Output.All());
-        CompileException failed = compilation.firstError(db.allReports());
+        CompileException failed = compilation.failure(db.allReports());
         if (failed != null) {
             throw failed;
         }
         for (String module : compilation.modules()) {
             if (!db.ask(new Output.ConstConstructions(module)).present()) {
-                CompileException bad = compilation.firstError(db.allReports());
+                CompileException bad = compilation.failure(db.allReports());
                 if (bad != null) {
                     throw bad;
                 }
@@ -424,13 +424,13 @@ public final class Compiler {
         compilation.measure(measure);
         Db db = compilation.db();
 
-        CompileException structural = compilation.firstError(compilation.structuralReports());
+        CompileException structural = compilation.failure(compilation.structuralReports());
         if (structural != null) {
             throw structural;
         }
 
         db.ask(new Output.All());
-        CompileException failed = compilation.firstError(db.allReports());
+        CompileException failed = compilation.failure(db.allReports());
         if (failed != null) {
             throw failed;
         }
@@ -442,7 +442,7 @@ public final class Compiler {
         List<String> exampleSources = new ArrayList<>();
         for (String module : compilation.modules()) {
             if (!db.ask(new Output.ConstConstructions(module)).present()) {
-                CompileException bad = compilation.firstError(db.allReports());
+                CompileException bad = compilation.failure(db.allReports());
                 if (bad != null) {
                     throw bad;
                 }

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -4,11 +4,14 @@ import souther.compiler.ast.Ast;
 import souther.compiler.check.Sig;
 import souther.compiler.check.Symbols;
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.LabeledRegion;
 import souther.compiler.diag.Located;
+import souther.compiler.diag.SourcePos;
 import souther.compiler.meta.ModulePath;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -441,30 +444,78 @@ public final class Compilation {
     }
 
     /**
-     * The first error among {@code found}, as the exception the pass raised, tagged with the source
-     * it belongs to — or null when nothing there is an error.
+     * The errors among {@code found} as one exception, the first of them leading — or null when
+     * nothing there is an error.
      *
-     * <p>First means first in the order the sources were given, not first worked out. A question is
-     * answered when something asks it, and what asks first is an implementation detail: resolving one
-     * module's names reaches another module's, so moving a report earlier in the compiler would
-     * otherwise change which file a batch compile sends the author to. A report about no source in
-     * particular comes before all of them.
+     * <p>Every error, not the first. A compilation answers each of its questions and files what it
+     * found, so by the time anything asks for the failure they are all in hand; handing back one of
+     * them sends the author to fix that one and compile again to be told the next, which the
+     * compiler already knew. The exception carries a list, and the command line and
+     * {@code --format json} render each of them, so nothing between here and the author needs them
+     * to be one.
+     *
+     * <p>Leading matters because a caller reading {@link CompileException#code()} or its message
+     * reads the first, and that is the error a reader is sent to first. First means first in the
+     * order the sources were given, then where in the source it is — not first worked out. A
+     * question is answered when something asks it, and what asks first is an implementation detail:
+     * resolving one module's names reaches another module's, so ordering by that would let moving a
+     * report earlier in the compiler change which file a batch compile sends the author to. A report
+     * about no source in particular comes before all of them, and one about no position before the
+     * rest of its source.
+     *
+     * <p>Two reports at one position keep the order the checker produced them in — a stable sort is
+     * what that takes. A check that reports each of its own violations puts them all at the
+     * declaration it is about, so this is the ordinary case rather than a tie to break arbitrarily.
+     *
+     * <p>Where a diagnostic is says where to look, and nothing about what caused what. An error a
+     * checker reports off a value another error produced — a name that resolved to nothing, a body
+     * that could not be typed — can be written to the left of the error it came from, and then it
+     * leads. That is not this order failing to find the cause: a cause is not recoverable from two
+     * positions, and a secondary diagnostic is the checker's to withhold where it should not be said
+     * at all. This decides how the errors are presented; whether one of them should have been
+     * reported is the checker's own question.
      */
     public CompileException firstError(List<Db.Found> found) {
-        Db.Found first = null;
-        int at = Integer.MAX_VALUE;
+        List<Db.Found> errors = new ArrayList<>();
         for (Db.Found f : found) {
-            if (!f.report().isError()) {
-                continue;
-            }
-            int index = indexOf(f);
-            int order = index < 0 ? -1 : index;
-            if (order < at) {
-                first = f;
-                at = order;
+            if (f.report().isError()) {
+                errors.add(f);
             }
         }
-        return first == null ? null : first.report().asException().inSource(sourceIdOf(first));
+        if (errors.isEmpty()) {
+            return null;
+        }
+        errors.sort(Comparator.comparingInt(this::orderOf)
+                .thenComparingInt(f -> lineOf(f.report().diagnostic()))
+                .thenComparingInt(f -> columnOf(f.report().diagnostic())));
+        Db.Found first = errors.get(0);
+        List<Diagnostic> rest = new ArrayList<>();
+        List<String> restSources = new ArrayList<>();
+        for (Db.Found f : errors.subList(1, errors.size())) {
+            rest.add(f.report().diagnostic());
+            restSources.add(sourceIdOf(f));
+        }
+        return first.report().asException()
+                .alsoReporting(rest, restSources)
+                .inSource(sourceIdOf(first));
+    }
+
+    /** Where a report sits among the sources for ordering, with the one naming none before them all. */
+    private int orderOf(Db.Found found) {
+        int index = indexOf(found);
+        return index < 0 ? -1 : index;
+    }
+
+    /** A report with no position comes before the ones in its source that have one: it is about the
+     *  source rather than about a line of it. */
+    private static int lineOf(Diagnostic diagnostic) {
+        SourcePos pos = diagnostic == null ? null : diagnostic.pos();
+        return pos == null ? -1 : pos.line();
+    }
+
+    private static int columnOf(Diagnostic diagnostic) {
+        SourcePos pos = diagnostic == null ? null : diagnostic.pos();
+        return pos == null ? -1 : pos.column();
     }
 
     /**

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -22,10 +22,10 @@ import java.util.Set;
  * One compile, as a set of questions that can be asked of it.
  *
  * <p>A caller sets the sources and then asks: for the classes, for a module's errors, for what a
- * name denotes. What it does with an error is its own — the batch compiler raises the first, an
- * editor publishes them all per file — and that decision is the only thing that differs between
- * them. Nothing here runs a pipeline; asking a question is what makes the work that answers it
- * happen, and only that work.
+ * name denotes. What it does with an error is its own — the batch compiler raises them together and
+ * stops, an editor publishes them all per file and carries on — and that decision is the only thing
+ * that differs between them. Nothing here runs a pipeline; asking a question is what makes the work
+ * that answers it happen, and only that work.
  */
 public final class Compilation {
 
@@ -462,6 +462,12 @@ public final class Compilation {
      * report earlier in the compiler change which file a batch compile sends the author to. A report
      * about no source in particular comes before all of them, and one about no position before the
      * rest of its source.
+     *
+     * <p>The order the sources were given is the index a compile of a list of them assigns
+     * ({@link #ofSources}). A compile of documents assigns none — a workspace has no first file —
+     * and there the reports fall together and are ordered by position alone. What asks this is a
+     * batch compile; an editor reads {@link #diagnostics()}, which files each report under the
+     * source it is in and never has the question.
      *
      * <p>Two reports at one position keep the order the checker produced them in — a stable sort is
      * what that takes. A check that reports each of its own violations puts them all at the

--- a/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
+++ b/souther-compiler/src/main/java/souther/compiler/query/Compilation.java
@@ -475,7 +475,7 @@ public final class Compilation {
      * at all. This decides how the errors are presented; whether one of them should have been
      * reported is the checker's own question.
      */
-    public CompileException firstError(List<Db.Found> found) {
+    public CompileException failure(List<Db.Found> found) {
         List<Db.Found> errors = new ArrayList<>();
         for (Db.Found f : found) {
             if (f.report().isError()) {
@@ -587,7 +587,7 @@ public final class Compilation {
 
     /**
      * The warnings among {@code found}, in order, each tagged with the source its primary region is
-     * in — the same tag {@link #firstError} puts on an error, so a warning can be quoted where it is.
+     * in — the same tag {@link #failure} puts on an error, so a warning can be quoted where it is.
      *
      * <p>One entry per warning, never one per file it is said at. A problem written in two files is
      * one thing to be told about on a terminal; the second telling is what an editor needs, and that
@@ -606,7 +606,7 @@ public final class Compilation {
     /**
      * The errors among {@code found}, tagged as {@link #warnings} tags a warning.
      *
-     * <p>All of them, where {@link #firstError} answers with one. A caller that stops at the first
+     * <p>All of them, where {@link #failure} answers with one. A caller that stops at the first
      * error wants the first; one that goes on to say something about the whole compilation has
      * already read past it, and showing a reader one error beside an account of everything else
      * would leave them to wonder what the rest of the errors were.

--- a/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/ADependencyOnThePathIsCountedLikeAnyOtherTest.java
@@ -179,7 +179,7 @@ class ADependencyOnThePathIsCountedLikeAnyOtherTest {
                 """), name -> null);
         compilation.answerEverything();
 
-        assertNull(compilation.firstError(compilation.db().allReports()));
+        assertNull(compilation.failure(compilation.db().allReports()));
         assertTrue(compilation.db()
                         .ask(new Output.EvaluationLinked("app.alone", Output.CoverageMode.NONE))
                         .value() != null,

--- a/souther-compiler/src/test/java/souther/compiler/AnEvaluationRunsTheClassesThisCompileGeneratedTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnEvaluationRunsTheClassesThisCompileGeneratedTest.java
@@ -72,7 +72,7 @@ class AnEvaluationRunsTheClassesThisCompileGeneratedTest {
         Compilation compilation = Compilation.ofSources(List.of(NOW), leftOverClassFiles());
         compilation.answerEverything();
 
-        assertNull(compilation.firstError(compilation.db().allReports()),
+        assertNull(compilation.failure(compilation.db().allReports()),
                 "the model is correct, so nothing is wrong with it");
 
         String sourceId = compilation.exampleSourcesOf("example.stale").get(0);

--- a/souther-compiler/src/test/java/souther/compiler/CompileHelperBodyTypingTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileHelperBodyTypingTest.java
@@ -440,7 +440,14 @@ class CompileHelperBodyTypingTest {
                 let f (x) = call(x)
                 """;
         CompileException e = assertThrows(CompileException.class, () -> Compiler.compile(src));
-        assertInstanceOf(BehaviorMessage.ABehaviorCannotBeCalledFromHere.class, e.diagnostic().said(), e.getMessage());
+        // Which of the errors leads is where in the source it is, so what this test is about is that
+        // the call is what the author is told about and the annotation is never asked for.
+        assertTrue(e.diagnostics().stream()
+                        .anyMatch(d -> d.said() instanceof BehaviorMessage.ABehaviorCannotBeCalledFromHere),
+                e.getMessage());
+        assertTrue(e.diagnostics().stream()
+                        .noneMatch(d -> d.said() instanceof HelperMessage.AParameterNeedsItsType),
+                e.getMessage());
     }
 
     @Test
@@ -610,10 +617,13 @@ class CompileHelperBodyTypingTest {
     void aLyingReturnTypeIsRejectedOnABodyTypedParameter() {
         // The declared return type is checked against the body on the completed environment, whether
         // the parameter was written or determined by the body.
+        // `f` passes its input through, so its `constructs` is left off: declaring one it does not
+        // build is an error of its own (E1006), and a fixture carrying two errors says nothing about
+        // which of them this test is for.
         String src = """
                 module demo
                 data X = Int
-                behavior f : (x: X) -> X constructs X
+                behavior f : (x: X) -> X
                 let g (n): String = n * 2
                 let f (x) = x
                 """;

--- a/souther-compiler/src/test/java/souther/compiler/CompileImplicitUnitDataTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileImplicitUnitDataTest.java
@@ -1,6 +1,7 @@
 package souther.compiler;
 
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.DiagnosticRenderer;
 
 import org.junit.jupiter.api.Test;
 
@@ -152,7 +153,12 @@ class CompileImplicitUnitDataTest {
                         let f (a) = Out { n = a.value }
                         """)));
 
-        assertTrue(e.getMessage().contains("Refused"), e.getMessage());
+        // Among what the compile answers with, not necessarily leading it: the name is reported
+        // unknown where it is written, and what its recovery value goes on to be refused for sits a
+        // few columns to the left of that.
+        assertTrue(e.diagnostics().stream()
+                        .anyMatch(d -> DiagnosticRenderer.legacyBody(d).contains("Refused")),
+                e.getMessage());
     }
 
     /** An imported name is declared — by the module it came from. Introducing one here would give a

--- a/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/CompileTypeVariableTest.java
@@ -27,7 +27,7 @@ class CompileTypeVariableTest {
     private static Map<String, byte[]> compileCore(String src) {
         Compilation compilation = Compilation.ofCoreSource(src);
         compilation.answerEverything();
-        CompileException failed = compilation.firstError(compilation.db().allReports());
+        CompileException failed = compilation.failure(compilation.db().allReports());
         if (failed != null) {
             throw failed;
         }

--- a/souther-compiler/src/test/java/souther/compiler/EveryPositionOfADeclaredTypeIsReadTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/EveryPositionOfADeclaredTypeIsReadTest.java
@@ -80,7 +80,7 @@ class EveryPositionOfADeclaredTypeIsReadTest {
     private static CompileException failure(String source) {
         Compilation compilation = Compilation.ofCoreSource(source);
         compilation.answerEverything();
-        return compilation.firstError(compilation.db().allReports());
+        return compilation.failure(compilation.db().allReports());
     }
 
     @ParameterizedTest(name = "{0}")

--- a/souther-compiler/src/test/java/souther/compiler/TheStepBudgetHasRoomOverWhatModelsActuallySpendTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/TheStepBudgetHasRoomOverWhatModelsActuallySpendTest.java
@@ -76,7 +76,7 @@ class TheStepBudgetHasRoomOverWhatModelsActuallySpendTest {
         Compilation compilation = Compilation.ofSource(source, "Main");
         compilation.answerEverything();
         souther.compiler.diag.CompileException wrong =
-                compilation.firstError(compilation.db().allReports());
+                compilation.failure(compilation.db().allReports());
         if (wrong != null) {
             throw new IllegalStateException("the census model has to compile: " + wrong.getMessage());
         }

--- a/souther-compiler/src/test/java/souther/compiler/check/TheSurfaceTreeStillHoldsACallOfTheWrongArityTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/TheSurfaceTreeStillHoldsACallOfTheWrongArityTest.java
@@ -2,8 +2,11 @@ package souther.compiler.check;
 
 import souther.compiler.Compiler;
 import souther.compiler.diag.CompileException;
+import souther.compiler.diag.DiagnosticRenderer;
 
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -119,8 +122,15 @@ class TheSurfaceTreeStillHoldsACallOfTheWrongArityTest {
     private static void besideAnotherError(String src) {
         CompileException e = assertThrows(CompileException.class,
                 () -> Compiler.compileWithWarnings(src));
-        assertTrue(e.getMessage().contains("argument(s)") || e.getMessage().contains("nosuchthing")
-                        || e.getMessage().contains("List.fold"),
-                "one of the two errors, and not an internal failure: " + e.getMessage());
+        // Both, rather than whichever leads. A compile answers with every error it found, so the
+        // arity being reported is not a claim about which of the two the author is sent to first.
+        assertTrue(said(e).stream().anyMatch(d -> d.contains("argument(s)") || d.contains("parameter(s)")),
+                "the arity is reported, and not an internal failure: " + said(e));
+        assertTrue(said(e).stream().anyMatch(d -> d.contains("nosuchthing")),
+                "and so is the error beside it: " + said(e));
+    }
+
+    private static List<String> said(CompileException e) {
+        return e.diagnostics().stream().map(DiagnosticRenderer::legacyBody).toList();
     }
 }

--- a/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
@@ -6,6 +6,8 @@ import souther.compiler.diag.Diagnostic;
 import souther.compiler.diag.DiagnosticRenderer;
 import souther.compiler.diag.Located;
 import souther.compiler.diag.SourcePos;
+import souther.compiler.diag.msg.InvariantMessage;
+import souther.compiler.meta.ModulePath;
 
 import org.junit.jupiter.api.Test;
 
@@ -117,13 +119,29 @@ class ACompileAnswersWithEveryErrorItFoundTest {
             """;
 
     private static Db.Found errorAt(int line, int column, String says) {
-        return new Db.Found("m.c", "a.sou",
-                Report.of(Diagnostic.literal(new SourcePos(line, column, "a.sou"), says)));
+        return errorIn("a.sou", line, column, says);
+    }
+
+    private static Db.Found errorIn(String sourceId, int line, int column, String says) {
+        return new Db.Found("m.c", sourceId,
+                Report.of(Diagnostic.literal(new SourcePos(line, column, sourceId), says)));
+    }
+
+    /** A warning, which is not what a compile fails with however many of them there are. */
+    private static Db.Found warningAt(int line, String says) {
+        return new Db.Found("m.c", "a.sou", Report.of(Diagnostic
+                .say(new InvariantMessage.TheGuardsDoNotEstablishTheInvariant(says))
+                .at(new SourcePos(line, 1, "a.sou")).build()));
     }
 
     private static Compilation ofOneSource() {
         return Compilation.ofDocuments(java.util.Map.of("a.sou", ONE_SOURCE), java.util.Set.of(),
-                souther.compiler.meta.ModulePath.EMPTY);
+                ModulePath.EMPTY);
+    }
+
+    /** Two sources handed over as a list, so each has the index its order in that list gives it. */
+    private static Compilation ofTwoSources() {
+        return Compilation.ofSources(List.of(ONE_SOURCE, ONE_SOURCE), ModulePath.EMPTY);
     }
 
     @Test
@@ -158,8 +176,20 @@ class ACompileAnswersWithEveryErrorItFoundTest {
     }
 
     @Test
+    void aSourceGivenFirstLeadsHoweverFarDownItsErrorIs() {
+        CompileException e = ofTwoSources().failure(List.of(
+                errorIn(Compilation.idOfSourceIndex(1), 1, 1, "at the top of the second"),
+                errorIn(Compilation.idOfSourceIndex(0), 20, 1, "far down the first")));
+
+        assertEquals(List.of("far down the first", "at the top of the second"), bodiesOf(e),
+                "a file is read through before the next one is opened");
+    }
+
+    @Test
     void nothingAmongThemIsNotAnError() {
         assertEquals(null, ofOneSource().failure(List.of()));
+        assertEquals(null, ofOneSource().failure(List.of(warningAt(3, "A"), warningAt(5, "B"))),
+                "a warning is not a reason to fail");
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
@@ -128,7 +128,7 @@ class ACompileAnswersWithEveryErrorItFoundTest {
 
     @Test
     void theyAreOrderedByWhereTheyAreNotByWhenTheyWereFound() {
-        CompileException e = ofOneSource().firstError(List.of(
+        CompileException e = ofOneSource().failure(List.of(
                 errorAt(9, 1, "third"),
                 errorAt(3, 1, "first"),
                 errorAt(5, 7, "second")));
@@ -139,7 +139,7 @@ class ACompileAnswersWithEveryErrorItFoundTest {
 
     @Test
     void aColumnBreaksATieOnALine() {
-        CompileException e = ofOneSource().firstError(List.of(
+        CompileException e = ofOneSource().failure(List.of(
                 errorAt(4, 20, "later"),
                 errorAt(4, 3, "earlier")));
 
@@ -148,7 +148,7 @@ class ACompileAnswersWithEveryErrorItFoundTest {
 
     @Test
     void twoAtOnePositionKeepTheOrderTheyWereFoundIn() {
-        CompileException e = ofOneSource().firstError(List.of(
+        CompileException e = ofOneSource().failure(List.of(
                 errorAt(6, 1, "said first"),
                 errorAt(6, 1, "said second"),
                 errorAt(6, 1, "said third")));
@@ -159,7 +159,7 @@ class ACompileAnswersWithEveryErrorItFoundTest {
 
     @Test
     void nothingAmongThemIsNotAnError() {
-        assertEquals(null, ofOneSource().firstError(List.of()));
+        assertEquals(null, ofOneSource().failure(List.of()));
     }
 
     @Test

--- a/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
@@ -1,0 +1,179 @@
+package souther.compiler.query;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.DiagnosticRenderer;
+import souther.compiler.diag.Located;
+import souther.compiler.diag.SourcePos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A compilation files every error it finds, and the exception it fails with carries all of them.
+ *
+ * <p>Handing back one of several sends the author to fix that one and compile again to be told the
+ * next, which the compiler had already worked out. What a caller reads off the exception —
+ * {@link CompileException#code()}, its message — answers from the first of them, and which one that
+ * is comes from where the errors are rather than from the order the questions were answered in.
+ */
+class ACompileAnswersWithEveryErrorItFoundTest {
+
+    /** Three behaviors, each building a data its `constructs` clause does not name. Each is its own
+     *  question, so none of them hides another. */
+    private static final String THREE_UNDER_DECLARED = """
+            module m.a exposing ( Ticket, CookLine, ItemCookState, Pending, InProgress, Done, start, finish, reopen )
+
+            data ItemCookState = Pending | InProgress | Done
+            data CookLine = { state: ItemCookState }
+            data Ticket = { lines: List<CookLine> }
+
+            behavior start : (t: Ticket) -> Ticket
+                constructs Ticket
+            let start (t) = Ticket { lines = [ CookLine { state = InProgress } ] }
+
+            behavior finish : (t: Ticket) -> Ticket
+                constructs Ticket
+            let finish (t) = Ticket { lines = [ CookLine { state = Done } ] }
+
+            behavior reopen : (t: Ticket) -> Ticket
+                constructs Ticket
+            let reopen (t) = Ticket { lines = [ CookLine { state = Pending } ] }
+            """;
+
+    private static CompileException failure(String source) {
+        return assertThrows(CompileException.class, () -> Compiler.compile(source));
+    }
+
+    /** Read off {@link CompileException#locatedDiagnostics()}, which is what a renderer walks. */
+    private static List<String> bodiesOf(CompileException e) {
+        List<String> said = new ArrayList<>();
+        for (Located located : e.locatedDiagnostics()) {
+            said.add(DiagnosticRenderer.legacyBody(located.diagnostic()));
+        }
+        return said;
+    }
+
+    @Test
+    void everyBehaviorsErrorIsCarried() {
+        CompileException e = failure(THREE_UNDER_DECLARED);
+
+        List<String> said = bodiesOf(e);
+        assertEquals(3, said.size(), "one per behavior that under-declares: " + said);
+        assertTrue(said.get(0).contains("`start`"), said.toString());
+        assertTrue(said.get(1).contains("`finish`"), said.toString());
+        assertTrue(said.get(2).contains("`reopen`"), said.toString());
+    }
+
+    @Test
+    void theFirstErrorLeads() {
+        CompileException e = failure(THREE_UNDER_DECLARED);
+
+        assertEquals("E1002", e.code(), "the code is the first diagnostic's");
+        assertTrue(e.getMessage().contains("`start`"),
+                "the message is the first diagnostic's: " + e.getMessage());
+        assertEquals(e.diagnostic(), e.diagnostics().get(0),
+                "and the first diagnostic is the one the list leads with");
+    }
+
+    @Test
+    void theyComeInTheOrderTheyAreWritten() {
+        CompileException e = failure(THREE_UNDER_DECLARED);
+
+        List<Integer> lines = new ArrayList<>();
+        for (Diagnostic d : e.diagnostics()) {
+            lines.add(d.pos().line());
+        }
+        List<Integer> ascending = new ArrayList<>(lines);
+        ascending.sort(Integer::compareTo);
+        assertEquals(ascending, lines, "a reader takes them down the file: " + lines);
+    }
+
+    @Test
+    void everyErrorIsTaggedWithTheSourceItIsIn() {
+        CompileException e = failure(THREE_UNDER_DECLARED);
+
+        for (int i = 0; i < e.diagnostics().size(); i++) {
+            assertEquals(e.sourceIdOf(0), e.sourceIdOf(i),
+                    "one source here, so every diagnostic names it");
+        }
+    }
+
+    /** A source that compiles, so the compilation the ordering is asked of has one to name. */
+    private static final String ONE_SOURCE = """
+            module m.c exposing ( A, f )
+
+            data A = { n: Int }
+
+            behavior f : (a: A) -> Int
+            let f (a) = a.n
+            """;
+
+    private static Db.Found errorAt(int line, int column, String says) {
+        return new Db.Found("m.c", "a.sou",
+                Report.of(Diagnostic.literal(new SourcePos(line, column, "a.sou"), says)));
+    }
+
+    private static Compilation ofOneSource() {
+        return Compilation.ofDocuments(java.util.Map.of("a.sou", ONE_SOURCE), java.util.Set.of(),
+                souther.compiler.meta.ModulePath.EMPTY);
+    }
+
+    @Test
+    void theyAreOrderedByWhereTheyAreNotByWhenTheyWereFound() {
+        CompileException e = ofOneSource().firstError(List.of(
+                errorAt(9, 1, "third"),
+                errorAt(3, 1, "first"),
+                errorAt(5, 7, "second")));
+
+        assertEquals(List.of("first", "second", "third"), bodiesOf(e),
+                "which question was answered first is not where the author looks");
+    }
+
+    @Test
+    void aColumnBreaksATieOnALine() {
+        CompileException e = ofOneSource().firstError(List.of(
+                errorAt(4, 20, "later"),
+                errorAt(4, 3, "earlier")));
+
+        assertEquals(List.of("earlier", "later"), bodiesOf(e));
+    }
+
+    @Test
+    void twoAtOnePositionKeepTheOrderTheyWereFoundIn() {
+        CompileException e = ofOneSource().firstError(List.of(
+                errorAt(6, 1, "said first"),
+                errorAt(6, 1, "said second"),
+                errorAt(6, 1, "said third")));
+
+        assertEquals(List.of("said first", "said second", "said third"), bodiesOf(e),
+                "a check reporting each of its own violations puts them all at one declaration");
+    }
+
+    @Test
+    void nothingAmongThemIsNotAnError() {
+        assertEquals(null, ofOneSource().firstError(List.of()));
+    }
+
+    @Test
+    void aCleanCompileStillCompiles() {
+        Compiler.compile("""
+                module m.b exposing ( Ticket, CookLine, ItemCookState, Pending, InProgress, Done, start )
+
+                data ItemCookState = Pending | InProgress | Done
+                data CookLine = { state: ItemCookState }
+                data Ticket = { lines: List<CookLine> }
+
+                behavior start : (t: Ticket) -> Ticket
+                    constructs Ticket, CookLine, InProgress
+                let start (t) = Ticket { lines = [ CookLine { state = InProgress } ] }
+                """);
+    }
+}

--- a/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
+++ b/souther-syntax/src/main/java/souther/compiler/diag/CompileException.java
@@ -145,6 +145,34 @@ public class CompileException extends RuntimeException {
     }
 
     /**
+     * This error, also carrying {@code more} — what a caller that collected several errors and has
+     * one of them as the exception a pass raised answers with.
+     *
+     * <p>Built from this one rather than from its diagnostic, so the message stays the message this
+     * error was raised with. A pass that words its own summary — the one that reports every failing
+     * {@code example} row — words it over what it found, and rendering the leading diagnostic again
+     * here would answer with a sentence about one row instead.
+     *
+     * @param moreSources one entry per added diagnostic, {@link Located#NO_SOURCE} for one that
+     *                    names no source
+     */
+    public CompileException alsoReporting(List<Diagnostic> more, List<String> moreSources) {
+        if (more.isEmpty()) {
+            return this;
+        }
+        if (more.size() != moreSources.size()) {
+            throw new IllegalArgumentException("one source per diagnostic");
+        }
+        List<Diagnostic> all = new java.util.ArrayList<>(diagnostics);
+        all.addAll(more);
+        List<String> allSources = new java.util.ArrayList<>(sources);
+        allSources.addAll(moreSources);
+        CompileException joined = new CompileException(all, getMessage(), allSources);
+        joined.setStackTrace(getStackTrace());
+        return joined;
+    }
+
+    /**
      * The same error, tagged with the source being compiled when it was thrown. The first tag wins:
      * an inner phase that already named its source keeps it, so a surrounding loop may tag freely.
      */

--- a/souther-syntax/src/test/java/souther/compiler/diag/AnErrorKeepsTheMessageItWasRaisedWithTest.java
+++ b/souther-syntax/src/test/java/souther/compiler/diag/AnErrorKeepsTheMessageItWasRaisedWithTest.java
@@ -1,0 +1,79 @@
+package souther.compiler.diag;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * An error that takes on the other errors a compilation found still says what it was raised with.
+ *
+ * <p>A pass that words its own summary — the one reporting every failing {@code example} row — words
+ * it over what it found. Rebuilding the message from the leading diagnostic would answer with a
+ * sentence about one row instead, and nothing about the collecting would say so.
+ */
+class AnErrorKeepsTheMessageItWasRaisedWithTest {
+
+    private static Diagnostic at(int line, String says) {
+        return Diagnostic.literal(new SourcePos(line, 1, "a.sou"), says);
+    }
+
+    @Test
+    void theSummaryAPassWordedIsStillTheMessage() {
+        CompileException raised = CompileException.ofAll(List.of(at(3, "one row"), at(4, "another")),
+                "2 example rows did not hold");
+        String said = raised.getMessage();
+
+        CompileException joined = raised.alsoReporting(List.of(at(9, "elsewhere")),
+                java.util.Arrays.asList(Located.NO_SOURCE));
+
+        assertEquals(said, joined.getMessage());
+        assertEquals(3, joined.diagnostics().size());
+        assertEquals(raised.code(), joined.code());
+        assertEquals(raised.pos(), joined.pos());
+    }
+
+    @Test
+    void whatItTakesOnComesAfterWhatItHad() {
+        CompileException raised = CompileException.of(at(3, "first"));
+
+        CompileException joined = raised.alsoReporting(List.of(at(5, "second"), at(7, "third")),
+                java.util.Arrays.asList("b.sou", Located.NO_SOURCE));
+
+        assertEquals(List.of("first", "second", "third"),
+                joined.diagnostics().stream().map(DiagnosticRenderer::legacyBody).toList());
+        assertEquals("b.sou", joined.sourceIdOf(1));
+        assertEquals(Located.NO_SOURCE, joined.sourceIdOf(2));
+    }
+
+    @Test
+    void anUnnamedSourceIsStillTaggedAfterwards() {
+        CompileException joined = CompileException.of(at(3, "first"))
+                .alsoReporting(List.of(at(5, "second")), java.util.Arrays.asList(Located.NO_SOURCE))
+                .inSource("a.sou");
+
+        assertEquals("a.sou", joined.sourceIdOf(0));
+        assertEquals("a.sou", joined.sourceIdOf(1));
+    }
+
+    @Test
+    void takingOnNothingIsTheSameError() {
+        CompileException raised = CompileException.of(at(3, "first"));
+
+        assertSame(raised, raised.alsoReporting(List.of(), List.of()));
+    }
+
+    @Test
+    void everyDiagnosticTakenOnNamesASource() {
+        CompileException raised = CompileException.of(at(3, "first"));
+
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> raised.alsoReporting(List.of(at(5, "second"), at(7, "third")),
+                        List.of("b.sou")));
+        assertTrue(e.getMessage().contains("one source per diagnostic"), e.getMessage());
+    }
+}


### PR DESCRIPTION
Closes #670.

A compilation works out every error it finds and files a report for each. `Compilation.firstError` then picked one of them and rebuilt a single-diagnostic exception, so the rest were dropped on the way out — and the author fixed one error, compiled again, and was told the next.

Nothing downstream needed them to be one. `CompileException` already carries a list, `Main.report` is handed `locatedDiagnostics()` and renders each with its own quoted line, `--format json` writes one object per diagnostic, and the editor path (`Compiler.diagnoseModules`) never went through here at all.

## Before / after

```souther
behavior start : (t: Ticket) -> Ticket
    constructs Ticket
let start (t) = Ticket { lines = [ CookLine { state = InProgress } ] }
-- and the same for `finish` and `reopen`
```

Before, one E1002. Now, on `souther compile`:

```
-- INSUFFICIENT CONSTRUCTION AUTHORITY  E1002 -repro.sou:7:1
7| behavior start : (t: Ticket) -> Ticket
   ^
Behavior `start` constructs `CookLine` but does not declare `constructs CookLine`.
Hint: Add `constructs CookLine` to `start`, or stop constructing CookLine here.

-- INSUFFICIENT CONSTRUCTION AUTHORITY  E1002 -repro.sou:11:1
... `finish` ...

-- INSUFFICIENT CONSTRUCTION AUTHORITY  E1002 -repro.sou:15:1
... `reopen` ...
```

`--format json` gives three lines. The exit code is unchanged.

## The order

Source order, then position within a source, stable where two sit at one place — so a check reporting each of its own violations at one declaration keeps the order it produced them in.

Where a diagnostic is says where to look and nothing about what caused what. A check reading a value another error produced can be written to the left of the error it came from, and then it leads; that is not this order failing to find the cause, because a cause is not recoverable from two positions. Withholding a diagnostic that should not be said at all is the checker's own question — #672, with the two pairs this surfaced.

## Leading

`code()` and `getMessage()` answer from the first of the list, and the error takes on the others through the exception it was raised with rather than being rebuilt from its leading diagnostic. A pass that words its own summary — the one reporting every failing `example` row — words it over what it found, and re-rendering would answer with a sentence about one row.

Deduplication needs nothing here: `Db.allReports` already keeps one report per (module, source, `Diagnostic.identity()`), and the identity carries what the diagnostic says with its arguments.

## Tests

New: `ACompileAnswersWithEveryErrorItFoundTest` (9) and `AnErrorKeepsTheMessageItWasRaisedWithTest` (5) — every error carried, the leading code and message, the ordering including the tie, and the raised message surviving.

Four existing tests were reading the leading diagnostic as though it were the only one. Two turned out to be sitting on a cascade and now say what they are about; one had a fixture carrying a second error of its own, written without it now; one had a disjunction narrower than its sibling's.

Verified: `mvn clean test` across all modules — 6916 tests, no failures — and the CLI run above.
