### PR TITLE
Say which argument a positive answer names as the greater

### DIFF
--- a/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/DischargeRules.java
@@ -363,10 +363,41 @@ final class DischargeRules {
             op("Decimal", "min"), op("Decimal", "max"));
 
     /**
-     * The operations answering the order of their two arguments as the sign of a number, and the
-     * relation between the first argument and the second that a positive answer states. Zero states
-     * the equality, and a negative answer the relation the other way, so one row is the whole of what
-     * such an operation says.
+     * Which of the two arguments a positive answer names as the greater. That is the whole of what a
+     * row of {@link #ORDERS} says, and it is two cases, so it is written as a type with two — not as
+     * one of the language's operators, which would say the same thing in a type where most of the
+     * values say nothing and the ones that do have to be agreed on somewhere else.
+     *
+     * <p>Each case carries the two positions itself, since which argument is the lesser is settled by
+     * which is the greater and there is no reading where the two are chosen apart.
+     */
+    enum PositiveOrder {
+        FIRST_ARGUMENT_GREATER(0, 1),
+        SECOND_ARGUMENT_GREATER(1, 0);
+
+        private final int greater;
+        private final int lesser;
+
+        PositiveOrder(int greater, int lesser) {
+            this.greater = greater;
+            this.lesser = lesser;
+        }
+
+        /** The argument of {@code call} a positive answer names as the greater. */
+        Core greaterOf(Core.PreservedCall call) {
+            return call.args().get(greater);
+        }
+
+        /** The other one. */
+        Core lesserOf(Core.PreservedCall call) {
+            return call.args().get(lesser);
+        }
+    }
+
+    /**
+     * The operations answering the order of their two arguments as the sign of a number, and which
+     * argument a positive answer names as the greater. Zero states the equality, and a negative
+     * answer the relation the other way, so one row is the whole of what such an operation says.
      *
      * <p>Which relation a guard writing one states then follows from where the sign stands against
      * zero and from nothing else, so the six relations and the two operand orders are one account
@@ -375,10 +406,10 @@ final class DischargeRules {
      * {@code daysBetween(from, to)} counts forward from its first argument, so it is positive where
      * the second one is.
      */
-    private static final Map<ValueName, Ast.BinOp> ORDERS = Map.of(
-            op("Int", "compare"), Ast.BinOp.GT,
-            op("Decimal", "compare"), Ast.BinOp.GT,
-            op("Date", "daysBetween"), Ast.BinOp.LT);
+    private static final Map<ValueName, PositiveOrder> ORDERS = Map.of(
+            op("Int", "compare"), PositiveOrder.FIRST_ARGUMENT_GREATER,
+            op("Decimal", "compare"), PositiveOrder.FIRST_ARGUMENT_GREATER,
+            op("Date", "daysBetween"), PositiveOrder.SECOND_ARGUMENT_GREATER);
 
     /**
      * The operations answering a number from two values of one type whose sign is not their order.
@@ -632,9 +663,9 @@ final class DischargeRules {
         return OPERATOR_CALLS.get(operation);
     }
 
-    /** The relation a positive answer from {@code operation} states between its first argument and
-     * its second, or null where its sign is not an order. */
-    static Ast.BinOp orderStatedBy(ValueName operation) {
+    /** Which argument a positive answer from {@code operation} names as the greater, or null where
+     * its sign is not an order. */
+    static PositiveOrder orderStatedBy(ValueName operation) {
         return ORDERS.get(operation);
     }
 

--- a/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
+++ b/souther-compiler/src/main/java/souther/compiler/check/Predicates.java
@@ -729,7 +729,7 @@ final class Predicates {
                 || !isZero(zero)) {
             return e;
         }
-        Ast.BinOp positive = DischargeRules.orderStatedBy(call.operation());
+        DischargeRules.PositiveOrder positive = DischargeRules.orderStatedBy(call.operation());
         if (positive == null
                 || terms.bodyKey(call.args().get(0), at) == null
                 || terms.bodyKey(call.args().get(1), at) == null) {
@@ -738,9 +738,7 @@ final class Predicates {
         // The relation the source wrote, read from the sign's side of the zero, and between the
         // arguments in the order this operation counts them.
         Ast.BinOp written = callFirst ? b.op() : mirrored(b.op());
-        Core greater = call.args().get(positive == Ast.BinOp.GT ? 0 : 1);
-        Core lesser = call.args().get(positive == Ast.BinOp.GT ? 1 : 0);
-        return comparison(written, greater, lesser, b);
+        return comparison(written, positive.greaterOf(call), positive.lesserOf(call), b);
     }
 
     /** Whether {@code e} is the number zero as written. */

--- a/souther-compiler/src/test/java/souther/compiler/check/AComparisonCallStatesTheOrderItDecidesTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/check/AComparisonCallStatesTheOrderItDecidesTest.java
@@ -160,6 +160,27 @@ class AComparisonCallStatesTheOrderItDecidesTest {
         reads("Span", Verdict.PROVED, m);
     }
 
+    /**
+     * And only that way round. The guard puts {@code hi} at or above {@code lo}, so the difference
+     * taken the other way is at or below zero and a {@code Span} built from it is not proved. A row
+     * read backwards proves it, from a relation between the two the program never states — which is
+     * the one failure of this table that reaches a construction rather than only losing one.
+     */
+    @Test
+    void theDifferenceTakenTheOtherWayIsNotProved() {
+        String m = INTS + """
+
+                behavior settle : (hi: Int, lo: Int) -> Held | TooSmall
+                    constructs Held, Span, TooSmall
+
+                let settle (hi, lo) = {
+                    guard Int.compare(hi, lo) >= 0 else TooSmall
+                    Held { span = Span(lo - hi) }
+                }
+                """;
+        reads("Span", Verdict.UNKNOWN, m);
+    }
+
     /** A comparison against something other than zero is not one relation between the arguments —
      * the sign is what the order decides, and a bound on the sign is not a bound on the values. */
     @Test
@@ -201,6 +222,29 @@ class AComparisonCallStatesTheOrderItDecidesTest {
                 }
                 """;
         reads("Period", Verdict.PROVED, m);
+    }
+
+    /** The other side of that direction: the same guard says nothing about {@code from} being the
+     * later, and a row read the way {@code compare} is read would say it does. */
+    @Test
+    void aCountForwardSaysNothingOfTheFirstBeingTheGreater() {
+        String m = """
+                module demo
+
+                data Period = { from: Date, to: Date }
+                    invariant notAfter = from >= to
+
+                data Backwards
+
+                behavior span : (from: Date, to: Date) -> Period | Backwards
+                    constructs Period, Backwards
+
+                let span (from, to) = {
+                    guard Date.daysBetween(from, to) >= 0 else Backwards
+                    Period { from = from, to = to }
+                }
+                """;
+        reads("Period", Verdict.UNKNOWN, m);
     }
 
     /**


### PR DESCRIPTION
Closes #677.

`DischargeRules.ORDERS` held an `Ast.BinOp` to say which way the sign of an order-deciding operation runs, and `Predicates.asOrderComparison` decoded it as `positive == GT ? 0 : 1` — so every value other than `GT` was read as `LT`. `GE` is the plausible slip, and nothing refused it.

The value is now `PositiveOrder`, which has the two cases the rule has. Each case carries the two argument positions, so `asOrderComparison` is handed the greater and the lesser and interprets nothing:

```java
return comparison(written, positive.greaterOf(call), positive.lesserOf(call), b);
```

`decidesOrder`, `orderings()` and `Question.ORDER` are unchanged. Whether an operation decides an order is a different question from which way it decides one, and those ask only the first.

## Tests

Two tests were added, for the direction the existing ones do not reach. A row read backwards moves verdicts both ways, and only one of the two is unsound:

| | what a reversed row shows | |
|---|---|---|
| the three existing tests | `PROVED` → `UNKNOWN` | a proof lost |
| `theDifferenceTakenTheOtherWayIsNotProved`, `aCountForwardSaysNothingOfTheFirstBeingTheGreater` | `UNKNOWN` → `PROVED` | a construction proved from a relation the program never states |

Each row was reversed on its own to check the tests answer for the row they are about: reversing `Int.compare` kills the three `compare` tests and neither `Date` one, and reversing `Date.daysBetween` kills the two `daysBetween` tests and none of the others.

Full suite: 7070 tests, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)