### PR TITLE
Tell a constructs clause every name it disagrees on

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/SpecChecker.java
@@ -12,6 +12,7 @@ import souther.compiler.diag.msg.TypeMessage;
 import souther.compiler.diag.msg.InjectionMessage;
 import souther.compiler.diag.msg.ModuleMessage;
 import souther.compiler.diag.DiagnosticCode;
+import souther.compiler.diag.DiagnosticRenderer;
 import souther.compiler.diag.SourcePos;
 import souther.compiler.types.Type;
 import souther.compiler.types.TypeName;
@@ -319,19 +320,38 @@ public final class SpecChecker {
             // and an `Amount` an import brings in are the same one. Each side keeps its own spelling
             // in whatever it has to report.
             Set<TypeName> declared = new HashSet<>(MatchElaborator.denoted(spec.constructs()));
+            // Every way this clause and this body disagree, and not the first of them. Both sides
+            // are worked out once and whole before any of it is said, so stopping at one left the
+            // author to fix that one, compile, and be told the next — a walk down the call graph,
+            // one build per name. One clause is one thing to rewrite, and a clause that is short of
+            // one name and carrying another it does not build is wrong in both directions at once:
+            // reporting the two separately is two builds to learn what one reading of the body
+            // already knows.
+            //
+            // One violation is one diagnostic. Each names the type it is about and carries the hint
+            // for that type, so an editor has one thing to act on per name rather than a sentence
+            // listing several. What is short comes before what is extra, in the order the body
+            // builds them (`originated` keeps the order it collected them in) and then the order the
+            // clause writes them — every one of them is at the declaration, so nothing reorders them
+            // afterwards.
+            List<Diagnostic> disagreements = new ArrayList<>();
             for (Map.Entry<TypeName, String> built : constructed.originated().entrySet()) {
                 if (!declared.contains(built.getKey())) {
                     String c = built.getValue();
-                    throw CompileException.of(Diagnostic.at(spec.pos())
+                    disagreements.add(Diagnostic.at(spec.pos())
                                     .hint(new DeclarationMessage.AddTheConstructsEntry(spec.name(), c)).say(new DeclarationMessage.ItConstructsWithoutDeclaringIt(spec.name(), c)).build());
                 }
             }
             for (Ast.Name declaredName : spec.constructs()) {
                 String name = declaredName.written();
                 if (!constructed.builds(declaredName.denotes())) {
-                    throw CompileException.of(Diagnostic.at(spec.pos())
+                    disagreements.add(Diagnostic.at(spec.pos())
                                     .hint(new DeclarationMessage.RemoveTheConstructsEntry(name)).say(new DeclarationMessage.ItDeclaresConstructsAndNeverBuilds(spec.name(), name)).build());
                 }
+            }
+            if (!disagreements.isEmpty()) {
+                throw CompileException.ofAll(disagreements,
+                        DiagnosticRenderer.legacyBody(disagreements.get(0)));
             }
         }
         // The `depends on` clause must match what the fn actually calls (spec §depends-on): missing -> E1602,

--- a/souther-compiler/src/test/java/souther/compiler/check/AConstructsClauseIsToldEveryNameItDisagreesOnTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AConstructsClauseIsToldEveryNameItDisagreesOnTest.java
@@ -1,0 +1,190 @@
+package souther.compiler.check;
+
+import souther.compiler.Compiler;
+import souther.compiler.diag.CompileException;
+import souther.compiler.diag.Diagnostic;
+import souther.compiler.diag.DiagnosticRenderer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * A {@code constructs} clause is told every name it and the body disagree on, at once.
+ *
+ * <p>Both sides are worked out whole before anything is reported, so stopping at the first
+ * disagreement left the author to fix that one, compile, and be told the next — one build per name,
+ * down whatever the call graph reaches. A clause short of one name and carrying another it never
+ * builds is wrong in both directions, and that is still one clause to rewrite.
+ *
+ * <p>Each name is its own diagnostic — E1002 for one the clause is short of, E1006 for one it
+ * carries and never builds — so each keeps the hint for the name it is about.
+ */
+class AConstructsClauseIsToldEveryNameItDisagreesOnTest {
+
+    /** `setState` builds a `CookLine` around a unit case two calls in, and neither is declared. */
+    private static final String TWO_NAMES_SHORT = """
+            module repro exposing ( Ticket, CookLine, ItemCookState, Pending, InProgress, Done, start )
+
+            data ItemCookState = Pending | InProgress | Done
+            data CookLine = { state: ItemCookState }
+            data Ticket = { lines: List<CookLine> }
+
+            let setState (next: ItemCookState, lines: List<CookLine>): List<CookLine> =
+                List.map(l -> CookLine { state = next }, lines)
+
+            behavior start : (t: Ticket) -> Ticket
+                constructs Ticket
+
+            let start (t) = Ticket { lines = setState(InProgress, t.lines) }
+            """;
+
+    private static List<String> bodiesOf(CompileException e) {
+        List<String> said = new ArrayList<>();
+        for (Diagnostic d : e.diagnostics()) {
+            said.add(DiagnosticRenderer.legacyBody(d));
+        }
+        return said;
+    }
+
+    private static CompileException failure(String source) {
+        return assertThrows(CompileException.class, () -> Compiler.compile(source));
+    }
+
+    @Test
+    void everyNameTheClauseIsShortOfIsReported() {
+        List<String> said = bodiesOf(failure(TWO_NAMES_SHORT));
+
+        assertEquals(2, said.size(), "one per name, and not the first of them: " + said);
+        assertTrue(said.get(0).contains("`InProgress`"), said.toString());
+        assertTrue(said.get(1).contains("`CookLine`"), said.toString());
+    }
+
+    @Test
+    void eachOneIsItsOwnE1002WithItsOwnHint() {
+        CompileException e = failure(TWO_NAMES_SHORT);
+
+        for (Diagnostic d : e.diagnostics()) {
+            assertEquals("E1002", d.code(), bodiesOf(e).toString());
+        }
+        assertTrue(bodiesOf(e).get(0).contains("Add `constructs InProgress`"), bodiesOf(e).toString());
+        assertTrue(bodiesOf(e).get(1).contains("Add `constructs CookLine`"), bodiesOf(e).toString());
+    }
+
+    @Test
+    void theyComeInTheOrderTheBodyBuildsThem() {
+        // `setState` is reached before the `Ticket` around it is built, and inside it the unit case
+        // is written before the record that holds it.
+        List<String> said = bodiesOf(failure("""
+                module repro exposing ( Out, Wrap, Flag, On, Off, f )
+
+                data Flag = On | Off
+                data Wrap = { flag: Flag }
+                data Out = { wraps: List<Wrap> }
+
+                let wrap (flags: List<Flag>): List<Wrap> = List.map(x -> Wrap { flag = x }, flags)
+
+                behavior f : (o: Out) -> Out
+                    constructs Out
+
+                let f (o) = Out { wraps = wrap([ On, Off ]) }
+                """));
+
+        assertEquals(3, said.size(), said.toString());
+        assertTrue(said.get(0).contains("`On`"), said.toString());
+        assertTrue(said.get(1).contains("`Off`"), said.toString());
+        assertTrue(said.get(2).contains("`Wrap`"), said.toString());
+    }
+
+    @Test
+    void oneNameShortIsStillOneDiagnostic() {
+        CompileException e = failure("""
+                module repro exposing ( Out, Flag, On, Off, f )
+
+                data Flag = On | Off
+                data Out = { flag: Flag }
+
+                behavior f : (o: Out) -> Out
+                    constructs Out
+
+                let f (o) = Out { flag = On }
+                """);
+
+        assertEquals(1, e.diagnostics().size(), bodiesOf(e).toString());
+        assertEquals("E1002", e.code());
+        assertTrue(e.getMessage().contains("`On`"), e.getMessage());
+    }
+
+    @Test
+    void everyNameTheClauseCarriesAndNeverBuildsIsReported() {
+        List<String> said = bodiesOf(failure("""
+                module repro exposing ( In, Out, Refused, Held, f )
+
+                data In = { n: Int }
+                data Out = { n: Int }
+                data Refused
+                data Held
+
+                behavior f : (i: In) -> Out
+                    constructs Out, Refused, Held
+
+                let f (i) = Out { n = i.n }
+                """));
+
+        assertEquals(2, said.size(), "one per name it never builds: " + said);
+        assertTrue(said.get(0).contains("`Refused`"), said.toString());
+        assertTrue(said.get(1).contains("`Held`"), said.toString());
+        assertTrue(said.get(0).contains("Remove `Refused`"), said.toString());
+    }
+
+    @Test
+    void aClauseWrongInBothDirectionsIsToldBothAtOnce() {
+        // Short of `On`, and carrying `Off`, which the body never builds. One clause to rewrite, so
+        // learning the second of them should not cost a build.
+        CompileException e = failure("""
+                module repro exposing ( Out, Flag, On, Off, f )
+
+                data Flag = On | Off
+                data Out = { flag: Flag }
+
+                behavior f : (o: Out) -> Out
+                    constructs Out, Off
+
+                let f (o) = Out { flag = On }
+                """);
+
+        List<String> said = bodiesOf(e);
+        assertEquals(2, said.size(), said.toString());
+        assertTrue(said.get(0).contains("`On`") && said.get(0).contains("does not declare"),
+                "what it is short of comes first: " + said);
+        assertTrue(said.get(1).contains("`Off`") && said.get(1).contains("never builds"),
+                "and what it carries follows: " + said);
+        assertEquals("E1002", e.code(), "so the leading code is the under-declaration");
+        assertEquals(List.of("E1002", "E1006"),
+                e.diagnostics().stream().map(Diagnostic::code).toList());
+    }
+
+    @Test
+    void aCompleteClauseIsStillComplete() {
+        Compiler.compile("""
+                module repro exposing ( Ticket, CookLine, ItemCookState, Pending, InProgress, Done, start )
+
+                data ItemCookState = Pending | InProgress | Done
+                data CookLine = { state: ItemCookState }
+                data Ticket = { lines: List<CookLine> }
+
+                let setState (next: ItemCookState, lines: List<CookLine>): List<CookLine> =
+                    List.map(l -> CookLine { state = next }, lines)
+
+                behavior start : (t: Ticket) -> Ticket
+                    constructs Ticket, CookLine, InProgress
+
+                let start (t) = Ticket { lines = setState(InProgress, t.lines) }
+                """);
+    }
+}

--- a/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/query/ACompileAnswersWithEveryErrorItFoundTest.java
@@ -28,8 +28,9 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
  */
 class ACompileAnswersWithEveryErrorItFoundTest {
 
-    /** Three behaviors, each building a data its `constructs` clause does not name. Each is its own
-     *  question, so none of them hides another. */
+    /** Three behaviors, each short of exactly one `constructs` entry — the unit case its line
+     *  holds. One name each, so what is counted here is the behaviors and not the names within one:
+     *  a clause short of several is its own question (E1002 reports each of them). */
     private static final String THREE_UNDER_DECLARED = """
             module m.a exposing ( Ticket, CookLine, ItemCookState, Pending, InProgress, Done, start, finish, reopen )
 
@@ -38,15 +39,15 @@ class ACompileAnswersWithEveryErrorItFoundTest {
             data Ticket = { lines: List<CookLine> }
 
             behavior start : (t: Ticket) -> Ticket
-                constructs Ticket
+                constructs Ticket, CookLine
             let start (t) = Ticket { lines = [ CookLine { state = InProgress } ] }
 
             behavior finish : (t: Ticket) -> Ticket
-                constructs Ticket
+                constructs Ticket, CookLine
             let finish (t) = Ticket { lines = [ CookLine { state = Done } ] }
 
             behavior reopen : (t: Ticket) -> Ticket
-                constructs Ticket
+                constructs Ticket, CookLine
             let reopen (t) = Ticket { lines = [ CookLine { state = Pending } ] }
             """;
 


### PR DESCRIPTION
Closes #664.

`SpecChecker` compared the `constructs` clause against the body's construction set — both worked out whole — and then threw the first disagreement. A behavior reaching a few unit cases and a record two calls down cost a build per name.

Now the walk finishes and reports what it found. Each name stays its own diagnostic, so each keeps the hint for the name it is about: no new message, no change to `DeclarationMessage` or the catalogs, no plural wording in the specification.

## The reproduction from the issue

```
$ souther compile issue664.sou
-- INSUFFICIENT CONSTRUCTION AUTHORITY  E1002 -issue664.sou:10:1

10| behavior start : (t: Ticket) -> Ticket
    ^

Behavior `start` constructs `InProgress` but does not declare `constructs InProgress`.
Hint: Add `constructs InProgress` to `start`, or stop constructing InProgress here.

-- INSUFFICIENT CONSTRUCTION AUTHORITY  E1002 -issue664.sou:10:1

10| behavior start : (t: Ticket) -> Ticket
    ^

Behavior `start` constructs `CookLine` but does not declare `constructs CookLine`.
Hint: Add `constructs CookLine` to `start`, or stop constructing CookLine here.
```

Adding both compiles clean. Two round trips became one.

## E1006 as well

Over-declaration had the same shape one line down, and a clause short of one name while carrying another it never builds cost two builds to learn what one reading of the body already knew. One clause is one thing to rewrite, so both directions are reported together: E1002 for what it is short of, E1006 for what it carries and never builds.

What it is short of comes first, in the order the body builds them, then what it carries, in the order the clause writes them. All of them sit at the declaration, so the ordering in `Compilation#failure` leaves them as they are.

## Position

`spec.pos()`, as before. Several diagnostics land on one range, which is blunt in an editor, but where E1002 points is a separate question from whether it stops early: what the author changes is the clause, and the construction site is better as a related location than as the primary one. `DataChecker.Constructs` carries no position today, so moving it is a data-model change with its own reasons.

## Tests

`AConstructsClauseIsToldEveryNameItDisagreesOnTest` (7): every name short, each one its own E1002 with its own hint, the order the body builds them, one name short still one diagnostic, every name carried and never built, a clause wrong in both directions at once, and a complete clause still compiling.

One existing fixture changed. `ACompileAnswersWithEveryErrorItFoundTest#everyBehaviorsErrorIsCarried` counts behaviors, and its three behaviors were each short of two names — so it counted three and would now see six. Each is short of exactly one now; how many names one clause answers with is the question this PR adds tests for.

Verified: `mvn clean test` across all modules — 6938 tests, no failures — and the CLI run above.
