### PR TITLE
Answer what a command takes, rather than say it while refusing

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ The `souther` binary answers questions about the language and its libraries itse
 person nor a coding agent has to hunt through a workspace or disassemble jars:
 
 ```sh
+souther help                   # every command, with a line saying what it is for
+souther help compile           # one command's arguments and every option it takes
 souther doc                    # every specification section and shipped topic, name<TAB>title
 souther doc newtype            # one section, by its anchor
 souther doc cli/run            # a topic the command line ships about itself

--- a/souther-compiler/src/main/java/souther/compiler/CliCommand.java
+++ b/souther-compiler/src/main/java/souther/compiler/CliCommand.java
@@ -1,0 +1,109 @@
+package souther.compiler;
+
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The commands this command line has, and what each one is for.
+ *
+ * <p>The one place a command name is resolved. The dispatch used to name them in a {@code switch}
+ * over strings and the usage text named them again in prose, so a command was two statements that
+ * agreed by hand: the text said {@code mcp} was an option of {@code api} for as long as nobody
+ * read it against anything. A name resolves to a constant here and the dispatch switches over the
+ * constants, so a command added to this table and left undispatched is a build that does not
+ * compile rather than a drift a test has to go looking for.
+ *
+ * <p>{@code help} is one of them and not a shape the dispatch knows about. It is a command an author
+ * writes like any other, so it has what the others have — arguments it takes, a line saying what it
+ * is for, and a section of its own that {@code souther help help} answers with. A meta-command
+ * special-cased above the table would be the one command unable to explain itself.
+ *
+ * <p>What a command takes is not written here. {@link CliOption} says which commands each option
+ * belongs to, and a section is built by asking it; the only thing this table says about an option
+ * is what it means <em>under this command</em>, where that differs from what the option means on
+ * its own.
+ */
+enum CliCommand {
+
+    COMPILE("compile", "<file.sou>...", "compile to .class files"),
+    RUN("run", "<file.sou>", "run one behavior and print its output",
+            Map.of(CliOption.BEHAVIOR, "which behavior to run (default: the only one)")),
+    FMT("fmt", "<file.sou>...", "format source, to stdout or in place"),
+    EXAMPLES("examples", "<file.sou>...", "how well the `example`s cover the model",
+            Map.of(CliOption.FORMAT, "how to render the report, and any compile error "
+                    + "(default human)")),
+    DOC("doc", "[<anchor> | <error-code> | <set>/<topic>[/<section>]]",
+            "read the language specification"),
+    API("api", "[<Module>[.<name>]]", "the stdlib surface and its signatures",
+            Map.of(CliOption.SEARCH, "the published names whose signature or document says the "
+                    + "term")),
+    JAPI("japi", "<class-or-package>[#<member>]", "a dependency jar's public API, with javadoc",
+            Map.of(CliOption.CLASS_PATH, "where to find the jar to read")),
+    MCP("mcp", "", "serve doc, api and japi over MCP stdio"),
+    HELP("help", "[<command>]", "what a command takes, and what its options mean");
+
+    private static final Map<String, CliCommand> BY_SPELLING = spellingIndex();
+
+    private static Map<String, CliCommand> spellingIndex() {
+        Map<String, CliCommand> index = new LinkedHashMap<>();
+        for (CliCommand command : values()) {
+            index.put(command.spelling, command);
+        }
+        return Map.copyOf(index);
+    }
+
+    private final String spelling;
+
+    /** What this command takes besides its options, in the form a synopsis writes them. */
+    private final String operands;
+
+    /** What this command is for, in one line. */
+    private final String summary;
+
+    /** What an option of this command's means here, where that is not what it means on its own. */
+    private final Map<CliOption, String> reads;
+
+    CliCommand(String spelling, String operands, String summary) {
+        this(spelling, operands, summary, Map.of());
+    }
+
+    CliCommand(String spelling, String operands, String summary, Map<CliOption, String> reads) {
+        this.spelling = spelling;
+        this.operands = operands;
+        this.summary = summary;
+        this.reads = reads.isEmpty() ? Map.of() : new EnumMap<>(reads);
+    }
+
+    /** The command this name is, or null where this compiler has no such command. */
+    static CliCommand named(String name) {
+        return BY_SPELLING.get(name);
+    }
+
+    String spelling() {
+        return spelling;
+    }
+
+    String operands() {
+        return operands;
+    }
+
+    String summary() {
+        return summary;
+    }
+
+    /**
+     * What the option means under this command.
+     *
+     * <p>This command's own reading where it has one, and the option's otherwise. The same spelling
+     * is read differently by commands that ask different questions with it — {@code --behavior}
+     * chooses what {@code run} runs and narrows what {@code examples} reports on, and {@code -cp}
+     * is where {@code compile} finds modules and where {@code japi} finds a jar — and a section
+     * that printed one sentence under both would be documenting the spelling rather than the
+     * option.
+     */
+    String describe(CliOption option) {
+        String read = reads.get(option);
+        return read != null ? read : option.description();
+    }
+}

--- a/souther-compiler/src/main/java/souther/compiler/CliOption.java
+++ b/souther-compiler/src/main/java/souther/compiler/CliOption.java
@@ -29,60 +29,123 @@ import java.util.Set;
  */
 enum CliOption {
 
-    FORMAT("compile/run/examples", Value.TAKEN, "--format"),
-    LANG("compile/run/examples", Value.TAKEN, "--lang"),
-    COLOR("compile/run/examples", Value.TAKEN, "--color"),
-    CLASS_PATH("compile/run/examples/japi", Value.TAKEN, "-cp", "--class-path"),
-    OUT_DIR("compile", Value.TAKEN, "-d"),
-    ADEQUACY("compile", Value.TAKEN, "--adequacy"),
-    WARNINGS("compile", Value.TAKEN, "--warnings"),
-    BEHAVIOR("run/examples", Value.TAKEN, "--behavior"),
-    INPUT("run", Value.TAKEN, "--input"),
-    WRITE("fmt", Value.NONE, "-w", "--write"),
-    CHECK("fmt", Value.NONE, "--check"),
-    MODULE("examples", Value.TAKEN, "--module"),
-    GENERATE("examples", Value.NONE, "--generate"),
-    BOUNDARIES("examples", Value.NONE, "--boundaries"),
-    STRICT("examples", Value.NONE, "--strict"),
-    SEARCH("doc/api", Value.TAKEN, "--search"),
-    LIMIT("doc", Value.TAKEN, "--limit"),
-    SOURCE("api", Value.TAKEN, "--source");
-
-    /** Whether the token after this one is its value or the next argument. */
-    enum Value { NONE, TAKEN }
+    OUT_DIR("compile", "<outdir>", "where the generated .class files are written", "-d"),
+    ADEQUACY("compile", "off|witness|all",
+            "warn about what the `example`s do not cover (default off)", "--adequacy"),
+    WARNINGS("compile", "report|error", "refuse a compile that warns (default report)",
+            "--warnings"),
+    BEHAVIOR("run/examples", "<name>", "report only this behavior", "--behavior"),
+    INPUT("run", "<json>", "the behavior's input, as JSON", "--input"),
+    WRITE("fmt", null, "write the formatted source back in place", "-w", "--write"),
+    CHECK("fmt", null, "write no file; exit non-zero on a file that is not formatted", "--check"),
+    MODULE("examples", "<name>", "report only this module", "--module"),
+    GENERATE("examples", null, "print commented rows for what nothing covers", "--generate"),
+    BOUNDARIES("examples", null, "with --generate, add rows at the untried boundaries",
+            "--boundaries"),
+    STRICT("examples", null, "exit non-zero on a gap the report names", "--strict"),
+    SEARCH("doc/api", "<term>", "sections and topics that say the term, best answer first",
+            "--search"),
+    LIMIT("doc", "<n>", "with --search, how many hits to show (default 20; 0 for all)", "--limit"),
+    SOURCE("api", "<Module>", "a stdlib module's own source, design comments included", "--source"),
+    CLASS_PATH("compile/run/examples/japi", "<path>",
+            "where to find modules another project compiled", "-cp", "--class-path"),
+    FORMAT("compile/run/examples", "human|json",
+            "how to render a compile error (default human)", "--format"),
+    LANG("compile/run/examples", "<tag>",
+            "message locale as a language tag, e.g. ja or en; overrides SOUTHER_LANG, and with "
+                    + "neither, en", "--lang"),
+    COLOR("compile/run/examples", "auto|always|never",
+            "color the human output (default auto); not read under --format json", "--color"),
+    /** Every command's, which is what the null owner means. */
+    HELP(null, null, "what this command takes, and what its options mean", "--help", "-h");
 
     /** Why a command line is refused: a catalog key and what fills it. */
     record Refusal(String key, Object... args) {}
 
     /**
-     * What one reading of a command line found: why it is refused, if it is, and the language it is
-     * to be answered in.
+     * What one reading of a command line found: why it is refused, if it is, the language it is to
+     * be answered in, and whether it asks what the command takes.
      *
-     * <p>The two come from the same walk because they are answers about the same tokens. Reading the
-     * line twice — once to find {@code --lang}, once to check it — is two rules for what a token is,
-     * and they part company on the lines that need them most: a value that is spelt like an option
-     * is a value to one walk and an option to the other.
+     * <p>The three come from the same walk because they are answers about the same tokens. Reading
+     * the line twice — once to find {@code --lang}, once to check it — is two rules for what a token
+     * is, and they part company on the lines that need them most: a value that is spelt like an
+     * option is a value to one walk and an option to the other.
+     *
+     * <p>{@code help} is that same reading and not a search for the word. {@code run --input --help}
+     * hands {@code run} the input {@code --help}; a line scanned for the token finds a request for
+     * help in it, and answers a question its author did not ask instead of running what they wrote.
+     * So this is true where the walk recognised {@link #HELP} in a position an option is read in,
+     * and there is no other way for it to become true.
      */
-    record Reading(Refusal refusal, String lang) {}
+    record Reading(Refusal refusal, String lang, boolean help) {}
 
     /**
-     * The commands that take the option, in the form a refusal names them.
+     * The commands that take the option, in the form a refusal names them, or null for an option
+     * every command takes.
      *
      * <p>Not the commands it is documented under. The usage text groups an option under one heading
      * — {@code --behavior} under {@code examples} — and {@code run} takes it too; a refusal built
      * from the heading would send an author to the wrong command line.
+     *
+     * <p>Null rather than the commands written out, where the answer is all of them. Writing them
+     * out is a copy of {@link CliCommand} with nothing holding the two together, and the copy goes
+     * wrong exactly where it matters: a command added to that table and missed here would be the one
+     * command that cannot be asked what it takes, and every check on this table would still pass.
      */
     private final String owners;
 
-    private final Value value;
+    /**
+     * How this option's value is written where it takes one, and null where it takes none.
+     *
+     * <p>Also what says which of the two it is. These were two statements — a {@code Value} in this
+     * table beside a value spelling written in the usage text — and an option's value is one fact: a
+     * token follows it exactly where there is something for that token to be.
+     */
+    private final String valueSpelling;
+
+    /**
+     * What the option does, in the words a reader is shown beside it.
+     *
+     * <p>The option's own, which is not always the whole of it: what {@code --behavior} selects
+     * differs between the command that drives one and the command that reports on one. A command
+     * that reads it differently says so itself (see {@code CliCommand}), and this is the reading
+     * every other command takes.
+     */
+    private final String description;
 
     /** Every spelling of the option, the first of which is the one a refusal names it by. */
     private final List<String> spellings;
 
-    CliOption(String owners, Value value, String... spellings) {
+    CliOption(String owners, String valueSpelling, String description, String... spellings) {
         this.owners = owners;
-        this.value = value;
+        this.valueSpelling = valueSpelling;
+        this.description = description;
         this.spellings = List.of(spellings);
+    }
+
+    /** The spelling a refusal names this option by, and the one a section lists it under. */
+    String spelling() {
+        return spellings.get(0);
+    }
+
+    /** Every spelling of this option, in the order a section writes them. */
+    List<String> spellings() {
+        return spellings;
+    }
+
+    /** How this option's value is written, or null where it takes none. */
+    String valueSpelling() {
+        return valueSpelling;
+    }
+
+    /** What this option does, where the command reading it has nothing of its own to say. */
+    String description() {
+        return description;
+    }
+
+    /** Whether the token after this one is read as its value. */
+    boolean takesAValue() {
+        return valueSpelling != null;
     }
 
     /**
@@ -116,17 +179,39 @@ enum CliOption {
     }
 
     /** Every spelling this compiler knows, in the order the table writes them. */
-    static Set<String> spellings() {
+    static Set<String> everySpelling() {
         return new LinkedHashSet<>(BY_SPELLING.keySet());
     }
 
     /** The commands that take the option written this way, or null where this compiler has none. */
     static String owners(String spelling) {
         CliOption option = BY_SPELLING.get(spelling);
-        return option == null ? null : option.owners;
+        return option == null ? null : option.owners();
     }
 
-    private boolean ownedBy(String command) {
+    /**
+     * The commands that take this option, in the form a refusal names them.
+     *
+     * <p>Asked of {@link CliCommand} where the answer is all of them, and asked when it is asked
+     * rather than when this table is built: an enum whose constants read another enum's constants
+     * while both are being initialised sees whichever of them got there first.
+     */
+    String owners() {
+        if (owners != null) {
+            return owners;
+        }
+        StringBuilder every = new StringBuilder();
+        for (CliCommand command : CliCommand.values()) {
+            every.append(every.isEmpty() ? "" : "/").append(command.spelling());
+        }
+        return every.toString();
+    }
+
+    /** Whether the named command is one of this option's, which is what a section lists it under. */
+    boolean ownedBy(String command) {
+        if (owners == null) {
+            return true;   // every command's, whichever commands there turn out to be
+        }
         for (String owner : owners.split("/")) {
             if (owner.equals(command)) {
                 return true;
@@ -152,6 +237,7 @@ enum CliOption {
         Map<CliOption, String> asWritten = new EnumMap<>(CliOption.class);
         Refusal token = null;
         String lang = null;
+        boolean help = false;
         for (int i = 0; i < args.length; i++) {
             String word = args[i];
             CliOption option = BY_SPELLING.get(word);
@@ -169,7 +255,10 @@ enum CliOption {
             }
             written.add(option);
             asWritten.put(option, word);
-            if (option.value == Value.TAKEN) {
+            if (option == HELP) {
+                help = true;   // recognised where an option is read, which is the whole of the rule
+            }
+            if (option.takesAValue()) {
                 // Whatever follows is this option's value, option-shaped or not: `--module
                 // --generate` names a module, which is what the command's own parser reads it as.
                 if (++i >= args.length) {
@@ -187,7 +276,19 @@ enum CliOption {
                 }
             }
         }
-        return new Reading(token != null ? token : unmet(written, asWritten), lang);
+        return new Reading(token != null ? token : unmet(written, asWritten), lang, help);
+    }
+
+    /**
+     * Whether this token is a spelling of {@link #HELP}.
+     *
+     * <p>For the one position no walk reaches: the command name. {@code souther --help} writes it
+     * where a command goes, and there is no command yet whose options could be read. Asked of the
+     * same table the walk asks, so that how help is spelt is stated once — a command line matching
+     * the two strings for itself is the second rule this class exists to stop there being.
+     */
+    static boolean isHelp(String token) {
+        return BY_SPELLING.get(token) == HELP;
     }
 
     /** The first constraint between options this line does not meet, or null where it meets them. */
@@ -212,7 +313,7 @@ enum CliOption {
     /** Whether the token after this one is read as its value. */
     static boolean takesValue(String spelling) {
         CliOption option = BY_SPELLING.get(spelling);
-        return option != null && option.value == Value.TAKEN;
+        return option != null && option.takesAValue();
     }
 
     /** What the option needs written beside it, or null where it stands on its own. */

--- a/souther-compiler/src/main/java/souther/compiler/Main.java
+++ b/souther-compiler/src/main/java/souther/compiler/Main.java
@@ -36,59 +36,20 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * CLI entry point with two subcommands: {@code souther compile <file.sou>... -d <outdir>} writes
- * {@code .class} files, and {@code souther run <file.sou> [-cp <path>] [--behavior <name>] [--input
- * <json>]} drives one behavior and prints its output (see {@link Runner}).
+ * The command line's entry point: it resolves the command a line names, holds the line against what
+ * that command takes, and runs it.
  *
- * <p>Both accept {@code --format human|json}, {@code --lang <tag>}, and {@code --color auto|always|never}
- * to control how a compile error is rendered (an Elm-style snippet or a JSON object, in the chosen
- * locale). These are pulled off before the subcommand's own arguments are parsed.
+ * <p>Which commands there are and what each takes is not written here. {@link CliCommand} is the
+ * table of commands and {@link CliOption} of options, and both {@link Usage} — what
+ * {@code souther help} writes — and the check above the dispatch are read off them. What this class
+ * holds is each command's own reading of its arguments, and the one boundary the whole run sits
+ * inside.
  */
 public final class Main {
 
-    private static final String USAGE = """
-            usage: souther <command> [args]
-            commands:
-              compile <file.sou>... -d <outdir> [-cp <path>]      compile to .class files
-              run <file.sou> [-cp <path>] [--behavior <name>] [--input <json>]  run a behavior, print its output
-              fmt <file.sou>... [-w|--write] [--check]             format source (stdout, or -w in place)
-              examples <file.sou>... [-cp <path>]                  how well the `example`s cover the model
-              doc [<anchor> | <error-code> | <set>/<topic> | --search <term>]  read the language specification
-              api [<Module>[.<name>] | --search <term>]            the stdlib surface and its signatures
-              japi <class-or-package>[#<member>] [-cp <path>]      a dependency jar's public API, with javadoc
-            options (doc):
-              --search <term>           sections and topics that say the term, best answer first
-              --limit <n>               with --search, how many hits to show (default 20; 0 for all)
-            options (api):
-              --source <Module>         a stdlib module's own source, design comments included
-              mcp                                                  serve doc/api/japi over MCP stdio
-            options (examples):
-              --module <name>           report only this module
-              --behavior <name>         report only this behavior
-              --generate                print commented rows for what nothing covers
-              --boundaries              with --generate, add rows at the untried boundaries
-              --strict                  exit non-zero on a gap the report names
-            options (compile):
-              --adequacy off|witness|all  warn about what the `example`s do not cover (default off)
-              --warnings report|error   refuse a compile that warns (default report)
-            options (compile/run/examples/japi):
-              -cp, --class-path <path>  where to find modules another project compiled
-
-            options (compile/run/examples):
-              --format human|json      how to render a compile error (default: human)
-              --lang <tag>             message locale as a language tag, e.g. ja or en
-                                       (overrides SOUTHER_LANG; with neither, en)
-              --color auto|always|never  color the human output (default: auto)
-                                       (not written with --format json, which reads no color)""";
-
-    /** Every option this compiler knows, for the test that holds the table against the usage text. */
+    /** Every option this compiler knows, for the test that holds the table against the parsers. */
     static java.util.Set<String> knownOptions() {
-        return CliOption.spellings();
-    }
-
-    /** The usage text, for the test that holds it against the table. */
-    static String usage() {
-        return USAGE;
+        return CliOption.everySpelling();
     }
 
     /** The commands that take {@code option}, or null where this compiler has no such option. */
@@ -134,51 +95,62 @@ public final class Main {
      * here, each of those is an ordinary result.
      */
     static int dispatch(String[] args) {
-        String command = args.length == 0 ? "" : args[0];
+        String named = args.length == 0 ? "" : args[0];
         String[] rest = args.length == 0 ? args : java.util.Arrays.copyOfRange(args, 1, args.length);
-        java.util.function.IntSupplier asked = commandNamed(command, rest);
-        if (asked == null) {
-            String hint = command.endsWith(".sou")
-                    ? "no command given — did you mean `souther compile " + command
-                            + " …` or `souther run " + command + " …`?"
-                    : command.isEmpty() ? "no command given" : "unknown command `" + command + "`";
+        // Written where a command goes, `--help` asks what `help` asks. Read as an option it would
+        // be an option of no command, since which command's options are read is what has not been
+        // said yet; read as its own shape it would be a line whose remaining arguments nothing
+        // looks at, and `souther --help compile` would answer with the listing.
+        CliCommand command = CliOption.isHelp(named) ? CliCommand.HELP : CliCommand.named(named);
+        if (command == null) {
+            String hint = named.endsWith(".sou")
+                    ? "no command given — did you mean `souther compile " + named
+                            + " …` or `souther run " + named + " …`?"
+                    : named.isEmpty() ? "no command given" : "unknown command `" + named + "`";
             System.err.println(hint);
-            System.err.println(USAGE);
+            System.err.println(Usage.all());
             return 2;
         }
         // Before the command, and the same check whichever one was named. What each parser used to
         // ask for itself — is this token mine — three of them asked and two did not, and none of
         // them could ask the question the tokens cannot answer one at a time: whether an option
         // written here is one this line ever reads.
-        CliOption.Reading read = CliOption.read(command, rest);
+        CliOption.Reading read = CliOption.read(command.spelling(), rest);
+        // Before the refusal. A line that asks what the command takes is asking because it does not
+        // know, so answering it with what is wrong with the line — and then not answering it — is
+        // the one reply that leaves its author where they started.
+        if (read.help()) {
+            System.out.println(Usage.of(command));
+            return 0;
+        }
         if (read.refusal() != null) {
             System.err.println(Messages.get(read.refusal().key(),
                     RenderOptions.asking(read.lang()).locale(), read.refusal().args()));
-            System.err.println(USAGE);
+            System.err.println(Usage.of(command));
             return 2;
         }
-        return asked.getAsInt();
+        return work(command, rest).getAsInt();
     }
 
     /**
-     * The command this line names, or null where it names none.
+     * What the command does, kept unrun until everything said above about the line holds.
      *
-     * <p>Resolved before its arguments are checked and kept unrun, so which commands there are is
-     * said once. A list of the names beside this one is a second statement of it, and the check
-     * above reads a command name — a name missing from that list is a command whose options nothing
-     * looks at, which is the shape of the defect the check exists for.
+     * <p>A {@code switch} over the table and not over the name, and an expression with no default
+     * arm: a command written into {@link CliCommand} and left out here is a compile error. The
+     * names used to be matched a second time in this method, which made the table and the dispatch
+     * two lists to keep in step — the drift a test would then have to go looking for.
      */
-    private static java.util.function.IntSupplier commandNamed(String command, String[] rest) {
+    private static java.util.function.IntSupplier work(CliCommand command, String[] rest) {
         return switch (command) {
-            case "run" -> () -> runSubcommand(rest);
-            case "compile" -> () -> compileSubcommand(rest);
-            case "fmt" -> () -> fmtSubcommand(rest);
-            case "examples" -> () -> examplesSubcommand(rest);
-            case "doc" -> () -> DocCommand.run(rest, System.out, System.err);
-            case "api" -> () -> ApiCommand.run(rest, System.out, System.err);
-            case "japi" -> () -> JapiCommand.run(rest, System.out, System.err);
-            case "mcp" -> () -> mcpSubcommand(rest);
-            default -> null;
+            case RUN -> () -> runSubcommand(rest);
+            case COMPILE -> () -> compileSubcommand(rest);
+            case FMT -> () -> fmtSubcommand(rest);
+            case EXAMPLES -> () -> examplesSubcommand(rest);
+            case DOC -> () -> DocCommand.run(rest, System.out, System.err);
+            case API -> () -> ApiCommand.run(rest, System.out, System.err);
+            case JAPI -> () -> JapiCommand.run(rest, System.out, System.err);
+            case MCP -> () -> mcpSubcommand(rest);
+            case HELP -> () -> helpSubcommand(rest);
         };
     }
 
@@ -241,7 +213,7 @@ public final class Main {
         }
         if (sources.isEmpty()) {
             System.err.println("compile takes at least one .sou file");
-            System.err.println(USAGE);
+            System.err.println(Usage.of(CliCommand.COMPILE));
             return 2;
         }
         List<Located> warnings = new ArrayList<>();
@@ -320,7 +292,7 @@ public final class Main {
         }
         if (sources.isEmpty()) {
             System.err.println("examples takes at least one .sou file");
-            System.err.println(USAGE);
+            System.err.println(Usage.of(CliCommand.EXAMPLES));
             return 2;
         }
         List<Located> warnings = new ArrayList<>();
@@ -412,10 +384,55 @@ public final class Main {
         if (args.length > 0) {
             System.err.println(Messages.get("cli.mcp.arguments",
                     RenderOptions.asking(null).locale(), String.join(", ", args)));
-            System.err.println(USAGE);
+            System.err.println(Usage.of(CliCommand.MCP));
             return 2;
         }
         return McpServer.serve(System.in, System.out);
+    }
+
+    /**
+     * {@code souther help [<command>]}: what this command line takes, asked rather than refused.
+     *
+     * <p>On stdout under a zero exit code, which is the whole point of it being a command. What it
+     * writes was reachable only from a failure before — no command, an unknown one, a missing
+     * argument — so it went to stderr every time and the exit code said the line was wrong. An
+     * author who wanted to read it had to write a line they knew this compiler would refuse, and a
+     * reader piping the answer anywhere got an empty pipe.
+     */
+    private static int helpSubcommand(String[] args) {
+        Locale locale = RenderOptions.asking(null).locale();
+        if (args.length == 0) {
+            System.out.println(Usage.all());
+            return 0;
+        }
+        if (args.length > 1) {
+            System.err.println(Messages.get("cli.help.arguments", locale,
+                    String.join(", ", args)));
+            System.err.println(Usage.of(CliCommand.HELP));
+            return 2;
+        }
+        CliCommand about = helpTarget(args);
+        if (about == null) {
+            // Not answered with the listing as though nothing had been asked: a word that is no
+            // command of this compiler's is a thing its author believes exists, and being shown
+            // every command without being told that is not one of them leaves them looking for it.
+            System.err.println(Messages.get("cli.help.command", locale, args[0]));
+            System.err.println(Usage.all());
+            return 2;
+        }
+        System.out.println(Usage.of(about));
+        return 0;
+    }
+
+    /**
+     * The command {@code souther help} was asked about, or null where its argument names none.
+     *
+     * <p>Of a line that names one: the argument is a command name, and a line that wrote no name or
+     * wrote two has not named a command to answer about. Which of those it is stays with the
+     * command that has to say so.
+     */
+    static CliCommand helpTarget(String[] args) {
+        return args.length == 1 ? CliCommand.named(args[0]) : null;
     }
 
     /** The level {@code --adequacy} names, or null where it names none. */
@@ -458,7 +475,7 @@ public final class Main {
         }
         if (files.isEmpty()) {
             System.err.println("fmt takes at least one .sou file");
-            System.err.println(USAGE);
+            System.err.println(Usage.of(CliCommand.FMT));
             return 2;
         }
         if (!write && !check && files.size() > 1) {

--- a/souther-compiler/src/main/java/souther/compiler/Usage.java
+++ b/souther-compiler/src/main/java/souther/compiler/Usage.java
@@ -1,0 +1,127 @@
+package souther.compiler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * What this command line takes, written out.
+ *
+ * <p>Nothing here knows a command from another one. What to write about {@code compile} is read off
+ * {@link CliCommand} and {@link CliOption} exactly as it is read off them for every other command,
+ * so a command or an option added to those tables is written out without this class being told. A
+ * branch on a particular command appearing here would mean the tables had stopped carrying
+ * something a reader is shown, and that thing would then be documented in a renderer.
+ *
+ * <p>This used to be one string held against the tables by a test, which is what it takes to keep
+ * two statements of one fact agreeing. It had drifted anyway: {@code mcp} was written as an option
+ * of {@code api}, and {@code --behavior} was documented under {@code examples} alone though
+ * {@code run} takes it too.
+ */
+final class Usage {
+
+    /** How wide a written line runs, the formatter's own width. */
+    private static final int WIDTH = 100;
+
+    /** What stands between the widest thing in a column and what is written against it. */
+    private static final int GAP = 2;
+
+    private static final String INDENT = "  ";
+
+    /** What the command line takes: every command it has, and how to ask about one of them. */
+    static String all() {
+        List<String> lines = new ArrayList<>();
+        lines.add("usage: souther <command> [options] [args]");
+        lines.add("");
+        lines.add("commands:");
+        int column = column(java.util.Arrays.stream(CliCommand.values())
+                .map(CliCommand::spelling).toList());
+        for (CliCommand command : CliCommand.values()) {
+            lines.addAll(entry(command.spelling(), command.summary(), column));
+        }
+        lines.add("");
+        lines.add("`souther help <command>` writes what one command takes,"
+                + " and `souther doc cli/commands` writes the whole of it.");
+        return String.join(System.lineSeparator(), lines);
+    }
+
+    /**
+     * What one command takes: how it is written, what it is for, and every option it has.
+     *
+     * <p>Its options are the ones {@link CliOption} says are this command's, in the order that
+     * table writes them — the command's own first and the ones every command shares last. Not the
+     * ones written under its heading somewhere, which is what left {@code run} documented without
+     * the {@code --behavior} it takes.
+     */
+    static String of(CliCommand command) {
+        List<String> lines = new ArrayList<>();
+        lines.add(("usage: souther " + command.spelling() + " [options] "
+                + command.operands()).stripTrailing());
+        lines.add(INDENT + command.summary());
+        // Never none of them: `--help` is every command's, so a command that takes nothing else
+        // still has this section, which is the one a reader who got here by asking is reading.
+        List<CliOption> options = optionsOf(command);
+        lines.add("");
+        lines.add("options:");
+        int column = column(options.stream().map(Usage::written).toList());
+        for (CliOption option : options) {
+            lines.addAll(entry(written(option), command.describe(option), column));
+        }
+        return String.join(System.lineSeparator(), lines);
+    }
+
+    /** The options this command takes, in the order the table writes them. */
+    private static List<CliOption> optionsOf(CliCommand command) {
+        List<CliOption> options = new ArrayList<>();
+        for (CliOption option : CliOption.values()) {
+            if (option.ownedBy(command.spelling())) {
+                options.add(option);
+            }
+        }
+        return options;
+    }
+
+    /** How an option is written where it is listed: every spelling it has, and its value. */
+    private static String written(CliOption option) {
+        String spelt = String.join(", ", option.spellings());
+        return option.takesAValue() ? spelt + " " + option.valueSpelling() : spelt;
+    }
+
+    /** Where the second column begins: past the widest thing in the first, and the gap. */
+    private static int column(List<String> first) {
+        int widest = 0;
+        for (String written : first) {
+            widest = Math.max(widest, written.length());
+        }
+        return INDENT.length() + widest + GAP;
+    }
+
+    /**
+     * One two-column line, and the lines its description runs onto.
+     *
+     * <p>A description too long for what is left of the width is carried on at the column it began
+     * at, rather than being written out past the edge or cut. What runs on is indented under the
+     * description and never under the name, so a line that runs on cannot be read as another
+     * option.
+     */
+    private static List<String> entry(String name, String description, int column) {
+        List<String> lines = new ArrayList<>();
+        String pad = " ".repeat(column);
+        StringBuilder line = new StringBuilder(INDENT).append(name);
+        while (line.length() < column) {
+            line.append(' ');
+        }
+        for (String word : description.split(" ")) {
+            if (line.length() > column && line.length() + 1 + word.length() > WIDTH) {
+                lines.add(line.toString());
+                line = new StringBuilder(pad);
+            } else if (line.length() > column) {
+                line.append(' ');
+            }
+            line.append(word);
+        }
+        lines.add(line.toString());
+        return lines;
+    }
+
+    private Usage() {}
+}

--- a/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
+++ b/souther-compiler/src/main/resources/META-INF/souther-docs/cli/commands.md
@@ -1,8 +1,12 @@
 # The `souther` command
 
 ```
-souther <command> [args]
+souther <command> [options] [args]
 ```
+
+`souther help` lists the commands, and `souther help <command>` writes one command's arguments and
+every option it takes. That listing is generated from the same table the compiler resolves an option
+against, so it says what this build does rather than what a text was last edited to say.
 
 <!-- souther-section: compile -->
 ## compile
@@ -379,6 +383,34 @@ The cursor is this server's to read, so it goes out as it came in: where it poin
 against the answer it is carried back to, and one measured against a different answer is refused
 rather than resumed at.
 
+<!-- souther-section: help -->
+## help
+
+```
+souther help [<command>]
+```
+
+What this command line takes. With no argument it lists every command with a line saying what it is
+for; with a command it writes that command's arguments and every option the command takes, each with
+what the option means there. `souther <command> --help` asks the same thing and is answered the same
+way, and so is `-h`.
+
+The answer goes to stdout under a zero exit code. Everything this writes used to be reachable only
+from a failure — no command, an unknown one, a missing argument — so it went to stderr and the exit
+code said the line was wrong. Reading it meant writing a line you knew would be refused, and piping
+it anywhere gave you an empty pipe.
+
+A section lists the options the compiler will resolve against that command, so an option two
+commands take is written under both. `--behavior` is `run`'s and `examples`', and what it selects is
+not the same question in the two of them: it chooses which behavior `run` drives, and narrows what
+`examples` reports on. Each section says the one that holds there.
+
+`--help` outranks what is wrong with the line. `souther compile --nonsense --help` writes compile's
+section and exits zero rather than refusing the option, because a line asking what a command takes is
+asking for the reason it is wrong. What does not ask is a line where the token stands in an option's
+value: `souther run m.sou --input --help` hands `run` the input `--help`, and that is read as the
+value it is, not as a request.
+
 <!-- souther-section: shared-options -->
 ## Options every command shares
 
@@ -387,8 +419,14 @@ rather than resumed at.
 | `--format human\|json` | how to render a compile error (default `human`) |
 | `--lang <tag>` | message locale, e.g. `ja` or `en`. Overrides `SOUTHER_LANG`; with neither, `en`, which is what the shipped documents are written in |
 | `--color auto\|always\|never` | color the human output (default `auto`) |
+| `--help`, `-h` | what this command takes, and what its options mean |
 
-These apply to `compile`, `run` and `examples`. Passing them to another command is an error.
+`--help` and `-h` are taken by every command, including `help` itself. The other three apply to
+`compile`, `run` and `examples`, and passing one of them to another command is an error.
+
+Because every command takes `-h`, no command reads that token as a file name. A single dash is
+otherwise read as a path by any command that has no such option — a file may be named `-d` — and
+this is the one short option that rule no longer reaches.
 
 `--format` and `--color` take the values written above and no others. A value outside the set is
 refused rather than read as the default: a caller that asked for `--format jsn` was answered with a

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages.properties
@@ -702,3 +702,5 @@ example.the-evaluation-spent-its-steps=The evaluation of this row did not finish
 example.spending-the-budget-is-not-diverging=What the counting shows is that the evaluation did not finish, not that the model does not: a `partial` recursion that never stops reaches this, and so does one that would have stopped shortly after. If the model does finish and needs more, raise `souther.example.step.limit`; otherwise bound the loop or make the recursion structural.
 example.the-evaluation-reached-its-depth-limit=The evaluation of this row reached its recursion-depth limit of {limit}.
 example.reaching-the-depth-limit-is-not-diverging=What the counting shows is that the recursion went deeper than the limit, not that it never bottoms out. If the data really is that deep, raise `souther.example.recursion.depth`; otherwise recurse on a part of the argument so it bottoms out.
+cli.help.command=`souther` has no command `{0}`
+cli.help.arguments=`souther help` is written about one command; it was given {0}

--- a/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
+++ b/souther-compiler/src/main/resources/souther/compiler/diag/messages_ja.properties
@@ -697,3 +697,5 @@ example.the-evaluation-spent-its-steps=この行の評価が、{budget} ステ�
 example.spending-the-budget-is-not-diverging=計数が示しているのは評価が終わらなかったことで、モデルが停止しないことではありません。止まらない `partial` な再帰もここに来ますし、あと少しで止まったものも来ます。モデルが実際に停止していてもっと必要なら `souther.example.step.limit` を上げてください。そうでなければループを押さえるか、再帰を構造的にしてください。
 example.the-evaluation-reached-its-depth-limit=この行の評価が、再帰深度の上限 {limit} に達しました。
 example.reaching-the-depth-limit-is-not-diverging=計数が示しているのは再帰が上限より深く進んだことで、底に到達しないことではありません。データが本当にそれだけ深いなら `souther.example.recursion.depth` を上げてください。そうでなければ引数の一部で再帰して底に到達するようにしてください。
+cli.help.command=`souther` に `{0}` というコマンドはありません。
+cli.help.arguments=`souther help` は1つのコマンドについて書きますが、{0} が指定されています。

--- a/souther-compiler/src/test/java/souther/compiler/AnUnknownOptionIsNotAFileNameTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AnUnknownOptionIsNotAFileNameTest.java
@@ -124,6 +124,13 @@ class AnUnknownOptionIsNotAFileNameTest {
                     ? run("compile", file.toString(), "-d", dir.resolve("out").toString(), option)
                     : run("fmt", file.toString(), "--check", option);
 
+            if (owners.split("/").length == CliCommand.values().length) {
+                // An option every command takes has no command to be refused by, so there is no
+                // refusal here to hold against the table. That it is taken everywhere is the thing
+                // to check, and it is what the row asserts instead of passing on a skip.
+                assertFalse(said.err().contains("unknown option"), option + ": " + said.err());
+                continue;
+            }
             assertEquals(2, said.code(), option);
             assertTrue(said.err().contains("unknown option `" + option + "`"), option + ": " + said.err());
             assertTrue(said.err().contains("it is an option of " + owners), option + ": " + said.err());
@@ -153,23 +160,6 @@ class AnUnknownOptionIsNotAFileNameTest {
                         owner + " is named as an owner of " + option + ": " + said.err());
             }
         }
-    }
-
-    /**
-     * The table and the usage text name the same options. They say different things about them — the
-     * usage groups an option under the commands it is documented with, which is not always every
-     * command that takes it — but an option in one and not the other is a drift between what the
-     * author is shown and what a refusal can say.
-     */
-    @Test
-    void theUsageTextAndTheTableNameTheSameOptions() {
-        Set<String> written = new TreeSet<>();
-        for (String word : Main.usage().split("[\\s,\\[\\]|]+")) {
-            if (word.startsWith("-")) {
-                written.add(word);
-            }
-        }
-        assertEquals(new TreeSet<>(Main.knownOptions()), written);
     }
 
     /** The commands whose option it is still take it. */

--- a/souther-compiler/src/test/java/souther/compiler/AskingForHelpIsAnAnswerNotAnErrorTest.java
+++ b/souther-compiler/src/test/java/souther/compiler/AskingForHelpIsAnAnswerNotAnErrorTest.java
@@ -1,0 +1,225 @@
+package souther.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * What this command line takes is something it can be asked, rather than something it says while
+ * refusing a line.
+ *
+ * <p>The usage text was reachable only from a failure — no command, an unknown one, an argument
+ * missing — so it went to stderr under a non-zero exit code every time. An author who wanted to read
+ * it had to write a line they knew to be wrong, and a reader piping the answer got nothing.
+ *
+ * <p>What is asked here is which section a line asks for and where the answer goes, and never what
+ * any of it says. The wording is the renderer's, and a test that reads it back holds this command
+ * line to the sentence it happens to print today.
+ */
+class AskingForHelpIsAnAnswerNotAnErrorTest {
+
+    private record Said(int code, String err, String out) {}
+
+    /** Runs the command line and answers with its exit code and what it wrote. */
+    private Said run(String... args) {
+        PrintStream originalErr = System.err;
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(err, true, StandardCharsets.UTF_8));
+        System.setOut(new PrintStream(out, true, StandardCharsets.UTF_8));
+        try {
+            int code = Main.dispatch(args);
+            return new Said(code, err.toString(StandardCharsets.UTF_8),
+                    out.toString(StandardCharsets.UTF_8));
+        } finally {
+            System.setErr(originalErr);
+            System.setOut(originalOut);
+        }
+    }
+
+    // --- where the answer goes ---------------------------------------------------------------
+
+    /** On stdout under a zero exit code: it is what was asked for, not a refusal. */
+    @Test
+    void helpIsAnsweredOnStdout() {
+        Said said = run("help");
+
+        assertEquals(0, said.code(), said.err());
+        assertEquals("", said.err());
+        assertFalse(said.out().isEmpty());
+    }
+
+    /** The option at the command position asks the same thing, and is answered the same way. */
+    @Test
+    void theHelpOptionOnItsOwnIsTheHelpCommand() {
+        for (String spelling : new String[] {"--help", "-h"}) {
+            Said said = run(spelling);
+
+            assertEquals(0, said.code(), spelling + ": " + said.err());
+            assertEquals("", said.err(), spelling);
+            assertFalse(said.out().isEmpty(), spelling);
+        }
+    }
+
+    /** A command line that names no command is still a line this compiler refuses. */
+    @Test
+    void anEmptyCommandLineIsStillRefused() {
+        Said said = run();
+
+        assertEquals(2, said.code());
+        assertEquals("", said.out());
+        assertFalse(said.err().isEmpty());
+    }
+
+    // --- which section a line asks for --------------------------------------------------------
+
+    /**
+     * Every command can be asked about, and each is answered with its own section.
+     *
+     * <p>A row per command, and the answer is the command itself rather than a count or a
+     * non-emptiness: a resolution that gave every name the same section would satisfy anything
+     * weaker. {@code help} is one of the rows — it is a command like the others, and a table that
+     * carries it as a name the dispatch happens to know would have nothing to say when asked about
+     * it.
+     */
+    @Test
+    void everyCommandCanBeAskedAbout() {
+        for (CliCommand command : CliCommand.values()) {
+            assertSame(command, Main.helpTarget(new String[] {command.spelling()}),
+                    command.spelling());
+
+            Said said = run("help", command.spelling());
+
+            assertEquals(0, said.code(), command.spelling() + ": " + said.err());
+            assertEquals("", said.err(), command.spelling());
+            assertFalse(said.out().isEmpty(), command.spelling());
+        }
+    }
+
+    /** Asking about it by the option is asking about it by name. */
+    @Test
+    void theHelpOptionNamesTheCommandItIsWrittenOn() {
+        for (CliCommand command : CliCommand.values()) {
+            assertTrue(CliOption.read(command.spelling(), new String[] {"--help"}).help(),
+                    command.spelling());
+            assertTrue(CliOption.read(command.spelling(), new String[] {"-h"}).help(),
+                    command.spelling());
+        }
+    }
+
+    /** A word that is no command of this compiler's is refused rather than answered with the lot. */
+    @Test
+    void helpAboutSomethingThatIsNotACommandIsRefused() {
+        assertNull(Main.helpTarget(new String[] {"nope"}));
+
+        Said said = run("help", "nope");
+
+        assertEquals(2, said.code());
+        assertFalse(said.err().isEmpty());
+    }
+
+    /** It answers about one command, so a line naming two has not said which. */
+    @Test
+    void helpAboutTwoCommandsIsRefused() {
+        Said said = run("help", "compile", "run");
+
+        assertEquals(2, said.code());
+        assertFalse(said.err().isEmpty());
+    }
+
+    // --- what makes a line a request for help -------------------------------------------------
+
+    /**
+     * A token in the position of an option's value is that value, whatever it is spelt like.
+     *
+     * <p>This is why the question is asked by the walk that reads the options and not by a search
+     * through the tokens: {@code --input --help} is a line handing {@code run} the input
+     * {@code --help}, and a search finds a request for help in it. The two readings part company
+     * exactly here.
+     */
+    @Test
+    void anOptionsValueIsNotARequestForHelp() {
+        assertFalse(CliOption.read("run",
+                new String[] {"m.sou", "--input", "--help"}).help());
+
+        Said said = run("run", "m.sou", "--input", "--help");
+
+        assertNotEquals(0, said.code());
+    }
+
+    /**
+     * A line this compiler would refuse is still a line asking what the command takes, and that is
+     * what it is answered with — whichever side of the refusal the option was written on.
+     *
+     * <p>Both orders, because a walk that stopped at its first refusal would answer the first of
+     * these and not the second.
+     */
+    @Test
+    void helpIsAnsweredBeforeTheLineIsRefused() {
+        for (String[] line : new String[][] {
+                {"--nonsense", "--help"},
+                {"--help", "--nonsense"}}) {
+            CliOption.Reading read = CliOption.read("run", line);
+
+            assertTrue(read.help(), String.join(" ", line));
+            assertNotNull(read.refusal(), String.join(" ", line));
+
+            Said said = run("run", line[0], line[1]);
+
+            assertEquals(0, said.code(), String.join(" ", line) + ": " + said.err());
+            assertEquals("", said.err(), String.join(" ", line));
+        }
+    }
+
+    // --- the table the sections are written from ----------------------------------------------
+
+    /**
+     * Every option a command takes has something to say under it, and every command has something
+     * to say about itself.
+     *
+     * <p>The defect this refuses is an option added to the table and left undescribed: it is listed
+     * in the section of every command that takes it, and what a reader is shown beside it is a
+     * blank. Asked of the table rather than of the text, so it is the answer the renderer would
+     * print that is held and not the shape it prints it in.
+     */
+    @Test
+    void everyOptionACommandTakesIsDescribedUnderIt() {
+        for (CliCommand command : CliCommand.values()) {
+            assertFalse(command.summary().isBlank(), command.spelling());
+
+            int described = 0;
+            for (CliOption option : CliOption.values()) {
+                if (!option.ownedBy(command.spelling())) {
+                    continue;
+                }
+                assertFalse(command.describe(option).isBlank(),
+                        command.spelling() + " " + option.spelling());
+                described++;
+            }
+            assertTrue(described > 0, command.spelling() + " takes no option at all");
+        }
+    }
+
+    /** An option that takes a value says what the value is; one that takes none says nothing. */
+    @Test
+    void anOptionSpellsItsValueWhereItTakesOne() {
+        for (CliOption option : CliOption.values()) {
+            if (option.takesAValue()) {
+                assertFalse(option.valueSpelling().isBlank(), option.spelling());
+            } else {
+                assertNull(option.valueSpelling(), option.spelling());
+            }
+        }
+    }
+}


### PR DESCRIPTION
`souther` had no `--help` and no `help`. The usage text was reachable only from a failure — no command, an unknown one, a missing argument — so it went to stderr under a non-zero exit code every time, and reading it meant writing a line you knew would be refused.

## What it answers now

```
souther help                  # every command, with a line saying what it is for
souther help compile          # one command's arguments and every option it takes
souther compile --help        # the same question, the same answer
souther --help compile        # also the same
souther -h                    # and this
```

All on stdout under a zero exit code. `help` is a command like any other rather than a shape the dispatch knows about — it has a section of its own, and `souther help help` answers with it.

```
$ souther help japi
usage: souther japi [options] <class-or-package>[#<member>]
  a dependency jar's public API, with javadoc

options:
  -cp, --class-path <path>  where to find the jar to read
  --help, -h                what this command takes, and what its options mean
```

## Where the text comes from

`CliCommand` (new) says what commands there are; `CliOption` says which of them each option belongs to; `Usage` (new) builds a section by asking the two and holds no knowledge of any particular command. The one hand-written string this replaces had drifted from those tables despite a test holding the options together — `mcp` was written as an option of `api`, and `--behavior` was documented under `examples` alone though `run` takes it too. Neither is corrected here; both stop being sayable.

An option that two commands read differently says so under each: `-cp` is where `compile` finds modules and where `japi` finds a jar, and `--behavior` chooses what `run` runs and narrows what `examples` reports on.

`CliCommand` is also the one place a command name resolves. The dispatch is a switch expression over the constants with no default arm, so a command added to the table and left undispatched does not compile. `--help` belongs to whichever commands there are, written as no owner at all rather than as a list — a list would be a copy of the command table, wrong exactly where it matters.

## What makes a line a request for help

The option walk's answer, not a search for the token:

```
souther run m.sou --input --help   # the input is `--help`; exit 2, no help
souther compile --nonsense --help  # compile's section; exit 0
souther compile --help --nonsense  # the same
```

Help is answered before the line is refused, on either side of the refusal: a line asking what a command takes is asking for the reason it is wrong.

Argument errors now print the command's own section instead of the whole listing — `souther compile` with no file answers with compile's.

## Tests

11 new, asking which section a line asks for and where the answer goes, never what any of it says. The test holding the old text against the table is gone, since one statement cannot drift from itself; the one asking which command refuses an option now asserts, for an option every command takes, that none of them does. `commands.md` gains a `help` section and the shared-options row, which the existing document test requires.

6961 tests green across the reactor.
