### PR TITLE
Take develop off the released version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.souther-lang</groupId>
     <artifactId>souther-parent</artifactId>
-    <version>0.1.0-rc4</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Souther</name>

--- a/souther-bench/pom.xml
+++ b/souther-bench/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc4</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-bench</artifactId>

--- a/souther-cli/pom.xml
+++ b/souther-cli/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc4</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-cli</artifactId>

--- a/souther-compiler/pom.xml
+++ b/souther-compiler/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc4</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-compiler</artifactId>

--- a/souther-fmt/pom.xml
+++ b/souther-fmt/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc4</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-fmt</artifactId>

--- a/souther-lsp/pom.xml
+++ b/souther-lsp/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc4</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-lsp</artifactId>

--- a/souther-runtime/pom.xml
+++ b/souther-runtime/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc4</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-runtime</artifactId>

--- a/souther-syntax/pom.xml
+++ b/souther-syntax/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.souther-lang</groupId>
         <artifactId>souther-parent</artifactId>
-        <version>0.1.0-rc4</version>
+        <version>0.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>souther-syntax</artifactId>


### PR DESCRIPTION
`0.1.0-rc4` is tagged and published, so `develop` goes back to `0.1.0-SNAPSHOT`. The examples repository builds against this SNAPSHOT and would otherwise resolve the released artifact instead of what is being built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)