### PR TITLE
Prepare 0.1.0-rc4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,15 @@ jobs:
           cp souther-lsp/target/souther-lsp.jar artifacts/
           cp souther-compiler/src/main/resources/souther/compiler/highlight/souther.tmLanguage.json artifacts/
 
+      # Over whatever the step above collected, rather than a second list of the same four names, and
+      # under the names the release publishes, so `sha256sum -c SHA256SUMS` works in a directory the
+      # assets were downloaded into. The file is written outside artifacts/ and moved in, so it
+      # cannot turn up in its own listing.
+      - name: Checksum the artifacts
+        run: |
+          sha256sum artifacts/* | sed 's#artifacts/##' > SHA256SUMS
+          mv SHA256SUMS artifacts/
+
       - name: Upload the artifacts to the workflow run
         uses: actions/upload-artifact@v7
         with:
@@ -50,3 +59,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: artifacts/*
+          # A tag carrying a pre-release identifier is not what a reader arriving at the repository
+          # should be handed as the current release. Semantic versioning puts that identifier after a
+          # hyphen and a final version has none, so the tag answers this itself and nothing has to be
+          # remembered at release time.
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.souther-lang</groupId>
     <artifactId>souther-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0-rc4</version>
     <packaging>pom</packaging>
 
     <name>Souther</name>

--- a/souther-bench/pom.xml
+++ b/souther-bench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc4</version>
     </parent>
 
     <artifactId>souther-bench</artifactId>

--- a/souther-cli/pom.xml
+++ b/souther-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc4</version>
     </parent>
 
     <artifactId>souther-cli</artifactId>

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc4</version>
     </parent>
 
     <artifactId>souther-compiler</artifactId>

--- a/souther-fmt/pom.xml
+++ b/souther-fmt/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc4</version>
     </parent>
 
     <artifactId>souther-fmt</artifactId>

--- a/souther-lsp/pom.xml
+++ b/souther-lsp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc4</version>
     </parent>
 
     <artifactId>souther-lsp</artifactId>

--- a/souther-runtime/pom.xml
+++ b/souther-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc4</version>
     </parent>
 
     <artifactId>souther-runtime</artifactId>

--- a/souther-syntax/pom.xml
+++ b/souther-syntax/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.1.0-rc4</version>
     </parent>
 
     <artifactId>souther-syntax</artifactId>


### PR DESCRIPTION
Two changes the release needs.

`SHA256SUMS` joins the four assets the release attaches. The Homebrew formula needs a `sha256` for `souther.jar` and there was nothing to read it from, so bumping it meant downloading the asset and computing one. The file is taken over whatever the collection step gathered rather than a second list of the same four names, so an asset added later is covered without touching it.

`prerelease` is derived from the tag. `v0.1.0-rc3` is currently what the repository offers as its release, over the `v0.1.0` tag that was marked pre-release by hand. Semantic versioning puts a pre-release identifier after a hyphen and a final version has none, so the tag answers this and nothing has to be remembered at release time.

Then the reactor moves to `0.1.0-rc4`. The examples pin the compiler in their own repository and track `develop` rather than a release, so they stay on the SNAPSHOT.

Verified: `mvn clean verify` green at `0.1.0-rc4` (8 modules), `souther-examples` `mvn clean compile` green against the merged split (12 modules), and the checksum step round-trips through `sha256sum -c` on the four real artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)