### PR TITLE
Read a comparison call as the order it decides

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -362,6 +362,40 @@ final class DischargeRules {
             op("Int", "min"), op("Int", "max"), op("Int", "floorMod"), op("Int", "compare"),
             op("Decimal", "min"), op("Decimal", "max"));
 
+    /**
+     * The operations answering the order of their two arguments as the sign of a number, and the
+     * relation between the first argument and the second that a positive answer states. Zero states
+     * the equality, and a negative answer the relation the other way, so one row is the whole of what
+     * such an operation says.
+     *
+     * <p>Which relation a guard writing one states then follows from where the sign stands against
+     * zero and from nothing else, so the six relations and the two operand orders are one account
+     * rather than twelve rows ({@link Predicates#asOrderComparison}). The direction is not the same
+     * for all of them: {@code compare(a, b)} is positive where {@code a} is the greater, and
+     * {@code daysBetween(from, to)} counts forward from its first argument, so it is positive where
+     * the second one is.
+     */
+    private static final Map<ValueName, Ast.BinOp> ORDERS = Map.of(
+            op("Int", "compare"), Ast.BinOp.GT,
+            op("Decimal", "compare"), Ast.BinOp.GT,
+            op("Date", "daysBetween"), Ast.BinOp.LT);
+
+    /**
+     * The operations answering a number from two values of one type whose sign is not their order.
+     *
+     * <p>Arithmetic and a choice between two values are not orders at all: what {@code Int.subtract}
+     * answers has the sign of one and says how far apart they are as well, which is what a term
+     * already reads it as, and {@code min} answers one of the two rather than anything about the
+     * pair. {@code DateTime.minutesBetween} is the one that has to be told apart: it counts whole
+     * minutes, so a zero says the two are less than a minute apart rather than that they are equal,
+     * and a non-negative count does not say the second is not the earlier. Its strict signs do state
+     * the order, and a rule that holds for four of the six relations is not this one.
+     */
+    static final Set<ValueName> DECIDES_NO_ORDER = Set.of(
+            op("Int", "add"), op("Int", "subtract"), op("Int", "multiply"),
+            op("Int", "min"), op("Int", "max"), op("Int", "floorMod"),
+            op("DateTime", "minutesBetween"));
+
     /** Denial, which the analysis representation keeps as the call it is. */
     static final ValueName NOT = op("Bool", "not");
 
@@ -427,6 +461,10 @@ final class DischargeRules {
 
     static Set<ValueName> operatorForms() {
         return OPERATOR_CALLS.keySet();
+    }
+
+    static Set<ValueName> orderings() {
+        return ORDERS.keySet();
     }
 
     /** Those of them the building table has, by name, for the test that holds each to a construction
@@ -592,6 +630,17 @@ final class DischargeRules {
     /** The operator {@code operation} is, where it is one written as a function, else null. */
     static Ast.BinOp operator(ValueName operation) {
         return OPERATOR_CALLS.get(operation);
+    }
+
+    /** The relation a positive answer from {@code operation} states between its first argument and
+     * its second, or null where its sign is not an order. */
+    static Ast.BinOp orderStatedBy(ValueName operation) {
+        return ORDERS.get(operation);
+    }
+
+    /** Whether {@code operation} answers the order of its two arguments as a sign. */
+    static boolean decidesOrder(ValueName operation) {
+        return ORDERS.containsKey(operation);
     }
 
     /** Whether the check has a rule about what a call answers, rather than only about how to render

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -228,9 +228,26 @@ final class Predicates {
         return obligations(inv, k, at, unnamed, true, decidesFalse);
     }
 
+    /**
+     * A clause is read as the comparison it states, and where an order call states one there are two
+     * readings of it: the order the call decides, and the bound on the sign that decides it. Which of
+     * them this construction can be read against is not known until it is read — a date the check can
+     * name is one thing, and the date a day after it is another — so the one that answers is the one
+     * taken. Reading a predicate never takes a reading away.
+     */
     private Owed obligations(Core rawInv, Known k, Denotations at, Set<Core> unnamed,
                              boolean positive, boolean decidesFalse) {
-        Core inv = asSizeComparison(rawInv);
+        Core sized = asSizeComparison(rawInv);
+        Core ordered = asOrderComparison(sized, at);
+        Owed read = read(ordered, k, at, unnamed, positive, decidesFalse);
+        return ordered != sized && read.unreadable()
+                ? read(sized, k, at, unnamed, positive, decidesFalse) : read;
+    }
+
+    /** What {@code inv} owes, read as it stands. Its parts are read through {@link #obligations},
+     * which is where each of them is taken as the comparison it states. */
+    private Owed read(Core inv, Known k, Denotations at, Set<Core> unnamed,
+                      boolean positive, boolean decidesFalse) {
         if (inv instanceof Core.Binary b && b.op() == Ast.BinOp.AND && positive) {
             // Each conjunct on its own: an invariant is a set of things that hold, and one the check
             // cannot read leaves its own run-time check standing without costing the others theirs.
@@ -298,6 +315,13 @@ final class Predicates {
      * outside the affine fragment, leave {@code k} unchanged (sound). */
     Known assumeCond(Core rawCond, Known k, Denotations at, boolean positive) {
         Core cond = asSizeComparison(rawCond);
+        Core ordered = asOrderComparison(cond, at);
+        if (ordered != cond) {
+            // Both hold of the same values: the order the call decides, and the bound on the sign
+            // that decides it. Which one a clause is read against is settled where the clause is
+            // read, so a guard states each of them rather than choosing here.
+            k = assumeCond(ordered, k, at, positive);
+        }
         // `&&` asserted true gives both sides; `||` asserted false gives both sides negated.
         if (cond instanceof Core.Binary b
                 && (b.op() == Ast.BinOp.AND && positive || b.op() == Ast.BinOp.OR && !positive)) {
@@ -672,6 +696,69 @@ final class Predicates {
                 default -> null;
             };
         }
+    }
+
+    /**
+     * A comparison against zero of an operation answering an order, as the comparison of the two
+     * values it orders — or {@code e} unchanged.
+     *
+     * <p>What such an operation answers is a sign ({@link DischargeRules#orderStatedBy}), so where
+     * its answer stands against zero the comparison is between the two arguments themselves. One
+     * account: the relation is the one written, taken between the argument a positive answer says is
+     * the greater and the other one, so the six relations and the two sides of the zero are all read
+     * from the row the library's operation has rather than from a case for each.
+     *
+     * <p>Only against zero. A sign compared with anything else bounds how far the answer is from
+     * zero, which is a statement about the number and not about the order it decides.
+     *
+     * <p>And only where both values are ones this check can name. The sign is a number the domain
+     * carries whatever it is the order of, so a comparison of two values it cannot name is less than
+     * what it already had: a clause reading {@code daysBetween(acquiredOn, lostOn) >= 0} is a bound
+     * on that count, and rewriting it into a comparison of two dates the check cannot relate would
+     * leave the clause unreadable — a construction dropped from the check where it had been reported.
+     * Reading a predicate never takes a reading away.
+     */
+    Core asOrderComparison(Core e, Denotations at) {
+        if (!(e instanceof Core.Binary b) || relOf(b.op()) == null) {
+            return e;
+        }
+        boolean callFirst = b.left() instanceof Core.PreservedCall;
+        Core side = callFirst ? b.left() : b.right();
+        Core zero = callFirst ? b.right() : b.left();
+        if (!(side instanceof Core.PreservedCall call) || call.args().size() != 2
+                || !isZero(zero)) {
+            return e;
+        }
+        Ast.BinOp positive = DischargeRules.orderStatedBy(call.operation());
+        if (positive == null
+                || terms.bodyKey(call.args().get(0), at) == null
+                || terms.bodyKey(call.args().get(1), at) == null) {
+            return e;
+        }
+        // The relation the source wrote, read from the sign's side of the zero, and between the
+        // arguments in the order this operation counts them.
+        Ast.BinOp written = callFirst ? b.op() : mirrored(b.op());
+        Core greater = call.args().get(positive == Ast.BinOp.GT ? 0 : 1);
+        Core lesser = call.args().get(positive == Ast.BinOp.GT ? 1 : 0);
+        return comparison(written, greater, lesser, b);
+    }
+
+    /** Whether {@code e} is the number zero as written. */
+    private static boolean isZero(Core e) {
+        return e instanceof Core.Int i && i.value() == 0
+                || e instanceof Core.Decimal d && d.value().signum() == 0;
+    }
+
+    /** {@code op} with its two sides exchanged: what the same fact is called when it is written the
+     * other way round. */
+    static Ast.BinOp mirrored(Ast.BinOp op) {
+        return switch (op) {
+            case LT -> Ast.BinOp.GT;
+            case GT -> Ast.BinOp.LT;
+            case LE -> Ast.BinOp.GE;
+            case GE -> Ast.BinOp.LE;
+            default -> op;
+        };
     }
 
     /** An emptiness check as the comparison it means, or {@code e} unchanged. */

--- a/souther-compiler/src/main/java/souther/compiler/check/Question.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Question.java
@@ -214,6 +214,35 @@ enum Question {
         }
     },
 
+    /**
+     * Whether it answers the order of its two arguments ({@link DischargeRules#decidesOrder}). Asked
+     * of an operation answering an {@code Int} from two values of one type — which is what an order
+     * is answered from, whatever the values are ordered by.
+     */
+    ORDER("whether it answers the order of its two arguments") {
+        @Override
+        boolean asksOf(Prelude.Signature signature) {
+            return signature.result() == Type.Prim.INT
+                    && signature.params().size() == 2
+                    && signature.params().get(0).equals(signature.params().get(1));
+        }
+
+        @Override
+        boolean answeredFor(ValueName operation) {
+            return DischargeRules.decidesOrder(operation);
+        }
+
+        @Override
+        Set<ValueName> answeredOperations() {
+            return DischargeRules.orderings();
+        }
+
+        @Override
+        Set<ValueName> nothingSaidOf() {
+            return DischargeRules.DECIDES_NO_ORDER;
+        }
+    },
+
     /** Which operator it is the function form of ({@link DischargeRules#operator}). Asked of an
      * operation over two numbers answering a number of the same kind. */
     OPERATOR("which operator it computes") {

--- a/souther-compiler/src/test/java/souther/compiler/check/AComparisonCallStatesTheOrderItDecidesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AComparisonCallStatesTheOrderItDecidesTest.java
@@ -1,0 +1,350 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.check.InvariantChecker.Said;
+import souther.compiler.check.InvariantChecker.Verdict;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * A guard written as the library's {@code compare} against zero states the order it decides.
+ *
+ * <p>{@code compare(a, b)} answers the sign of the order of its two arguments, so its result
+ * standing in a comparison with zero is that same comparison between {@code a} and {@code b} — one
+ * account, from which the six relations and both operand orders follow. Without it the same fact
+ * settles a construction when written with the operator and settles nothing when written as the
+ * call, and which spelling an author reached for decides whether they see a warning they cannot
+ * clear.
+ *
+ * <p>Read off the verdicts: what a guard failed to state and what it stated and could not settle are
+ * both reported, and only the first is what this is about.
+ */
+class AComparisonCallStatesTheOrderItDecidesTest {
+
+    private static final String DECIMALS = """
+            module demo
+
+            data Net = Decimal
+                invariant value >= 0.0m
+
+            data Refund = { net: Net }
+            data FeeTooHigh
+            """;
+
+    private static final String INTS = """
+            module demo
+
+            data Span = Int
+                invariant value >= 0
+
+            data Held = { span: Span }
+            data TooSmall
+            """;
+
+    private static List<Verdict> verdictsOn(String type, String source) {
+        List<Said> said = Collections.synchronizedList(new ArrayList<>());
+        InvariantChecker.WATCHING = said;
+        try {
+            Compiler.compileWithWarnings(source);
+        } finally {
+            InvariantChecker.WATCHING = null;
+        }
+        List<Verdict> on = said.stream()
+                .filter(s -> s.type().equals(type)).map(Said::verdict).toList();
+        assertFalse(on.isEmpty(), "no construction of `" + type + "` was checked at all");
+        return on;
+    }
+
+    private static void reads(String type, Verdict expected, String source) {
+        for (Verdict verdict : verdictsOn(type, source)) {
+            assertEquals(expected, verdict, "on a construction of `" + type + "`");
+        }
+    }
+
+    /** A guard over decimals, written both ways, settles the same construction. */
+    @Test
+    void aDecimalComparisonAgainstZeroSettlesWhatTheOperatorSettles() {
+        String written = DECIMALS + """
+
+                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
+                    constructs Refund, Net, FeeTooHigh
+
+                let settle (paid, fee) = {
+                    guard Decimal.compare(paid, fee) >= 0 else FeeTooHigh
+                    Refund { net = Net(paid - fee) }
+                }
+                """;
+        reads("Net", Verdict.PROVED, written);
+    }
+
+    /** And settles no more than it says. */
+    @Test
+    void aDecimalComparisonAgainstZeroSettlesNoMore() {
+        String m = DECIMALS + """
+
+                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
+                    constructs Refund, Net, FeeTooHigh
+
+                let settle (paid, fee) = {
+                    guard Decimal.compare(paid, fee) >= 0 else FeeTooHigh
+                    Refund { net = Net(paid - fee - 1.0m) }
+                }
+                """;
+        reads("Net", Verdict.UNKNOWN, m);
+    }
+
+    /** The zero on the left is the same guard mirrored. */
+    @Test
+    void theCallOnTheRightOfTheZero() {
+        String m = DECIMALS + """
+
+                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
+                    constructs Refund, Net, FeeTooHigh
+
+                let settle (paid, fee) = {
+                    guard 0 <= Decimal.compare(paid, fee) else FeeTooHigh
+                    Refund { net = Net(paid - fee) }
+                }
+                """;
+        reads("Net", Verdict.PROVED, m);
+    }
+
+    /** A strict order states the strict relation: `> 0` is `paid > fee`, which settles the
+     * difference as `>= 0` does. */
+    @Test
+    void aStrictComparison() {
+        String m = DECIMALS + """
+
+                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
+                    constructs Refund, Net, FeeTooHigh
+
+                let settle (paid, fee) = {
+                    guard Decimal.compare(paid, fee) > 0 else FeeTooHigh
+                    Refund { net = Net(paid - fee) }
+                }
+                """;
+        reads("Net", Verdict.PROVED, m);
+    }
+
+    /** Equality: the two are one value, so their difference is zero. */
+    @Test
+    void anEqualityComparison() {
+        String m = DECIMALS + """
+
+                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
+                    constructs Refund, Net, FeeTooHigh
+
+                let settle (paid, fee) = {
+                    guard Decimal.compare(paid, fee) == 0 else FeeTooHigh
+                    Refund { net = Net(paid - fee) }
+                }
+                """;
+        reads("Net", Verdict.PROVED, m);
+    }
+
+    /** The relation the guard denies is the one its departure carries: `< 0` sends the smaller case
+     * away, so what is left is `paid >= fee`. */
+    @Test
+    void aDeniedComparison() {
+        String m = DECIMALS + """
+
+                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
+                    constructs Refund, Net, FeeTooHigh
+
+                let settle (paid, fee) = {
+                    guard Decimal.compare(paid, fee) < 0 else FeeTooHigh
+                    Refund { net = Net(fee - paid) }
+                }
+                """;
+        reads("Net", Verdict.PROVED, m);
+    }
+
+    /** The same of integers. */
+    @Test
+    void anIntComparisonAgainstZero() {
+        String m = INTS + """
+
+                behavior settle : (hi: Int, lo: Int) -> Held | TooSmall
+                    constructs Held, Span, TooSmall
+
+                let settle (hi, lo) = {
+                    guard Int.compare(hi, lo) >= 0 else TooSmall
+                    Held { span = Span(hi - lo) }
+                }
+                """;
+        reads("Span", Verdict.PROVED, m);
+    }
+
+    /** A comparison against something other than zero is not one relation between the arguments —
+     * the sign is what the order decides, and a bound on the sign is not a bound on the values. */
+    @Test
+    void aComparisonAgainstSomethingOtherThanZero() {
+        String m = INTS + """
+
+                behavior settle : (hi: Int, lo: Int) -> Held | TooSmall
+                    constructs Held, Span, TooSmall
+
+                let settle (hi, lo) = {
+                    guard Int.compare(hi, lo) >= 2 else TooSmall
+                    Held { span = Span(hi - lo) }
+                }
+                """;
+        reads("Span", Verdict.UNKNOWN, m);
+    }
+
+    /**
+     * The direction is the library's to say. {@code daysBetween(from, to)} counts forward from its
+     * first argument, so a non-negative count says the second is the later — the relation the other
+     * way round from what {@code compare} states, read off the same one row.
+     */
+    @Test
+    void aCountForwardIsPositiveWhereTheSecondIsTheGreater() {
+        String m = """
+                module demo
+
+                data Period = { from: Date, to: Date }
+                    invariant notBefore = to >= from
+
+                data Backwards
+
+                behavior span : (from: Date, to: Date) -> Period | Backwards
+                    constructs Period, Backwards
+
+                let span (from, to) = {
+                    guard Date.daysBetween(from, to) >= 0 else Backwards
+                    Period { from = from, to = to }
+                }
+                """;
+        reads("Period", Verdict.PROVED, m);
+    }
+
+    /**
+     * And a count that truncates decides no order: whole minutes between two date-times are zero
+     * wherever they are less than a minute apart, in either direction, so a non-negative count does
+     * not say which is the earlier.
+     */
+    @Test
+    void aTruncatedCountDecidesNoOrder() {
+        String m = """
+                module demo
+
+                data Window = { start: DateTime, end: DateTime }
+                    invariant notBefore = end >= start
+
+                data Backwards
+
+                behavior span : (start: DateTime, end: DateTime) -> Window | Backwards
+                    constructs Window, Backwards
+
+                let span (start, end) = {
+                    guard DateTime.minutesBetween(start, end) >= 0 else Backwards
+                    Window { start = start, end = end }
+                }
+                """;
+        reads("Window", Verdict.UNKNOWN, m);
+    }
+
+    /**
+     * Reading a clause as the order it states must not cost the reading it had. The count itself is a
+     * number this check names, and a bound on it is a clause it can read; the two dates it orders are
+     * not always both nameable — one of them here is the day after a date — and rewriting the clause
+     * into a comparison of those would leave it unreadable, which is a construction dropped from the
+     * check where it had been reported. Both readings stand, and the one that answers is taken.
+     */
+    @Test
+    void theOrderReadingDoesNotCostTheBoundOnTheCount() {
+        String m = """
+                module demo
+
+                data Coverage =
+                    { acquiredOn: Date
+                    , lostOn: Date
+                    }
+                    invariant Date.daysBetween(acquiredOn, lostOn) >= 0
+
+                behavior lose : (acquiredOn: Date, separatedOn: Date) -> Coverage
+                    constructs Coverage
+
+                let lose (acquiredOn, separatedOn) = {
+                    Coverage { acquiredOn = acquiredOn, lostOn = Date.addDays(1, separatedOn) }
+                }
+                """;
+        reads("Coverage", Verdict.UNKNOWN, m);
+    }
+
+    /** The model a quantified cap is stated over. */
+    private static final String CAPPED = """
+            module demo
+
+            data Rate = Decimal
+                invariant value >= 0.0m && value <= 0.5m
+
+            data Line = { discount: Decimal }
+            data Quote = { rates: List<Rate> }
+            data OverCap
+
+            behavior build : (lines: List<Line>) -> Quote | OverCap
+                constructs Quote, Rate, OverCap
+
+            let build (lines) = {
+                guard withinCaps(lines) else OverCap
+                Quote { rates = List.map(r -> Rate(r.discount), lines) }
+            }
+            """;
+
+    /** What a quantifier states of every element is stated of the one a closure is handed, so a cap
+     * written as a comparison call reaches the construction over that element. */
+    @Test
+    void aCapStatedOfEveryElementAsAComparisonCall() {
+        String m = CAPPED + """
+
+                let withinCaps (lines: List<Line>): Bool =
+                    List.all(r -> Decimal.compare(r.discount, 0.5m) <= 0
+                              && Decimal.compare(r.discount, 0.0m) >= 0, lines)
+                """;
+        reads("Rate", Verdict.PROVED, m);
+    }
+
+    /** And a cap that leaves room past the clause does not: the relation the call states is the one
+     * it was written with, not the one the type wanted. */
+    @Test
+    void aCapLooserThanTheClauseSettlesNothing() {
+        String m = CAPPED + """
+
+                let withinCaps (lines: List<Line>): Bool =
+                    List.all(r -> Decimal.compare(r.discount, 0.6m) <= 0
+                              && Decimal.compare(r.discount, 0.0m) >= 0, lines)
+                """;
+        reads("Rate", Verdict.UNKNOWN, m);
+    }
+
+    /** A clause written as a comparison call and a guard written with the operator are one fact:
+     * the reading is the same at both ends, so which end wrote which spelling does not matter. */
+    @Test
+    void aClauseWrittenAsAComparisonMeetsAGuardWrittenAsAnOperator() {
+        String m = """
+                module demo
+
+                data Ordered = { low: Int, high: Int }
+                    invariant inOrder = Int.compare(high, low) >= 0
+
+                data NotOrdered
+
+                behavior order : (a: Int, b: Int) -> Ordered | NotOrdered
+                    constructs Ordered, NotOrdered
+
+                let order (a, b) = {
+                    guard a >= b else NotOrdered
+                    Ordered { low = b, high = a }
+                }
+                """;
+        reads("Ordered", Verdict.PROVED, m);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/check/AComparisonCallStatesTheOrderItDecidesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AComparisonCallStatesTheOrderItDecidesTest.java
@@ -5,6 +5,9 @@ import souther.compiler.check.InvariantChecker.Said;
 import souther.compiler.check.InvariantChecker.Verdict;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -53,6 +56,9 @@ class AComparisonCallStatesTheOrderItDecidesTest {
         InvariantChecker.WATCHING = said;
         try {
             Compiler.compileWithWarnings(source);
+        } catch (souther.compiler.diag.CompileException refused) {
+            // A construction the guards refute is an error, and the verdict that says so was reached
+            // before it was raised. What is asked here is which verdict, not whether it compiles.
         } finally {
             InvariantChecker.WATCHING = null;
         }
@@ -68,23 +74,44 @@ class AComparisonCallStatesTheOrderItDecidesTest {
         }
     }
 
-    /** A guard over decimals, written both ways, settles the same construction. */
-    @Test
-    void aDecimalComparisonAgainstZeroSettlesWhatTheOperatorSettles() {
-        String written = DECIMALS + """
-
-                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
-                    constructs Refund, Net, FeeTooHigh
-
-                let settle (paid, fee) = {
-                    guard Decimal.compare(paid, fee) >= 0 else FeeTooHigh
-                    Refund { net = Net(paid - fee) }
-                }
-                """;
-        reads("Net", Verdict.PROVED, written);
+    /**
+     * The six relations, each written with the call on either side of the zero.
+     *
+     * <p>What is held is the whole account at once: the relation the guard states is the one written,
+     * taken between the two arguments, and writing the zero on the other side states the same fact
+     * mirrored. So the two spellings of a row answer alike, and what they answer is what that
+     * relation gives a construction of `paid - fee` — settled where the guard puts `paid` at or above
+     * `fee`, refuted where it puts it below, and unsettled where it leaves both open.
+     */
+    @ParameterizedTest(name = "{0} 0 and 0 {1}")
+    @MethodSource("relations")
+    void eachRelationOnEitherSideOfTheZero(String written, String mirrored, Verdict expected) {
+        reads("Net", expected, guarded("Decimal.compare(paid, fee) " + written + " 0"));
+        reads("Net", expected, guarded("0 " + mirrored + " Decimal.compare(paid, fee)"));
     }
 
-    /** And settles no more than it says. */
+    private static List<Arguments> relations() {
+        return List.of(
+                Arguments.of(">=", "<=", Verdict.PROVED),
+                Arguments.of(">", "<", Verdict.PROVED),
+                Arguments.of("==", "==", Verdict.PROVED),
+                Arguments.of("/=", "/=", Verdict.UNKNOWN),
+                Arguments.of("<=", ">=", Verdict.UNKNOWN),
+                Arguments.of("<", ">", Verdict.REFUTED_NOT_ALONE));
+    }
+
+    /** The model those are read in: a difference the guard is what settles. */
+    private static String guarded(String condition) {
+        return DECIMALS
+                + "\nbehavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh\n"
+                + "    constructs Refund, Net, FeeTooHigh\n\n"
+                + "let settle (paid, fee) = {\n"
+                + "    guard " + condition + " else FeeTooHigh\n"
+                + "    Refund { net = Net(paid - fee) }\n"
+                + "}\n";
+    }
+
+    /** What the table above settles, it settles no more of. */
     @Test
     void aDecimalComparisonAgainstZeroSettlesNoMore() {
         String m = DECIMALS + """
@@ -98,55 +125,6 @@ class AComparisonCallStatesTheOrderItDecidesTest {
                 }
                 """;
         reads("Net", Verdict.UNKNOWN, m);
-    }
-
-    /** The zero on the left is the same guard mirrored. */
-    @Test
-    void theCallOnTheRightOfTheZero() {
-        String m = DECIMALS + """
-
-                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
-                    constructs Refund, Net, FeeTooHigh
-
-                let settle (paid, fee) = {
-                    guard 0 <= Decimal.compare(paid, fee) else FeeTooHigh
-                    Refund { net = Net(paid - fee) }
-                }
-                """;
-        reads("Net", Verdict.PROVED, m);
-    }
-
-    /** A strict order states the strict relation: `> 0` is `paid > fee`, which settles the
-     * difference as `>= 0` does. */
-    @Test
-    void aStrictComparison() {
-        String m = DECIMALS + """
-
-                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
-                    constructs Refund, Net, FeeTooHigh
-
-                let settle (paid, fee) = {
-                    guard Decimal.compare(paid, fee) > 0 else FeeTooHigh
-                    Refund { net = Net(paid - fee) }
-                }
-                """;
-        reads("Net", Verdict.PROVED, m);
-    }
-
-    /** Equality: the two are one value, so their difference is zero. */
-    @Test
-    void anEqualityComparison() {
-        String m = DECIMALS + """
-
-                behavior settle : (paid: Decimal, fee: Decimal) -> Refund | FeeTooHigh
-                    constructs Refund, Net, FeeTooHigh
-
-                let settle (paid, fee) = {
-                    guard Decimal.compare(paid, fee) == 0 else FeeTooHigh
-                    Refund { net = Net(paid - fee) }
-                }
-                """;
-        reads("Net", Verdict.PROVED, m);
     }
 
     /** The relation the guard denies is the one its departure carries: `< 0` sends the smaller case


### PR DESCRIPTION
Fixes #668.

`guard Decimal.compare(paid, fee) >= 0` stated no relation between `paid` and `fee`, so a
construction the same fact settles when written `paid >= fee` was reported. The sign was read as a
number and nothing asked what it was the sign of.

## The rule is the library's

An operation answering an `Int` from two values of one type is now asked whether its sign is their
order, and answers with the relation a positive answer states between its first argument and its
second. One row per operation, and the six relations and both sides of the zero follow from it —
there is no case in the reader naming `Int.compare` or `Decimal.compare`.

`Question` holds every operation in that range to an answer, which is what turned up the two the
library already had beyond `compare`:

- `Date.daysBetween(from, to)` counts forward from its first argument, so it is positive where the
  **second** is the greater — the direction the other way round from `compare`, read off the same
  row.
- `DateTime.minutesBetween` answers no order: it counts whole minutes, so a zero says the two are
  less than a minute apart rather than that they are equal, and a non-negative count does not say
  which is the earlier. Its strict signs do state the order, and a rule holding for four of the six
  relations is not this one.

## Reading a predicate never takes a reading away

The first version rewrote the clause in place, and that **silenced a warning in the corpus**: the
count is itself a number this check names, so `invariant Date.daysBetween(acquiredOn, lostOn) >= 0`
is a clause it can read, while the two dates it orders need not both be nameable — read against a
construction whose `lostOn` is `Date.addDays(1, separatedOn)`, the rewritten clause compares two
dates nothing relates and stops being read at all. A construction that had been reported left the
check, which is the shape #667 was about.

Both readings stand now. A guard states each of them; a clause is owed the order where that can be
read and the bound on the count where it cannot. `theOrderReadingDoesNotCostTheBoundOnTheCount`
holds that case at `UNKNOWN` rather than `UNREPRESENTABLE`.

## What it is held to

14 cases in `AComparisonCallStatesTheOrderItDecidesTest`, read off the verdicts: `PROVED` where the
guard settles the construction, `UNKNOWN` where it does not. Each spelling is paired with one step
past what it establishes, so a silence cannot pass for a discharge — the relations, both operand
orders, `Int` and `Decimal`, a comparison against something other than zero, the two date
operations, a clause written as a call meeting a guard written as an operator, and a cap stated of
every element through `List.all`.

`mvn clean test`: BUILD SUCCESS.

The example corpus goes from 71 diagnostics to 69, none added:

- `forecasting.sou:375` — the gap taken in the branch where `Decimal.compare(got, quota) >= 0` was
  false, so the subtraction is positive there. Reversing that comparison turns the diagnostic into
  **E2010**, a refutation: the difference is then negative wherever it is written.
- `quoting.sou:228` — a discount cap stated of every line as a comparison call. Held here by a pair:
  a cap at the clause's own bound proves the construction, and one that leaves room past it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
